### PR TITLE
chore: tag async migrations queries with product/feature

### DIFF
--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -9,6 +9,7 @@ from semantic_version.base import Version
 
 from posthog.async_migrations.runner import complete_migration, is_migration_dependency_fulfilled, start_async_migration
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS, setup_async_migrations, setup_model
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.constants import FROZEN_POSTHOG_VERSION
 from posthog.models.async_migration import (
     AsyncMigration,
@@ -58,17 +59,18 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        setup_async_migrations(ignore_posthog_version=True)
-        necessary_migrations = get_necessary_migrations()
+        with tags_context(product=Product.INTERNAL, feature=Feature.MIGRATION):
+            setup_async_migrations(ignore_posthog_version=True)
+            necessary_migrations = get_necessary_migrations()
 
-        if options["check"]:
-            handle_check(necessary_migrations)
-        elif options["plan"]:
-            handle_plan(necessary_migrations)
-        elif options["complete_noop_migrations"]:
-            handle_complete_noop_migrations()
-        else:
-            handle_run(necessary_migrations)
+            if options["check"]:
+                handle_check(necessary_migrations)
+            elif options["plan"]:
+                handle_plan(necessary_migrations)
+            elif options["complete_noop_migrations"]:
+                handle_complete_noop_migrations()
+            else:
+                handle_run(necessary_migrations)
 
 
 def handle_check(necessary_migrations: Sequence[AsyncMigration]):


### PR DESCRIPTION
## Problem

Running the `run_async_migrations` management command locally raises `UntaggedQueryError` because several ClickHouse queries issued during migration setup, `is_required()` / `precheck` / `healthcheck` / `progress` checks, and ad-hoc helpers inside individual migrations (e.g. `0010_move_old_partitions._get_partitions_to_move`) don't set the `product` or `feature` query tags. In DEBUG mode `sync_execute` now fails fast on missing tags.

## Changes

Wrap the `run_async_migrations` command's `handle` in `tags_context(product=Product.INTERNAL, feature=Feature.MIGRATION)` so every ClickHouse query triggered during the command (setup, plan, check, complete-noop, run) inherits product/feature tags. Uses the existing `Feature.MIGRATION` value that was recently added to the enum.

## How did you test this code?

- No new automated tests; existing `posthog/management/commands/test/test_run_async_migrations.py` covers the happy paths.
- Agent-authored: I have not run the command manually in a local DEBUG environment.

## Publish to changelog?

no

## 🤖 LLM context

Authored by [PostHog Code](https://posthog.com/code?ref=pr). The fix is scoped to the CLI entry point; the Celery task entry point (`posthog/tasks/async_migrations.py`) is not covered in this PR — happy to extend if desired.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*