### PR TITLE
feat(capture): scope lifecycle::Manager capture metrics by deployment

### DIFF
--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -111,7 +111,12 @@ async fn main() {
     let pod = std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
     let _root_span = tracing::info_span!("service", pod = %pod).entered();
 
-    let mut manager = lifecycle::Manager::builder("capture")
+    // Use OTEL_SERVICE_NAME (set per-variant by the chart's releaseName) as the
+    // lifecycle Manager identity so `common/lifecycle` metrics carry the correct
+    // `service_name` label. This binary is shared by capture, capture-replay,
+    // capture-mirrored, and capture-ai deployments — hardcoding a literal here
+    // would collapse their lifecycle metrics into a single bucket in Grafana.
+    let mut manager = lifecycle::Manager::builder(config.otel_service_name.as_str())
         .with_trap_signals(true)
         .with_prestop_check(true)
         .with_health_poll_interval(Duration::from_secs(2))


### PR DESCRIPTION
## Problem
`capture` deployments should scope their emitted `common/lifecycle` shutdown metrics by their properly scoped deploy names (releaseName) which in this service comes from `OTEL_SERVICE_NAME`
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
One-liner fix to properly scope metrics
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI, but library performing this scoping properly in live in prod all over the place
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
