### PR TITLE
feat(retention): basic backend for data warehouse in fixed interval retention

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -64,10 +64,6 @@ class RetentionBaseQueryBuilder(ABC):
         return self.runner.global_event_filters
 
     @property
-    def events_timestamp_filter(self) -> ast.Expr:
-        return self.runner.events_timestamp_filter
-
-    @property
     def is_first_ever_occurrence(self) -> bool:
         return self.runner.is_first_ever_occurrence
 
@@ -131,6 +127,9 @@ class RetentionBaseQueryBuilder(ABC):
         if breakdown_expr:
             base_query.select.append(ast.Alias(alias="breakdown_value", expr=breakdown_expr))
             cast(list[ast.Expr], base_query.group_by).append(ast.Field(chain=["breakdown_value"]))
+
+    def events_timestamp_filter(self, field: ast.Expr | None = None) -> ast.Expr:
+        return self.runner.events_timestamp_filter(field=field)
 
     def get_first_time_anchor_expr(self) -> ast.Expr:
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:

--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -75,6 +75,10 @@ class RetentionBaseQueryBuilder(ABC):
     def is_custom_bracket_retention(self) -> bool:
         return self.runner.is_custom_bracket_retention
 
+    @property
+    def minimum_occurrences(self) -> int:
+        return self.query.retentionFilter.minimumOccurrences or 1
+
     def build(
         self,
         start_interval_index_filter: Optional[int] = None,

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -38,6 +38,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
         event_filters = self._event_filters()
+        is_valid_start_interval = self._is_valid_start_interval_expr()
         start_entity_is_dwh = self.start_event.type == EntityType.DATA_WAREHOUSE
 
         start_actor_column_name = (
@@ -319,13 +320,13 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 },
             )
             # interval must be same as first interval of in which start event happened
-            is_valid_start_interval = parse_expr("start_event_timestamps[1] = interval_date")
+            is_valid_start_interval = self._is_valid_start_interval_expr()
             is_first_interval_after_start_event = parse_expr(
                 "start_event_timestamps[1] = date_range[start_interval_index + 1]"
             )
         else:
             # start event must have happened in the interval
-            is_valid_start_interval = parse_expr("has(start_event_timestamps, interval_date)")
+            is_valid_start_interval = self._is_valid_start_interval_expr()
             is_first_interval_after_start_event = parse_expr(
                 "has(start_event_timestamps, date_range[start_interval_index + 1])"
             )
@@ -634,6 +635,12 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 )
 
         return event_filters
+
+    def _is_valid_start_interval_expr(self) -> ast.Expr:
+        if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
+            return parse_expr("start_event_timestamps[1] = interval_date")
+
+        return parse_expr("has(start_event_timestamps, interval_date)")
 
     def _get_return_event_timestamps_expr(
         self, minimum_occurrences: int, start_of_interval_sql: ast.Expr, return_entity_expr: ast.Expr

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -1,3 +1,5 @@
+from posthog.schema import EntityType
+
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
 
@@ -7,6 +9,40 @@ from posthog.queries.breakdown_props import ALL_USERS_COHORT_ID
 
 class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
     def build_base_query(
+        self,
+        start_interval_index_filter: int | None = None,
+        selected_breakdown_value: str | list[str] | int | None = None,
+    ) -> ast.SelectQuery:
+        has_data_warehouse_series = (
+            self.start_event.type == EntityType.DATA_WAREHOUSE or self.return_event.type == EntityType.DATA_WAREHOUSE
+        )
+
+        if has_data_warehouse_series:
+            return self.build_base_query_dwh(
+                start_interval_index_filter=start_interval_index_filter,
+                selected_breakdown_value=selected_breakdown_value,
+            )
+
+        return self.build_base_query_legacy(
+            start_interval_index_filter=start_interval_index_filter,
+            selected_breakdown_value=selected_breakdown_value,
+        )
+
+    # Nested fixed-interval query with data warehouse support.
+    # Intended as a drop-in replacement for the legacy query while we verify
+    # parity in production.
+    def build_base_query_dwh(
+        self,
+        start_interval_index_filter: int | None = None,
+        selected_breakdown_value: str | list[str] | int | None = None,
+    ) -> ast.SelectQuery:
+        return self.build_base_query_legacy(
+            start_interval_index_filter=start_interval_index_filter,
+            selected_breakdown_value=selected_breakdown_value,
+        )
+
+    # Original version of the fixed interval query.
+    def build_base_query_legacy(
         self,
         start_interval_index_filter: int | None = None,
         selected_breakdown_value: str | list[str] | int | None = None,

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -263,7 +263,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             {
                 "start_of_interval_sql": start_of_interval_sql,
                 "start_entity_expr": self.start_entity_expr,
-                "filter_timestamp": self.events_timestamp_filter,
+                "filter_timestamp": self.events_timestamp_filter(),
             },
         )
 
@@ -295,7 +295,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                     "start_of_interval_sql": start_of_interval_sql,
                     "property_aggregation_expr": self.property_aggregation_expr,
                     "start_entity_expr": self.start_entity_expr,
-                    "filter_timestamp": self.events_timestamp_filter,
+                    "filter_timestamp": self.events_timestamp_filter(),
                 },
             )
             return_event_data = self._get_return_event_timestamps_expr(
@@ -610,7 +610,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 {
                     "start_of_interval_timestamp": start_of_interval_sql,
                     "returning_entity_expr": return_entity_expr,
-                    "filter_timestamp": self.events_timestamp_filter,
+                    "filter_timestamp": self.events_timestamp_filter(),
                 },
             ),
         )
@@ -645,7 +645,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                     "start_of_interval_timestamp": start_of_interval_sql,
                     "property_aggregation_expr": self.property_aggregation_expr,
                     "returning_entity_expr": return_entity_expr,
-                    "filter_timestamp": self.events_timestamp_filter,
+                    "filter_timestamp": self.events_timestamp_filter(),
                 },
             )
 
@@ -676,7 +676,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             {
                 "start_of_interval_timestamp": start_of_interval_sql,
                 "returning_entity_expr": return_entity_expr,
-                "filter_timestamp": self.events_timestamp_filter,
+                "filter_timestamp": self.events_timestamp_filter(),
             },
         )
 

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -136,42 +136,16 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         base_query = ast.SelectQuery(
             select=[
-                ast.Alias(alias="actor_id", expr=ast.Field(chain=["retention_events", "actor_id"])),
+                ast.Alias(alias="actor_id", expr=ast.Field(chain=["actor_id"])),
                 ast.Alias(
                     alias="start_event_timestamps",
-                    expr=parse_expr(
-                        """
-                        arraySort(
-                            arrayDistinct(
-                                arrayFlatten(
-                                    groupArrayIf(
-                                        start_event_timestamps,
-                                        isNotNull(start_event_timestamps)
-                                    )
-                                )
-                            )
-                        )
-                        """
-                    ),
+                    expr=parse_expr("arrayFlatten(groupArray(start_event_timestamps))"),
                 ),
-                self._date_range_alias(),
                 ast.Alias(
                     alias="return_event_timestamps",
-                    expr=parse_expr(
-                        """
-                        arraySort(
-                            arrayDistinct(
-                                arrayFlatten(
-                                    groupArrayIf(
-                                        return_event_timestamps,
-                                        isNotNull(return_event_timestamps)
-                                    )
-                                )
-                            )
-                        )
-                        """
-                    ),
+                    expr=parse_expr("arrayFlatten(groupArray(return_event_timestamps))"),
                 ),
+                self._date_range_alias(),
                 ast.Alias(
                     alias="start_interval_index",
                     expr=parse_expr(
@@ -198,7 +172,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
             ],
             select_from=ast.JoinExpr(table=retention_events, alias="retention_events"),
-            group_by=[ast.Field(chain=["retention_events", "actor_id"])],
+            group_by=[ast.Field(chain=["actor_id"])],
             having=ast.And(
                 exprs=[
                     (

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -37,6 +37,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_interval_index_filter: int | None = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
+        event_filters = self._event_filters()
         start_entity_is_dwh = self.start_event.type == EntityType.DATA_WAREHOUSE
 
         start_actor_column_name = (
@@ -232,23 +233,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             source=ast.Field(chain=["events", "timestamp"])
         )
 
-        event_filters = self.global_event_filters.copy()
-        if (
-            self.query.breakdownFilter
-            and self.query.breakdownFilter.breakdowns
-            and len(self.query.breakdownFilter.breakdowns) == 1
-            and self.query.breakdownFilter.breakdowns[0].type == "cohort"
-        ):
-            cohort_id = self.query.breakdownFilter.breakdowns[0].property
-            # Don't add cohort filter for "all users" (cohort_id = 0)
-            if int(cohort_id) != ALL_USERS_COHORT_ID:
-                event_filters.append(
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.InCohort,
-                        left=ast.Field(chain=["person_id"]),
-                        right=ast.Constant(value=int(cohort_id)),
-                    )
-                )
+        event_filters = self._event_filters()
 
         start_event_timestamps = parse_expr(
             """
@@ -629,6 +614,27 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 },
             ),
         )
+
+    def _event_filters(self) -> list[ast.Expr]:
+        event_filters = self.global_event_filters.copy()
+        if (
+            self.query.breakdownFilter
+            and self.query.breakdownFilter.breakdowns
+            and len(self.query.breakdownFilter.breakdowns) == 1
+            and self.query.breakdownFilter.breakdowns[0].type == "cohort"
+        ):
+            cohort_id = self.query.breakdownFilter.breakdowns[0].property
+            # Don't add cohort filter for "all users" (cohort_id = 0)
+            if int(cohort_id) != ALL_USERS_COHORT_ID:
+                event_filters.append(
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.InCohort,
+                        left=ast.Field(chain=["person_id"]),
+                        right=ast.Constant(value=int(cohort_id)),
+                    )
+                )
+
+        return event_filters
 
     def _get_return_event_timestamps_expr(
         self, minimum_occurrences: int, start_of_interval_sql: ast.Expr, return_entity_expr: ast.Expr

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -73,6 +73,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
         start_table_name = self.start_event.table_name if start_entity_is_dwh else "events"
+        assert start_table_name
         start_where_expr = None if start_entity_is_dwh else ast.And(exprs=event_filters)
 
         start_event_query = ast.SelectQuery(
@@ -93,13 +94,16 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             if return_entity_is_dwh
             else self.aggregation_target_events_column
         )
+        assert return_actor_column_name
         return_actor_field = ast.Field(chain=[return_actor_column_name])
 
         return_timestamp_column_name = self.return_event.timestamp_field if return_entity_is_dwh else "timestamp"
+        assert return_timestamp_column_name
         return_timestamp_field = ast.Field(chain=[return_timestamp_column_name])
         return_start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=return_timestamp_field)
 
         return_table_name = self.return_event.table_name if return_entity_is_dwh else "events"
+        assert return_table_name
         return_where_expr = None if return_entity_is_dwh else ast.And(exprs=event_filters)
 
         return_entity_expr = (

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -151,7 +151,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                         """
                     ),
                 ),
-                date_range_expr,
+                self._date_range_alias(),
                 ast.Alias(
                     alias="return_event_timestamps",
                     expr=parse_expr(
@@ -487,25 +487,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             # when TARGET_FIRST_TIME, also adds filter for start (target) event performed for first time
             ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
             # get all intervals between date_from and date_to (represented by start of interval)
-            ast.Alias(
-                alias="date_range",
-                expr=parse_expr(
-                    """
-                        arrayMap(
-                            x -> {date_from_start_of_interval} + {to_interval_function},
-                            range(0, {intervals_between})
-                        )
-                    """,
-                    {
-                        "intervals_between": ast.Constant(value=self.query_date_range.intervals_between),
-                        "date_from_start_of_interval": self.query_date_range.date_from_to_start_of_interval_hogql(),
-                        "to_interval_function": ast.Call(
-                            name=f"toInterval{self.query_date_range.interval_name.capitalize()}",
-                            args=[ast.Field(chain=["x"])],
-                        ),
-                    },
-                ),
-            ),
+            self._date_range_alias(),
             *minimum_occurrences_aliases,
         ]
 
@@ -626,6 +608,27 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             ),
         )
         return [return_event_timestamps_with_dupes, return_event_counts_by_interval]
+
+    def _date_range_alias(self) -> ast.Alias:
+        return ast.Alias(
+            alias="date_range",
+            expr=parse_expr(
+                """
+                    arrayMap(
+                        x -> {date_from_start_of_interval} + {to_interval_function},
+                        range(0, {intervals_between})
+                    )
+                """,
+                {
+                    "intervals_between": ast.Constant(value=self.query_date_range.intervals_between),
+                    "date_from_start_of_interval": self.query_date_range.date_from_to_start_of_interval_hogql(),
+                    "to_interval_function": ast.Call(
+                        name=f"toInterval{self.query_date_range.interval_name.capitalize()}",
+                        args=[ast.Field(chain=["x"])],
+                    ),
+                },
+            ),
+        )
 
     def _get_return_event_timestamps_expr(
         self, minimum_occurrences: int, start_of_interval_sql: ast.Expr, return_entity_expr: ast.Expr

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -39,6 +39,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
     ) -> ast.SelectQuery:
         event_filters = self._event_filters()
         is_valid_start_interval = self._is_valid_start_interval_expr()
+        intervals_from_base_expr, _ = self._get_intervals_from_base_exprs()
         start_entity_is_dwh = self.start_event.type == EntityType.DATA_WAREHOUSE
 
         start_actor_column_name = (
@@ -321,150 +322,13 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             )
             # interval must be same as first interval of in which start event happened
             is_valid_start_interval = self._is_valid_start_interval_expr()
-            is_first_interval_after_start_event = parse_expr(
-                "start_event_timestamps[1] = date_range[start_interval_index + 1]"
-            )
         else:
             # start event must have happened in the interval
             is_valid_start_interval = self._is_valid_start_interval_expr()
-            is_first_interval_after_start_event = parse_expr(
-                "has(start_event_timestamps, date_range[start_interval_index + 1])"
-            )
-
-        intervals_from_base_array_aggregator = "arrayJoin"
-
-        intervals_from_base_expr: ast.Expr
-        retention_value_expr: ast.Expr | None = None
-
-        if self.property_aggregation_expr and return_event_values:
-            # return_event_values raw exprs are added as named SELECT aliases (_start_event_data, _return_event_data)
-            # in select_fields below. Here we only build the combined_data expression using field references.
-            start_event_data_ref = ast.Field(chain=["_start_event_data"])
-            return_event_data_ref = ast.Field(chain=["_return_event_data"])
-
-            # When start and return events are different event types, return events that occur
-            # strictly after the start event within interval 0 are counted for that interval.
-            # When they are the same event type, start_data already captures all occurrences in
-            # interval 0; allowing return_data to also contribute would double-count.
-            different_event_entities = (
-                self.start_event.id != self.return_event.id or self.start_event.type != self.return_event.type
-            )
-
-            if different_event_entities:
-                # Include return events in interval 0 (index 0 = same interval as cohort) only when
-                # they happen strictly after the earliest start event in that interval.
-                combined_data = parse_expr(
-                    """
-                    arrayConcat(
-                        arrayFilter(
-                            x -> x.1 >= 0,
-                            arrayMap(
-                                item -> (toInt(if(item.1 = date_range[start_interval_index + 1], 0, -1)), item.2),
-                                {start_data}
-                            )
-                        ),
-                        arrayFilter(
-                            x -> x.1 >= 0,
-                            arrayMap(
-                                item -> (
-                                    toInt(indexOf(
-                                        arraySlice(date_range, start_interval_index + 1, {lookahead_plus_one}),
-                                        item.1
-                                    ) - 1),
-                                    item.2
-                                ),
-                                arrayFilter(
-                                    x -> (
-                                        x.1 > date_range[start_interval_index + 1] OR (
-                                            x.1 = date_range[start_interval_index + 1] AND
-                                            x.3 > arrayMin(
-                                                arrayMap(
-                                                    y -> y.3,
-                                                    arrayFilter(
-                                                        z -> z.1 = date_range[start_interval_index + 1],
-                                                        {start_data}
-                                                    )
-                                                )
-                                            )
-                                        )
-                                    ),
-                                    {return_data}
-                                )
-                            )
-                        )
-                    )
-                    """,
-                    {
-                        "lookahead_plus_one": ast.Constant(value=self.query_date_range.lookahead + 1),
-                        "start_data": start_event_data_ref,
-                        "return_data": return_event_data_ref,
-                    },
-                )
-            else:
-                # Same event: return events only contribute to intervals > 0 (current behaviour).
-                combined_data = parse_expr(
-                    """
-                    arrayConcat(
-                        arrayFilter(
-                            x -> x.1 >= 0,
-                            arrayMap(
-                                item -> (toInt(if(item.1 = date_range[start_interval_index + 1], 0, -1)), item.2),
-                                {start_data}
-                            )
-                        ),
-                        arrayFilter(
-                            x -> x.1 > 0,
-                            arrayMap(
-                                item -> (
-                                    toInt(indexOf(
-                                        arraySlice(date_range, start_interval_index + 2, {lookahead}),
-                                        item.1
-                                    )),
-                                    item.2
-                                ),
-                                {return_data}
-                            )
-                        )
-                    )
-                    """,
-                    {
-                        "lookahead": ast.Constant(value=self.query_date_range.lookahead),
-                        "start_data": start_event_data_ref,
-                        "return_data": return_event_data_ref,
-                    },
-                )
-
-            intervals_from_base_expr = parse_expr("(arrayJoin({data})).1", {"data": combined_data})
-            retention_value_expr = parse_expr("(arrayJoin({data})).2", {"data": combined_data})
-
-        elif self.is_custom_bracket_retention:
-            bucket_logic = self._get_custom_bracket_intervals_from_base_expr()
-            intervals_from_base_expr = parse_expr(
-                f"""
-                {intervals_from_base_array_aggregator}(
-                    arrayDistinct(
-                        arrayConcat(
-                            if({{is_first_interval_after_start_event}}, [0], []),
-                            arrayFilter(
-                                x -> x >= 0,
-                                arrayMap(
-                                    _timestamp -> {{bucket_logic}},
-                                    return_event_timestamps
-                                )
-                            )
-                        )
-                    )
-                )
-                """,
-                {
-                    "is_first_interval_after_start_event": is_first_interval_after_start_event,
-                    "bucket_logic": bucket_logic,
-                },
-            )
-        else:
-            intervals_from_base_expr = self._get_default_intervals_from_base_expr(
-                is_first_interval_after_start_event, intervals_from_base_array_aggregator
-            )
+        retention_value_expr: ast.Expr | None
+        intervals_from_base_expr, retention_value_expr = self._get_intervals_from_base_exprs(
+            has_property_aggregation_aliases=bool(self.property_aggregation_expr and return_event_values)
+        )
 
         select_fields: list[ast.Expr] = [
             ast.Alias(alias="actor_id", expr=ast.Field(chain=["events", self.aggregation_target_events_column])),
@@ -641,6 +505,155 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return parse_expr("start_event_timestamps[1] = interval_date")
 
         return parse_expr("has(start_event_timestamps, interval_date)")
+
+    def _is_first_interval_after_start_event_expr(self) -> ast.Expr:
+        if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
+            return parse_expr("start_event_timestamps[1] = date_range[start_interval_index + 1]")
+
+        return parse_expr("has(start_event_timestamps, date_range[start_interval_index + 1])")
+
+    def _get_intervals_from_base_exprs(
+        self, has_property_aggregation_aliases: bool = False
+    ) -> tuple[ast.Expr, ast.Expr | None]:
+        is_first_interval_after_start_event = self._is_first_interval_after_start_event_expr()
+        intervals_from_base_array_aggregator = "arrayJoin"
+
+        if self.property_aggregation_expr and has_property_aggregation_aliases:
+            # _start_event_data and _return_event_data are added as aliases before intervals_from_base is selected.
+            start_event_data_ref = ast.Field(chain=["_start_event_data"])
+            return_event_data_ref = ast.Field(chain=["_return_event_data"])
+
+            # When start and return events are different event types, return events that occur
+            # strictly after the start event within interval 0 are counted for that interval.
+            # When they are the same event type, start_data already captures all occurrences in
+            # interval 0; allowing return_data to also contribute would double-count.
+            different_event_entities = (
+                self.start_event.id != self.return_event.id or self.start_event.type != self.return_event.type
+            )
+
+            if different_event_entities:
+                # Include return events in interval 0 (index 0 = same interval as cohort) only when
+                # they happen strictly after the earliest start event in that interval.
+                combined_data = parse_expr(
+                    """
+                    arrayConcat(
+                        arrayFilter(
+                            x -> x.1 >= 0,
+                            arrayMap(
+                                item -> (toInt(if(item.1 = date_range[start_interval_index + 1], 0, -1)), item.2),
+                                {start_data}
+                            )
+                        ),
+                        arrayFilter(
+                            x -> x.1 >= 0,
+                            arrayMap(
+                                item -> (
+                                    toInt(indexOf(
+                                        arraySlice(date_range, start_interval_index + 1, {lookahead_plus_one}),
+                                        item.1
+                                    ) - 1),
+                                    item.2
+                                ),
+                                arrayFilter(
+                                    x -> (
+                                        x.1 > date_range[start_interval_index + 1] OR (
+                                            x.1 = date_range[start_interval_index + 1] AND
+                                            x.3 > arrayMin(
+                                                arrayMap(
+                                                    y -> y.3,
+                                                    arrayFilter(
+                                                        z -> z.1 = date_range[start_interval_index + 1],
+                                                        {start_data}
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    ),
+                                    {return_data}
+                                )
+                            )
+                        )
+                    )
+                    """,
+                    {
+                        "lookahead_plus_one": ast.Constant(value=self.query_date_range.lookahead + 1),
+                        "start_data": start_event_data_ref,
+                        "return_data": return_event_data_ref,
+                    },
+                )
+            else:
+                # Same event: return events only contribute to intervals > 0 (current behaviour).
+                combined_data = parse_expr(
+                    """
+                    arrayConcat(
+                        arrayFilter(
+                            x -> x.1 >= 0,
+                            arrayMap(
+                                item -> (toInt(if(item.1 = date_range[start_interval_index + 1], 0, -1)), item.2),
+                                {start_data}
+                            )
+                        ),
+                        arrayFilter(
+                            x -> x.1 > 0,
+                            arrayMap(
+                                item -> (
+                                    toInt(indexOf(
+                                        arraySlice(date_range, start_interval_index + 2, {lookahead}),
+                                        item.1
+                                    )),
+                                    item.2
+                                ),
+                                {return_data}
+                            )
+                        )
+                    )
+                    """,
+                    {
+                        "lookahead": ast.Constant(value=self.query_date_range.lookahead),
+                        "start_data": start_event_data_ref,
+                        "return_data": return_event_data_ref,
+                    },
+                )
+
+            return (
+                parse_expr("(arrayJoin({data})).1", {"data": combined_data}),
+                parse_expr("(arrayJoin({data})).2", {"data": combined_data}),
+            )
+
+        if self.is_custom_bracket_retention:
+            bucket_logic = self._get_custom_bracket_intervals_from_base_expr()
+            return (
+                parse_expr(
+                    f"""
+                    {intervals_from_base_array_aggregator}(
+                        arrayDistinct(
+                            arrayConcat(
+                                if({{is_first_interval_after_start_event}}, [0], []),
+                                arrayFilter(
+                                    x -> x >= 0,
+                                    arrayMap(
+                                        _timestamp -> {{bucket_logic}},
+                                        return_event_timestamps
+                                    )
+                                )
+                            )
+                        )
+                    )
+                    """,
+                    {
+                        "is_first_interval_after_start_event": is_first_interval_after_start_event,
+                        "bucket_logic": bucket_logic,
+                    },
+                ),
+                None,
+            )
+
+        return (
+            self._get_default_intervals_from_base_expr(
+                is_first_interval_after_start_event, intervals_from_base_array_aggregator
+            ),
+            None,
+        )
 
     def _get_return_event_timestamps_expr(
         self, minimum_occurrences: int, start_of_interval_sql: ast.Expr, return_entity_expr: ast.Expr

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -1,4 +1,6 @@
-from posthog.schema import EntityType
+from typing import Literal
+
+from posthog.schema import EntityType, RetentionEntity
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
@@ -37,99 +39,18 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_interval_index_filter: int | None = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
-        event_filters = self._event_filters()
         is_valid_start_interval = self._is_valid_start_interval_expr()
         intervals_from_base_expr, _ = self._get_intervals_from_base_exprs()
-        start_entity_is_dwh = self.start_event.type == EntityType.DATA_WAREHOUSE
 
-        start_actor_column_name = (
-            self.start_event.aggregation_target_field if start_entity_is_dwh else self.aggregation_target_events_column
+        start_event_query = self._build_dwh_retention_event_query(
+            entity=self.start_event,
+            legacy_entity_expr=self.start_entity_expr,
+            query_kind="start",
         )
-        assert start_actor_column_name
-        start_actor_field = ast.Field(chain=[start_actor_column_name])
-
-        start_timestamp_column_name = self.start_event.timestamp_field if start_entity_is_dwh else "timestamp"
-        assert start_timestamp_column_name
-        start_timestamp_field = ast.Field(chain=[start_timestamp_column_name])
-
-        start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=start_timestamp_field)
-        start_entity_expr = (
-            property_to_expr(self.start_event.properties, self.team)
-            if start_entity_is_dwh and self.start_event.properties
-            else (ast.Constant(value=True) if start_entity_is_dwh else self.start_entity_expr)
-        )
-        start_event_timestamps = parse_expr(
-            """
-            arraySort(
-                groupUniqArrayIf(
-                    {start_of_interval_sql},
-                    {start_entity_expr} and
-                    {filter_timestamp}
-                )
-            )
-            """,
-            {
-                "start_of_interval_sql": start_of_interval_sql,
-                "start_entity_expr": start_entity_expr,
-                "filter_timestamp": self.events_timestamp_filter(field=start_timestamp_field),
-            },
-        )
-
-        start_table_name = self.start_event.table_name if start_entity_is_dwh else "events"
-        assert start_table_name
-        start_where_expr = None if start_entity_is_dwh else ast.And(exprs=event_filters)
-
-        start_event_query = ast.SelectQuery(
-            select=[
-                ast.Alias(alias="actor_id", expr=start_actor_field),
-                ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
-                ast.Alias(alias="return_event_timestamps", expr=ast.Array(exprs=[])),
-            ],
-            select_from=ast.JoinExpr(table=ast.Field(chain=[start_table_name])),
-            where=start_where_expr,
-            group_by=[ast.Field(chain=["actor_id"])],
-        )
-
-        return_entity_is_dwh = self.return_event.type == EntityType.DATA_WAREHOUSE
-
-        return_actor_column_name = (
-            self.return_event.aggregation_target_field
-            if return_entity_is_dwh
-            else self.aggregation_target_events_column
-        )
-        assert return_actor_column_name
-        return_actor_field = ast.Field(chain=[return_actor_column_name])
-
-        return_timestamp_column_name = self.return_event.timestamp_field if return_entity_is_dwh else "timestamp"
-        assert return_timestamp_column_name
-        return_timestamp_field = ast.Field(chain=[return_timestamp_column_name])
-        return_start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=return_timestamp_field)
-
-        return_table_name = self.return_event.table_name if return_entity_is_dwh else "events"
-        assert return_table_name
-        return_where_expr = None if return_entity_is_dwh else ast.And(exprs=event_filters)
-
-        return_entity_expr = (
-            property_to_expr(self.return_event.properties, self.team)
-            if return_entity_is_dwh and self.return_event.properties
-            else (ast.Constant(value=True) if return_entity_is_dwh else self.return_entity_expr)
-        )
-        return_event_timestamps = self._get_return_event_timestamps_expr(
-            minimum_occurrences=self.minimum_occurrences,
-            start_of_interval_sql=return_start_of_interval_sql,
-            return_entity_expr=return_entity_expr,
-            timestamp_field=return_timestamp_field,
-        )
-
-        return_event_query = ast.SelectQuery(
-            select=[
-                ast.Alias(alias="actor_id", expr=return_actor_field),
-                ast.Alias(alias="start_event_timestamps", expr=ast.Array(exprs=[])),
-                ast.Alias(alias="return_event_timestamps", expr=return_event_timestamps),
-            ],
-            select_from=ast.JoinExpr(table=ast.Field(chain=[return_table_name])),
-            where=return_where_expr,
-            group_by=[ast.Field(chain=["actor_id"])],
+        return_event_query = self._build_dwh_retention_event_query(
+            entity=self.return_event,
+            legacy_entity_expr=self.return_entity_expr,
+            query_kind="return",
         )
 
         retention_events = ast.SelectSetQuery.create_from_queries([start_event_query, return_event_query], "UNION ALL")
@@ -198,6 +119,80 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
         return base_query
+
+    def _build_dwh_retention_event_query(
+        self,
+        entity: RetentionEntity,
+        legacy_entity_expr: ast.Expr,
+        query_kind: Literal["start", "return"],
+    ) -> ast.SelectQuery:
+        entity_is_dwh = entity.type == EntityType.DATA_WAREHOUSE
+
+        actor_column_name = entity.aggregation_target_field if entity_is_dwh else self.aggregation_target_events_column
+        assert actor_column_name
+        actor_field = ast.Field(chain=[actor_column_name])
+
+        timestamp_column_name = entity.timestamp_field if entity_is_dwh else "timestamp"
+        assert timestamp_column_name
+        timestamp_field = ast.Field(chain=[timestamp_column_name])
+
+        start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=timestamp_field)
+        entity_expr = self._get_dwh_retention_entity_expr(entity=entity, legacy_entity_expr=legacy_entity_expr)
+
+        if query_kind == "start":
+            timestamps_expr = parse_expr(
+                """
+                arraySort(
+                    groupUniqArrayIf(
+                        {start_of_interval_sql},
+                        {entity_expr} and
+                        {filter_timestamp}
+                    )
+                )
+                """,
+                {
+                    "start_of_interval_sql": start_of_interval_sql,
+                    "entity_expr": entity_expr,
+                    "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
+                },
+            )
+        else:
+            timestamps_expr = self._get_return_event_timestamps_expr(
+                minimum_occurrences=self.minimum_occurrences,
+                start_of_interval_sql=start_of_interval_sql,
+                return_entity_expr=entity_expr,
+                timestamp_field=timestamp_field,
+            )
+
+        table_name = entity.table_name if entity_is_dwh else "events"
+        assert table_name
+        where_expr = None if entity_is_dwh else ast.And(exprs=self._event_filters())
+
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(alias="actor_id", expr=actor_field),
+                ast.Alias(
+                    alias="start_event_timestamps",
+                    expr=timestamps_expr if query_kind == "start" else ast.Array(exprs=[]),
+                ),
+                ast.Alias(
+                    alias="return_event_timestamps",
+                    expr=ast.Array(exprs=[]) if query_kind == "start" else timestamps_expr,
+                ),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=[table_name])),
+            where=where_expr,
+            group_by=[ast.Field(chain=["actor_id"])],
+        )
+
+    def _get_dwh_retention_entity_expr(self, entity: RetentionEntity, legacy_entity_expr: ast.Expr) -> ast.Expr:
+        if entity.type != EntityType.DATA_WAREHOUSE:
+            return legacy_entity_expr
+
+        if entity.properties:
+            return property_to_expr(entity.properties, self.team)
+
+        return ast.Constant(value=True)
 
     # Original version of the fixed interval query.
     def build_base_query_legacy(

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -2,6 +2,7 @@ from posthog.schema import EntityType
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
+from posthog.hogql.property import property_to_expr
 
 from posthog.hogql_queries.insights.retention.retention_base_query_builder import RetentionBaseQueryBuilder
 from posthog.queries.breakdown_props import ALL_USERS_COHORT_ID
@@ -36,10 +37,186 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_interval_index_filter: int | None = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
-        return self.build_base_query_legacy(
-            start_interval_index_filter=start_interval_index_filter,
-            selected_breakdown_value=selected_breakdown_value,
+        start_entity_is_dwh = self.start_event.type == EntityType.DATA_WAREHOUSE
+
+        start_actor_column_name = (
+            self.start_event.aggregation_target_field if start_entity_is_dwh else self.aggregation_target_events_column
         )
+        assert start_actor_column_name
+        start_actor_field = ast.Field(chain=[start_actor_column_name])
+
+        start_timestamp_column_name = self.start_event.timestamp_field if start_entity_is_dwh else "timestamp"
+        assert start_timestamp_column_name
+        start_timestamp_field = ast.Field(chain=[start_timestamp_column_name])
+
+        start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=start_timestamp_field)
+        start_entity_expr = (
+            property_to_expr(self.start_event.properties, self.team)
+            if start_entity_is_dwh and self.start_event.properties
+            else (ast.Constant(value=True) if start_entity_is_dwh else self.start_entity_expr)
+        )
+        start_event_timestamps = parse_expr(
+            """
+            arraySort(
+                groupUniqArrayIf(
+                    {start_of_interval_sql},
+                    {start_entity_expr} and
+                    {filter_timestamp}
+                )
+            )
+            """,
+            {
+                "start_of_interval_sql": start_of_interval_sql,
+                "start_entity_expr": start_entity_expr,
+                "filter_timestamp": self.events_timestamp_filter(field=start_timestamp_field),
+            },
+        )
+
+        start_table_name = self.start_event.table_name if start_entity_is_dwh else "events"
+        start_where_expr = None if start_entity_is_dwh else ast.And(exprs=event_filters)
+
+        start_event_query = ast.SelectQuery(
+            select=[
+                ast.Alias(alias="actor_id", expr=start_actor_field),
+                ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
+                ast.Alias(alias="return_event_timestamps", expr=ast.Array(exprs=[])),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=[start_table_name])),
+            where=start_where_expr,
+            group_by=[ast.Field(chain=["actor_id"])],
+        )
+
+        return_entity_is_dwh = self.return_event.type == EntityType.DATA_WAREHOUSE
+
+        return_actor_column_name = (
+            self.return_event.aggregation_target_field
+            if return_entity_is_dwh
+            else self.aggregation_target_events_column
+        )
+        return_actor_field = ast.Field(chain=[return_actor_column_name])
+
+        return_timestamp_column_name = self.return_event.timestamp_field if return_entity_is_dwh else "timestamp"
+        return_timestamp_field = ast.Field(chain=[return_timestamp_column_name])
+        return_start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=return_timestamp_field)
+
+        return_table_name = self.return_event.table_name if return_entity_is_dwh else "events"
+        return_where_expr = None if return_entity_is_dwh else ast.And(exprs=event_filters)
+
+        return_entity_expr = (
+            property_to_expr(self.return_event.properties, self.team)
+            if return_entity_is_dwh and self.return_event.properties
+            else (ast.Constant(value=True) if return_entity_is_dwh else self.return_entity_expr)
+        )
+        return_event_timestamps = self._get_return_event_timestamps_expr(
+            minimum_occurrences=minimum_occurrences,
+            start_of_interval_sql=return_start_of_interval_sql,
+            return_entity_expr=return_entity_expr,
+            timestamp_field=return_timestamp_field,
+        )
+
+        return_event_query = ast.SelectQuery(
+            select=[
+                ast.Alias(alias="actor_id", expr=return_actor_field),
+                ast.Alias(alias="start_event_timestamps", expr=ast.Array(exprs=[])),
+                ast.Alias(alias="return_event_timestamps", expr=return_event_timestamps),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=[return_table_name])),
+            where=return_where_expr,
+            group_by=[ast.Field(chain=["actor_id"])],
+        )
+
+        retention_events = ast.SelectSetQuery.create_from_queries([start_event_query, return_event_query], "UNION ALL")
+
+        base_query = ast.SelectQuery(
+            select=[
+                ast.Alias(alias="actor_id", expr=ast.Field(chain=["retention_events", "actor_id"])),
+                ast.Alias(
+                    alias="start_event_timestamps",
+                    expr=parse_expr(
+                        """
+                        arraySort(
+                            arrayDistinct(
+                                arrayFlatten(
+                                    groupArrayIf(
+                                        start_event_timestamps,
+                                        isNotNull(start_event_timestamps)
+                                    )
+                                )
+                            )
+                        )
+                        """
+                    ),
+                ),
+                date_range_expr,
+                ast.Alias(
+                    alias="return_event_timestamps",
+                    expr=parse_expr(
+                        """
+                        arraySort(
+                            arrayDistinct(
+                                arrayFlatten(
+                                    groupArrayIf(
+                                        return_event_timestamps,
+                                        isNotNull(return_event_timestamps)
+                                    )
+                                )
+                            )
+                        )
+                        """
+                    ),
+                ),
+                ast.Alias(
+                    alias="start_interval_index",
+                    expr=parse_expr(
+                        """
+                        arrayJoin(
+                            arrayFilter(
+                                x -> x > -1,
+                                arrayMap(
+                                (interval_index, interval_date) ->
+                                    if(
+                                        {is_valid_start_interval},
+                                        interval_index - 1,
+                                        -1
+                                    ),
+                                    arrayEnumerate(date_range),
+                                    date_range
+                                )
+                            )
+                        )
+                    """,
+                        {"is_valid_start_interval": is_valid_start_interval},
+                    ),
+                ),
+                ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
+            ],
+            select_from=ast.JoinExpr(table=retention_events, alias="retention_events"),
+            group_by=[ast.Field(chain=["retention_events", "actor_id"])],
+            having=ast.And(
+                exprs=[
+                    (
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=["start_interval_index"]),
+                            right=ast.Constant(value=start_interval_index_filter),
+                        )
+                        if start_interval_index_filter is not None
+                        else ast.Constant(value=1)
+                    ),
+                    (
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=["breakdown_value"]),
+                            right=ast.Constant(value=selected_breakdown_value),
+                        )
+                        if selected_breakdown_value is not None
+                        else ast.Constant(value=1)
+                    ),
+                ]
+            ),
+        )
+
+        return base_query
 
     # Original version of the fixed interval query.
     def build_base_query_legacy(

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -113,7 +113,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             else (ast.Constant(value=True) if return_entity_is_dwh else self.return_entity_expr)
         )
         return_event_timestamps = self._get_return_event_timestamps_expr(
-            minimum_occurrences=minimum_occurrences,
+            minimum_occurrences=self.minimum_occurrences,
             start_of_interval_sql=return_start_of_interval_sql,
             return_entity_expr=return_entity_expr,
             timestamp_field=return_timestamp_field,
@@ -252,9 +252,8 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             },
         )
 
-        minimum_occurrences = self.query.retentionFilter.minimumOccurrences or 1
         minimum_occurrences_aliases = self._get_minimum_occurrences_aliases(
-            minimum_occurrences=minimum_occurrences,
+            minimum_occurrences=self.minimum_occurrences,
             start_of_interval_sql=start_of_interval_sql,
             return_entity_expr=self.return_entity_expr,
         )
@@ -284,7 +283,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 },
             )
             return_event_data = self._get_return_event_timestamps_expr(
-                minimum_occurrences=minimum_occurrences,
+                minimum_occurrences=self.minimum_occurrences,
                 start_of_interval_sql=start_of_interval_sql,
                 return_entity_expr=self.return_entity_expr,
             )
@@ -293,7 +292,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return_event_values = (start_event_data, return_event_data)
         else:
             return_event_timestamps = self._get_return_event_timestamps_expr(
-                minimum_occurrences=minimum_occurrences,
+                minimum_occurrences=self.minimum_occurrences,
                 start_of_interval_sql=start_of_interval_sql,
                 return_entity_expr=self.return_entity_expr,
             )

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -656,7 +656,11 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
     def _get_return_event_timestamps_expr(
-        self, minimum_occurrences: int, start_of_interval_sql: ast.Expr, return_entity_expr: ast.Expr
+        self,
+        minimum_occurrences: int,
+        start_of_interval_sql: ast.Expr,
+        return_entity_expr: ast.Expr,
+        timestamp_field: ast.Expr | None = None,
     ) -> ast.Expr:
         if self.property_aggregation_expr:
             # Collect 3-tuples of (interval_start, value, actual_timestamp) for return events.
@@ -704,7 +708,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             {
                 "start_of_interval_timestamp": start_of_interval_sql,
                 "returning_entity_expr": return_entity_expr,
-                "filter_timestamp": self.events_timestamp_filter(),
+                "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
             },
         )
 

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -271,12 +271,11 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
     def breakdowns_in_query(self) -> bool:
         return has_breakdown_filter(self.query.breakdownFilter)
 
-    @cached_property
-    def events_timestamp_filter(self) -> ast.Expr:
+    def events_timestamp_filter(self, field: ast.Expr | None = None) -> ast.Expr:
         """
         Timestamp filter between date_from and date_to
         """
-        field_to_compare = ast.Field(chain=["events", "timestamp"])
+        field_to_compare = field or ast.Field(chain=["events", "timestamp"])
         return ast.And(
             exprs=[
                 ast.CompareOperation(
@@ -343,7 +342,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
         if not is_first_occurrence_matching_filters and not is_first_ever_occurrence:
             # when it's recurring, we only have to grab events for the period, rather than events for all time
-            events_where.append(self.events_timestamp_filter)
+            events_where.append(self.events_timestamp_filter())
 
         # Pre-filter by event name
         events = self.get_events_for_entity(self.start_event) + self.get_events_for_entity(self.return_event)

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -1,0 +1,135 @@
+# serializer version: 1
+# name: TestRetentionDataWarehouse.test_retention_data_warehouse_and_events
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.start_event_timestamps, isNotNull(retention_events.start_event_timestamps))))) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.return_event_timestamps, isNotNull(retention_events.return_event_timestamps))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM
+       (SELECT posthog_test_warehouse_event_mix_signups.person_id AS actor_id,
+               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_event_mix_signups.signed_up_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_event_mix_signups.signed_up_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_event_mix_signups.signed_up_at, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_event_mix_signups/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `signed_up_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_event_mix_signups
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'paid'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid', 'posthog_test_warehouse_event_mix_signups')), or(equals(events.event, 'posthog_test_warehouse_event_mix_signups'), equals(events.event, 'paid')))
+        GROUP BY actor_id) AS retention_events
+     GROUP BY retention_events.actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS format_csv_allow_double_quotes=1,
+                        readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetentionDataWarehouse.test_retention_data_warehouse_different_tables
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.start_event_timestamps, isNotNull(retention_events.start_event_timestamps))))) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.return_event_timestamps, isNotNull(retention_events.return_event_timestamps))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM
+       (SELECT posthog_test_warehouse_signups.person_id AS actor_id,
+               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_signups.signed_up_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_signups.signed_up_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_signups.signed_up_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_signups/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `signed_up_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_signups
+        GROUP BY actor_id
+        UNION ALL SELECT posthog_test_warehouse_renewals.person_id AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))) AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_renewals/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `renewed_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_renewals
+        GROUP BY actor_id) AS retention_events
+     GROUP BY retention_events.actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS format_csv_allow_double_quotes=1,
+                        readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetentionDataWarehouse.test_retention_data_warehouse_same_table
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.start_event_timestamps, isNotNull(retention_events.start_event_timestamps))))) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.return_event_timestamps, isNotNull(retention_events.return_event_timestamps))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM
+       (SELECT posthog_test_warehouse_activity.person_id AS actor_id,
+               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity.activity_type, 'signed_up'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity
+        GROUP BY actor_id
+        UNION ALL SELECT posthog_test_warehouse_activity.person_id AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity.activity_type, 'renewed'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity
+        GROUP BY actor_id) AS retention_events
+     GROUP BY retention_events.actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS format_csv_allow_double_quotes=1,
+                        readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -6,9 +6,9 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT retention_events.actor_id AS actor_id,
-            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.start_event_timestamps, isNotNull(retention_events.start_event_timestamps))))) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
-            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.return_event_timestamps, isNotNull(retention_events.return_event_timestamps))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM
@@ -30,7 +30,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid', 'posthog_test_warehouse_event_mix_signups')), or(equals(events.event, 'posthog_test_warehouse_event_mix_signups'), equals(events.event, 'paid')))
         GROUP BY actor_id) AS retention_events
-     GROUP BY retention_events.actor_id
+     GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
            intervals_from_base
@@ -56,9 +56,9 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT retention_events.actor_id AS actor_id,
-            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.start_event_timestamps, isNotNull(retention_events.start_event_timestamps))))) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
-            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.return_event_timestamps, isNotNull(retention_events.return_event_timestamps))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM
@@ -72,7 +72,7 @@
                          arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_renewals.renewed_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC'))))) AS return_event_timestamps
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_renewals/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `renewed_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_renewals
         GROUP BY actor_id) AS retention_events
-     GROUP BY retention_events.actor_id
+     GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
            intervals_from_base
@@ -98,9 +98,9 @@
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
     (SELECT retention_events.actor_id AS actor_id,
-            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.start_event_timestamps, isNotNull(retention_events.start_event_timestamps))))) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
-            arraySort(arrayDistinct(arrayFlatten(groupArrayIf(retention_events.return_event_timestamps, isNotNull(retention_events.return_event_timestamps))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 4), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
      FROM
@@ -114,7 +114,7 @@
                          arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC')), and(equals(posthog_test_warehouse_activity.activity_type, 'renewed'), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_activity.occurred_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))))) AS return_event_timestamps
         FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_activity/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\'), `activity_type` String') AS posthog_test_warehouse_activity
         GROUP BY actor_id) AS retention_events
-     GROUP BY retention_events.actor_id
+     GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
            intervals_from_base

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -1,0 +1,306 @@
+import csv
+import tempfile
+from pathlib import Path
+
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+    flush_persons_and_events,
+    snapshot_clickhouse_queries,
+)
+
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+from posthog.hogql_queries.insights.retention.test.utils import pad, pluck
+
+from products.data_warehouse.backend.test.utils import create_data_warehouse_table_from_csv
+
+TEST_BUCKET = "test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse"
+
+
+class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.cleanup_fns = []
+        self.temp_dirs = []
+
+    def tearDown(self):
+        for cleanup in self.cleanup_fns:
+            cleanup()
+
+        for temp_dir in self.temp_dirs:
+            temp_dir.cleanup()
+
+        super().tearDown()
+
+    def _write_csv(self, filename: str, header: list[str], rows: list[list[object]]) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dirs.append(temp_dir)
+        path = Path(temp_dir.name) / filename
+
+        with open(path, "w", newline="") as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerow(header)
+            writer.writerows(rows)
+
+        return path
+
+    def _create_people(self) -> dict[str, str]:
+        person_ids = {
+            "user-1": "00000000-0000-0000-0000-000000000001",
+            "user-2": "00000000-0000-0000-0000-000000000002",
+            "user-3": "00000000-0000-0000-0000-000000000003",
+            "user-4": "00000000-0000-0000-0000-000000000004",
+        }
+
+        for distinct_id, person_id in person_ids.items():
+            _create_person(team=self.team, distinct_ids=[distinct_id], uuid=person_id)
+
+        flush_persons_and_events()
+        return person_ids
+
+    def _create_data_warehouse_table(
+        self,
+        *,
+        filename: str,
+        table_name: str,
+        header: list[str],
+        rows: list[list[object]],
+        table_columns: dict[str, str],
+    ) -> str:
+        csv_path = self._write_csv(filename, header, rows)
+        table, _source, _credential, _df, cleanup = create_data_warehouse_table_from_csv(
+            csv_path=csv_path,
+            table_name=table_name,
+            table_columns=table_columns,
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+        )
+        self.cleanup_fns.append(cleanup)
+        return table.name
+
+    def run_query(self, query: dict) -> list[dict]:
+        runner = RetentionQueryRunner(team=self.team, query=query)
+        return runner.calculate().model_dump()["results"]
+
+    @snapshot_clickhouse_queries
+    def test_retention_data_warehouse_same_table(self):
+        person_ids = self._create_people()
+        activity_table_name = self._create_data_warehouse_table(
+            filename="warehouse_activity.csv",
+            table_name="warehouse_activity",
+            header=["id", "person_id", "activity_type", "occurred_at"],
+            rows=[
+                [1, person_ids["user-1"], "signed_up", "2025-01-01 09:00:00"],
+                [2, person_ids["user-2"], "signed_up", "2025-01-01 10:00:00"],
+                [3, person_ids["user-3"], "signed_up", "2025-01-02 09:00:00"],
+                [4, person_ids["user-4"], "signed_up", "2025-01-02 10:00:00"],
+                [5, person_ids["user-1"], "renewed", "2025-01-02 12:00:00"],
+                [6, person_ids["user-2"], "renewed", "2025-01-03 12:00:00"],
+                [7, person_ids["user-3"], "renewed", "2025-01-03 13:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "activity_type": "String",
+                "occurred_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        result = self.run_query(
+            query={
+                "dateRange": {
+                    "date_from": "2025-01-01T00:00:00Z",
+                    "date_to": "2025-01-05T00:00:00Z",
+                },
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "targetEntity": {
+                        "id": activity_table_name,
+                        "name": activity_table_name,
+                        "type": "data_warehouse",
+                        "table_name": activity_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "occurred_at",
+                        "properties": [
+                            {
+                                "key": "activity_type",
+                                "value": "signed_up",
+                                "operator": "exact",
+                                "type": "data_warehouse",
+                            }
+                        ],
+                    },
+                    "returningEntity": {
+                        "id": activity_table_name,
+                        "name": activity_table_name,
+                        "type": "data_warehouse",
+                        "table_name": activity_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "occurred_at",
+                        "properties": [
+                            {"key": "activity_type", "value": "renewed", "operator": "exact", "type": "data_warehouse"}
+                        ],
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad(
+                [
+                    [2, 1, 1, 0],
+                    [2, 1, 0],
+                    [0, 0],
+                    [0],
+                    [0],
+                ]
+            ),
+        )
+
+    @snapshot_clickhouse_queries
+    def test_retention_data_warehouse_different_tables(self):
+        person_ids = self._create_people()
+        signups_table_name = self._create_data_warehouse_table(
+            filename="warehouse_signups.csv",
+            table_name="warehouse_signups",
+            header=["id", "person_id", "signed_up_at"],
+            rows=[
+                [1, person_ids["user-1"], "2025-01-01 09:00:00"],
+                [2, person_ids["user-2"], "2025-01-01 10:00:00"],
+                [3, person_ids["user-3"], "2025-01-02 09:00:00"],
+                [4, person_ids["user-4"], "2025-01-02 10:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "signed_up_at": "DateTime64(3, 'UTC')",
+            },
+        )
+        renewals_table_name = self._create_data_warehouse_table(
+            filename="warehouse_renewals.csv",
+            table_name="warehouse_renewals",
+            header=["id", "person_id", "renewed_at"],
+            rows=[
+                [1, person_ids["user-1"], "2025-01-02 12:00:00"],
+                [2, person_ids["user-2"], "2025-01-03 12:00:00"],
+                [3, person_ids["user-3"], "2025-01-03 13:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "renewed_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        result = self.run_query(
+            query={
+                "dateRange": {
+                    "date_from": "2025-01-01T00:00:00Z",
+                    "date_to": "2025-01-05T00:00:00Z",
+                },
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "targetEntity": {
+                        "id": signups_table_name,
+                        "name": signups_table_name,
+                        "type": "data_warehouse",
+                        "table_name": signups_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "signed_up_at",
+                    },
+                    "returningEntity": {
+                        "id": renewals_table_name,
+                        "name": renewals_table_name,
+                        "type": "data_warehouse",
+                        "table_name": renewals_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "renewed_at",
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad(
+                [
+                    [2, 1, 1, 0],
+                    [2, 1, 0],
+                    [0, 0],
+                    [0],
+                    [0],
+                ]
+            ),
+        )
+
+    @snapshot_clickhouse_queries
+    def test_retention_data_warehouse_and_events(self):
+        person_ids = self._create_people()
+        signups_table_name = self._create_data_warehouse_table(
+            filename="warehouse_event_mix_signups.csv",
+            table_name="warehouse_event_mix_signups",
+            header=["id", "person_id", "signed_up_at"],
+            rows=[
+                [1, person_ids["user-1"], "2025-01-01 09:00:00"],
+                [2, person_ids["user-2"], "2025-01-01 10:00:00"],
+                [3, person_ids["user-3"], "2025-01-02 09:00:00"],
+                [4, person_ids["user-4"], "2025-01-02 10:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "signed_up_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        for distinct_id, timestamp in [
+            ("user-1", "2025-01-02T12:00:00Z"),
+            ("user-2", "2025-01-03T12:00:00Z"),
+            ("user-3", "2025-01-03T13:00:00Z"),
+        ]:
+            _create_event(team=self.team, event="paid", distinct_id=distinct_id, timestamp=timestamp)
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {
+                    "date_from": "2025-01-01T00:00:00Z",
+                    "date_to": "2025-01-05T00:00:00Z",
+                },
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "targetEntity": {
+                        "id": signups_table_name,
+                        "name": signups_table_name,
+                        "type": "data_warehouse",
+                        "table_name": signups_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "signed_up_at",
+                    },
+                    "returningEntity": {
+                        "id": "paid",
+                        "name": "paid",
+                        "type": "events",
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad(
+                [
+                    [2, 1, 1, 0],
+                    [2, 1, 0],
+                    [0, 0],
+                    [0],
+                    [0],
+                ]
+            ),
+        )

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -35,6 +35,7 @@ from posthog.constants import (
 )
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+from posthog.hogql_queries.insights.retention.test.utils import pad, pluck
 from posthog.hogql_queries.insights.trends.breakdown import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.models import Action, Cohort
 from posthog.models.group.util import create_group
@@ -58,27 +59,6 @@ def _create_signup_actions(team, user_and_timestamps):
 
 def _date(day, hour=5, month=0, minute=0):
     return datetime(2020, 6 + month, 10 + day, hour, minute).isoformat()
-
-
-def pluck(list_of_dicts, key, child_key=None):
-    return [pluck(d[key], child_key) if child_key else d[key] for d in list_of_dicts]
-
-
-def pad(retention_result: list[list[int]]) -> list[list[int]]:
-    """
-    changes the old 'triangle' format to the new 'matrix' format
-    after retention updates
-    """
-    result = []
-    max_length = max(len(row) for row in retention_result)
-
-    for row in retention_result:
-        if len(row) < max_length:
-            row.extend([0] * (max_length - len(row)))
-
-        result.append(row)
-
-    return result
 
 
 def _create_events(team, user_and_timestamps, event="$pageview"):

--- a/posthog/hogql_queries/insights/retention/test/utils.py
+++ b/posthog/hogql_queries/insights/retention/test/utils.py
@@ -1,0 +1,19 @@
+def pluck(list_of_dicts, key, child_key=None):
+    return [pluck(d[key], child_key) if child_key else d[key] for d in list_of_dicts]
+
+
+def pad(retention_result: list[list[int]]) -> list[list[int]]:
+    """
+    changes the old 'triangle' format to the new 'matrix' format
+    after retention updates
+    """
+    result = []
+    max_length = max(len(row) for row in retention_result)
+
+    for row in retention_result:
+        if len(row) < max_length:
+            row.extend([0] * (max_length - len(row)))
+
+        result.append(row)
+
+    return result


### PR DESCRIPTION
## Problem

This PR starts work towards supporting data warehouse sources for retention insights. It's possible to change the starting event, returning event or both to data warehouse. Only fixed interval retention and no breakdown or property aggregation support for now.

## Changes

The retention base events query looks something like this:
```sql
SELECT 
    -- actor
    person_id as actor_id,
    -- all unique days where the actor did the start event
    arraySort(groupUniqArrayIf(toStartOfDay(timestamp), matches_start_entity)) as start_event_days,
    -- all unique days where the actor did the return event
    arraySort(groupUniqArrayIf(toStartOfDay(timestamp), matches_return_entity)) as return_event_days,

    -- all days in the date range
    arrayMap(x -> date_from + x days, range(0, 11)) AS date_range,
    -- indices of days where actor had a start event
    arrayJoin(fn(start_event_timestamps, date_range)) AS start_interval_index,
    -- retention offsets from each start day (0 = same day, 1 = next day, ...)
    arrayJoin(fn(start_event_timestamps, return_event_timestamps, date_range, start_interval_index)) AS intervals_from_base
FROM events
WHERE ...
GROUP BY actor_id
```

The last three columns do not depend on the `GROUP BY` and can be moved into a wrapping `SELECT`. This enables us to compute the start_event_days (start entity) and return_event_days (return entity) independently in a `UNION`:

```sql
SELECT
    actor_id,
    -- combine populated and placeholder arrays
    arrayFlatten(groupArray(start_event_timestamps)) as start_event_timestamps,
    arrayFlatten(groupArray(return_event_timestamps)) as start_event_timestamps,

    ... as date_range,
    arrayJoin(fn(start_event_timestamps, date_range)) AS start_interval_index
    arrayJoin(fn(start_event_timestamps, return_event_timestamps, date_range, start_interval_index)) AS intervals_from_base
FROM (
    SELECT
        start_actor_field as actor_id,
        arraySort(groupUniqArrayIf(toStartOfDay(start_timestamp_field), matches_start_entity)) as start_event_timestamps,
        [] as return_event_days
    FROM start_table
    WHERE ...
    GROUP BY actor_id

    UNION ALL

    SELECT
        return_actor_field as actor_id,
        [] as start_event_days,
        arraySort(groupUniqArrayIf(toStartOfDay(return_timestamp_field), matches_return_entity)) as return_event_timestamps
    FROM return_table
    WHERE ...
    GROUP BY actor_id
) AS retention_events
GROUP BY actor_id
```

At the moment we use this structure only for the data warehouse branch. There's nothing that'd prevent us from using it for events based queries, and in theory there shouldn't be any noticeable performance impact. Definitely something to test on real world queries though.

## How did you test this code?

Added test cases