### PR TITLE
feat(llma): hide eval clustering jobs from admin panel when FF off

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
@@ -132,6 +132,17 @@ function JobEditor({
 export function ClusteringJobsPanel(): JSX.Element {
     const { isJobsPanelOpen, jobs, jobsLoading, editingJob } = useValues(clusteringJobsLogic)
     const { closeJobsPanel, setEditingJob, createJob, updateJob, deleteJob } = useActions(clusteringJobsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const evaluationsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_CLUSTERING]
+
+    // Hide eval-level jobs from the admin list when the FF is off so the
+    // auto-seeded "Default - evaluations" row (from the migration + post_save
+    // signal) doesn't surface for teams that aren't on the feature yet. The
+    // create dropdown's "Evaluations" option is already FF-gated below, so
+    // mirroring the gate on the list keeps the two surfaces consistent.
+    const visibleJobs = evaluationsEnabled
+        ? jobs
+        : jobs.filter((job: ClusteringJob) => job.analysis_level !== 'evaluation')
 
     return (
         <LemonModal
@@ -156,7 +167,7 @@ export function ClusteringJobsPanel(): JSX.Element {
                 />
             ) : (
                 <div className="space-y-3">
-                    {jobs.map((job: ClusteringJob) => (
+                    {visibleJobs.map((job: ClusteringJob) => (
                         <div
                             key={job.id}
                             className="flex items-center justify-between border rounded p-3 hover:bg-surface-secondary transition-colors"
@@ -204,7 +215,7 @@ export function ClusteringJobsPanel(): JSX.Element {
                         </div>
                     ))}
 
-                    {jobs.length === 0 && !jobsLoading && (
+                    {visibleJobs.length === 0 && !jobsLoading && (
                         <div className="text-center text-muted p-4">No clustering jobs configured yet.</div>
                     )}
 

--- a/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
@@ -135,14 +135,17 @@ export function ClusteringJobsPanel(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const evaluationsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_CLUSTERING]
 
-    // Hide eval-level jobs from the admin list when the FF is off so the
-    // auto-seeded "Default - evaluations" row (from the migration + post_save
-    // signal) doesn't surface for teams that aren't on the feature yet. The
-    // create dropdown's "Evaluations" option is already FF-gated below, so
-    // mirroring the gate on the list keeps the two surfaces consistent.
+    // Hide only the auto-seeded "Default - evaluations" row from the admin
+    // list when the FF is off, so teams that aren't on the feature yet don't
+    // see a mystery default row they didn't create. Any custom evaluation
+    // jobs (rename of the default, or created explicitly when the FF was on
+    // and later toggled off) stay visible — otherwise we'd leave hidden-but-
+    // still-scheduled jobs with no UI surface to manage them.
     const visibleJobs = evaluationsEnabled
         ? jobs
-        : jobs.filter((job: ClusteringJob) => job.analysis_level !== 'evaluation')
+        : jobs.filter(
+              (job: ClusteringJob) => !(job.analysis_level === 'evaluation' && job.name === 'Default - evaluations')
+          )
 
     return (
         <LemonModal


### PR DESCRIPTION
## Problem

Once the backfill migration (#56073) and the post_save signal (#56074) land, every team has a \`Default - evaluations\` \`ClusteringJob\` row — even teams that aren't on the \`llm-analytics-evaluations-clustering\` feature flag. The admin modal's create dropdown already gates the "Evaluations" option on the FF, but the **list of existing jobs** renders every row the API returns with no level filter, so FF-off teams would see a mysterious \`Default - evaluations\` row in their clustering jobs panel.

## Changes

One small frontend file:

**\`products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx\`** — read \`evaluationsEnabled\` at the outer \`ClusteringJobsPanel\` component (same FF lookup pattern the inner \`JobEditor\` component already uses), and filter \`analysis_level === 'evaluation'\` rows out of the rendered list when the FF is off.

Filter applied at two render surfaces:

- \`visibleJobs.map(...)\` — the rendered list of job cards
- \`visibleJobs.length === 0\` — the empty-state message

The \`jobs.length >= MAX_JOBS\` check for the Add Job button's disabled state is **intentionally left against the unfiltered count** so the button reflects the backend's real cap (\`MAX_JOBS_PER_TEAM = 10\` in \`clustering_job.py\`) and doesn't enable a click that'd 400.

## How did you test this code?

- \`pnpm --filter=@posthog/frontend format\` clean.
- Full \`tsc --noEmit\` OOM'd locally (unrelated — known heavy TS check), so CI will validate types.

No in-prod validation by the agent. Post-merge behavior:

- FF off → user opens clustering admin panel → sees only trace / generation rows, no eval row.
- FF on → user sees all three levels including eval.
- FF flips on for a team → the default eval row appears on next panel open, no other action needed.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored, the third PR in the \`llma-eval-clustering\` followup chain. Pairs with #56073 (existing-team backfill) and #56074 (new-team signal). Once the FF is fully rolled out or removed, this filter can be deleted — worth beading a cleanup when that happens.

Matches the existing gating pattern in \`ClusteringJobsPanel.tsx:62\` (inner \`JobEditor\`) and \`ClusteringAdminModal.tsx:16\` — FF-aware, frontend-only. Did **not** add a backend filter to \`ClusteringJobViewSet.safely_get_queryset\` (Option 1 from the design discussion with Andy) because the existing gating convention is frontend-only and the additional consumers (MCP tools) can be covered separately if needed.

Bead: \`beads-tracking-fx5b\`.