### PR TITLE
refactor(redis): widen HINCRBY count type to i64

### DIFF
--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -240,14 +240,8 @@ impl Client for RedisClient {
         Ok(())
     }
 
-    async fn hincrby(
-        &self,
-        k: String,
-        v: String,
-        count: Option<i32>,
-    ) -> Result<(), CustomRedisError> {
+    async fn hincrby(&self, k: String, v: String, count: i64) -> Result<(), CustomRedisError> {
         let mut conn = self.connection.clone();
-        let count = count.unwrap_or(1);
         conn.hincr::<_, _, _, ()>(k, v, count).await?;
         Ok(())
     }

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -204,12 +204,7 @@ pub trait Client: Send + Sync {
     /// Add a single (member, score) pair to a sorted set.
     async fn zadd(&self, k: String, member: String, score: i64) -> Result<(), CustomRedisError>;
 
-    async fn hincrby(
-        &self,
-        k: String,
-        v: String,
-        count: Option<i32>,
-    ) -> Result<(), CustomRedisError>;
+    async fn hincrby(&self, k: String, v: String, count: i64) -> Result<(), CustomRedisError>;
 
     async fn get(&self, k: String) -> Result<String, CustomRedisError>;
     async fn get_with_format(

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -176,7 +176,6 @@ pub enum MockRedisValue {
     String(String),
     StringWithTTL(String, u64),
     VecString(Vec<String>),
-    I32(i32),
     I64(i64),
     MinMax(String, String),
     StringWithFormat(String, RedisValueFormat),
@@ -228,16 +227,13 @@ impl Client for MockRedisClient {
         &self,
         key: String,
         field: String,
-        count: Option<i32>,
+        count: i64,
     ) -> Result<(), CustomRedisError> {
         let mut calls = self.lock_calls();
         calls.push(MockRedisCall {
             op: "hincrby".to_string(),
             key: format!("{key}:{field}"),
-            value: match count {
-                None => MockRedisValue::None,
-                Some(v) => MockRedisValue::I32(v),
-            },
+            value: MockRedisValue::I64(count),
         });
 
         match self.hincrby_ret.get(&key) {
@@ -653,7 +649,7 @@ impl MockRedisClient {
                 self.record_call(
                     "pipeline_hincrby",
                     format!("{key}:{field}"),
-                    MockRedisValue::I32(count),
+                    MockRedisValue::I64(count),
                 );
                 Self::lookup_or_ok(&self.hincrby_ret, &key).map(|_| PipelineResult::Ok)
             }

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -78,7 +78,7 @@ pub enum PipelineCommand {
     HIncrBy {
         key: String,
         field: String,
-        count: i32,
+        count: i64,
     },
     Scard {
         key: String,
@@ -228,7 +228,7 @@ impl<C> Pipeline<C> {
     }
 
     /// Add an HINCRBY command to the pipeline.
-    pub fn hincrby(mut self, key: impl Into<String>, field: impl Into<String>, count: i32) -> Self {
+    pub fn hincrby(mut self, key: impl Into<String>, field: impl Into<String>, count: i64) -> Self {
         self.commands.push(PipelineCommand::HIncrBy {
             key: key.into(),
             field: field.into(),

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -433,12 +433,7 @@ impl Client for ReadWriteClient {
         self.writer.del(k).await
     }
 
-    async fn hincrby(
-        &self,
-        k: String,
-        v: String,
-        count: Option<i32>,
-    ) -> Result<(), CustomRedisError> {
+    async fn hincrby(&self, k: String, v: String, count: i64) -> Result<(), CustomRedisError> {
         self.writer.hincrby(k, v, count).await
     }
 
@@ -608,7 +603,7 @@ mod tests {
         assert!(result.is_ok());
 
         let result = client
-            .hincrby("counter".to_string(), "field".to_string(), Some(5))
+            .hincrby("counter".to_string(), "field".to_string(), 5)
             .await;
         assert!(result.is_ok());
     }

--- a/rust/feature-flags/src/flags/flag_analytics.rs
+++ b/rust/feature-flags/src/flags/flag_analytics.rs
@@ -42,7 +42,7 @@ pub fn get_team_request_library_key(
 pub async fn increment_request_count(
     redis_client: Arc<dyn RedisClient + Send + Sync>,
     team_id: i32,
-    count: i32,
+    count: i64,
     request_type: FlagRequestType,
     library: Option<Library>,
 ) -> Result<(), CustomRedisError> {
@@ -175,13 +175,13 @@ mod tests {
             / CACHE_BUCKET_SIZE;
 
         // Verify the counts in Redis
-        let decide_count: i32 = redis_client
+        let decide_count: i64 = redis_client
             .hget(decide_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
             .parse()
             .unwrap();
-        let flag_definitions_count: i32 = redis_client
+        let flag_definitions_count: i64 = redis_client
             .hget(flag_definitions_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
@@ -226,13 +226,13 @@ mod tests {
             .as_secs()
             / CACHE_BUCKET_SIZE;
 
-        let decide_count: i32 = redis_client
+        let decide_count: i64 = redis_client
             .hget(decide_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
             .parse()
             .unwrap();
-        let library_count: i32 = redis_client
+        let library_count: i64 = redis_client
             .hget(library_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
@@ -277,7 +277,7 @@ mod tests {
             .as_secs()
             / CACHE_BUCKET_SIZE;
 
-        let decide_count: i32 = redis_client
+        let decide_count: i64 = redis_client
             .hget(decide_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
@@ -343,19 +343,19 @@ mod tests {
             .as_secs()
             / CACHE_BUCKET_SIZE;
 
-        let decide_count: i32 = redis_client
+        let decide_count: i64 = redis_client
             .hget(decide_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
             .parse()
             .unwrap();
-        let js_count: i32 = redis_client
+        let js_count: i64 = redis_client
             .hget(js_key.clone(), time_bucket.to_string())
             .await
             .unwrap()
             .parse()
             .unwrap();
-        let node_count: i32 = redis_client
+        let node_count: i64 = redis_client
             .hget(node_key.clone(), time_bucket.to_string())
             .await
             .unwrap()


### PR DESCRIPTION
## Problem

The `common-redis` wrapper capped HINCRBY counts at `i32` (~2.1B), but Redis natively supports the full `i64` range (64-bit signed integer). The cap existed only because the wrapper's single original caller incremented by 1 per request — any future caller that batches larger accumulated counts would need to saturate or narrow on every call.

## Changes

- `PipelineCommand::HIncrBy.count`: `i32` → `i64`; `Pipeline::hincrby()` builder param widened to match.
- `Client::hincrby` trait method: `count: Option<i32>` → `count: i64`. Drops the `Option`-wrapper-with-implicit-default-of-1 ergonomic — callers pass an explicit count. The only existing caller is an internal test that passed `Some(5)` and is now `5`.
- Removes the now-unused `MockRedisValue::I32` variant.
- `feature-flags::increment_request_count`: `count: i32` → `i64` — the one external caller of the pipeline builder. Call sites pass integer literals, no caller change needed. Test parse targets widened `i32` → `i64` mechanically.

Net delete ~20 lines.

## How did you test this code?

- `cargo check --workspace --tests --all-features` — clean (pre-existing `celes` and `js-source-scopes` warnings are unrelated).
- `cargo clippy -p common-redis -p feature-flags --all-targets --all-features -- -D warnings` — clean.
- Existing unit and integration tests in `common-redis` and `feature-flags::flag_analytics` cover the HINCRBY path; all compile with the widened types.
- Manual testing.

## Publish to changelog?

do not publish to changelog