### PR TITLE
chore(admin): allow deleted insights and dashboards to be searchable/viewable

### DIFF
--- a/posthog/admin/admins/dashboard_admin.py
+++ b/posthog/admin/admins/dashboard_admin.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 
+from posthog.admin.filters import DeletedFilter
+
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
@@ -11,36 +13,6 @@ class DashboardTileInline(admin.TabularInline):
     model = DashboardTile
     autocomplete_fields = ("insight", "text")
     readonly_fields = ("filters_hash",)
-
-
-class DeletedDashboardFilter(admin.SimpleListFilter):
-    title = "deleted"
-    parameter_name = "deleted"
-
-    def lookups(self, request, model_admin):
-        return (
-            ("no", "No"),
-            ("yes", "Yes"),
-            ("all", "All"),
-        )
-
-    def choices(self, changelist):
-        # Override default "All" choice so "No" is the default selected option
-        value = self.value() or "no"
-        for lookup, title in self.lookup_choices:
-            yield {
-                "selected": value == lookup,
-                "query_string": changelist.get_query_string({self.parameter_name: lookup}),
-                "display": title,
-            }
-
-    def queryset(self, request, queryset):
-        value = self.value() or "no"
-        if value == "no":
-            return queryset.filter(deleted=False)
-        if value == "yes":
-            return queryset.filter(deleted=True)
-        return queryset
 
 
 class DashboardAdmin(admin.ModelAdmin):
@@ -54,7 +26,7 @@ class DashboardAdmin(admin.ModelAdmin):
         "deleted",
     )
     list_display_links = ("id", "name")
-    list_filter = (DeletedDashboardFilter,)
+    list_filter = (DeletedFilter,)
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "name", "team__name", "team__organization__name")
     readonly_fields = (

--- a/posthog/admin/admins/dashboard_admin.py
+++ b/posthog/admin/admins/dashboard_admin.py
@@ -13,6 +13,36 @@ class DashboardTileInline(admin.TabularInline):
     readonly_fields = ("filters_hash",)
 
 
+class DeletedDashboardFilter(admin.SimpleListFilter):
+    title = "deleted"
+    parameter_name = "deleted"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("no", "No"),
+            ("yes", "Yes"),
+            ("all", "All"),
+        )
+
+    def choices(self, changelist):
+        # Override default "All" choice so "No" is the default selected option
+        value = self.value() or "no"
+        for lookup, title in self.lookup_choices:
+            yield {
+                "selected": value == lookup,
+                "query_string": changelist.get_query_string({self.parameter_name: lookup}),
+                "display": title,
+            }
+
+    def queryset(self, request, queryset):
+        value = self.value() or "no"
+        if value == "no":
+            return queryset.filter(deleted=False)
+        if value == "yes":
+            return queryset.filter(deleted=True)
+        return queryset
+
+
 class DashboardAdmin(admin.ModelAdmin):
     list_display = (
         "id",
@@ -21,8 +51,10 @@ class DashboardAdmin(admin.ModelAdmin):
         "organization_link",
         "created_at",
         "created_by",
+        "deleted",
     )
     list_display_links = ("id", "name")
+    list_filter = (DeletedDashboardFilter,)
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "name", "team__name", "team__organization__name")
     readonly_fields = (
@@ -34,6 +66,9 @@ class DashboardAdmin(admin.ModelAdmin):
     autocomplete_fields = ("team", "created_by")
     ordering = ("-created_at", "creation_mode")
     inlines = (DashboardTileInline,)
+
+    def get_queryset(self, request):
+        return Dashboard.objects_including_soft_deleted.all()
 
     @admin.display(description="Team")
     def team_link(self, dashboard: Dashboard):

--- a/posthog/admin/admins/insight_admin.py
+++ b/posthog/admin/admins/insight_admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 
+from posthog.admin.filters import DeletedFilter
 from posthog.models import Insight
 
 
@@ -51,36 +52,6 @@ class InsightAdminForm(forms.ModelForm):
         return instance
 
 
-class DeletedInsightFilter(admin.SimpleListFilter):
-    title = "deleted"
-    parameter_name = "deleted"
-
-    def lookups(self, request, model_admin):
-        return (
-            ("no", "No"),
-            ("yes", "Yes"),
-            ("all", "All"),
-        )
-
-    def choices(self, changelist):
-        # Override default "All" choice so "No" is the default selected option
-        value = self.value() or "no"
-        for lookup, title in self.lookup_choices:
-            yield {
-                "selected": value == lookup,
-                "query_string": changelist.get_query_string({self.parameter_name: lookup}),
-                "display": title,
-            }
-
-    def queryset(self, request, queryset):
-        value = self.value() or "no"
-        if value == "no":
-            return queryset.filter(deleted=False)
-        if value == "yes":
-            return queryset.filter(deleted=True)
-        return queryset
-
-
 class InsightAdmin(admin.ModelAdmin):
     form = InsightAdminForm
     exclude = ("layouts",)
@@ -97,7 +68,7 @@ class InsightAdmin(admin.ModelAdmin):
         "deleted",
     )
     list_display_links = ("id", "short_id", "effective_name")
-    list_filter = (DeletedInsightFilter,)
+    list_filter = (DeletedFilter,)
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "name", "short_id", "team__name", "team__organization__name")
     readonly_fields = (

--- a/posthog/admin/admins/insight_admin.py
+++ b/posthog/admin/admins/insight_admin.py
@@ -51,6 +51,36 @@ class InsightAdminForm(forms.ModelForm):
         return instance
 
 
+class DeletedInsightFilter(admin.SimpleListFilter):
+    title = "deleted"
+    parameter_name = "deleted"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("no", "No"),
+            ("yes", "Yes"),
+            ("all", "All"),
+        )
+
+    def choices(self, changelist):
+        # Override default "All" choice so "No" is the default selected option
+        value = self.value() or "no"
+        for lookup, title in self.lookup_choices:
+            yield {
+                "selected": value == lookup,
+                "query_string": changelist.get_query_string({self.parameter_name: lookup}),
+                "display": title,
+            }
+
+    def queryset(self, request, queryset):
+        value = self.value() or "no"
+        if value == "no":
+            return queryset.filter(deleted=False)
+        if value == "yes":
+            return queryset.filter(deleted=True)
+        return queryset
+
+
 class InsightAdmin(admin.ModelAdmin):
     form = InsightAdminForm
     exclude = ("layouts",)
@@ -64,8 +94,10 @@ class InsightAdmin(admin.ModelAdmin):
         "sampling_factor_display",
         "created_at",
         "created_by",
+        "deleted",
     )
     list_display_links = ("id", "short_id", "effective_name")
+    list_filter = (DeletedInsightFilter,)
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "name", "short_id", "team__name", "team__organization__name")
     readonly_fields = (
@@ -77,6 +109,9 @@ class InsightAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ("team", "dashboard", "created_by", "last_modified_by")
     ordering = ("-created_at",)
+
+    def get_queryset(self, request):
+        return Insight.objects_including_soft_deleted.all()
 
     fieldsets = (
         (None, {"fields": ("name", "description", "team", "short_id")}),

--- a/posthog/admin/filters.py
+++ b/posthog/admin/filters.py
@@ -1,0 +1,28 @@
+from django.contrib import admin
+
+
+class DeletedFilter(admin.SimpleListFilter):
+    """Sidebar filter for models with a soft-delete `deleted` boolean, defaulting to hiding deleted rows."""
+
+    title = "deleted"
+    parameter_name = "deleted"
+
+    def lookups(self, request, model_admin):
+        return (("no", "No"), ("yes", "Yes"), ("all", "All"))
+
+    def choices(self, changelist):
+        value = self.value() or "no"
+        for lookup, title in self.lookup_choices:
+            yield {
+                "selected": value == lookup,
+                "query_string": changelist.get_query_string({self.parameter_name: lookup}),
+                "display": title,
+            }
+
+    def queryset(self, request, queryset):
+        value = self.value() or "no"
+        if value == "no":
+            return queryset.filter(deleted=False)
+        if value == "yes":
+            return queryset.filter(deleted=True)
+        return queryset


### PR DESCRIPTION
## Problem

If you want to undelete a soft-deleted dashbaord or insight right now, the only way to do this is via an API call using personal access token. When helping customers restore a dashboard or insight it would be better to be able to do this directly from our admin panel

## Changes

1. Adds a filter to both insights and dashboards to allow filtering is deleted. The default is `No`, we override the default `All` so this option still exists.
2. Includes deleted models in the queryset so that you can get to the insight/dashboard.

Before:
<img width="1558" height="321" alt="Screenshot 2026-04-24 at 09 24 24" src="https://github.com/user-attachments/assets/21848036-a60c-4cca-9277-3178240488a5" />

After:
<img width="1560" height="670" alt="image" src="https://github.com/user-attachments/assets/492b19c2-7682-411d-9fb9-0eeffba10f53" />

The filters appear as follows:
<img width="1563" height="591" alt="image" src="https://github.com/user-attachments/assets/6c58a2a5-e70e-4b88-ae23-91dd5b162898" />

Insights work in the same way:
<img width="1578" height="529" alt="image" src="https://github.com/user-attachments/assets/9e9dcde9-9b8f-4894-8267-1238d86c6d96" />


## How did you test this code?

Manually in dev.

## Publish to changelog?

no.

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 LLM context

Claude