### PR TITLE
fix(insights): bound annotation cluster width

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -26,6 +26,9 @@ import { AnnotationsOverlayLogicProps, annotationsOverlayLogic } from './annotat
 import { useAnnotationsPositioning } from './useAnnotationsPositioning'
 
 const MIN_BADGE_SPACING_PX = 24
+/** Clusters anchor on their starting badge (leftPx) so a chain of near-adjacent badges
+ *  can't keep absorbing each other into one oversized cluster spanning a wide date range. */
+const MAX_CLUSTER_WIDTH_PX = 17
 const EMPTY_ANNOTATIONS: DatedAnnotationType[] = []
 
 const GROUPING_UNIT_TO_HUMAN_DAYJS_FORMAT: Record<IntervalType, string> = {
@@ -141,7 +144,7 @@ export const AnnotationsOverlay = React.memo(function AnnotationsOverlay({
         const out: AnnotationBadgeCluster[] = []
         for (const badge of positioned) {
             const last = out[out.length - 1]
-            if (last && badge.leftPx - last.rightPx < MIN_BADGE_SPACING_PX) {
+            if (last && badge.leftPx - last.leftPx < MAX_CLUSTER_WIDTH_PX) {
                 last.annotations = [...last.annotations, ...badge.annotations]
                 last.dateRange = [last.dateRange[0], badge.date]
                 last.rightPx = badge.leftPx


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0ACRAMJUAG/p1776973634522349

## Changes

Make annotation clustering less aggressive, can now be like this if you have lots:
<img width="997" height="167" alt="Screenshot 2026-04-24 at 14 34 30" src="https://github.com/user-attachments/assets/621340c6-de19-477a-a570-f799e4f5988a" />


## How did you test this code?

Manually, got an insight with a tonne of annotations

## Publish to changelog?
no
<!-- For features only -->