### PR TITLE
feat(logs): add count endpoint for cheap pre-query volume sizing

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -37,6 +37,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.tasks.exporter import export_asset
 
 from products.logs.backend.alerts_api import LogsAlertViewSet
+from products.logs.backend.count_query_runner import CountQueryRunner
 from products.logs.backend.explain import LogExplainViewSet
 from products.logs.backend.has_logs_query_runner import team_has_logs
 from products.logs.backend.log_attributes_query_runner import LogAttributesQueryRunner
@@ -272,6 +273,36 @@ class _LogsSparklineRequestSerializer(serializers.Serializer):
     query = _LogsSparklineBodySerializer(help_text="The sparkline query to execute.")
 
 
+class _LogsCountBodySerializer(serializers.Serializer):
+    dateRange = _DateRangeSerializer(
+        required=False,
+        help_text="Date range for the count. Defaults to last hour.",
+    )
+    severityLevels = serializers.ListField(
+        child=serializers.ChoiceField(choices=["trace", "debug", "info", "warn", "error", "fatal"]),
+        required=False,
+        default=list,
+        help_text="Filter by log severity levels.",
+    )
+    serviceNames = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        help_text="Filter by service names.",
+    )
+    searchTerm = serializers.CharField(required=False, help_text="Full-text search term to filter log bodies.")
+    filterGroup = serializers.ListField(
+        child=_LogPropertyFilterSerializer(),
+        required=False,
+        default=list,
+        help_text="Property filters for the query.",
+    )
+
+
+class _LogsCountRequestSerializer(serializers.Serializer):
+    query = _LogsCountBodySerializer(help_text="The count query to execute.")
+
+
 class _LogsServicesBodySerializer(serializers.Serializer):
     dateRange = _DateRangeSerializer(
         required=False,
@@ -348,6 +379,10 @@ class _LogsQueryResponseSerializer(serializers.Serializer):
     maxExportableLogs = serializers.IntegerField(
         help_text="Maximum number of rows the `export` endpoint will produce — informational.",
     )
+
+
+class _LogsCountResponseSerializer(serializers.Serializer):
+    count = serializers.IntegerField(help_text="Number of log entries matching the filters.")
 
 
 class _LogsSparklineBucketSerializer(serializers.Serializer):
@@ -587,6 +622,44 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
                 "severity_levels_count": len(query_data.get("severityLevels", [])),
                 "service_names_count": len(query_data.get("serviceNames", [])),
                 "breakdown_by": query_data.get("sparklineBreakdownBy"),
+            },
+            team=self.team,
+            request=request,
+        )
+
+        return Response(response.results, status=status.HTTP_200_OK)
+
+    @extend_schema(request=_LogsCountRequestSerializer, responses={200: _LogsCountResponseSerializer})
+    @action(detail=False, methods=["POST"], required_scopes=["logs:read"])
+    def count(self, request: Request, *args, **kwargs) -> Response:
+        query_data = request.data.get("query", {})
+
+        date_range_data = query_data.get("dateRange")
+        date_range = self.get_model(date_range_data, DateRange) if date_range_data else DateRange(date_from="-1h")
+
+        query = LogsQuery(
+            dateRange=date_range,
+            severityLevels=query_data.get("severityLevels", []),
+            serviceNames=query_data.get("serviceNames", []),
+            searchTerm=query_data.get("searchTerm", None),
+            filterGroup=self._normalize_filter_group(query_data.get("filterGroup", None)),
+        )
+
+        runner = CountQueryRunner(team=self.team, query=query)
+        response = runner.run(
+            ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props=get_request_analytics_properties(request),
+        )
+        assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
+
+        report_user_action(
+            request.user,
+            "logs count queried",
+            {
+                "has_search_term": bool(query_data.get("searchTerm")),
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "severity_levels_count": len(query_data.get("severityLevels", [])),
+                "service_names_count": len(query_data.get("serviceNames", [])),
             },
             team=self.team,
             request=request,

--- a/products/logs/backend/count_query_runner.py
+++ b/products/logs/backend/count_query_runner.py
@@ -1,0 +1,68 @@
+from functools import cached_property
+
+from posthog.schema import CachedLogsQueryResponse, LogsQuery
+
+from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client.connection import Workload
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+
+from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin
+
+
+class CountQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):
+    """Returns a scalar count of log entries matching the given filters."""
+
+    query: LogsQuery
+    cached_response: CachedLogsQueryResponse
+
+    @cached_property
+    def settings(self) -> HogQLGlobalSettings:
+        # A count should fail fast rather than scan unbounded data. Matches the
+        # caps AlertCheckQuery uses against the same table.
+        return HogQLGlobalSettings(
+            max_execution_time=30,
+            max_bytes_to_read=10_000_000_000,
+            read_overflow_mode="throw",
+        )
+
+    def _calculate(self) -> LogsQueryResponse:
+        response = execute_hogql_query(
+            query_type="LogsQuery",
+            query=self.to_query(),
+            modifiers=self.modifiers,
+            team=self.team,
+            workload=Workload.LOGS,
+            timings=self.timings,
+            limit_context=self.limit_context,
+            settings=self.settings,
+        )
+        count = response.results[0][0] if response.results else 0
+        return LogsQueryResponse(results={"count": count})
+
+    def to_query(self) -> ast.SelectQuery:
+        # LogsFilterBuilder.where() filters by toStartOfDay(time_bucket) which is
+        # day-precision; adding explicit per-row timestamp bounds (half-open to
+        # avoid double-counting on boundaries) makes the count match the requested
+        # window. Same pattern as AlertCheckQuery.
+        where_with_timestamp = ast.And(
+            exprs=[
+                self.where(),
+                parse_expr(
+                    "timestamp >= {date_from} AND timestamp < {date_to}",
+                    placeholders={
+                        "date_from": ast.Constant(value=self.query_date_range.date_from()),
+                        "date_to": ast.Constant(value=self.query_date_range.date_to()),
+                    },
+                ),
+            ]
+        )
+        query = parse_select(
+            "SELECT count() FROM logs WHERE {where}",
+            placeholders={"where": where_with_timestamp},
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query

--- a/products/logs/backend/test/test_count_api.py
+++ b/products/logs/backend/test/test_count_api.py
@@ -1,0 +1,120 @@
+import os
+import json
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.clickhouse.client import sync_execute
+
+_FIXTURE_WINDOW = {"date_from": "2025-12-14T00:00:00Z", "date_to": "2025-12-19T00:00:00Z"}
+
+
+class TestCountApi(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            sql = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                sql += json.dumps(log_item) + "\n"
+            sync_execute(f"""
+                INSERT INTO logs
+                FORMAT JSONEachRow
+                {sql}
+            """)
+
+    def _count(self, query_params, expected_status=status.HTTP_200_OK):
+        response = self.client.post(f"/api/projects/{self.team.id}/logs/count", data={"query": query_params})
+        self.assertEqual(response.status_code, expected_status)
+        return response.json() if expected_status == status.HTTP_200_OK else response
+
+    @parameterized.expand(
+        [
+            ("full_window", _FIXTURE_WINDOW, 1011),
+            ("empty_window", {"date_from": "2000-01-01T00:00:00Z", "date_to": "2000-01-02T00:00:00Z"}, 0),
+        ]
+    )
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_count_date_range(self, _name, date_range, expected):
+        response = self._count({"dateRange": date_range})
+        self.assertEqual(response["count"], expected)
+
+    @parameterized.expand(
+        [
+            (["info"], 848),
+            (["debug"], 66),
+            (["error"], 97),
+            (["info", "error"], 945),
+        ]
+    )
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_count_severity_filter(self, severities, expected):
+        response = self._count({"dateRange": _FIXTURE_WINDOW, "severityLevels": severities})
+        self.assertEqual(response["count"], expected)
+
+    @parameterized.expand(
+        [
+            (["argo-rollouts"], 100),
+            (["contour"], 100),
+            (["argo-rollouts", "contour"], 200),
+            (["nonexistent-service-xyz"], 0),
+        ]
+    )
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_count_service_filter(self, services, expected):
+        response = self._count({"dateRange": _FIXTURE_WINDOW, "serviceNames": services})
+        self.assertEqual(response["count"], expected)
+
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_count_search_term_matches_body_text(self):
+        response = self._count({"dateRange": _FIXTURE_WINDOW, "searchTerm": "connection refused"})
+        self.assertEqual(response["count"], 1)
+
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_count_defaults_date_range_to_last_hour(self):
+        # No dateRange in request; default should be -1h relative to frozen "now".
+        # Fixture's latest timestamp is 2025-12-18T02:00Z — outside the last hour.
+        response = self._count({})
+        self.assertEqual(response["count"], 0)
+
+    @parameterized.expand(
+        [
+            # Multi-day window — exercises full WHERE clause
+            ("full_window_no_filters", _FIXTURE_WINDOW, {}),
+            ("full_window_severity_info", _FIXTURE_WINDOW, {"severityLevels": ["info"]}),
+            ("full_window_service_argo", _FIXTURE_WINDOW, {"serviceNames": ["argo-rollouts"]}),
+            # Sub-day window — the case that would fail if count regressed to toStartOfDay precision
+            (
+                "sub_day_hour",
+                {"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T10:00:00Z"},
+                {},
+            ),
+        ]
+    )
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_count_matches_sparkline_sum(self, _name, date_range, filters):
+        # Cross-verify: sum of sparkline bucket counts should equal the scalar count
+        # for the same query. Catches drift between the two endpoints' WHERE handling.
+        # An explicit empty filterGroup is passed because sparkline currently requires it.
+        params = {
+            "dateRange": date_range,
+            "filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+            **filters,
+        }
+
+        count_result = self._count(params)
+        sparkline_response = self.client.post(
+            f"/api/projects/{self.team.id}/logs/sparkline",
+            data={"query": params},
+        )
+        self.assertEqual(sparkline_response.status_code, status.HTTP_200_OK)
+
+        sparkline_sum = sum(bucket["count"] for bucket in sparkline_response.json())
+        self.assertEqual(count_result["count"], sparkline_sum)

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -639,6 +639,29 @@ export const SeverityLevelsEnumApi = {
     Fatal: 'fatal',
 } as const
 
+export interface _LogsCountBodyApi {
+    /** Date range for the count. Defaults to last hour. */
+    dateRange?: _DateRangeApi
+    /** Filter by log severity levels. */
+    severityLevels?: SeverityLevelsEnumApi[]
+    /** Filter by service names. */
+    serviceNames?: string[]
+    /** Full-text search term to filter log bodies. */
+    searchTerm?: string
+    /** Property filters for the query. */
+    filterGroup?: _LogPropertyFilterApi[]
+}
+
+export interface _LogsCountRequestApi {
+    /** The count query to execute. */
+    query: _LogsCountBodyApi
+}
+
+export interface _LogsCountResponseApi {
+    /** Number of log entries matching the filters. */
+    count: number
+}
+
 /**
  * * `latest` - latest
  * `earliest` - earliest

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -32,6 +32,8 @@ import type {
     PatchedLogsViewApi,
     PluginConfigsLogsListParams,
     _LogsAttributesResponseApi,
+    _LogsCountRequestApi,
+    _LogsCountResponseApi,
     _LogsQueryRequestApi,
     _LogsQueryResponseApi,
     _LogsServicesRequestApi,
@@ -442,6 +444,23 @@ export const logsAttributesRetrieve = async (
     return apiMutator<_LogsAttributesResponseApi>(getLogsAttributesRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getLogsCountCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/count/`
+}
+
+export const logsCountCreate = async (
+    projectId: string,
+    _logsCountRequestApi: _LogsCountRequestApi,
+    options?: RequestInit
+): Promise<_LogsCountResponseApi> => {
+    return apiMutator<_LogsCountResponseApi>(getLogsCountCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(_logsCountRequestApi),
     })
 }
 

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -330,6 +330,88 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
     date_from: zod.string().describe("Relative date string for how far back to simulate (e.g. '-24h', '-7d', '-30d')."),
 })
 
+export const LogsCountCreateBody = /* @__PURE__ */ zod.object({
+    query: zod
+        .object({
+            dateRange: zod
+                .object({
+                    date_from: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Start of the date range. Accepts ISO 8601 timestamps or relative formats: -7d, -1h, -1mStart, etc.'
+                        ),
+                    date_to: zod
+                        .string()
+                        .nullish()
+                        .describe('End of the date range. Same format as date_from. Omit or null for \"now\".'),
+                })
+                .optional()
+                .describe('Date range for the count. Defaults to last hour.'),
+            severityLevels: zod
+                .array(
+                    zod
+                        .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+                        .describe(
+                            '* `trace` - trace\n* `debug` - debug\n* `info` - info\n* `warn` - warn\n* `error` - error\n* `fatal` - fatal'
+                        )
+                )
+                .optional()
+                .describe('Filter by log severity levels.'),
+            serviceNames: zod.array(zod.string()).optional().describe('Filter by service names.'),
+            searchTerm: zod.string().optional().describe('Full-text search term to filter log bodies.'),
+            filterGroup: zod
+                .array(
+                    zod.object({
+                        key: zod
+                            .string()
+                            .describe(
+                                'Attribute key. For type \"log\", use \"message\". For \"log_attribute\"/\"log_resource_attribute\", use the attribute key (e.g. \"k8s.container.name\").'
+                            ),
+                        type: zod
+                            .enum(['log', 'log_attribute', 'log_resource_attribute'])
+                            .describe(
+                                '* `log` - log\n* `log_attribute` - log_attribute\n* `log_resource_attribute` - log_resource_attribute'
+                            )
+                            .describe(
+                                '\"log\" filters the log body/message. \"log_attribute\" filters log-level attributes. \"log_resource_attribute\" filters resource-level attributes.\n\n* `log` - log\n* `log_attribute` - log_attribute\n* `log_resource_attribute` - log_resource_attribute'
+                            ),
+                        operator: zod
+                            .enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'lt',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'is_set',
+                                'is_not_set',
+                            ])
+                            .describe(
+                                '* `exact` - exact\n* `is_not` - is_not\n* `icontains` - icontains\n* `not_icontains` - not_icontains\n* `regex` - regex\n* `not_regex` - not_regex\n* `gt` - gt\n* `lt` - lt\n* `is_date_exact` - is_date_exact\n* `is_date_before` - is_date_before\n* `is_date_after` - is_date_after\n* `is_set` - is_set\n* `is_not_set` - is_not_set'
+                            )
+                            .describe(
+                                'Comparison operator.\n\n* `exact` - exact\n* `is_not` - is_not\n* `icontains` - icontains\n* `not_icontains` - not_icontains\n* `regex` - regex\n* `not_regex` - not_regex\n* `gt` - gt\n* `lt` - lt\n* `is_date_exact` - is_date_exact\n* `is_date_before` - is_date_before\n* `is_date_after` - is_date_after\n* `is_set` - is_set\n* `is_not_set` - is_not_set'
+                            ),
+                        value: zod
+                            .unknown()
+                            .nullish()
+                            .describe(
+                                'Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators.'
+                            ),
+                    })
+                )
+                .optional()
+                .describe('Property filters for the query.'),
+        })
+        .describe('The count query to execute.'),
+})
+
 export const logsQueryCreateBodyQueryOneSeverityLevelsDefault = []
 export const logsQueryCreateBodyQueryOneServiceNamesDefault = []
 export const logsQueryCreateBodyQueryOneFilterGroupDefault = []

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -64,7 +64,6 @@ tools:
     logs-alerts-list:
         operation: logs_alerts_list
         enabled: true
-        feature_flag: logs-alerting
         scopes:
             - logs:read
         annotations:
@@ -76,6 +75,7 @@ tools:
         description: >
             List log alert configurations in the current project, newest first. Returns alert name, state, threshold,
             filters, and scheduling details. Use this to review existing alerts before creating or modifying them.
+        feature_flag: logs-alerting
         response:
             include:
                 - id
@@ -90,7 +90,6 @@ tools:
     logs-alerts-create:
         operation: logs_alerts_create
         enabled: true
-        feature_flag: logs-alerting
         scopes:
             - logs:write
         annotations:
@@ -112,6 +111,7 @@ tools:
             - created_at
             - created_by
             - updated_at
+        feature_flag: logs-alerting
         response:
             include:
                 - id
@@ -137,7 +137,6 @@ tools:
     logs-alerts-retrieve:
         operation: logs_alerts_retrieve
         enabled: true
-        feature_flag: logs-alerting
         scopes:
             - logs:read
         annotations:
@@ -148,6 +147,7 @@ tools:
         description: >
             Get a log alert configuration by ID. Returns full details including current state, threshold settings,
             filters, and scheduling information.
+        feature_flag: logs-alerting
         response:
             include:
                 - id
@@ -173,7 +173,6 @@ tools:
     logs-alerts-partial-update:
         operation: logs_alerts_partial_update
         enabled: true
-        feature_flag: logs-alerting
         scopes:
             - logs:write
         annotations:
@@ -195,6 +194,7 @@ tools:
             - created_at
             - created_by
             - updated_at
+        feature_flag: logs-alerting
         response:
             include:
                 - id
@@ -220,7 +220,6 @@ tools:
     logs-alerts-destroy:
         operation: logs_alerts_destroy
         enabled: true
-        feature_flag: logs-alerting
         scopes:
             - logs:write
         annotations:
@@ -230,6 +229,7 @@ tools:
         title: Delete log alert
         description: |
             Permanently delete a log alert configuration by ID.
+        feature_flag: logs-alerting
     logs-alerts-simulate-create:
         operation: logs_alerts_simulate_create
         enabled: false
@@ -315,4 +315,7 @@ tools:
         enabled: false
     tasks-runs-logs-retrieve:
         operation: tasks_runs_logs_retrieve
+        enabled: false
+    logs-count-create:
+        operation: logs_count_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -36518,6 +36518,29 @@ export namespace Schemas {
       count: number;
     }
 
+    export interface _LogsCountBody {
+      /** Date range for the count. Defaults to last hour. */
+      dateRange?: _DateRange;
+      /** Filter by log severity levels. */
+      severityLevels?: SeverityLevelsEnum[];
+      /** Filter by service names. */
+      serviceNames?: string[];
+      /** Full-text search term to filter log bodies. */
+      searchTerm?: string;
+      /** Property filters for the query. */
+      filterGroup?: _LogPropertyFilter[];
+    }
+
+    export interface _LogsCountRequest {
+      /** The count query to execute. */
+      query: _LogsCountBody;
+    }
+
+    export interface _LogsCountResponse {
+      /** Number of log entries matching the filters. */
+      count: number;
+    }
+
     export interface _LogsQueryBody {
       /** Date range for the query. Defaults to last hour. */
       dateRange?: _DateRange;


### PR DESCRIPTION
## Problem

The logs product lacked a dedicated endpoint to retrieve a scalar count of log entries matching a given set of filters - this meant the mcp was burning through tokens just to see how many logs exist for a certain query.

## Changes

- Added a new `CountQueryRunner` that executes a `SELECT count()` against the `logs` table, applying the same filter logic as the existing query runners. Explicit per-row timestamp bounds are added on top of the base `WHERE` clause to ensure sub-hour windows are counted accurately (avoiding the `toStartOfDay` precision issue).
- Added a `POST /api/projects/{projectId}/logs/count/` endpoint that accepts date range, severity levels, service names, search term, and filter group, and returns `{ count: number }`. Defaults to the last hour if no date range is provided.
- Added analytics tracking via `report_user_action` on each count query.
- Generated updated TypeScript API schemas, client functions, and Zod validators for the new endpoint.

## How did you test this code?

Added `TestCountApi` integration tests (`test_count_api.py`) covering:

- Full fixture window returns the expected total count (1011 entries).
- Empty/out-of-range window returns zero.
- Severity level filtering (single and combined levels).
- Service name filtering (single, combined, and nonexistent service).
- Full-text search term matching against log body text.
- Default date range behaviour (no `dateRange` supplied → last hour, which falls outside the fixture window → 0).
- Cross-verification that the scalar count matches the sum of sparkline bucket counts for the same query, including a sub-day (one-hour) window to catch any day-precision regression.

## Publish to changelog?

No