### PR TITLE
feat(retention): use rule based validations

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -1,8 +1,7 @@
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from math import ceil
 from typing import Any, Optional, cast
-
-from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     AggregationType,
@@ -39,11 +38,14 @@ from posthog.hogql_queries.insights.retention.retention_base_query_fixed import 
 from posthog.hogql_queries.insights.retention.retention_base_query_rolling import (
     RetentionRollingIntervalBaseQueryBuilder,
 )
+from posthog.hogql_queries.insights.retention.retention_validation_rules import DisallowCumulativeWith24HourWindows
 from posthog.hogql_queries.insights.retention.utils import has_cohort_property
 from posthog.hogql_queries.insights.trends.breakdown import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter, has_single_breakdown
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRangeWithIntervals
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings
+from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.action.action import Action
 from posthog.models.filters.mixins.utils import cached_property
@@ -101,18 +103,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         self.__post_init__()
 
     def __post_init__(self) -> None:
-        self.validate()
-
         # Called after __init__ and after dashboard filters are applied. This ensures cohort optimizations work for both direct filters and dashboard-level filters.
         self.update_hogql_modifiers()
-
-    def validate(self) -> None:
-        if (
-            self.query.retentionFilter
-            and self.query.retentionFilter.timeWindowMode == "24_hour_windows"
-            and self.query.retentionFilter.cumulative
-        ):
-            raise ValidationError("Cumulative retention is not supported for 24 hour windows.")
 
     def update_hogql_modifiers(self) -> None:
         """
@@ -137,6 +129,9 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             # Use LEFTJOIN for cohort filters to avoid slow subquery evaluation
             if has_cohort_filter:
                 self.modifiers.inCohortVia = InCohortVia.LEFTJOIN
+
+    def validators(self) -> Sequence[QueryValidationRule[RetentionQuery]]:
+        return (DisallowCumulativeWith24HourWindows(), DisallowUnsupportedDataWarehouseSettings())
 
     @cached_property
     def property_aggregation_expr(self) -> ast.Expr | None:

--- a/posthog/hogql_queries/insights/retention/retention_validation_rules.py
+++ b/posthog/hogql_queries/insights/retention/retention_validation_rules.py
@@ -1,0 +1,14 @@
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import RetentionQuery
+
+from posthog.hogql_queries.validation.validation import QueryValidationContext
+
+
+class DisallowCumulativeWith24HourWindows:
+    code = "retention_cumulative_24_hour_windows_unsupported"
+
+    def validate(self, context: QueryValidationContext[RetentionQuery]) -> None:
+        retention_filter = context.query.retentionFilter
+        if retention_filter.timeWindowMode == "24_hour_windows" and retention_filter.cumulative:
+            raise ValidationError("Cumulative retention is not supported for 24 hour windows.", code=self.code)

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -6749,7 +6749,7 @@ class TestClickhouseRetentionGroupAggregation(ClickhouseTestMixin, APIBaseTest):
                         "cumulative": True,
                     },
                 },
-            )
+            ).calculate()
 
     def test_custom_brackets_day_period(self):
         """

--- a/posthog/hogql_queries/insights/retention/test/test_retention_validation_rules.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_validation_rules.py
@@ -1,0 +1,93 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import AggregationType, EntityType, RetentionFilter, RetentionQuery, TimeWindowMode
+
+from posthog.hogql_queries.insights.retention.retention_validation_rules import DisallowCumulativeWith24HourWindows
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings
+from posthog.hogql_queries.validation.validation import QueryValidationContext
+
+
+class TestRetentionValidationRules(BaseTest):
+    def _context(self, query: RetentionQuery) -> QueryValidationContext:
+        runner = MagicMock(query=query, team=self.team, user=None)
+        return QueryValidationContext(query=query, team=self.team, user=None, runner=runner)
+
+    def _data_warehouse_entity(self) -> dict[str, str]:
+        return {
+            "id": "signups",
+            "table_name": "signups",
+            "timestamp_field": "signed_up_at",
+            "aggregation_target_field": "person_id",
+            "type": EntityType.DATA_WAREHOUSE,
+        }
+
+    @parameterized.expand(
+        [
+            ("non_cumulative_default_window", False, None, False),
+            ("cumulative_default_window", True, None, False),
+            ("non_cumulative_24_hour_windows", False, TimeWindowMode.FIELD_24_HOUR_WINDOWS, False),
+            ("cumulative_24_hour_windows", True, TimeWindowMode.FIELD_24_HOUR_WINDOWS, True),
+        ]
+    )
+    def test_disallow_cumulative_with_24h_windows(
+        self, _name: str, cumulative: bool, time_window_mode: TimeWindowMode | None, raises_error: bool
+    ) -> None:
+        query = RetentionQuery(retentionFilter=RetentionFilter(cumulative=cumulative, timeWindowMode=time_window_mode))
+
+        if not raises_error:
+            DisallowCumulativeWith24HourWindows().validate(self._context(query))
+            return
+
+        with self.assertRaises(ValidationError) as context:
+            DisallowCumulativeWith24HourWindows().validate(self._context(query))
+
+        self.assertIn("Cumulative retention is not supported for 24 hour windows.", str(context.exception))
+
+    @parameterized.expand(
+        [
+            (
+                "filters",
+                {"properties": [{"key": "text", "value": "new", "operator": "exact", "type": "data_warehouse"}]},
+                "Filters are not supported for retention insights with a data warehouse series.",
+            ),
+            (
+                "test_account_filters",
+                {"filterTestAccounts": True},
+                "Test account filters are not supported for retention insights with a data warehouse series.",
+            ),
+            (
+                "sampling",
+                {"samplingFactor": 0.1},
+                "Sampling is not supported for retention insights with a data warehouse series.",
+            ),
+            (
+                "multiple_settings",
+                {"filterTestAccounts": True, "samplingFactor": 0.1},
+                "Test account filters and sampling are not supported for retention insights with a data warehouse series.",
+            ),
+        ]
+    )
+    def test_disallows_unsupported_data_warehouse_settings(self, _name, query_kwargs, expected_error):
+        query = RetentionQuery(
+            retentionFilter=RetentionFilter(targetEntity=self._data_warehouse_entity()),
+            **query_kwargs,
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))
+
+        self.assertIn(expected_error, str(context.exception))
+        self.assertEqual(context.exception.get_codes(), ["data_warehouse_series_unsupported_settings"])
+
+    def test_allows_unsupported_settings_without_data_warehouse_series(self):
+        query = RetentionQuery(
+            filterTestAccounts=True,
+            samplingFactor=0.1,
+            retentionFilter=RetentionFilter(totalIntervals=8, aggregationType=AggregationType.COUNT),
+        )
+
+        DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))

--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -1,6 +1,6 @@
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
+from posthog.schema import EntityType, FunnelsQuery, LifecycleQuery, RetentionQuery, StickinessQuery, TrendsQuery
 
 from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
@@ -27,9 +27,10 @@ class DisallowUnsupportedDataWarehouseSettings:
     code = "data_warehouse_series_unsupported_settings"
 
     def validate(
-        self, context: QueryValidationContext[TrendsQuery | FunnelsQuery | StickinessQuery | LifecycleQuery]
+        self,
+        context: QueryValidationContext[TrendsQuery | FunnelsQuery | StickinessQuery | LifecycleQuery | RetentionQuery],
     ) -> None:
-        if not has_data_warehouse_node(context.query.series):
+        if not _query_has_data_warehouse_series(context.query):
             return
 
         unsupported_settings: list[str] = []
@@ -47,3 +48,15 @@ class DisallowUnsupportedDataWarehouseSettings:
                 f"{settings.capitalize()} {verb} not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
                 code=self.code,
             )
+
+
+def _query_has_data_warehouse_series(
+    query: TrendsQuery | FunnelsQuery | StickinessQuery | LifecycleQuery | RetentionQuery,
+) -> bool:
+    if isinstance(query, RetentionQuery):
+        return any(
+            entity is not None and entity.type == EntityType.DATA_WAREHOUSE
+            for entity in (query.retentionFilter.targetEntity, query.retentionFilter.returningEntity)
+        )
+
+    return has_data_warehouse_node(query.series)


### PR DESCRIPTION
## Problem

Wanted to add the `DisallowUnsupportedDataWarehouseSettings` validation rule to retention insights.

## Changes

- uses rule base validations for retention insights
- added the unsupported data warehouse settings rules, and made it work with retention entities (instead of series)

## How did you test this code?

Added test cases