### PR TITLE
feat(integrations): add role external references api

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -149,6 +149,7 @@ from . import (
     query,
     quick_filters,
     resource_transfer,
+    role_external_reference,
     scheduled_change,
     schema_property_group,
     search,
@@ -697,6 +698,12 @@ organizations_router.register(
     r"resource_transfers",
     resource_transfer.ResourceTransferViewSet,
     "organization_resource_transfers",
+    ["organization_id"],
+)
+organizations_router.register(
+    r"role_external_references",
+    role_external_reference.RoleExternalReferenceViewSet,
+    "organization_role_external_references",
     ["organization_id"],
 )
 organizations_router.register(

--- a/posthog/api/role_external_reference.py
+++ b/posthog/api/role_external_reference.py
@@ -1,0 +1,160 @@
+from typing import Any
+
+from django.db.models import Q, QuerySet
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import mixins, serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.shared import UserBasicSerializer
+from posthog.models.role_external_reference import RoleExternalReference
+from posthog.permissions import OrganizationAdminWritePermissions, TimeSensitiveActionPermission
+
+from ee.models.rbac.role import Role
+
+
+class RoleExternalReferenceSerializer(serializers.ModelSerializer):
+    created_by = UserBasicSerializer(read_only=True)
+    role = serializers.PrimaryKeyRelatedField(
+        queryset=Role.objects.none(),
+        help_text="PostHog role UUID this external role maps to.",
+    )
+
+    class Meta:
+        model = RoleExternalReference
+        fields = [
+            "id",
+            "provider",
+            "provider_organization_id",
+            "provider_role_id",
+            "provider_role_slug",
+            "provider_role_name",
+            "role",
+            "created_at",
+            "created_by",
+        ]
+        read_only_fields = ["id", "created_at", "created_by"]
+        extra_kwargs = {
+            "provider": {"help_text": "Integration kind (e.g., github, linear, jira, slack)."},
+            "provider_organization_id": {"help_text": "Provider organization/workspace/site identifier."},
+            "provider_role_id": {"help_text": "Stable provider role identifier."},
+            "provider_role_slug": {"help_text": "Human-friendly provider role identifier."},
+            "provider_role_name": {"help_text": "Display name of the provider role."},
+        }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        view = self.context.get("view")
+        if view and hasattr(view, "organization"):
+            self.fields["role"].queryset = Role.objects.filter(organization=view.organization)
+
+    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+        organization = self.context["view"].organization
+        provider = data.get("provider", "")
+        provider_organization_id = data.get("provider_organization_id", "")
+
+        provider_role_slug = data.get("provider_role_slug", "")
+        if provider_role_slug:
+            slug_conflict = RoleExternalReference.objects.filter(
+                organization=organization,
+                provider=provider,
+                provider_organization_id__iexact=provider_organization_id,
+                provider_role_slug__iexact=provider_role_slug,
+            ).exists()
+            if slug_conflict:
+                raise serializers.ValidationError(
+                    "A role external reference with this provider, organization, and role slug already exists."
+                )
+
+        provider_role_id = data.get("provider_role_id", "")
+        if provider_role_id:
+            id_conflict = RoleExternalReference.objects.filter(
+                organization=organization,
+                provider=provider,
+                provider_organization_id__iexact=provider_organization_id,
+                provider_role_id__iexact=provider_role_id,
+            ).exists()
+            if id_conflict:
+                raise serializers.ValidationError(
+                    "A role external reference with this provider, organization, and role ID already exists."
+                )
+
+        return data
+
+    def create(self, validated_data: dict[str, Any]) -> RoleExternalReference:
+        validated_data["organization"] = self.context["view"].organization
+        validated_data["created_by"] = self.context["request"].user
+        return super().create(validated_data)
+
+
+class RoleLookupQuerySerializer(serializers.Serializer):
+    provider = serializers.CharField(help_text="Integration kind (e.g., github, linear, jira, slack).")
+    provider_organization_id = serializers.CharField(help_text="Provider organization/workspace/site identifier.")
+    provider_role_slug = serializers.CharField(required=False, help_text="Human-friendly provider role identifier.")
+    provider_role_id = serializers.CharField(required=False, help_text="Stable provider role identifier.")
+
+    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+        if not data.get("provider_role_slug") and not data.get("provider_role_id"):
+            raise serializers.ValidationError("Either provider_role_slug or provider_role_id must be provided.")
+        return data
+
+
+class RoleLookupResponseSerializer(serializers.Serializer):
+    reference = RoleExternalReferenceSerializer(
+        allow_null=True, help_text="Matching reference, or null if none exists."
+    )
+
+
+@extend_schema(tags=["integrations"])
+class RoleExternalReferenceViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "organization"
+    serializer_class = RoleExternalReferenceSerializer
+    queryset = RoleExternalReference.objects.select_related("created_by", "role").all()
+    permission_classes = [OrganizationAdminWritePermissions, TimeSensitiveActionPermission]
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        provider = self.request.query_params.get("provider")
+        if provider:
+            queryset = queryset.filter(provider=provider)
+
+        provider_organization_id = self.request.query_params.get("provider_organization_id")
+        if provider_organization_id:
+            queryset = queryset.filter(provider_organization_id__iexact=provider_organization_id)
+
+        role_id = self.request.query_params.get("role_id")
+        if role_id:
+            queryset = queryset.filter(role_id=role_id)
+
+        return queryset.order_by("provider", "provider_organization_id", "provider_role_slug")
+
+    @extend_schema(parameters=[RoleLookupQuerySerializer], responses={200: RoleLookupResponseSerializer})
+    @action(detail=False, methods=["GET"], url_path="lookup")
+    def lookup(self, request: Request, **kwargs: Any) -> Response:
+        query = RoleLookupQuerySerializer(data=request.query_params)
+        query.is_valid(raise_exception=True)
+
+        base_q = Q(
+            organization=self.organization,
+            provider=query.validated_data["provider"],
+            provider_organization_id__iexact=query.validated_data["provider_organization_id"],
+        )
+
+        match_q = Q()
+        if query.validated_data.get("provider_role_slug"):
+            match_q |= Q(provider_role_slug__iexact=query.validated_data["provider_role_slug"])
+        if query.validated_data.get("provider_role_id"):
+            match_q |= Q(provider_role_id__iexact=query.validated_data["provider_role_id"])
+
+        reference = RoleExternalReference.objects.filter(base_q & match_q).select_related("created_by", "role").first()
+
+        serializer = RoleExternalReferenceSerializer(reference) if reference else None
+        return Response({"reference": serializer.data if serializer else None})

--- a/posthog/api/role_external_reference.py
+++ b/posthog/api/role_external_reference.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 from django.db import IntegrityError
 from django.db.models import Q, QuerySet
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.scoped_related_fields import OrgScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
 from posthog.models.role_external_reference import RoleExternalReference
 from posthog.permissions import OrganizationAdminWritePermissions, TimeSensitiveActionPermission
@@ -17,10 +18,14 @@ from posthog.permissions import OrganizationAdminWritePermissions, TimeSensitive
 from ee.models.rbac.role import Role
 
 
+class OrganizationRoleScopedPrimaryKeyRelatedField(OrgScopedPrimaryKeyRelatedField):
+    scope_field = "organization"
+
+
 class RoleExternalReferenceSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
-    role = serializers.PrimaryKeyRelatedField(
-        queryset=Role.objects.none(),
+    role = OrganizationRoleScopedPrimaryKeyRelatedField(
+        queryset=Role.objects.all(),
         help_text="PostHog role UUID this external role maps to.",
     )
 
@@ -45,13 +50,6 @@ class RoleExternalReferenceSerializer(serializers.ModelSerializer):
             "provider_role_slug": {"help_text": "Human-friendly provider role identifier."},
             "provider_role_name": {"help_text": "Display name of the provider role."},
         }
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        view = self.context.get("view")
-        if view and hasattr(view, "organization"):
-            role_field = cast(serializers.PrimaryKeyRelatedField, self.fields["role"])
-            role_field.queryset = Role.objects.filter(organization=view.organization)
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         organization = self.context["view"].organization

--- a/posthog/api/role_external_reference.py
+++ b/posthog/api/role_external_reference.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from django.db.models import Q, QuerySet
 
@@ -49,7 +49,8 @@ class RoleExternalReferenceSerializer(serializers.ModelSerializer):
         super().__init__(*args, **kwargs)
         view = self.context.get("view")
         if view and hasattr(view, "organization"):
-            self.fields["role"].queryset = Role.objects.filter(organization=view.organization)
+            role_field = cast(serializers.PrimaryKeyRelatedField, self.fields["role"])
+            role_field.queryset = Role.objects.filter(organization=view.organization)
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         organization = self.context["view"].organization

--- a/posthog/api/role_external_reference.py
+++ b/posthog/api/role_external_reference.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
 
+from django.db import IntegrityError
 from django.db.models import Q, QuerySet
 
 from drf_spectacular.utils import extend_schema
@@ -88,7 +89,12 @@ class RoleExternalReferenceSerializer(serializers.ModelSerializer):
     def create(self, validated_data: dict[str, Any]) -> RoleExternalReference:
         validated_data["organization"] = self.context["view"].organization
         validated_data["created_by"] = self.context["request"].user
-        return super().create(validated_data)
+        try:
+            return super().create(validated_data)
+        except IntegrityError as err:
+            raise serializers.ValidationError(
+                "A role external reference with this provider, organization, and role identifier already exists."
+            ) from err
 
 
 class RoleLookupQuerySerializer(serializers.Serializer):
@@ -157,5 +163,5 @@ class RoleExternalReferenceViewSet(
 
         reference = RoleExternalReference.objects.filter(base_q & match_q).select_related("created_by", "role").first()
 
-        serializer = RoleExternalReferenceSerializer(reference) if reference else None
+        serializer = self.get_serializer(reference) if reference else None
         return Response({"reference": serializer.data if serializer else None})

--- a/posthog/api/test/test_role_external_reference.py
+++ b/posthog/api/test/test_role_external_reference.py
@@ -80,7 +80,6 @@ class TestRoleExternalReferenceAPI(APILicensedTest):
     @parameterized.expand(
         [
             ({"provider_role_slug": "other-team"},),
-            ({"provider_role_slug": "other-team", "provider_role_id": "12345"},),
         ]
     )
     def test_unique_constraint_on_role_id(self, overrides: dict[str, str]) -> None:

--- a/posthog/api/test/test_role_external_reference.py
+++ b/posthog/api/test/test_role_external_reference.py
@@ -77,14 +77,9 @@ class TestRoleExternalReferenceAPI(APILicensedTest):
         response = self._create_reference(**overrides)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @parameterized.expand(
-        [
-            ({"provider_role_slug": "other-team"},),
-        ]
-    )
-    def test_unique_constraint_on_role_id(self, overrides: dict[str, str]) -> None:
+    def test_unique_constraint_on_role_id(self) -> None:
         self._create_reference()
-        response = self._create_reference(**overrides)
+        response = self._create_reference(provider_role_slug="other-team")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 

--- a/posthog/api/test/test_role_external_reference.py
+++ b/posthog/api/test/test_role_external_reference.py
@@ -1,0 +1,172 @@
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.role_external_reference import RoleExternalReference
+
+from ee.api.test.base import APILicensedTest
+from ee.models.rbac.role import Role
+
+
+class TestRoleExternalReferenceAPI(APILicensedTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        self.role = Role.objects.create(name="Frontend", organization=self.organization)
+
+    def _base_url(self, org_id: str | None = None) -> str:
+        selected_org_id = org_id or str(self.organization.id)
+        return f"/api/organizations/{selected_org_id}/role_external_references"
+
+    def _create_reference(self, **overrides: str):
+        payload = {
+            "provider": "github",
+            "provider_organization_id": "posthog",
+            "provider_role_id": "12345",
+            "provider_role_slug": "frontend-team",
+            "provider_role_name": "Frontend Team",
+            "role": str(self.role.id),
+            **overrides,
+        }
+        return self.client.post(f"{self._base_url()}/", payload)
+
+    def test_create_list_delete(self) -> None:
+        create_response = self._create_reference()
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+
+        list_response = self.client.get(f"{self._base_url()}/")
+        self.assertEqual(list_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(list_response.json()["results"]), 1)
+
+        reference_id = create_response.json()["id"]
+        delete_response = self.client.delete(f"{self._base_url()}/{reference_id}/")
+        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(RoleExternalReference.objects.filter(id=reference_id).exists())
+
+    @parameterized.expand(
+        [
+            ("provider_role_slug=frontend-team", "provider_role_slug", "frontend-team"),
+            ("provider_role_id=12345", "provider_role_id", "12345"),
+        ]
+    )
+    def test_lookup(self, query_string: str, expected_key: str, expected_value: str) -> None:
+        self._create_reference()
+        response = self.client.get(
+            f"{self._base_url()}/lookup/?provider=github&provider_organization_id=posthog&{query_string}"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(response.json()["reference"])
+        self.assertEqual(response.json()["reference"][expected_key], expected_value)
+
+    def test_lookup_requires_identifier(self) -> None:
+        response = self.client.get(f"{self._base_url()}/lookup/?provider=github&provider_organization_id=posthog")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand(
+        [
+            ({"provider_role_id": "67890"},),
+            ({"provider_role_slug": "Frontend-Team", "provider_organization_id": "PostHog"},),
+        ]
+    )
+    def test_unique_constraint_on_role_slug(self, overrides: dict[str, str]) -> None:
+        self._create_reference()
+        response = self._create_reference(**overrides)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand(
+        [
+            ({"provider_role_slug": "other-team"},),
+            ({"provider_role_slug": "other-team", "provider_role_id": "12345"},),
+        ]
+    )
+    def test_unique_constraint_on_role_id(self, overrides: dict[str, str]) -> None:
+        self._create_reference()
+        response = self._create_reference(**overrides)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestRoleExternalReferencePermissions(APILicensedTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.role = Role.objects.create(name="Frontend", organization=self.organization)
+
+    def _base_url(self) -> str:
+        return f"/api/organizations/{self.organization.id}/role_external_references"
+
+    def test_member_can_list(self) -> None:
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.get(f"{self._base_url()}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_member_cannot_create(self) -> None:
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.post(
+            f"{self._base_url()}/",
+            {
+                "provider": "github",
+                "provider_organization_id": "posthog",
+                "provider_role_id": "12345",
+                "provider_role_slug": "frontend-team",
+                "provider_role_name": "Frontend Team",
+                "role": str(self.role.id),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TestRoleExternalReferenceCrossOrgIsolation(APILicensedTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.org_a = self.organization
+        self.role_a = Role.objects.create(name="Role A", organization=self.org_a)
+
+        self.org_b = Organization.objects.create(name="Org B")
+        self.org_b.update_available_product_features()
+        self.org_b.save()
+        self.role_b = Role.objects.create(name="Role B", organization=self.org_b)
+
+        self.ref_a = RoleExternalReference.objects.create(
+            organization=self.org_a,
+            role=self.role_a,
+            provider="github",
+            provider_organization_id="posthog",
+            provider_role_id="111",
+            provider_role_slug="team-a",
+            provider_role_name="Team A",
+            created_by=self.user,
+        )
+        self.ref_b = RoleExternalReference.objects.create(
+            organization=self.org_b,
+            role=self.role_b,
+            provider="github",
+            provider_organization_id="posthog",
+            provider_role_id="222",
+            provider_role_slug="team-b",
+            provider_role_name="Team B",
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+    def test_list_only_returns_current_org_references(self) -> None:
+        response = self.client.get(f"/api/organizations/{self.org_a.id}/role_external_references/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 1)
+        self.assertEqual(response.json()["results"][0]["id"], str(self.ref_a.id))
+
+    def test_cannot_delete_reference_from_other_org(self) -> None:
+        response = self.client.delete(f"/api/organizations/{self.org_a.id}/role_external_references/{self.ref_b.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -104,6 +104,54 @@ export interface OrganizationIntegrationApi {
     readonly created_by: UserBasicApi
 }
 
+export interface RoleExternalReferenceApi {
+    readonly id: string
+    /**
+     * Integration kind (e.g., github, linear, jira, slack).
+     * @maxLength 32
+     */
+    provider: string
+    /**
+     * Provider organization/workspace/site identifier.
+     * @maxLength 255
+     */
+    provider_organization_id: string
+    /**
+     * Stable provider role identifier.
+     * @maxLength 255
+     */
+    provider_role_id: string
+    /**
+     * Human-friendly provider role identifier.
+     * @maxLength 255
+     * @nullable
+     */
+    provider_role_slug?: string | null
+    /**
+     * Display name of the provider role.
+     * @maxLength 255
+     */
+    provider_role_name: string
+    /** PostHog role UUID this external role maps to. */
+    role: string
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+}
+
+export interface PaginatedRoleExternalReferenceListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: RoleExternalReferenceApi[]
+}
+
+export interface RoleLookupResponseApi {
+    /** Matching reference, or null if none exists. */
+    reference: RoleExternalReferenceApi | null
+}
+
 /**
  * * `slack` - Slack
  * `slack-posthog-code` - Slack Posthog Code
@@ -237,6 +285,40 @@ export interface GitHubReposResponseApi {
 export interface GitHubReposRefreshResponseApi {
     /** The refreshed repository cache. */
     repositories: GitHubRepoApi[]
+}
+
+export type RoleExternalReferencesListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type RoleExternalReferencesLookupRetrieveParams = {
+    /**
+     * Integration kind (e.g., github, linear, jira, slack).
+     * @minLength 1
+     */
+    provider: string
+    /**
+     * Provider organization/workspace/site identifier.
+     * @minLength 1
+     */
+    provider_organization_id: string
+    /**
+     * Stable provider role identifier.
+     * @minLength 1
+     */
+    provider_role_id?: string
+    /**
+     * Human-friendly provider role identifier.
+     * @minLength 1
+     */
+    provider_role_slug?: string
 }
 
 export type IntegrationsListParams = {

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -18,8 +18,13 @@ import type {
     IntegrationsListParams,
     OrganizationIntegrationApi,
     PaginatedIntegrationConfigListApi,
+    PaginatedRoleExternalReferenceListApi,
     PatchedIntegrationConfigApi,
     PatchedOrganizationIntegrationApi,
+    RoleExternalReferenceApi,
+    RoleExternalReferencesListParams,
+    RoleExternalReferencesLookupRetrieveParams,
+    RoleLookupResponseApi,
 } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
@@ -68,6 +73,95 @@ export const integrationsEnvironmentMappingPartialUpdate = async (
             body: JSON.stringify(patchedOrganizationIntegrationApi),
         }
     )
+}
+
+export const getRoleExternalReferencesListUrl = (organizationId: string, params?: RoleExternalReferencesListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/organizations/${organizationId}/role_external_references/?${stringifiedParams}`
+        : `/api/organizations/${organizationId}/role_external_references/`
+}
+
+export const roleExternalReferencesList = async (
+    organizationId: string,
+    params?: RoleExternalReferencesListParams,
+    options?: RequestInit
+): Promise<PaginatedRoleExternalReferenceListApi> => {
+    return apiMutator<PaginatedRoleExternalReferenceListApi>(getRoleExternalReferencesListUrl(organizationId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getRoleExternalReferencesCreateUrl = (organizationId: string) => {
+    return `/api/organizations/${organizationId}/role_external_references/`
+}
+
+export const roleExternalReferencesCreate = async (
+    organizationId: string,
+    roleExternalReferenceApi: NonReadonly<RoleExternalReferenceApi>,
+    options?: RequestInit
+): Promise<RoleExternalReferenceApi> => {
+    return apiMutator<RoleExternalReferenceApi>(getRoleExternalReferencesCreateUrl(organizationId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(roleExternalReferenceApi),
+    })
+}
+
+export const getRoleExternalReferencesDestroyUrl = (organizationId: string, id: string) => {
+    return `/api/organizations/${organizationId}/role_external_references/${id}/`
+}
+
+export const roleExternalReferencesDestroy = async (
+    organizationId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getRoleExternalReferencesDestroyUrl(organizationId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getRoleExternalReferencesLookupRetrieveUrl = (
+    organizationId: string,
+    params: RoleExternalReferencesLookupRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/organizations/${organizationId}/role_external_references/lookup/?${stringifiedParams}`
+        : `/api/organizations/${organizationId}/role_external_references/lookup/`
+}
+
+export const roleExternalReferencesLookupRetrieve = async (
+    organizationId: string,
+    params: RoleExternalReferencesLookupRetrieveParams,
+    options?: RequestInit
+): Promise<RoleLookupResponseApi> => {
+    return apiMutator<RoleLookupResponseApi>(getRoleExternalReferencesLookupRetrieveUrl(organizationId, params), {
+        ...options,
+        method: 'GET',
+    })
 }
 
 export const getIntegrationsListUrl = (projectId: string, params?: IntegrationsListParams) => {

--- a/products/integrations/frontend/generated/api.zod.ts
+++ b/products/integrations/frontend/generated/api.zod.ts
@@ -23,6 +23,41 @@ export const IntegrationsEnvironmentMappingPartialUpdateBody = /* @__PURE__ */ z
     .object({})
     .describe('Serializer for organization-level integrations.')
 
+export const roleExternalReferencesCreateBodyProviderMax = 32
+
+export const roleExternalReferencesCreateBodyProviderOrganizationIdMax = 255
+
+export const roleExternalReferencesCreateBodyProviderRoleIdMax = 255
+
+export const roleExternalReferencesCreateBodyProviderRoleSlugMax = 255
+
+export const roleExternalReferencesCreateBodyProviderRoleNameMax = 255
+
+export const RoleExternalReferencesCreateBody = /* @__PURE__ */ zod.object({
+    provider: zod
+        .string()
+        .max(roleExternalReferencesCreateBodyProviderMax)
+        .describe('Integration kind (e.g., github, linear, jira, slack).'),
+    provider_organization_id: zod
+        .string()
+        .max(roleExternalReferencesCreateBodyProviderOrganizationIdMax)
+        .describe('Provider organization/workspace/site identifier.'),
+    provider_role_id: zod
+        .string()
+        .max(roleExternalReferencesCreateBodyProviderRoleIdMax)
+        .describe('Stable provider role identifier.'),
+    provider_role_slug: zod
+        .string()
+        .max(roleExternalReferencesCreateBodyProviderRoleSlugMax)
+        .nullish()
+        .describe('Human-friendly provider role identifier.'),
+    provider_role_name: zod
+        .string()
+        .max(roleExternalReferencesCreateBodyProviderRoleNameMax)
+        .describe('Display name of the provider role.'),
+    role: zod.uuid().describe('PostHog role UUID this external role maps to.'),
+})
+
 export const IntegrationsCreateBody = /* @__PURE__ */ zod
     .object({
         kind: zod

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -114,3 +114,15 @@ tools:
     integrations-github-repos-refresh-create:
         operation: integrations_github_repos_refresh_create
         enabled: false
+    role-external-references-list:
+        operation: role_external_references_list
+        enabled: false
+    role-external-references-create:
+        operation: role_external_references_create
+        enabled: false
+    role-external-references-destroy:
+        operation: role_external_references_destroy
+        enabled: false
+    role-external-references-lookup-retrieve:
+        operation: role_external_references_lookup_retrieve
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23461,6 +23461,49 @@ export namespace Schemas {
       results: ReviewQueue[];
     }
 
+    export interface RoleExternalReference {
+      readonly id: string;
+      /**
+       * Integration kind (e.g., github, linear, jira, slack).
+       * @maxLength 32
+       */
+      provider: string;
+      /**
+       * Provider organization/workspace/site identifier.
+       * @maxLength 255
+       */
+      provider_organization_id: string;
+      /**
+       * Stable provider role identifier.
+       * @maxLength 255
+       */
+      provider_role_id: string;
+      /**
+       * Human-friendly provider role identifier.
+       * @maxLength 255
+       * @nullable
+       */
+      provider_role_slug?: string | null;
+      /**
+       * Display name of the provider role.
+       * @maxLength 255
+       */
+      provider_role_name: string;
+      /** PostHog role UUID this external role maps to. */
+      role: string;
+      readonly created_at: string;
+      readonly created_by: UserBasic;
+    }
+
+    export interface PaginatedRoleExternalReferenceList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: RoleExternalReference[];
+    }
+
     export type RoleMembersItem = {[key: string]: unknown};
 
     export interface Role {
@@ -34538,6 +34581,11 @@ export namespace Schemas {
       stale: number;
     }
 
+    export interface RoleLookupResponse {
+      /** Matching reference, or null if none exists. */
+      reference: RoleExternalReference | null;
+    }
+
     export interface RunInsightsResponse {
       /** Results for each insight tile on the dashboard. */
       results: DashboardTileResult[];
@@ -39932,6 +39980,40 @@ export namespace Schemas {
      * A search term.
      */
     search?: string;
+    };
+
+    export type RoleExternalReferencesListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type RoleExternalReferencesLookupRetrieveParams = {
+    /**
+     * Integration kind (e.g., github, linear, jira, slack).
+     * @minLength 1
+     */
+    provider: string;
+    /**
+     * Provider organization/workspace/site identifier.
+     * @minLength 1
+     */
+    provider_organization_id: string;
+    /**
+     * Stable provider role identifier.
+     * @minLength 1
+     */
+    provider_role_id?: string;
+    /**
+     * Human-friendly provider role identifier.
+     * @minLength 1
+     */
+    provider_role_slug?: string;
     };
 
     export type RolesListParams = {


### PR DESCRIPTION
## Problem

Organization admins need an API to create and list mappings between external provider roles and PostHog roles so role mappings can be managed centrally per organization.

## Changes

- add a new RoleExternalReference API viewset with list/create/destroy and lookup actions
- register organization-scoped routing for /api/organizations/:id/role_external_references
- add serializer-level uniqueness validation for provider role slug and provider role ID
- add API tests for CRUD flow, lookup behavior, uniqueness, permissions, and cross-organization isolation

## How did you test this code?

- added automated API tests in posthog/api/test/test_role_external_reference.py
- verified module syntax with python3 -m py_compile on the new API and test files

Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update required.

## LLM context

Authored with the runtime agent. Implemented DRF endpoint, routing, and tests, then ran code-level validation.
