### PR TITLE
fix(observability): default product/feature tags for CLI commands and the query API

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -27,7 +27,7 @@ def main():
     # tags at their own boundaries, so this only effectively applies to direct CLI commands.
     from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 
-    with tags_context(product=Product.INTERNAL, feature=Feature.MIGRATION):
+    with tags_context(product=Product.INTERNAL, feature=Feature.MANAGEMENT_COMMAND):
         execute_from_command_line(sys.argv)
 
 

--- a/manage.py
+++ b/manage.py
@@ -21,7 +21,14 @@ def main():
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-    execute_from_command_line(sys.argv)
+
+    # Default query tags so management commands don't trip the DEBUG-only UntaggedQueryError
+    # in sync_execute. HTTP requests (runserver's CHQueries middleware) and Celery tasks reset
+    # tags at their own boundaries, so this only effectively applies to direct CLI commands.
+    from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+
+    with tags_context(product=Product.INTERNAL, feature=Feature.MIGRATION):
+        execute_from_command_line(sys.argv)
 
 
 if __name__ == "__main__":

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -39,7 +39,7 @@ from posthog.api.services.query import process_query_model
 from posthog.api.utils import action, is_async_query, is_insight_actors_options_query, is_insight_actors_query
 from posthog.clickhouse.client.execute_async import cancel_query, get_query_status
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
-from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Product, get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
 from posthog.event_usage import get_request_analytics_properties, report_user_or_team_action
@@ -171,6 +171,10 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 data, self.team, data.client_query_id, request.user
             )
 
+            # Default product tag so queries routed through the generic query API are never
+            # untagged. Queries that provide `tags.productKey` (or specific runners that tag
+            # themselves) override this before `sync_execute` runs.
+            tag_queries(product=Product.PRODUCT_ANALYTICS)
             self._tag_client_query_id(client_query_id)
             analytics_props = get_request_analytics_properties(request)
             query_dict = query.model_dump()

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -18,6 +18,7 @@ from posthog.schema import (
     HogQLQuery,
     HogQLQueryModifiers,
     LimitContext as SchemaLimitContext,
+    ProductKey,
     QueryRequest,
     QueryResponseAlternative,
     QueryStatusResponse,
@@ -70,6 +71,20 @@ QUERY_VALIDATION_ERROR_TOTAL = Counter(
     "Query validation failures returned from the query API.",
     labelnames=["query_type", "validation_code"],
 )
+
+
+# Scene -> tags to apply. The scene is set by the frontend in the query payload's
+# `tags.scene` (see addTags in dataNodeLogic.ts). Add entries as new scenes need specific
+# tagging. Scenes not listed here stay untagged and trip UntaggedQueryError in DEBUG,
+# which is the signal to register them.
+_SCENE_TO_TAGS: dict[str, dict[str, Product | ProductKey | Feature]] = {
+    "Cohort": {"product": ProductKey.COHORTS, "feature": Feature.COHORT},
+}
+
+
+def _infer_query_tags(query: BaseModel) -> dict[str, Product | ProductKey | Feature]:
+    scene = getattr(getattr(query, "tags", None), "scene", None) or ""
+    return _SCENE_TO_TAGS.get(scene, {})
 
 
 def _extract_validation_code(error: ValidationError) -> str:
@@ -171,10 +186,13 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 data, self.team, data.client_query_id, request.user
             )
 
-            # Default product tag so queries routed through the generic query API are never
-            # untagged. Queries that provide `tags.productKey` (or specific runners that tag
-            # themselves) override this before `sync_execute` runs.
-            tag_queries(product=Product.PRODUCT_ANALYTICS)
+            # Tag product and feature based on the frontend-supplied `tags.scene`. A per-query
+            # `tags.productKey` or a product-specific runner can still override this inside
+            # QueryRunner.run or QueryRunner.calculate before sync_execute fires. Scenes not
+            # registered in `_infer_query_tags` stay untagged — they surface as
+            # UntaggedQueryError in DEBUG, which is the signal to add them.
+            if inferred_tags := _infer_query_tags(query):
+                tag_queries(**inferred_tags)
             self._tag_client_query_id(client_query_id)
             analytics_props = get_request_analytics_properties(request)
             query_dict = query.model_dump()

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -16,9 +16,11 @@ from unittest.mock import patch
 from rest_framework import status
 
 from posthog.schema import (
+    ActorsQuery,
     CachedEventsQueryResponse,
     CachedHogQLQueryResponse,
     CachedRetentionQueryResponse,
+    CohortPropertyFilter,
     EventPropertyFilter,
     EventsQuery,
     HogLanguage,
@@ -27,12 +29,16 @@ from posthog.schema import (
     HogQLQuery,
     MeanRetentionCalculation,
     PersonPropertyFilter,
+    ProductKey,
     PropertyOperator,
+    QueryLogTags,
     RetentionQuery,
 )
 
 from posthog.hogql.constants import LimitContext
 
+from posthog.api.monitoring import Feature
+from posthog.api.query import _infer_query_tags
 from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.models.insight_variable import InsightVariable
@@ -1383,3 +1389,15 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
         data = response.json()
         self.assertIn("results", data)
         self.assertNotIn("formatted_results", data)
+
+
+class TestInferQueryTags(APIBaseTest):
+    def test_cohort_scene_infers_cohorts_product_and_cohort_feature(self):
+        # Mirrors the payload fired by the Cohort scene when listing members: the frontend's
+        # addTags attaches `tags.scene = "Cohort"` to every query issued from that scene.
+        query = ActorsQuery(
+            fixedProperties=[CohortPropertyFilter(value=1)],
+            select=["person_display_name -- Person", "id", "created_at"],
+            tags=QueryLogTags(scene="Cohort"),
+        )
+        assert _infer_query_tags(query) == {"product": ProductKey.COHORTS, "feature": Feature.COHORT}

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -77,6 +77,7 @@ class Feature(StrEnum):
     BILLING_ETL = "billing_etl"
     QUOTA_LIMITING = "quota_limiting"
     MIGRATION = "migration"
+    MANAGEMENT_COMMAND = "management_command"
 
 
 class TemporalTags(BaseModel):


### PR DESCRIPTION
## Problem

PR #55901 made `sync_execute` raise `UntaggedQueryError` in local dev (`DEBUG=1`) whenever a ClickHouse query runs without both `product` and `feature` tags. That broke several developer flows:

- Running an `ActorsQuery` from the Cohort scene (via `POST /api/environments/.../query/ActorsQuery/`) — the frontend sends `tags.scene` but no `tags.productKey`, so `product` was never set.
- Every Django management command that touches ClickHouse: `generate_demo_data`, `run_async_migrations`, `bin/migrate`, `bin/hogli db:migrate`, `bin/hogli db:restore-schema`, etc.

## Changes

- `manage.py`: wrap `execute_from_command_line` in `tags_context(product=Product.INTERNAL, feature=Feature.MANAGEMENT_COMMAND)` so every Django management command inherits a sensible default. HTTP requests via `runserver` still reset tags per-request in `CHQueries` middleware, and Celery tasks reset on `task_postrun`, so the default only effectively applies to direct CLI commands.
- `posthog/clickhouse/query_tagging.py`: add `Feature.MANAGEMENT_COMMAND` for the new default above — `Feature.MIGRATION` would have mislabelled non-migration commands in `system.query_log`.
- `posthog/api/query.py`: `QueryViewSet.create` now reads `query.tags.scene` and maps it to `(product, feature)` via a small `_SCENE_TO_TAGS` table. Currently registered: `"Cohort"` → `(ProductKey.COHORTS, Feature.COHORT)`. Scenes not in the table stay untagged — intentionally — so new scenes surface as `UntaggedQueryError` in DEBUG and get registered explicitly rather than hiding behind a generic default.
- `posthog/api/test/test_query.py`: `TestInferQueryTags` covers the cohort mapping.

## How did you test this code?

Authored by PostHog Code agent — no manual runtime verification beyond code review and `ruff check` / `ruff format`. The failing cases reported by the user (ActorsQuery from the Cohort page, `generate_demo_data`, `run_async_migrations`) all converge on the DEBUG check in `sync_execute`, which now passes because the relevant entry points set the required tags.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. Iterated from a blanket `PRODUCT_ANALYTICS` default on the query endpoint to frontend-supplied `tags.scene`-driven mapping on reviewer feedback, and swapped the CLI default from `Feature.MIGRATION` to the new `Feature.MANAGEMENT_COMMAND` for more honest labelling.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*