### PR TITLE
fix(llma): classify openrouter 402 as non-retryable quota error

### DIFF
--- a/products/llm_analytics/backend/llm/providers/openai.py
+++ b/products/llm_analytics/backend/llm/providers/openai.py
@@ -178,6 +178,13 @@ class OpenAIAdapter:
             if error_code == "insufficient_quota":
                 raise QuotaExceededError(str(e))
             raise RateLimitError(str(e))
+        except openai.APIStatusError as e:
+            # OpenRouter returns 402 when the key can't afford the requested
+            # max_tokens (or is out of credits). Retrying never helps — mirror
+            # the quota path so the workflow marks the key errored and stops.
+            if getattr(e, "status_code", None) == 402:
+                raise QuotaExceededError(str(e))
+            raise
 
     def _complete_with_json_fallback(
         self,

--- a/products/llm_analytics/backend/llm/providers/test/test_openai_adapter.py
+++ b/products/llm_analytics/backend/llm/providers/test/test_openai_adapter.py
@@ -1,6 +1,55 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+
+from products.llm_analytics.backend.llm.errors import QuotaExceededError
 from products.llm_analytics.backend.llm.providers.openai import OpenAIAdapter, OpenAIConfig
+from products.llm_analytics.backend.llm.types import AnalyticsContext, CompletionRequest
 
 
 class TestOpenAIRecommendedModels:
     def test_recommended_models_equals_supported_models(self):
         assert OpenAIAdapter.recommended_models() == set(OpenAIConfig.SUPPORTED_MODELS)
+
+
+def _make_api_status_error(status_code: int, message: str) -> openai.APIStatusError:
+    request = httpx.Request("POST", "https://example.invalid/v1/chat/completions")
+    response = httpx.Response(status_code=status_code, request=request, json={"error": {"message": message}})
+    return openai.APIStatusError(message, response=response, body={"error": {"message": message, "code": status_code}})
+
+
+class TestOpenAIAdapterErrorMapping:
+    @pytest.fixture
+    def request_no_structured_output(self) -> CompletionRequest:
+        return CompletionRequest(
+            model="gpt-4.1",
+            system="s",
+            messages=[{"role": "user", "content": "hi"}],
+            provider="openai",
+        )
+
+    def test_402_is_mapped_to_quota_exceeded(self, request_no_structured_output: CompletionRequest):
+        adapter = OpenAIAdapter()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _make_api_status_error(
+            402, "This request requires more credits, or fewer max_tokens."
+        )
+
+        with patch("products.llm_analytics.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
+            with pytest.raises(QuotaExceededError, match="credits"):
+                adapter.complete(
+                    request_no_structured_output, api_key="sk-test", analytics=AnalyticsContext(capture=False)
+                )
+
+    def test_non_402_status_error_is_not_swallowed(self, request_no_structured_output: CompletionRequest):
+        adapter = OpenAIAdapter()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _make_api_status_error(500, "server error")
+
+        with patch("products.llm_analytics.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
+            with pytest.raises(openai.APIStatusError):
+                adapter.complete(
+                    request_no_structured_output, api_key="sk-test", analytics=AnalyticsContext(capture=False)
+                )


### PR DESCRIPTION
## Problem

LLM Analytics evals have a large unclassified-error rate in the EU. Root cause: `OpenAIAdapter.complete` only maps `AuthenticationError`, `NotFoundError`, `PermissionDeniedError`, and `RateLimitError`. An `openai.APIStatusError` with status 402 — which OpenRouter returns when a BYOK key can't afford the requested `max_tokens` ("This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens, but can only afford 47945") — falls through to the generic `except Exception` branch in `execute_llm_judge_activity`, which re-raises as a retryable error. Temporal's `LLM_JUDGE_RETRY_POLICY` (maximum_attempts=3) then runs the same doomed request three times, and because the key's state is never touched, every subsequent ingested `$ai_generation` event enqueues yet another 3× retry cycle. The asymmetry against EU comes from a single customer there whose three eval configs fan out per event (visible as repeated `evaluation_id` prefixes across failed workflows in the `posthog-prod-eu` Temporal UI).

## Changes

- `products/llm_analytics/backend/llm/providers/openai.py`: catch `openai.APIStatusError` after the existing `RateLimitError` handler; when `status_code == 402`, re-raise as `QuotaExceededError`. This funnels OpenRouter credit errors through the existing non-retryable path in `execute_llm_judge_activity` (`error_type="quota_error"`) and triggers `update_key_state_activity` to flag the key as `ERROR`, so the provider-keys UI surfaces the failure and the workflow stops hammering.
- Unit tests pinning the 402 → `QuotaExceededError` mapping and verifying that non-402 `APIStatusError`s still bubble up unchanged.

No behavior change for OpenAI-direct keys (OpenAI doesn't return 402); this only affects OpenRouter.

## How did you test this code?

- `hogli test products/llm_analytics/backend/llm/providers/test/test_openai_adapter.py` — 3 passing.
- `hogli test products/llm_analytics/backend/llm/providers/test/` — 46 passing, no regressions.

## Publish to changelog?

no

## Docs update

Not needed.

## 🤖 LLM context

Authored by Claude Opus 4.7 with ultrathink-mode review, driven by the Temporal EU failure screenshot + a sampled failed event showing a 402 from OpenRouter inside `execute_llm_judge_activity`. Hypothesis validation used the Grafana EU/US MCPs to pull `llma_eval_errors` totals shown above.
