### PR TITLE
fix(workflows): move duplicate observer

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -46,7 +46,7 @@ const DUPLICATE_OBSERVATION_TTL_SECONDS = 15 * 60
 
 const hogflowDuplicateInvocationDetectedTotal = new Counter({
     name: 'hogflow_duplicate_invocation_detected_total',
-    help: 'Workflow invocations created for a (workflow, event) pair already seen within the observation window',
+    help: 'Fired once per action reached by a duplicate invocation of the same (workflow, event). Inflated by N actions per duplicate pair - treat as trend signal, not exact count.',
     labelNames: ['workflow_id'],
 })
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -153,7 +153,6 @@ export class HogFlowExecutorService {
 
             const invocation = createHogFlowInvocation(triggerGlobals, hogFlow, filterGlobals)
             invocations.push(invocation)
-            this.observeDuplicateInvocation(invocation)
         }
 
         return {
@@ -163,22 +162,29 @@ export class HogFlowExecutorService {
         }
     }
 
-    private observeDuplicateInvocation(invocation: CyclotronJobInvocationHogFlow): void {
-        const eventUuid = invocation.state.event?.uuid
+    private async observeDuplicateInvocation(
+        invocation: CyclotronJobInvocationHogFlow,
+        currentAction: HogFlowAction
+    ): Promise<void> {
+        const eventUuid = invocation.state?.event?.uuid
         if (!this.redis || !eventUuid) {
             return
         }
-        const key = `hogflow:observe:${invocation.functionId}:${eventUuid}`
-        void this.redis
-            .useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
+        const key = `hogflow:observe:${invocation.functionId}:${eventUuid}:${currentAction.id}`
+        try {
+            await this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, async (client) => {
                 const wasSet = await client.set(key, invocation.id, 'EX', DUPLICATE_OBSERVATION_TTL_SECONDS, 'NX')
-                if (!wasSet) {
+                if (wasSet) {
+                    return
+                }
+                const existingId = await client.get(key)
+                if (existingId && existingId !== invocation.id) {
                     hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })
                 }
             })
-            .catch((error: unknown) => {
-                logger.debug('🦔', '[HogFlowExecutor] Duplicate observer skipped', { error: String(error) })
-            })
+        } catch (error) {
+            logger.debug('🦔', '[HogFlowExecutor] Duplicate observer failed', { error: String(error) })
+        }
     }
 
     async execute(
@@ -370,6 +376,8 @@ export class HogFlowExecutorService {
 
                 return result
             }
+
+            await this.observeDuplicateInvocation(invocation, currentAction)
 
             result.logs.push({
                 level: 'debug',


### PR DESCRIPTION
## Problem

The duplicate-invocation observer added in #56094 was placed in `buildHogFlowInvocations` (the events consumer side). In production the counter never emitted, despite ClickHouse confirming duplicate invocations still happen at baseline rate. No Redis error logs either, so the observer was silently bailing or not being reached on that path.

## Changes

Move `observeDuplicateInvocation` from `buildHogFlowInvocations` into `executeCurrentAction`, at the exact spot where `checkActionDeduplication` used to be called (right after `shouldSkipAction`, before the "Executing action" log). The method now mirrors the old dedup pattern:

- Per-action key: `hogflow:observe:{workflow_id}:{event_uuid}:{action_id}`
- Stores the current `invocation.id` on first arrival via `SET NX`
- On collision, `GET` the stored id and compare: if it differs from the current `invocation.id` the counter increments, if it matches (same invocation retrying the action) we don't count
- Awaited, wrapped in `try/catch`, and still uses `useClient` with `failOpen: true` so nothing can propagate into the action execution

This puts the observer on the same pod deployment (`cdp-cyclotron-worker-hogflow`) and in the same method where the previous `hogflow_action_dedup_blocked_total` counter emitted successfully. The ID comparison avoids counting same-invocation retries (wait_until_condition polls, delay resumes, etc).

Known limitation: the counter will inflate the same way the old dedup counter did if invocation IDs get regenerated across Cyclotron re-queues, because a legitimate retry will look like a different invocation. Acceptable as a trend indicator while we diagnose.

## How did you test this code?

- Observer is behind three layers of protection: early-return guard, outer `try/catch`, and `useClient`'s `failOpen: true`. Any Redis or prom-client error becomes a debug log, never propagates into `executeCurrentAction`.
- Same shape as the previous dedup logic we know emits metrics in production.

Reviewer should confirm after deploy that `hogflow_duplicate_invocation_detected_total` starts emitting.

## Publish to changelog?

No