### PR TITLE
feat(gateway): Scope plan cache and rate limit buckets by team

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -48,7 +48,7 @@ async def get_usage(
     user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
 ) -> UsageResponse:
     runner: ThrottleRunner = request.app.state.throttle_runner
-    plan_info = await resolve_plan_info(request, user.user_id, product)
+    plan_info = await resolve_plan_info(request, user.user_id, product, team_id=user.team_id)
 
     context = ThrottleContext(
         user=user,
@@ -91,5 +91,5 @@ async def invalidate_plan_cache(
     if product != POSTHOG_CODE_PRODUCT:
         raise HTTPException(status_code=404, detail="Plan cache not available for this product")
     plan_resolver: PlanResolver = request.app.state.plan_resolver
-    await plan_resolver.invalidate(user.user_id)
+    await plan_resolver.invalidate(user.user_id, team_id=user.team_id)
     return {"ok": True}

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -158,7 +158,7 @@ async def enforce_throttles(
     else:
         end_user_id = await _extract_end_user_id_from_body(request)
 
-    plan_info = await resolve_plan_info(request, user.user_id, product)
+    plan_info = await resolve_plan_info(request, user.user_id, product, team_id=user.team_id)
 
     context = ThrottleContext(
         user=user,

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -196,8 +196,9 @@ class _UserCostThrottleBase(CostThrottle):
     def _get_cache_key(self, context: ThrottleContext) -> str:
         if not context.end_user_id:
             return ""
+        team_id = context.user.team_id or 0
         team_mult = self._get_team_multiplier(context)
-        base = f"cost:user:{self.scope}:{context.product}:{context.end_user_id}"
+        base = f"cost:user:{self.scope}:{context.product}:{context.end_user_id}:t{team_id}"
         if team_mult == 1:
             return base
         return f"{base}:tm{team_mult}"

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -118,6 +118,12 @@ class PlanResolver:
         self._http = http_client
 
     async def invalidate(self, user_id: int, team_id: int | None = None) -> None:
+        """Invalidate the plan cache for a specific (user, team) pair.
+
+        Only deletes the entry for the given team_id. Entries cached under
+        other team_ids are left to expire naturally via TTL since reads are
+        always scoped to the current team's key.
+        """
         if not self._redis:
             return
         try:

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -44,8 +44,8 @@ class PlanInfo:
     billing_period: BillingPeriod | None = None
 
 
-def _redis_key(user_id: int) -> str:
-    return f"{PLAN_CACHE_PREFIX}:{user_id}"
+def _redis_key(user_id: int, team_id: int | None) -> str:
+    return f"{PLAN_CACHE_PREFIX}:{user_id}:{team_id or 0}"
 
 
 def is_pro_plan(plan_key: str | None) -> bool:
@@ -89,6 +89,7 @@ async def resolve_plan_info(
     request: Request,
     user_id: int,
     product: str,
+    team_id: int | None = None,
 ) -> PlanInfo:
     """Resolve plan info, returning safe defaults on failure."""
     if product != POSTHOG_CODE_PRODUCT:
@@ -100,6 +101,7 @@ async def resolve_plan_info(
         return await plan_resolver.get_plan(
             user_id=user_id,
             auth_header=auth_header,
+            team_id=team_id,
         )
     except Exception:
         logger.warning("plan_resolve_failed", user_id=user_id)
@@ -115,20 +117,20 @@ class PlanResolver:
         self._redis = redis
         self._http = http_client
 
-    async def invalidate(self, user_id: int) -> None:
+    async def invalidate(self, user_id: int, team_id: int | None = None) -> None:
         if not self._redis:
             return
         try:
-            await self._redis.delete(_redis_key(user_id))
+            await self._redis.delete(_redis_key(user_id, team_id))
         except Exception:
             logger.debug("plan_cache_invalidate_failed", user_id=user_id)
 
-    async def get_plan(self, user_id: int, auth_header: str) -> PlanInfo:
+    async def get_plan(self, user_id: int, auth_header: str, team_id: int | None = None) -> PlanInfo:
         """Return the user's plan info, using cache when available."""
         if not auth_header:
             return PlanInfo(plan_key=None, seat_created_at=None)
 
-        cached = await self._get_cached(user_id)
+        cached = await self._get_cached(user_id, team_id)
         if cached is not None:
             return cached
 
@@ -138,18 +140,18 @@ class PlanResolver:
             logger.warning("seat_fetch_failed", user_id=user_id, exc_info=True)
             return PlanInfo(plan_key=None, seat_created_at=None)
 
-        await self._set_cached(user_id, plan_key, seat_created_at, billing_period)
+        await self._set_cached(user_id, plan_key, seat_created_at, billing_period, team_id)
         return PlanInfo(
             plan_key=plan_key,
             seat_created_at=seat_created_at,
             billing_period=billing_period,
         )
 
-    async def _get_cached(self, user_id: int) -> PlanInfo | None:
+    async def _get_cached(self, user_id: int, team_id: int | None = None) -> PlanInfo | None:
         if not self._redis:
             return None
         try:
-            val = await self._redis.get(_redis_key(user_id))
+            val = await self._redis.get(_redis_key(user_id, team_id))
             if val is not None:
                 data = json.loads(val.decode())
                 plan_key = data.get("plan_key") or None
@@ -170,6 +172,7 @@ class PlanResolver:
         plan_key: str | None,
         seat_created_at: str | None,
         billing_period: BillingPeriod | None = None,
+        team_id: int | None = None,
     ) -> None:
         if not self._redis:
             return
@@ -183,7 +186,7 @@ class PlanResolver:
                     "interval": billing_period.interval,
                 }
             data = json.dumps(payload)
-            await self._redis.set(_redis_key(user_id), data, ex=ttl)
+            await self._redis.set(_redis_key(user_id, team_id), data, ex=ttl)
         except Exception:
             logger.debug("plan_cache_write_failed", user_id=user_id)
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -234,7 +234,7 @@ class TestUserCostBurstThrottle:
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_burst:posthog_code:42"
+        assert key == "cost:user:user_cost_burst:posthog_code:42:t1"
 
     @pytest.mark.asyncio
     async def test_different_users_have_separate_limits(self) -> None:
@@ -309,7 +309,7 @@ class TestUserCostSustainedThrottle:
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_free_plan(self) -> None:
@@ -327,7 +327,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
 
     @pytest.mark.asyncio
     async def test_cache_key_period_increments_after_period_days(self) -> None:
@@ -345,7 +345,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:1"
 
     def test_cache_key_uses_billing_period_start_over_seat_created_at(self) -> None:
         from datetime import UTC, datetime, timedelta
@@ -364,7 +364,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
 
     def test_cache_key_falls_back_to_seat_created_at_without_billing_period(self) -> None:
         from datetime import UTC, datetime, timedelta
@@ -382,7 +382,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:1"
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_pro_plan(self) -> None:
@@ -400,7 +400,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
 
 
 class TestBurstSustainedInteraction:
@@ -596,7 +596,7 @@ class TestCostRateLimiterRedisIntegration:
 
         mock_redis.eval.assert_called_once()
         call_args = mock_redis.eval.call_args
-        assert "ratelimit:cost:user:user_cost_burst:posthog_code:1" in call_args[0]
+        assert "ratelimit:cost:user:user_cost_burst:posthog_code:1:t1" in call_args[0]
 
     @pytest.mark.asyncio
     async def test_redis_get_current_returns_accumulated_cost(self) -> None:
@@ -668,7 +668,7 @@ class TestTeamRateLimitMultipliers:
 
         key = throttle._get_cache_key(context)
         assert ":tm" not in key
-        assert key == "cost:user:user_cost_burst:posthog_code:1"
+        assert key == "cost:user:user_cost_burst:posthog_code:1:t99"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -682,7 +682,7 @@ class TestTeamRateLimitMultipliers:
         context = make_context(user=user, product="posthog_code")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_burst:posthog_code:1:tm10"
+        assert key == "cost:user:user_cost_burst:posthog_code:1:t2:tm10"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -1054,8 +1054,8 @@ class TestRateLimitPoisoningPrevention:
         victim_key = throttle._get_cache_key(victim_ctx)
 
         assert attacker_key != victim_key
-        assert ":999" in attacker_key
-        assert ":42" in victim_key
+        assert ":999:" in attacker_key
+        assert ":42:" in victim_key
 
 
 class TestPlanAwareThrottling:

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -230,7 +230,7 @@ class TestUsageEndpoint:
         )
         assert response.status_code == 200
         assert response.json() == {"ok": True}
-        app.state.plan_resolver.invalidate.assert_called_once_with(42)
+        app.state.plan_resolver.invalidate.assert_called_once_with(42, team_id=1)
 
     def test_invalidate_plan_cache_404_for_other_product(self, authenticated_usage_client: TestClient) -> None:
         response = authenticated_usage_client.post(


### PR DESCRIPTION
## Problem

Plan cache and rate limit buckets were keyed by user_id only, so switching orgs would serve a stale cached plan and share cost usage across orgs with different plan tiers.<!-- Who are we building for, what are their needs, why is this important? -->

**IMPORTANT:** This changes rate limit buckets from per-user to per-user-per-team. This means usage counters reset when a user switches orgs. This is intentional, a user can have a free seat on one org and a pro seat on another, so limits must be scoped per org. Without this, a free-plan user could get served pro limits (or vice versa) by switching orgs.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add team_id to plan cache Redis key (plan:posthog_code:{user_id}:{team_id})
2. Add team_id to user cost throttle cache key (cost:user:{scope}:{product}:{user_id}:t{team_id})
3. Thread team_id through resolve_plan_info, PlanResolver, and invalidate callers
4. Update all affected test assertions for new key format

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->