### PR TITLE
chore(flags): update internal docs for Rust definitions fleet

### DIFF
--- a/docs/internal/feature-flags/django-api-endpoints.md
+++ b/docs/internal/feature-flags/django-api-endpoints.md
@@ -2,7 +2,7 @@
 
 Django serves the admin/management API for feature flags: CRUD operations, local SDK evaluation, analytics, and organization-level operations. Runtime flag evaluation (`/flags`, `/decide`) is routed directly to the [Rust service](rust-service-overview.md) by Contour/Envoy at the Kubernetes infrastructure level -- these requests never reach Django. Django does make internal service-to-service HTTP calls to the Rust service for actions like `my_flags` and `evaluation_reasons`.
 
-The `/api/feature_flag/local_evaluation` endpoint (used by server-side SDKs for local flag evaluation) runs on a **dedicated Django deployment** (`posthog-local-evaluation`), separate from the main Django web service.
+The `/api/feature_flag/local_evaluation` endpoint was historically served by a dedicated Django deployment (`posthog-local-evaluation`). As of April 2026, all local evaluation traffic is served by the Rust definitions fleet at `/flags/definitions` (see [Rust service overview](rust-service-overview.md)). The Django endpoint and deployment are deprecated and pending removal.
 
 ## Architecture overview
 

--- a/docs/internal/feature-flags/rust-service-overview.md
+++ b/docs/internal/feature-flags/rust-service-overview.md
@@ -1,6 +1,6 @@
 # Rust feature flags service
 
-The Rust feature flags service (`rust/feature-flags/`) handles all runtime feature flag evaluation. It serves the `/flags` and `/decide` endpoints that SDKs call. Django remains the admin API for flag CRUD operations (`/api/projects/{id}/feature_flags/`) and serves the local evaluation endpoint (`/api/feature_flag/local_evaluation`).
+The Rust feature flags service (`rust/feature-flags/`) handles all runtime feature flag evaluation and local SDK evaluation. It serves the `/flags` and `/decide` endpoints for flag evaluation, and the `/flags/definitions` endpoint for local SDK evaluation. Django remains the admin API for flag CRUD operations (`/api/projects/{id}/feature_flags/`).
 
 ## Infrastructure routing
 
@@ -15,11 +15,12 @@ AWS ALB
   ▼
 Contour / Envoy (path-based routing)
   │
-  ├── /decide/*              ──▶ posthog-feature-flags:3001  (Rust)
-  ├── /flags/?               ──▶ posthog-feature-flags:3001  (Rust)
-  ├── /api/feature_flag/local_evaluation ──▶ posthog-local-evaluation:8000 (Django, dedicated deployment)
-  ├── /api/*                 ──▶ posthog-web-django:8000     (Django, catch-all)
-  └── /*                     ──▶ posthog-web-django:8000     (Django, final catch-all)
+  ├── /decide/*              ──▶ posthog-feature-flags:3001              (Rust, flags fleet)
+  ├── /flags/?               ──▶ posthog-feature-flags:3001              (Rust, flags fleet)
+  ├── /flags/definitions     ──▶ posthog-feature-flags-definitions:3001  (Rust, definitions fleet)
+  ├── /api/feature_flag/local_evaluation ──▶ posthog-feature-flags-definitions:3001 (Rust, definitions fleet, legacy alias)
+  ├── /api/*                 ──▶ posthog-web-django:8000                 (Django, catch-all)
+  └── /*                     ──▶ posthog-web-django:8000                 (Django, final catch-all)
 ```
 
 Key routing details:
@@ -29,6 +30,18 @@ Key routing details:
 - A **dedicated subdomain** (`us-d.i.posthog.com` / `eu-d.i.posthog.com`) routes only to `decide` + `feature-flags` with no Django fallback
 - All flag routes have a **5-second timeout** and 2 retries on `reset`/`cancelled`
 - Canary rollouts are supported via Argo Rollouts adjusting weights on the HTTPProxy resources
+
+### Fleet split
+
+The Rust service runs as two separate fleets controlled by the `SERVICE_MODE` env var:
+
+| Fleet                               | `SERVICE_MODE` | Routes                                                     | Purpose                                   |
+| ----------------------------------- | -------------- | ---------------------------------------------------------- | ----------------------------------------- |
+| `posthog-feature-flags`             | `flags`        | `/flags`, `/decide`                                        | Runtime flag evaluation                   |
+| `posthog-feature-flags-definitions` | `definitions`  | `/flags/definitions`, `/api/feature_flag/local_evaluation` | Flag definitions for local SDK evaluation |
+
+Both fleets share the same Kubernetes secret (`posthog-feature-flags`) via the `secretName` chart override.
+The `all` mode (default) registers all routes and is used for local development.
 
 Routing config lives in the `charts` repo: `argocd/contour-ingress/values/values.prod-us.yaml` (and `prod-eu`, `dev` variants).
 
@@ -78,17 +91,18 @@ Routing config lives in the `charts` repo: `argocd/contour-ingress/values/values
 
 All routes are defined in `rust/feature-flags/src/router.rs`.
 
-| Route                | Method | Handler                               | Purpose                                                                                                                  |
-| -------------------- | ------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `/flags`             | POST   | `endpoint::flags`                     | Feature flag evaluation (primary endpoint)                                                                               |
-| `/flags`             | GET    | `endpoint::flags`                     | Returns minimal response with empty flags                                                                                |
-| `/decide`            | POST   | `endpoint::flags`                     | Same handler as `/flags`, response format varies via `X-Original-Endpoint: decide` header                                |
-| `/flags/definitions` | GET    | `flag_definitions::flags_definitions` | **WIP, not routed in production.** Flag definitions for local SDK evaluation (requires secret token or personal API key) |
-| `/`                  | GET    | `index`                               | Returns `"feature flags"` (basic health check)                                                                           |
-| `/_readiness`        | GET    | `readiness`                           | Kubernetes readiness probe, tests all 4 DB pool connections                                                              |
-| `/_liveness`         | GET    | `liveness`                            | Kubernetes liveness probe, heartbeat-based                                                                               |
-| `/_startup`          | GET    | `startup`                             | Kubernetes startup probe, warms DB pools                                                                                 |
-| `/metrics`           | GET    | Prometheus                            | Metrics scrape endpoint (when `ENABLE_METRICS=true`)                                                                     |
+| Route                                | Method | Handler                               | Purpose                                                                                   |
+| ------------------------------------ | ------ | ------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `/flags`                             | POST   | `endpoint::flags`                     | Feature flag evaluation (primary endpoint)                                                |
+| `/flags`                             | GET    | `endpoint::flags`                     | Returns minimal response with empty flags                                                 |
+| `/decide`                            | POST   | `endpoint::flags`                     | Same handler as `/flags`, response format varies via `X-Original-Endpoint: decide` header |
+| `/flags/definitions`                 | GET    | `flag_definitions::flags_definitions` | Flag definitions for local SDK evaluation (requires secret token or personal API key)     |
+| `/api/feature_flag/local_evaluation` | GET    | `flag_definitions::flags_definitions` | Legacy alias for `/flags/definitions` (backward compat with old SDK versions)             |
+| `/`                                  | GET    | `index`                               | Returns `"feature flags"` (basic health check)                                            |
+| `/_readiness`                        | GET    | `readiness`                           | Kubernetes readiness probe, tests all 4 DB pool connections                               |
+| `/_liveness`                         | GET    | `liveness`                            | Kubernetes liveness probe, heartbeat-based                                                |
+| `/_startup`                          | GET    | `startup`                             | Kubernetes startup probe, warms DB pools                                                  |
+| `/metrics`                           | GET    | Prometheus                            | Metrics scrape endpoint (when `ENABLE_METRICS=true`)                                      |
 
 All flag routes accept trailing slashes.
 
@@ -117,11 +131,11 @@ The response format depends on the `v` query parameter and the endpoint:
 | `v=1`     | `/decide` | `DecideV1Response`: list of active flag keys                                                 |
 | `v=2`     | `/decide` | `DecideV2Response`: flat `feature_flags: { key: value }` map                                 |
 
-### `/flags/definitions` endpoint (under construction)
+### `/flags/definitions` endpoint
 
-**Not live in production.** This endpoint is under active development and is not routed by Contour. Local evaluation is currently served by Django at `/api/feature_flag/local_evaluation` (see [Django API endpoints](django-api-endpoints.md)), which remains the production endpoint for server-side SDKs.
+This endpoint serves flag definitions for server-side SDKs that evaluate flags locally. It replaced the Django `/api/feature_flag/local_evaluation` endpoint (which is preserved as a Rust alias for backward compatibility). All 7 server-side SDKs (Python, Node, Go, Ruby, PHP, .NET, Rust) now poll this endpoint by default.
 
-The goal is for this Rust endpoint to replace the Django local evaluation endpoint. When complete, it will serve flag definitions for SDKs that evaluate flags locally, authenticated via:
+Authenticated via:
 
 - Team secret API token (`Authorization: Bearer phs_...`), or
 - Personal API key with `feature_flag:read` scope
@@ -206,6 +220,7 @@ All values come from environment variables via the `envconfig` crate. Defined in
 | `MAX_CONCURRENCY` | `1000`           | Max concurrent flag evaluation requests           |
 | `DEBUG`           | `false`          | Pretty console logging vs JSON structured logging |
 | `ENABLE_METRICS`  | `false`          | Expose `/metrics` endpoint                        |
+| `SERVICE_MODE`    | `all`            | Fleet mode: `flags`, `definitions`, or `all`      |
 
 ### PostgreSQL
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
     "paramiko==3.4.1",
     "pillow==12.2.0",
     "protobuf~=5.29.6",
-    "posthoganalytics==7.10.2",
+    "posthoganalytics==7.13.0",
     "polars==1.37.1",
     "psycopg2-binary==2.9.10",
     "psycopg[binary]==3.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T01:13:20.083593713Z"
+exclude-newer = "2026-04-15T13:39:17.802103Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -5377,7 +5377,7 @@ requires-dist = [
     { name = "pixelhog", specifier = "~=1.0.0" },
     { name = "playwright", specifier = "~=1.54.0" },
     { name = "polars", specifier = "==1.37.1" },
-    { name = "posthoganalytics", specifier = "==7.10.2" },
+    { name = "posthoganalytics", specifier = "==7.13.0" },
     { name = "protobuf", specifier = "~=5.29.6" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.4" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
@@ -5505,19 +5505,18 @@ sentiment = [
 
 [[package]]
 name = "posthoganalytics"
-version = "7.10.2"
+version = "7.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
     { name = "python-dateutil" },
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/07/a90abd8bf52ff20eedb0d4e181552c6c44bd566ca73c3879c751e6e94921/posthoganalytics-7.10.2.tar.gz", hash = "sha256:e07e26d3fd53304228c546eac7501064d69db7560b853e1b3e9a7178f079c089", size = 186998, upload-time = "2026-04-08T13:50:34.539Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/27/34aa6241cdc0145d6a7ceedfd590425d9f35ca17983f6f812f83ffce5e08/posthoganalytics-7.13.0.tar.gz", hash = "sha256:a1dc24da926f016df3c50cd6846eb899326bf83eedaa2486d1c6956a41250f16", size = 193851, upload-time = "2026-04-21T09:12:15.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/12799dc26d81fd0f8eecfc5164ebd97f26901238b1dc53b4942c9e067c68/posthoganalytics-7.10.2-py3-none-any.whl", hash = "sha256:281b42853a7fa5957650544cfac6aabe5e1f906e5589d05a1ad89ba5a52601ce", size = 217460, upload-time = "2026-04-08T13:50:32.723Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/703fc06f56231f81c522cb895ebdcd9d14bfbe38f1b8d4f07a358b6696ab/posthoganalytics-7.13.0-py3-none-any.whl", hash = "sha256:87d8f04f9255645efd058caf027b7f6a68642186d91de5f174f369c8e1819f1d", size = 229183, upload-time = "2026-04-21T09:12:13.981Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Internal docs for the feature flags service were out of date after the local evaluation migration from Django to Rust.

## Changes

**`rust-service-overview.md`:**
- Updated routing diagram to reflect Rust definitions fleet serving `/flags/definitions` and `/api/feature_flag/local_evaluation`
- Added fleet split section documenting `SERVICE_MODE` and the two-fleet architecture
- Updated route table with `/api/feature_flag/local_evaluation` legacy alias
- Replaced "under construction" `/flags/definitions` section with production description
- Added `SERVICE_MODE` to config reference

**`django-api-endpoints.md`:**
- Marked Django local evaluation endpoint as deprecated, pointing to Rust service overview

## How did you test this code?

Docs only.

## Publish to changelog?

no