### PR TITLE
chore(tasks): stop CI follow-up loop when no PR exists

### DIFF
--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -29,6 +29,7 @@ from .process_task.activities import (
     track_workflow_event,
     update_task_run_status,
 )
+from .process_task.activities.get_pr_context import get_pr_context
 from .process_task.workflow import ProcessTaskWorkflow
 from .slack_relay import PostHogCodeAgentRelayWorkflow, relay_slack_message
 
@@ -60,6 +61,7 @@ ACTIVITIES = [
     track_workflow_event,
     post_slack_update,
     update_task_run_status,
+    get_pr_context,
     relay_slack_message,
     run_task_automation_activity,
     # create_snapshot activities

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -199,6 +199,7 @@ def _mock_send_followup_records(input: SendFollowupToSandboxInput) -> None:
 def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
     behavior = _pr_context_overrides.get("behavior", "changing")
     if behavior == "missing":
+        _pr_context_overrides["_call_count"] = _pr_context_overrides.get("_call_count", 0) + 1
         return None
     if behavior == "closed":
         return GetPrContextOutput(
@@ -443,8 +444,8 @@ class TestFollowupGuards:
                     retry_policy=RetryPolicy(maximum_attempts=1),
                     execution_timeout=timedelta(hours=2),
                 )
-                await env.sleep(CI_FOLLOW_UP_DELAY.total_seconds() * 2 + 60)
-                await handle.signal(ProcessTaskWorkflow.complete_task, args=["completed", None])
+                # The CI loop stops after finding no PR, then the workflow
+                # exits via inactivity timeout — no signal needed.
                 await handle.result()
 
         assert _ci_followup_calls == []
@@ -533,4 +534,31 @@ class TestFollowupGuards:
         assert _pr_context_overrides.get("_call_count") == 4, (
             f"expected 4 get_pr_context calls (fire, skip, fire, fire) — broken persistence "
             f"would yield 3. Got {_pr_context_overrides.get('_call_count')}"
+        )
+
+    @pytest.mark.timeout(60)
+    async def test_stops_ci_loop_when_no_pr_and_agent_idle(self):
+        """When get_pr_context returns None and the agent is idle, the CI loop
+        should stop after a single check instead of polling all 3 repetitions."""
+        _pr_context_overrides["behavior"] = "missing"
+
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            task_queue = f"test-{uuid.uuid4()}"
+            async with _make_worker(env, task_queue):
+                handle = await env.client.start_workflow(
+                    ProcessTaskWorkflow.run,
+                    ProcessTaskInput(run_id="run-1"),
+                    id=f"test-{uuid.uuid4()}",
+                    task_queue=task_queue,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    execution_timeout=timedelta(hours=2),
+                )
+                # No heartbeats sent — agent is idle. The CI loop should stop
+                # after one check and the workflow exits via inactivity timeout.
+                await handle.result()
+
+        assert _ci_followup_calls == [], "no follow-up should be sent when no PR exists"
+        assert _pr_context_overrides.get("_call_count") == 1, (
+            f"expected exactly 1 get_pr_context call — loop should stop immediately after "
+            f"discovering no PR. Got {_pr_context_overrides.get('_call_count')}"
         )

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -3,7 +3,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from django.conf import settings
 
@@ -238,7 +238,20 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 return task_result
         raise RuntimeError("No event was completed successfully")
 
-    async def _should_run_ci_follow_up(self) -> bool:
+    async def _should_run_ci_follow_up(self) -> Literal["fire", "skip", "no_pr"]:
+        """Check whether a CI follow-up message should be sent to the agent.
+
+        Returns "fire" when the PR has changed and the agent should act,
+        "skip" when the PR exists but hasn't changed (or is closed), and
+        "no_pr" when no PR was created — the caller should stop the CI
+        loop entirely in that case.
+
+        This is safe because the CI timer only fires after the agent has
+        been idle for the full CI_FOLLOW_UP_DELAY (heartbeats preempt
+        and restart the timer). By the time we reach this check, the
+        agent has finished working — if no PR exists at this point, one
+        won't appear later.
+        """
         pr_context = await workflow.execute_activity(
             get_pr_context,
             GetPrContextInput(context=self.context),
@@ -247,10 +260,10 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         )
         if not pr_context:
             workflow.logger.info(
-                "PR context is missing, skipping CI follow-up",
+                "PR context is missing, stopping CI follow-up loop",
                 run_id=self.context.run_id,
             )
-            return False
+            return "no_pr"
         if pr_context.pr_state == "closed":
             workflow.logger.info(
                 "PR is closed, skipping CI follow-up",
@@ -258,7 +271,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 pr_url=pr_context.pr_url,
                 pr_state=pr_context.pr_state,
             )
-            return False
+            return "skip"
         if self._pr_fingerprint != pr_context.fingerprint:
             workflow.logger.info(
                 "PR context has changed, running CI follow-up",
@@ -267,7 +280,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 pr_state=pr_context.pr_state,
             )
             self._pr_fingerprint = pr_context.fingerprint
-            return True
+            return "fire"
         else:
             workflow.logger.info(
                 "PR context has not changed, skipping CI follow-up",
@@ -275,7 +288,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 pr_url=pr_context.pr_url,
                 pr_state=pr_context.pr_state,
             )
-            return False
+            return "skip"
 
     async def _dispatch_ci_follow_up(self) -> None:
         self._ci_repetitions += 1
@@ -357,8 +370,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                             "CI follow-up event triggered", run_id=self.context.run_id, repetitions=self._ci_repetitions
                         )
                         _deprecate_ci_follow_up_pr_context_patch()
-                        if await self._should_run_ci_follow_up():
+                        follow_up_result = await self._should_run_ci_follow_up()
+                        if follow_up_result == "fire":
                             await self._dispatch_ci_follow_up()
+                        elif follow_up_result == "no_pr":
+                            # No PR will ever appear — stop the CI loop entirely.
+                            self._ci_repetitions = MAX_CI_REPETITIONS
                     case TaskEvent.SIGNAL_RECEIVED:
                         if self._pending_followup is not None:
                             workflow.logger.info(


### PR DESCRIPTION
## Problem

When a task has a repository but the agent never creates a PR (e.g. research/analysis tasks), the CI follow-up loop polls `get_pr_context` indefinitely every 15 minutes. Each poll finds no PR URL in the task run output and skips the follow-up message, but never increments `_ci_repetitions`, so the loop never terminates. The workflow stays alive with an extended 16-min inactivity timeout for the entire duration, burning sandbox resources.

## Changes

- Change `_should_run_ci_follow_up` return type from `bool` to `Literal["fire", "skip", "no_pr"]` to distinguish between "PR exists but unchanged" and "no PR at all"
- When `get_pr_context` returns `None` (no `pr_url` in task run output), return `"no_pr"` instead of `False`
- In the event loop, when the result is `"no_pr"`, set `_ci_repetitions = MAX_CI_REPETITIONS` to stop the CI loop immediately
- This is safe because heartbeats from an active agent always preempt and restart the CI timer — the check only runs after the agent has been idle for the full 15-minute delay
- Register `get_pr_context` as a Temporal activity on the worker — it was called from the workflow but never added to the `ACTIVITIES` list, causing "activity not registered" errors at runtime

## How did you test this code?

- Added `test_stops_ci_loop_when_no_pr_and_agent_idle` — verifies `get_pr_context` is called exactly once and no follow-up is sent when the agent is idle with no PR
- Updated `test_skips_ci_follow_up_when_pr_context_missing` — removed the manual completion signal since the workflow now exits naturally via inactivity timeout after the CI loop stops
- All 19 existing follow-up tests pass
- Verified locally on Docker sandbox: after stopping the container (simulating agent idle), `get_pr_context` fires, returns `None`, the CI loop stops, and the workflow exits via inactivity timeout

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. The change integrates with the existing Temporal patch guard (`_ci_follow_up_pr_context_guard_enabled`) for rolling-deploy compatibility — no new patch gate needed since `"no_pr"` doesn't introduce new activity calls.