### PR TITLE
fix: handle future amplitude event_time in batch-import

### DIFF
--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -1023,6 +1023,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_timestamp_falls_back_to_client_event_time_when_event_time_is_in_future() {
+        let amp_event = AmplitudeEvent {
+            event_time: Some("2099-01-01 00:00:00".to_string()),
+            client_event_time: Some("2024-06-01 12:00:00".to_string()),
+            server_received_time: Some("2024-06-01 12:00:05".to_string()),
+            ..Default::default()
+        };
+
+        let ts = parse_timestamp(&amp_event).unwrap();
+        assert_eq!(ts, parse_timestamp_string("2024-06-01 12:00:00").unwrap());
+    }
+
+    #[test]
     fn test_distinct_id_fallback() {
         // Test with user_id
         let amp_event = AmplitudeEvent {

--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -710,15 +710,23 @@ fn parse_timestamp_string(time_str: &str) -> Result<chrono::DateTime<Utc>, chron
 }
 
 fn parse_timestamp(amp: &AmplitudeEvent) -> Result<chrono::DateTime<Utc>, Error> {
+    let now = Utc::now();
+
+    // Prefer event_time / client_event_time,
+    // fall back to server_received_time if they resolve to a future timestamp.
     if let Some(event_time) = &amp.event_time {
         if let Ok(timestamp) = parse_timestamp_string(event_time) {
-            return Ok(timestamp);
+            if timestamp <= now {
+                return Ok(timestamp);
+            }
         }
     }
 
     if let Some(client_event_time) = &amp.client_event_time {
         if let Ok(timestamp) = parse_timestamp_string(client_event_time) {
-            return Ok(timestamp);
+            if timestamp <= now {
+                return Ok(timestamp);
+            }
         }
     }
 
@@ -729,7 +737,7 @@ fn parse_timestamp(amp: &AmplitudeEvent) -> Result<chrono::DateTime<Utc>, Error>
     }
 
     // If all timestamp parsing fails, use current time as last resort
-    Ok(Utc::now())
+    Ok(now)
 }
 
 #[cfg(test)]
@@ -987,6 +995,31 @@ mod tests {
                 assert!(data.timestamp.is_some());
             }
         }
+    }
+
+    #[test]
+    fn test_parse_timestamp_falls_back_to_server_time_when_event_time_is_in_future() {
+        let amp_event = AmplitudeEvent {
+            event_time: Some("2099-01-01 00:00:00".to_string()),
+            client_event_time: Some("2099-01-01 00:00:00".to_string()),
+            server_received_time: Some("2024-06-01 12:00:00".to_string()),
+            ..Default::default()
+        };
+
+        let ts = parse_timestamp(&amp_event).unwrap();
+        assert_eq!(ts, parse_timestamp_string("2024-06-01 12:00:00").unwrap());
+    }
+
+    #[test]
+    fn test_parse_timestamp_prefers_event_time_when_valid() {
+        let amp_event = AmplitudeEvent {
+            event_time: Some("2024-06-01 12:00:00".to_string()),
+            server_received_time: Some("2024-06-01 12:00:05".to_string()),
+            ..Default::default()
+        };
+
+        let ts = parse_timestamp(&amp_event).unwrap();
+        assert_eq!(ts, parse_timestamp_string("2024-06-01 12:00:00").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Batch import from Amplitude via [managed migration](https://us.posthog.com/project/2/managed_migrations) is failing for a customer. Digging into the raw Amplitude data, I found that `event_time` can be in the future (user device clock issue). And a malformed event causes:

![Screenshot 2026-04-21 at 10.28.24 AM (2).png](https://app.graphite.com/user-attachments/assets/84f56f35-9fa0-4173-906b-f98733e91b2f.png)

This happens because we pass `event_time` straight through to `posthog_rs::Event::set_timestamp` in `src/emit/capture.rs:63`, which hard-rejects anything `> now + 1s`. 

posthog-rs is all-or-nothing, so one bad event kills the whole batch, the worker drops the job, re-claims, re-downloads, and loops on the same chunk forever.

Support ticket: https://posthoghelp.zendesk.com/agent/tickets/55897 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/58533)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

In `parse_timestamp` (`rust/batch-import-worker/src/parse/content/amplitude.rs`), skip `event_time` / `client_event_time` if they parse to a value `> Utc::now()` and fall through to `server_received_time` — Amplitude writes it server-side, so it's not affected by client clock skew. 

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests:

- future `event_time` + `client_event_time` → falls back to `server_received_time`
- past `event_time` → still used as-is<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->