### PR TITLE
fix(sandbox): add @posthog/enricher to local Docker image build

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -6,17 +6,20 @@ FROM posthog-sandbox-base
 
 COPY local-shared /local-shared
 COPY local-git /local-git
+COPY local-enricher /local-enricher
 COPY local-agent /local-agent
 
-# Pack shared first, then update git and agent dependencies to use the tarball
-# Git depends on shared, agent depends on both shared and git
+# Pack shared and enricher first (no workspace deps), then git (depends on shared),
+# then agent (depends on shared, git, and enricher).
 RUN cd /local-shared && pnpm pack && \
+    cd /local-enricher && pnpm pack && \
     cd /local-git && \
     sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
     pnpm pack && \
     cd /local-agent && \
     sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
     sed -i 's/"@posthog\/git": "workspace:\*"/"@posthog\/git": "file:\/local-git\/posthog-git-1.0.0.tgz"/' package.json && \
+    sed -i 's/"@posthog\/enricher": "workspace:\*"/"@posthog\/enricher": "file:\/local-enricher\/posthog-enricher-1.0.0.tgz"/' package.json && \
     pnpm pack && \
     cd /scripts && pnpm install /local-agent/*.tgz && \
-    rm -rf /local-agent /local-shared /local-git
+    rm -rf /local-agent /local-shared /local-git /local-enricher

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -107,12 +107,12 @@ class DockerSandbox(SandboxBase):
         return result
 
     @staticmethod
-    def _get_local_posthog_code_packages() -> tuple[str, str, str] | None:
+    def _get_local_posthog_code_packages() -> tuple[str, str, str, str] | None:
         """
         Get paths to local PostHog Code packages for development builds.
 
         Configure via LOCAL_POSTHOG_CODE_MONOREPO_ROOT pointing to the PostHog Code monorepo root.
-        Returns tuple of (agent_path, shared_path, git_path) or None if not configured.
+        Returns tuple of (agent_path, shared_path, git_path, enricher_path) or None if not configured.
         """
         monorepo_root = os.environ.get(
             "LOCAL_POSTHOG_CODE_MONOREPO_ROOT", os.environ.get("LOCAL_TWIG_MONOREPO_ROOT", "")
@@ -124,6 +124,7 @@ class DockerSandbox(SandboxBase):
         agent_path = os.path.join(monorepo_root, "packages", "agent")
         shared_path = os.path.join(monorepo_root, "packages", "shared")
         git_path = os.path.join(monorepo_root, "packages", "git")
+        enricher_path = os.path.join(monorepo_root, "packages", "enricher")
 
         missing = []
         if not os.path.isdir(agent_path):
@@ -132,6 +133,8 @@ class DockerSandbox(SandboxBase):
             missing.append(f"shared: {shared_path}")
         if not os.path.isdir(git_path):
             missing.append(f"git: {git_path}")
+        if not os.path.isdir(enricher_path):
+            missing.append(f"enricher: {enricher_path}")
 
         if missing:
             raise SandboxProvisionError(
@@ -140,7 +143,7 @@ class DockerSandbox(SandboxBase):
                 cause=RuntimeError(f"Missing packages: {', '.join(missing)}"),
             )
 
-        return agent_path, shared_path, git_path
+        return agent_path, shared_path, git_path, enricher_path
 
     @staticmethod
     def _build_image_if_needed(image_name: str, dockerfile_path: str) -> None:
@@ -172,7 +175,7 @@ class DockerSandbox(SandboxBase):
         )
 
     @staticmethod
-    def _build_local_image(agent_path: str, shared_path: str, git_path: str) -> None:
+    def _build_local_image(agent_path: str, shared_path: str, git_path: str, enricher_path: str) -> None:
         """Build the local sandbox image with local PostHog Code packages."""
         logger.info("Building posthog-sandbox-base-local image with local PostHog Code packages...")
         dockerfile_path = os.path.join(
@@ -193,6 +196,11 @@ class DockerSandbox(SandboxBase):
             shutil.copytree(
                 git_path,
                 os.path.join(tmpdir, "local-git"),
+                ignore=shutil.ignore_patterns("node_modules"),
+            )
+            shutil.copytree(
+                enricher_path,
+                os.path.join(tmpdir, "local-enricher"),
                 ignore=shutil.ignore_patterns("node_modules"),
             )
 
@@ -226,8 +234,8 @@ class DockerSandbox(SandboxBase):
 
         local_packages = DockerSandbox._get_local_posthog_code_packages()
         if local_packages:
-            agent_path, shared_path, git_path = local_packages
-            DockerSandbox._build_local_image(agent_path, shared_path, git_path)
+            agent_path, shared_path, git_path, enricher_path = local_packages
+            DockerSandbox._build_local_image(agent_path, shared_path, git_path, enricher_path)
             return "posthog-sandbox-base-local"
 
         return DEFAULT_IMAGE_NAME


### PR DESCRIPTION
## Problem

  The `@posthog/agent` package added a workspace dependency on `@posthog/enricher`, but the local sandbox Docker image build (`Dockerfile.sandbox-local`) and `DockerSandbox._build_local_image` only handled `@posthog/shared` and `@posthog/git`. This caused the local image build to fail with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` when `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` is set.

  ## Changes

  - Add `@posthog/enricher` package to `Dockerfile.sandbox-local` (COPY, pack, sed rewrite)
  - Update `DockerSandbox._get_local_posthog_code_packages` to discover and validate the enricher package path
  - Update `DockerSandbox._build_local_image` to copy the enricher package into the build context

  ## How did you test this code?

  Built both `posthog-sandbox-base` and `posthog-sandbox-base-local` Docker images locally — both succeeded.

  ## Publish to changelog?

  No