### PR TITLE
feat(ingestion): add kafka produce latency histogram

### DIFF
--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -142,6 +142,7 @@ export class KafkaProducerWrapper {
         }
         try {
             const produceTimer = ingestEventKafkaProduceLatency.labels(labels).startTimer()
+            const produceLatencyTimer = kafkaProducerProduceLatencySeconds.labels(labels).startTimer()
             kafkaProducerMessagesQueuedCounter.labels(labels).inc()
             if (value) {
                 kafkaProducerMessageSizeBytes.labels(labels).observe(value.length)
@@ -180,6 +181,7 @@ export class KafkaProducerWrapper {
             kafkaProducerMessagesWrittenCounter.labels(labels).inc()
             logger.debug('📤', 'Produced message', { topic: topic, offset: result })
             produceTimer()
+            produceLatencyTimer()
         } catch (error) {
             const errorCode = (error as LibrdKafkaError)?.code
             const failureLabels = {
@@ -320,6 +322,13 @@ export const ingestEventKafkaProduceLatency = new Summary({
     help: 'Wait time for individual Kafka produces',
     labelNames: ['topic_name', 'producer_name'],
     percentiles: [0.5, 0.9, 0.95, 0.99],
+})
+
+export const kafkaProducerProduceLatencySeconds = new Histogram({
+    name: 'kafka_producer_produce_latency_seconds',
+    help: 'Latency of individual Kafka produces, from queue time to delivery ack.',
+    labelNames: ['topic_name', 'producer_name'],
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 45, 60],
 })
 
 export const kafkaProducerMessageSizeBytes = new Histogram({


### PR DESCRIPTION
## Problem

The existing `ingest_event_kafka_produce_latency` metric is a Prometheus summary. Summaries compute quantiles locally per instance, so aggregating across instances (e.g. `avg by(producer_name)` over `quantile="0.99"`) produces misleading numbers — the avg of per-instance p99s is not the fleet p99.

## Changes

- Add a new histogram `kafka_producer_produce_latency_seconds` (labels: `topic_name`, `producer_name`) recorded alongside the existing summary, so dashboards can compute accurate cross-instance percentiles with `histogram_quantile`.
- Buckets cover 1ms → 60s with denser resolution near the typical range (ms–seconds) and additional granularity at the tail (7.5, 15, 20, 45).
- The old summary is kept in place so existing dashboards continue to work during migration; it can be removed once dashboards are switched over.

## How did you test this code?

No new tests. The change is a metric definition plus a paired `startTimer()`/stop alongside the existing summary — mirrors the instrumentation pattern already in place, which also has no unit tests. Validating the histogram is recorded would effectively test `prom-client`, not our code.

## Publish to changelog?

no