### PR TITLE
fix(tasks): keep cloud runs replayable and connected

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -1,6 +1,7 @@
 import os
 import json
 import uuid
+import asyncio
 import logging
 import builtins
 from collections.abc import AsyncGenerator
@@ -97,7 +98,15 @@ from .services.staged_artifacts import (
     get_task_staged_artifacts,
     tag_task_artifact,
 )
-from .stream.redis_stream import TaskRunRedisStream, TaskRunStreamError, get_task_run_stream_key
+from .stream.redis_stream import (
+    TASK_RUN_STREAM_WAIT_DELAY_INCREMENT_SECONDS,
+    TASK_RUN_STREAM_WAIT_INITIAL_DELAY_SECONDS,
+    TASK_RUN_STREAM_WAIT_MAX_DELAY_SECONDS,
+    TASK_RUN_STREAM_WAIT_TIMEOUT_SECONDS,
+    TaskRunRedisStream,
+    TaskRunStreamError,
+    get_task_run_stream_key,
+)
 from .temporal.client import (
     execute_posthog_code_agent_relay_workflow,
     execute_task_processing_workflow,
@@ -2033,9 +2042,28 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         async def async_stream() -> AsyncGenerator[bytes, None]:
             redis_stream = TaskRunRedisStream(stream_key)
-            if not await redis_stream.wait_for_stream():
-                yield format_sse_event({"error": "Stream not available"}, event_name="error")
-                return
+            delay = TASK_RUN_STREAM_WAIT_INITIAL_DELAY_SECONDS
+            wait_started_at = asyncio.get_running_loop().time()
+            last_keepalive_at = wait_started_at
+
+            while not await redis_stream.exists():
+                now = asyncio.get_running_loop().time()
+                if now - wait_started_at >= TASK_RUN_STREAM_WAIT_TIMEOUT_SECONDS:
+                    yield format_sse_event({"error": "Stream not available"}, event_name="error")
+                    return
+
+                if now - last_keepalive_at >= TASK_RUN_STREAM_KEEPALIVE_INTERVAL_SECONDS:
+                    last_keepalive_at = now
+                    yield format_sse_event(
+                        TASK_RUN_STREAM_KEEPALIVE_PAYLOAD,
+                        event_name=TASK_RUN_STREAM_KEEPALIVE_EVENT_NAME,
+                    )
+
+                await asyncio.sleep(delay)
+                delay = min(
+                    delay + TASK_RUN_STREAM_WAIT_DELAY_INCREMENT_SECONDS,
+                    TASK_RUN_STREAM_WAIT_MAX_DELAY_SECONDS,
+                )
 
             start_id = last_event_id or "0"
             if not last_event_id and start_latest:

--- a/products/tasks/backend/stream/redis_stream.py
+++ b/products/tasks/backend/stream/redis_stream.py
@@ -19,6 +19,10 @@ TASK_RUN_STREAM_MAX_LENGTH = 20_000
 TASK_RUN_STREAM_TIMEOUT = 60 * 60  # 60 minutes
 TASK_RUN_STREAM_PREFIX = "task-run-stream:"
 TASK_RUN_STREAM_READ_COUNT = 16
+TASK_RUN_STREAM_WAIT_INITIAL_DELAY_SECONDS = 0.05
+TASK_RUN_STREAM_WAIT_DELAY_INCREMENT_SECONDS = 0.15
+TASK_RUN_STREAM_WAIT_MAX_DELAY_SECONDS = 2.0
+TASK_RUN_STREAM_WAIT_TIMEOUT_SECONDS = 120.0  # sandbox provisioning can be slow
 
 DATA_KEY = b"data"
 TaskRunStreamEntry = tuple[str, dict]
@@ -60,20 +64,21 @@ class TaskRunRedisStream:
         """Set expiry on the stream key to prevent unbounded growth."""
         await self._redis_client.expire(self._stream_key, self._timeout)
 
+    async def exists(self) -> bool:
+        """Return whether the Redis stream key already exists."""
+        return bool(await self._redis_client.exists(self._stream_key))
+
     async def wait_for_stream(self) -> bool:
         """Wait for the stream to be created using linear backoff.
 
         Returns True if the stream exists, False on timeout.
         """
-        delay = 0.05
-        delay_increment = 0.15
-        max_delay = 2.0
-        timeout = 120.0  # 2 min — sandbox provisioning can be slow
+        delay = TASK_RUN_STREAM_WAIT_INITIAL_DELAY_SECONDS
         start_time = asyncio.get_running_loop().time()
 
         while True:
             elapsed = asyncio.get_running_loop().time() - start_time
-            if elapsed >= timeout:
+            if elapsed >= TASK_RUN_STREAM_WAIT_TIMEOUT_SECONDS:
                 logger.debug(
                     "task_run_stream_wait_timeout",
                     stream_key=self._stream_key,
@@ -81,11 +86,14 @@ class TaskRunRedisStream:
                 )
                 return False
 
-            if await self._redis_client.exists(self._stream_key):
+            if await self.exists():
                 return True
 
             await asyncio.sleep(delay)
-            delay = min(delay + delay_increment, max_delay)
+            delay = min(
+                delay + TASK_RUN_STREAM_WAIT_DELAY_INCREMENT_SECONDS,
+                TASK_RUN_STREAM_WAIT_MAX_DELAY_SECONDS,
+            )
 
     async def get_latest_stream_id(self) -> str | None:
         """Return the latest stream ID if the stream has any events."""

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 
 import pytest
+from unittest.mock import patch
 
 from temporalio import activity
 from temporalio.common import RetryPolicy
@@ -469,6 +470,30 @@ class TestFollowupGuards:
                 await handle.result()
 
         assert _ci_followup_calls == []
+
+    @pytest.mark.timeout(60)
+    async def test_legacy_replay_branch_still_dispatches_ci_follow_up_without_pr_context_guard(self):
+        _pr_context_overrides["behavior"] = "closed"
+
+        with patch(
+            "products.tasks.backend.temporal.process_task.workflow._ci_follow_up_pr_context_guard_enabled",
+            return_value=False,
+        ):
+            async with await WorkflowEnvironment.start_time_skipping() as env:
+                task_queue = f"test-{uuid.uuid4()}"
+                async with _make_worker(env, task_queue):
+                    handle = await env.client.start_workflow(
+                        ProcessTaskWorkflow.run,
+                        ProcessTaskInput(run_id="run-1"),
+                        id=f"test-{uuid.uuid4()}",
+                        task_queue=task_queue,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                        execution_timeout=timedelta(hours=4),
+                    )
+                    await handle.result()
+
+        assert len(_ci_followup_calls) == MAX_CI_REPETITIONS
+        assert all(msg == DEFAULT_CI_MESSAGE for msg in _ci_followup_calls)
 
     @pytest.mark.timeout(60)
     async def test_skips_ci_follow_up_when_fingerprint_unchanged(self):

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -272,6 +272,10 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             return False
 
     async def _dispatch_ci_follow_up(self) -> None:
+        # Rolling-deploy note (tasks-ci-follow-up-pr-context-cleanup): any
+        # behavior change here that must also preserve replay for in-flight
+        # histories needs a new patch gate. Do not "keep these in sync" by
+        # editing the legacy helper below.
         self._ci_repetitions += 1
         ci_message = self.context.ci_prompt or DEFAULT_CI_MESSAGE
         self._last_active_time = workflow.now()
@@ -282,6 +286,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
 
         This preserves the pre-rollout command shape for replay of histories
         that scheduled `send_followup_to_sandbox` directly on CI ticks.
+        Cleanup is tracked under `tasks-ci-follow-up-pr-context-cleanup`.
         """
         self._ci_repetitions += 1
         ci_message = self.context.ci_prompt or DEFAULT_CI_MESSAGE

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -101,6 +101,18 @@ Hard limits (refuse regardless of who asked):
 After fixing, commit and push so CI can re-run.
 """.strip()
 
+# Rolling-deploy compatibility (TODO slug: tasks-ci-follow-up-pr-context-cleanup)
+# ---------------------------------------------------------------------------
+# The PR-context guard inserts a new `get_pr_context` activity before the
+# existing CI follow-up dispatch. Without versioning, replay of pre-rollout
+# histories fails with nondeterminism because those histories scheduled
+# `send_followup_to_sandbox` directly at this point in the workflow.
+_PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT = "tasks-ci-follow-up-pr-context"
+
+
+def _ci_follow_up_pr_context_guard_enabled() -> bool:
+    return workflow.patched(_PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT)
+
 
 @temporalio.workflow.defn(name="process-task")
 class ProcessTaskWorkflow(PostHogWorkflow):
@@ -259,6 +271,23 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             )
             return False
 
+    async def _dispatch_ci_follow_up(self) -> None:
+        self._ci_repetitions += 1
+        ci_message = self.context.ci_prompt or DEFAULT_CI_MESSAGE
+        self._last_active_time = workflow.now()
+        await self._send_followup_to_sandbox(ci_message, [])
+
+    async def _dispatch_legacy_ci_follow_up_for_replay(self) -> None:
+        """DO NOT MODIFY without a new Temporal patch gate.
+
+        This preserves the pre-rollout command shape for replay of histories
+        that scheduled `send_followup_to_sandbox` directly on CI ticks.
+        """
+        self._ci_repetitions += 1
+        ci_message = self.context.ci_prompt or DEFAULT_CI_MESSAGE
+        self._last_active_time = workflow.now()
+        await self._send_followup_to_sandbox(ci_message, [])
+
     @workflow.run
     async def run(self, input: ProcessTaskInput) -> ProcessTaskOutput:
         sandbox_id = None
@@ -332,13 +361,10 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                         workflow.logger.info(
                             "CI follow-up event triggered", run_id=self.context.run_id, repetitions=self._ci_repetitions
                         )
-                        if await self._should_run_ci_follow_up():
-                            self._ci_repetitions += 1
-                            ci_message = self.context.ci_prompt or DEFAULT_CI_MESSAGE
-
-                            self._last_active_time = workflow.now()  # Reset inactivity timer on CI follow-up
-
-                            await self._send_followup_to_sandbox(ci_message, [])
+                        if not _ci_follow_up_pr_context_guard_enabled():
+                            await self._dispatch_legacy_ci_follow_up_for_replay()
+                        elif await self._should_run_ci_follow_up():
+                            await self._dispatch_ci_follow_up()
                     case TaskEvent.SIGNAL_RECEIVED:
                         if self._pending_followup is not None:
                             workflow.logger.info(

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3309,6 +3309,44 @@ class TestTaskRunStreamKeepaliveAPI(BaseTaskAPITest):
     def _stream_url(self, task: Task, run: TaskRun) -> str:
         return f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/stream/"
 
+    def test_stream_emits_keepalive_while_waiting_for_stream_creation(self):
+        task = self.create_task()
+        run = task.create_run()
+
+        async def fake_read_stream_entries(self, *args, **kwargs):
+            yield (
+                "1-0",
+                {
+                    "type": "notification",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "notification": {
+                        "jsonrpc": "2.0",
+                        "method": "_posthog/console",
+                        "params": {
+                            "sessionId": str(run.id),
+                            "level": "info",
+                            "message": "after stream creation",
+                        },
+                    },
+                },
+            )
+
+        with (
+            patch.object(TaskRunRedisStream, "exists", new=AsyncMock(side_effect=[False, True])),
+            patch.object(TaskRunRedisStream, "read_stream_entries", new=fake_read_stream_entries),
+            patch("products.tasks.backend.api.TASK_RUN_STREAM_KEEPALIVE_INTERVAL_SECONDS", 0),
+        ):
+            response = cast(
+                StreamingHttpResponse,
+                self.client.get(self._stream_url(task, run), HTTP_ACCEPT="text/event-stream"),
+            )
+            content = b"".join(cast(Iterator[bytes], response.streaming_content)).decode("utf-8")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("event: keepalive", content)
+        self.assertIn("after stream creation", content)
+        self.assertLess(content.index("event: keepalive"), content.index("after stream creation"))
+
     def test_stream_emits_keepalive_comments_while_idle(self):
         task = self.create_task()
         run = task.create_run()


### PR DESCRIPTION
## Problem

Cloud task runs can get stuck in `queued` for two separate reasons (maybe more lol)

1) the task workflow's new PR-context CI follow-up check changed the activity sequence for in-flight Temporal workflows, which causes replay nondeterminism and prevents queued runs from progressing, https://github.com/PostHog/posthog/pull/55662 introduced get_pr_context activity into the CI follow-up path without a Temporal patch gate
2) the task SSE endpoint stays silent while it waits for the Redis stream to appear, so proxies can tear down the connection and PostHog Code falls into a reconnect loop while the run still shows as `queued`

## Changes

- temporal patch gate around the PR-context CI follow-up branch so pre-existing workflow histories replay through the legacy activity sequence
- keep the legacy CI follow-up dispatch path isolated for replay safety
- emit SSE keepalives while waiting for the task Redis stream to be created, using shared wait timing constants
