### PR TITLE
fix: batch-import worker retries on connection-level failures

### DIFF
--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -121,7 +121,7 @@ pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
 pub fn is_transient_server_error(error: &anyhow::Error) -> bool {
     error.chain().any(|err| {
         err.downcast_ref::<reqwest::Error>()
-            .is_some_and(|re| matches!(re.status().map(|s| s.as_u16()), Some(502 | 503 | 504)))
+            .is_some_and(|re| matches!(re.status().map(|s| s.as_u16()), Some(502..=504)))
     })
 }
 

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -108,7 +108,8 @@ pub fn is_timeout_error(error: &anyhow::Error) -> bool {
 
 /// Returns true if the error chain contains a transport-level reqwest error
 /// (connection refused/closed/reset, DNS, TLS, premature body close). Transient,
-/// retry with backoff. Excludes timeouts (see is_timeout_error) and HTTP status errors.
+/// retry with backoff. Excludes timeouts (see is_timeout_error), HTTP status errors,
+/// and builder errors (malformed URL / illegal header).
 pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
     if let Some(reqwest_err) = error.downcast_ref::<reqwest::Error>() {
         if !reqwest_err.is_timeout() && reqwest_err.status().is_none() {
@@ -119,7 +120,7 @@ pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
     let mut source = error.source();
     while let Some(err) = source {
         if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
-            if !reqwest_err.is_timeout() && reqwest_err.status().is_none() {
+            if !reqwest_err.is_timeout() && !reqwest_err.is_builder() && reqwest_err.status().is_none() {
                 return true;
             }
         }
@@ -348,5 +349,19 @@ mod tests {
         let err = anyhow::Error::from(err);
         assert!(is_transient_network_error(&err));
         assert!(!is_timeout_error(&err));
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_network_error_false_for_builder_error() {
+        // Null byte in header value — rejected at request construction, not transient.
+        let client = Client::new();
+        let err = client
+            .get("http://127.0.0.1:1/")
+            .header("X-Test", "bad\0value")
+            .send()
+            .await
+            .unwrap_err();
+        let err = anyhow::Error::from(err);
+        assert!(!is_transient_network_error(&err));
     }
 }

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -106,6 +106,28 @@ pub fn is_timeout_error(error: &anyhow::Error) -> bool {
     false
 }
 
+/// Returns true if the error chain contains a transport-level reqwest error
+/// (connection refused/closed/reset, DNS, TLS, premature body close). Transient,
+/// retry with backoff. Excludes timeouts (see is_timeout_error) and HTTP status errors.
+pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
+    if let Some(reqwest_err) = error.downcast_ref::<reqwest::Error>() {
+        if !reqwest_err.is_timeout() && reqwest_err.status().is_none() {
+            return true;
+        }
+    }
+
+    let mut source = error.source();
+    while let Some(err) = source {
+        if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
+            if !reqwest_err.is_timeout() && reqwest_err.status().is_none() {
+                return true;
+            }
+        }
+        source = err.source();
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,6 +290,63 @@ mod tests {
         let resp = client.get(server.url("/ok")).send().await.unwrap();
         let http_err = resp.error_for_status().unwrap_err();
         let err = anyhow::Error::from(http_err);
+        assert!(!is_timeout_error(&err));
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_network_error_true_for_connection_refused() {
+        // Bind to get a free port, then drop so nothing is listening.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let client = Client::new();
+        let err = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .unwrap_err();
+        let err = anyhow::Error::from(err);
+        assert!(is_transient_network_error(&err));
+        assert!(!is_timeout_error(&err));
+        assert!(!is_rate_limited_error(&err));
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_network_error_false_for_http_status() {
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/err");
+            then.status(500);
+        });
+
+        let client = Client::new();
+        let resp = client.get(server.url("/err")).send().await.unwrap();
+        let http_err = resp.error_for_status().unwrap_err();
+        let err = anyhow::Error::from(http_err);
+        assert!(!is_transient_network_error(&err));
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_network_error_true_for_connection_closed_mid_request() {
+        // Server accepts the TCP connection then immediately drops it — reproduces
+        // the "connection closed before message completed" reqwest variant we saw in prod.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                drop(stream);
+            }
+        });
+
+        let client = Client::new();
+        let err = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .unwrap_err();
+        let err = anyhow::Error::from(err);
+        assert!(is_transient_network_error(&err));
         assert!(!is_timeout_error(&err));
     }
 }

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -112,18 +112,16 @@ pub fn is_timeout_error(error: &anyhow::Error) -> bool {
 /// and builder errors (malformed URL / illegal header).
 pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
     error.chain().any(|err| {
-        err.downcast_ref::<reqwest::Error>().is_some_and(|re| {
-            !re.is_timeout() && !re.is_builder() && re.status().is_none()
-        })
+        err.downcast_ref::<reqwest::Error>()
+            .is_some_and(|re| !re.is_timeout() && !re.is_builder() && re.status().is_none())
     })
 }
 
 /// Returns true if the error chain contains a reqwest::Error with HTTP 502/503/504.
 pub fn is_transient_server_error(error: &anyhow::Error) -> bool {
     error.chain().any(|err| {
-        err.downcast_ref::<reqwest::Error>().is_some_and(|re| {
-            matches!(re.status().map(|s| s.as_u16()), Some(502 | 503 | 504))
-        })
+        err.downcast_ref::<reqwest::Error>()
+            .is_some_and(|re| matches!(re.status().map(|s| s.as_u16()), Some(502 | 503 | 504)))
     })
 }
 
@@ -393,7 +391,10 @@ mod tests {
             let resp = client.get(server.url("/e")).send().await.unwrap();
             let http_err = resp.error_for_status().unwrap_err();
             let err = anyhow::Error::from(http_err);
-            assert!(is_transient_server_error(&err), "expected true for {status}");
+            assert!(
+                is_transient_server_error(&err),
+                "expected true for {status}"
+            );
         }
     }
 
@@ -411,7 +412,10 @@ mod tests {
             let resp = client.get(server.url("/e")).send().await.unwrap();
             let http_err = resp.error_for_status().unwrap_err();
             let err = anyhow::Error::from(http_err);
-            assert!(!is_transient_server_error(&err), "expected false for {status}");
+            assert!(
+                !is_transient_server_error(&err),
+                "expected false for {status}"
+            );
         }
     }
 }

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -111,22 +111,11 @@ pub fn is_timeout_error(error: &anyhow::Error) -> bool {
 /// retry with backoff. Excludes timeouts (see is_timeout_error), HTTP status errors,
 /// and builder errors (malformed URL / illegal header).
 pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
-    if let Some(reqwest_err) = error.downcast_ref::<reqwest::Error>() {
-        if !reqwest_err.is_timeout() && reqwest_err.status().is_none() {
-            return true;
-        }
-    }
-
-    let mut source = error.source();
-    while let Some(err) = source {
-        if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
-            if !reqwest_err.is_timeout() && !reqwest_err.is_builder() && reqwest_err.status().is_none() {
-                return true;
-            }
-        }
-        source = err.source();
-    }
-    false
+    error.chain().any(|err| {
+        err.downcast_ref::<reqwest::Error>().is_some_and(|re| {
+            !re.is_timeout() && !re.is_builder() && re.status().is_none()
+        })
+    })
 }
 
 #[cfg(test)]

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -118,6 +118,15 @@ pub fn is_transient_network_error(error: &anyhow::Error) -> bool {
     })
 }
 
+/// Returns true if the error chain contains a reqwest::Error with HTTP 502/503/504.
+pub fn is_transient_server_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|err| {
+        err.downcast_ref::<reqwest::Error>().is_some_and(|re| {
+            matches!(re.status().map(|s| s.as_u16()), Some(502 | 503 | 504))
+        })
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,5 +361,57 @@ mod tests {
             .unwrap_err();
         let err = anyhow::Error::from(err);
         assert!(!is_transient_network_error(&err));
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_server_error_true_for_502() {
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/e");
+            then.status(502);
+        });
+
+        let client = Client::new();
+        let resp = client.get(server.url("/e")).send().await.unwrap();
+        let http_err = resp.error_for_status().unwrap_err();
+        let err = anyhow::Error::from(http_err);
+        assert!(is_transient_server_error(&err));
+        assert!(!is_rate_limited_error(&err));
+        assert!(!is_transient_network_error(&err));
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_server_error_true_for_503_and_504() {
+        for status in [503, 504] {
+            let server = MockServer::start();
+            let _mock = server.mock(|when, then| {
+                when.method(httpmock::Method::GET).path("/e");
+                then.status(status);
+            });
+
+            let client = Client::new();
+            let resp = client.get(server.url("/e")).send().await.unwrap();
+            let http_err = resp.error_for_status().unwrap_err();
+            let err = anyhow::Error::from(http_err);
+            assert!(is_transient_server_error(&err), "expected true for {status}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_is_transient_server_error_false_for_500_and_4xx() {
+        // 500 is ambiguous (could be a real bug) and 4xx are client errors — neither auto-retries.
+        for status in [500, 400, 404] {
+            let server = MockServer::start();
+            let _mock = server.mock(|when, then| {
+                when.method(httpmock::Method::GET).path("/e");
+                then.status(status);
+            });
+
+            let client = Client::new();
+            let resp = client.get(server.url("/e")).send().await.unwrap();
+            let http_err = resp.error_for_status().unwrap_err();
+            let err = anyhow::Error::from(http_err);
+            assert!(!is_transient_server_error(&err), "expected false for {status}");
+        }
     }
 }

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -78,13 +78,6 @@ fn decide_on_error(
         }
     } else if is_transient_server_error(err) {
         let delay = policy.next_delay(current_attempt);
-        warn!(
-            date_range = ?current_date_range,
-            attempt = current_attempt,
-            delay_secs = delay.as_secs(),
-            "upstream 5xx error, scheduling retry: {:#}",
-            err
-        );
         let (status_msg, display_msg) =
             format_backoff_messages(current_date_range, delay, "Upstream server error (5xx)");
         ErrorHandlingDecision::Backoff {

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     emit::Emitter,
     error::{
         extract_retry_after_from_error, get_user_message, is_rate_limited_error, is_timeout_error,
-        UserError,
+        is_transient_network_error, UserError,
     },
     job::{backoff::format_backoff_messages, config::SinkConfig},
     parse::{format::ParserFn, Parsed},
@@ -62,6 +62,15 @@ fn decide_on_error(
         let delay = policy.next_delay(current_attempt);
         let (status_msg, display_msg) =
             format_backoff_messages(current_date_range, delay, "Request timed out");
+        ErrorHandlingDecision::Backoff {
+            delay,
+            status_msg,
+            display_msg,
+        }
+    } else if is_transient_network_error(err) {
+        let delay = policy.next_delay(current_attempt);
+        let (status_msg, display_msg) =
+            format_backoff_messages(current_date_range, delay, "Transient network error");
         ErrorHandlingDecision::Backoff {
             delay,
             status_msg,
@@ -908,6 +917,57 @@ mod tests {
                 );
             }
             _ => panic!("expected backoff for timeout error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decide_on_error_backoff_for_transient_network_error() {
+        // Bind then drop to close the port — connecting will be refused.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let client = Client::new();
+        let err = client
+            .get(format!("http://{addr}/export"))
+            .send()
+            .await
+            .unwrap_err();
+        let err = anyhow::Error::from(err);
+
+        let decision = decide_on_error(
+            &err,
+            Some("2026-01-01 10:00 UTC to 2026-01-01 11:00 UTC"),
+            crate::job::backoff::BackoffPolicy::new(
+                std::time::Duration::from_secs(60),
+                2.0,
+                std::time::Duration::from_secs(3600),
+            ),
+            0,
+            "Transient network error",
+        );
+
+        match decision {
+            ErrorHandlingDecision::Backoff {
+                delay,
+                status_msg,
+                display_msg,
+            } => {
+                assert_eq!(delay.as_secs(), 60);
+                assert!(
+                    status_msg.contains("Transient network error"),
+                    "status_msg should mention transient network error: {status_msg}"
+                );
+                assert!(
+                    display_msg.contains("Date range"),
+                    "display_msg should include date range: {display_msg}"
+                );
+                assert!(
+                    display_msg.contains("Transient network error"),
+                    "display_msg should mention transient network error: {display_msg}"
+                );
+            }
+            _ => panic!("expected backoff for transient network error"),
         }
     }
 

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     emit::Emitter,
     error::{
         extract_retry_after_from_error, get_user_message, is_rate_limited_error, is_timeout_error,
-        is_transient_network_error, UserError,
+        is_transient_network_error, is_transient_server_error, UserError,
     },
     job::{backoff::format_backoff_messages, config::SinkConfig},
     parse::{format::ParserFn, Parsed},
@@ -71,6 +71,22 @@ fn decide_on_error(
         let delay = policy.next_delay(current_attempt);
         let (status_msg, display_msg) =
             format_backoff_messages(current_date_range, delay, "Transient network error");
+        ErrorHandlingDecision::Backoff {
+            delay,
+            status_msg,
+            display_msg,
+        }
+    } else if is_transient_server_error(err) {
+        let delay = policy.next_delay(current_attempt);
+        warn!(
+            date_range = ?current_date_range,
+            attempt = current_attempt,
+            delay_secs = delay.as_secs(),
+            "upstream 5xx error, scheduling retry: {:#}",
+            err
+        );
+        let (status_msg, display_msg) =
+            format_backoff_messages(current_date_range, delay, "Upstream server error (5xx)");
         ErrorHandlingDecision::Backoff {
             delay,
             status_msg,
@@ -968,6 +984,50 @@ mod tests {
                 );
             }
             _ => panic!("expected backoff for transient network error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decide_on_error_backoff_for_502() {
+        let server = httpmock::MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/e");
+            then.status(502);
+        });
+        let client = Client::new();
+        let resp = client.get(server.url("/e")).send().await.unwrap();
+        let http_err = resp.error_for_status().unwrap_err();
+        let err = anyhow::Error::from(http_err);
+
+        let decision = decide_on_error(
+            &err,
+            Some("2026-01-01 10:00 UTC to 2026-01-01 11:00 UTC"),
+            crate::job::backoff::BackoffPolicy::new(
+                std::time::Duration::from_secs(60),
+                2.0,
+                std::time::Duration::from_secs(3600),
+            ),
+            0,
+            "Upstream server error (5xx)",
+        );
+
+        match decision {
+            ErrorHandlingDecision::Backoff {
+                delay,
+                status_msg,
+                display_msg,
+            } => {
+                assert_eq!(delay.as_secs(), 60);
+                assert!(
+                    status_msg.contains("Upstream server error"),
+                    "status_msg should mention upstream server error: {status_msg}"
+                );
+                assert!(
+                    display_msg.contains("Date range"),
+                    "display_msg should include date range: {display_msg}"
+                );
+            }
+            _ => panic!("expected backoff for 502"),
         }
     }
 


### PR DESCRIPTION
## Problem

A batch import paused on a HTTP error fetching from Amplitude:

`error sending request for url (https://amplitude.com/api/2/export?start=20260221T05&end=20260221T05): client error (SendRequest): connection closed before message completed`

`HTTP status server error (502 Bad Gateway) for url (https://amplitude.com/api/2/export?start=20260225T22&end=20260225T22)`

Error Logs: [https://us.posthog.com/project/2/logs?searchTerm=019d8cf1-e887-0000-7d19-2ec4cd95cace&serviceNames=batch-import-worker&severityLevels=error&dateRange={"date_from"%3A"-1d"}](https://us.posthog.com/project/2/logs?searchTerm=019d8cf1-e887-0000-7d19-2ec4cd95cace&serviceNames=batch-import-worker&severityLevels=error&dateRange=%7B%22date_from%22%3A%22-1d%22%7D)

In `decide_on_error`, only two error classes trigger backoff + retry: HTTP 429 and `reqwest::is_timeout()`. Everything else pauses, including transport-level failures (connection refused/closed/reset, DNS, TLS) and upstream 5xx errors, which are just as transient as timeouts. Customer has to resume manually, worker doesn't auto-recover.

Support ticket: https://posthoghelp.zendesk.com/agent/tickets/55897 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/58533)

These errors are fairly common (at least for Amplitude batch imports) - it took me 5 retries to import about 1.5 months of data. 

## Changes

Added two classifiers in `error/mod.rs` alongside the existing 429/timeout ones, and wires both into `decide_on_error` as new `Backoff` branches:

  - `is_transient_network_error` - reqwest errors with no HTTP status (transport-level failures where we never got a response).
  - `is_transient_server_error` - reqwest errors with HTTP 5xx status (upstream server flakes like 502/503/504).

Affects **all batch imports**, not just Amplitude — every source (Amplitude, Mixpanel, S3, S3+gzip, URL list, folder) gets automatic retry on connection-level and 5xx failures.

## How did you test this code?

- `is_transient_network_error`: connection refused + connection closed mid-request (positive)
- `is_transient_server_error`: 502 response (positive), 400 response (negative).
- `decide_on_error`: new branch fires `Backoff` with correct delay and message.

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->