### PR TITLE
fix(experiments/MCP): Add experiment-get-all back as deprecated

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -29,6 +29,21 @@
             "readOnlyHint": true
         }
     },
+    "experiment-get-all": {
+        "description": "DEPRECATED: renamed to experiment-list. This alias forwards to experiment-list and will be removed. Call experiment-list directly with the same arguments.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Deprecated alias for experiment-list.",
+        "title": "Get all experiments (deprecated)",
+        "required_scopes": ["experiment:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "insight-query": {
         "description": "Execute a saved insight's query and return results. THIS IS THE ONLY WAY TO RETRIEVE INSIGHT RESULTS — the insights-list, insight-get, insight-create, and insight-update tools all return metadata and query definitions but never the actual data. Call insight-query whenever the user asks to see, analyze, summarize, or compare data from a saved insight, and immediately after creating or updating an insight if they want to verify the output. Supports two output formats: 'optimized' (default) returns a human-readable summary from server-side formatters ideal for analysis, while 'json' returns the raw query results.",
         "category": "Insights & analytics",

--- a/services/mcp/src/tools/experiments/listDeprecated.ts
+++ b/services/mcp/src/tools/experiments/listDeprecated.ts
@@ -1,0 +1,27 @@
+import type { z } from 'zod'
+
+import { GENERATED_TOOLS } from '@/tools/generated/experiments'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+/**
+ * Deprecation alias for the renamed `experiment-list` tool. Forwards arguments
+ * to the current handler and annotates the response so agents discover the new
+ * name without the call failing. Remove once callers have migrated.
+ */
+const experimentListDeprecated = (): ToolBase<ZodObjectAny> => {
+    const inner = GENERATED_TOOLS['experiment-list']!()
+    return {
+        ...inner,
+        name: 'experiment-get-all',
+        handler: async (context: Context, params: z.infer<ZodObjectAny>) => {
+            const result = await inner.handler(context, params)
+            return {
+                ...(result as object),
+                _deprecation_notice:
+                    'experiment-get-all has been renamed to experiment-list. Call experiment-list directly next time — this alias will be removed.',
+            }
+        },
+    }
+}
+
+export default experimentListDeprecated

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -6,6 +6,7 @@ import debugMcpUiApps from './debug/debugMcpUiApps'
 import searchDocs from './documentation/searchDocs'
 // Experiments (hand-written — CRUD + lifecycle are codegen in generated/experiments.ts)
 import getExperimentResults from './experiments/getResults'
+import experimentListDeprecated from './experiments/listDeprecated'
 // Generated tools (from definitions/*.yaml)
 import { GENERATED_TOOL_MAP } from './generated'
 // Insights
@@ -58,6 +59,8 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
 
     // Experiments (results is hand-written; CRUD + lifecycle are codegen)
     'experiment-results-get': getExperimentResults,
+    // Deprecated alias for experiment-list — forwards and annotates the response.
+    'experiment-get-all': experimentListDeprecated,
 
     // Insights
     'insight-query': queryInsight,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-get-all.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-get-all.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

We renamed the MCP call `experiment-get-all` to `experiment-list` for consistency. Some stale session reference the old name.

While agents should be self-healing to pick this up automatically, this PR adds it back as deprecated for smoother experience.

## Changes

- Add experiment-get-all back and mark as deprecated

## How did you test this code?

Local MCP understands it's deprecated and is guided to the new action

## Publish to changelog?

No