### PR TITLE
fix(navigation): defer hidden tab title updates

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
@@ -44,15 +44,32 @@ describe('breadcrumbsLogic', () => {
         await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Product analytics • PostHog' })
         expect(global.document.title).toEqual('Product analytics • PostHog')
 
-        Object.defineProperty(document, 'visibilityState', { value: 'hidden', writable: true })
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden', writable: true })
 
         router.actions.push(urls.dashboards())
         await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Dashboards • PostHog' })
         expect(global.document.title).toEqual('Product analytics • PostHog')
 
-        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible', writable: true })
         document.dispatchEvent(new Event('visibilitychange'))
 
         expect(global.document.title).toEqual('Dashboards • PostHog')
+    })
+
+    it('does not update the default document.title while hidden during startup', async () => {
+        global.document.title = 'PostHog'
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden', writable: true })
+
+        logic = breadcrumbsLogic()
+        logic.mount()
+
+        router.actions.push(urls.savedInsights())
+        await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Product analytics • PostHog' })
+        expect(global.document.title).toEqual('PostHog')
+
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible', writable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(global.document.title).toEqual('Product analytics • PostHog')
     })
 })

--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -211,8 +211,9 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
             if (cache.desiredTitle == null || document.title === cache.desiredTitle) {
                 return
             }
-            const isDefault = document.title === 'PostHog' || document.title === 'PostHog Demo'
-            if (document.visibilityState === 'visible' || isDefault) {
+            // Chrome treats background title updates as a reason to keep a tab alive,
+            // so we always defer syncing until the page is visible again.
+            if (document.visibilityState === 'visible') {
                 document.title = cache.desiredTitle
             }
         }


### PR DESCRIPTION
## Problem

Chrome was treating hidden PostHog tabs as ineligible for discard because the app could still update `document.title` during startup while the tab was hidden. This could be problematic when PostHog tabs are restored from an old Chrome session on startup.

This behavior was visible via `chrome://discards`, where tabs were marked as ineligible for discard due to `tab is updating favicon or title in the background`.

## Changes

- only sync the breadcrumb-derived `document.title` when the page is visible, regardless of the page title
- add a regression test covering the hidden-startup case where the default `PostHog` title should remain unchanged until the tab becomes visible again
- add an inline comment explaining why hidden title updates are intentionally deferred

## How did you test this code?

- Ran `pnpm --filter=@posthog/frontend exec jest frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts --runInBand`
- Manual verification in Chrome `chrome://discards` confirmed the tab is no longer blocked by `tab is updating favicon or title in the background`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 LLM context

This PR was authored with pi.
We first reproduced the hidden-tab title update locally, then narrowed the fix to the breadcrumb title sync logic after comparing `chrome://discards` behavior before and after the change.
