### PR TITLE
fix(llma): Fix kea logic mount check in evaluation report creation

### DIFF
--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -520,9 +520,13 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     actions.saveEvaluationSuccess(response)
                     // Create the pending report before navigating away. The 'new'-keyed
                     // evaluationReportLogic unmounts when the component tears down, so
-                    // snapshot its draft now and fire the create directly.
-                    if (response?.id) {
-                        const draft = evaluationReportLogic({ evaluationId: 'new' }).values.configDraft
+                    // snapshot its draft now and fire the create directly. The logic is
+                    // only mounted when EvaluationReportConfig is rendered (gated on the
+                    // reports feature flag), so skip when it isn't — there's no draft to
+                    // forward and reading .values would throw a kea "path not found" error.
+                    const newReportLogic = evaluationReportLogic({ evaluationId: 'new' })
+                    if (response?.id && newReportLogic.isMounted()) {
+                        const draft = newReportLogic.values.configDraft
                         const targets = buildDeliveryTargets(draft)
                         if (draft.enabled && (targets.length > 0 || draft.reportPromptGuidance.trim().length > 0)) {
                             const body: Record<string, unknown> = {


### PR DESCRIPTION
## Problem

When creating an evaluation, the code attempts to access the `evaluationReportLogic` to capture a draft report configuration. However, this logic is only mounted when the `EvaluationReportConfig` component is rendered, which is gated behind a feature flag. Accessing `.values` on an unmounted kea logic throws a "path not found" error, causing the evaluation creation flow to fail when the reports feature is disabled.

## Changes

- Added a check using `isMounted()` before accessing the `evaluationReportLogic` values
- Store the logic instance in a variable to avoid instantiating it twice
- Improved code comments to explain why the mount check is necessary

## How did you test this code?

This is a defensive fix that prevents runtime errors when the reports feature flag is disabled. The change ensures the code gracefully skips report creation when the logic isn't available, rather than throwing an error. Existing tests should continue to pass, and the fix prevents errors in scenarios where the feature flag gates the component.

No manual testing needed — this is a straightforward null-safety improvement.

## Publish to changelog?

no

https://claude.ai/code/session_01U5td5bR36vgcoyT9dp7jbY