### PR TITLE
chore(replay): refine session_summary_ready event emission

### DIFF
--- a/posthog/temporal/session_replay/session_summary/activities/a1_prep_session_video_asset.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a1_prep_session_video_asset.py
@@ -101,7 +101,9 @@ async def prep_session_video_asset_activity(
                 signals_type="session-summaries",
             )
             success = True
-            return PrepSessionVideoAssetResult(asset_id=existing_asset.id, needs_export=False)
+            return PrepSessionVideoAssetResult(
+                asset_id=existing_asset.id, needs_export=False, team_api_token=team.api_token
+            )
 
         # Create ExportedAsset record (the actual video rendering happens as a child workflow)
         created_at = now()
@@ -127,7 +129,7 @@ async def prep_session_video_asset_activity(
         )
 
         success = True
-        return PrepSessionVideoAssetResult(asset_id=exported_asset.id, needs_export=True)
+        return PrepSessionVideoAssetResult(asset_id=exported_asset.id, needs_export=True, team_api_token=team.api_token)
 
     except Exception as e:
         logger.exception(

--- a/posthog/temporal/session_replay/session_summary/activities/a6b_store_video_session_summary.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a6b_store_video_session_summary.py
@@ -10,6 +10,7 @@ import structlog
 import temporalio
 
 from posthog.sync import database_sync_to_async
+from posthog.temporal.session_replay.session_summary.events import capture_session_summary_ready
 from posthog.temporal.session_replay.session_summary.state import (
     StateActivitiesEnum,
     get_data_class_from_redis,
@@ -21,7 +22,6 @@ from posthog.temporal.session_replay.session_summary.types.video import (
 )
 from posthog.temporal.session_replay.session_summary.utils import parse_str_timestamp_to_ms
 
-from ee.hogai.session_summaries.events import capture_session_summary_ready
 from ee.hogai.session_summaries.session.summarize_session import SingleSessionSummaryLlmInputs
 from ee.hogai.session_summaries.utils import (
     calculate_time_since_start,
@@ -39,6 +39,7 @@ logger = structlog.get_logger(__name__)
 async def store_video_session_summary_activity(
     inputs: VideoSummarySingleSessionInputs,
     analysis: ConsolidatedVideoAnalysis,
+    team_api_token: str,
 ) -> None:
     """Convert video segments to session summary format and store in database
 
@@ -52,7 +53,6 @@ async def store_video_session_summary_activity(
     try:
         from dateutil import parser as dateutil_parser
 
-        from posthog.models.team import Team
         from posthog.models.user import User
 
         from ee.hogai.session_summaries.session.output_data import SessionSummarySerializer
@@ -133,14 +133,9 @@ async def store_video_session_summary_activity(
             distinct_id=distinct_id,
             created_by=user,
         )
-        team_api_token = await database_sync_to_async(
-            lambda: Team.objects.only("api_token").get(id=inputs.team_id).api_token,
-            thread_sensitive=False,
-        )()
         await asyncio.to_thread(
             capture_session_summary_ready,
             stored_summary,
-            summary_origin="single",
             team_api_token=team_api_token,
         )
         logger.debug(

--- a/posthog/temporal/session_replay/session_summary/events.py
+++ b/posthog/temporal/session_replay/session_summary/events.py
@@ -1,15 +1,13 @@
-from typing import Literal
-
 from django.conf import settings
 
 import structlog
 
 from posthog.api.capture import capture_internal
+from posthog.temporal.session_replay.session_summary.types.events import SessionSummaryReadyProperties
 
 from ee.models.session_summaries import SingleSessionSummary
 
 EVENT_SOURCE = "session_summary_events"
-SummaryOrigin = Literal["single", "group"]
 logger = structlog.get_logger(__name__)
 
 
@@ -20,12 +18,23 @@ def _build_replay_url(summary: SingleSessionSummary) -> str:
 def capture_session_summary_ready(
     summary: SingleSessionSummary,
     *,
-    summary_origin: SummaryOrigin,
     team_api_token: str,
 ) -> None:
     summary_context = summary.extra_summary_context
-    summary_content = summary.summary
     run_metadata = summary.run_metadata or {}
+    properties = SessionSummaryReadyProperties(
+        insert_id=str(summary.id),
+        session_id=summary.session_id,
+        team_id=summary.team_id,
+        summary_id=str(summary.id),
+        session_summary=summary.summary,
+        extra_summary_context=summary_context,
+        session_summary_focus_area=summary_context.get("focus_area") if summary_context else None,
+        replay_url=_build_replay_url(summary),
+        model_used=run_metadata.get("model_used"),
+        session_start_time=summary.session_start_time,
+        session_duration=summary.session_duration,
+    )
     try:
         response = capture_internal(
             token=team_api_token,
@@ -33,21 +42,7 @@ def capture_session_summary_ready(
             event_source=EVENT_SOURCE,
             distinct_id=summary.distinct_id or f"session_summary:{summary.team_id}:{summary.session_id}",
             timestamp=summary.created_at,
-            properties={
-                "$insert_id": str(summary.id),
-                "session_id": summary.session_id,
-                "team_id": summary.team_id,
-                "summary_id": str(summary.id),
-                "summary_origin": summary_origin,
-                "session_summary": summary_content,
-                "extra_summary_context": summary_context,
-                "session_summary_focus_area": summary_context.get("focus_area") if summary_context else None,
-                "replay_url": _build_replay_url(summary),
-                "visual_confirmation": bool(run_metadata.get("visual_confirmation", False)),
-                "model_used": run_metadata.get("model_used"),
-                "session_start_time": summary.session_start_time.isoformat() if summary.session_start_time else None,
-                "session_duration": summary.session_duration,
-            },
+            properties=properties.model_dump(by_alias=True, mode="json"),
         )
         response.raise_for_status()
     except Exception:
@@ -56,5 +51,4 @@ def capture_session_summary_ready(
             summary_id=str(summary.id),
             session_id=summary.session_id,
             team_id=summary.team_id,
-            summary_origin=summary_origin,
         )

--- a/posthog/temporal/session_replay/session_summary/summarize_session.py
+++ b/posthog/temporal/session_replay/session_summary/summarize_session.py
@@ -671,7 +671,7 @@ async def ensure_llm_single_session_summary(
                 ),
                 temporalio.workflow.execute_activity(
                     store_video_session_summary_activity,
-                    args=(video_inputs, consolidated_analysis),
+                    args=(video_inputs, consolidated_analysis, export_result.team_api_token),
                     start_to_close_timeout=timedelta(minutes=5),
                     retry_policy=retry_policy,
                 ),
@@ -699,7 +699,7 @@ async def ensure_llm_single_session_summary(
             )
             await temporalio.workflow.execute_activity(
                 store_video_session_summary_activity,
-                args=(video_inputs, consolidated_analysis),
+                args=(video_inputs, consolidated_analysis, export_result.team_api_token),
                 start_to_close_timeout=timedelta(minutes=5),
                 retry_policy=retry_policy,
             )

--- a/posthog/temporal/session_replay/session_summary/types/events.py
+++ b/posthog/temporal/session_replay/session_summary/types/events.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SessionSummaryReadyProperties(BaseModel):
+    """Properties of the `$session_summary_ready` event."""
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    insert_id: str = Field(alias="$insert_id")
+    session_id: str
+    team_id: int
+    summary_id: str
+    session_summary: dict[str, Any]
+    extra_summary_context: dict[str, Any] | None
+    session_summary_focus_area: str | None
+    replay_url: str
+    model_used: str | None
+    session_start_time: datetime | None
+    session_duration: int | None

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -45,6 +45,7 @@ class PrepSessionVideoAssetResult(BaseModel):
 
     asset_id: int
     needs_export: bool
+    team_api_token: str
 
 
 class UploadedVideo(BaseModel):

--- a/posthog/temporal/tests/session_replay/session_summary/test_session_summary_events.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_session_summary_events.py
@@ -41,11 +41,13 @@ def test_capture_session_summary_ready_emits_internal_project_event(
     )
     settings.SITE_URL = "http://localhost:8000"
     response = mocker.MagicMock()
-    capture_internal = mocker.patch("ee.hogai.session_summaries.events.capture_internal", return_value=response)
+    capture_internal = mocker.patch(
+        "posthog.temporal.session_replay.session_summary.events.capture_internal", return_value=response
+    )
 
-    from ee.hogai.session_summaries.events import capture_session_summary_ready
+    from posthog.temporal.session_replay.session_summary.events import capture_session_summary_ready
 
-    capture_session_summary_ready(summary, summary_origin="single", team_api_token="token-override")
+    capture_session_summary_ready(summary, team_api_token="token-override")
 
     capture_internal.assert_called_once()
     _, kwargs = capture_internal.call_args
@@ -57,12 +59,10 @@ def test_capture_session_summary_ready_emits_internal_project_event(
     assert kwargs["properties"]["session_id"] == "summary-session-1"
     assert kwargs["properties"]["team_id"] == team.id
     assert kwargs["properties"]["summary_id"] == str(summary.id)
-    assert kwargs["properties"]["summary_origin"] == "single"
     assert kwargs["properties"]["session_summary"] == summary.summary
     assert kwargs["properties"]["replay_url"] == f"http://localhost:8000/project/{team.id}/replay/summary-session-1"
     assert kwargs["properties"]["extra_summary_context"] == {"focus_area": "checkout"}
     assert kwargs["properties"]["session_summary_focus_area"] == "checkout"
-    assert kwargs["properties"]["visual_confirmation"] is False
     assert kwargs["properties"]["model_used"] == "gpt-test"
     assert kwargs["properties"]["session_start_time"] is None
     assert kwargs["properties"]["session_duration"] is None
@@ -85,12 +85,12 @@ def test_capture_session_summary_ready_swallow_capture_errors(
     )
     response = mocker.MagicMock()
     response.raise_for_status.side_effect = HTTPError("boom", response=Response())
-    mocker.patch("ee.hogai.session_summaries.events.capture_internal", return_value=response)
-    logger = mocker.patch("ee.hogai.session_summaries.events.logger")
+    mocker.patch("posthog.temporal.session_replay.session_summary.events.capture_internal", return_value=response)
+    logger = mocker.patch("posthog.temporal.session_replay.session_summary.events.logger")
 
-    from ee.hogai.session_summaries.events import capture_session_summary_ready
+    from posthog.temporal.session_replay.session_summary.events import capture_session_summary_ready
 
-    capture_session_summary_ready(summary, summary_origin="single", team_api_token=team.api_token)
+    capture_session_summary_ready(summary, team_api_token=team.api_token)
 
     logger.exception.assert_called_once()
 
@@ -148,13 +148,12 @@ async def test_store_video_session_summary_activity_emits_summary_ready_event(
         sentiment=SessionSentiment(frustration_score=0.8, outcome="blocked", sentiment_signals=[]),
     )
 
-    await store_video_session_summary_activity(inputs, analysis)
+    await store_video_session_summary_activity(inputs, analysis, ateam.api_token)
 
     capture_session_summary_ready.assert_called_once()
     emitted_summary = capture_session_summary_ready.call_args.args[0]
     assert emitted_summary.session_id == "video-session-1"
     assert emitted_summary.team_id == ateam.id
-    assert capture_session_summary_ready.call_args.kwargs["summary_origin"] == "single"
     assert capture_session_summary_ready.call_args.kwargs["team_api_token"] == ateam.api_token
     assert emitted_summary.run_metadata["visual_confirmation"] is True
     assert emitted_summary.run_metadata["model_used"] == "gpt-test"
@@ -204,7 +203,7 @@ async def test_store_video_session_summary_activity_does_not_emit_existing_summa
         sentiment=SessionSentiment(frustration_score=0.8, outcome="blocked", sentiment_signals=[]),
     )
 
-    await store_video_session_summary_activity(inputs, analysis)
+    await store_video_session_summary_activity(inputs, analysis, ateam.api_token)
 
     capture_session_summary_ready.assert_not_called()
     get_data_class_from_redis.assert_not_called()


### PR DESCRIPTION
## Problem

Follow-up to #55645. A few small refinements to the newly-added `$session_summary_ready` emission path:

- The storage activity re-fetches the team just to read `api_token`, even though the prep activity earlier in the same workflow already loads the team. In the group-summary flow this scales with N sessions.
- `capture_session_summary_ready` takes a `summary_origin` kwarg typed as `Literal["single", "group"]`, but only `"single"` is currently emitted; similarly, the `visual_confirmation` event property is always `True` at the only emit site. Both can be reintroduced when a second emitter lands.
- The helper lives under `ee/hogai/session_summaries/events.py`, but its only caller is the video summarization Temporal activity — colocating it with the workflow code makes the ownership clearer.
- Event properties are assembled as a raw `dict[str, Any]`, so the payload shape isn't type-checked.

## Changes

- Thread `team_api_token` through `PrepSessionVideoAssetResult` from `prep_session_video_asset_activity` to `store_video_session_summary_activity`, so the storage activity no longer needs its own team query.
- Remove the `summary_origin` parameter and event property, and remove the `visual_confirmation` event property.
- Move `events.py` to `posthog/temporal/session_replay/session_summary/events.py`, alongside `types/`, `state/`, and the activity that calls it.
- Introduce a `SessionSummaryReadyProperties` pydantic model under `types/events.py`; the event `properties` dict is now produced via `model_dump(by_alias=True, mode="json")`, so the shape is type-checked and datetimes serialize consistently.
- Update the unit tests (import paths, mock targets, dropped assertions).

`distinct_id` fallback behavior is unchanged from #55645 — we still prefer `summary.distinct_id` and only fall back to the synthetic `session_summary:<team>:<session>` identifier when unset.

## How did you test this code?

I'm an automated agent — no manual verification. Verified via:
- `hogli test posthog/temporal/tests/session_replay/session_summary/test_session_summary_events.py` — 4 passed
- `hogli test posthog/temporal/tests/session_replay/session_summary/` — 63 passed
- `ruff check` + `ruff format --check` on all touched files

The event contract change (dropping two properties) only affects downstream consumers of `$session_summary_ready`, which was newly added in #55645 and has no external consumers yet.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7) during a pair-programming session reviewing PR #55645 post-merge. All edits were reviewed inline; tests and lint were run locally.