### PR TITLE
chore(experiments): consolidate metric error tracking into single event

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -668,32 +668,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             experiment,
             dashboardId,
         }),
-        reportExperimentMetricTimeout: (
-            experimentId: ExperimentIdType,
-            metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery,
-            teamId?: number | null,
-            queryId?: string | null
-        ) => ({
-            experimentId,
-            metric,
-            teamId,
-            queryId,
-        }),
-        reportExperimentMetricOutOfMemory: (
-            experimentId: ExperimentIdType,
-            metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery,
-            teamId?: number | null,
-            queryId?: string | null,
-            errorCode?: string | null,
-            errorMessage?: string | null
-        ) => ({
-            experimentId,
-            metric,
-            teamId,
-            queryId,
-            errorCode,
-            errorMessage,
-        }),
         reportExperimentMetricFinished: (
             experimentId: ExperimentIdType,
             metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery,
@@ -1689,26 +1663,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 experiment_name: experiment.name,
                 experiment_id: experiment.id,
                 dashboard_id: dashboardId,
-            })
-        },
-        reportExperimentMetricTimeout: ({ experimentId, metric, teamId, queryId }) => {
-            posthog.capture('experiment metric timeout', {
-                experiment_id: experimentId,
-                team_id: teamId,
-                query_id: queryId,
-                ...getEventPropertiesForMetric(metric),
-                metric,
-            })
-        },
-        reportExperimentMetricOutOfMemory: ({ experimentId, metric, teamId, queryId, errorCode, errorMessage }) => {
-            posthog.capture('experiment metric out of memory', {
-                experiment_id: experimentId,
-                team_id: teamId,
-                query_id: queryId,
-                error_code: errorCode,
-                error_message: errorMessage,
-                ...getEventPropertiesForMetric(metric),
-                metric,
             })
         },
         reportExperimentMetricFinished: ({ experimentId, metric, teamId, queryId, context }) => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -460,21 +460,6 @@ const loadMetrics = async ({
 
                 erroredCount++
 
-                // Keep backwards-compatible events firing
-                if (errorType === 'timeout') {
-                    eventUsageLogic.actions.reportExperimentMetricTimeout(experimentId, metric, teamId, queryId)
-                } else if (errorType === 'out_of_memory') {
-                    eventUsageLogic.actions.reportExperimentMetricOutOfMemory(
-                        experimentId,
-                        metric,
-                        teamId,
-                        queryId,
-                        errorCode,
-                        errorMessage
-                    )
-                }
-
-                // Unified error event for all error types
                 eventUsageLogic.actions.reportExperimentMetricError(experimentId, metric, teamId, queryId, {
                     duration_ms: durationMs,
                     metric_index: metricIndex,
@@ -611,7 +596,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 'reportExperimentHoldoutAssigned',
                 'reportExperimentSharedMetricAssigned',
                 'reportExperimentDashboardCreated',
-                'reportExperimentMetricTimeout',
                 'reportExperimentTimeseriesViewed',
                 'reportExperimentTimeseriesRecalculated',
                 'reportExperimentAiSummaryRequested',

--- a/frontend/src/scenes/experiments/legacy/legacyExperimentLogic.tsx
+++ b/frontend/src/scenes/experiments/legacy/legacyExperimentLogic.tsx
@@ -323,21 +323,6 @@ const loadLegacyMetrics = async ({
 
                 erroredCount++
 
-                // Keep backwards-compatible events firing
-                if (errorType === 'timeout') {
-                    eventUsageLogic.actions.reportExperimentMetricTimeout(experimentId, metric, teamId, queryId)
-                } else if (errorType === 'out_of_memory') {
-                    eventUsageLogic.actions.reportExperimentMetricOutOfMemory(
-                        experimentId,
-                        metric,
-                        teamId,
-                        queryId,
-                        errorCode,
-                        errorMessage
-                    )
-                }
-
-                // Unified error event for all error types
                 eventUsageLogic.actions.reportExperimentMetricError(experimentId, metric, teamId, queryId, {
                     duration_ms: durationMs,
                     metric_index: metricIndex,


### PR DESCRIPTION
## Problem

Experiment metric load failures were split across three separate capture events: `experiment metric timeout`, `experiment metric out of memory`, and `experiment metric error`. That made it hard to get a single view of failure rates, and the two specific ones were strict subsets of the generic one — every error path was firing two events.

## Changes

- Drop the `experiment metric timeout` and `experiment metric out of memory` captures in both `experimentLogic.tsx` and `legacyExperimentLogic.tsx`
- Remove the now-unused `reportExperimentMetricTimeout` / `reportExperimentMetricOutOfMemory` actions and listeners from `eventUsageLogic.ts`
- Drop the stale `'reportExperimentMetricTimeout'` entry from `experimentLogic`'s `connect` list

The unified `experiment metric error` event already carries an `error_type` property (`timeout | out_of_memory | server_error | network_error | unknown`) plus `error_code`, `error_message`, `status_code`, and timing/context — so no analytics information is lost.

## How did you test this code?

Agent-authored. Verified statically:

- `tsc --noEmit` reports no new errors in the touched files
- `pnpm typegen:write` regenerates cleanly (stale refs in `*LogicType.ts` removed)
- `pnpm format` clean

No manual QA was performed — this only removes redundant `posthog.capture(...)` calls whose properties are already covered by the retained unified event.

## Publish to changelog?

no

## Docs update

n/a — internal analytics event change, no user-facing surface affected.

## 🤖 LLM context

Authored with Claude Code. Context: branch already contained the unified `reportExperimentMetricError` action with full property coverage; the two legacy events were explicitly labeled "Keep backwards-compatible events firing" and were the last callers of the two removed actions.