### PR TITLE
feat(insights): expose list filters and creator fields in MCP

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1104,6 +1104,76 @@ Background calculation can be tracked using the `query_status` response field.""
                 type=OpenApiTypes.BOOL,
                 description="Return basic insight metadata only (no results, faster).",
             ),
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                description="Case-insensitive substring match across name, derived_name, description, and tag names.",
+            ),
+            OpenApiParameter(
+                name="created_by",
+                type=OpenApiTypes.STR,
+                description="JSON-encoded array of user IDs. Only returns insights whose `created_by` is in the list, e.g. `[1,42]`.",
+            ),
+            OpenApiParameter(
+                name="user",
+                type=OpenApiTypes.BOOL,
+                description="When truthy, restricts results to insights created by the authenticated user.",
+            ),
+            OpenApiParameter(
+                name="favorited",
+                type=OpenApiTypes.BOOL,
+                description="When truthy, restricts results to insights marked as favorited.",
+            ),
+            OpenApiParameter(
+                name="saved",
+                type=OpenApiTypes.BOOL,
+                description="When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.",
+            ),
+            OpenApiParameter(
+                name="insight",
+                enum=["TRENDS", "FUNNELS", "RETENTION", "PATHS", "STICKINESS", "LIFECYCLE", "JSON", "SQL"],
+                description="Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.",
+            ),
+            OpenApiParameter(
+                name="date_from",
+                type=OpenApiTypes.STR,
+                description="Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).",
+            ),
+            OpenApiParameter(
+                name="date_to",
+                type=OpenApiTypes.STR,
+                description="Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.",
+            ),
+            OpenApiParameter(
+                name="created_date_from",
+                type=OpenApiTypes.STR,
+                description="Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.",
+            ),
+            OpenApiParameter(
+                name="created_date_to",
+                type=OpenApiTypes.STR,
+                description="Filter by `created_at < created_date_to`. Accepts absolute or relative dates.",
+            ),
+            OpenApiParameter(
+                name="last_viewed_date_from",
+                type=OpenApiTypes.STR,
+                description="Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.",
+            ),
+            OpenApiParameter(
+                name="last_viewed_date_to",
+                type=OpenApiTypes.STR,
+                description="Filter by `last_viewed_at < last_viewed_date_to`. Accepts absolute or relative dates.",
+            ),
+            OpenApiParameter(
+                name="dashboards",
+                type=OpenApiTypes.STR,
+                description="JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).",
+            ),
+            OpenApiParameter(
+                name="tags",
+                type=OpenApiTypes.STR,
+                description="JSON-encoded array of tag names. Returns insights with any of the listed tags.",
+            ),
         ]
     ),
     update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1117,12 +1117,12 @@ Background calculation can be tracked using the `query_status` response field.""
             OpenApiParameter(
                 name="user",
                 type=OpenApiTypes.BOOL,
-                description="When truthy, restricts results to insights created by the authenticated user.",
+                description="Include this parameter (any value) to restrict results to insights created by the authenticated user.",
             ),
             OpenApiParameter(
                 name="favorited",
                 type=OpenApiTypes.BOOL,
-                description="When truthy, restricts results to insights marked as favorited.",
+                description="Include this parameter (any value) to restrict results to insights marked as favorited.",
             ),
             OpenApiParameter(
                 name="saved",
@@ -1137,7 +1137,7 @@ Background calculation can be tracked using the `query_status` response field.""
             OpenApiParameter(
                 name="date_from",
                 type=OpenApiTypes.STR,
-                description="Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).",
+                description="Filter by `last_modified_at > date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).",
             ),
             OpenApiParameter(
                 name="date_to",
@@ -1147,7 +1147,7 @@ Background calculation can be tracked using the `query_status` response field.""
             OpenApiParameter(
                 name="created_date_from",
                 type=OpenApiTypes.STR,
-                description="Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.",
+                description="Filter by `created_at > created_date_from`. Accepts absolute or relative dates.",
             ),
             OpenApiParameter(
                 name="created_date_to",
@@ -1157,7 +1157,7 @@ Background calculation can be tracked using the `query_status` response field.""
             OpenApiParameter(
                 name="last_viewed_date_from",
                 type=OpenApiTypes.STR,
-                description="Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.",
+                description="Filter by `last_viewed_at > last_viewed_date_from`. Accepts absolute or relative dates.",
             ),
             OpenApiParameter(
                 name="last_viewed_date_to",

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -170,7 +170,14 @@ insights: PostgresTable = PostgresTable(
         "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
         "_saved": BooleanDatabaseField(name="saved", hidden=True),
         "saved": ExpressionField(name="saved", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_saved"])])),
+        "_favorited": BooleanDatabaseField(name="favorited", hidden=True),
+        "favorited": ExpressionField(
+            name="favorited", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_favorited"])])
+        ),
         "created_at": DateTimeDatabaseField(name="created_at"),
+        "created_by_id": IntegerDatabaseField(name="created_by_id", nullable=True),
+        "last_modified_at": DateTimeDatabaseField(name="last_modified_at"),
+        "last_modified_by_id": IntegerDatabaseField(name="last_modified_by_id", nullable=True),
         "updated_at": DateTimeDatabaseField(name="updated_at"),
     },
 )

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -5966,6 +5966,16 @@
                   "table": null,
                   "type": "expression"
               },
+              "favorited": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "favorited",
+                  "id": null,
+                  "name": "favorited",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
               "created_at": {
                   "chain": null,
                   "fields": null,
@@ -5975,6 +5985,36 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "datetime"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "last_modified_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_modified_at",
+                  "id": null,
+                  "name": "last_modified_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "last_modified_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_modified_by_id",
+                  "id": null,
+                  "name": "last_modified_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
               },
               "updated_at": {
                   "chain": null,
@@ -12070,6 +12110,16 @@
                   "table": null,
                   "type": "expression"
               },
+              "favorited": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "favorited",
+                  "id": null,
+                  "name": "favorited",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
               "created_at": {
                   "chain": null,
                   "fields": null,
@@ -12079,6 +12129,36 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "datetime"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "last_modified_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_modified_at",
+                  "id": null,
+                  "name": "last_modified_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "last_modified_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_modified_by_id",
+                  "id": null,
+                  "name": "last_modified_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
               },
               "updated_at": {
                   "chain": null,

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9809,7 +9809,7 @@ export type InsightsListParams = {
      */
     created_by?: string
     /**
-     * Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.
+     * Filter by `created_at > created_date_from`. Accepts absolute or relative dates.
      */
     created_date_from?: string
     /**
@@ -9821,7 +9821,7 @@ export type InsightsListParams = {
      */
     dashboards?: string
     /**
-     * Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
+     * Filter by `last_modified_at > date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
      */
     date_from?: string
     /**
@@ -9829,7 +9829,7 @@ export type InsightsListParams = {
      */
     date_to?: string
     /**
-     * When truthy, restricts results to insights marked as favorited.
+     * Include this parameter (any value) to restrict results to insights marked as favorited.
      */
     favorited?: boolean
     format?: InsightsListFormat
@@ -9838,7 +9838,7 @@ export type InsightsListParams = {
      */
     insight?: InsightsListInsight
     /**
-     * Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.
+     * Filter by `last_viewed_at > last_viewed_date_from`. Accepts absolute or relative dates.
      */
     last_viewed_date_from?: string
     /**
@@ -9879,7 +9879,7 @@ Background calculation can be tracked using the `query_status` response field.
      */
     tags?: string
     /**
-     * When truthy, restricts results to insights created by the authenticated user.
+     * Include this parameter (any value) to restrict results to insights created by the authenticated user.
      */
     user?: boolean
 }

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9804,7 +9804,47 @@ export type InsightsListParams = {
      * Return basic insight metadata only (no results, faster).
      */
     basic?: boolean
+    /**
+     * JSON-encoded array of user IDs. Only returns insights whose `created_by` is in the list, e.g. `[1,42]`.
+     */
+    created_by?: string
+    /**
+     * Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.
+     */
+    created_date_from?: string
+    /**
+     * Filter by `created_at < created_date_to`. Accepts absolute or relative dates.
+     */
+    created_date_to?: string
+    /**
+     * JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).
+     */
+    dashboards?: string
+    /**
+     * Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
+     */
+    date_from?: string
+    /**
+     * Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.
+     */
+    date_to?: string
+    /**
+     * When truthy, restricts results to insights marked as favorited.
+     */
+    favorited?: boolean
     format?: InsightsListFormat
+    /**
+     * Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.
+     */
+    insight?: InsightsListInsight
+    /**
+     * Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.
+     */
+    last_viewed_date_from?: string
+    /**
+     * Filter by `last_viewed_at < last_viewed_date_to`. Accepts absolute or relative dates.
+     */
+    last_viewed_date_to?: string
     /**
      * Number of results to return per page.
      */
@@ -9825,7 +9865,23 @@ Whether to refresh the retrieved insights, how aggressively, and if sync or asyn
 Background calculation can be tracked using the `query_status` response field.
  */
     refresh?: InsightsListRefresh
+    /**
+     * When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.
+     */
+    saved?: boolean
+    /**
+     * Case-insensitive substring match across name, derived_name, description, and tag names.
+     */
+    search?: string
     short_id?: string
+    /**
+     * JSON-encoded array of tag names. Returns insights with any of the listed tags.
+     */
+    tags?: string
+    /**
+     * When truthy, restricts results to insights created by the authenticated user.
+     */
+    user?: boolean
 }
 
 export type InsightsListFormat = (typeof InsightsListFormat)[keyof typeof InsightsListFormat]
@@ -9833,6 +9889,19 @@ export type InsightsListFormat = (typeof InsightsListFormat)[keyof typeof Insigh
 export const InsightsListFormat = {
     Csv: 'csv',
     Json: 'json',
+} as const
+
+export type InsightsListInsight = (typeof InsightsListInsight)[keyof typeof InsightsListInsight]
+
+export const InsightsListInsight = {
+    Funnels: 'FUNNELS',
+    Json: 'JSON',
+    Lifecycle: 'LIFECYCLE',
+    Paths: 'PATHS',
+    Retention: 'RETENTION',
+    Sql: 'SQL',
+    Stickiness: 'STICKINESS',
+    Trends: 'TRENDS',
 } as const
 
 export type InsightsListRefresh = (typeof InsightsListRefresh)[keyof typeof InsightsListRefresh]

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -42,6 +42,7 @@ tools:
                 - created_at
                 - created_by
                 - last_modified_at
+                - last_modified_by
                 - last_viewed_at
                 - alerts
     insight-get:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37144,7 +37144,47 @@ export namespace Schemas {
      * Return basic insight metadata only (no results, faster).
      */
     basic?: boolean;
+    /**
+     * JSON-encoded array of user IDs. Only returns insights whose `created_by` is in the list, e.g. `[1,42]`.
+     */
+    created_by?: string;
+    /**
+     * Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.
+     */
+    created_date_from?: string;
+    /**
+     * Filter by `created_at < created_date_to`. Accepts absolute or relative dates.
+     */
+    created_date_to?: string;
+    /**
+     * JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).
+     */
+    dashboards?: string;
+    /**
+     * Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
+     */
+    date_from?: string;
+    /**
+     * Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.
+     */
+    date_to?: string;
+    /**
+     * When truthy, restricts results to insights marked as favorited.
+     */
+    favorited?: boolean;
     format?: EnvironmentsInsightsListFormat;
+    /**
+     * Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.
+     */
+    insight?: EnvironmentsInsightsListInsight;
+    /**
+     * Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.
+     */
+    last_viewed_date_from?: string;
+    /**
+     * Filter by `last_viewed_at < last_viewed_date_to`. Accepts absolute or relative dates.
+     */
+    last_viewed_date_to?: string;
     /**
      * Number of results to return per page.
      */
@@ -37165,7 +37205,23 @@ export namespace Schemas {
     Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsListRefresh;
+    /**
+     * When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.
+     */
+    saved?: boolean;
+    /**
+     * Case-insensitive substring match across name, derived_name, description, and tag names.
+     */
+    search?: string;
     short_id?: string;
+    /**
+     * JSON-encoded array of tag names. Returns insights with any of the listed tags.
+     */
+    tags?: string;
+    /**
+     * When truthy, restricts results to insights created by the authenticated user.
+     */
+    user?: boolean;
     };
 
     export type EnvironmentsInsightsListFormat = typeof EnvironmentsInsightsListFormat[keyof typeof EnvironmentsInsightsListFormat];
@@ -37174,6 +37230,20 @@ export namespace Schemas {
     export const EnvironmentsInsightsListFormat = {
       Csv: 'csv',
       Json: 'json',
+    } as const;
+
+    export type EnvironmentsInsightsListInsight = typeof EnvironmentsInsightsListInsight[keyof typeof EnvironmentsInsightsListInsight];
+
+
+    export const EnvironmentsInsightsListInsight = {
+      Funnels: 'FUNNELS',
+      Json: 'JSON',
+      Lifecycle: 'LIFECYCLE',
+      Paths: 'PATHS',
+      Retention: 'RETENTION',
+      Sql: 'SQL',
+      Stickiness: 'STICKINESS',
+      Trends: 'TRENDS',
     } as const;
 
     export type EnvironmentsInsightsListRefresh = typeof EnvironmentsInsightsListRefresh[keyof typeof EnvironmentsInsightsListRefresh];
@@ -41302,7 +41372,47 @@ export namespace Schemas {
      * Return basic insight metadata only (no results, faster).
      */
     basic?: boolean;
+    /**
+     * JSON-encoded array of user IDs. Only returns insights whose `created_by` is in the list, e.g. `[1,42]`.
+     */
+    created_by?: string;
+    /**
+     * Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.
+     */
+    created_date_from?: string;
+    /**
+     * Filter by `created_at < created_date_to`. Accepts absolute or relative dates.
+     */
+    created_date_to?: string;
+    /**
+     * JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).
+     */
+    dashboards?: string;
+    /**
+     * Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
+     */
+    date_from?: string;
+    /**
+     * Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.
+     */
+    date_to?: string;
+    /**
+     * When truthy, restricts results to insights marked as favorited.
+     */
+    favorited?: boolean;
     format?: InsightsListFormat;
+    /**
+     * Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.
+     */
+    insight?: InsightsListInsight;
+    /**
+     * Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.
+     */
+    last_viewed_date_from?: string;
+    /**
+     * Filter by `last_viewed_at < last_viewed_date_to`. Accepts absolute or relative dates.
+     */
+    last_viewed_date_to?: string;
     /**
      * Number of results to return per page.
      */
@@ -41323,7 +41433,23 @@ export namespace Schemas {
     Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsListRefresh;
+    /**
+     * When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.
+     */
+    saved?: boolean;
+    /**
+     * Case-insensitive substring match across name, derived_name, description, and tag names.
+     */
+    search?: string;
     short_id?: string;
+    /**
+     * JSON-encoded array of tag names. Returns insights with any of the listed tags.
+     */
+    tags?: string;
+    /**
+     * When truthy, restricts results to insights created by the authenticated user.
+     */
+    user?: boolean;
     };
 
     export type InsightsListFormat = typeof InsightsListFormat[keyof typeof InsightsListFormat];
@@ -41332,6 +41458,20 @@ export namespace Schemas {
     export const InsightsListFormat = {
       Csv: 'csv',
       Json: 'json',
+    } as const;
+
+    export type InsightsListInsight = typeof InsightsListInsight[keyof typeof InsightsListInsight];
+
+
+    export const InsightsListInsight = {
+      Funnels: 'FUNNELS',
+      Json: 'JSON',
+      Lifecycle: 'LIFECYCLE',
+      Paths: 'PATHS',
+      Retention: 'RETENTION',
+      Sql: 'SQL',
+      Stickiness: 'STICKINESS',
+      Trends: 'TRENDS',
     } as const;
 
     export type InsightsListRefresh = typeof InsightsListRefresh[keyof typeof InsightsListRefresh];

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37149,7 +37149,7 @@ export namespace Schemas {
      */
     created_by?: string;
     /**
-     * Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.
+     * Filter by `created_at > created_date_from`. Accepts absolute or relative dates.
      */
     created_date_from?: string;
     /**
@@ -37161,7 +37161,7 @@ export namespace Schemas {
      */
     dashboards?: string;
     /**
-     * Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
+     * Filter by `last_modified_at > date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
      */
     date_from?: string;
     /**
@@ -37169,7 +37169,7 @@ export namespace Schemas {
      */
     date_to?: string;
     /**
-     * When truthy, restricts results to insights marked as favorited.
+     * Include this parameter (any value) to restrict results to insights marked as favorited.
      */
     favorited?: boolean;
     format?: EnvironmentsInsightsListFormat;
@@ -37178,7 +37178,7 @@ export namespace Schemas {
      */
     insight?: EnvironmentsInsightsListInsight;
     /**
-     * Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.
+     * Filter by `last_viewed_at > last_viewed_date_from`. Accepts absolute or relative dates.
      */
     last_viewed_date_from?: string;
     /**
@@ -37219,7 +37219,7 @@ export namespace Schemas {
      */
     tags?: string;
     /**
-     * When truthy, restricts results to insights created by the authenticated user.
+     * Include this parameter (any value) to restrict results to insights created by the authenticated user.
      */
     user?: boolean;
     };
@@ -41377,7 +41377,7 @@ export namespace Schemas {
      */
     created_by?: string;
     /**
-     * Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.
+     * Filter by `created_at > created_date_from`. Accepts absolute or relative dates.
      */
     created_date_from?: string;
     /**
@@ -41389,7 +41389,7 @@ export namespace Schemas {
      */
     dashboards?: string;
     /**
-     * Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
+     * Filter by `last_modified_at > date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).
      */
     date_from?: string;
     /**
@@ -41397,7 +41397,7 @@ export namespace Schemas {
      */
     date_to?: string;
     /**
-     * When truthy, restricts results to insights marked as favorited.
+     * Include this parameter (any value) to restrict results to insights marked as favorited.
      */
     favorited?: boolean;
     format?: InsightsListFormat;
@@ -41406,7 +41406,7 @@ export namespace Schemas {
      */
     insight?: InsightsListInsight;
     /**
-     * Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.
+     * Filter by `last_viewed_at > last_viewed_date_from`. Accepts absolute or relative dates.
      */
     last_viewed_date_from?: string;
     /**
@@ -41447,7 +41447,7 @@ export namespace Schemas {
      */
     tags?: string;
     /**
-     * When truthy, restricts results to insights created by the authenticated user.
+     * Include this parameter (any value) to restrict results to insights created by the authenticated user.
      */
     user?: boolean;
     };

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -28,7 +28,50 @@ export const insightsListQueryRefreshDefault = `force_cache`
 
 export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
     basic: zod.boolean().optional().describe('Return basic insight metadata only (no results, faster).'),
+    created_by: zod
+        .string()
+        .optional()
+        .describe(
+            'JSON-encoded array of user IDs. Only returns insights whose `created_by` is in the list, e.g. `[1,42]`.'
+        ),
+    created_date_from: zod
+        .string()
+        .optional()
+        .describe('Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.'),
+    created_date_to: zod
+        .string()
+        .optional()
+        .describe('Filter by `created_at < created_date_to`. Accepts absolute or relative dates.'),
+    dashboards: zod
+        .string()
+        .optional()
+        .describe('JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).'),
+    date_from: zod
+        .string()
+        .optional()
+        .describe(
+            'Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).'
+        ),
+    date_to: zod
+        .string()
+        .optional()
+        .describe('Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.'),
+    favorited: zod.boolean().optional().describe('When truthy, restricts results to insights marked as favorited.'),
     format: zod.enum(['csv', 'json']).optional(),
+    insight: zod
+        .enum(['FUNNELS', 'JSON', 'LIFECYCLE', 'PATHS', 'RETENTION', 'SQL', 'STICKINESS', 'TRENDS'])
+        .optional()
+        .describe(
+            'Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.'
+        ),
+    last_viewed_date_from: zod
+        .string()
+        .optional()
+        .describe('Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.'),
+    last_viewed_date_to: zod
+        .string()
+        .optional()
+        .describe('Filter by `last_viewed_at < last_viewed_date_to`. Accepts absolute or relative dates.'),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     refresh: zod
@@ -45,7 +88,25 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "\nWhether to refresh the retrieved insights, how aggressively, and if sync or async:\n- `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates\n- `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache\n- `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache\n- `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache\n- `'force_blocking'` - calculate synchronously, even if fresh results are already cached\n- `'force_async'` - kick off background calculation, even if fresh results are already cached\nBackground calculation can be tracked using the `query_status` response field."
         ),
+    saved: zod
+        .boolean()
+        .optional()
+        .describe(
+            'When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.'
+        ),
+    search: zod
+        .string()
+        .optional()
+        .describe('Case-insensitive substring match across name, derived_name, description, and tag names.'),
     short_id: zod.string().optional(),
+    tags: zod
+        .string()
+        .optional()
+        .describe('JSON-encoded array of tag names. Returns insights with any of the listed tags.'),
+    user: zod
+        .boolean()
+        .optional()
+        .describe('When truthy, restricts results to insights created by the authenticated user.'),
 })
 
 /**

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -37,7 +37,7 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
     created_date_from: zod
         .string()
         .optional()
-        .describe('Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.'),
+        .describe('Filter by `created_at > created_date_from`. Accepts absolute or relative dates.'),
     created_date_to: zod
         .string()
         .optional()
@@ -50,13 +50,16 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).'
+            'Filter by `last_modified_at > date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).'
         ),
     date_to: zod
         .string()
         .optional()
         .describe('Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.'),
-    favorited: zod.boolean().optional().describe('When truthy, restricts results to insights marked as favorited.'),
+    favorited: zod
+        .boolean()
+        .optional()
+        .describe('Include this parameter (any value) to restrict results to insights marked as favorited.'),
     format: zod.enum(['csv', 'json']).optional(),
     insight: zod
         .enum(['FUNNELS', 'JSON', 'LIFECYCLE', 'PATHS', 'RETENTION', 'SQL', 'STICKINESS', 'TRENDS'])
@@ -67,7 +70,7 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
     last_viewed_date_from: zod
         .string()
         .optional()
-        .describe('Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.'),
+        .describe('Filter by `last_viewed_at > last_viewed_date_from`. Accepts absolute or relative dates.'),
     last_viewed_date_to: zod
         .string()
         .optional()
@@ -106,7 +109,9 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
     user: zod
         .boolean()
         .optional()
-        .describe('When truthy, restricts results to insights created by the authenticated user.'),
+        .describe(
+            'Include this parameter (any value) to restrict results to insights created by the authenticated user.'
+        ),
 })
 
 /**

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -105,9 +105,23 @@ const insightsList = (): ToolBase<typeof InsightsListSchema, WithPostHogUrl<Sche
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/`,
             query: {
+                created_by: params.created_by,
+                created_date_from: params.created_date_from,
+                created_date_to: params.created_date_to,
+                dashboards: params.dashboards,
+                date_from: params.date_from,
+                date_to: params.date_to,
+                favorited: params.favorited,
+                insight: params.insight,
+                last_viewed_date_from: params.last_viewed_date_from,
+                last_viewed_date_to: params.last_viewed_date_to,
                 limit: params.limit,
                 offset: params.offset,
+                saved: params.saved,
+                search: params.search,
                 short_id: params.short_id,
+                tags: params.tags,
+                user: params.user,
             },
         })
         const filtered = {
@@ -125,6 +139,7 @@ const insightsList = (): ToolBase<typeof InsightsListSchema, WithPostHogUrl<Sche
                     'created_at',
                     'created_by',
                     'last_modified_at',
+                    'last_modified_by',
                     'last_viewed_at',
                     'alerts',
                 ])

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insights-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insights-list.json
@@ -1,6 +1,47 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "created_by": {
+            "description": "JSON-encoded array of user IDs. Only returns insights whose `created_by` is in the list, e.g. `[1,42]`.",
+            "type": "string"
+        },
+        "created_date_from": {
+            "description": "Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.",
+            "type": "string"
+        },
+        "created_date_to": {
+            "description": "Filter by `created_at < created_date_to`. Accepts absolute or relative dates.",
+            "type": "string"
+        },
+        "dashboards": {
+            "description": "JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).",
+            "type": "string"
+        },
+        "date_from": {
+            "description": "Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).",
+            "type": "string"
+        },
+        "date_to": {
+            "description": "Filter by `last_modified_at < date_to`. Accepts absolute dates or relative strings.",
+            "type": "string"
+        },
+        "favorited": {
+            "description": "When truthy, restricts results to insights marked as favorited.",
+            "type": "boolean"
+        },
+        "insight": {
+            "description": "Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.",
+            "enum": ["FUNNELS", "JSON", "LIFECYCLE", "PATHS", "RETENTION", "SQL", "STICKINESS", "TRENDS"],
+            "type": "string"
+        },
+        "last_viewed_date_from": {
+            "description": "Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.",
+            "type": "string"
+        },
+        "last_viewed_date_to": {
+            "description": "Filter by `last_viewed_at < last_viewed_date_to`. Accepts absolute or relative dates.",
+            "type": "string"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"
@@ -9,8 +50,24 @@
             "description": "The initial index from which to return the results.",
             "type": "number"
         },
+        "saved": {
+            "description": "When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.",
+            "type": "boolean"
+        },
+        "search": {
+            "description": "Case-insensitive substring match across name, derived_name, description, and tag names.",
+            "type": "string"
+        },
         "short_id": {
             "type": "string"
+        },
+        "tags": {
+            "description": "JSON-encoded array of tag names. Returns insights with any of the listed tags.",
+            "type": "string"
+        },
+        "user": {
+            "description": "When truthy, restricts results to insights created by the authenticated user.",
+            "type": "boolean"
         }
     },
     "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insights-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insights-list.json
@@ -6,7 +6,7 @@
             "type": "string"
         },
         "created_date_from": {
-            "description": "Filter by `created_at >= created_date_from`. Accepts absolute or relative dates.",
+            "description": "Filter by `created_at > created_date_from`. Accepts absolute or relative dates.",
             "type": "string"
         },
         "created_date_to": {
@@ -18,7 +18,7 @@
             "type": "string"
         },
         "date_from": {
-            "description": "Filter by `last_modified_at >= date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).",
+            "description": "Filter by `last_modified_at > date_from`. Accepts absolute dates (`2025-04-23`) or relative strings (`-7d`, `-1m`).",
             "type": "string"
         },
         "date_to": {
@@ -26,7 +26,7 @@
             "type": "string"
         },
         "favorited": {
-            "description": "When truthy, restricts results to insights marked as favorited.",
+            "description": "Include this parameter (any value) to restrict results to insights marked as favorited.",
             "type": "boolean"
         },
         "insight": {
@@ -35,7 +35,7 @@
             "type": "string"
         },
         "last_viewed_date_from": {
-            "description": "Filter by `last_viewed_at >= last_viewed_date_from`. Accepts absolute or relative dates.",
+            "description": "Filter by `last_viewed_at > last_viewed_date_from`. Accepts absolute or relative dates.",
             "type": "string"
         },
         "last_viewed_date_to": {
@@ -66,7 +66,7 @@
             "type": "string"
         },
         "user": {
-            "description": "When truthy, restricts results to insights created by the authenticated user.",
+            "description": "Include this parameter (any value) to restrict results to insights created by the authenticated user.",
             "type": "boolean"
         }
     },


### PR DESCRIPTION
## Problem

The PostHog MCP's `insights-list` tool only exposes `limit`, `offset`, and `short_id`. Anything else an agent might want to narrow by — creator, text search, date windows, favorited, type, saved, tags, dashboards — can't be passed. That's because `InsightViewSet` declares `filterset_fields = ["short_id"]` and hand-rolls the other filters inside a `_filter_request` method that drf-spectacular never sees. The generated OpenAPI spec, Orval schemas, and MCP tool schema all stop at the three fields drf-spectacular can discover.

Three consequences:

1. Agents can't answer "find the MAU insight I created last April" in a single call; they have to paginate the full 76k-row list by id.
2. Even when paginating, the `insights-list` response drops `last_modified_by`, so "last used by me" matching requires a per-row `insight-get`.
3. `system.insights` (HogQL) has no `created_by_id` / `last_modified_by_id` columns, so agents can't filter by creator via SQL either.

## Changes

- `posthog/api/insight.py` — declare the real list filters on `InsightViewSet.list` via `@extend_schema(parameters=[…])`: `search`, `created_by`, `user`, `favorited`, `saved`, `insight`, `date_from`/`date_to`, `created_date_from`/`to`, `last_viewed_date_from`/`to`, `dashboards`, `tags`. Purely additive — the runtime `_filter_request` logic already handled these; only the schema was missing.
- `products/product_analytics/mcp/tools.yaml` — add `last_modified_by` to the `insights-list` response include list.
- `posthog/hogql/database/schema/system.py` — add `created_by_id`, `last_modified_by_id`, `last_modified_at`, and `favorited` to the `system.insights` PostgresTable so SQL-based discovery has the columns.
- Regenerated files: OpenAPI → Orval zod schemas → MCP tool handler → frontend API types; plus the HogQL database schema snapshot.

After this, the agent flow collapses to:

```
insights-list { search: "MAU", user: true, created_date_from: "-400d", created_date_to: "-330d" }
```

## How did you test this code?

I'm an agent and haven't tested this manually. Verification I did run:

- `hogli build:openapi` regenerated the full MCP toolchain cleanly (27 modules, 174 enabled ops, tool schemas picked up all 13 new filter params).
- `pnpm --filter=@posthog/mcp typecheck` passes.
- `pytest posthog/hogql/database/test/test_database.py` passes after updating snapshots (2 snapshot updates for the new columns).
- `pytest posthog/api/test/test_insight.py -k 'list or filter or created_by or search'` passes (20/20). Other pre-existing failures on `test_funnel_breakdown_override` and `test_insight_funnels_hogql_*` reproduce on master and are unrelated.

Reviewers should manually spot-check an `insights-list` call against a local dev instance with a filter like `?search=MAU&user=true`, and confirm the generated MCP tool description lists the new params.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude (Opus 4.7, 1M context) in Claude Code, paired with @timgl. The work grew out of a frustrating MCP session where answering "find me a graph of MAUs using the app" took 34 tool calls — the root cause analysis identified the missing filters, the dropped `last_modified_by` response field, and the missing HogQL columns as three independent issues with shared leverage. This PR bundles all three.