### PR TITLE
feat(hogql): add llm_complete() for per-row LLM completions

### DIFF
--- a/ee/settings.py
+++ b/ee/settings.py
@@ -97,6 +97,12 @@ OPENAI_BASE_URL = get_from_env("OPENAI_BASE_URL", "https://api.openai.com/v1")
 # LLM Gateway (internal service for proxying LLM requests with rate limiting and attribution)
 LLM_GATEWAY_URL = get_from_env("LLM_GATEWAY_URL", "http://localhost:3308" if DEBUG else "")
 LLM_GATEWAY_API_KEY = get_from_env("LLM_GATEWAY_PERSONAL_API_KEY", DEV_API_KEY if DEBUG else "")
+
+# Safety limits for __preview_llm_complete() calls inside HogQL queries
+HOGQL_LLM_COMPLETE_MAX_ROWS = get_from_env("HOGQL_LLM_COMPLETE_MAX_ROWS", 1000, type_cast=int)
+HOGQL_LLM_COMPLETE_CONCURRENCY = get_from_env("HOGQL_LLM_COMPLETE_CONCURRENCY", 20, type_cast=int)
+HOGQL_LLM_COMPLETE_TIMEOUT_SECONDS = get_from_env("HOGQL_LLM_COMPLETE_TIMEOUT_SECONDS", 30.0, type_cast=float)
+HOGQL_LLM_COMPLETE_MAX_TOKENS = get_from_env("HOGQL_LLM_COMPLETE_MAX_TOKENS", 512, type_cast=int)
 INKEEP_API_KEY = get_from_env("INKEEP_API_KEY", "")
 MISTRAL_API_KEY = get_from_env("MISTRAL_API_KEY", "")
 GEMINI_API_KEY = get_from_env("GEMINI_API_KEY", "")

--- a/posthog/hogql/context.py
+++ b/posthog/hogql/context.py
@@ -11,6 +11,7 @@ from posthog.clickhouse.workload import Workload
 
 if TYPE_CHECKING:
     from posthog.hogql.database.database import Database
+    from posthog.hogql.transforms.llm_completions import LlmCompletionSpec
     from posthog.hogql.transforms.property_types import PropertySwapper
 
     from posthog.models import Team, User
@@ -75,6 +76,11 @@ class HogQLContext:
     property_swapper: Optional["PropertySwapper"] = None
     # Workload detected during AST resolution (set by prepare_ast_for_printing)
     workload: Optional[Workload] = None
+
+    # LLM completion column specs harvested during the llm_completions transform.
+    # After ClickHouse returns rows, the executor iterates this list and replaces the
+    # matching column values with gateway completions. See posthog/llm/hogql_runner.py.
+    llm_completions: list["LlmCompletionSpec"] = field(default_factory=list)
 
     def __post_init__(self):
         if self.team:

--- a/posthog/hogql/functions/llm_complete.py
+++ b/posthog/hogql/functions/llm_complete.py
@@ -1,0 +1,31 @@
+from posthog.hogql import ast
+from posthog.hogql.errors import QueryError
+
+
+LLM_COMPLETE_FUNCTION_NAME = "__preview_llm_complete"
+
+
+def extract_llm_complete_args(node: ast.Call) -> tuple[str, ast.Expr, str | None]:
+    """Validate a __preview_llm_complete(...) call and return (model, prompt_expr, system_prompt).
+
+    The model and optional system arguments must be string literals; the prompt is an
+    arbitrary HogQL expression that ClickHouse will evaluate per row.
+    """
+    if node.name != LLM_COMPLETE_FUNCTION_NAME:
+        raise QueryError(f"Expected {LLM_COMPLETE_FUNCTION_NAME} call, got {node.name!r}")
+    if len(node.args) < 2 or len(node.args) > 3:
+        raise QueryError(f"{LLM_COMPLETE_FUNCTION_NAME}() takes 2 or 3 arguments, got {len(node.args)}")
+
+    model_arg, prompt_arg, *rest = node.args
+
+    if not isinstance(model_arg, ast.Constant) or not isinstance(model_arg.value, str) or not model_arg.value:
+        raise QueryError(f"{LLM_COMPLETE_FUNCTION_NAME}(): model (1st arg) must be a non-empty string literal")
+
+    system_prompt: str | None = None
+    if rest:
+        system_arg = rest[0]
+        if not isinstance(system_arg, ast.Constant) or not isinstance(system_arg.value, str):
+            raise QueryError(f"{LLM_COMPLETE_FUNCTION_NAME}(): system prompt (3rd arg) must be a string literal")
+        system_prompt = system_arg.value
+
+    return model_arg.value, prompt_arg, system_prompt

--- a/posthog/hogql/functions/posthog.py
+++ b/posthog/hogql/functions/posthog.py
@@ -75,6 +75,17 @@ HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
             ((StringType(), DateTimeType(), DateTimeType()), StringType()),
         ],
     ),
+    # LLM completion (experimental). Rewritten by the llm_completions transform —
+    # ClickHouse evaluates the per-row prompt, Python calls the LLM gateway.
+    "__preview_llm_complete": HogQLFunctionMeta(
+        "__preview_llm_complete",
+        2,
+        3,
+        signatures=[
+            ((StringType(), StringType()), StringType()),
+            ((StringType(), StringType(), StringType()), StringType()),
+        ],
+    ),
     # traffic type classification functions (experimental)
     "__preview_getTrafficType": HogQLFunctionMeta(
         "__preview_getTrafficType", 1, 1, signatures=[((StringType(),), StringType())]

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -17,6 +17,7 @@ from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.resolver import resolve_types
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
+from posthog.hogql.transforms.llm_completions import rewrite_llm_completions
 from posthog.hogql.transforms.projection_pushdown import pushdown_projections
 from posthog.hogql.transforms.property_types import PropertySwapper, build_property_swapper
 from posthog.hogql.visitor import clone_expr
@@ -156,6 +157,12 @@ def prepare_ast_for_printing(
     if context.modifiers.inCohortVia == InCohortVia.LEFTJOIN:
         with context.timings.measure("resolve_in_cohorts"):
             resolve_in_cohorts(node, dialect, stack, context)
+
+    # Rewrite __preview_llm_complete() calls only for ClickHouse — this is the path that
+    # actually executes a query. Other dialects just print the original AST.
+    if dialect == "clickhouse":
+        with context.timings.measure("rewrite_llm_completions"):
+            rewrite_llm_completions(node, context)
 
     # We add a team_id guard right before printing. It's not a separate step here.
     return node

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -842,6 +842,21 @@ class HogQLQueryExecutor:
                     printed_sql=self.clickhouse_sql,
                 )
 
+    def _apply_llm_completions(self) -> None:
+        if self.results is None or not self.clickhouse_context:
+            return
+        specs = self.clickhouse_context.llm_completions
+        if not specs:
+            return
+        from posthog.llm.hogql_runner import apply_llm_completions
+
+        self.results = apply_llm_completions(
+            self.results,
+            specs,
+            user=self.user,
+            timings=self.timings,
+        )
+
     @tracer.start_as_current_span("HogQLQueryExecutor.generate_clickhouse_sql")
     def generate_clickhouse_sql(self) -> tuple[str, HogQLContext]:
         prepared_execution = self._prepare_execution()
@@ -859,6 +874,8 @@ class HogQLQueryExecutor:
                 self._execute_direct_postgres_query()
             elif self.clickhouse_sql is not None:
                 self._execute_clickhouse_query()
+
+        self._apply_llm_completions()
 
         return HogQLQueryResponse(
             query=self.query,

--- a/posthog/hogql/test/test_llm_complete.py
+++ b/posthog/hogql/test/test_llm_complete.py
@@ -1,0 +1,302 @@
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from posthog.test.base import BaseTest
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.errors import QueryError
+from posthog.hogql.functions.llm_complete import extract_llm_complete_args
+from posthog.hogql.parser import parse_select
+from posthog.hogql.timings import HogQLTimings
+from posthog.hogql.transforms.llm_completions import LlmCompletionSpec, rewrite_llm_completions
+from posthog.llm.hogql_runner import apply_llm_completions
+
+
+class TestExtractLlmCompleteArgs(BaseTest):
+    def test_two_args(self):
+        call = ast.Call(
+            name="__preview_llm_complete",
+            args=[ast.Constant(value="claude-haiku-4-5"), ast.Constant(value="hi")],
+        )
+        model, prompt, system = extract_llm_complete_args(call)
+        self.assertEqual(model, "claude-haiku-4-5")
+        self.assertEqual(prompt, ast.Constant(value="hi"))
+        self.assertIsNone(system)
+
+    def test_three_args(self):
+        call = ast.Call(
+            name="__preview_llm_complete",
+            args=[
+                ast.Constant(value="m"),
+                ast.Constant(value="hi"),
+                ast.Constant(value="be terse"),
+            ],
+        )
+        _, _, system = extract_llm_complete_args(call)
+        self.assertEqual(system, "be terse")
+
+    def test_non_constant_model_rejected(self):
+        call = ast.Call(
+            name="__preview_llm_complete",
+            args=[ast.Field(chain=["model"]), ast.Constant(value="hi")],
+        )
+        with self.assertRaises(QueryError):
+            extract_llm_complete_args(call)
+
+    def test_empty_model_rejected(self):
+        call = ast.Call(
+            name="__preview_llm_complete",
+            args=[ast.Constant(value=""), ast.Constant(value="hi")],
+        )
+        with self.assertRaises(QueryError):
+            extract_llm_complete_args(call)
+
+    def test_non_constant_system_rejected(self):
+        call = ast.Call(
+            name="__preview_llm_complete",
+            args=[
+                ast.Constant(value="m"),
+                ast.Constant(value="hi"),
+                ast.Field(chain=["sys"]),
+            ],
+        )
+        with self.assertRaises(QueryError):
+            extract_llm_complete_args(call)
+
+    def test_arity_rejected(self):
+        call = ast.Call(name="__preview_llm_complete", args=[ast.Constant(value="m")])
+        with self.assertRaises(QueryError):
+            extract_llm_complete_args(call)
+
+
+class TestRewriteLlmCompletions(BaseTest):
+    def _ctx(self) -> HogQLContext:
+        return HogQLContext(team_id=self.team.id)
+
+    def test_noop_when_absent(self):
+        select = cast(ast.SelectQuery, parse_select("SELECT 1, 2"))
+        ctx = self._ctx()
+        rewrite_llm_completions(select, ctx)
+        self.assertEqual(ctx.llm_completions, [])
+
+    def test_rewrites_aliased_top_level(self):
+        select = cast(
+            ast.SelectQuery,
+            parse_select("SELECT event, __preview_llm_complete('m', concat('p: ', properties)) AS summary FROM events"),
+        )
+        ctx = self._ctx()
+        rewrite_llm_completions(select, ctx)
+        self.assertEqual(len(ctx.llm_completions), 1)
+        spec = ctx.llm_completions[0]
+        self.assertEqual(spec.column_index, 1)
+        self.assertEqual(spec.column_alias, "summary")
+        self.assertEqual(spec.model, "m")
+        self.assertIsNone(spec.system_prompt)
+
+        # After rewrite, the second column should be an Alias(summary, concat(...)) — no Call.
+        rewritten = select.select[1]
+        self.assertIsInstance(rewritten, ast.Alias)
+        self.assertEqual(rewritten.alias, "summary")
+        assert isinstance(rewritten.expr, ast.Call)
+        self.assertEqual(rewritten.expr.name, "concat")
+
+    def test_assigns_synthetic_alias_when_missing(self):
+        select = cast(
+            ast.SelectQuery,
+            parse_select("SELECT __preview_llm_complete('m', 'hi') FROM events"),
+        )
+        ctx = self._ctx()
+        rewrite_llm_completions(select, ctx)
+        self.assertEqual(ctx.llm_completions[0].column_alias, "__llm_complete_0")
+        self.assertIsInstance(select.select[0], ast.Alias)
+
+    def test_three_arg_system_prompt(self):
+        select = cast(
+            ast.SelectQuery,
+            parse_select("SELECT __preview_llm_complete('m', 'hi', 'be terse') AS s FROM events"),
+        )
+        ctx = self._ctx()
+        rewrite_llm_completions(select, ctx)
+        self.assertEqual(ctx.llm_completions[0].system_prompt, "be terse")
+
+    def test_rejects_use_in_where(self):
+        select = cast(
+            ast.SelectQuery,
+            parse_select(
+                "SELECT event FROM events WHERE __preview_llm_complete('m', 'hi') = 'yes'"
+            ),
+        )
+        with self.assertRaises(QueryError):
+            rewrite_llm_completions(select, self._ctx())
+
+    def test_rejects_nested_usage(self):
+        select = cast(
+            ast.SelectQuery,
+            parse_select("SELECT lower(__preview_llm_complete('m', 'hi')) AS s FROM events"),
+        )
+        with self.assertRaises(QueryError):
+            rewrite_llm_completions(select, self._ctx())
+
+    def test_multiple_calls_each_get_spec(self):
+        select = cast(
+            ast.SelectQuery,
+            parse_select(
+                "SELECT __preview_llm_complete('m', 'a') AS x, __preview_llm_complete('m', 'b') AS y FROM events"
+            ),
+        )
+        ctx = self._ctx()
+        rewrite_llm_completions(select, ctx)
+        self.assertEqual([s.column_alias for s in ctx.llm_completions], ["x", "y"])
+        self.assertEqual([s.column_index for s in ctx.llm_completions], [0, 1])
+
+
+def _make_response(text: str) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content=text))]
+    return response
+
+
+class TestApplyLlmCompletions(BaseTest):
+    def _spec(self, **kwargs) -> LlmCompletionSpec:
+        return LlmCompletionSpec(
+            column_index=kwargs.get("column_index", 0),
+            column_alias=kwargs.get("column_alias", "x"),
+            model=kwargs.get("model", "claude-haiku-4-5"),
+            system_prompt=kwargs.get("system_prompt"),
+        )
+
+    def test_empty_specs_shortcircuits(self):
+        result = apply_llm_completions(
+            [("a",), ("b",)],
+            [],
+            user=None,
+            timings=HogQLTimings(),
+        )
+        self.assertEqual(result, [("a",), ("b",)])
+
+    def test_row_cap_raises_before_any_calls(self):
+        with patch("posthog.llm.hogql_runner.get_async_llm_client") as client:
+            with patch("posthog.llm.hogql_runner.settings") as mock_settings:
+                mock_settings.HOGQL_LLM_COMPLETE_MAX_ROWS = 2
+                mock_settings.HOGQL_LLM_COMPLETE_CONCURRENCY = 20
+                mock_settings.HOGQL_LLM_COMPLETE_TIMEOUT_SECONDS = 30.0
+                mock_settings.HOGQL_LLM_COMPLETE_MAX_TOKENS = 512
+                with self.assertRaises(QueryError):
+                    apply_llm_completions(
+                        [("p1",), ("p2",), ("p3",)],
+                        [self._spec()],
+                        user=None,
+                        timings=HogQLTimings(),
+                    )
+                client.assert_not_called()
+
+    def test_deduplicates_identical_prompts(self):
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(return_value=_make_response("OUT"))
+        with patch("posthog.llm.hogql_runner.get_async_llm_client", return_value=async_client):
+            result = apply_llm_completions(
+                [("same",), ("same",), ("other",), ("same",)],
+                [self._spec()],
+                user=None,
+                timings=HogQLTimings(),
+            )
+        # Two distinct prompts → two gateway calls, not four.
+        self.assertEqual(async_client.chat.completions.create.await_count, 2)
+        self.assertEqual([row[0] for row in result], ["OUT", "OUT", "OUT", "OUT"])
+
+    def test_per_row_errors_become_none(self):
+        async_client = MagicMock()
+
+        async def flaky(**kwargs):
+            content = kwargs["messages"][-1]["content"]
+            if content == "bad":
+                raise RuntimeError("boom")
+            return _make_response("ok-" + content)
+
+        async_client.chat.completions.create = AsyncMock(side_effect=flaky)
+        with patch("posthog.llm.hogql_runner.get_async_llm_client", return_value=async_client):
+            result = apply_llm_completions(
+                [("good",), ("bad",), ("good",)],
+                [self._spec()],
+                user=None,
+                timings=HogQLTimings(),
+            )
+        self.assertEqual(result[0][0], "ok-good")
+        self.assertIsNone(result[1][0])
+        self.assertEqual(result[2][0], "ok-good")
+
+    def test_distinct_id_attributed_when_user_present(self):
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(return_value=_make_response("x"))
+        user = MagicMock()
+        user.distinct_id = "user-123"
+        with patch("posthog.llm.hogql_runner.get_async_llm_client", return_value=async_client):
+            apply_llm_completions(
+                [("p",)],
+                [self._spec()],
+                user=user,
+                timings=HogQLTimings(),
+            )
+        kwargs = async_client.chat.completions.create.await_args.kwargs
+        self.assertEqual(kwargs["user"], "user-123")
+
+    def test_no_user_attribution_when_none(self):
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(return_value=_make_response("x"))
+        with patch("posthog.llm.hogql_runner.get_async_llm_client", return_value=async_client):
+            apply_llm_completions(
+                [("p",)],
+                [self._spec()],
+                user=None,
+                timings=HogQLTimings(),
+            )
+        self.assertNotIn("user", async_client.chat.completions.create.await_args.kwargs)
+
+    def test_system_prompt_is_first_message(self):
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(return_value=_make_response("x"))
+        with patch("posthog.llm.hogql_runner.get_async_llm_client", return_value=async_client):
+            apply_llm_completions(
+                [("u",)],
+                [self._spec(system_prompt="you are terse")],
+                user=None,
+                timings=HogQLTimings(),
+            )
+        messages = async_client.chat.completions.create.await_args.kwargs["messages"]
+        self.assertEqual(messages[0], {"role": "system", "content": "you are terse"})
+        self.assertEqual(messages[1], {"role": "user", "content": "u"})
+
+
+class TestLlmCompleteFunctionRegistration(BaseTest):
+    def test_function_registered(self):
+        from posthog.hogql.functions import find_hogql_posthog_function
+
+        meta = find_hogql_posthog_function("__preview_llm_complete")
+        self.assertIsNotNone(meta)
+        assert meta is not None  # narrow for mypy
+        self.assertEqual(meta.clickhouse_name, "__preview_llm_complete")
+        self.assertEqual(meta.min_args, 2)
+        self.assertEqual(meta.max_args, 3)
+
+
+class TestTimingsEntry(BaseTest):
+    def test_llm_completions_timing_recorded(self):
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(return_value=_make_response("ok"))
+        timings = HogQLTimings()
+        with patch("posthog.llm.hogql_runner.get_async_llm_client", return_value=async_client):
+            apply_llm_completions(
+                [("p",)],
+                [LlmCompletionSpec(column_index=0, column_alias="x", model="m", system_prompt=None)],
+                user=None,
+                timings=timings,
+            )
+        keys = [k for k in timings.to_dict().keys() if "llm_completions" in k]
+        self.assertTrue(keys, f"expected an llm_completions timing entry, got {list(timings.to_dict().keys())}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/posthog/hogql/transforms/llm_completions.py
+++ b/posthog/hogql/transforms/llm_completions.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.errors import QueryError
+from posthog.hogql.functions.llm_complete import LLM_COMPLETE_FUNCTION_NAME, extract_llm_complete_args
+from posthog.hogql.visitor import TraversingVisitor
+
+
+@dataclass
+class LlmCompletionSpec:
+    """Describes one column in the outer SELECT that needs post-query LLM substitution."""
+
+    column_index: int
+    column_alias: str
+    model: str
+    system_prompt: str | None
+
+
+def rewrite_llm_completions(node: ast.AST, context: HogQLContext) -> None:
+    """Rewrite top-level `__preview_llm_complete(...)` calls in the outer SELECT.
+
+    Each call is replaced with its prompt expression so ClickHouse renders the prompt
+    string per row. A spec is appended to ``context.llm_completions`` that the executor
+    uses to replace the rendered prompts with LLM completions after the query returns.
+
+    For v1, calls are only allowed as the direct expression of an outer SELECT item
+    (optionally wrapped in an Alias). Any other position raises QueryError.
+    """
+    outer = _find_outer_select(node)
+    if outer is None:
+        _ForbidLlmComplete().visit(node)
+        return
+
+    allowed_call_ids: set[int] = set()
+    for idx, column in enumerate(outer.select):
+        call = _direct_llm_call(column)
+        if call is None:
+            continue
+        allowed_call_ids.add(id(call))
+        model, prompt_expr, system_prompt = extract_llm_complete_args(call)
+        alias = column.alias if isinstance(column, ast.Alias) else f"__llm_complete_{idx}"
+        outer.select[idx] = ast.Alias(alias=alias, expr=prompt_expr)
+        context.llm_completions.append(
+            LlmCompletionSpec(
+                column_index=idx,
+                column_alias=alias,
+                model=model,
+                system_prompt=system_prompt,
+            )
+        )
+
+    _ForbidLlmComplete(allowed_call_ids=allowed_call_ids).visit(outer)
+
+
+def _find_outer_select(node: ast.AST) -> ast.SelectQuery | None:
+    if isinstance(node, ast.SelectQuery):
+        return node
+    if isinstance(node, ast.SelectSetQuery):
+        # For UNIONs we only rewrite the initial SELECT's columns — its aliases drive the result schema.
+        return _find_outer_select(node.initial_select_query)
+    return None
+
+
+def _direct_llm_call(column: ast.Expr) -> ast.Call | None:
+    inner = column.expr if isinstance(column, ast.Alias) else column
+    if isinstance(inner, ast.Call) and inner.name == LLM_COMPLETE_FUNCTION_NAME:
+        return inner
+    return None
+
+
+class _ForbidLlmComplete(TraversingVisitor):
+    """Raises if it encounters __preview_llm_complete anywhere the rewrite didn't own."""
+
+    def __init__(self, allowed_call_ids: set[int] | None = None) -> None:
+        super().__init__()
+        self._allowed = allowed_call_ids or set()
+
+    def visit_call(self, node: ast.Call) -> None:
+        if node.name == LLM_COMPLETE_FUNCTION_NAME and id(node) not in self._allowed:
+            raise QueryError(
+                f"{LLM_COMPLETE_FUNCTION_NAME}() may only be used as a top-level column "
+                "in the outer SELECT (optionally aliased). Nested or non-SELECT positions "
+                "are not supported."
+            )
+        super().visit_call(node)

--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -19,6 +19,7 @@ Product = Literal[
     "customer_archetype_classification",
     "slack-posthog-code",
     "product_analytics",
+    "hogql",
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 

--- a/posthog/llm/hogql_runner.py
+++ b/posthog/llm/hogql_runner.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+from asgiref.sync import async_to_sync
+
+from posthog.hogql.errors import QueryError
+from posthog.hogql.timings import HogQLTimings
+from posthog.llm.gateway_client import get_async_llm_client
+
+if TYPE_CHECKING:
+    from posthog.hogql.transforms.llm_completions import LlmCompletionSpec
+    from posthog.models import User
+
+
+logger = logging.getLogger(__name__)
+
+
+def apply_llm_completions(
+    results: list[tuple] | list[list],
+    specs: list["LlmCompletionSpec"],
+    *,
+    user: "User | None",
+    timings: HogQLTimings,
+) -> list[list]:
+    """Replace rendered-prompt column values with LLM completions.
+
+    Enforces a row cap before firing any calls; dedupes prompts within the query; caps
+    concurrency and per-call timeout; per-row errors become ``None`` and are logged
+    rather than failing the whole query.
+
+    Returns a new results list (tuples converted to lists so cells can be mutated).
+    """
+    if not specs:
+        return list(results)
+
+    max_rows: int = getattr(settings, "HOGQL_LLM_COMPLETE_MAX_ROWS", 1000)
+    if len(results) > max_rows:
+        raise QueryError(
+            f"__preview_llm_complete(): query would fire {len(results)} LLM calls, "
+            f"which exceeds the limit of {max_rows}. Add a stricter LIMIT."
+        )
+
+    with timings.measure("llm_completions"):
+        unique_calls = _collect_unique_calls(results, specs)
+        if not unique_calls:
+            return [list(row) for row in results]
+
+        distinct_id = user.distinct_id if user is not None and getattr(user, "distinct_id", None) else None
+        completions = async_to_sync(_fire_completions)(unique_calls, distinct_id=distinct_id)
+
+        mutable_rows: list[list] = [list(row) for row in results]
+        for spec in specs:
+            for row in mutable_rows:
+                prompt = row[spec.column_index]
+                if not isinstance(prompt, str):
+                    row[spec.column_index] = None
+                    continue
+                key = (spec.model, spec.system_prompt, prompt)
+                row[spec.column_index] = completions.get(key)
+        return mutable_rows
+
+
+_CallKey = tuple[str, str | None, str]
+
+
+def _collect_unique_calls(
+    results: list[tuple] | list[list],
+    specs: list["LlmCompletionSpec"],
+) -> list[_CallKey]:
+    seen: dict[_CallKey, None] = {}
+    for row in results:
+        for spec in specs:
+            prompt = row[spec.column_index]
+            if not isinstance(prompt, str):
+                continue
+            key: _CallKey = (spec.model, spec.system_prompt, prompt)
+            if key not in seen:
+                seen[key] = None
+    return list(seen.keys())
+
+
+async def _fire_completions(
+    calls: list[_CallKey],
+    *,
+    distinct_id: str | None,
+) -> dict[_CallKey, str | None]:
+    concurrency: int = getattr(settings, "HOGQL_LLM_COMPLETE_CONCURRENCY", 20)
+    timeout_seconds: float = getattr(settings, "HOGQL_LLM_COMPLETE_TIMEOUT_SECONDS", 30.0)
+    max_tokens: int = getattr(settings, "HOGQL_LLM_COMPLETE_MAX_TOKENS", 512)
+
+    client = get_async_llm_client("hogql")
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def one(key: _CallKey) -> str | None:
+        model, system, prompt = key
+        messages: list[dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        async with semaphore:
+            try:
+                kwargs: dict = {
+                    "model": model,
+                    "messages": messages,
+                    "max_tokens": max_tokens,
+                }
+                if distinct_id:
+                    kwargs["user"] = distinct_id
+                response = await asyncio.wait_for(
+                    client.chat.completions.create(**kwargs),
+                    timeout=timeout_seconds,
+                )
+            except TimeoutError:
+                logger.warning("llm_complete timeout", extra={"model": model})
+                return None
+            except Exception as exc:
+                logger.warning("llm_complete error: %s", type(exc).__name__, extra={"model": model})
+                return None
+        try:
+            return response.choices[0].message.content
+        except (AttributeError, IndexError):
+            logger.warning("llm_complete unexpected response shape", extra={"model": model})
+            return None
+
+    tasks = [asyncio.create_task(one(key)) for key in calls]
+    values = await asyncio.gather(*tasks)
+    return dict(zip(calls, values))

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -74,7 +74,7 @@
   
   And lastly these are some HogQL specific functions:
   ```
-  ['matchesAction', 'sparkline', 'recordingButton', 'explainCSPReport', 'sortablesemver', 'embedText', 'lookupDomainType', 'lookupPaidSourceType', 'lookupPaidMediumType', 'lookupOrganicSourceType', 'lookupOrganicMediumType', 'convertCurrency', 'getSurveyResponse', 'uniqueSurveySubmissionsFilter', '__preview_getTrafficType', '__preview_getTrafficCategory', '__preview_isBot', '__preview_getBotType', '__preview_getBotName']
+  ['matchesAction', 'sparkline', 'recordingButton', 'explainCSPReport', 'sortablesemver', 'embedText', 'lookupDomainType', 'lookupPaidSourceType', 'lookupPaidMediumType', 'lookupOrganicSourceType', 'lookupOrganicMediumType', 'convertCurrency', 'getSurveyResponse', 'uniqueSurveySubmissionsFilter', '__preview_llm_complete', '__preview_getTrafficType', '__preview_getTrafficCategory', '__preview_isBot', '__preview_getBotType', '__preview_getBotName']
   ```
   
   You fix HogQL errors that may come from either HogQL resolver errors or clickhouse execution errors. You don't help with other knowledge.

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -121,6 +121,19 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_models=frozenset({"gpt-4.1-mini"}),
         allow_api_keys=True,
     ),
+    "hogql": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=frozenset(
+            {
+                "claude-haiku-4-5",
+                "claude-sonnet-4-5",
+                "gpt-4.1-mini",
+                "gpt-4.1-nano",
+                "gpt-5-mini",
+            }
+        ),
+        allow_api_keys=True,
+    ),
 }
 
 


### PR DESCRIPTION
Introduces a Snowflake-Cortex-style completion function usable in HogQL SELECT columns. ClickHouse renders the per-row prompt expression; the executor then calls the LLM gateway for each distinct prompt after the query returns, dedupes identical prompts, caps concurrency and row count, and substitutes completions back into the result rows.

Generated-By: PostHog Code
Task-Id: 14b9ea08-97d9-4f8d-9131-9d4c3f896eb4

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
