### PR TITLE
feat(replay): skip event expansion if too many events

### DIFF
--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -723,8 +723,14 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
                 return [], property_to_expr(p, team=team, scope="replay")
 
             events_that_have_the_property: list[str] = list(
-                EventProperty.objects.filter(team_id=team.id, property=p.key).values_list("event", flat=True)
+                EventProperty.objects.filter(team_id=team.id, property=p.key).values_list("event", flat=True)[:101]
             )
+
+            if len(events_that_have_the_property) > 100:
+                # Skip expansion when too many events have this property (e.g. $current_url).
+                # Inlining thousands of event names into WHERE event IN (...) can exceed
+                # ClickHouse's max_query_size limit without providing meaningful optimization.
+                return [], property_to_expr(p, team=team, scope="replay")
 
             return events_that_have_the_property, property_to_expr(p, team=team, scope="replay")
         except Exception as e:


### PR DESCRIPTION
## Problem

when there are a TON of events, and a really popular field (ie current_url) this can explode

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

if there are more than 100 events that have the field, just do it normal

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

this is defaulting to already-exisitng behavior

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->a realpopul