### PR TITLE
fix(trends): drop filter-only cohort rows before breakdown aggregation

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -128,25 +128,17 @@ class Breakdown:
             isinstance(breakdown_filter.breakdown, list)
             and self.modifiers.inCohortVia == InCohortVia.LEFTJOIN_CONJOINED
         ):
-            # `__in_cohort` is a LEFT JOIN of every cohort referenced anywhere in the
-            # query — breakdown cohorts *and* any cohort used in a series-level `person in cohort` filter.
-            # Reading `cohort_id` straight from it lets filter-only cohorts appear as extra breakdown bars.
-            # Restrict the column to the declared breakdown IDs.
-            # non-matches become NULL and are dropped by the outer `breakdown_value IS NOT NULL` filter.
-            breakdown_ids = ast.Array(
-                exprs=[
-                    ast.Constant(value=int(breakdown)) for breakdown in breakdown_filter.breakdown if breakdown != "all"
-                ]
-            )
-
+            # `__in_cohort` is a LEFT JOIN of every cohort referenced in the query — breakdown
+            # cohorts *and* any cohort used in a series-level `person in cohort` filter. Restrict
+            # to declared breakdown IDs via `get_trends_query_where_filter` so filter-only-cohort
+            # JOIN rows are dropped at the events WHERE level (before aggregation and ranking).
             return [
                 ast.Alias(
                     alias=self.breakdown_alias,
                     expr=parse_expr(
-                        "if({cohort_id} IN {ids}, toString({cohort_id}), NULL)",
+                        "toString({cohort_id})",
                         placeholders={
                             "cohort_id": ast.Field(chain=["__in_cohort", "cohort_id"]),
-                            "ids": breakdown_ids,
                         },
                     ),
                 )
@@ -217,11 +209,35 @@ class Breakdown:
         )
 
     def get_trends_query_where_filter(self) -> ast.Expr | None:
-        if self.is_cohort_breakdown:
-            assert self._breakdown_filter.breakdown is not None  # type checking
-            return self._get_cohort_filter(self._breakdown_filter.breakdown)
+        if not self.is_cohort_breakdown:
+            return None
 
-        return None
+        assert self._breakdown_filter.breakdown is not None  # type checking
+        base_filter = self._get_cohort_filter(self._breakdown_filter.breakdown)
+
+        # `__in_cohort` emits one row per cohort the person matches — including filter-only
+        # cohorts referenced elsewhere (e.g. a series `person in cohort X` filter). Drop those
+        # rows here so they can't compete for rank slots at the `breakdown_limit` truncation.
+        if (
+            isinstance(self._breakdown_filter.breakdown, list)
+            and self.modifiers.inCohortVia == InCohortVia.LEFTJOIN_CONJOINED
+        ):
+            breakdown_ids: list[ast.Expr] = [
+                ast.Constant(value=int(breakdown))
+                for breakdown in self._breakdown_filter.breakdown
+                if breakdown != "all"
+            ]
+            if breakdown_ids:
+                cohort_id_filter = parse_expr(
+                    "{cohort_id} IN {ids}",
+                    placeholders={
+                        "cohort_id": ast.Field(chain=["__in_cohort", "cohort_id"]),
+                        "ids": ast.Array(exprs=breakdown_ids),
+                    },
+                )
+                return ast.And(exprs=[base_filter, cohort_id_filter]) if base_filter is not None else cohort_id_filter
+
+        return base_filter
 
     def get_actors_query_where_filter(self, lookup_values: str | int | list[int | str] | list[str]) -> ast.Expr | None:
         if self.is_cohort_breakdown:

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1151,6 +1151,70 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # Every emitted breakdown_value must be one of the selected cohort PKs.
         assert breakdown_values.issubset({c.pk for c in cohorts})
 
+    @parameterized.expand(
+        [
+            ("total_value_display", TrendsFilter(display=ChartDisplayType.ACTIONS_BAR_VALUE)),
+            ("line_graph_display", None),
+        ]
+    )
+    def test_cohort_breakdown_with_filter_only_cohort(self, _name, trends_filter):
+        # Setup:
+        #   - 4 narrow breakdown cohorts (one person each)
+        #   - 1 broad filter-only cohort, used only in a series `person in cohort` filter
+        #   - `breakdown_limit` below the cohort count
+        # Runs through both outer-query paths (total-value rank and line-chart CTE chain).
+        self._create_test_events()
+
+        breakdown_cohorts = [
+            Cohort.objects.create(
+                team=self.team,
+                groups=[{"properties": [{"key": "name", "value": name, "type": "person"}]}],
+                name=f"breakdown {name}",
+            )
+            for name in ("p1", "p2", "p3", "p4")
+        ]
+        for cohort in breakdown_cohorts:
+            cohort.calculate_people_ch(pending_version=0)
+
+        # Broad enough to outrank any breakdown cohort — so if the filter-only cohort were to
+        # leak into the breakdown, it would push a declared cohort past the limit.
+        filter_only_cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {"key": "name", "value": ["p1", "p2", "p3", "p4"], "type": "person", "operator": "exact"}
+                    ]
+                }
+            ],
+            name="filter only",
+        )
+        filter_only_cohort.calculate_people_ch(pending_version=0)
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [
+                EventsNode(
+                    event="$pageview",
+                    math=BaseMathType.DAU,
+                    properties=[{"key": "id", "value": filter_only_cohort.pk, "type": "cohort"}],
+                )
+            ],
+            trends_filter,
+            BreakdownFilter(
+                breakdown_type=BreakdownType.COHORT,
+                breakdown=[c.pk for c in breakdown_cohorts],
+                breakdown_limit=2,
+            ),
+        )
+
+        breakdown_values = {result["breakdown_value"] for result in response.results}
+        assert BREAKDOWN_OTHER_STRING_LABEL not in breakdown_values
+        assert filter_only_cohort.pk not in breakdown_values
+        assert breakdown_values.issubset({c.pk for c in breakdown_cohorts})
+
     def test_trends_avg_session_duration_with_event_breakdown(self):
         # Regression test: queries with avg session_duration and event property
         # breakdown should not crash with AttributeError on SelectQueryAliasType

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -607,19 +607,14 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         breakdown_limit = breakdown_filter.breakdown_limit if breakdown_filter else None
         limit = breakdown_limit or get_breakdown_limit_for_context(self.limit_context)
 
-        # Cohort breakdowns are over a user-picked, enumerable set — a limit smaller than
-        # the cohort count would bucket some selected cohorts as "Other", which then crashes
-        # the label lookup in `build_series_response` (Cohort.objects.get(pk=<Other sentinel>)).
-        # The `+ 1` reserves a rank slot for the NULL bucket that `__in_cohort` produces on the
-        # LEFTJOIN_CONJOINED path when any series has a `person in cohort` filter whose cohort
-        # isn't in the breakdown list — without it, that NULL row steals a slot and one real
-        # cohort overflows into "Other". Proper fix is to drop NULL before ranking; hotfix for now.
+        # Cohorts are a user-picked, enumerable set — a smaller limit would push declared
+        # cohorts into "Other", which crashes the label lookup in `build_series_response`.
         if (
             breakdown_filter is not None
             and breakdown_filter.breakdown_type == "cohort"
             and isinstance(breakdown_filter.breakdown, list)
         ):
-            limit = max(limit, len(breakdown_filter.breakdown) + 1)
+            limit = max(limit, len(breakdown_filter.breakdown))
 
         return limit
 


### PR DESCRIPTION
## Problem

Initially, we were displaying cohorts used in series filters in the chart (even if they weren't part of the breakdowns). 
To hide them, we set their ID to null and then filtered out the nulls. 
Now, I've refactored it so it doesn't mark them as null, but simply filters out cohorts that aren't part of the breakdown array.

## Changes

Push the breakdown-set restriction from the SELECT column into the events WHERE clause via `get_trends_query_where_filter`:

- **Column simplifies** to `toString(__in_cohort.cohort_id)` — no `if ... NULL` wrapper.
- **WHERE gains** `in(__in_cohort.cohort_id, [declared_ids])` on the `LEFTJOIN_CONJOINED` cohort path. Filter-only-cohort JOIN rows are dropped before aggregation, so they can't reach the rank step.

Result: no `NULL` bucket, no competition for rank slots, no "Other" overflow for cohort breakdowns. The existing `max(limit, len(breakdown))` guard in `_get_breakdown_limit` remains in place for its original purpose (preventing user-picked cohorts from being truncated by a small `breakdown_limit`).

Supersedes #56121 — the `+1` band-aid is no longer needed.

## How did you test this code?

Manually + Tests


## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7). The session traced the crash from a production stack trace through the query-builder and breakdown SQL generation, validated the mechanism against bound ClickHouse SQL dumps locally, explored three possible fix placements (outer rank CTE, intermediate WHERE, events WHERE), and settled on the events-WHERE placement as the most surgical — scoped to `breakdown.py`, pushes the filter deepest, touches no shared query-builder logic.