### PR TITLE
feat(personhog): zstd compression bw router and be services

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10242,6 +10242,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -161,7 +161,7 @@ regex = "1.11.1"
 fancy-regex = "0.17"
 lz-str = "0.2.1"
 opentelemetry-proto = { version = "0.29.0", features = ["with-serde"] }
-tonic = "0.12.3"
+tonic = { version = "0.12.3", features = ["zstd"] }
 tonic-build = "0.12"
 clickhouse = { version = "0.13.2", features = [
     "uuid",

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -11,6 +11,7 @@ use lifecycle::{ComponentOptions, Manager};
 use personhog_coordination::pod::{PodConfig, PodHandle};
 use personhog_coordination::store::PersonhogStore;
 use personhog_proto::personhog::leader::v1::person_hog_leader_server::PersonHogLeaderServer;
+use tonic::codec::CompressionEncoding;
 use tonic::transport::Server;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt;
@@ -192,7 +193,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         let _guard = grpc_handle.process_scope();
         if let Err(e) = Server::builder()
-            .add_service(PersonHogLeaderServer::new(service))
+            .add_service(
+                PersonHogLeaderServer::new(service)
+                    .accept_compressed(CompressionEncoding::Zstd)
+                    .send_compressed(CompressionEncoding::Zstd),
+            )
             .serve_with_shutdown(grpc_addr, grpc_handle.shutdown_signal())
             .await
         {

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -8,6 +8,7 @@ use lifecycle::{ComponentOptions, Manager};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use personhog_common::grpc::{tracked_tcp_incoming, GrpcMetricsLayer};
 use personhog_proto::personhog::replica::v1::person_hog_replica_server::PersonHogReplicaServer;
+use tonic::codec::CompressionEncoding;
 use tonic::transport::Server;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt;
@@ -264,7 +265,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .add_service(
                 PersonHogReplicaServer::new(service)
                     .max_encoding_message_size(max_send)
-                    .max_decoding_message_size(max_recv),
+                    .max_decoding_message_size(max_recv)
+                    .accept_compressed(CompressionEncoding::Zstd)
+                    .send_compressed(CompressionEncoding::Zstd),
             )
             .serve_with_incoming_shutdown(incoming, grpc_handle.shutdown_signal())
             .await

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -11,6 +11,7 @@ use personhog_proto::personhog::types::v1::{
     UpdatePersonPropertiesResponse,
 };
 use tokio::sync::RwLock;
+use tonic::codec::CompressionEncoding;
 use tonic::transport::Channel;
 use tonic::{Request, Status};
 
@@ -120,7 +121,9 @@ impl LeaderBackend {
             .connect_lazy();
         let client = PersonHogLeaderClient::new(channel)
             .max_encoding_message_size(self.max_send_message_size)
-            .max_decoding_message_size(self.max_recv_message_size);
+            .max_decoding_message_size(self.max_recv_message_size)
+            .send_compressed(CompressionEncoding::Zstd)
+            .accept_compressed(CompressionEncoding::Zstd);
         self.clients.insert(address, client.clone());
         Ok(client)
     }

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -122,7 +122,6 @@ impl LeaderBackend {
         let client = PersonHogLeaderClient::new(channel)
             .max_encoding_message_size(self.max_send_message_size)
             .max_decoding_message_size(self.max_recv_message_size)
-            .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
         self.clients.insert(address, client.clone());
         Ok(client)

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -21,6 +21,7 @@ use personhog_proto::personhog::types::v1::{
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
+use tonic::codec::CompressionEncoding;
 use tonic::transport::{Channel, Endpoint};
 use tonic::{Request, Status};
 use tracing::info;
@@ -79,6 +80,8 @@ fn create_clients(config: &ReplicaBackendConfig) -> Vec<PersonHogReplicaClient<C
             PersonHogReplicaClient::new(channel)
                 .max_encoding_message_size(config.max_send_message_size)
                 .max_decoding_message_size(config.max_recv_message_size)
+                .send_compressed(CompressionEncoding::Zstd)
+                .accept_compressed(CompressionEncoding::Zstd)
         })
         .collect()
 }

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -80,7 +80,6 @@ fn create_clients(config: &ReplicaBackendConfig) -> Vec<PersonHogReplicaClient<C
             PersonHogReplicaClient::new(channel)
                 .max_encoding_message_size(config.max_send_message_size)
                 .max_decoding_message_size(config.max_recv_message_size)
-                .send_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Zstd)
         })
         .collect()

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -41,6 +41,7 @@ use personhog_router::router::PersonHogRouter;
 use personhog_router::service::PersonHogRouterService;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
+use tonic::codec::CompressionEncoding;
 use tonic::transport::{Channel, Server};
 use tonic::{Request, Response, Status};
 
@@ -361,7 +362,11 @@ pub async fn start_test_replica(service: TestReplicaService) -> SocketAddr {
 
     tokio::spawn(async move {
         Server::builder()
-            .add_service(PersonHogReplicaServer::new(service))
+            .add_service(
+                PersonHogReplicaServer::new(service)
+                    .accept_compressed(CompressionEncoding::Zstd)
+                    .send_compressed(CompressionEncoding::Zstd),
+            )
             .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
             .await
             .unwrap();
@@ -527,7 +532,11 @@ pub async fn start_test_leader(service: TestLeaderService) -> SocketAddr {
 
     tokio::spawn(async move {
         Server::builder()
-            .add_service(PersonHogLeaderServer::new(service))
+            .add_service(
+                PersonHogLeaderServer::new(service)
+                    .accept_compressed(CompressionEncoding::Zstd)
+                    .send_compressed(CompressionEncoding::Zstd),
+            )
             .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
             .await
             .unwrap();


### PR DESCRIPTION
## Problem

gRPC traffic between personhog-router and its backends (personhog-replica, personhog-leader) is sent uncompressed.
For batch endpoints that return large person/group payloads, this adds unnecessary network overhead on the internal pod-to-pod links.

## Changes

- Enable the `zstd` feature on the workspace `tonic` dependency
- Configure the router's replica and leader gRPC **clients** to send and accept zstd-compressed messages
- Configure the replica and leader gRPC **servers** to accept and send zstd-compressed responses
- The router's external-facing `PersonHogServiceServer` is intentionally left unchanged -- compression for Node.js clients requesting from the router is out of scope for now

Compression is negotiated transparently via the `grpc-encoding` header, so this is backwards-compatible during rollout.
If a peer doesn't advertise zstd support, tonic falls back to uncompressed automatically.


## How did you test this code?

Will have to test through the roll out to dev.
