### PR TITLE
feat(cdp): make kafka consumer rebalanceTimeoutMs configurable

### DIFF
--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -112,6 +112,7 @@ export type CommonConfig = BaseServerConfig & {
     CONSUMER_MAX_BACKGROUND_TASKS: number
     CONSUMER_BACKGROUND_TASK_TIMEOUT_MS: number
     CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean
+    CONSUMER_REBALANCE_TIMEOUT_MS: number
     CONSUMER_AUTO_CREATE_TOPICS: boolean
 
     // Kafka
@@ -268,6 +269,7 @@ export function getDefaultCommonConfig(): CommonConfig {
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
         CONSUMER_BACKGROUND_TASK_TIMEOUT_MS: 60_000,
         CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
+        CONSUMER_REBALANCE_TIMEOUT_MS: 20_000,
         CONSUMER_AUTO_CREATE_TOPICS: true,
 
         // Kafka

--- a/nodejs/src/kafka/consumer.ts
+++ b/nodejs/src/kafka/consumer.ts
@@ -178,7 +178,7 @@ export class KafkaConsumer {
     private lastStatsEmitTime = 0
     private rebalanceCoordination: RebalanceCoordination = {
         isRebalancing: false,
-        rebalanceTimeoutMs: 20000,
+        rebalanceTimeoutMs: defaultConfig.CONSUMER_REBALANCE_TIMEOUT_MS,
         rebalanceStartTime: 0,
     }
     private consumerLogStatsLevel: LogLevel


### PR DESCRIPTION
## Problem

The Kafka consumer in the plugin-server has a hardcoded 20-second `rebalanceTimeoutMs` at `nodejs/src/kafka/consumer.ts:181`. When `CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE=true` (which is on for all CDP services), the consumer pauses during a partition rebalance and waits up to this timeout for in-flight background tasks (Cyclotron writes, etc.) to drain. When the timeout fires, the consumer logs `rebalancing_timeout_forcing_recovery` and forces the rebalance to proceed even though some offsets were never committed. Kafka then reassigns those partitions, the new owner consumes from the last committed offset, and we re-process messages that already had side effects applied (creating duplicate hogflow invocations for the same event).

Under steady CDP load the 20s window is too tight for the events consumer. Background task queues regularly take longer than 20s to drain, so the timeout fires routinely (measured at around 60 times per hour per region on the events consumer in prod) and each occurrence is a direct cause of duplicate workflow executions downstream. For other consumers the existing 20s may still be fine, so we want per-deployment control rather than a flat change.

## Changes

- Add `CONSUMER_REBALANCE_TIMEOUT_MS` to `CommonConfig` in `nodejs/src/common/config.ts`, defaulting to `20_000` (current behavior preserved).
- Replace the hardcoded `20000` in `nodejs/src/kafka/consumer.ts` with `defaultConfig.CONSUMER_REBALANCE_TIMEOUT_MS`.

This PR is a pure refactor: no behavior change on merge. The actual bump for the events consumer will land in a separate charts PR so we can tune per deployment without code churn.

## How did you test this code?

- Reviewed `session.timeout.ms` (30s) and `max.poll.interval.ms` (300s) in the same file to confirm any value we pick via env var (up to ~270s) stays within Kafka-level broker heartbeat boundaries
- The change is narrow enough that the behavior difference with the default is zero, the control flow around `rebalancing_timeout_forcing_recovery` is untouched

## Publish to changelog?

No