### PR TITLE
feat(flags): evolve timing instrumentation 

### DIFF
--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -8,11 +8,10 @@ use crate::{
         flag_request::FlagRequestType,
         flag_service::FlagService,
     },
-    handler::types::Library,
+    handler::{billing::record_billing_increment_timing, types::Library},
     metrics::consts::{
-        FLAG_BILLING_INCREMENT_TIME, FLAG_DEFINITIONS_AUTH_COUNTER,
-        FLAG_DEFINITIONS_CACHE_HIT_COUNTER, FLAG_DEFINITIONS_CACHE_MISS_COUNTER,
-        FLAG_DEFINITIONS_ETAG_COUNTER,
+        FLAG_DEFINITIONS_AUTH_COUNTER, FLAG_DEFINITIONS_CACHE_HIT_COUNTER,
+        FLAG_DEFINITIONS_CACHE_MISS_COUNTER, FLAG_DEFINITIONS_ETAG_COUNTER,
     },
     router::State as AppState,
     team::team_models::Team,
@@ -24,8 +23,7 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 use common_hypercache::{HyperCacheError, KeyType};
-use common_metrics::{histogram, inc};
-use common_redis::CustomRedisError;
+use common_metrics::inc;
 use common_types::TeamId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -250,16 +248,7 @@ pub async fn flags_definitions(
         .await;
         let elapsed_ms = start.elapsed().as_millis() as u64;
 
-        let outcome = match &result {
-            Ok(()) => "ok",
-            Err(CustomRedisError::Timeout) => "timeout",
-            Err(_) => "error",
-        };
-        histogram(
-            FLAG_BILLING_INCREMENT_TIME,
-            &[("outcome".to_string(), outcome.to_string())],
-            elapsed_ms as f64,
-        );
+        record_billing_increment_timing(&result, elapsed_ms);
 
         if let Err(e) = result {
             inc(

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -10,8 +10,9 @@ use crate::{
     },
     handler::types::Library,
     metrics::consts::{
-        FLAG_DEFINITIONS_AUTH_COUNTER, FLAG_DEFINITIONS_CACHE_HIT_COUNTER,
-        FLAG_DEFINITIONS_CACHE_MISS_COUNTER, FLAG_DEFINITIONS_ETAG_COUNTER,
+        FLAG_BILLING_INCREMENT_TIME, FLAG_DEFINITIONS_AUTH_COUNTER,
+        FLAG_DEFINITIONS_CACHE_HIT_COUNTER, FLAG_DEFINITIONS_CACHE_MISS_COUNTER,
+        FLAG_DEFINITIONS_ETAG_COUNTER,
     },
     router::State as AppState,
     team::team_models::Team,
@@ -23,13 +24,15 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 use common_hypercache::{HyperCacheError, KeyType};
-use common_metrics::inc;
+use common_metrics::{histogram, inc};
+use common_redis::CustomRedisError;
 use common_types::TeamId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::PgPool;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{info, warn};
 
 const ALLOWLIST_TTL_SECS: u64 = 60;
@@ -236,15 +239,29 @@ pub async fn flags_definitions(
     // matching Django's /local_evaluation behavior.
     if !*state.config.skip_writes && has_billable_flags(&cached_response) {
         let library = Library::from_headers(&headers);
-        if let Err(e) = increment_request_count(
+        let start = Instant::now();
+        let result = increment_request_count(
             state.redis_client.clone(),
             team.id,
             1,
             FlagRequestType::FlagDefinitions,
             Some(library),
         )
-        .await
-        {
+        .await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        let outcome = match &result {
+            Ok(()) => "ok",
+            Err(CustomRedisError::Timeout) => "timeout",
+            Err(_) => "error",
+        };
+        histogram(
+            FLAG_BILLING_INCREMENT_TIME,
+            &[("outcome".to_string(), outcome.to_string())],
+            elapsed_ms as f64,
+        );
+
+        if let Err(e) = result {
             inc(
                 "flag_request_redis_error",
                 &[("error".to_string(), e.to_string())],

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -16,6 +16,23 @@ use std::time::Instant;
 use super::canonical_log::with_canonical_log;
 use super::types::{Library, RequestContext};
 
+/// Emit the `flags_billing_increment_time_ms` histogram for a completed
+/// `increment_request_count` call, bucketing the Redis result into
+/// `outcome="ok" | "timeout" | "error"` to isolate the happy path from
+/// Redis timeouts.
+pub fn record_billing_increment_timing(result: &Result<(), CustomRedisError>, elapsed_ms: u64) {
+    let outcome = match result {
+        Ok(()) => "ok",
+        Err(CustomRedisError::Timeout) => "timeout",
+        Err(_) => "error",
+    };
+    histogram(
+        FLAG_BILLING_INCREMENT_TIME,
+        &[("outcome".to_string(), outcome.to_string())],
+        elapsed_ms as f64,
+    );
+}
+
 pub async fn check_limits(
     context: &RequestContext,
     verified_token: &str,
@@ -68,16 +85,7 @@ pub async fn record_usage(
         .await;
         let elapsed_ms = start.elapsed().as_millis() as u64;
 
-        let outcome = match &result {
-            Ok(()) => "ok",
-            Err(CustomRedisError::Timeout) => "timeout",
-            Err(_) => "error",
-        };
-        histogram(
-            FLAG_BILLING_INCREMENT_TIME,
-            &[("outcome".to_string(), outcome.to_string())],
-            elapsed_ms as f64,
-        );
+        record_billing_increment_timing(&result, elapsed_ms);
         with_canonical_log(|log| log.billing_duration_ms = Some(elapsed_ms));
 
         if let Err(e) = result {

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -5,11 +5,15 @@ use crate::{
         flag_models::FeatureFlagList,
         flag_request::FlagRequestType,
     },
+    metrics::consts::FLAG_BILLING_INCREMENT_TIME,
 };
-use common_metrics::inc;
+use common_metrics::{histogram, inc};
+use common_redis::CustomRedisError;
 use limiters::redis::ServiceName;
 use std::collections::HashMap;
+use std::time::Instant;
 
+use super::canonical_log::with_canonical_log;
 use super::types::{Library, RequestContext};
 
 pub async fn check_limits(
@@ -53,15 +57,30 @@ pub async fn record_usage(
     let has_billable_flags = contains_billable_flags(filtered_flags);
 
     if has_billable_flags {
-        if let Err(e) = increment_request_count(
+        let start = Instant::now();
+        let result = increment_request_count(
             context.state.redis_client.clone(),
             team_id,
             1,
             FlagRequestType::Decide,
             Some(library),
         )
-        .await
-        {
+        .await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        let outcome = match &result {
+            Ok(()) => "ok",
+            Err(CustomRedisError::Timeout) => "timeout",
+            Err(_) => "error",
+        };
+        histogram(
+            FLAG_BILLING_INCREMENT_TIME,
+            &[("outcome".to_string(), outcome.to_string())],
+            elapsed_ms as f64,
+        );
+        with_canonical_log(|log| log.billing_duration_ms = Some(elapsed_ms));
+
+        if let Err(e) = result {
             inc(
                 "flag_request_redis_error",
                 &[("error".to_string(), e.to_string())],

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -256,7 +256,10 @@ pub struct FlagsCanonicalLogLine {
     pub queue_time_ms: Option<i64>,
 
     /// Duration of the Redis HINCRBY billing increment call in milliseconds.
-    /// None when billing was skipped (no billable flags or `skip_writes`).
+    /// Only populated from endpoints that run inside a canonical log scope
+    /// (currently `/flags` and `/decide`). `None` when billing was skipped
+    /// (no billable flags or `skip_writes`), or when called from an endpoint
+    /// that does not emit a canonical log line (e.g. `/flags/definitions`).
     pub billing_duration_ms: Option<u64>,
 
     // Cache sources (populated during data fetching)

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -255,6 +255,10 @@ pub struct FlagsCanonicalLogLine {
     /// None when the header is missing or the computed delta is negative.
     pub queue_time_ms: Option<i64>,
 
+    /// Duration of the Redis HINCRBY billing increment call in milliseconds.
+    /// None when billing was skipped (no billable flags or `skip_writes`).
+    pub billing_duration_ms: Option<u64>,
+
     // Cache sources (populated during data fetching)
     /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
     pub team_cache_source: Option<&'static str>,
@@ -302,6 +306,7 @@ impl Default for FlagsCanonicalLogLine {
             rate_limited: false,
             rate_limit_warned: false,
             queue_time_ms: None,
+            billing_duration_ms: None,
             team_cache_source: None,
             http_status: 200,
             error_code: None,
@@ -367,6 +372,7 @@ impl FlagsCanonicalLogLine {
             rate_limited = self.rate_limited,
             rate_limit_warned = self.rate_limit_warned,
             queue_time_ms = self.queue_time_ms,
+            billing_duration_ms = self.billing_duration_ms,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,
             "canonical_log_line"

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -38,11 +38,13 @@ pub const DB_CONNECTION_POOL_IDLE_COUNTER: &str = "flags_db_connection_pool_idle
 pub const DB_CONNECTION_POOL_MAX_COUNTER: &str = "flags_db_connection_pool_max_total";
 pub const DB_CONNECTION_POOL_SIZE_GAUGE: &str = "flags_db_connection_pool_size";
 
-// Flag evaluation timing
+// Flag billing timing
 // Duration of the Redis HINCRBY billing increment call. Labeled by
 // `outcome` ("ok" | "timeout" | "error") to isolate the happy path from
 // Redis timeouts — closes a sub-metric blind spot on the billing path.
 pub const FLAG_BILLING_INCREMENT_TIME: &str = "flags_billing_increment_time_ms";
+
+// Flag evaluation timing
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
 pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time";
 pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_properties_db_fetch_time";

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -39,6 +39,10 @@ pub const DB_CONNECTION_POOL_MAX_COUNTER: &str = "flags_db_connection_pool_max_t
 pub const DB_CONNECTION_POOL_SIZE_GAUGE: &str = "flags_db_connection_pool_size";
 
 // Flag evaluation timing
+// Duration of the Redis HINCRBY billing increment call. Labeled by
+// `outcome` ("ok" | "timeout" | "error") to isolate the happy path from
+// Redis timeouts — closes a sub-metric blind spot on the billing path.
+pub const FLAG_BILLING_INCREMENT_TIME: &str = "flags_billing_increment_time_ms";
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
 pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time";
 pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_properties_db_fetch_time";


### PR DESCRIPTION
## Problem

We don't have enough metrics covering all the time spent in a request. We should be able to determine the time spent on Redis operations.

## Changes

This branch adds timing instrumentation around the Redis HINCRBY billing increment call (`increment_request_count`) on both the `/flags`/`/decide` path and the `/flags/definitions` path, emitting a new `flags_billing_increment_time_ms` histogram labeled by outcome (`ok` / `timeout` / `error`) to separate happy-path latency from Redis timeouts. On the canonical-log-emitting endpoints, it also surfaces the same duration as a `billing_duration_ms` field on the canonical log line, closing a blind spot on billing-path latency.

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
