### PR TITLE
feat(workflows): add observer metric for duplicate hogflow invocations

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -172,7 +172,7 @@ export function createCdpCoreServices(
 
     const recipientsManager = new RecipientsManagerService(deps.postgres)
     const recipientPreferencesService = new RecipientPreferencesService(recipientsManager)
-    const hogFlowExecutor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService)
+    const hogFlowExecutor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService, redis)
 
     const hogFunctionMonitoringService = new HogFunctionMonitoringService(
         new IngestionOutputs({

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -1,5 +1,8 @@
 import { get } from 'lodash'
 import { DateTime } from 'luxon'
+import { Counter } from 'prom-client'
+
+import { RedisV2 } from '~/common/redis/redis-v2'
 
 import { HogFlow, HogFlowAction } from '../../../schema/hogflow'
 import { logger } from '../../../utils/logger'
@@ -38,6 +41,13 @@ import {
 } from './hogflow-utils'
 
 export const MAX_ACTION_STEPS_HARD_LIMIT = 1000
+
+const DUPLICATE_OBSERVATION_TTL_SECONDS = 15 * 60
+
+const hogflowDuplicateInvocationDetectedTotal = new Counter({
+    name: 'hogflow_duplicate_invocation_detected_total',
+    help: 'Workflow invocations created for a (workflow, event) pair already seen within the observation window',
+})
 
 export function createHogFlowInvocation(
     globals: HogFunctionInvocationGlobals,
@@ -78,11 +88,14 @@ export function createHogFlowInvocation(
 
 export class HogFlowExecutorService {
     private readonly actionHandlers: Record<HogFlowAction['type'], ActionHandler>
+    private readonly redis: RedisV2 | null
 
     constructor(
         hogFlowFunctionsService: HogFlowFunctionsService,
-        recipientPreferencesService: RecipientPreferencesService
+        recipientPreferencesService: RecipientPreferencesService,
+        redis?: RedisV2
     ) {
+        this.redis = redis ?? null
         const hogFunctionHandler = new HogFunctionHandler(hogFlowFunctionsService, recipientPreferencesService, 'fetch')
         const hogFunctionEmailHandler = new HogFunctionHandler(
             hogFlowFunctionsService,
@@ -139,6 +152,7 @@ export class HogFlowExecutorService {
 
             const invocation = createHogFlowInvocation(triggerGlobals, hogFlow, filterGlobals)
             invocations.push(invocation)
+            this.observeDuplicateInvocation(invocation)
         }
 
         return {
@@ -146,6 +160,22 @@ export class HogFlowExecutorService {
             metrics,
             logs,
         }
+    }
+
+    private observeDuplicateInvocation(invocation: CyclotronJobInvocationHogFlow): void {
+        const eventUuid = invocation.state.event?.uuid
+        if (!this.redis || !eventUuid) {
+            return
+        }
+        const key = `hogflow:observe:${invocation.functionId}:${eventUuid}`
+        void this.redis
+            .useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
+                const wasSet = await client.set(key, invocation.id, 'EX', DUPLICATE_OBSERVATION_TTL_SECONDS, 'NX')
+                if (!wasSet) {
+                    hogflowDuplicateInvocationDetectedTotal.inc()
+                }
+            })
+            .catch(() => {})
     }
 
     async execute(

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -47,6 +47,7 @@ const DUPLICATE_OBSERVATION_TTL_SECONDS = 15 * 60
 const hogflowDuplicateInvocationDetectedTotal = new Counter({
     name: 'hogflow_duplicate_invocation_detected_total',
     help: 'Workflow invocations created for a (workflow, event) pair already seen within the observation window',
+    labelNames: ['workflow_id'],
 })
 
 export function createHogFlowInvocation(
@@ -172,10 +173,12 @@ export class HogFlowExecutorService {
             .useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
                 const wasSet = await client.set(key, invocation.id, 'EX', DUPLICATE_OBSERVATION_TTL_SECONDS, 'NX')
                 if (!wasSet) {
-                    hogflowDuplicateInvocationDetectedTotal.inc()
+                    hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })
                 }
             })
-            .catch(() => {})
+            .catch((error: unknown) => {
+                logger.debug('🦔', '[HogFlowExecutor] Duplicate observer skipped', { error: String(error) })
+            })
     }
 
     async execute(


### PR DESCRIPTION
## Problem

We have no real-time metric for duplicate hogflow invocations (the same event triggering the same workflow more than once). These duplicates have been showing up in production and investigating them today required ad-hoc ClickHouse queries against `log_entries`. A Prometheus counter lets us watch the rate on dashboards, alert on regressions, and verify the impact of related fixes (e.g. Kafka consumer / rebalance tuning) without having to re-run SQL.

## Changes

- Add a Prometheus counter `hogflow_duplicate_invocation_detected_total` in `nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts`.
- Wire an observer call into `buildHogFlowInvocations`: after an invocation is created, fire a Redis `SET NX` on `hogflow:observe:{workflow_id}:{event_uuid}` with a 15-minute TTL (the longest gap in the current data was less than 5 minutes). If the key already exists, increment the counter. Fire-and-forget with `failOpen: true` so execution is never blocked or slowed by the observer.
- Wire `redis` through `nodejs/src/cdp/cdp-services.ts` so the executor can use it; the constructor param is optional and falls back to null for existing callers and tests.

Observer-only - does not alter execution, does not read back or compare invocation IDs, uses a distinct key namespace from the historical `hogflow:dedup:` keys.

## How did you test this code?

- Reviewed usage against the existing `useClient` / `failOpen` pattern already used elsewhere in the code
- Logic is equivalent (same key shape, shorter TTL) to a ClickHouse query that matched known duplicates across US and EU during the ghost run investigation

## Publish to changelog?

No