### PR TITLE
chore(devex): rename LLM context to Agent context in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,9 @@
 
 ## How did you test this code?
 
-<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
+<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
 <!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
-<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
+<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
 
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 
@@ -30,6 +30,13 @@
 
 <!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
 
-<!-- ## 🤖 LLM context -->
+## 🤖 Agent context
 
-<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
+<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
+<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
+<!-- Rules for agent-authored PRs:
+     - All PRs must be attributable to a human author, even if agent-assisted.
+     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
+     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
+     - Do NOT claim manual testing you haven't done.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Examples:
 
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.
 Do not invent a different format.
-Always uncomment and fill the `## LLM context` section for agent-authored PRs.
+Always fill the `## 🤖 Agent context` section when creating PRs.
 Keep descriptions high-level, focusing on rationale and architecture for the human reviewer.
 
 ### Rules

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -18,8 +18,8 @@ Before submitting, please verify the change actually works end-to-end — don't 
 PRs that clearly weren't run or tested will be closed under this policy.
 
 **Disclose AI usage.**
-Our [PR template](.github/pull_request_template.md) includes an LLM context section — please use it (most agents will pick it up automatically).
-If an LLM co-authored or authored your PR, say so and leave context about the tools and session.
+Our [PR template](.github/pull_request_template.md) includes an Agent context section — please use it (most agents will pick it up automatically).
+If an agent co-authored or authored your PR, say so and leave context about the tools and session.
 This helps reviewers calibrate.
 
 **Prefer PRs over AI-generated issues.**


### PR DESCRIPTION
**Problem**
The PR template had an "LLM context" section that was commented out by default, and agents had to know to uncomment it. "LLM" is also an implementation detail that doesn't match the rest of the handbook, which uses "agent" throughout.

**Changes**
- Rename `## 🤖 LLM context` → `## 🤖 Agent context` and make it always visible (humans remove it, agents fill it)
- Inline agent-specific rules (attribution, review, testing honesty) directly in the template so agents read them at PR creation time
- Tighten the testing section guidance for agents
- Update AGENTS.md to match the new section name

## 🤖 Agent context
Co-authored with Claude Code. Reference: PostHog handbook development process for agent attribution rules.