### PR TITLE
fix(clickhouse): tag materialized columns introspection query

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -23,7 +23,7 @@ from posthog.clickhouse.materialized_columns import (
     ColumnName,
     TablesWithMaterializedColumns,
 )
-from posthog.clickhouse.query_tagging import tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.person.sql import PERSONS_TABLE
 from posthog.models.property import PropertyName, TableColumn, TableWithProperties
@@ -109,7 +109,11 @@ class MaterializedColumn:
         table_info = tables.get(table)
         data_table = table_info.data_table if table_info else table
 
-        with tags_context(name="get_all_materialized_columns"):
+        with tags_context(
+            name="get_all_materialized_columns",
+            product=Product.INTERNAL,
+            feature=Feature.SCHEMA_INTROSPECTION,
+        ):
             # Query columns and their indexes using multiple LEFT JOINs
             # Returns index names as an array, parsed in Python to set boolean flags
             # Note: Columns exist on both distributed and data tables, but indexes only exist on data tables


### PR DESCRIPTION
## Problem

`get_materialized_columns(table)` raised `posthog.clickhouse.client.execute.UntaggedQueryError` in DEBUG mode. The `sync_execute` call in `MaterializedColumn._get_all` was wrapped in `tags_context(name=...)`, which sets the `name` tag but leaves `product` and `feature` unset — and in DEBUG (non-TEST) mode `sync_execute` raises `UntaggedQueryError` when either is missing.

## Changes

Tag the `system.columns` / `system.data_skipping_indices` introspection query as `Product.INTERNAL` / `Feature.SCHEMA_INTROSPECTION`. This matches the tagging used by the analogous `DESCRIBE TABLE` introspection in `products/endpoints/backend/models.py`.

## How did you test this code?

Agent-authored — no manual verification. The fix is a pure tagging change; CI covers the code path.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. The failure surfaced in DEBUG mode because `sync_execute` raises `UntaggedQueryError` when both `product` and `feature` tags are missing (see `posthog/clickhouse/client/execute.py`). The existing `tags_context(name=...)` wrapper around the query only set `name`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*