### PR TITLE
feat(logs-alerting): add ALERTING feature to query tagging and update alert check queries

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -58,6 +58,7 @@ class Product(StrEnum):
 
 
 class Feature(StrEnum):
+    ALERTING = "alerting"
     BACKFILL = "backfill"
     BEHAVIORAL_COHORTS = "behavioral_cohorts"
     COHORT = "cohort"

--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -20,7 +20,7 @@ from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
 
@@ -170,7 +170,13 @@ class AlertCheckQuery:
         )
 
     def _tag(self) -> None:
-        tag_queries(source="logs_alert", kind="temporal", alert_config_id=str(self.alert.id), team_id=str(self.team.id))
+        tag_queries(
+            product=Product.LOGS,
+            feature=Feature.ALERTING,
+            source="logs_alert",
+            alert_config_id=str(self.alert.id),
+            team_id=str(self.team.id),
+        )
 
     def _build_logs_query(self) -> LogsQuery:
         filters = self.alert.filters
@@ -210,6 +216,12 @@ CHECKPOINT_MAX_STALENESS = dt.timedelta(minutes=5)
 
 
 def fetch_live_logs_checkpoint(team: Team) -> dt.datetime | None:
+    tag_queries(
+        product=Product.LOGS,
+        feature=Feature.ALERTING,
+        source="logs_alert",
+        team_id=str(team.id),
+    )
     response = execute_hogql_query(
         query_type="alert_check_checkpoint",
         query=parse_select(_LIVE_LOGS_CHECKPOINT_SQL),


### PR DESCRIPTION
## Problem

ClickHouse queries related to logs alerting were not being tagged with the appropriate `product` and `feature` identifiers, making it harder to attribute and analyze query performance and usage by feature area.

## Changes

- Added `ALERTING` to the `Feature` enum in `query_tagging.py`.
- Updated the `_tag` method in the logs alert check query to include `product=Product.LOGS` and `feature=Feature.ALERTING`, and removed the now-redundant `kind="temporal"` tag.
- Added query tagging to `fetch_live_logs_checkpoint` so that queries executed there are also properly attributed to the logs alerting feature.

## How did you test this code?

Changes are additive metadata tagging with no behavioral impact. Verified that the `Feature.ALERTING` enum value is correctly defined and that the updated `tag_queries` calls pass the correct arguments.

## Publish to changelog?

No