### PR TITLE
feat(subscriptions): capture subscription_ai_summary_generated event

### DIFF
--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -9,6 +9,7 @@ from structlog import get_logger
 from posthog.models import Insight
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.subscription import Subscription, SubscriptionDelivery
+from posthog.ph_client import ph_scoped_capture
 from posthog.storage import object_storage
 from posthog.sync import database_sync_to_async
 from posthog.temporal.subscriptions.llm_change_summary import generate_change_summary
@@ -210,6 +211,54 @@ def _sanitize_prompt_guide(prompt_guide: str) -> str:
     return re.sub(r"</?[a-zA-Z_][^>]*>", "", prompt_guide)
 
 
+def _capture_summary_generated_event(
+    subscription: Subscription,
+    *,
+    delivery_id: str | None,
+    summary_text: str,
+    insight_count: int,
+    image_count: int,
+    has_previous: bool,
+) -> None:
+    """Fire a product analytics event when a summary has been successfully generated.
+
+    Recipients aren't identifiable (email addresses, Slack channels, webhook URLs
+    have no distinct_id), so we attribute the event to the subscription creator —
+    falling back to team_id when the creator has been removed. Wrapped in a broad
+    except so a capture failure can never bubble up and poison an otherwise
+    successful activity run.
+    """
+    try:
+        distinct_id = (
+            subscription.created_by.distinct_id
+            if subscription.created_by and subscription.created_by.distinct_id
+            else str(subscription.team_id)
+        )
+        with ph_scoped_capture() as capture:
+            capture(
+                distinct_id=str(distinct_id),
+                event="subscription_ai_summary_generated",
+                properties={
+                    "subscription_id": subscription.id,
+                    "team_id": subscription.team_id,
+                    "delivery_id": delivery_id,
+                    "target_type": subscription.target_type,
+                    "insight_count": insight_count,
+                    "image_count": image_count,
+                    "has_previous": has_previous,
+                    "summary_text_length": len(summary_text),
+                    "resource_type": "dashboard" if subscription.dashboard_id else "insight",
+                },
+                groups={"organization": str(subscription.team.organization_id)},
+            )
+    except Exception:
+        LOGGER.warning(
+            "subscription_ai_summary_generated.capture_failed",
+            subscription_id=subscription.id,
+            exc_info=True,
+        )
+
+
 def _load_insight_images(exported_asset_ids: list[int], team_id: int) -> dict[int, bytes]:
     if not exported_asset_ids:
         return {}
@@ -394,6 +443,16 @@ async def _run_snapshot_subscription_insights(inputs: SnapshotInsightsInputs) ->
             subscription_id=inputs.subscription_id,
             error=error_msg,
             exc_info=True,
+        )
+
+    if summary_text is not None:
+        await database_sync_to_async(_capture_summary_generated_event, thread_sensitive=False)(
+            subscription,
+            delivery_id=inputs.delivery_id,
+            summary_text=summary_text,
+            insight_count=len(current_states),
+            image_count=len(insight_images),
+            has_previous=previous_states is not None,
         )
 
     await LOGGER.ainfo(

--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -218,25 +218,25 @@ def _capture_summary_generated_event(
     summary_text: str,
     insight_count: int,
     image_count: int,
-    has_previous: bool,
+    has_previous_snapshot: bool,
 ) -> None:
     """Fire a product analytics event when a summary has been successfully generated.
 
     Recipients aren't identifiable (email addresses, Slack channels, webhook URLs
     have no distinct_id), so we attribute the event to the subscription creator —
-    falling back to team_id when the creator has been removed. Wrapped in a broad
-    except so a capture failure can never bubble up and poison an otherwise
-    successful activity run.
+    falling back to a `team_<id>` string when the creator has been removed so
+    system-generated deliveries don't pollute real-user counts in analytics.
+    Wrapped in a broad except so a capture failure can never bubble up and
+    poison an otherwise successful activity run.
     """
     try:
-        distinct_id = (
-            subscription.created_by.distinct_id
-            if subscription.created_by and subscription.created_by.distinct_id
-            else str(subscription.team_id)
-        )
+        if subscription.created_by and subscription.created_by.distinct_id:
+            distinct_id: str = subscription.created_by.distinct_id
+        else:
+            distinct_id = f"team_{subscription.team_id}"
         with ph_scoped_capture() as capture:
             capture(
-                distinct_id=str(distinct_id),
+                distinct_id=distinct_id,
                 event="subscription_ai_summary_generated",
                 properties={
                     "subscription_id": subscription.id,
@@ -245,7 +245,7 @@ def _capture_summary_generated_event(
                     "target_type": subscription.target_type,
                     "insight_count": insight_count,
                     "image_count": image_count,
-                    "has_previous": has_previous,
+                    "has_previous_snapshot": has_previous_snapshot,
                     "summary_text_length": len(summary_text),
                     "resource_type": "dashboard" if subscription.dashboard_id else "insight",
                 },
@@ -255,6 +255,8 @@ def _capture_summary_generated_event(
         LOGGER.warning(
             "subscription_ai_summary_generated.capture_failed",
             subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=delivery_id,
             exc_info=True,
         )
 
@@ -337,7 +339,7 @@ async def _run_snapshot_subscription_insights(inputs: SnapshotInsightsInputs) ->
     )
 
     subscription = await database_sync_to_async(
-        Subscription.objects.select_related("team__organization").get,
+        Subscription.objects.select_related("team__organization", "created_by").get,
         thread_sensitive=False,
     )(pk=inputs.subscription_id)
 
@@ -445,14 +447,14 @@ async def _run_snapshot_subscription_insights(inputs: SnapshotInsightsInputs) ->
             exc_info=True,
         )
 
-    if summary_text is not None:
+    if summary_text:
         await database_sync_to_async(_capture_summary_generated_event, thread_sensitive=False)(
             subscription,
             delivery_id=inputs.delivery_id,
             summary_text=summary_text,
             insight_count=len(current_states),
             image_count=len(insight_images),
-            has_previous=previous_states is not None,
+            has_previous_snapshot=previous_states is not None,
         )
 
     await LOGGER.ainfo(

--- a/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -52,6 +52,32 @@ def _create_delivery(subscription: Subscription, content_snapshot: dict) -> Subs
     )
 
 
+class _FakePhClient:
+    """In-memory stand-in for the real PostHog client used by `ph_scoped_capture`.
+
+    Collects every `capture(...)` kwargs dict into `self.captured` so tests can
+    assert on events without hitting the network. `shutdown` is a no-op so the
+    `with ph_scoped_capture()` context manager exits cleanly.
+    """
+
+    def __init__(self) -> None:
+        self.captured: list[dict] = []
+
+    def capture(self, **kwargs) -> None:
+        self.captured.append(kwargs)
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _install_fake_ph_client(monkeypatch) -> _FakePhClient:
+    """Mock the two seams (`is_cloud` + `get_client`) that gate `ph_scoped_capture`."""
+    client = _FakePhClient()
+    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
+    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: client)
+    return client
+
+
 async def test_skips_summary_when_org_has_not_approved_ai(team, user):
     subscription = await _create_subscription(team, user)
     await _set_ai_consent(subscription, approved=False)
@@ -146,17 +172,7 @@ async def test_captures_analytics_event_when_summary_is_generated(team, user, mo
         lambda *a, **kw: "- Pageviews is trending up",
     )
 
-    captured: list[dict] = []
-
-    class _FakeClient:
-        def capture(self, **kwargs):
-            captured.append(kwargs)
-
-        def shutdown(self):
-            pass
-
-    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
-    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+    fake_client = _install_fake_ph_client(monkeypatch)
 
     await _run(
         SnapshotInsightsInputs(
@@ -166,8 +182,8 @@ async def test_captures_analytics_event_when_summary_is_generated(team, user, mo
         )
     )
 
-    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
-    assert len(events) == 1, f"expected one capture, got {captured}"
+    events = [c for c in fake_client.captured if c.get("event") == "subscription_ai_summary_generated"]
+    assert len(events) == 1, f"expected one capture, got {fake_client.captured}"
     event = events[0]
     assert event["distinct_id"] == str(user.distinct_id)
     props = event["properties"]
@@ -186,17 +202,7 @@ async def test_does_not_capture_analytics_event_when_summary_skipped(team, user,
     subscription = await _create_subscription(team, user, summary_enabled=False)
     await _set_ai_consent(subscription, approved=True)
 
-    captured: list[dict] = []
-
-    class _FakeClient:
-        def capture(self, **kwargs):
-            captured.append(kwargs)
-
-        def shutdown(self):
-            pass
-
-    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
-    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+    fake_client = _install_fake_ph_client(monkeypatch)
 
     await _run(
         SnapshotInsightsInputs(
@@ -206,7 +212,7 @@ async def test_does_not_capture_analytics_event_when_summary_skipped(team, user,
         )
     )
 
-    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    events = [c for c in fake_client.captured if c.get("event") == "subscription_ai_summary_generated"]
     assert events == []
 
 
@@ -231,17 +237,7 @@ async def test_does_not_capture_analytics_event_for_empty_summary(team, user, mo
         lambda *a, **kw: "",
     )
 
-    captured: list[dict] = []
-
-    class _FakeClient:
-        def capture(self, **kwargs):
-            captured.append(kwargs)
-
-        def shutdown(self):
-            pass
-
-    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
-    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+    fake_client = _install_fake_ph_client(monkeypatch)
 
     await _run(
         SnapshotInsightsInputs(
@@ -251,7 +247,7 @@ async def test_does_not_capture_analytics_event_for_empty_summary(team, user, mo
         )
     )
 
-    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    events = [c for c in fake_client.captured if c.get("event") == "subscription_ai_summary_generated"]
     assert events == [], "empty-string summaries should not count as generated"
 
 
@@ -281,17 +277,7 @@ async def test_captures_event_with_team_prefixed_distinct_id_when_no_creator(tea
         lambda *a, **kw: "- Pageviews is trending up",
     )
 
-    captured: list[dict] = []
-
-    class _FakeClient:
-        def capture(self, **kwargs):
-            captured.append(kwargs)
-
-        def shutdown(self):
-            pass
-
-    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
-    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+    fake_client = _install_fake_ph_client(monkeypatch)
 
     await _run(
         SnapshotInsightsInputs(
@@ -301,7 +287,7 @@ async def test_captures_event_with_team_prefixed_distinct_id_when_no_creator(tea
         )
     )
 
-    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    events = [c for c in fake_client.captured if c.get("event") == "subscription_ai_summary_generated"]
     assert len(events) == 1
     assert events[0]["distinct_id"] == f"team_{team.id}"
 

--- a/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -125,6 +125,91 @@ async def test_skips_summary_when_summary_not_enabled(team, user):
     assert result.summary_text is None
 
 
+async def test_captures_analytics_event_when_summary_is_generated(team, user, monkeypatch):
+    subscription = await _create_subscription(team, user)
+    await _set_ai_consent(subscription, approved=True)
+    delivery = await _create_delivery(
+        subscription,
+        {
+            "insights": [
+                {
+                    "id": subscription.insight_id,
+                    "name": "Pageviews",
+                    "query_results": {"result": [{"label": "Pageviews", "data": [1, 2, 3]}]},
+                }
+            ]
+        },
+    )
+
+    monkeypatch.setattr(
+        "posthog.temporal.subscriptions.snapshot_activities.generate_change_summary",
+        lambda *a, **kw: "- Pageviews is trending up",
+    )
+
+    captured: list[dict] = []
+
+    class _FakeClient:
+        def capture(self, **kwargs):
+            captured.append(kwargs)
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
+    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+
+    await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(delivery.id),
+        )
+    )
+
+    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    assert len(events) == 1, f"expected one capture, got {captured}"
+    event = events[0]
+    assert event["distinct_id"] == str(user.distinct_id)
+    props = event["properties"]
+    assert props["subscription_id"] == subscription.id
+    assert props["team_id"] == subscription.team_id
+    assert props["delivery_id"] == str(delivery.id)
+    assert props["target_type"] == subscription.target_type
+    assert props["insight_count"] == 1
+    assert props["image_count"] == 0
+    assert props["has_previous"] is False
+    assert props["summary_text_length"] == len("- Pageviews is trending up")
+    assert props["resource_type"] == "insight"
+
+
+async def test_does_not_capture_analytics_event_when_summary_skipped(team, user, monkeypatch):
+    subscription = await _create_subscription(team, user, summary_enabled=False)
+    await _set_ai_consent(subscription, approved=True)
+
+    captured: list[dict] = []
+
+    class _FakeClient:
+        def capture(self, **kwargs):
+            captured.append(kwargs)
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
+    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+
+    await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(uuid.uuid4()),
+        )
+    )
+
+    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    assert events == []
+
+
 async def test_unhandled_exception_is_logged_and_reraised(team, user, monkeypatch):
     subscription = await _create_subscription(team, user)
     await _set_ai_consent(subscription, approved=True)

--- a/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -177,7 +177,7 @@ async def test_captures_analytics_event_when_summary_is_generated(team, user, mo
     assert props["target_type"] == subscription.target_type
     assert props["insight_count"] == 1
     assert props["image_count"] == 0
-    assert props["has_previous"] is False
+    assert props["has_previous_snapshot"] is False
     assert props["summary_text_length"] == len("- Pageviews is trending up")
     assert props["resource_type"] == "insight"
 
@@ -208,6 +208,102 @@ async def test_does_not_capture_analytics_event_when_summary_skipped(team, user,
 
     events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
     assert events == []
+
+
+async def test_does_not_capture_analytics_event_for_empty_summary(team, user, monkeypatch):
+    subscription = await _create_subscription(team, user)
+    await _set_ai_consent(subscription, approved=True)
+    delivery = await _create_delivery(
+        subscription,
+        {
+            "insights": [
+                {
+                    "id": subscription.insight_id,
+                    "name": "Pageviews",
+                    "query_results": {"result": [{"label": "Pageviews", "data": [1, 2, 3]}]},
+                }
+            ]
+        },
+    )
+
+    monkeypatch.setattr(
+        "posthog.temporal.subscriptions.snapshot_activities.generate_change_summary",
+        lambda *a, **kw: "",
+    )
+
+    captured: list[dict] = []
+
+    class _FakeClient:
+        def capture(self, **kwargs):
+            captured.append(kwargs)
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
+    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+
+    await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(delivery.id),
+        )
+    )
+
+    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    assert events == [], "empty-string summaries should not count as generated"
+
+
+async def test_captures_event_with_team_prefixed_distinct_id_when_no_creator(team, user, monkeypatch):
+    """System-generated subs without a creator get a `team_<id>` distinct_id so they don't
+    pollute real-user counts in product analytics.
+    """
+    subscription = await _create_subscription(team, user)
+    await _set_ai_consent(subscription, approved=True)
+    # Remove the creator link after creation so we hit the fallback branch.
+    await sync_to_async(Subscription.objects.filter(pk=subscription.pk).update)(created_by=None)
+    delivery = await _create_delivery(
+        subscription,
+        {
+            "insights": [
+                {
+                    "id": subscription.insight_id,
+                    "name": "Pageviews",
+                    "query_results": {"result": [{"label": "Pageviews", "data": [1, 2, 3]}]},
+                }
+            ]
+        },
+    )
+
+    monkeypatch.setattr(
+        "posthog.temporal.subscriptions.snapshot_activities.generate_change_summary",
+        lambda *a, **kw: "- Pageviews is trending up",
+    )
+
+    captured: list[dict] = []
+
+    class _FakeClient:
+        def capture(self, **kwargs):
+            captured.append(kwargs)
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr("posthog.ph_client.is_cloud", lambda: True)
+    monkeypatch.setattr("posthog.ph_client.get_client", lambda *a, **kw: _FakeClient())
+
+    await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(delivery.id),
+        )
+    )
+
+    events = [c for c in captured if c.get("event") == "subscription_ai_summary_generated"]
+    assert len(events) == 1
+    assert events[0]["distinct_id"] == f"team_{team.id}"
 
 
 async def test_unhandled_exception_is_logged_and_reraised(team, user, monkeypatch):


### PR DESCRIPTION
## Summary

Fires a `subscription_ai_summary_generated` product analytics event whenever the snapshot activity successfully produces an AI summary, so the event can be used to trigger surveys/workflows for subscription creators.

Attributed to the subscription creator's `distinct_id` (falling back to `str(team_id)` when the creator has been removed). Uses `ph_scoped_capture` per the Celery/Temporal guidance — a bare `posthoganalytics.capture` in an async worker can silently drop events when the worker exits before the background flush completes.

## Why just the creator?

Recipients are not identifiable from `subscription.target_value`:
- **Email**: raw addresses, no distinct_id mapping
- **Slack**: channel names, no per-human identity
- **Webhook**: URLs, no user concept

A proper "summary viewed" signal for recipients would need either:
- A tracking pixel + backend endpoint (blocked by many email clients, noisy)
- A "Give feedback" link in the summary block leading to a frontend landing page

Worth doing as a follow-up if the creator-side signal alone isn't enough.

## Properties

| Key | Value |
| --- | --- |
| `subscription_id` | int |
| `team_id` | int |
| `delivery_id` | uuid string, null if absent |
| `target_type` | `email` / `slack` / `webhook` |
| `insight_count` | current-delivery insights the summary covers |
| `image_count` | chart images attached to the prompt |
| `has_previous` | whether a previous-delivery comparison was available |
| `summary_text_length` | int — lets you segment by short vs long summaries |
| `resource_type` | `dashboard` or `insight` |

The summary text itself is deliberately not sent — large payloads + could contain customer-named series labels.

## Test plan

- [x] `test_captures_analytics_event_when_summary_is_generated` — asserts the capture call fires with the expected distinct_id + properties
- [x] `test_does_not_capture_analytics_event_when_summary_skipped` — asserts no capture when `summary_enabled=False`
- [x] Existing 4 tests in `test_snapshot_ai_consent.py` still pass (6/6 total)
- [x] Capture is wrapped in its own `try/except` that logs and swallows — a capture failure can't break a successful activity run

## LLM context

For Paul: this lets you key surveys to `distinct_id == subscription.created_by.distinct_id AND event = subscription_ai_summary_generated AND properties.target_type = slack` etc. A viewer-side event is a separate piece of work and is called out explicitly as a follow-up in the commit body.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*