### PR TITLE
feat(llma): seed default clustering jobs on new team

### DIFF
--- a/products/llm_analytics/backend/api/test/test_clustering_job.py
+++ b/products/llm_analytics/backend/api/test/test_clustering_job.py
@@ -10,6 +10,14 @@ from products.llm_analytics.backend.models.clustering_job import ClusteringJob
 
 
 class TestClusteringJobViewSet(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Team creation auto-seeds three "Default - <level>" rows via the post_save
+        # signal on Team (see models/clustering_job.py). Clear them so each test
+        # starts from a clean slate — tests that specifically exercise the default
+        # behavior recreate the rows they need.
+        ClusteringJob.objects.filter(team=self.team).delete()
+
     def _url(self, suffix: str = "") -> str:
         base = f"/api/environments/{self.team.id}/llm_analytics/clustering_jobs/"
         return f"{base}{suffix}" if suffix else base
@@ -198,6 +206,39 @@ class TestClusteringJobViewSet(APIBaseTest):
 
         custom.refresh_from_db()
         self.assertTrue(custom.enabled)
+
+
+class TestDefaultClusteringJobsOnTeamCreate(APIBaseTest):
+    """Exercises the post_save signal in models/clustering_job.py that seeds the three
+    Default - <level> rows when a new Team is created."""
+
+    def test_creates_defaults_for_all_three_levels_on_team_create(self):
+        from posthog.models import Organization, Project, Team
+
+        org = Organization.objects.create(name="signal-test")
+        project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=org)
+        team = Team.objects.create(id=project.id, project=project, organization=org)
+
+        jobs = ClusteringJob.objects.filter(team=team).order_by("analysis_level")
+        specs = {(j.name, j.analysis_level, j.enabled, tuple(j.event_filters)) for j in jobs}
+        assert specs == {
+            ("Default - evaluations", "evaluation", True, ()),
+            ("Default - generations", "generation", True, ()),
+            ("Default - traces", "trace", True, ()),
+        }
+
+    def test_no_extra_rows_on_team_update(self):
+        from posthog.models import Organization, Project, Team
+
+        org = Organization.objects.create(name="update-signal-test")
+        project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=org)
+        team = Team.objects.create(id=project.id, project=project, organization=org)
+
+        baseline = ClusteringJob.objects.filter(team=team).count()
+        team.name = "Renamed"
+        team.save()
+
+        assert ClusteringJob.objects.filter(team=team).count() == baseline
 
 
 class TestClusteringRunWithJobId(APIBaseTest):

--- a/products/llm_analytics/backend/models/clustering_job.py
+++ b/products/llm_analytics/backend/models/clustering_job.py
@@ -1,5 +1,8 @@
 from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 
+from posthog.models.team import Team
 from posthog.models.utils import UUIDModel
 
 
@@ -36,3 +39,43 @@ class ClusteringJob(UUIDModel):
 
     def __str__(self) -> str:
         return f"ClusteringJob(team={self.team_id}, name={self.name!r}, level={self.analysis_level})"
+
+
+DEFAULT_LEVEL_SPECS = (
+    ("Default - traces", "trace"),
+    ("Default - generations", "generation"),
+    ("Default - evaluations", "evaluation"),
+)
+
+
+@receiver(post_save, sender=Team)
+def create_default_clustering_jobs_for_new_team(sender, instance: Team, created: bool, **kwargs) -> None:
+    """Auto-create ``Default - <level>`` rows for each of the three analysis levels when
+    a new Team is created, so clustering is available end-to-end without the user having
+    to open the admin modal.
+
+    Why this is safe:
+
+    - ``ClusteringJobViewSet.perform_create`` flips the matching ``Default - <level>`` row
+      to ``enabled=False`` when a user creates a custom job for the same level, so the
+      default and custom scopes don't both run for a level the user has customized.
+    - ``ignore_conflicts=True`` against the ``(team, name)`` unique constraint makes the
+      signal idempotent and covers the race with backfill migrations during deploy.
+    - Runs only when ``created=True``, so it fires once per team lifetime.
+    """
+    if not created:
+        return
+
+    ClusteringJob.objects.bulk_create(
+        [
+            ClusteringJob(
+                team=instance,
+                name=name,
+                analysis_level=level,
+                event_filters=[],
+                enabled=True,
+            )
+            for name, level in DEFAULT_LEVEL_SPECS
+        ],
+        ignore_conflicts=True,
+    )


### PR DESCRIPTION
## Problem

After migration 0029 (PR #56073) backfills `Default - evaluations` for existing teams with clustering history, new teams created *afterwards* still start with zero default `ClusteringJob` rows — the clustering coordinators silently skip them. Same gap has existed for trace/generation since migration 0018 was also one-shot.

This PR closes the forward-looking half of the "every team gets eval clustering without setup" intent from #56073.

## Changes

One file of production code + test updates:

**`products/llm_analytics/backend/models/clustering_job.py`** — add a `post_save` signal receiver on `Team` that, on `created=True`, bulk-creates all three `Default - <level>` rows (trace, generation, evaluation) with empty `event_filters`, `enabled=True`, `ignore_conflicts=True`.

Mirrors the pattern at `posthog/models/hog_functions/hog_function.py:304` (`enabled_default_hog_functions_for_new_team`): receiver co-located with the model file so it auto-registers when Django imports the app, early-returns on `created=False` to avoid firing on Team updates, and uses the existing `(team, name)` unique constraint + `ignore_conflicts=True` for idempotency (covers races between backfill migrations and the signal during deploy).

User intent still wins: `ClusteringJobViewSet.perform_create` already flips the matching `Default - <level>` row to `enabled=False` when a user creates a custom job for that level, and hard-deleting via the API removes the row (so the team stops running clustering for that level until they create a new row).

**`products/llm_analytics/backend/api/test/test_clustering_job.py`** — add a `setUp` hook that clears the auto-seeded rows so existing tests keep control of their own `ClusteringJob` state. Added a small `TestDefaultClusteringJobsOnTeamCreate` covering the signal behavior directly (fires on create, stays quiet on update).

## How did you test this code?

- `hogli test products/llm_analytics/backend/api/test/test_clustering_job.py` — 24 tests pass (22 existing + 2 new signal tests).
- `ruff check` + `ruff format` clean.
- Only three importers of `ClusteringJob` across the codebase (viewset, this test file, worker's `shared_activities.py`) — all exercised.

No in-prod validation by the agent.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored follow-up to the `llma-eval-clustering` stack (#54890–#54907 merged 2026-04-23) and companion PR #56073 (one-shot backfill migration 0029 for existing teams with clustering history).

Companion, not dependent: the signal only fires on *new* Team creation, so this PR is strictly additive and can land independently of #56073. Together they cover the full "every team gets clustering for all three levels without manual setup" intent; alone, each handles half the timeline.

Pattern reference: `enabled_default_hog_functions_for_new_team` at `posthog/models/hog_functions/hog_function.py:304`. Considered the Team Extension helper (`register_team_extension_signal` in `posthog/models/team/extensions.py`) but it's one-to-one only and `ClusteringJob` is multi-row keyed by `(team, name)`.

Bead: `beads-tracking-godz`.