### PR TITLE
fix(sql-editor): gate 'Save as endpoint' behind the endpoints feature flag

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { IconBook, IconChevronDown, IconDownload, IconX } from '@posthog/icons'
 import { LemonModal, Spinner } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
@@ -251,6 +252,7 @@ function SQLEditorSceneTitle(): JSX.Element | null {
         saveAsMenuItems,
         isSourceQueryLastRun,
         isMultiQuery,
+        featureFlags,
     } = useValues(sqlEditorLogic)
     const {
         updateView,
@@ -421,11 +423,15 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                                             disabledReason: saveAsDisabledReason,
                                                             onClick: () => saveAsView(),
                                                         },
-                                                        {
-                                                            label: 'Save as endpoint...',
-                                                            disabledReason: saveAsDisabledReason,
-                                                            onClick: () => saveAsEndpoint(),
-                                                        },
+                                                        ...(featureFlags[FEATURE_FLAGS.ENDPOINTS]
+                                                            ? [
+                                                                  {
+                                                                      label: 'Save as endpoint...',
+                                                                      disabledReason: saveAsDisabledReason,
+                                                                      onClick: () => saveAsEndpoint(),
+                                                                  },
+                                                              ]
+                                                            : []),
                                                     ]}
                                                 />
                                             ),
@@ -474,11 +480,15 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                                             disabledReason: saveAsDisabledReason,
                                                             onClick: () => saveAsView(),
                                                         },
-                                                        {
-                                                            label: 'Save as endpoint...',
-                                                            disabledReason: saveAsDisabledReason,
-                                                            onClick: () => saveAsEndpoint(),
-                                                        },
+                                                        ...(featureFlags[FEATURE_FLAGS.ENDPOINTS]
+                                                            ? [
+                                                                  {
+                                                                      label: 'Save as endpoint...',
+                                                                      disabledReason: saveAsDisabledReason,
+                                                                      onClick: () => saveAsEndpoint(),
+                                                                  },
+                                                              ]
+                                                            : []),
                                                     ]}
                                                 />
                                             ),

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -2178,8 +2178,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         ],
 
         saveAsMenuItems: [
-            (s) => [s.editorSource, s.dashboardId],
-            (editorSource, dashboardId): { primary: SaveAsMenuItem; secondary: SaveAsMenuItem[] } => {
+            (s) => [s.editorSource, s.dashboardId, s.featureFlags],
+            (editorSource, dashboardId, featureFlags): { primary: SaveAsMenuItem; secondary: SaveAsMenuItem[] } => {
+                const endpointsEnabled = !!featureFlags[FEATURE_FLAGS.ENDPOINTS]
                 const saveAsInsightItem: SaveAsMenuItem = {
                     action: 'insight',
                     label: dashboardId ? 'Save & add to dashboard' : 'Save as insight',
@@ -2194,7 +2195,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     dataAttr: 'sql-editor-save-view-button',
                 }
 
-                if (editorSource === 'endpoint') {
+                if (editorSource === 'endpoint' && endpointsEnabled) {
                     return {
                         primary: saveAsEndpointItem,
                         secondary: [saveAsInsightItem, saveAsViewItem],
@@ -2203,7 +2204,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                 return {
                     primary: saveAsInsightItem,
-                    secondary: [saveAsEndpointItem, saveAsViewItem],
+                    secondary: endpointsEnabled ? [saveAsEndpointItem, saveAsViewItem] : [saveAsViewItem],
                 }
             },
         ],


### PR DESCRIPTION
## Problem

The "Save as endpoint" option in the SQL editor save menu was visible to all users regardless of whether the `embedded-analytics` feature flag (which controls the Endpoints product) was enabled. Users could create endpoints with no way to navigate back to them, since the Endpoints nav item, Files tree entry, and sidebar link are all gated behind the same flag.

This was an oversight introduced when `saveAsEndpoint` was added to the SQL editor (Feb 2026) — the flag was already in place, gating the nav, but was never applied to the save menu.

## Changes

- `sqlEditorLogic.tsx`: added `featureFlags` to the `saveAsMenuItems` selector dependencies; excludes the endpoint item when `FEATURE_FLAGS.ENDPOINTS` is off
- `SQLEditor.tsx`: added the same flag check to the two hardcoded "Save as endpoint..." dropdown items in the editing-view and editing-insight toolbar dropdowns

## How did you test this code?

I haven't tested this manually yet, but here's what I would do:
1. With `embedded-analytics` flag **off**: open the SQL editor, run a query, open the save dropdown — "Save as endpoint" should not appear in any dropdown (new query, editing view, editing insight)
2. With `embedded-analytics` flag **on**: same steps — "Save as endpoint" should appear as before

## Publish to changelog?

No

## 🤖 LLM context

Co-created with Claude Code (Opus 4.7)
