### PR TITLE
fix(subscriptions): log unhandled exceptions in snapshot activity

### DIFF
--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -251,6 +251,22 @@ def _load_insight_images(exported_asset_ids: list[int], team_id: int) -> dict[in
 
 @temporalio.activity.defn
 async def snapshot_subscription_insights(inputs: SnapshotInsightsInputs) -> SnapshotInsightsResult:
+    try:
+        return await _run_snapshot_subscription_insights(inputs)
+    except Exception:
+        # Temporal's workflow-level logger swallows activity failures on pods
+        # where `configure_logger` raised at startup (e.g. Kafka log producer
+        # init failure). Emit the traceback via structlog so operators can see
+        # why the activity died instead of finding a bare `starting` log.
+        await LOGGER.aexception(
+            "snapshot_subscription_insights.failed",
+            subscription_id=inputs.subscription_id,
+            delivery_id=inputs.delivery_id,
+        )
+        raise
+
+
+async def _run_snapshot_subscription_insights(inputs: SnapshotInsightsInputs) -> SnapshotInsightsResult:
     await LOGGER.ainfo(
         "snapshot_subscription_insights.starting",
         subscription_id=inputs.subscription_id,

--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -254,10 +254,9 @@ async def snapshot_subscription_insights(inputs: SnapshotInsightsInputs) -> Snap
     try:
         return await _run_snapshot_subscription_insights(inputs)
     except Exception:
-        # Temporal's workflow-level logger swallows activity failures on pods
-        # where `configure_logger` raised at startup (e.g. Kafka log producer
-        # init failure). Emit the traceback via structlog so operators can see
-        # why the activity died instead of finding a bare `starting` log.
+        # The metric survives Kafka log producer init failure in `configure_logger`;
+        # the log emission may not, so both are deliberate.
+        SUBSCRIPTION_SUMMARY_FAILURE.labels(reason="activity_error").inc()
         await LOGGER.aexception(
             "snapshot_subscription_insights.failed",
             subscription_id=inputs.subscription_id,

--- a/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+import structlog
 from asgiref.sync import sync_to_async
 from temporalio.testing import ActivityEnvironment
 
@@ -140,11 +141,18 @@ async def test_unhandled_exception_is_logged_and_reraised(team, user, monkeypatc
         boom,
     )
 
-    with pytest.raises(RuntimeError, match="boom while building states"):
-        await _run(
-            SnapshotInsightsInputs(
-                subscription_id=subscription.id,
-                team_id=subscription.team_id,
-                delivery_id=str(delivery.id),
+    with structlog.testing.capture_logs() as captured_logs:
+        with pytest.raises(RuntimeError, match="boom while building states"):
+            await _run(
+                SnapshotInsightsInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    delivery_id=str(delivery.id),
+                )
             )
-        )
+
+    failed_events = [log for log in captured_logs if log.get("event") == "snapshot_subscription_insights.failed"]
+    assert len(failed_events) == 1, f"expected one .failed log, got {failed_events}"
+    assert failed_events[0]["subscription_id"] == subscription.id
+    assert failed_events[0]["delivery_id"] == str(delivery.id)
+    assert failed_events[0]["log_level"] == "error"

--- a/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -122,3 +122,29 @@ async def test_skips_summary_when_summary_not_enabled(team, user):
     )
 
     assert result.summary_text is None
+
+
+async def test_unhandled_exception_is_logged_and_reraised(team, user, monkeypatch):
+    subscription = await _create_subscription(team, user)
+    await _set_ai_consent(subscription, approved=True)
+    delivery = await _create_delivery(
+        subscription,
+        {"insights": [{"id": subscription.insight_id, "name": "Pageviews", "query_results": {"result": []}}]},
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom while building states")
+
+    monkeypatch.setattr(
+        "posthog.temporal.subscriptions.snapshot_activities._build_states_from_content_snapshot",
+        boom,
+    )
+
+    with pytest.raises(RuntimeError, match="boom while building states"):
+        await _run(
+            SnapshotInsightsInputs(
+                subscription_id=subscription.id,
+                team_id=subscription.team_id,
+                delivery_id=str(delivery.id),
+            )
+        )


### PR DESCRIPTION
## Summary

- Wrap the `snapshot_subscription_insights` activity body in a top-level try/except that emits `snapshot_subscription_insights.failed` via structlog with `subscription_id`, `delivery_id`, and the full traceback before re-raising.

## Why

On pods where `configure_logger` crashes at startup (observed today: `RuntimeError: no running event loop` in `posthog/temporal/common/logger.py:536`, triggered during Kafka log producer init), the workflow-level `temporalio.workflow.logger.warning` calls don't land in our log aggregator. When the activity then throws, the workflow's `except Exception` swallows the error and proceeds to `deliver_subscription` — the delivery ships without a summary and the only log we see is the activity's `starting` entry. Seven days of `process_subscription.snapshot_failed` across the whole service: zero hits.

For subscription 74620 (a dashboard sub on team 2) this is reproducing on every run: `snapshot_subscription_insights.starting` then nothing, followed ~140ms later by `deliver_subscription.starting`. No skip log, no completed log, no visible exception. With this change the next run of that sub will leave the exception class and stack in structlog so we can actually debug what's throwing.

## Test plan

- [x] `test_unhandled_exception_is_logged_and_reraised` — mocks `_build_states_from_content_snapshot` to throw mid-activity, asserts the activity re-raises (so Temporal still marks it failed) and that the error surfaces via structlog.
- [x] Existing 3 tests in `test_snapshot_ai_consent.py` still pass — the refactor extracted the body into `_run_snapshot_subscription_insights` without changing behavior on the success/skip paths.
- [x] `ruff check` and `ruff format` clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*