### PR TITLE
chore(cloud-agent): add cloud-run state gauges

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -43,6 +43,7 @@ from posthog.tasks.surveys import sync_all_surveys_cache
 from posthog.tasks.tasks import (
     calculate_cohort,
     calculate_decide_usage,
+    capture_task_run_state_metrics,
     check_async_migration_health,
     check_flags_to_rollback,
     clean_stale_partials,
@@ -168,6 +169,12 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     # These are fine because they run more frequently than beat restarts.
     if not settings.DEBUG:
         sender.add_periodic_task(10, redis_celery_queue_depth.s(), name="10 sec queue probe")
+
+    sender.add_periodic_task(
+        60,
+        capture_task_run_state_metrics.s(),
+        name="tasks run state metrics",
+    )
 
     sender.add_periodic_task(10, redis_heartbeat.s(), name="10 sec heartbeat")
     sender.add_periodic_task(

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -482,6 +482,104 @@ def redis_celery_queue_depth() -> None:
         return
 
 
+_TASKS_RUN_OPEN_STATUSES = ("not_started", "queued", "in_progress")
+_TASKS_RUN_AGE_STATUSES = ("queued", "in_progress")
+_TASKS_RUN_TERMINAL_STATUSES = ("completed", "failed", "cancelled")
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.STATS.value)
+def capture_task_run_state_metrics() -> None:
+    """Emit gauges describing the current state of the Tasks product's TaskRun table"""
+    from django.db.models import Count, Min
+
+    from products.tasks.backend.models import TaskRun
+
+    try:
+        with pushed_metrics_registry("tasks_run_state") as registry:
+            runs_in_status_gauge = Gauge(
+                "posthog_tasks_runs_in_status",
+                "Number of open TaskRun rows by status, origin_product, and environment.",
+                registry=registry,
+                labelnames=["status", "origin_product", "environment"],
+            )
+            oldest_age_gauge = Gauge(
+                "posthog_tasks_oldest_open_run_age_seconds",
+                "Age (seconds) of the oldest TaskRun still in a given non-terminal status, by origin_product and environment.",
+                registry=registry,
+                labelnames=["status", "origin_product", "environment"],
+            )
+            runs_created_1h_gauge = Gauge(
+                "posthog_tasks_runs_created_1h",
+                "Number of TaskRun rows created in the last hour, by origin_product and environment.",
+                registry=registry,
+                labelnames=["origin_product", "environment"],
+            )
+            runs_terminal_1h_gauge = Gauge(
+                "posthog_tasks_runs_terminal_1h",
+                "Number of TaskRun rows that reached a terminal status in the last hour, by status, origin_product, and environment.",
+                registry=registry,
+                labelnames=["status", "origin_product", "environment"],
+            )
+
+            counts = (
+                TaskRun.objects.filter(status__in=_TASKS_RUN_OPEN_STATUSES)
+                .values("status", "environment", "task__origin_product")
+                .annotate(count=Count("id"))
+            )
+            for row in counts:
+                runs_in_status_gauge.labels(
+                    status=row["status"],
+                    origin_product=row["task__origin_product"] or "unknown",
+                    environment=row["environment"],
+                ).set(row["count"])
+
+            oldest = (
+                TaskRun.objects.filter(status__in=_TASKS_RUN_AGE_STATUSES)
+                .values("status", "environment", "task__origin_product")
+                .annotate(oldest_created_at=Min("created_at"))
+            )
+            now = timezone.now()
+            for row in oldest:
+                age_seconds = (now - row["oldest_created_at"]).total_seconds()
+                oldest_age_gauge.labels(
+                    status=row["status"],
+                    origin_product=row["task__origin_product"] or "unknown",
+                    environment=row["environment"],
+                ).set(age_seconds)
+
+            created_1h = (
+                TaskRun.objects.filter(created_at__gte=now - datetime.timedelta(hours=1))
+                .values("environment", "task__origin_product")
+                .annotate(count=Count("id"))
+            )
+            for row in created_1h:
+                runs_created_1h_gauge.labels(
+                    origin_product=row["task__origin_product"] or "unknown",
+                    environment=row["environment"],
+                ).set(row["count"])
+
+            # Terminal runs: approximated by updated_at since completed_at can be null for FAILED/CANCELLED
+            # paths that didn't take the happy-path write.
+            terminal_1h = (
+                TaskRun.objects.filter(
+                    status__in=_TASKS_RUN_TERMINAL_STATUSES,
+                    updated_at__gte=now - datetime.timedelta(hours=1),
+                )
+                .values("status", "environment", "task__origin_product")
+                .annotate(count=Count("id"))
+            )
+            for row in terminal_1h:
+                runs_terminal_1h_gauge.labels(
+                    status=row["status"],
+                    origin_product=row["task__origin_product"] or "unknown",
+                    environment=row["environment"],
+                ).set(row["count"])
+
+    except Exception as err:
+        logger.exception("capture_task_run_state_metrics", exception=err)
+        capture_exception(err)
+
+
 @shared_task(ignore_result=True)
 def update_event_partitions() -> None:
     with connection.cursor() as cursor:

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -97,6 +97,7 @@
     'posthog.tasks.tasks.background_delete_model_task',
     'posthog.tasks.tasks.calculate_cohort',
     'posthog.tasks.tasks.calculate_decide_usage',
+    'posthog.tasks.tasks.capture_task_run_state_metrics',
     'posthog.tasks.tasks.check_async_migration_health',
     'posthog.tasks.tasks.check_flags_to_rollback',
     'posthog.tasks.tasks.clean_stale_partials',

--- a/posthog/tasks/test/test_task_run_state_metrics.py
+++ b/posthog/tasks/test/test_task_run_state_metrics.py
@@ -1,0 +1,210 @@
+from datetime import datetime, timedelta
+from typing import ClassVar, Optional
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from parameterized import parameterized
+from prometheus_client import CollectorRegistry
+
+from posthog.models import Organization, Team
+from posthog.tasks.tasks import capture_task_run_state_metrics
+
+from products.tasks.backend.models import Task, TaskRun
+
+
+class TestCaptureTaskRunStateMetrics(TestCase):
+    organization: ClassVar[Organization]
+    team: ClassVar[Team]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.organization = Organization.objects.create(name="Test Org")
+        cls.team = Team.objects.create(organization=cls.organization, name="Test Team")
+
+    def _make_task_run(
+        self,
+        *,
+        origin: Task.OriginProduct,
+        status: TaskRun.Status,
+        environment: TaskRun.Environment = TaskRun.Environment.CLOUD,
+        created_at: Optional[datetime] = None,
+    ) -> TaskRun:
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=origin,
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=status,
+            environment=environment,
+        )
+        if created_at is not None:
+            TaskRun.objects.filter(pk=run.pk).update(created_at=created_at)
+            run.refresh_from_db()
+        return run
+
+    def _run_with_registry(self) -> CollectorRegistry:
+        registry = CollectorRegistry()
+        context = MagicMock()
+        context.__enter__ = MagicMock(return_value=registry)
+        context.__exit__ = MagicMock(return_value=False)
+        with patch("posthog.tasks.tasks.pushed_metrics_registry", return_value=context):
+            capture_task_run_state_metrics()
+        return registry
+
+    def test_emits_counts_grouped_by_status_origin_and_environment(self) -> None:
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
+        self._make_task_run(origin=Task.OriginProduct.USER_CREATED, status=TaskRun.Status.IN_PROGRESS)
+        self._make_task_run(
+            origin=Task.OriginProduct.USER_CREATED,
+            status=TaskRun.Status.IN_PROGRESS,
+            environment=TaskRun.Environment.LOCAL,
+        )
+
+        registry = self._run_with_registry()
+
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_in_status",
+                {"status": "queued", "origin_product": "slack", "environment": "cloud"},
+            )
+            == 2
+        )
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_in_status",
+                {"status": "in_progress", "origin_product": "user_created", "environment": "cloud"},
+            )
+            == 1
+        )
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_in_status",
+                {"status": "in_progress", "origin_product": "user_created", "environment": "local"},
+            )
+            == 1
+        )
+
+    @parameterized.expand(
+        [
+            (TaskRun.Status.COMPLETED,),
+            (TaskRun.Status.FAILED,),
+            (TaskRun.Status.CANCELLED,),
+        ]
+    )
+    def test_ignores_terminal_statuses(self, status: TaskRun.Status) -> None:
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=status)
+
+        registry = self._run_with_registry()
+
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_in_status",
+                {"status": status.value, "origin_product": "slack", "environment": "cloud"},
+            )
+            is None
+        )
+
+    def test_emits_oldest_open_run_age(self) -> None:
+        long_ago = timezone.now() - timedelta(minutes=30)
+        self._make_task_run(
+            origin=Task.OriginProduct.SLACK,
+            status=TaskRun.Status.QUEUED,
+            created_at=long_ago,
+        )
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
+
+        registry = self._run_with_registry()
+
+        age = registry.get_sample_value(
+            "posthog_tasks_oldest_open_run_age_seconds",
+            {"status": "queued", "origin_product": "slack", "environment": "cloud"},
+        )
+        assert age is not None
+        # Oldest run was ~30 minutes ago; allow generous slack for test timing.
+        assert 1500 < age < 2400
+
+    def test_emits_runs_created_1h_by_origin_and_environment(self) -> None:
+        # Two Slack runs created just now, one old run (outside the 1h window), one PostHog-code run.
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.COMPLETED)
+        self._make_task_run(
+            origin=Task.OriginProduct.SLACK,
+            status=TaskRun.Status.COMPLETED,
+            created_at=timezone.now() - timedelta(hours=2),
+        )
+        self._make_task_run(origin=Task.OriginProduct.USER_CREATED, status=TaskRun.Status.COMPLETED)
+
+        registry = self._run_with_registry()
+
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_created_1h",
+                {"origin_product": "slack", "environment": "cloud"},
+            )
+            == 2
+        )
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_created_1h",
+                {"origin_product": "user_created", "environment": "cloud"},
+            )
+            == 1
+        )
+
+    def test_emits_runs_terminal_1h_grouped_by_status_and_origin(self) -> None:
+        # 2 completed Slack runs + 1 failed User run in the last hour, plus 1 old completed run (outside 1h).
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.COMPLETED)
+        self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.COMPLETED)
+        self._make_task_run(origin=Task.OriginProduct.USER_CREATED, status=TaskRun.Status.FAILED)
+        old = self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.COMPLETED)
+        TaskRun.objects.filter(pk=old.pk).update(updated_at=timezone.now() - timedelta(hours=2))
+
+        registry = self._run_with_registry()
+
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_terminal_1h",
+                {"status": "completed", "origin_product": "slack", "environment": "cloud"},
+            )
+            == 2
+        )
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_terminal_1h",
+                {"status": "failed", "origin_product": "user_created", "environment": "cloud"},
+            )
+            == 1
+        )
+
+    def test_age_gauge_only_covers_queued_and_in_progress(self) -> None:
+        self._make_task_run(
+            origin=Task.OriginProduct.SLACK,
+            status=TaskRun.Status.NOT_STARTED,
+            created_at=timezone.now() - timedelta(minutes=5),
+        )
+
+        registry = self._run_with_registry()
+
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_oldest_open_run_age_seconds",
+                {"status": "not_started", "origin_product": "slack", "environment": "cloud"},
+            )
+            is None
+        )
+        # But it should still appear in the count gauge (not_started is "open").
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_runs_in_status",
+                {"status": "not_started", "origin_product": "slack", "environment": "cloud"},
+            )
+            == 1
+        )


### PR DESCRIPTION
## Problem

we need better observability into cloud runs, they are kicked off from multiple entry points but there's no app-level observability into what's happening to them once they enter the queue. 

a [recent incident](https://posthog.slack.com/archives/C0AUUSSSR6X) prompted into being a bit more diligent here.

this adds a Celery job that exposes the aggregate state of the `TaskRun` table as Prometheus gauges (on top of what we get out of Temporal SDK metrics)

## Changes

- beat scheduled every 60s 
- cardinality is bounded: 6 statuses × 8 origins × 2 environments ≤ 96 series per gauge.
