### PR TITLE
fix(temporal): build kafka log producer inside the event loop

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -533,9 +533,7 @@ def configure_logger(
         ]
     else:
         try:
-            log_producer = KafkaLogProducerFromQueueAsync(
-                queue=log_queue, topic=KAFKA_LOG_ENTRIES, producer=producer, loop=loop
-            )
+            log_producer = KafkaLogProducerFromQueueAsync(queue=log_queue, topic=KAFKA_LOG_ENTRIES, producer=producer)
         except Exception as e:
             # Skip putting logs in queue if we don't have a producer that can consume the queue.
             # We save the error to log it later as the logger hasn't yet been configured at this time.
@@ -567,12 +565,13 @@ def configure_logger(
     )
 
     if log_producer is None:
-        # Always surface producer init failures — if we only log when a loop is
-        # available, regressions here fall back to write-only without a trace in
-        # ClickHouse `log_entries`, which hides the fault from dashboards that
-        # consume those logs.
-        logger = structlog.get_logger()
-        logger.error("Failed to initialize log producer", exc_info=log_producer_error)
+        # In test/TTY mode we deliberately skip building a Kafka producer, so
+        # `log_producer_error` stays None. Only log when we actually tried and
+        # failed — the old `if loop is not None` guard hid real regressions
+        # (KafkaLogProducerFromQueueAsync init raising silently).
+        if log_producer_error is not None:
+            logger = structlog.get_logger()
+            logger.error("Failed to initialize log producer", exc_info=log_producer_error)
         return
 
     listen_task = create_background_task(
@@ -650,7 +649,6 @@ class KafkaLogProducerFromQueueAsync:
         topic: str = KAFKA_LOG_ENTRIES,
         key: str | None = None,
         producer: "_AsyncKafkaProducer | None" = None,
-        loop: None | asyncio.AbstractEventLoop = None,
     ):
         self.queue = queue
         self.topic = topic
@@ -690,7 +688,8 @@ class KafkaLogProducerFromQueueAsync:
         We catch any exceptions so as to continue processing the queue even if the broker is unavailable
         or we fail to produce for whatever other reason. We log the failure to not fail silently.
         """
-        assert self.producer is not None, "producer must be initialized by listen() before produce()"
+        if self.producer is None:
+            raise RuntimeError("producer must be initialized by listen() before produce()")
         fut = await self.producer.produce(
             topic=self.topic,
             data=msg,

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -567,9 +567,12 @@ def configure_logger(
     )
 
     if log_producer is None:
-        if loop is not None:
-            logger = structlog.get_logger()
-            logger.error("Failed to initialize log producer", exc_info=log_producer_error)
+        # Always surface producer init failures — if we only log when a loop is
+        # available, regressions here fall back to write-only without a trace in
+        # ClickHouse `log_entries`, which hides the fault from dashboards that
+        # consume those logs.
+        logger = structlog.get_logger()
+        logger.error("Failed to initialize log producer", exc_info=log_producer_error)
         return
 
     listen_task = create_background_task(
@@ -649,12 +652,15 @@ class KafkaLogProducerFromQueueAsync:
         producer: "_AsyncKafkaProducer | None" = None,
         loop: None | asyncio.AbstractEventLoop = None,
     ):
-        from posthog.kafka_client.routing import new_async_producer
-
         self.queue = queue
         self.topic = topic
         self.key = key
-        self.producer = producer if producer is not None else new_async_producer(topic=topic)
+        # Deferred: confluent_kafka's AIOProducer calls asyncio.get_running_loop()
+        # inside its __init__, so the underlying producer must be constructed from
+        # within the worker's event loop. configure_logger() runs synchronously
+        # before the loop starts, so we build the producer on the first `listen()`
+        # call instead of here.
+        self.producer: _AsyncKafkaProducer | None = producer
         self.logger = structlog.get_logger("posthog.temporal.common.logger.KafkaLogProducerFromQueueAsync")
 
     async def listen(self):
@@ -663,6 +669,11 @@ class KafkaLogProducerFromQueueAsync:
         This is designed to be ran as an asyncio.Task, as it will wait forever for the queue
         to have messages.
         """
+        if self.producer is None:
+            from posthog.kafka_client.routing import new_async_producer
+
+            self.producer = new_async_producer(topic=self.topic)
+
         try:
             while True:
                 msg = await self.queue.get()
@@ -670,7 +681,8 @@ class KafkaLogProducerFromQueueAsync:
 
         finally:
             await self.flush()
-            await self.producer.close()
+            if self.producer is not None:
+                await self.producer.close()
 
     async def produce(self, msg: bytes):
         """Produce messages to configured topic and key.
@@ -678,6 +690,7 @@ class KafkaLogProducerFromQueueAsync:
         We catch any exceptions so as to continue processing the queue even if the broker is unavailable
         or we fail to produce for whatever other reason. We log the failure to not fail silently.
         """
+        assert self.producer is not None, "producer must be initialized by listen() before produce()"
         fut = await self.producer.produce(
             topic=self.topic,
             data=msg,
@@ -693,6 +706,8 @@ class KafkaLogProducerFromQueueAsync:
             self.logger.debug("Message that couldn't be produced to Kafka topic %s: %s", self.topic, msg)
 
     async def flush(self):
+        if self.producer is None:
+            return
         try:
             await self.producer.flush()
         except Exception:

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -205,6 +205,28 @@ def structlog_context():
     structlog.contextvars.bind_contextvars(**ctx)
 
 
+async def test_kafka_log_producer_init_does_not_require_running_loop():
+    """`KafkaLogProducerFromQueueAsync.__init__` must not require a running event loop.
+
+    `configure_logger()` is called from `start_temporal_worker` synchronously, before
+    `asyncio.Runner.run(...)` starts the loop. confluent_kafka's underlying `AIOProducer`
+    calls `asyncio.get_running_loop()` in its own `__init__`, so building the producer
+    eagerly raised `RuntimeError: no running event loop` and the whole log pipeline
+    silently fell back to write-only — dropping all temporal worker logs from
+    `log_entries` in ClickHouse. This test guards against regressing back to eager init.
+    """
+    from posthog.temporal.common.logger import KafkaLogProducerFromQueueAsync
+
+    def _construct_without_running_loop() -> KafkaLogProducerFromQueueAsync:
+        # Thread has no running loop, mirroring configure_logger() running before
+        # asyncio.Runner.run(...) starts the worker loop.
+        return KafkaLogProducerFromQueueAsync(queue=asyncio.Queue(maxsize=0))
+
+    log_producer = await asyncio.to_thread(_construct_without_running_loop)
+
+    assert log_producer.producer is None
+
+
 async def test_logger_context(log_capture):
     """Test whether log messages contain the expected context.
 


### PR DESCRIPTION
## Problem

Since #54702 landed, every temporal worker hits `RuntimeError: no running event loop` at startup and silently falls back to the write-only logger. No rows reach `KAFKA_LOG_ENTRIES` → nothing in ClickHouse `log_entries` → Sync tab is blank for Postgres data-warehouse imports (and batch-export / data-modeling logs stop on pod restart too).

Root cause: `KafkaLogProducerFromQueueAsync.__init__` now builds a confluent `_AsyncKafkaProducer` via `new_async_producer()`. confluent_kafka's `AIOProducer.__init__` calls `asyncio.get_running_loop()`. But `configure_logger(loop=loop)` is called synchronously from `start_temporal_worker` before `runner.run(...)` starts the loop, so construction raises.

Stacktrace from prod (`temporal-worker-data-warehouse`, 2026-04-22):
```
RuntimeError: no running event loop
  posthog/temporal/common/logger.py:536  configure_logger
  posthog/temporal/common/logger.py:657  KafkaLogProducerFromQueueAsync.__init__
  posthog/kafka_client/routing.py:268    new_async_producer
  posthog/kafka_client/routing.py:184    _build_async_producer
  posthog/kafka_client/client.py:389     _AsyncKafkaProducer.__init__
  confluent_kafka/aio/producer/_AIOProducer.py:49
```

The regression was hidden because `configure_logger` catches the exception and only logs it when a loop is available — which it isn't in this failure mode.

## Changes

- Defer `_AsyncKafkaProducer` construction to the first `listen()` call (runs on the worker's loop).
- Drop the `if loop is not None` guard around the "Failed to initialize log producer" error log so future regressions surface loudly instead of being invisible.
- Regression test: construct `KafkaLogProducerFromQueueAsync` via `asyncio.to_thread` (no running loop) and assert it doesn't eagerly build the producer.

## How did you test this code?

- `hogli test posthog/temporal/tests/common/test_logger.py::test_kafka_log_producer_init_does_not_require_running_loop` passes.
- No production / staging verification — this PR was drafted by an AI agent based on the prod stacktrace; please verify on dev/staging before merge.

## Publish to changelog?

no

## 🤖 LLM context

Drafted by Claude Opus 4.7 after investigating dropped Postgres import Sync-tab logs. Investigation trace: confirmed timing (log volume drops immediately after #54702 pod rollout, only affecting deployments that had already restarted), located `RuntimeError: no running event loop` traceback in `temporal-worker-data-warehouse` logs, mapped frames to the new code path introduced in #54702.