### PR TITLE
fix(subscriptions): handle list-shaped rows in generic summarizer

### DIFF
--- a/posthog/temporal/subscriptions/results_summarizer.py
+++ b/posthog/temporal/subscriptions/results_summarizer.py
@@ -4,12 +4,19 @@ from typing import Any
 MAX_SUMMARY_LENGTH = 2000
 
 
-def build_results_summary(query_kind: str, results: list[dict[str, Any]] | None) -> str:
+def build_results_summary(
+    query_kind: str,
+    results: list[Any] | None,
+    columns: list[str] | None = None,
+) -> str:
     if not results:
         return "No results"
 
-    summarizer = _SUMMARIZERS.get(query_kind, _summarize_generic)
-    text = summarizer(results)
+    summarizer = _SUMMARIZERS.get(query_kind)
+    if summarizer is not None:
+        text = summarizer(results)
+    else:
+        text = _summarize_generic(results, columns)
     if len(text) > MAX_SUMMARY_LENGTH:
         text = text[:MAX_SUMMARY_LENGTH] + "\n... (truncated)"
     return text
@@ -120,12 +127,15 @@ def _summarize_retention(results: list[dict[str, Any]]) -> str:
     return "\n".join(lines) if lines else "No retention cohorts"
 
 
-def _summarize_generic(results: list[Any]) -> str:
+def _summarize_generic(results: list[Any], columns: list[str] | None = None) -> str:
     """Fallback for query kinds without a dedicated summarizer.
 
     Handles both row shapes we see in practice:
     - dict rows (most PostHog query results): skip known noisy keys, join the rest.
-    - list/tuple rows (HogQL / DataVisualizationNode): position-indexed columns.
+    - list/tuple rows (HogQL / DataVisualizationNode): label each value with the
+      corresponding entry from `columns` when provided, falling back to
+      position-indexed `colN` names when a column list is unavailable or shorter
+      than the row.
     Any other shape falls back to str() so a surprising result shape produces a
     usable summary instead of an AttributeError that kills the whole activity.
     """
@@ -139,7 +149,8 @@ def _summarize_generic(results: list[Any]) -> str:
                 parts.append(f"{key}={val}")
         elif isinstance(row, (list, tuple)):
             for col_index, val in enumerate(row):
-                parts.append(f"col{col_index}={val}")
+                label = _column_label(columns, col_index)
+                parts.append(f"{label}={val}")
         else:
             parts.append(str(row))
         if parts:
@@ -147,6 +158,14 @@ def _summarize_generic(results: list[Any]) -> str:
     if len(results) > 20:
         lines.append(f"... and {len(results) - 20} more rows")
     return "\n".join(lines) if lines else "No results data"
+
+
+def _column_label(columns: list[str] | None, index: int) -> str:
+    if columns and index < len(columns):
+        name = columns[index]
+        if isinstance(name, str) and name.strip():
+            return name
+    return f"col{index}"
 
 
 def _trend_direction(values: list[float | int]) -> str:

--- a/posthog/temporal/subscriptions/results_summarizer.py
+++ b/posthog/temporal/subscriptions/results_summarizer.py
@@ -1,6 +1,10 @@
 import math
 from typing import Any
 
+from structlog import get_logger
+
+LOGGER = get_logger(__name__)
+
 MAX_SUMMARY_LENGTH = 2000
 
 
@@ -152,6 +156,12 @@ def _summarize_generic(results: list[Any], columns: list[str] | None = None) -> 
                 label = _column_label(columns, col_index)
                 parts.append(f"{label}={val}")
         else:
+            # Emit a signal rather than silently producing an ok-ish summary — if a
+            # new shape appears in practice we find out from logs, not from a user.
+            LOGGER.info(
+                "subscription_summary.unexpected_row_shape",
+                row_type=type(row).__name__,
+            )
             parts.append(str(row))
         if parts:
             lines.append(f"- Row {i + 1}: {', '.join(parts)}")
@@ -161,10 +171,8 @@ def _summarize_generic(results: list[Any], columns: list[str] | None = None) -> 
 
 
 def _column_label(columns: list[str] | None, index: int) -> str:
-    if columns and index < len(columns):
-        name = columns[index]
-        if isinstance(name, str) and name.strip():
-            return name
+    if columns and index < len(columns) and columns[index].strip():
+        return columns[index]
     return f"col{index}"
 
 

--- a/posthog/temporal/subscriptions/results_summarizer.py
+++ b/posthog/temporal/subscriptions/results_summarizer.py
@@ -120,14 +120,28 @@ def _summarize_retention(results: list[dict[str, Any]]) -> str:
     return "\n".join(lines) if lines else "No retention cohorts"
 
 
-def _summarize_generic(results: list[dict[str, Any]]) -> str:
+def _summarize_generic(results: list[Any]) -> str:
+    """Fallback for query kinds without a dedicated summarizer.
+
+    Handles both row shapes we see in practice:
+    - dict rows (most PostHog query results): skip known noisy keys, join the rest.
+    - list/tuple rows (HogQL / DataVisualizationNode): position-indexed columns.
+    Any other shape falls back to str() so a surprising result shape produces a
+    usable summary instead of an AttributeError that kills the whole activity.
+    """
     lines: list[str] = []
     for i, row in enumerate(results[:20]):
-        parts = []
-        for key, val in row.items():
-            if key in ("data", "values", "days", "labels", "timestamps"):
-                continue
-            parts.append(f"{key}={val}")
+        parts: list[str] = []
+        if isinstance(row, dict):
+            for key, val in row.items():
+                if key in ("data", "values", "days", "labels", "timestamps"):
+                    continue
+                parts.append(f"{key}={val}")
+        elif isinstance(row, (list, tuple)):
+            for col_index, val in enumerate(row):
+                parts.append(f"col{col_index}={val}")
+        else:
+            parts.append(str(row))
         if parts:
             lines.append(f"- Row {i + 1}: {', '.join(parts)}")
     if len(results) > 20:

--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -71,9 +71,11 @@ def _build_states_from_content_snapshot(
 
         query_kind = (insight_query_kinds or {}).get(insight_id, "Unknown")
         result_payload = query_results.get("result") if query_results else None
+        raw_columns = query_results.get("columns") if query_results else None
+        columns = raw_columns if isinstance(raw_columns, list) else None
 
         if query_results and result_payload:
-            results_summary = build_results_summary(query_kind, result_payload)
+            results_summary = build_results_summary(query_kind, result_payload, columns=columns)
             fallback_reason: str | None = None
         elif query_error:
             results_summary = "Query failed"

--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -51,6 +51,21 @@ def _get_query_kind_from_insight(insight: Insight) -> str:
     return source.get("kind", "Unknown")
 
 
+def _extract_columns(query_results: Any) -> list[str] | None:
+    """Coerce the raw `columns` payload to a trusted `list[str]`.
+
+    Keeping the isinstance filtering here means `_summarize_generic` downstream
+    can trust its input shape instead of re-validating each entry.
+    """
+    if not isinstance(query_results, dict):
+        return None
+    raw_columns = query_results.get("columns")
+    if not isinstance(raw_columns, list):
+        return None
+    cleaned = [c for c in raw_columns if isinstance(c, str)]
+    return cleaned or None
+
+
 def _build_states_from_content_snapshot(
     content_snapshot: dict,
     insight_query_kinds: dict[int, str] | None = None,
@@ -71,8 +86,7 @@ def _build_states_from_content_snapshot(
 
         query_kind = (insight_query_kinds or {}).get(insight_id, "Unknown")
         result_payload = query_results.get("result") if query_results else None
-        raw_columns = query_results.get("columns") if query_results else None
-        columns = raw_columns if isinstance(raw_columns, list) else None
+        columns = _extract_columns(query_results)
 
         if query_results and result_payload:
             results_summary = build_results_summary(query_kind, result_payload, columns=columns)

--- a/posthog/temporal/subscriptions/test_results_summarizer.py
+++ b/posthog/temporal/subscriptions/test_results_summarizer.py
@@ -1,3 +1,4 @@
+import structlog
 from parameterized import parameterized_class
 
 from posthog.temporal.subscriptions.results_summarizer import MAX_SUMMARY_LENGTH, build_results_summary
@@ -221,10 +222,26 @@ class TestBuildResultsSummaryColumns:
         assert "col1=b" in summary
 
     def test_columns_ignored_for_dict_rows(self):
-        results = [{"label": "Metric", "data": [1, 2, 3]}]
-        summary = build_results_summary("PathsQuery", results, columns=["a", "b", "c"])
-        assert "label=Metric" in summary
-        assert "col0" not in summary
+        # Row key intentionally collides with a positional column label so
+        # the assertions prove we did NOT feed `columns` into the dict branch.
+        results = [{"col0": "wrong"}]
+        summary = build_results_summary("PathsQuery", results, columns=["right"])
+        assert "col0=wrong" in summary
+        assert "right=wrong" not in summary
+
+
+class TestBuildResultsSummaryUnexpectedShape:
+    """Rows that are neither dict nor list/tuple emit a log so we find out about new shapes."""
+
+    def test_unexpected_shape_emits_log(self):
+        with structlog.testing.capture_logs() as captured_logs:
+            summary = build_results_summary("HogQLQuery", ["a bare string", 42])
+        assert "Row 1: a bare string" in summary
+        assert "Row 2: 42" in summary
+        events = [log for log in captured_logs if log.get("event") == "subscription_summary.unexpected_row_shape"]
+        assert len(events) == 2, f"expected one log per unexpected row, got {events}"
+        assert events[0]["row_type"] == "str"
+        assert events[1]["row_type"] == "int"
 
 
 class TestBuildResultsSummaryEdgeCases:

--- a/posthog/temporal/subscriptions/test_results_summarizer.py
+++ b/posthog/temporal/subscriptions/test_results_summarizer.py
@@ -96,6 +96,27 @@ class TestBuildResultsSummaryEmpty:
             ["source=/home", "target=/about", "value=42"],
         ),
         (
+            "hogql_list_rows_do_not_crash",
+            "HogQLQuery",
+            [
+                ["2026-04-20", "TrendsQuery", 12345],
+                ["2026-04-21", "FunnelsQuery", 67890],
+            ],
+            ["col0=2026-04-20", "col1=TrendsQuery", "col2=12345", "col0=2026-04-21"],
+        ),
+        (
+            "hogql_tuple_rows_do_not_crash",
+            "HogQLQuery",
+            [("a", 1), ("b", 2)],
+            ["col0=a", "col1=1", "col0=b", "col1=2"],
+        ),
+        (
+            "unexpected_row_shape_falls_back_to_str",
+            "HogQLQuery",
+            ["just a string row", 42],
+            ["Row 1: just a string row", "Row 2: 42"],
+        ),
+        (
             "trends_boxplot_quantile_rows",
             "TrendsQuery",
             [

--- a/posthog/temporal/subscriptions/test_results_summarizer.py
+++ b/posthog/temporal/subscriptions/test_results_summarizer.py
@@ -187,6 +187,46 @@ class TestBuildResultsSummaryTruncation:
         assert "truncated" in summary
 
 
+class TestBuildResultsSummaryColumns:
+    """Column labels from the HogQL result payload are used to label list-shaped rows."""
+
+    def test_named_columns_are_used_for_list_rows(self):
+        results = [["2026-04-20", "TrendsQuery", 12345], ["2026-04-21", "FunnelsQuery", 67890]]
+        columns = ["day", "query_type", "count"]
+        summary = build_results_summary("HogQLQuery", results, columns=columns)
+        assert "day=2026-04-20" in summary
+        assert "query_type=TrendsQuery" in summary
+        assert "count=12345" in summary
+        assert "col0" not in summary
+
+    def test_missing_columns_fall_back_to_positional(self):
+        results = [["a", "b"]]
+        summary = build_results_summary("HogQLQuery", results, columns=None)
+        assert "col0=a" in summary
+        assert "col1=b" in summary
+
+    def test_partial_columns_mix_named_and_positional(self):
+        results = [["a", "b", "c"]]
+        columns = ["first"]  # shorter than row
+        summary = build_results_summary("HogQLQuery", results, columns=columns)
+        assert "first=a" in summary
+        assert "col1=b" in summary
+        assert "col2=c" in summary
+
+    def test_blank_column_names_fall_back_to_positional(self):
+        results = [["a", "b"]]
+        columns = ["", "  "]
+        summary = build_results_summary("HogQLQuery", results, columns=columns)
+        assert "col0=a" in summary
+        assert "col1=b" in summary
+
+    def test_columns_ignored_for_dict_rows(self):
+        results = [{"label": "Metric", "data": [1, 2, 3]}]
+        summary = build_results_summary("PathsQuery", results, columns=["a", "b", "c"])
+        assert "label=Metric" in summary
+        assert "col0" not in summary
+
+
 class TestBuildResultsSummaryEdgeCases:
     def test_inf_values_do_not_crash(self):
         results = [{"label": "Metric", "data": [1.0, float("inf"), 3.0]}]


### PR DESCRIPTION
## Summary

as a haiku:

Dashboards stayed quiet—                                                                                                                   
  because most likely HogQL,                                                                                                                 
  summaries missing.

- Make `_summarize_generic` in the subscriptions results summarizer handle list/tuple rows as well as dict rows, falling back to `str(row)` for anything else.

## Why

[PR #56047](https://github.com/PostHog/posthog/pull/56047) added structlog exception capture to the snapshot activity and immediately surfaced this:

```
AttributeError: 'list' object has no attribute 'items'
  File "/code/posthog/temporal/subscriptions/results_summarizer.py", line 127, in _summarize_generic
    for key, val in row.items():
```

Subscription `74620` has a HogQL / `DataVisualizationNode` insight on its dashboard. HogQL queries return rows as lists (one value per column), while every PostHog query kind returns dicts. The summarizer falls through to `_summarize_generic` for unknown kinds, and generic called `row.items()` unconditionally — so the first HogQL row crashed the whole snapshot activity, the workflow's `except Exception` swallowed the ActivityError, and the delivery shipped with no summary. This happened every single time.

Fix is surgical: dispatch on `isinstance(row, dict) / (list, tuple) / else`. List/tuple rows yield `col0=..., col1=...` lines — not beautiful, but good enough to let the LLM produce a summary instead of handing it a fatal traceback. Known-shape query kinds (`TrendsQuery`, `FunnelsQuery`, `RetentionQuery`, `LifecycleQuery`, `StickinessQuery`) still go through their dedicated summarizers and are unaffected.

## Test plan

- [x] `test_results_summarizer.py` — added 3 parameterized cases (`hogql_list_rows_do_not_crash`, `hogql_tuple_rows_do_not_crash`, `unexpected_row_shape_falls_back_to_str`). All 17 tests pass locally.
- [x] Verified locally with `hogli test posthog/temporal/subscriptions/test_results_summarizer.py`.
- [x] `ruff check` / `ruff format` clean.

## LLM context

Caught by the exception logging added in #56047. The next delivery of subscription 74620 should produce a summary instead of the activity dying silently.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*