### PR TITLE
fix(surveys): notify on survey dismissals

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -25,6 +25,10 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
                     id: SurveyEventName.SENT,
                     type: 'events',
                 },
+                {
+                    id: SurveyEventName.DISMISSED,
+                    type: 'events',
+                },
             ],
         },
     },
@@ -133,16 +137,16 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'],
             template_id: 'template-webhook',
             name: 'HTTP Webhook on survey response',
-            description: 'Send a webhook when a survey response is submitted',
+            description: 'Send a webhook when a survey is completed or dismissed',
         },
         {
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'],
             template_id: 'template-discord',
             name: 'Post to Discord on survey response',
-            description: 'Posts a message to Discord when a user responds to a survey',
+            description: 'Posts a message to Discord when a survey is completed or dismissed',
             inputs: {
                 content: {
-                    value: '**{person.name}** responded to survey **{event.properties.$survey_name}**',
+                    value: "**{person.name}** {event.event == 'survey dismissed' ? 'dismissed' : 'completed'} survey **{event.properties.$survey_name}**",
                 },
             },
         },
@@ -150,10 +154,10 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'],
             template_id: 'template-microsoft-teams',
             name: 'Post to Microsoft Teams on survey response',
-            description: 'Posts a message to Microsoft Teams when a user responds to a survey',
+            description: 'Posts a message to Microsoft Teams when a survey is completed or dismissed',
             inputs: {
                 text: {
-                    value: '**{person.name}** responded to survey **{event.properties.$survey_name}**',
+                    value: "**{person.name}** {event.event == 'survey dismissed' ? 'dismissed' : 'completed'} survey **{event.properties.$survey_name}**",
                 },
             },
         },
@@ -161,13 +165,13 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'],
             template_id: 'template-slack',
             name: 'Post to Slack on survey response',
-            description: 'Posts a message to Slack when a user responds to a survey',
+            description: 'Posts a message to Slack when a survey is completed or dismissed',
             inputs: {
                 blocks: {
                     value: [
                         {
                             text: {
-                                text: '*{person.name}* responded to survey *{event.properties.$survey_name}*',
+                                text: "*{person.name}* {event.event == 'survey dismissed' ? 'dismissed' : 'completed'} survey *{event.properties.$survey_name}*",
                                 type: 'mrkdwn',
                             },
                             type: 'section',
@@ -190,7 +194,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     ],
                 },
                 text: {
-                    value: '*{person.name}* responded to survey *{event.properties.$survey_name}*',
+                    value: "*{person.name}* {event.event == 'survey dismissed' ? 'dismissed' : 'completed'} survey *{event.properties.$survey_name}*",
                 },
             },
         },

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Field, Form } from 'kea-forms'
 
-import { LemonButton, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
@@ -148,7 +148,6 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
         isNotificationFormSubmitting,
         selectedSlackIntegration,
         hasSlackIntegration,
-        canNotifyOnPartialResponses,
         templateGlobals,
         submitDisabledReason,
         notificationSubmissionError,
@@ -224,26 +223,9 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                 {destinationDeliveryDescription(notificationForm.destination)}
                             </div>
                             <div className="text-xs text-muted">
-                                Notifications send when a survey is completed or dismissed. If someone leaves the survey
-                                open and never submits or dismisses it, nothing is sent.
+                                Notifications send when a survey is completed or dismissed after at least one response.
+                                If someone closes it without answering or leaves it open forever, nothing is sent.
                             </div>
-                            {canNotifyOnPartialResponses ? (
-                                <>
-                                    <Field name="onlyCompletedResponses">
-                                        {({ value, onChange }) => (
-                                            <LemonSwitch
-                                                checked={value}
-                                                onChange={onChange}
-                                                label="Only notify on completed or dismissed surveys"
-                                            />
-                                        )}
-                                    </Field>
-                                    <div className="text-xs text-muted">
-                                        Turn this off to also notify on in-progress `survey sent` events before the
-                                        survey is finished.
-                                    </div>
-                                </>
-                            ) : null}
                         </div>
 
                         {notificationForm.destination === 'slack' ? (

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Field, Form } from 'kea-forms'
 
-import { LemonButton, LemonInput, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -171,7 +171,7 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
             isOpen={isOpen}
             onClose={closeDialog}
             title="Add survey notification"
-            description="Send survey responses to Slack, Discord, Microsoft Teams, or a webhook."
+            description="Send survey updates to Slack, Discord, Microsoft Teams, or a webhook."
             width={720}
             footer={
                 <>
@@ -223,6 +223,10 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                             <div className="text-xs text-muted">
                                 {destinationDeliveryDescription(notificationForm.destination)}
                             </div>
+                            <div className="text-xs text-muted">
+                                Notifications send when a survey is completed or dismissed. If someone leaves the survey
+                                open and never submits or dismisses it, nothing is sent.
+                            </div>
                             {canNotifyOnPartialResponses ? (
                                 <>
                                     <Field name="onlyCompletedResponses">
@@ -230,12 +234,13 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                             <LemonSwitch
                                                 checked={value}
                                                 onChange={onChange}
-                                                label="Only notify for full responses"
+                                                label="Only notify on completed or dismissed surveys"
                                             />
                                         )}
                                     </Field>
                                     <div className="text-xs text-muted">
-                                        Turn this off if partial responses matter for this survey.
+                                        Turn this off to also notify on in-progress `survey sent` events before the
+                                        survey is finished.
                                     </div>
                                 </>
                             ) : null}
@@ -406,8 +411,8 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                     <div className="space-y-1">
                                         <div className="text-sm font-medium text-default">Webhook request body</div>
                                         <div className="text-xs text-muted">
-                                            Survey webhooks send the survey metadata, person context, and one answer
-                                            field per question.
+                                            Survey webhooks send the trigger status, survey metadata, person context,
+                                            and one answer field per question.
                                         </div>
                                     </div>
                                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">

--- a/frontend/src/scenes/surveys/components/SurveyResponseKeysReference.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyResponseKeysReference.tsx
@@ -2,6 +2,7 @@ import { IconCopy } from '@posthog/icons'
 import { LemonButton, LemonCollapse } from '@posthog/lemon-ui'
 
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { SURVEY_EVENT_TOKEN, SURVEY_STATUS_TOKEN } from 'scenes/surveys/surveyNotificationModalLogic'
 
 import { SurveyQuestion, SurveyQuestionType } from '~/types'
 
@@ -14,6 +15,8 @@ export function SurveyResponseKeysReference({ questions }: { questions: SurveyQu
     const commonFields = [
         { label: 'Survey name', templateKey: "{event.properties['$survey_name']}" },
         { label: 'Survey ID', templateKey: "{event.properties['$survey_id']}" },
+        { label: 'Trigger event', templateKey: SURVEY_EVENT_TOKEN },
+        { label: 'Survey status', templateKey: SURVEY_STATUS_TOKEN },
         { label: 'Respondent name', templateKey: '{person.name}' },
         { label: 'Respondent email', templateKey: '{person.properties.email}' },
     ]
@@ -27,7 +30,8 @@ export function SurveyResponseKeysReference({ questions }: { questions: SurveyQu
                     content: (
                         <div className="flex flex-col gap-1.5">
                             <p className="text-xs text-muted m-0">
-                                Use these in notification message templates to include survey context and responses.
+                                Use these in notification message templates to include survey context, status, and
+                                responses.
                             </p>
                             {commonFields.map(({ label, templateKey }) => (
                                 <div

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts
@@ -1,0 +1,22 @@
+import { SurveyQuestionType } from '~/types'
+
+import { getDefaultSurveyMessage } from './surveyNotificationModalLogic'
+
+describe('surveyNotificationModalLogic', () => {
+    it('includes survey status text in the default notification message', () => {
+        expect(
+            getDefaultSurveyMessage([
+                {
+                    id: 'question-1',
+                    question: 'What can we improve?',
+                    type: SurveyQuestionType.Open,
+                },
+            ])
+        ).toEqual(`*Survey update on {event.properties['$survey_name']}*
+{event.event == 'survey dismissed' ? (event.properties['$survey_partially_completed'] ? 'Dismissed after a partial response' : 'Dismissed before completion') : 'Completed response'}
+{person.name} · {person.properties.email}
+
+*Responses*
+- What can we improve?: {event.properties['$survey_response_question-1']}`)
+    })
+})

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -45,7 +45,6 @@ export type SurveyQuestionForNotification = {
 
 export interface SurveyNotificationForm {
     destination: DestinationKey
-    onlyCompletedResponses: boolean
     slackIntegrationId: number | null
     slackChannel: string | null
     slackMessage: string
@@ -201,7 +200,6 @@ function buildSurveyNotificationForm(survey: SurveyNotificationContext): SurveyN
 
     return {
         destination: 'slack',
-        onlyCompletedResponses: true,
         slackIntegrationId: null,
         slackChannel: null,
         slackMessage: defaultMessage,
@@ -249,14 +247,12 @@ function createSurveyNotificationPayload({
     destination,
     surveyName,
     surveyId,
-    canNotifyOnPartialResponses,
     form,
 }: {
     template: HogFunctionTemplateType
     destination: DestinationKey
     surveyName?: string | null
     surveyId: string
-    canNotifyOnPartialResponses: boolean
     form: SurveyNotificationForm
 }): Partial<HogFunctionType> {
     const destinationOption = DESTINATION_OPTIONS.find((option) => option.value === destination)
@@ -314,10 +310,7 @@ function createSurveyNotificationPayload({
         description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
         inputs,
         inputs_schema: template.inputs_schema,
-        filters: getSurveyNotificationFilters(
-            surveyId,
-            canNotifyOnPartialResponses ? form.onlyCompletedResponses : true
-        ),
+        filters: getSurveyNotificationFilters(surveyId),
         hog: template.code,
         icon_url: template.icon_url,
         enabled: true,
@@ -426,7 +419,6 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
                     destination: form.destination,
                     surveyName: values.survey.name,
                     surveyId: values.survey.id,
-                    canNotifyOnPartialResponses: values.survey.enable_partial_responses === true,
                     form,
                 })
 
@@ -446,10 +438,6 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
             (integrations: IntegrationType[] | null, form: SurveyNotificationForm) =>
                 integrations?.find((integration: IntegrationType) => integration.id === form.slackIntegrationId) ??
                 null,
-        ],
-        canNotifyOnPartialResponses: [
-            (s) => [s.survey],
-            (survey: SurveyNotificationContext) => survey.enable_partial_responses === true,
         ],
         templateGlobals: [(s) => [s.survey], (survey: SurveyNotificationContext) => buildTemplateGlobals(survey)],
         submitDisabledReason: [
@@ -474,9 +462,6 @@ export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType
         openDialog: () => {
             actions.resetNotificationForm()
             actions.setNotificationFormValues(buildSurveyNotificationForm(values.survey))
-            if (values.survey.enable_partial_responses !== true) {
-                actions.setNotificationFormValue('onlyCompletedResponses', true)
-            }
         },
         closeDialog: () => {
             actions.resetNotificationForm()

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -18,7 +18,14 @@ import {
     getSurveyIdBasedResponseKey,
 } from 'scenes/surveys/utils'
 
-import { HogFunctionTemplateType, HogFunctionType, IntegrationType, Survey, SurveyQuestionType } from '~/types'
+import {
+    HogFunctionTemplateType,
+    HogFunctionType,
+    IntegrationType,
+    Survey,
+    SurveyEventProperties,
+    SurveyQuestionType,
+} from '~/types'
 
 import type { surveyNotificationModalLogicType } from './surveyNotificationModalLogicType'
 
@@ -63,9 +70,11 @@ type SurveyNotificationFormErrors = Partial<Record<keyof SurveyNotificationForm,
 const MAX_EXAMPLE_QUESTIONS = 3
 export const SURVEY_NAME_TOKEN = "{event.properties['$survey_name']}"
 export const SURVEY_ID_TOKEN = "{event.properties['$survey_id']}"
+export const SURVEY_EVENT_TOKEN = '{event.event}'
 export const RESPONDENT_NAME_TOKEN = '{person.name}'
 export const RESPONDENT_EMAIL_TOKEN = '{person.properties.email}'
 export const RESPONDENT_DETAILS_LINE = `${RESPONDENT_NAME_TOKEN} · ${RESPONDENT_EMAIL_TOKEN}`
+export const SURVEY_STATUS_TOKEN = `{event.event == 'survey dismissed' ? (event.properties['${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'] ? 'Dismissed after a partial response' : 'Dismissed before completion') : 'Completed response'}`
 
 function getResponseToken(questionId: string): string {
     return `{event.properties['${getSurveyIdBasedResponseKey(questionId)}']}`
@@ -85,7 +94,8 @@ export function getDefaultSurveyMessage(questions: SurveyQuestionForNotification
         .slice(0, MAX_EXAMPLE_QUESTIONS)
 
     return [
-        `*New response on ${SURVEY_NAME_TOKEN}*`,
+        `*Survey update on ${SURVEY_NAME_TOKEN}*`,
+        SURVEY_STATUS_TOKEN,
         RESPONDENT_DETAILS_LINE,
         ...(exampleQuestions.length > 0
             ? ['', '*Responses*', ...exampleQuestions.map((question, index) => getQuestionLine(question, index))]
@@ -163,6 +173,10 @@ function buildSlackBlocks(message: string, includeButtons: boolean): Record<stri
 
 function buildWebhookBodyTemplate(questions: SurveyQuestionForNotification[]): Record<string, unknown> {
     return {
+        event: {
+            name: SURVEY_EVENT_TOKEN,
+            status: SURVEY_STATUS_TOKEN,
+        },
         survey: {
             id: SURVEY_ID_TOKEN,
             name: SURVEY_NAME_TOKEN,

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -180,6 +180,18 @@ describe('survey utils', () => {
                             },
                         ],
                     },
+                    {
+                        id: SurveyEventName.DISMISSED,
+                        type: 'events',
+                        properties: [
+                            {
+                                key: SurveyEventProperties.SURVEY_ID,
+                                type: PropertyFilterType.Event,
+                                value: 'survey-123',
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                    },
                 ],
             })
         })
@@ -189,6 +201,18 @@ describe('survey utils', () => {
                 events: [
                     {
                         id: SurveyEventName.SENT,
+                        type: 'events',
+                        properties: [
+                            {
+                                key: SurveyEventProperties.SURVEY_ID,
+                                type: PropertyFilterType.Event,
+                                value: 'survey-123',
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                    },
+                    {
+                        id: SurveyEventName.DISMISSED,
                         type: 'events',
                         properties: [
                             {

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -190,35 +190,10 @@ describe('survey utils', () => {
                                 value: 'survey-123',
                                 operator: PropertyOperator.Exact,
                             },
-                        ],
-                    },
-                ],
-            })
-        })
-
-        it('can include partial responses when requested', () => {
-            expect(getSurveyNotificationFilters('survey-123', false)).toEqual({
-                events: [
-                    {
-                        id: SurveyEventName.SENT,
-                        type: 'events',
-                        properties: [
                             {
-                                key: SurveyEventProperties.SURVEY_ID,
+                                key: SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED,
                                 type: PropertyFilterType.Event,
-                                value: 'survey-123',
-                                operator: PropertyOperator.Exact,
-                            },
-                        ],
-                    },
-                    {
-                        id: SurveyEventName.DISMISSED,
-                        type: 'events',
-                        properties: [
-                            {
-                                key: SurveyEventProperties.SURVEY_ID,
-                                type: PropertyFilterType.Event,
-                                value: 'survey-123',
+                                value: true,
                                 operator: PropertyOperator.Exact,
                             },
                         ],

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1116,10 +1116,7 @@ export function getSurveyDisplayConditionsSummary(survey: Survey | NewSurvey): S
     return parts
 }
 
-export function getSurveyNotificationFilters(
-    surveyId: string,
-    onlyCompletedResponses: boolean = true
-): CyclotronJobFiltersType {
+export function getSurveyNotificationFilters(surveyId: string): CyclotronJobFiltersType {
     const sentEventProperties: EventPropertyFilter[] = [
         {
             key: SurveyEventProperties.SURVEY_ID,
@@ -1127,16 +1124,13 @@ export function getSurveyNotificationFilters(
             value: surveyId,
             operator: PropertyOperator.Exact,
         },
-    ]
-
-    if (onlyCompletedResponses) {
-        sentEventProperties.push({
+        {
             key: SurveyEventProperties.SURVEY_COMPLETED,
             type: PropertyFilterType.Event,
             value: true,
             operator: PropertyOperator.Exact,
-        })
-    }
+        },
+    ]
 
     return {
         events: [
@@ -1153,6 +1147,12 @@ export function getSurveyNotificationFilters(
                         key: SurveyEventProperties.SURVEY_ID,
                         type: PropertyFilterType.Event,
                         value: surveyId,
+                        operator: PropertyOperator.Exact,
+                    },
+                    {
+                        key: SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED,
+                        type: PropertyFilterType.Event,
+                        value: true,
                         operator: PropertyOperator.Exact,
                     },
                 ],

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1120,7 +1120,7 @@ export function getSurveyNotificationFilters(
     surveyId: string,
     onlyCompletedResponses: boolean = true
 ): CyclotronJobFiltersType {
-    const properties: EventPropertyFilter[] = [
+    const sentEventProperties: EventPropertyFilter[] = [
         {
             key: SurveyEventProperties.SURVEY_ID,
             type: PropertyFilterType.Event,
@@ -1130,7 +1130,7 @@ export function getSurveyNotificationFilters(
     ]
 
     if (onlyCompletedResponses) {
-        properties.push({
+        sentEventProperties.push({
             key: SurveyEventProperties.SURVEY_COMPLETED,
             type: PropertyFilterType.Event,
             value: true,
@@ -1143,7 +1143,19 @@ export function getSurveyNotificationFilters(
             {
                 id: SurveyEventName.SENT,
                 type: 'events',
-                properties,
+                properties: sentEventProperties,
+            },
+            {
+                id: SurveyEventName.DISMISSED,
+                type: 'events',
+                properties: [
+                    {
+                        key: SurveyEventProperties.SURVEY_ID,
+                        type: PropertyFilterType.Event,
+                        value: surveyId,
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
             },
         ],
     }


### PR DESCRIPTION
## Problem

Survey notifications originally only fired for completed `survey sent` events. That missed cases where a user answered part of a survey and then dismissed it, even though those partial responses are still useful feedback. We also do not want notifications for empty dismissals where someone simply closes the popup without answering anything.

## Changes

- Update survey notification filters so they trigger for either completed `survey sent` events or `survey dismissed` events with `$survey_partially_completed = true`
- Remove the partial-response toggle from the survey notification modal so the behavior is consistent and avoids duplicate notifications from intermediate events
- Refresh the default destination template copy and placeholder reference to show whether the survey was completed or dismissed

## How did you test this code?

- Ran `hogli test frontend/src/scenes/surveys/utils.test.ts frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts`

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored with Codex. I inspected the existing survey notification flow in `dotcom`, verified the browser SDK dismissal payload shape, updated notification filters and copy to use only terminal survey outcomes, removed the toggle that allowed intermediate-event notifications, and added focused frontend tests. I also opened a companion `posthog-js` PR to bring React Native dismissal events to the same payload shape.
