### PR TITLE
style: default LemonModal and Popover widths to prose, normalise overrides

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -462,7 +462,6 @@ function AddItemsControlsModal(props: {
             isOpen={props.modelOpen || false}
             onClose={() => props.setModelOpen(false)}
             title="Add access"
-            maxWidth="30rem"
             description="Allow other users or roles to access this resource"
             footer={
                 <div className="flex items-center justify-end gap-2">

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/GroupedAccessControlRuleModal.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/GroupedAccessControlRuleModal.tsx
@@ -20,7 +20,6 @@ export function GroupedAccessControlRuleModal(props: { state: GroupedAccessContr
             isOpen={true}
             onClose={loading ? undefined : close}
             title={modalTitle}
-            maxWidth="32rem"
             footer={
                 <GroupedAccessControlRuleModalFooter close={close} loading={loading} canEdit={canEdit} onSave={save} />
             }

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourcesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourcesAccessControls.tsx
@@ -568,7 +568,6 @@ function ResourceAccessControlModal(props: {
             isOpen={props.modalOpen || false}
             onClose={props.loading ? undefined : props.setModalOpen}
             title={getModalTitle()}
-            maxWidth="30rem"
             description={`Set resource access levels for ${props.type === 'member' ? 'members' : 'roles'}`}
             footer={
                 <div className="flex items-center justify-end gap-2">
@@ -724,7 +723,6 @@ function DefaultResourceAccessControlModal(props: {
             isOpen={props.modalOpen || false}
             onClose={props.loading ? undefined : props.setModalOpen}
             title="Edit project defaults"
-            maxWidth="30rem"
             description="Set default resource access levels for all roles and members"
             footer={
                 <div className="flex items-center justify-end gap-2">

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
@@ -80,7 +80,6 @@ export function ImpersonationReasonModal({
                     </LemonButton>
                 </>
             }
-            width={500}
         >
             <div className="space-y-2">
                 {description && <p className="text-sm text-secondary">{description}</p>}

--- a/frontend/src/layout/panel-layout/PinnedFolder/EditCustomProductsModal.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/EditCustomProductsModal.tsx
@@ -40,7 +40,7 @@ export function EditCustomProductsModal(): JSX.Element {
                     Close
                 </LemonButton>
             }
-            width={600}
+            maxWidth="48rem"
         >
             <div className="flex flex-col gap-2">
                 <div>

--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -152,7 +152,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
     )
 
     return (
-        <LemonModal isOpen={isOpen} onClose={onClose} title="Configure tabs & home" width="48rem">
+        <LemonModal isOpen={isOpen} onClose={onClose} title="Configure tabs & home" maxWidth="48rem">
             <div className="space-y-6">
                 <section className="flex flex-col gap-3">
                     <div className="flex flex-col">

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -228,7 +228,7 @@ export function EditAlertModal({
     ])
 
     return (
-        <LemonModal onClose={handleClose} isOpen={isOpen} width={750} simple title="">
+        <LemonModal onClose={handleClose} isOpen={isOpen} maxWidth="48rem" simple title="">
             {alertLoading && !alert ? (
                 <SpinnerOverlay />
             ) : (

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -106,7 +106,7 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
     const showDeferredListSpinner = props.deferInitialAlertsLoad && props.isOpen && alertsLoading
 
     return (
-        <LemonModal onClose={props.onClose} isOpen={props.isOpen} width={600} simple title="">
+        <LemonModal onClose={props.onClose} isOpen={props.isOpen} maxWidth="48rem" simple title="">
             <LemonModal.Header>
                 <h3 className="!m-0">Manage Alerts</h3>
             </LemonModal.Header>

--- a/frontend/src/lib/components/QuickFilters/QuickFiltersModal.tsx
+++ b/frontend/src/lib/components/QuickFilters/QuickFiltersModal.tsx
@@ -12,7 +12,7 @@ export function QuickFiltersModal({ context, onNewFilterCreated }: QuickFiltersM
     const { closeModal } = useActions(quickFiltersModalLogic(logicProps))
 
     return (
-        <LemonModal title={modalTitle} isOpen={isModalOpen} onClose={closeModal} width={800}>
+        <LemonModal title={modalTitle} isOpen={isModalOpen} onClose={closeModal} maxWidth="48rem">
             {view === ModalView.List ? (
                 <QuickFiltersModalContent context={context} />
             ) : (

--- a/frontend/src/lib/components/Sharing/SharePasswordsTable.tsx
+++ b/frontend/src/lib/components/Sharing/SharePasswordsTable.tsx
@@ -135,7 +135,6 @@ export function SharePasswordsTable({ dashboardId, insightId, recordingId }: Sha
                 isOpen={newPasswordModalOpen}
                 onClose={handleCloseModal}
                 title="Create new share password"
-                width={480}
                 zIndex="1166"
                 footer={
                     createdPasswordResult ? (

--- a/frontend/src/lib/components/Subscriptions/SubscriptionsModal.tsx
+++ b/frontend/src/lib/components/Subscriptions/SubscriptionsModal.tsx
@@ -37,7 +37,7 @@ export function SubscriptionsModal(props: SubscriptionsModalProps): JSX.Element 
         <LemonModal
             onClose={closeModal}
             isOpen={isOpen}
-            width={600}
+            maxWidth="48rem"
             simple
             title=""
             inline={inline}

--- a/frontend/src/lib/components/Superpowers/Superpowers.tsx
+++ b/frontend/src/lib/components/Superpowers/Superpowers.tsx
@@ -19,7 +19,7 @@ export function SuperpowersModal(): JSX.Element | null {
     const { closeSuperpowers } = useActions(superpowersLogic)
 
     return (
-        <LemonModal title="" isOpen={isSuperpowersOpen} onClose={closeSuperpowers} width={500}>
+        <LemonModal title="" isOpen={isSuperpowersOpen} onClose={closeSuperpowers}>
             <SuperpowersContent />
         </LemonModal>
     )

--- a/frontend/src/lib/components/heatmaps/HeatmapEventsPanel.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapEventsPanel.tsx
@@ -57,7 +57,7 @@ export function HeatmapEventsPanel({ context, exportToken }: HeatmapDataLogicPro
     ]
 
     return (
-        <LemonModal title="Events in this area" onClose={handleClose} isOpen width={700}>
+        <LemonModal title="Events in this area" onClose={handleClose} isOpen maxWidth="48rem">
             {areaEventsLoading ? (
                 <div className="space-y-2 p-4">
                     <LemonSkeleton className="h-8 w-full" />

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -80,7 +80,7 @@ export const LemonModalContent = ({ children, className, embedded = false }: Lem
 
 export function LemonModal({
     width,
-    maxWidth = '65ch',
+    maxWidth,
     children,
     isOpen = true,
     onClose,
@@ -173,7 +173,7 @@ export function LemonModal({
     )
 
     width = !fullScreen ? width : undefined
-    maxWidth = !fullScreen ? maxWidth : undefined
+    maxWidth = !fullScreen ? (maxWidth ?? '65ch') : undefined
     const floatingContainer = useFloatingContainer()
 
     return inline ? (

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -75,7 +75,7 @@ export const LemonModalContent = ({ children, className, embedded = false }: Lem
 
 export function LemonModal({
     width,
-    maxWidth,
+    maxWidth = '65ch',
     children,
     isOpen = true,
     onClose,

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -28,6 +28,11 @@ export interface LemonModalProps {
     onClose?: () => void
     onAfterClose?: () => void
     width?: number | string
+    /**
+     * Caps the modal width. Defaults to prose (`65ch`).
+     * Tier vocabulary: `'48rem'` for wide content, `'90vw'` for extra-wide.
+     * Pass the CSS literal `'none'` (i.e. `max-width: none`) to opt out.
+     */
     maxWidth?: number | string
     inline?: boolean
     title?: React.ReactNode

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -346,7 +346,12 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
                                     <div
                                         className="Popover__box"
                                         // eslint-disable-next-line react/forbid-dom-props
-                                        style={{ maxWidth }}
+                                        // floating-ui sets an imperative maxWidth on the outer .Popover to keep it
+                                        // inside the viewport; this cap on .Popover__box shapes the content width
+                                        // (prose / wide / extra-wide) without fighting the viewport clamp. When the
+                                        // popover matches the reference width we skip the cap so the dropdown can
+                                        // line up with a wider trigger.
+                                        style={matchWidth ? undefined : { maxWidth }}
                                     >
                                         {showArrow && isAttached && (
                                             // Arrow is outside of .Popover__content to avoid affecting :nth-child for content

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -349,9 +349,10 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
                                         // floating-ui sets an imperative maxWidth on the outer .Popover to keep it
                                         // inside the viewport; this cap on .Popover__box shapes the content width
                                         // (prose / wide / extra-wide) without fighting the viewport clamp. When the
-                                        // popover matches the reference width we skip the cap so the dropdown can
-                                        // line up with a wider trigger.
-                                        style={matchWidth ? undefined : { maxWidth }}
+                                        // popover matches the reference width (matchWidth) or hugs its content
+                                        // (maxContentWidth) we skip the cap so the dropdown can line up with a
+                                        // wider trigger or let long items dictate their own width.
+                                        style={matchWidth || maxContentWidth ? undefined : { maxWidth }}
                                     >
                                         {showArrow && isAttached && (
                                             // Arrow is outside of .Popover__content to avoid affecting :nth-child for content

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -62,10 +62,10 @@ export interface PopoverProps {
     matchWidth?: boolean
     maxContentWidth?: boolean
     /**
-     * Caps the popover content width. Defaults to prose (`65ch`).
-     * Tier vocabulary: `'48rem'` for wide content, `'90vw'` for extra-wide.
-     * Pass the CSS literal `'none'` (i.e. `max-width: none`) for overlays
-     * whose content is naturally wider than prose and should not be capped.
+     * Optional cap on the popover content width. Not applied by default so
+     * naturally wider overlays (e.g. TaxonomicFilter, column pickers) keep
+     * their intrinsic size. Pass `'65ch'` for prose-style pop-ins,
+     * `'48rem'` for wide content, `'90vw'` for extra-wide.
      */
     maxWidth?: number | string
     className?: string
@@ -118,7 +118,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         middleware,
         matchWidth = false,
         maxContentWidth = false,
-        maxWidth = '65ch',
+        maxWidth,
         additionalRefs = [],
         closeParentPopoverOnClickInside = false,
         referenceRef: extraReferenceRef,

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -61,7 +61,12 @@ export interface PopoverProps {
     /** Whether the popover's width should be synced with the children's width or bigger. */
     matchWidth?: boolean
     maxContentWidth?: boolean
-    /** Caps the popover content width. Defaults to prose (`65ch`); use `'48rem'` for wide content, `'90vw'` for extra-wide, or `'none'` to opt out. */
+    /**
+     * Caps the popover content width. Defaults to prose (`65ch`).
+     * Tier vocabulary: `'48rem'` for wide content, `'90vw'` for extra-wide.
+     * Pass the CSS literal `'none'` (i.e. `max-width: none`) for overlays
+     * whose content is naturally wider than prose and should not be capped.
+     */
     maxWidth?: number | string
     className?: string
     /** Whether default box padding should be applies. @default true */

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -61,6 +61,8 @@ export interface PopoverProps {
     /** Whether the popover's width should be synced with the children's width or bigger. */
     matchWidth?: boolean
     maxContentWidth?: boolean
+    /** Caps the popover content width. Defaults to prose (`65ch`); use `'48rem'` for wide content, `'90vw'` for extra-wide, or `'none'` to opt out. */
+    maxWidth?: number | string
     className?: string
     /** Whether default box padding should be applies. @default true */
     padded?: boolean
@@ -111,6 +113,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         middleware,
         matchWidth = false,
         maxContentWidth = false,
+        maxWidth = '65ch',
         additionalRefs = [],
         closeParentPopoverOnClickInside = false,
         referenceRef: extraReferenceRef,
@@ -340,7 +343,11 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
                                     onMouseLeave={onMouseLeaveInside}
                                     aria-level={currentPopoverLevel}
                                 >
-                                    <div className="Popover__box">
+                                    <div
+                                        className="Popover__box"
+                                        // eslint-disable-next-line react/forbid-dom-props
+                                        style={{ maxWidth }}
+                                    >
                                         {showArrow && isAttached && (
                                             // Arrow is outside of .Popover__content to avoid affecting :nth-child for content
                                             <div

--- a/frontend/src/queries/nodes/InsightViz/ResultCustomizationsModal.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ResultCustomizationsModal.tsx
@@ -39,7 +39,6 @@ export function ResultCustomizationsModal(): JSX.Element | null {
             data-attr="legend-entry-modal"
             isOpen={modalVisible}
             title="Customize result color"
-            width={520}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={closeModal}>

--- a/frontend/src/scenes/annotations/AnnotationModal.tsx
+++ b/frontend/src/scenes/annotations/AnnotationModal.tsx
@@ -139,7 +139,6 @@ export function AnnotationModal({
                     </div>
                 </div>
             }
-            width={512}
         >
             <Form
                 logic={annotationModalLogic}

--- a/frontend/src/scenes/dashboard/DashboardQuickFiltersButton.tsx
+++ b/frontend/src/scenes/dashboard/DashboardQuickFiltersButton.tsx
@@ -50,7 +50,7 @@ export function DashboardQuickFiltersButton({ context, dashboard }: DashboardQui
                 isOpen={isModalOpen}
                 onClose={cancelModal}
                 hasUnsavedInput={hasDashboardSelectionChanges}
-                width={800}
+                maxWidth="48rem"
             >
                 {view === ModalView.List ? (
                     <QuickFiltersModalContent

--- a/frontend/src/scenes/dashboard/DashboardTemplateEditor.tsx
+++ b/frontend/src/scenes/dashboard/DashboardTemplateEditor.tsx
@@ -28,7 +28,7 @@ export function DashboardTemplateEditor({ inline = false }: DashboardTemplateEdi
         <LemonModal
             title={id ? 'Edit dashboard template' : 'New dashboard template'}
             isOpen={isOpenNewDashboardTemplateModal}
-            width={1000}
+            maxWidth="90vw"
             onClose={() => {
                 closeDashboardTemplateEditor()
             }}

--- a/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
@@ -55,7 +55,7 @@ export function AddInsightToDashboardModal(): JSX.Element {
                 title="Add insight to dashboard"
                 onClose={handleClose}
                 isOpen={addInsightToDashboardModalVisible}
-                width={860}
+                maxWidth="48rem"
                 className="bg-surface-secondary"
             >
                 <div className="-mt-1 space-y-3">

--- a/frontend/src/scenes/data-management/MaterializedColumns/CreateSlotModal.tsx
+++ b/frontend/src/scenes/data-management/MaterializedColumns/CreateSlotModal.tsx
@@ -55,7 +55,6 @@ export function CreateSlotModal(): JSX.Element {
             isOpen
             onClose={() => setShowCreateModal(false)}
             title="Assign Materialized Column Slot"
-            width="36rem"
             footer={
                 <>
                     <LemonButton type="secondary" onClick={() => setShowCreateModal(false)}>

--- a/frontend/src/scenes/data-management/schema/PropertyGroupModal.tsx
+++ b/frontend/src/scenes/data-management/schema/PropertyGroupModal.tsx
@@ -177,7 +177,7 @@ export function PropertyGroupModal({ logicKey, onAfterSave }: PropertyGroupModal
             isOpen={propertyGroupModalOpen}
             onClose={handleClose}
             title={editingPropertyGroup ? 'Edit Property Group' : 'New Property Group'}
-            width={900}
+            maxWidth="90vw"
         >
             <Form
                 logic={schemaManagementLogic}

--- a/frontend/src/scenes/data-management/schema/SelectPropertyGroupModal.tsx
+++ b/frontend/src/scenes/data-management/schema/SelectPropertyGroupModal.tsx
@@ -116,7 +116,7 @@ export function SelectPropertyGroupModal({
 
     return (
         <>
-            <LemonModal isOpen={isOpen} onClose={onClose} title="Add property group" width={900}>
+            <LemonModal isOpen={isOpen} onClose={onClose} title="Add property group" maxWidth="90vw">
                 <div className="space-y-4">
                     <div className="flex gap-2">
                         <LemonInput

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfillModal.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfillModal.tsx
@@ -50,7 +50,6 @@ export function BatchExportBackfillModal({ id, context }: BatchExportBackfillMod
             title="Start backfill"
             onClose={closeBackfillModal}
             isOpen={isBackfillModalOpen}
-            width="30rem"
             footer={
                 <>
                     <LemonButton

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -61,7 +61,7 @@ export function ViewLinkModal({ mode }: ViewLinkModalProps): JSX.Element {
             }
             isOpen={isJoinTableModalOpen}
             onClose={toggleJoinTableModal}
-            width={hasPreviewFlag ? 1200 : 700}
+            maxWidth={hasPreviewFlag ? '90vw' : '48rem'}
         >
             {hasPreviewFlag ? <ViewLinkFormWithPreview mode={mode} /> : <ViewLinkForm mode={mode} />}
         </LemonModal>

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -231,7 +231,7 @@ function RowDetailsModal({ isOpen, onClose, row, columns, columnKeys }: RowDetai
     })
 
     return (
-        <LemonModal title="Row Details" isOpen={isOpen} onClose={onClose} width={800}>
+        <LemonModal title="Row Details" isOpen={isOpen} onClose={onClose} maxWidth="48rem">
             <div className="RowDetailsModal max-h-[70vh] overflow-y-auto px-2 overflow-x-hidden">
                 <LemonTable
                     dataSource={tableData}

--- a/frontend/src/scenes/data-warehouse/editor/QueryHistoryModal.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryHistoryModal.tsx
@@ -143,7 +143,7 @@ export function QueryHistoryModal(): JSX.Element {
     const { editingView } = useValues(sqlEditorLogic)
 
     return (
-        <LemonModal title="View history" isOpen={isHistoryModalOpen} onClose={closeHistoryModal} width={800}>
+        <LemonModal title="View history" isOpen={isHistoryModalOpen} onClose={closeHistoryModal} maxWidth="48rem">
             <div className="ActivityLog">
                 <QueryHistoryLog id={editingView?.id} />
             </div>

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -217,7 +217,7 @@ function MaterializationModal({ tabId }: { tabId: string }): JSX.Element {
             title={materializationModalView ? `Materialize ${materializationModalView.name}` : 'Materialize view'}
             isOpen={materializationModalOpen}
             onClose={closeMaterializationModal}
-            width={960}
+            maxWidth="90vw"
         >
             <div className="max-h-[75vh] overflow-auto">
                 {viewLoading ? (

--- a/frontend/src/scenes/experiments/CopyExperimentToProjectModal.tsx
+++ b/frontend/src/scenes/experiments/CopyExperimentToProjectModal.tsx
@@ -171,7 +171,7 @@ export function CopyExperimentToProjectModal({
             isOpen={isOpen}
             onClose={handleClose}
             title="Copy experiment to project"
-            width="max-content"
+            maxWidth="90vw"
             footer={
                 <div className="flex justify-end">
                     <LemonButton

--- a/frontend/src/scenes/experiments/DuplicateExperimentModal.tsx
+++ b/frontend/src/scenes/experiments/DuplicateExperimentModal.tsx
@@ -77,7 +77,7 @@ export function DuplicateExperimentModal({ isOpen, onClose, experiment }: Duplic
             isOpen={isOpen}
             onClose={handleClose}
             title="Duplicate experiment"
-            width="max-content"
+            maxWidth="90vw"
             footer={
                 <div className="flex justify-end">
                     <LemonButton type="primary" onClick={handleDuplicate} data-attr="duplicate-experiment-submit">

--- a/frontend/src/scenes/experiments/ExperimentForm/SelectExistingFeatureFlagModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/SelectExistingFeatureFlagModal.tsx
@@ -39,7 +39,7 @@ export const SelectExistingFeatureFlagModal = ({
     )
 
     return (
-        <LemonModal isOpen={isModalOpen} onClose={handleClose} title="Choose an existing feature flag" width="50%">
+        <LemonModal isOpen={isModalOpen} onClose={handleClose} title="Choose an existing feature flag" maxWidth="90vw">
             <div className="deprecated-space-y-2">
                 <div className="text-muted mb-2 max-w-xl">
                     Select an existing multivariate feature flag to use with this experiment. The feature flag must use

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -48,7 +48,7 @@ export function DistributionModal(): JSX.Element {
     }, [
         isDistributionModalOpen,
         experiment.feature_flag?.filters?.multivariate?.variants,
-        experiment.feature_flag.filters.groups,
+        experiment.feature_flag?.filters?.groups,
     ])
 
     const handleClose = (): void => {

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -45,7 +45,11 @@ export function DistributionModal(): JSX.Element {
             setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
             setRolloutPercentage(experiment.feature_flag?.filters?.groups?.[0]?.rollout_percentage ?? 100)
         }
-    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants])
+    }, [
+        isDistributionModalOpen,
+        experiment.feature_flag?.filters?.multivariate?.variants,
+        experiment.feature_flag.filters.groups,
+    ])
 
     const handleClose = (): void => {
         closeDistributionModal()
@@ -60,7 +64,7 @@ export function DistributionModal(): JSX.Element {
         <LemonModal
             isOpen={isDistributionModalOpen}
             onClose={handleClose}
-            width={600}
+            maxWidth="48rem"
             title="Change experiment distribution"
             footer={
                 <div className="flex items-center gap-2">

--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -32,7 +32,7 @@ export function ExposureCriteriaModal({ onSave }: ExposureCriteriaModalProps): J
         <LemonModal
             isOpen={isExposureCriteriaModalOpen}
             onClose={closeExposureCriteriaModal}
-            width={860}
+            maxWidth="48rem"
             title="Edit exposure criteria"
             zIndex="1169"
             footer={

--- a/frontend/src/scenes/experiments/ExperimentView/ReleaseConditionsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ReleaseConditionsTable.tsx
@@ -26,7 +26,7 @@ export function ReleaseConditionsModal(): JSX.Element {
         <LemonModal
             isOpen={isReleaseConditionsModalOpen}
             onClose={closeReleaseConditionsModal}
-            width={600}
+            maxWidth="48rem"
             title="Change release conditions"
             footer={
                 <div className="flex items-center gap-2">

--- a/frontend/src/scenes/experiments/ExperimentView/StatsMethodModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/StatsMethodModal.tsx
@@ -55,7 +55,7 @@ export function StatsMethodModal(): JSX.Element {
 
     return (
         <LemonModal
-            maxWidth={600}
+            maxWidth="48rem"
             isOpen={isStatsEngineModalOpen}
             onClose={onClose}
             title="Statistics configuration"

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -539,7 +539,7 @@ export function EditConclusionModal(): JSX.Element {
             isOpen={isEditConclusionModalOpen}
             onClose={closeEditConclusionModal}
             title="Edit conclusion"
-            width={600}
+            maxWidth="48rem"
             footer={
                 <div className="flex items-center gap-2">
                     <LemonButton
@@ -583,7 +583,7 @@ export function PauseExperimentModal(): JSX.Element {
             isOpen={isPauseExperimentModalOpen}
             onClose={closePauseExperimentModal}
             title="Pause experiment"
-            width={600}
+            maxWidth="48rem"
             footer={
                 <div className="flex items-center gap-2">
                     <LemonButton type="secondary" onClick={closePauseExperimentModal}>
@@ -622,7 +622,7 @@ export function ResumeExperimentModal(): JSX.Element {
             isOpen={isResumeExperimentModalOpen}
             onClose={closeResumeExperimentModal}
             title="Resume experiment"
-            width={600}
+            maxWidth="48rem"
             footer={
                 <div className="flex items-center gap-2">
                     <LemonButton type="secondary" onClick={closeResumeExperimentModal}>
@@ -690,7 +690,7 @@ export function FinishExperimentModal(): JSX.Element {
                     restoreUnmodifiedExperiment()
                     closeFinishExperimentModal()
                 }}
-                width={600}
+                maxWidth="48rem"
                 title="End experiment"
                 footer={
                     <div className="flex items-center gap-2">

--- a/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
@@ -26,7 +26,7 @@ export const MetricSourceModal = (): JSX.Element | null => {
     const showWarning = metricCount >= METRIC_COUNT_WARNING_THRESHOLD || isRunning
 
     return (
-        <LemonModal isOpen={isModalOpen} onClose={closeMetricSourceModal} width={1000} title="Choose metric source">
+        <LemonModal isOpen={isModalOpen} onClose={closeMetricSourceModal} maxWidth="90vw" title="Choose metric source">
             <div className="flex gap-4 mb-4">
                 <div
                     className="flex-1 cursor-pointer p-4 rounded border hover:border-accent"

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
@@ -78,7 +78,7 @@ export function SharedMetricDetailsModal({
         <LemonModal
             isOpen={isModalOpen}
             onClose={closeSharedMetricDetailModal}
-            maxWidth={800}
+            maxWidth="48rem"
             title="Shared metric"
             footer={
                 <div className="flex justify-between w-full">

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -64,7 +64,7 @@ export function SharedMetricModal({
         <LemonModal
             isOpen={isModalOpen}
             onClose={closeModal}
-            maxWidth={800}
+            maxWidth="48rem"
             title="Select one or more shared metrics"
             footer={
                 <div className="flex justify-between w-full">

--- a/frontend/src/scenes/experiments/MetricsView/MetricsReorderModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsReorderModal.tsx
@@ -223,7 +223,7 @@ export function MetricsReorderModal({ isSecondary = false }: { isSecondary?: boo
         <LemonModal
             onClose={closeModal}
             isOpen={isOpen}
-            width={600}
+            maxWidth="48rem"
             title={`Reorder ${isSecondary ? 'secondary' : 'primary'} metrics`}
             description={<p>Drag and drop to reorder, or remove metrics you no longer need.</p>}
             footer={

--- a/frontend/src/scenes/experiments/MetricsView/new/DetailsModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/DetailsModal.tsx
@@ -21,7 +21,7 @@ export function DetailsModal({ isOpen, onClose, metric, result, experiment }: De
         <LemonModal
             isOpen={isOpen}
             onClose={onClose}
-            width={1200}
+            maxWidth="90vw"
             title={`Metric results: ${metric.name || 'Untitled metric'}`}
             footer={
                 <LemonButton type="secondary" onClick={onClose}>

--- a/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
@@ -75,7 +75,7 @@ export function TimeseriesModal({
         <LemonModal
             isOpen={isOpen}
             onClose={onClose}
-            width={1000}
+            maxWidth="90vw"
             title={
                 <div className="flex items-center gap-2 text-sm min-w-0">
                     <div className="flex items-center shrink-0">

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
@@ -42,7 +42,7 @@ export function RunningTimeCalculatorModal(): JSX.Element {
         <LemonModal
             isOpen={isCalculateRunningTimeModalOpen}
             onClose={closeCalculateRunningTimeModal}
-            width={700}
+            maxWidth="48rem"
             title="Calculate estimated running time"
             footer={
                 <RunningTimeCalculatorModalFooter

--- a/frontend/src/scenes/experiments/RunningTimeCalculatorNew/RunningTimeConfigModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculatorNew/RunningTimeConfigModal.tsx
@@ -62,7 +62,7 @@ export function RunningTimeConfigModal({ experimentId, tabId }: RunningTimeConfi
     const isPreLaunch = !isLaunched(experiment)
 
     return (
-        <LemonModal isOpen={isRunningTimeConfigModalOpen} onClose={cancel} width={480} simple>
+        <LemonModal isOpen={isRunningTimeConfigModalOpen} onClose={cancel} simple>
             <LemonModal.Header>
                 <h3>{isPreLaunch ? 'Estimate running time' : 'Running time configuration'}</h3>
             </LemonModal.Header>

--- a/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
@@ -84,7 +84,7 @@ export function SampledSessionsModal(): JSX.Element {
     ]
 
     return (
-        <LemonModal isOpen={isOpen} onClose={closeModal} title={`Sampled persons - ${variant}`} width={720}>
+        <LemonModal isOpen={isOpen} onClose={closeModal} title={`Sampled persons - ${variant}`} maxWidth="48rem">
             <div className="space-y-4">
                 <div className="text">
                     Persons in <strong>{variant}</strong> with <strong>{stepName}</strong> as their last funnel step.

--- a/frontend/src/scenes/experiments/legacy/metricsView/LegacyChartModal.tsx
+++ b/frontend/src/scenes/experiments/legacy/metricsView/LegacyChartModal.tsx
@@ -42,7 +42,7 @@ export function LegacyChartModal({
         <LemonModal
             isOpen={isOpen}
             onClose={onClose}
-            width={1200}
+            maxWidth="90vw"
             title="Metric results"
             footer={
                 <LemonButton type="secondary" onClick={onClose}>

--- a/frontend/src/scenes/feature-flags/BulkDeleteResultsModal.tsx
+++ b/frontend/src/scenes/feature-flags/BulkDeleteResultsModal.tsx
@@ -135,7 +135,7 @@ export function BulkDeleteResultsModal(): JSX.Element | null {
             isOpen={resultsModalVisible}
             onClose={hideResultsModal}
             title="Bulk deletion results"
-            width={600}
+            maxWidth="48rem"
             footer={
                 <LemonButton type="primary" onClick={hideResultsModal}>
                     Done

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -595,6 +595,7 @@ function NativeEmailTemplaterForm({
                             isOpen={!!previewTemplate}
                             onClose={() => setPreviewTemplate(null)}
                             title={`Preview: ${previewTemplate?.name}`}
+                            width="90vw"
                             maxWidth="90vw"
                         >
                             <div className="h-[80vh] overflow-auto">
@@ -739,6 +740,7 @@ function EmailTemplaterModal(): JSX.Element {
         <>
             <LemonModal
                 isOpen={isModalOpen}
+                width="90vw"
                 maxWidth="90vw"
                 onClose={() => closeWithConfirmation()}
                 hasUnsavedInput={emailTemplateChanged}

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -595,7 +595,7 @@ function NativeEmailTemplaterForm({
                             isOpen={!!previewTemplate}
                             onClose={() => setPreviewTemplate(null)}
                             title={`Preview: ${previewTemplate?.name}`}
-                            width="90vw"
+                            maxWidth="90vw"
                         >
                             <div className="h-[80vh] overflow-auto">
                                 <iframe
@@ -739,7 +739,7 @@ function EmailTemplaterModal(): JSX.Element {
         <>
             <LemonModal
                 isOpen={isModalOpen}
-                width="90vw"
+                maxWidth="90vw"
                 onClose={() => closeWithConfirmation()}
                 hasUnsavedInput={emailTemplateChanged}
             >

--- a/frontend/src/scenes/hog-functions/list/HogFunctionOrderModal.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionOrderModal.tsx
@@ -124,7 +124,7 @@ export function HogFunctionOrderModal(): JSX.Element {
         <LemonModal
             onClose={() => setReorderModalOpen(false)}
             isOpen={reorderModalOpen}
-            width={600}
+            maxWidth="48rem"
             title="Reorder transformations"
             description={
                 <p>

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -273,7 +273,7 @@ function ReportListPane(): JSX.Element {
         <ResizableElement
             defaultWidth={420}
             minWidth={280}
-            maxWidth="48rem"
+            maxWidth={768}
             borderPosition="right"
             onResize={() => {}}
             className={clsx(

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -273,7 +273,7 @@ function ReportListPane(): JSX.Element {
         <ResizableElement
             defaultWidth={420}
             minWidth={280}
-            maxWidth={600}
+            maxWidth="48rem"
             borderPosition="right"
             onResize={() => {}}
             className={clsx(

--- a/frontend/src/scenes/inbox/SourcesModal.tsx
+++ b/frontend/src/scenes/inbox/SourcesModal.tsx
@@ -50,7 +50,7 @@ export function SourcesModal(): JSX.Element {
                 isOpen={sourcesModalOpen}
                 onClose={closeSourcesModal}
                 simple
-                width={sessionAnalysisSetupOpen || isDataSourceSetupOpen ? '48rem' : '32rem'}
+                maxWidth={sessionAnalysisSetupOpen || isDataSourceSetupOpen ? '48rem' : undefined}
             >
                 <LemonModal.Header>
                     <div className="flex items-center gap-2">

--- a/frontend/src/scenes/inbox/SourcesModal.tsx
+++ b/frontend/src/scenes/inbox/SourcesModal.tsx
@@ -50,7 +50,8 @@ export function SourcesModal(): JSX.Element {
                 isOpen={sourcesModalOpen}
                 onClose={closeSourcesModal}
                 simple
-                maxWidth={sessionAnalysisSetupOpen || isDataSourceSetupOpen ? '48rem' : undefined}
+                width={sessionAnalysisSetupOpen || isDataSourceSetupOpen ? '48rem' : '32rem'}
+                maxWidth="none"
             >
                 <LemonModal.Header>
                     <div className="flex items-center gap-2">

--- a/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
@@ -28,7 +28,6 @@ export function RenameModal({ typeKey, view }: RenameModalProps): JSX.Element {
             data-attr="filter-rename-modal"
             isOpen={modalVisible}
             title={title}
-            width={520}
             forceAbovePopovers={true}
             footer={
                 <>

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -71,7 +71,6 @@ export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => vo
             isOpen={isOpen}
             closable={!loading}
             onClose={onClose}
-            width={576}
             footer={
                 <>
                     <LemonButton

--- a/frontend/src/scenes/onboarding/PostOnboardingModal.tsx
+++ b/frontend/src/scenes/onboarding/PostOnboardingModal.tsx
@@ -63,7 +63,6 @@ export function PostOnboardingModal(): JSX.Element | null {
             isOpen={isModalOpen}
             onClose={() => dismissModal('close_button')}
             simple
-            width={400}
             overlayClassName="!items-center"
             data-attr="post-onboarding-modal"
         >

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/variants/WizardOnlyVariant.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/variants/WizardOnlyVariant.tsx
@@ -82,7 +82,7 @@ export function WizardOnlyVariant({
                 isOpen={manualModalOpen}
                 onClose={() => setManualModalOpen(false)}
                 title="Manual SDK setup"
-                width="80vw"
+                maxWidth="90vw"
             >
                 <div className="p-4">
                     <SDKGrid {...{ ...sdkGridProps, onSDKClick: handleWizardOnlySDKClick }} showTopControls />

--- a/frontend/src/scenes/organization/CreateOrganizationModal.tsx
+++ b/frontend/src/scenes/organization/CreateOrganizationModal.tsx
@@ -33,7 +33,6 @@ export function CreateOrganizationModal({
 
     return (
         <LemonModal
-            width={440}
             title="Create an organization"
             description={
                 <p>

--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -19,7 +19,6 @@ export function MergeSplitPerson({ person }: { person: PersonType }): JSX.Elemen
     return (
         <LemonModal
             isOpen
-            width="40rem"
             title="Split persons"
             footer={
                 <div className="flex items-center gap-2">

--- a/frontend/src/scenes/product-tours/ProductTour.tsx
+++ b/frontend/src/scenes/product-tours/ProductTour.tsx
@@ -59,7 +59,7 @@ export function ProductTourComponent({ id }: ProductTourLogicProps): JSX.Element
                         description="Select a URL to launch the toolbar"
                         isOpen={isToolbarModalOpen}
                         onClose={closeToolbarModal}
-                        width={600}
+                        maxWidth="48rem"
                     >
                         <div className="mt-4">
                             <AuthorizedUrlList

--- a/frontend/src/scenes/product-tours/components/AutoShowModal.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowModal.tsx
@@ -27,7 +27,7 @@ export function AutoShowModal({ tourId, isOpen, onClose }: AutoShowModalProps): 
             isOpen={isOpen}
             onClose={onClose}
             title="Auto-show settings"
-            width={640}
+            maxWidth="48rem"
             footer={
                 <LemonButton type="primary" onClick={onClose}>
                     Done

--- a/frontend/src/scenes/product-tours/components/NewProductTourModal.tsx
+++ b/frontend/src/scenes/product-tours/components/NewProductTourModal.tsx
@@ -69,7 +69,7 @@ export function NewProductTourModal({
     }
 
     return (
-        <LemonModal title="What would you like to create?" isOpen={isOpen} onClose={handleClose} width={800}>
+        <LemonModal title="What would you like to create?" isOpen={isOpen} onClose={handleClose} maxWidth="48rem">
             <div className="flex flex-col gap-4">
                 <div className="flex gap-3 mt-2">
                     <TourTypeButton

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -312,7 +312,7 @@ export function ProductTourStepsEditor({ tourId }: ProductTourStepsEditorProps):
                     isOpen={showPreviewModal}
                     onClose={() => setShowPreviewModal(false)}
                     title={`Preview: ${getStepTitle(selectedStep, selectedStepIndex)}`}
-                    width={800}
+                    maxWidth="48rem"
                 >
                     <div className="flex justify-center items-center p-8 bg-[#f0f0f0] rounded min-h-[300px]">
                         {selectedStep && (

--- a/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
@@ -556,7 +556,7 @@ export function StepContentEditor({
                 <ResizableElement
                     defaultWidth={getWidthValue(selectedStep?.maxWidth)}
                     minWidth={200}
-                    maxWidth={700}
+                    maxWidth="48rem"
                     onResize={(width) => updateSelectedStep({ maxWidth: width })}
                     className="mx-auto"
                 >

--- a/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
@@ -556,7 +556,7 @@ export function StepContentEditor({
                 <ResizableElement
                     defaultWidth={getWidthValue(selectedStep?.maxWidth)}
                     minWidth={200}
-                    maxWidth="48rem"
+                    maxWidth={768}
                     onResize={(width) => updateSelectedStep({ maxWidth: width })}
                     className="mx-auto"
                 >

--- a/frontend/src/scenes/project/CreateProjectModal.tsx
+++ b/frontend/src/scenes/project/CreateProjectModal.tsx
@@ -58,7 +58,6 @@ export function CreateProjectModal({
 
     return (
         <LemonModal
-            width={560}
             title={currentOrganization ? `Create a project within ${currentOrganization.name}` : 'Create a project'}
             description={
                 <>

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -148,7 +148,7 @@ export function RetentionModal(): JSX.Element | null {
                         </div>
                     </div>
                 }
-                width={isEmpty ? undefined : '90%'}
+                maxWidth={isEmpty ? undefined : '90vw'}
                 title={modalTitle}
             >
                 {people && !!people.missing_persons && (

--- a/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
+++ b/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
@@ -47,7 +47,7 @@ export function SessionPlayerModal(): JSX.Element | null {
             onClose={closeSessionPlayer}
             simple
             title=""
-            width={1600}
+            maxWidth="90vw"
             fullScreen={isFullScreen}
             closable={!isFullScreen}
             hideCloseButton

--- a/frontend/src/scenes/settings/environment/CoreEventsSettings.tsx
+++ b/frontend/src/scenes/settings/environment/CoreEventsSettings.tsx
@@ -340,7 +340,7 @@ export function CoreEventsSettings(): JSX.Element {
                 isOpen={isModalOpen}
                 onClose={handleCloseModal}
                 title={isEditing ? 'Edit core event' : 'Add core event'}
-                width="40rem"
+                maxWidth="48rem"
                 footer={
                     <>
                         <LemonButton onClick={handleCloseModal}>Cancel</LemonButton>

--- a/frontend/src/scenes/settings/environment/DataColorThemeModal.tsx
+++ b/frontend/src/scenes/settings/environment/DataColorThemeModal.tsx
@@ -21,7 +21,7 @@ export function DataColorThemeModal(): JSX.Element {
             title={title}
             onClose={closeModal}
             isOpen={isOpen}
-            width={768}
+            maxWidth="48rem"
             footer={
                 isOfficial ? (
                     <div className="flex justify-between items-center w-full">

--- a/frontend/src/scenes/settings/environment/ProxySDKSetup.tsx
+++ b/frontend/src/scenes/settings/environment/ProxySDKSetup.tsx
@@ -67,7 +67,7 @@ export function ProxySDKSetup(): JSX.Element {
                 isOpen={showFullSetup}
                 onClose={() => setShowFullSetup(false)}
                 title={`${name} setup`}
-                width={640}
+                maxWidth="48rem"
             >
                 {wizardIntegrationName && <SetupWizardBanner integrationName={wizardIntegrationName} />}
                 <OnboardingDocsContentWrapper snippets={snippets} useReverseProxy>

--- a/frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx
+++ b/frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx
@@ -370,7 +370,7 @@ export function SDKSetupInstructions(): JSX.Element {
                 isOpen={showFullSetup}
                 onClose={() => setShowFullSetup(false)}
                 title={`${name} setup`}
-                width={640}
+                maxWidth="48rem"
             >
                 {wizardIntegrationName && <SetupWizardBanner integrationName={wizardIntegrationName} />}
                 <OnboardingDocsContentWrapper snippets={snippets} useReverseProxy={isClientSideSDK}>

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -301,7 +301,7 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
         <LemonModal
             isOpen
             onClose={onClose}
-            width={600}
+            maxWidth="48rem"
             title={policy ? 'Edit approval policy' : 'Create approval policy'}
             footer={
                 <>

--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -420,7 +420,7 @@ export function InviteModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
                     resetInviteRows()
                     onClose()
                 }}
-                width={800}
+                maxWidth="48rem"
                 title={<>Invite others to {user?.organization?.name || 'PostHog'}</>}
                 description={
                     preflight?.email_service_available ? (

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/ScimLogsModal.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/ScimLogsModal.tsx
@@ -112,7 +112,7 @@ export function ScimLogsModal(): JSX.Element {
     const handleClose = (): void => setScimLogsModalId(null)
 
     return (
-        <LemonModal onClose={handleClose} isOpen={!!scimLogsModalId} title="SCIM request logs" width={960}>
+        <LemonModal onClose={handleClose} isOpen={!!scimLogsModalId} title="SCIM request logs" maxWidth="90vw">
             <div className="space-y-4">
                 <div className="flex items-center gap-2">
                     <LemonSegmentedButton

--- a/frontend/src/scenes/settings/project/ProjectMove.tsx
+++ b/frontend/src/scenes/settings/project/ProjectMove.tsx
@@ -30,7 +30,6 @@ export function MoveProjectModal({
             title="Move the project to another organization?"
             onClose={!projectBeingMovedLoading ? () => setIsOpen(false) : undefined}
             closable={!projectBeingMovedLoading}
-            maxWidth="30rem"
             footer={
                 <>
                     <LemonButton

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -61,7 +61,7 @@ export function EditKeyModal({ zIndex }: EditKeyModalProps): JSX.Element {
                 title={`${isNew ? 'Create' : 'Edit'} personal API key`}
                 onClose={() => setEditingKeyId(null)}
                 isOpen={!!editingKeyId}
-                width="40rem"
+                maxWidth="48rem"
                 hasUnsavedInput={editingKeyChanged}
                 zIndex={zIndex}
                 footer={

--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -289,7 +289,7 @@ export function QuickSurveyModal({
     showFollowupToggle?: boolean
 }): JSX.Element {
     return (
-        <LemonModal title={modalTitle || 'Quick feedback survey'} isOpen={isOpen} onClose={onCancel} width={900}>
+        <LemonModal title={modalTitle || 'Quick feedback survey'} isOpen={isOpen} onClose={onCancel} maxWidth="48rem">
             {context && (
                 <QuickSurveyForm
                     context={context}

--- a/frontend/src/scenes/surveys/SurveySQLHelper.tsx
+++ b/frontend/src/scenes/surveys/SurveySQLHelper.tsx
@@ -96,7 +96,7 @@ LIMIT
                     </p>
                 </div>
             }
-            width={800}
+            maxWidth="48rem"
         >
             <div className="flex flex-col gap-2">
                 <div className="flex flex-col gap-1">

--- a/frontend/src/scenes/surveys/branching-flow/SurveyBranchingFlowModal.tsx
+++ b/frontend/src/scenes/surveys/branching-flow/SurveyBranchingFlowModal.tsx
@@ -13,7 +13,7 @@ interface SurveyBranchingFlowModalProps {
 
 export function SurveyBranchingFlowModal({ survey, isOpen, onClose }: SurveyBranchingFlowModalProps): JSX.Element {
     return (
-        <LemonModal title="Survey flow" isOpen={isOpen} onClose={onClose} width="90vw">
+        <LemonModal title="Survey flow" isOpen={isOpen} onClose={onClose} width="90vw" maxWidth="90vw">
             <div className="h-[70vh]">
                 <SurveyBranchingFlow survey={survey} />
             </div>

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -172,7 +172,7 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
             onClose={closeDialog}
             title="Add survey notification"
             description="Send survey responses to Slack, Discord, Microsoft Teams, or a webhook."
-            width={720}
+            maxWidth="48rem"
             footer={
                 <>
                     <LemonButton type="secondary" onClick={closeDialog}>

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -131,7 +131,7 @@ export function PersonsModal({
                 onClose={closeModal}
                 onAfterClose={onAfterClose}
                 simple
-                width={600}
+                maxWidth="48rem"
                 inline={inline}
             >
                 <LemonModal.Header>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsModal.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsModal.tsx
@@ -36,7 +36,7 @@ export const WebAnalyticsModal = (): JSX.Element | null => {
             onClose={closeModal}
             simple={false}
             title={modal?.title || ''}
-            width={1600}
+            maxWidth="90vw"
             fullScreen={false}
             closable={true}
         >

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/ConversionGoalModal.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/ConversionGoalModal.tsx
@@ -50,7 +50,7 @@ export function ConversionGoalModal(): JSX.Element {
             isOpen={conversionGoalModalVisible}
             onClose={hideConversionGoalModal}
             title="Conversion goal"
-            width={600}
+            maxWidth="48rem"
             footer={
                 <div className="flex justify-between items-center w-full">
                     <LemonButton

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsColumnConfigModal.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsColumnConfigModal.tsx
@@ -192,7 +192,7 @@ export function MarketingAnalyticsColumnConfigModal({ query: rawQuery }: { query
             isOpen={columnConfigModalVisible}
             onClose={hideColumnConfigModal}
             title="Configure columns"
-            width={600}
+            maxWidth="48rem"
             footer={
                 <div className="flex justify-between items-center w-full">
                     <LemonButton

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ColumnMappingModal.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ColumnMappingModal.tsx
@@ -251,7 +251,7 @@ export function ColumnMappingModal({ table, isOpen, onClose }: ColumnMappingModa
             isOpen={isOpen}
             onClose={onClose}
             title={`Configure ${table.name} mapping`}
-            width={600}
+            maxWidth="48rem"
             footer={
                 <div className="flex justify-between items-center w-full">
                     <span className="text-sm text-muted">

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/IntegrationSettingsModal.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/IntegrationSettingsModal.tsx
@@ -49,7 +49,7 @@ export function IntegrationSettingsModal({
                     <span>{integrationName} settings</span>
                 </div>
             }
-            width={600}
+            maxWidth="48rem"
         >
             <LemonTabs
                 activeKey={activeTab}

--- a/frontend/src/scenes/welcome/WelcomeDialog.tsx
+++ b/frontend/src/scenes/welcome/WelcomeDialog.tsx
@@ -51,7 +51,7 @@ export function WelcomeDialog(): JSX.Element | null {
         <LemonModal
             isOpen={shouldShowDialog}
             onClose={() => closeDialog()}
-            width={640}
+            maxWidth="48rem"
             title={`Welcome to ${organizationName || 'PostHog'}`}
             description={inviterLine}
             data-attr="welcome-dialog"

--- a/frontend/src/toolbar/experiments/SelectorEditor.tsx
+++ b/frontend/src/toolbar/experiments/SelectorEditor.tsx
@@ -48,6 +48,7 @@ export function SelectorEditor({ selector, variant, transformIndex }: SelectorEd
                 isOpen={editSelectorOpen}
                 onClose={() => setEditSelectorOpen(false)}
                 title="Edit selector"
+                maxWidth="48rem"
                 footer={
                     <>
                         <LemonButton onClick={() => setEditSelectorOpen(false)}>Cancel</LemonButton>

--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -342,7 +342,7 @@ export function ProductToursSidebar(): JSX.Element | null {
                 title="Help us improve Product Tours"
                 forceAbovePopovers
                 overlayClassName="items-center"
-                maxWidth="42rem"
+                maxWidth="48rem"
                 footer={
                     <>
                         <LemonButton type="secondary" onClick={() => setSessionRecordingConsent(false)}>

--- a/products/conversations/frontend/components/SavedViews/SavedViewsModal.tsx
+++ b/products/conversations/frontend/components/SavedViews/SavedViewsModal.tsx
@@ -166,7 +166,7 @@ export function SavedViewsModal({ id }: TicketViewsLogicProps): JSX.Element {
                 isOpen={isModalOpen}
                 onClose={closeModal}
                 title="Saved views"
-                width={720}
+                maxWidth="48rem"
                 footer={
                     <div className="flex justify-between w-full">
                         <LemonButton type="primary" onClick={openSaveModal}>

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -338,7 +338,7 @@ CREATE PUBLICATION "${pubName}" FOR TABLE ${tableList}
             onClose={closeCdcSelfManagedSetupDialog}
             title="Create your publication"
             description={`Self-managed CDC needs the publication to exist before PostHog connects — PostHog will create and manage the replication slot itself. Run the SQL below (covering the ${cdcTableNames.length} table${cdcTableNames.length === 1 ? '' : 's'} you selected for CDC) as the table owner, then click Verify & create.`}
-            width={720}
+            maxWidth="48rem"
             footer={
                 <>
                     <LemonButton

--- a/products/data_warehouse/frontend/shared/components/FreeHistoricalSyncsBanner.tsx
+++ b/products/data_warehouse/frontend/shared/components/FreeHistoricalSyncsBanner.tsx
@@ -37,7 +37,7 @@ export function FreeHistoricalSyncsBanner({ hideGetStarted }: { hideGetStarted?:
                 isOpen={showModal}
                 onClose={() => setShowModal(false)}
                 title="Free rows for the first 7-days on new sources"
-                width={600}
+                maxWidth="48rem"
                 footer={
                     <div className="flex items-center justify-between gap-2 w-full">
                         <Link

--- a/products/early_access_features/frontend/InstructionsModal.tsx
+++ b/products/early_access_features/frontend/InstructionsModal.tsx
@@ -84,7 +84,7 @@ export function InstructionsModal({ onClose, visible, flag }: InstructionsModalP
     const panels: JSX.Element = preflight?.cloud ? getCloudPanels() : getSelfHostedPanels()
 
     return (
-        <LemonModal title="How to implement opt-in feature flags" isOpen={visible} onClose={onClose} width={640}>
+        <LemonModal title="How to implement opt-in feature flags" isOpen={visible} onClose={onClose} maxWidth="48rem">
             <div>
                 <div className="mb-2">
                     Implement manual release condition toggles to give your users the ability choose which features they

--- a/products/endpoints/frontend/EndpointFromInsightModal.tsx
+++ b/products/endpoints/frontend/EndpointFromInsightModal.tsx
@@ -62,7 +62,7 @@ export function EndpointFromInsightModal({
     }
 
     return (
-        <LemonModal isOpen={createFromInsightModalOpen} onClose={handleClose} width={600}>
+        <LemonModal isOpen={createFromInsightModalOpen} onClose={handleClose} maxWidth="48rem">
             <LemonModal.Header>
                 <h3>{duplicateEndpoint ? 'Duplicate insight-based endpoint' : 'Create endpoint from insight'}</h3>
             </LemonModal.Header>

--- a/products/endpoints/frontend/InsightPickerEndpointModal.tsx
+++ b/products/endpoints/frontend/InsightPickerEndpointModal.tsx
@@ -70,12 +70,7 @@ export function InsightPickerEndpointModal({ tabId }: InsightPickerEndpointModal
     return (
         <>
             <BindLogic logic={addSavedInsightsModalLogic} props={{}}>
-                <LemonModal
-                    title="New insight-based endpoint"
-                    onClose={closeModal}
-                    isOpen={isOpen}
-                    width="min(80vw, 64rem)"
-                >
+                <LemonModal title="New insight-based endpoint" onClose={closeModal} isOpen={isOpen} maxWidth="90vw">
                     <div className="space-y-4">
                         <div className="flex flex-wrap items-center gap-3 p-4 bg-surface-secondary rounded-lg">
                             <IconPlus className="text-2xl text-secondary shrink-0" />

--- a/products/error_tracking/frontend/components/ExceptionCard/FixModal.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/FixModal.tsx
@@ -81,7 +81,7 @@ PostHog issue: ${issueUrl}
             isOpen={isOpen}
             onClose={onClose}
             title={mode === 'explain' ? 'Explain this error with AI' : 'Fix this error with AI'}
-            width="50rem"
+            maxWidth="48rem"
             footer={
                 <div className="flex items-center justify-end gap-2">
                     <LemonButton type="secondary" onClick={onClose}>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/AssignmentRuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/AssignmentRuleModal.tsx
@@ -22,6 +22,7 @@ export function AssignmentRuleModal(): JSX.Element {
             ruleLabel="assignment"
             description="Matching exceptions will be automatically assigned to the chosen user or role."
             pageKey="assignment-rule-modal"
+            maxWidth="48rem"
             taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
             saveDisabledReason={saveDisabledReason}
             suffix={(issuesLink, dateRangeLabel) => (

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/GroupingRuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/GroupingRuleModal.tsx
@@ -21,6 +21,7 @@ export function GroupingRuleModal(): JSX.Element {
             ruleLabel="grouping"
             description="Matching exceptions will be grouped as a single issue."
             pageKey="grouping-rule-modal"
+            maxWidth="48rem"
             taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
             suffix={(issuesLink, dateRangeLabel) => (
                 <>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleModal.tsx
@@ -18,6 +18,7 @@ interface RuleModalProps {
     description: string
     pageKey: string
     width?: number
+    maxWidth?: number | string
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
     saveDisabledReason?: string
     suffix: (issuesLink: JSX.Element, dateRangeLabel: string) => JSX.Element
@@ -33,7 +34,8 @@ export function RuleModal({
     ruleLabel,
     description,
     pageKey,
-    width = 700,
+    width,
+    maxWidth,
     taxonomicGroupTypes,
     saveDisabledReason,
     suffix,
@@ -89,6 +91,7 @@ export function RuleModal({
             isOpen={isOpen}
             onClose={closeModal}
             width={width}
+            maxWidth={maxWidth}
             overlayClassName="pt-20"
             footer={
                 <div className="flex justify-between w-full">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRuleModal.tsx
@@ -23,7 +23,7 @@ export function SuppressionRuleModal(): JSX.Element {
             ruleLabel="suppression"
             description="Matching exceptions will be dropped before they create issues."
             pageKey="suppression-rule-modal"
-            width={800}
+            maxWidth="48rem"
             taxonomicGroupTypes={[
                 TaxonomicFilterGroupType.ErrorTrackingProperties,
                 TaxonomicFilterGroupType.EventProperties,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/AlertsRecommendationCard.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/AlertsRecommendationCard.tsx
@@ -110,7 +110,7 @@ function AlertsRecommendationWizardModal({
     }
 
     return (
-        <LemonModal isOpen onClose={onClose} width={560} simple>
+        <LemonModal isOpen onClose={onClose} maxWidth="48rem" simple>
             <BindLogic logic={alertWizardLogic} props={wizardProps}>
                 <AlertsRecommendationWizardContent onClose={onClose} />
             </BindLogic>

--- a/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
@@ -153,7 +153,7 @@ export function ClusteringJobsPanel(): JSX.Element {
             onClose={closeJobsPanel}
             title="Clustering jobs"
             description="Define independent clustering configurations for different subpopulations."
-            width={600}
+            maxWidth="48rem"
         >
             {editingJob ? (
                 <JobEditor

--- a/products/llm_analytics/frontend/datasets/DatasetItemModal.tsx
+++ b/products/llm_analytics/frontend/datasets/DatasetItemModal.tsx
@@ -45,7 +45,7 @@ export const DatasetItemModal = React.memo(function DatasetItemModal({
         <LemonModal
             isOpen={isOpen}
             onClose={() => onClose(refetchDatasetItems)}
-            maxWidth="40rem"
+            maxWidth="48rem"
             simple
             className="w-full"
         >

--- a/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
@@ -732,6 +732,7 @@ function ToolsButton({ promptId }: { promptId: string }): JSX.Element {
                 onClose={() => setEditModal(null)}
                 title="Tools"
                 description="Define functions the model can call during generation. Tools use the OpenAI function calling format."
+                width="90vw"
                 maxWidth="90vw"
                 footer={
                     <div className="flex justify-end gap-2">
@@ -929,6 +930,7 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
                 isOpen={showEditModal}
                 onClose={() => setEditModal(null)}
                 title="Edit system prompt"
+                width="90vw"
                 maxWidth="90vw"
                 footer={
                     <div className="flex justify-end gap-2">
@@ -1101,6 +1103,7 @@ function MessageDisplay({
                 isOpen={showEditModal}
                 onClose={() => setEditModal(null)}
                 title="Edit message"
+                width="90vw"
                 maxWidth="90vw"
                 footer={
                     <div className="flex justify-end gap-2">

--- a/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
@@ -732,8 +732,7 @@ function ToolsButton({ promptId }: { promptId: string }): JSX.Element {
                 onClose={() => setEditModal(null)}
                 title="Tools"
                 description="Define functions the model can call during generation. Tools use the OpenAI function calling format."
-                width="90vw"
-                maxWidth={640}
+                maxWidth="90vw"
                 footer={
                     <div className="flex justify-end gap-2">
                         <LemonButton
@@ -930,8 +929,7 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
                 isOpen={showEditModal}
                 onClose={() => setEditModal(null)}
                 title="Edit system prompt"
-                width="90vw"
-                maxWidth="1200px"
+                maxWidth="90vw"
                 footer={
                     <div className="flex justify-end gap-2">
                         <LemonButton type="secondary" onClick={() => setEditModal(null)}>
@@ -1103,8 +1101,7 @@ function MessageDisplay({
                 isOpen={showEditModal}
                 onClose={() => setEditModal(null)}
                 title="Edit message"
-                width="90vw"
-                maxWidth="1200px"
+                maxWidth="90vw"
                 footer={
                     <div className="flex justify-end gap-2">
                         <LemonButton type="secondary" onClick={() => setEditModal(null)}>

--- a/products/llm_analytics/frontend/reviewQueues/LLMAnalyticsReviewQueues.tsx
+++ b/products/llm_analytics/frontend/reviewQueues/LLMAnalyticsReviewQueues.tsx
@@ -372,7 +372,7 @@ export function LLMAnalyticsReviewQueues({ tabId }: { tabId?: string }): JSX.Ele
             )}
 
             {queueEditorMode ? (
-                <LemonModal isOpen onClose={closeQueueEditor} simple maxWidth="28rem">
+                <LemonModal isOpen onClose={closeQueueEditor} simple>
                     <LemonModalHeader>{queueEditorTitle}</LemonModalHeader>
                     <LemonModalContent className="space-y-4">
                         <div className="space-y-2">

--- a/products/llm_analytics/frontend/scoreDefinitions/LLMAnalyticsScoreDefinitions.tsx
+++ b/products/llm_analytics/frontend/scoreDefinitions/LLMAnalyticsScoreDefinitions.tsx
@@ -260,7 +260,7 @@ function ScoreDefinitionModal({
     const { draft, isCreateMode, isMetadataMode, isConfigMode, title, submitting } = useValues(logic)
 
     return (
-        <LemonModal isOpen onClose={onClose} simple maxWidth="42rem">
+        <LemonModal isOpen onClose={onClose} simple maxWidth="48rem">
             <LemonModalHeader>
                 <h3>{title}</h3>
             </LemonModalHeader>

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -219,7 +219,6 @@ function AddKeyModal({ restrictionReason }: { restrictionReason: string | null }
             isOpen={newKeyModalOpen}
             onClose={handleClose}
             title="Add API key"
-            width={480}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={handleClose}>
@@ -433,7 +432,6 @@ function DeleteKeyModal({
             isOpen
             onClose={handleClose}
             title="Delete API key?"
-            width={480}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={handleClose}>
@@ -550,7 +548,6 @@ function AssignKeyModal(): JSX.Element | null {
             isOpen={isOpen}
             onClose={dismissAssignKey}
             title={`Apply "${newlyCreatedKey.name}" to existing evaluations?`}
-            width={520}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={dismissAssignKey}>

--- a/products/llm_analytics/frontend/traceReviews/TraceReviewButton.tsx
+++ b/products/llm_analytics/frontend/traceReviews/TraceReviewButton.tsx
@@ -413,7 +413,7 @@ export function TraceReviewButton({
                 )}
             </AccessControlAction>
 
-            <LemonModal isOpen={isOpen} onClose={closeModal} title={modalTitle} width={680}>
+            <LemonModal isOpen={isOpen} onClose={closeModal} title={modalTitle} maxWidth="48rem">
                 {modalDataLoading ? (
                     <div className="py-12 flex justify-center">
                         <Spinner />

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
@@ -23,7 +23,7 @@ export function LogsAlertEventHistoryModal({ alert, onClose }: LogsAlertEventHis
         <LemonModal
             isOpen={alert !== null}
             onClose={onClose}
-            width={640}
+            maxWidth="48rem"
             title={alert ? `Alert history · ${alert.name}` : 'Alert history'}
             description="Transitions, errors, and user actions."
         >

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -56,7 +56,7 @@ function LogsAlertingSectionInner(): JSX.Element {
                 }}
                 title=""
                 simple
-                width={720}
+                maxWidth="48rem"
             >
                 {isModalOpen && <LogsAlertModalContent editingAlert={editingAlert} />}
             </LemonModal>

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -146,7 +146,7 @@ function LogsAlertModalContent({ editingAlert }: { editingAlert: LogsAlertConfig
                     onClose={closeSimulationPanel}
                     title="Alert simulation"
                     description="Run the alert against historical data to preview when it would have fired. Includes threshold evaluation, N-of-M noise reduction, and cooldown."
-                    width={960}
+                    maxWidth="90vw"
                 >
                     <LogsAlertSimulation />
                 </LemonModal>

--- a/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
@@ -141,7 +141,7 @@ export function SavedViewsModal({ id }: LogsViewsLogicProps): JSX.Element {
                 isOpen={isModalOpen}
                 onClose={closeModal}
                 title="Saved views"
-                width={720}
+                maxWidth="48rem"
                 footer={
                     <div className="flex justify-between w-full">
                         <LemonButton type="primary" onClick={openSaveModal}>

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
@@ -100,7 +100,7 @@ export function LogsAlertDetailScene(): JSX.Element {
                         onClose={closeSimulationPanel}
                         title="Alert simulation"
                         description="Run the alert against historical data to preview when it would have fired. Includes threshold evaluation, N-of-M noise reduction, and cooldown."
-                        width={960}
+                        maxWidth="90vw"
                     >
                         <LogsAlertSimulation />
                     </LemonModal>

--- a/products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene.tsx
@@ -73,7 +73,7 @@ export function LogsAlertNewScene(): JSX.Element {
                     onClose={closeSimulationPanel}
                     title="Alert simulation"
                     description="Run the alert against historical data to preview when it would have fired. Includes threshold evaluation, N-of-M noise reduction, and cooldown."
-                    width={960}
+                    maxWidth="90vw"
                 >
                     <LogsAlertSimulation />
                 </LemonModal>

--- a/products/revenue_analytics/frontend/nodes/modals/MRRBreakdownModal.tsx
+++ b/products/revenue_analytics/frontend/nodes/modals/MRRBreakdownModal.tsx
@@ -66,7 +66,7 @@ export function MRRBreakdownModal(): JSX.Element | null {
             onClose={closeModal}
             simple={false}
             title="MRR Breakdown"
-            width={1600}
+            maxWidth="90vw"
             fullScreen={false}
             closable={true}
         >

--- a/products/revenue_analytics/frontend/settings/EventConfigurationModal.tsx
+++ b/products/revenue_analytics/frontend/settings/EventConfigurationModal.tsx
@@ -99,7 +99,7 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
     }
 
     return (
-        <LemonModal isOpen onClose={handleClose} width={800}>
+        <LemonModal isOpen onClose={handleClose} maxWidth="48rem">
             <LemonModal.Header>
                 <h3>{originalEvent ? `Edit Event: ${originalEvent?.eventName}` : 'Add Revenue Event'}</h3>
             </LemonModal.Header>

--- a/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
@@ -64,7 +64,7 @@ export function SessionGroupSummaryDetailsModal({ isOpen, onClose, event }: Sess
             onClose={onClose}
             simple
             title=""
-            width={1600}
+            maxWidth="90vw"
             closable={true}
             hideCloseButton={true}
         >

--- a/products/tasks/frontend/components/TaskCreateModal.tsx
+++ b/products/tasks/frontend/components/TaskCreateModal.tsx
@@ -24,7 +24,7 @@ export function TaskCreateModal({ isOpen, onClose }: TaskCreateModalProps): JSX.
             isOpen={isOpen}
             onClose={handleCancel}
             title="Create new task"
-            width={800}
+            maxWidth="48rem"
             footer={
                 <div className="flex gap-2">
                     <LemonButton type="secondary" onClick={handleCancel}>

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -138,6 +138,7 @@ export default function TracingScene(): JSX.Element {
                 isOpen={isTraceModalOpen}
                 onClose={closeTraceModal}
                 width="90vw"
+                maxWidth="90vw"
             >
                 <div className="relative min-h-32">
                     {isLoadingFullTrace && <SpinnerOverlay />}

--- a/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
+++ b/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
@@ -29,7 +29,7 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
 
     return (
         <>
-            <LemonModal title="Configure email sender" width="auto" onClose={props.onClose}>
+            <LemonModal title="Configure email sender" maxWidth="90vw" onClose={props.onClose}>
                 <Form logic={emailSetupModalLogic} props={props} formKey="emailSender">
                     <div className="space-y-4">
                         <FlaggedFeature flag="messaging-ses">

--- a/products/workflows/frontend/OptOuts/CustomerIOImportModal.tsx
+++ b/products/workflows/frontend/OptOuts/CustomerIOImportModal.tsx
@@ -557,7 +557,7 @@ export function CustomerIOImportModal(): JSX.Element {
             description="Import categories and unsubscribed users from Customer.io."
             isOpen={isImportModalOpen}
             onClose={closeImportModal}
-            width={640}
+            maxWidth="48rem"
         >
             {isAdminOrOwner === false ? (
                 <AccessDenied object="Customer.io integration" inline />

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -140,7 +140,7 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                 isOpen={Boolean(selectedIdentifier)}
                 onClose={handleCloseModal}
                 title={`Persons for ${selectedIdentifier}`}
-                width="50rem"
+                maxWidth="48rem"
                 footer={null}
             >
                 {actorsQuery && (

--- a/products/workflows/frontend/Workflows/NewWorkflowModal.tsx
+++ b/products/workflows/frontend/Workflows/NewWorkflowModal.tsx
@@ -24,7 +24,7 @@ export function NewWorkflowModal(): JSX.Element {
         <LemonModal
             onClose={hideNewWorkflowModal}
             isOpen={newWorkflowModalVisible}
-            width={1200}
+            maxWidth="90vw"
             title="Create a workflow"
             data-attr="new-workflow-chooser"
             description={

--- a/products/workflows/frontend/Workflows/templates/TemplateJsonModal.tsx
+++ b/products/workflows/frontend/Workflows/templates/TemplateJsonModal.tsx
@@ -18,7 +18,7 @@ export function TemplateJsonModal(props: WorkflowTemplateLogicProps = {}): JSX.E
             onClose={hideTemplateJsonModal}
             isOpen={templateJsonModalVisible}
             title="Template JSON"
-            width="60vw"
+            maxWidth="90vw"
             footer={
                 <LemonButton type="secondary" onClick={hideTemplateJsonModal}>
                     Close


### PR DESCRIPTION
we had a popover and modal that were way too wide
so I'm trying to default all popovers and modals to prose width unless they're overridden

## Problem

Modal and popover widths were set ad-hoc across the codebase — 60+ different explicit pixel/rem values scattered through `LemonModal` callers, plus no default width discipline for `Popover`. That meant "how wide should a dialog be?" was re-decided every time someone built one, with the inevitable drift toward "whatever number the nearest-looking modal used." Stacked on top of #55549 / #55969, which motivated the discussion: the AI consent legal dialog needed a sensible default, and it turned out the whole system wanted one.

## Changes

Establish **three width tiers** across modals and popovers:

| Tier | Value | Use for |
| --- | --- | --- |
| **prose** | `65ch` (new default) | Default for `LemonModal.maxWidth` and `Popover.maxWidth`. ~520-620px depending on body font — the typographic reading-comfort range for short prompts, forms, and legal copy. |
| **wide** | `maxWidth="48rem"` (768px) | Forms, tables, and comparable medium-density content. |
| **extra-wide** | `maxWidth="90vw"` | Data-viz modals, full-screen editors, playgrounds. |

- `LemonModal` now defaults `maxWidth` to `'65ch'`. Callers that still need a specific cap pass one — the three tiers above cover everyone.
- `Popover` gains a new `maxWidth` prop (defaulted to `'65ch'`) that caps `.Popover__box`. `floating-ui`'s viewport-edge clamp continues to handle overflow separately, so tall dropdowns still clip themselves against the window edge.
- Swept 96 files:
  - **Narrow modals** previously overriding to ≤ 600px (e.g. `RenameModal`, `CreateProjectModal`, all `*AccessControl*` at 30rem, `PostOnboardingModal` at 400) drop their override and inherit the new prose default.
  - **Mid-sized modals** in the 600-900 range (forms, list/table modals, setup wizards) consolidate at `maxWidth="48rem"`.
  - **Data-viz / editor modals** (`WebAnalyticsModal`, `MRRBreakdownModal`, `SessionGroupSummaryDetailsModal`, `SQLEditor`, `NewWorkflowModal`, etc.) consolidate at `maxWidth="90vw"`. The email templater and the LLM playground were previously the only `90vw` modals — they now share the tier with the rest of the extra-wides.
- Conditional widths (`ViewLinkModal`, `SourcesModal`, `RetentionModal`) keep their conditional logic but switch to `maxWidth` and map each branch to one of the three tiers.

## How did you test this code?

- [ ] (author) spot-check a representative modal from each tier locally: a prose modal (e.g. `CreateOrganizationModal`), a wide modal (e.g. `InviteModal`), an extra-wide modal (e.g. `SQLEditor`'s preview, `WebAnalyticsModal`)
- [ ] (author) review visual snapshots — there will be many changes, most deliberate; flag any regressions
- [x] (agent) `pnpm format` + `pnpm typescript:check` pass (unrelated pre-existing `products/workflows` errors excluded)
- [x] (agent) re-grepped `<LemonModal` call sites after the sweep and confirmed every remaining explicit width/maxWidth is now one of `48rem`, `90vw`, or a deliberate conditional

## Publish to changelog?

no — this is an internal design-system consolidation, no user-visible feature change.

## Docs update

No docs change required.

## 🤖 LLM context

Authored by PostHog Code (task id `8ac00cc2-de0e-4a8a-9797-54f3480568de`), stacked on top of #55969.

Reasoning trail:
1. AI consent legal dialog in #55969 needed a sensible cap. Landed on `65ch` (prose).
2. User noticed the same discipline was missing across other modals; audit found 60+ overrides in 40+ shapes.
3. Agreed on three tiers: prose / wide / extra-wide. This PR is the sweep.
4. Popover got a new `maxWidth` prop because its width story was even more ad-hoc — everyone wrapped their overlay JSX in a `max-w-sm` / `max-w-md` / `max-w-prose` utility. With the prop, the default is prose and callers with wider content opt out.

Things worth flagging for reviewers:
- The prose default on `LemonModal` does constrain modals that previously relied on content-hug + `max-width: 90%` to grow naturally. Those modals are now either caught by the sweep (wide or extra-wide) or they're prose-sized. If any modal I missed silently squishes, we'll spot it in visual regression.
- The `Popover` default cap is applied via inline `style` on `.Popover__box`. `floating-ui`'s viewport clamp is set on `.Popover` (outer) imperatively and takes precedence for overflow-prevention. The two don't conflict — inner cap sets content width, outer clamp caps viewport overflow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
