### PR TITLE
fix(trends): reserve rank slot for null bucket in cohort breakdowns

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -610,12 +610,16 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         # Cohort breakdowns are over a user-picked, enumerable set — a limit smaller than
         # the cohort count would bucket some selected cohorts as "Other", which then crashes
         # the label lookup in `build_series_response` (Cohort.objects.get(pk=<Other sentinel>)).
+        # The `+ 1` reserves a rank slot for the NULL bucket that `__in_cohort` produces on the
+        # LEFTJOIN_CONJOINED path when any series has a `person in cohort` filter whose cohort
+        # isn't in the breakdown list — without it, that NULL row steals a slot and one real
+        # cohort overflows into "Other". Proper fix is to drop NULL before ranking; hotfix for now.
         if (
             breakdown_filter is not None
             and breakdown_filter.breakdown_type == "cohort"
             and isinstance(breakdown_filter.breakdown, list)
         ):
-            limit = max(limit, len(breakdown_filter.breakdown))
+            limit = max(limit, len(breakdown_filter.breakdown) + 1)
 
         return limit
 


### PR DESCRIPTION
## Problem

Trends insights with a cohort breakdown crash with a 500 when a series also has a `person in cohort` filter whose cohort isn't in the breakdown list:

```
ValueError: Field 'id' expected a number but got '$$_posthog_breakdown_other_$$'.
```

Root cause is in the `LEFTJOIN_CONJOINED` cohort breakdown path:

1. Each series query joins `__in_cohort`, which includes every cohort referenced in that series — both breakdown cohorts *and* any filter-only cohort.
2. The breakdown column is `if(cohort_id IN {declared}, toString(cohort_id), NULL)`. Events whose person matches a filter-only cohort contribute rows that collapse into a single NULL bucket.
3. In `_total_value_by_breakdown_query` (used for `ActionsBarValue` / any total-value display), `row_number()` ranks breakdown values *before* the outer `WHERE breakdown_value IS NOT NULL` filter. The NULL bucket can outrank a real cohort on total count.
4. When the NULL bucket ranks high and the combined distinct-value count exceeds `breakdown_limit`, one **real** cohort overflows to the `$$_posthog_breakdown_other_$$` sentinel.
5. `build_series_response` passes that sentinel directly to `Cohort.objects.get(pk=...)`, which Django tries to coerce to `int` → crash.

The existing guard in `_get_breakdown_limit` already bumps the limit to `len(breakdown)` to prevent declared cohorts from being bucketed as "Other", but it doesn't account for the extra NULL bucket.

## Changes

Bump the cohort-breakdown limit by `+1` so the NULL bucket has a reserved rank slot and no declared cohort gets pushed past the limit. Comment the `+1` with why and flag it as a hotfix.

Scope: single line change + a comment in `trends_query_builder.py::_get_breakdown_limit`. No SQL surgery, no behavior change for cohort breakdowns without filter-only cohorts.

Proper follow-up (tracked separately):
- Move `breakdown_value IS NOT NULL` before `row_number()` in both `_total_value_by_breakdown_query` and `_outer_select_query` so NULL never competes for rank.
- Add sentinel / `Cohort.DoesNotExist` guards in the cohort branch of `build_series_response` so this class of bug can never 500 the response again, regardless of how the sentinel got there.
- Add a regression test covering the filter-only-cohort case (filter-only cohort broader than any breakdown cohort → NULL ranks high → would overflow without the bump).

## How did you test this code?

Automated tests only — I'm an agent and didn't run manual UI testing.

- `hogli test posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py -k cohort` → 17 passed (including existing `test_cohort_breakdown_with_lower_breakdown_limit` regression)
- `hogli test posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py -k breakdown` → 84 passed
- `hogli test posthog/hogql_queries/insights/trends/test/test_formula.py` → 29 passed (all 29 snapshots unchanged — the `+1` doesn't affect non-cohort breakdowns)

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7) in a debugging session that traced the crash from the stack trace through the query builder and breakdown SQL generation. The session explored two fix options — a targeted SQL change to drop NULL before ranking vs. a single-line limit bump — and the user opted for the limit bump as a hotfix to ship quickly, with the SQL fix queued as a follow-up.