### PR TITLE
feat(insights): show TrendsLineChart behind flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1592,18 +1592,18 @@ snapshots:
         hash: v1.k794b7964.d669cc7bd939e7cd9bae4003a228e194a6c383d827feb04baf491a89dfc0b698.eD11DZ4cr8p1GMBdBaTW1doXInEVj9CIhnyMP8RNpFo
     insights-insightstable--is-legend--light:
         hash: v1.k794b7964.d9eec920b0b2f3c9ea87c9e0d2b298bc37339217e4211d0cf1a147630f09b75d.xGcJlQO8pvoNnHyoMNZ4F58uqKh5PDg_UiGlO5bAMn8
-    insights-trendslinechartd3--breakdown--dark:
-        hash: v1.k794b7964.387cc7a7d8bb6415de59aa9c83338a048f553470864229a5683d35f11cc57323.i4Iy4_K2zpwMq-fNkpJmFf7TCd0XTCdBZ0p9bMBqvyw
-    insights-trendslinechartd3--breakdown--light:
-        hash: v1.k794b7964.43f5bd8a76c37619febc27195fba8a173b021a4894078670379791da5e3729af.fIhS1KB8PUxvuvWnURlKw5yLnUB-4orulj-9zgzCgNE
-    insights-trendslinechartd3--default--dark:
-        hash: v1.k794b7964.e60c7e31c5f57da6cdb31c3ecacec19e1cc7a040f323dcd84b1aa0aa3e315f88.4bofwrOlSqFXxpJ5uXF6mce1WtZsjpwCUl56r8x54bo
-    insights-trendslinechartd3--default--light:
-        hash: v1.k794b7964.90a4e15f1ad98e1891dddf3be7abd078c2c36b136c5380143c24db7ddb780c80.4KGgMlDXwVr9a7XR-7Eby55XpSqvOj8woSU0cHB3pBo
-    insights-trendslinechartd3--single-series--dark:
-        hash: v1.k794b7964.aa944593aba5114f92c2bcf9a0d387a8127858d5a0400c1fa8fbacaf2adb632e.QUOG2kM_4XXSWCqCAiR4rx8ViIs5u9UJqtSrTHToWYg
-    insights-trendslinechartd3--single-series--light:
-        hash: v1.k794b7964.de01e8eeecd42f4ddaa8c615020d0b7ab3d5d44048f62850a9c598f2a6ea5d69.R0MZRlGXe44hOD7RlJuRlvXIxaB3vMa0OGg1Gjrqeiw
+    insights-trendslinechart--breakdown--dark:
+        hash: v1.k794b7964.387cc7a7d8bb6415de59aa9c83338a048f553470864229a5683d35f11cc57323.d_wMI_eqzESXc8o9d9f94At9w5bd7CdycMOg2OLCuTY
+    insights-trendslinechart--breakdown--light:
+        hash: v1.k794b7964.43f5bd8a76c37619febc27195fba8a173b021a4894078670379791da5e3729af.qyLnBMVy_lPm25Qff_IOmIDuchynGbfCyMADd1vxsSo
+    insights-trendslinechart--default--dark:
+        hash: v1.k794b7964.e60c7e31c5f57da6cdb31c3ecacec19e1cc7a040f323dcd84b1aa0aa3e315f88.sayO3c8NnP6y4xw7PvHmE--XPmrW0Ss29Ks6W4pzHwg
+    insights-trendslinechart--default--light:
+        hash: v1.k794b7964.90a4e15f1ad98e1891dddf3be7abd078c2c36b136c5380143c24db7ddb780c80.pN4-UVwWvHFd3JZdInXmiymuyAzNLh-LB__B9VbAcMg
+    insights-trendslinechart--single-series--dark:
+        hash: v1.k794b7964.aa944593aba5114f92c2bcf9a0d387a8127858d5a0400c1fa8fbacaf2adb632e.VEsS_ZBrSu6R2P3xN_DJ97t5-M-IGmyCPl59RFvV5no
+    insights-trendslinechart--single-series--light:
+        hash: v1.k794b7964.de01e8eeecd42f4ddaa8c615020d0b7ab3d5d44048f62850a9c598f2a6ea5d69.BcFSMoEqgKyxmRbGHHVmoyzR0YeGOr8Ug10l0pUOfsA
     layout-feature-previews--basic--dark:
         hash: v1.k794b7964.65cb2d154c4f630bc48a9f6b45b24e641c97b4412ca5170e0c1de8bc5c7d759d.vu2XHwyh2oLXbqNS7NdZd2tABaC8nM7J0iJps6FVYl8
     layout-feature-previews--basic--light:

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -23,9 +23,7 @@ const TrendsCalendarHeatMap = lazy(() =>
 )
 const BoxPlotChart = lazy(() => import('scenes/insights/views/BoxPlot').then((m) => ({ default: m.BoxPlotChart })))
 // Flag-gated — keep full d3 out of the eager Trends/Dashboard bundle
-const TrendsLineChart = lazy(() =>
-    import('./viz/TrendsLineChart').then((m) => ({ default: m.TrendsLineChart }))
-)
+const TrendsLineChart = lazy(() => import('./viz/TrendsLineChart').then((m) => ({ default: m.TrendsLineChart })))
 
 interface Props {
     view: InsightType
@@ -45,49 +43,34 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
     )
     const { updateBreakdownFilter } = useActions(trendsDataLogic(insightProps))
 
+    const commonProps = {
+        showPersonsModal,
+        context,
+        inCardView: embedded && !inSharedMode,
+        inSharedMode,
+    }
+
     const renderViz = (): JSX.Element | undefined => {
+        if (featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]) {
+            return <TrendsLineChart context={context} />
+        }
+
         if (
             !display ||
             display === ChartDisplayType.ActionsLineGraph ||
             display === ChartDisplayType.ActionsLineGraphCumulative ||
-            display === ChartDisplayType.ActionsAreaGraph
+            display === ChartDisplayType.ActionsAreaGraph ||
+            display === ChartDisplayType.ActionsBar ||
+            display === ChartDisplayType.ActionsUnstackedBar
         ) {
-            if (featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]) {
-                return <TrendsLineChart context={context} />
-            }
-            return (
-                <ActionsLineGraph
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
-        }
-        if (display === ChartDisplayType.ActionsBar || display === ChartDisplayType.ActionsUnstackedBar) {
-            return (
-                <ActionsLineGraph
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <ActionsLineGraph {...commonProps} />
         }
         if (display === ChartDisplayType.BoldNumber) {
-            return (
-                <BoldNumber
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <BoldNumber {...commonProps} />
         }
         if (display === ChartDisplayType.ActionsTable) {
-            const ActionsTable = InsightsTable
             return (
-                <ActionsTable
+                <InsightsTable
                     embedded
                     filterKey={`trends_${view}`}
                     canEditSeriesNameInline={editMode}
@@ -97,24 +80,10 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
             )
         }
         if (display === ChartDisplayType.ActionsPie) {
-            return (
-                <ActionsPie
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <ActionsPie {...commonProps} />
         }
         if (display === ChartDisplayType.ActionsBarValue) {
-            return (
-                <ActionsHorizontalBar
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <ActionsHorizontalBar {...commonProps} />
         }
         if (display === ChartDisplayType.WorldMap) {
             const hasSubdivisionBreakdown =
@@ -125,44 +94,16 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
                 )
 
             if (hasSubdivisionBreakdown) {
-                return (
-                    <RegionMap
-                        showPersonsModal={showPersonsModal}
-                        context={context}
-                        inCardView={embedded && !inSharedMode}
-                        inSharedMode={inSharedMode}
-                    />
-                )
+                return <RegionMap {...commonProps} />
             }
 
-            return (
-                <WorldMap
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <WorldMap {...commonProps} />
         }
         if (display === ChartDisplayType.CalendarHeatmap) {
-            return (
-                <TrendsCalendarHeatMap
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded && !inSharedMode}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <TrendsCalendarHeatMap {...commonProps} />
         }
         if (display === ChartDisplayType.BoxPlot) {
-            return (
-                <BoxPlotChart
-                    showPersonsModal={showPersonsModal}
-                    context={context}
-                    inCardView={embedded}
-                    inSharedMode={inSharedMode}
-                />
-            )
+            return <BoxPlotChart {...commonProps} inCardView={embedded} />
         }
     }
 

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -15,7 +15,6 @@ import { ChartDisplayType, InsightType } from '~/types'
 
 import { trendsDataLogic } from './trendsDataLogic'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from './viz'
-import { TrendsLineChartD3 } from './viz/TrendsLineChartD3'
 // Lazy-loaded viz types that are rarely used on dashboards
 const WorldMap = lazy(() => import('scenes/insights/views/WorldMap').then((m) => ({ default: m.WorldMap })))
 const RegionMap = lazy(() => import('scenes/insights/views/RegionMap').then((m) => ({ default: m.RegionMap })))
@@ -23,6 +22,10 @@ const TrendsCalendarHeatMap = lazy(() =>
     import('scenes/insights/views/CalendarHeatMap').then((m) => ({ default: m.TrendsCalendarHeatMap }))
 )
 const BoxPlotChart = lazy(() => import('scenes/insights/views/BoxPlot').then((m) => ({ default: m.BoxPlotChart })))
+// Flag-gated — keep full d3 out of the eager Trends/Dashboard bundle
+const TrendsLineChartD3 = lazy(() =>
+    import('./viz/TrendsLineChartD3').then((m) => ({ default: m.TrendsLineChartD3 }))
+)
 
 interface Props {
     view: InsightType

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -23,8 +23,8 @@ const TrendsCalendarHeatMap = lazy(() =>
 )
 const BoxPlotChart = lazy(() => import('scenes/insights/views/BoxPlot').then((m) => ({ default: m.BoxPlotChart })))
 // Flag-gated — keep full d3 out of the eager Trends/Dashboard bundle
-const TrendsLineChartD3 = lazy(() =>
-    import('./viz/TrendsLineChartD3').then((m) => ({ default: m.TrendsLineChartD3 }))
+const TrendsLineChart = lazy(() =>
+    import('./viz/TrendsLineChart').then((m) => ({ default: m.TrendsLineChart }))
 )
 
 interface Props {
@@ -53,7 +53,7 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
             display === ChartDisplayType.ActionsAreaGraph
         ) {
             if (featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]) {
-                return <TrendsLineChartD3 context={context} />
+                return <TrendsLineChart context={context} />
             }
             return (
                 <ActionsLineGraph

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -3,6 +3,8 @@ import { Suspense, lazy } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { BoldNumber } from 'scenes/insights/views/BoldNumber'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
@@ -13,6 +15,7 @@ import { ChartDisplayType, InsightType } from '~/types'
 
 import { trendsDataLogic } from './trendsDataLogic'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from './viz'
+import { TrendsLineChartD3 } from './viz/TrendsLineChartD3'
 // Lazy-loaded viz types that are rarely used on dashboards
 const WorldMap = lazy(() => import('scenes/insights/views/WorldMap').then((m) => ({ default: m.WorldMap })))
 const RegionMap = lazy(() => import('scenes/insights/views/RegionMap').then((m) => ({ default: m.RegionMap })))
@@ -32,6 +35,7 @@ interface Props {
 export function TrendInsight({ view, context, embedded, inSharedMode, editMode }: Props): JSX.Element {
     const { insightProps, showPersonsModal: insightLogicShowPersonsModal } = useValues(insightLogic)
     const showPersonsModal = insightLogicShowPersonsModal && !inSharedMode
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const { display, series, breakdownFilter, hasBreakdownMore, breakdownValuesLoading } = useValues(
         trendsDataLogic(insightProps)
@@ -43,10 +47,21 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
             !display ||
             display === ChartDisplayType.ActionsLineGraph ||
             display === ChartDisplayType.ActionsLineGraphCumulative ||
-            display === ChartDisplayType.ActionsAreaGraph ||
-            display === ChartDisplayType.ActionsBar ||
-            display === ChartDisplayType.ActionsUnstackedBar
+            display === ChartDisplayType.ActionsAreaGraph
         ) {
+            if (featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]) {
+                return <TrendsLineChartD3 context={context} />
+            }
+            return (
+                <ActionsLineGraph
+                    showPersonsModal={showPersonsModal}
+                    context={context}
+                    inCardView={embedded && !inSharedMode}
+                    inSharedMode={inSharedMode}
+                />
+            )
+        }
+        if (display === ChartDisplayType.ActionsBar || display === ChartDisplayType.ActionsUnstackedBar) {
             return (
                 <ActionsLineGraph
                     showPersonsModal={showPersonsModal}

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -51,18 +51,18 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
     }
 
     const renderViz = (): JSX.Element | undefined => {
-        if (featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]) {
-            return <TrendsLineChart context={context} />
-        }
-
         if (
             !display ||
             display === ChartDisplayType.ActionsLineGraph ||
             display === ChartDisplayType.ActionsLineGraphCumulative ||
-            display === ChartDisplayType.ActionsAreaGraph ||
-            display === ChartDisplayType.ActionsBar ||
-            display === ChartDisplayType.ActionsUnstackedBar
+            display === ChartDisplayType.ActionsAreaGraph
         ) {
+            if (featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]) {
+                return <TrendsLineChart context={context} inSharedMode={inSharedMode} />
+            }
+            return <ActionsLineGraph {...commonProps} />
+        }
+        if (display === ChartDisplayType.ActionsBar || display === ChartDisplayType.ActionsUnstackedBar) {
             return <ActionsLineGraph {...commonProps} />
         }
         if (display === ChartDisplayType.BoldNumber) {

--- a/frontend/src/scenes/trends/viz/TrendsAlertOverlays.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsAlertOverlays.tsx
@@ -22,7 +22,7 @@ interface TrendsAlertOverlaysProps {
 
 /** Renders alert threshold lines and anomaly point markers on top of the trends chart.
  *
- *  Lifted into its own component (rather than inlined in TrendsLineChartD3) so that
+ *  Lifted into its own component (rather than inlined in TrendsLineChart) so that
  *  insightAlertsLogic only mounts for saved insights — mounting it with `insightId: undefined`
  *  causes a spurious unfiltered alerts API call. The parent renders this only when
  *  `insight.id` is truthy. */

--- a/frontend/src/scenes/trends/viz/TrendsLineChart.stories.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChart.stories.tsx
@@ -11,13 +11,13 @@ import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
 import { InsightLogicProps, InsightShortId } from '~/types'
 
-import { TrendsLineChartD3 } from './TrendsLineChartD3'
+import { TrendsLineChart } from './TrendsLineChart'
 
 type Story = StoryObj<{}>
 
 const meta: Meta = {
-    title: 'Insights/TrendsLineChartD3',
-    component: TrendsLineChartD3,
+    title: 'Insights/TrendsLineChart',
+    component: TrendsLineChart,
     parameters: {
         layout: 'centered',
         mockDate: '2023-07-11',
@@ -84,8 +84,8 @@ function Stage({ children }: { children: React.ReactNode }): JSX.Element {
     )
 }
 
-function renderTrendsLineChartD3(insightFixture: any): JSX.Element {
-    const [dashboardItemId] = useState(() => `TrendsLineChartD3Story.${uniqueNode++}` as InsightShortId)
+function renderTrendsLineChart(insightFixture: any): JSX.Element {
+    const [dashboardItemId] = useState(() => `TrendsLineChartStory.${uniqueNode++}` as InsightShortId)
     const cachedInsight = { ...insightFixture, short_id: dashboardItemId }
 
     const insightProps: InsightLogicProps = { dashboardItemId, doNotLoad: true, cachedInsight }
@@ -100,7 +100,7 @@ function renderTrendsLineChartD3(insightFixture: any): JSX.Element {
         <BindLogic logic={insightLogic} props={insightProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
                 <Stage>
-                    <TrendsLineChartD3 />
+                    <TrendsLineChart />
                 </Stage>
             </BindLogic>
         </BindLogic>
@@ -110,17 +110,17 @@ function renderTrendsLineChartD3(insightFixture: any): JSX.Element {
 /* eslint-disable @typescript-eslint/no-var-requires */
 export const Default: Story = {
     render: () =>
-        renderTrendsLineChartD3(require('../../../mocks/fixtures/api/projects/team_id/insights/trendsLineMulti.json')),
+        renderTrendsLineChart(require('../../../mocks/fixtures/api/projects/team_id/insights/trendsLineMulti.json')),
 }
 
 export const SingleSeries: Story = {
     render: () =>
-        renderTrendsLineChartD3(require('../../../mocks/fixtures/api/projects/team_id/insights/trendsLine.json')),
+        renderTrendsLineChart(require('../../../mocks/fixtures/api/projects/team_id/insights/trendsLine.json')),
 }
 
 export const Breakdown: Story = {
     render: () =>
-        renderTrendsLineChartD3(
+        renderTrendsLineChart(
             require('../../../mocks/fixtures/api/projects/team_id/insights/trendsLineBreakdown.json')
         ),
 }

--- a/frontend/src/scenes/trends/viz/TrendsLineChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChart.test.tsx
@@ -24,7 +24,7 @@ afterEach(() => {
 
 const HOG_CHARTS_FLAG = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS]: true }
 
-describe('TrendsLineChartD3', () => {
+describe('TrendsLineChart', () => {
     describe('tooltips', () => {
         it('shows the series value and glyph for a single series', async () => {
             renderInsight({ query: buildTrendsQuery(), featureFlags: HOG_CHARTS_FLAG })

--- a/frontend/src/scenes/trends/viz/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChart.tsx
@@ -30,12 +30,12 @@ import { buildTrendsYTickFormatter } from './trendsAxisFormat'
 import type { TrendsSeriesMeta } from './trendsSeriesMeta'
 import { TrendsTooltip } from './TrendsTooltip'
 
-interface TrendsLineChartD3Props {
+interface TrendsLineChartProps {
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean
 }
 
-export function TrendsLineChartD3({ context, inSharedMode = false }: TrendsLineChartD3Props): JSX.Element | null {
+export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineChartProps): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
     const { insightProps, insight } = useValues(insightLogic)

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.test.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.test.tsx
@@ -2,16 +2,6 @@ import '@testing-library/jest-dom'
 
 import { cleanup, screen, waitFor } from '@testing-library/react'
 
-// Trends.tsx routes line/area displays through ActionsLineGraph (chart.js) until
-// the hog-charts feature-flag gate lands. Swap it at the import boundary so
-// renderInsight() picks up TrendsLineChartD3 — the one under test.
-jest.mock('scenes/trends/viz', () => {
-    const actual = jest.requireActual('scenes/trends/viz')
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { TrendsLineChartD3 } = require('scenes/trends/viz/TrendsLineChartD3')
-    return { ...actual, ActionsLineGraph: TrendsLineChartD3 }
-})
-
 import { FEATURE_FLAGS } from 'lib/constants'
 import { setupJsdom } from 'lib/hog-charts/test-helpers'
 

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -44,7 +44,7 @@ export function TrendsTooltip({
     onRowClick,
 }: TrendsTooltipProps): React.ReactElement {
     // TODO: CI bands and moving-average datasets aren't yet built in the hog-charts path. When they
-    // are, the bridge (or TrendsLineChartD3) will need to mark them as non-tooltip rows — legacy
+    // are, the bridge (or TrendsLineChart) will need to mark them as non-tooltip rows — legacy
     // Chart.js path used a `hideTooltip: true` flag on the dataset for this.
     const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
         const meta = entry.series.meta ?? {}

--- a/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.tsx
+++ b/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.tsx
@@ -21,7 +21,7 @@ export interface TrendsLineChartClickDeps {
     openPersonsModal: (props: OpenPersonsModalProps) => void
 }
 
-// TrendsLineChartD3 keys each hog-charts Series by `${r.id}`, so we can
+// TrendsLineChart keys each hog-charts Series by `${r.id}`, so we can
 // resolve back to the source IndexedTrendResult without stashing it on meta.
 function resolveDataset(seriesKey: string, indexedResults: IndexedTrendResult[]): IndexedTrendResult | null {
     return indexedResults.find((r) => String(r.id) === seriesKey) ?? null


### PR DESCRIPTION
## Problem

Got a new chart component, want to render it!

## Changes

Adds a FF and show this new chart component

## How did you test this code?

Removed a mock from the new test file I had, so we test the actual new chart with no mock now.


## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (task `f2b7e00a-539f-4b86-9ac0-8b4a96f748b3`). Scope intentionally narrow: only the flag wiring plus the mock removal — no component changes inside `TrendsLineChartD3` itself.