### PR TITLE
chore(personhog): enables zstd on BE clients

### DIFF
--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -122,6 +122,7 @@ impl LeaderBackend {
         let client = PersonHogLeaderClient::new(channel)
             .max_encoding_message_size(self.max_send_message_size)
             .max_decoding_message_size(self.max_recv_message_size)
+            .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
         self.clients.insert(address, client.clone());
         Ok(client)

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -80,6 +80,7 @@ fn create_clients(config: &ReplicaBackendConfig) -> Vec<PersonHogReplicaClient<C
             PersonHogReplicaClient::new(channel)
                 .max_encoding_message_size(config.max_send_message_size)
                 .max_decoding_message_size(config.max_recv_message_size)
+                .send_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Zstd)
         })
         .collect()


### PR DESCRIPTION
## Problem

gRPC traffic between personhog-router and its backends (personhog-replica, personhog-leader) is sent uncompressed.
For batch endpoints that return large person/group payloads, this adds unnecessary network overhead on the internal pod-to-pod links.

## Changes

Phase 2 of a two-phase rollout for zstd compression on personhog gRPC traffic.

**Phase 1** (already deployed): enabled `accept_compressed(Zstd)` on the router's gRPC clients and both `accept_compressed(Zstd)` + `send_compressed(Zstd)` on the backend servers. This allowed backends to send compressed responses while keeping the router's outgoing requests uncompressed — safe regardless of deploy order.

**Phase 2** (this PR): adds `send_compressed(Zstd)` to the router's replica and leader gRPC clients, enabling compressed requests from router to backends. Safe to deploy now that all backend pods already accept zstd.


## How did you test this code?

Compression change, will test via shipping it.
