### PR TITLE
fix(email): sanitize dataclass instances in template_context

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -3,6 +3,7 @@
 import sys
 import html
 import uuid
+import datetime
 import dataclasses
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional
@@ -286,7 +287,7 @@ def sanitize_email_properties(properties: dict[str, Any] | None) -> dict[str, An
     skip_sanitization_keys = ["utm_tags"]
 
     # Supported types (besides containers like dict and list)
-    supported_types = (str, int, float, bool, type(None), Decimal, uuid.UUID)
+    supported_types = (str, int, float, bool, type(None), Decimal, uuid.UUID, datetime.datetime, datetime.date)
 
     def sanitize_value(value: Any) -> Any:
         if isinstance(value, str):
@@ -298,6 +299,10 @@ def sanitize_email_properties(properties: dict[str, Any] | None) -> dict[str, An
         elif isinstance(value, uuid.UUID):
             # Handle UUID by converting to string and escaping
             return html.escape(str(value))
+        elif isinstance(value, datetime.datetime | datetime.date):
+            # Convert datetime/date to ISO-8601 string and escape — reached via
+            # dataclasses.asdict() for facade contracts with created_at-style fields
+            return html.escape(value.isoformat())
         elif hasattr(value, "_meta") and hasattr(value, "pk"):
             # Handle Django models by converting to string and escaping
             return html.escape(str(value))

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -3,6 +3,7 @@
 import sys
 import html
 import uuid
+import dataclasses
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -306,11 +307,14 @@ def sanitize_email_properties(properties: dict[str, Any] | None) -> dict[str, An
         elif isinstance(value, int | float | bool | type(None)):
             # These types are safe as-is
             return value
+        elif dataclasses.is_dataclass(value) and not isinstance(value, type):
+            # Convert dataclass instances to a dict and recurse so their string fields get escaped
+            return {k: sanitize_value(v) for k, v in dataclasses.asdict(value).items()}
         else:
             # Raise an error for unsupported types - this is a security measure to prevent uncaught injections
             raise TypeError(
                 f"Unsupported type in email properties: {type(value).__name__}. "
-                f"Only {', '.join(t.__name__ for t in supported_types)}, dict, list, and Django models are supported."
+                f"Only {', '.join(t.__name__ for t in supported_types)}, dict, list, dataclasses, and Django models are supported."
             )
 
     result = {}

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -1,4 +1,7 @@
+import datetime
+import dataclasses
 from decimal import Decimal
+from uuid import UUID
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
@@ -226,9 +229,9 @@ class TestEmail(BaseTest):
     def test_sanitize_email_properties_handles_dataclasses(self) -> None:
         # Regression test: facade contracts (frozen dataclasses) used to raise TypeError,
         # silently killing tasks like send_error_tracking_issue_assigned via autoretry.
-        import dataclasses
-        from uuid import UUID
-
+        # Mirror the real ErrorTrackingIssueAssignmentNotification shape — in particular
+        # include a datetime field, since dataclasses.asdict() does not recurse into
+        # datetime and the naive fix missed that.
         @dataclasses.dataclass(frozen=True)
         class Inner:
             id: UUID
@@ -238,10 +241,12 @@ class TestEmail(BaseTest):
         @dataclasses.dataclass(frozen=True)
         class Outer:
             id: UUID
+            created_at: datetime.datetime
             issue: Inner
 
         outer = Outer(
             id=UUID("00000000-0000-0000-0000-000000000001"),
+            created_at=datetime.datetime(2024, 1, 1, 12, 0, 0),
             issue=Inner(
                 id=UUID("00000000-0000-0000-0000-000000000002"),
                 name='<script>alert("xss")</script>',
@@ -252,6 +257,7 @@ class TestEmail(BaseTest):
         sanitized = sanitize_email_properties({"assignment": outer})
 
         self.assertEqual(sanitized["assignment"]["id"], "00000000-0000-0000-0000-000000000001")
+        self.assertEqual(sanitized["assignment"]["created_at"], "2024-01-01T12:00:00")
         self.assertEqual(sanitized["assignment"]["issue"]["id"], "00000000-0000-0000-0000-000000000002")
         self.assertEqual(
             sanitized["assignment"]["issue"]["name"],

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -223,6 +223,42 @@ class TestEmail(BaseTest):
         # Check that utm_tags are not sanitized (to preserve valid URL query parameters)
         self.assertEqual(sanitized["utm_tags"], "utm_source=posthog&utm_medium=email&utm_campaign=test")
 
+    def test_sanitize_email_properties_handles_dataclasses(self) -> None:
+        # Regression test: facade contracts (frozen dataclasses) used to raise TypeError,
+        # silently killing tasks like send_error_tracking_issue_assigned via autoretry.
+        import dataclasses
+        from uuid import UUID
+
+        @dataclasses.dataclass(frozen=True)
+        class Inner:
+            id: UUID
+            name: str | None
+            description: str | None
+
+        @dataclasses.dataclass(frozen=True)
+        class Outer:
+            id: UUID
+            issue: Inner
+
+        outer = Outer(
+            id=UUID("00000000-0000-0000-0000-000000000001"),
+            issue=Inner(
+                id=UUID("00000000-0000-0000-0000-000000000002"),
+                name='<script>alert("xss")</script>',
+                description=None,
+            ),
+        )
+
+        sanitized = sanitize_email_properties({"assignment": outer})
+
+        self.assertEqual(sanitized["assignment"]["id"], "00000000-0000-0000-0000-000000000001")
+        self.assertEqual(sanitized["assignment"]["issue"]["id"], "00000000-0000-0000-0000-000000000002")
+        self.assertEqual(
+            sanitized["assignment"]["issue"]["name"],
+            "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;",
+        )
+        self.assertIsNone(sanitized["assignment"]["issue"]["description"])
+
     def test_sanitize_email_properties_raises_for_unsupported_types(self) -> None:
         # Test that sanitize_email_properties raises TypeError for unsupported types
         properties = {


### PR DESCRIPTION
## Problem

Since [9a84ad66f5](https://github.com/PostHog/posthog/commit/9a84ad66f5) (Apr 16, "feat(error_tracking): migrate digest and task callers to facade"), `send_error_tracking_issue_assigned` has been failing + retrying silently on every manual issue assignment, so no assignment notification emails go out.

The facade migration started passing a frozen dataclass — `ErrorTrackingIssueAssignmentNotification` — as a value in `template_context`. `EmailMessage.__init__` runs the context through `sanitize_email_properties`, which only allowlisted Django models (duck-typed via `_meta`+`pk`), UUID, scalars, dict, and list. A dataclass matches none of those and trips the explicit `raise TypeError` at `posthog/email.py:311`. Celery's `autoretry_for=(Exception,)` then retries 3× and gives up.

Confirmed in prod logs across multiple teams, e.g.:

```
TypeError: Unsupported type in email properties: ErrorTrackingIssueAssignmentNotification.
  File "/code/posthog/tasks/email.py", line 828, in send_error_tracking_issue_assigned
    message = EmailMessage(...)
  File "/code/posthog/email.py", line 389, in __init__
    self.properties = sanitize_email_properties(template_context)
  File "/code/posthog/email.py", line 311, in sanitize_value
    raise TypeError(...)
```

## Changes

Teach `sanitize_email_properties` about dataclasses: when a value is a dataclass instance, convert via `dataclasses.asdict(...)` and recurse so nested string fields still get HTML-escaped. This is the general fix — any future facade/contract dataclass handed to an email template will now just work, rather than silently killing its task.

Added a regression test mirroring the exact failing shape (nested frozen dataclass with UUID + `<script>`-bearing string) to lock in both the flattening and the escaping.

## How did you test this code?

- Added `test_sanitize_email_properties_handles_dataclasses` covering the exact regression shape.
- Ran existing + new sanitize tests: 4/4 pass locally (`hogli test posthog/test/test_email.py -k sanitize` + `test_email_message_sanitizes_properties`).
- Not manually end-to-end tested (would require a real SMTP/Customer.io env); the code path between `EmailMessage(...)` and `_send_via_smtp` is unchanged — only the sanitize step is fixed. I'm an agent and have not sent a real email — please do a manual smoke-test before shipping, e.g. have a teammate assign an error tracking issue to you on staging / dev and confirm the inbox.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude via an investigation session driven by @ci. Flow:
1. User forwarded a customer-ish report: "Issue assigned" toggle enabled, no emails received for manual or auto assignments.
2. Code-read the notification path: preference storage, `assign_issue` endpoint, Celery task, email sanitizer.
3. First hypothesis (auto-assignment path never triggers the task from Rust cymbal) turned out to be correct for auto-assign but didn't explain the manual-assign failure — user's data showed the Celery task was being enqueued + retried.
4. Pulled Loki logs via Grafana MCP. The `task_retrying` + `task_failed` events for `send_error_tracking_issue_assigned` carry the full `TypeError` trace and pin the failure to `sanitize_email_properties` on the dataclass — confirming the real manual-path bug.
5. Implemented the sanitizer fix + regression test. Running `hogli test` on the changed test file: 4/4 pass.