### PR TITLE
chore: update iOS onboarding project token snippets

### DIFF
--- a/docs/onboarding/error-tracking/ios.tsx
+++ b/docs/onboarding/error-tracking/ios.tsx
@@ -7,8 +7,8 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     const installSteps = getIOSStepsPA(ctx, {
-        minVersionPod: '3.50',
-        minVersionSPM: '3.50.0',
+        minVersionPod: '3.56',
+        minVersionSPM: '3.56.0',
     })
 
     const exceptionAutocaptureStep: StepDefinition = {
@@ -49,7 +49,7 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                               import PostHog
 
                               let config = PostHogConfig(
-                                  apiKey: "<ph_project_token>",
+                                  projectToken: "<ph_project_token>",
                                   host: "<ph_client_api_host>"
                               )
                               config.errorTrackingConfig.autoCapture = true
@@ -182,7 +182,7 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                               import PostHog
 
                               let config = PostHogConfig(
-                                  apiKey: "<ph_project_token>",
+                                  projectToken: "<ph_project_token>",
                                   host: "<ph_client_api_host>"
                               )
                               

--- a/docs/onboarding/product-analytics/ios.tsx
+++ b/docs/onboarding/product-analytics/ios.tsx
@@ -13,8 +13,8 @@ export const getIOSSteps = (
 ): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
-    const podVersion = options?.minVersionPod || '3.0'
-    const spmVersion = options?.minVersionSPM || '3.0.0'
+    const podVersion = options?.minVersionPod || '3.56'
+    const spmVersion = options?.minVersionSPM || '3.56.0'
 
     return [
         {
@@ -77,7 +77,7 @@ export const getIOSSteps = (
                                             let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
                                             let POSTHOG_HOST = "<ph_client_api_host>"
 
-                                            let config = PostHogConfig(apiKey: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
+                                            let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
                                             PostHogSDK.shared.setup(config)
 
                                             return true

--- a/docs/onboarding/session-replay/ios.tsx
+++ b/docs/onboarding/session-replay/ios.tsx
@@ -19,7 +19,7 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'ruby',
                                 file: 'Podfile',
                                 code: dedent`
-                                    pod "PostHog", "~> 3.0"
+                                    pod "PostHog", "~> 3.56"
                                 `,
                             },
                         ]}
@@ -32,7 +32,7 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 file: 'Package.swift',
                                 code: dedent`
                                     dependencies: [
-                                      .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0")
+                                      .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.56.0")
                                     ]
                                 `,
                             },
@@ -79,10 +79,10 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
 
                                     class AppDelegate: NSObject, UIApplicationDelegate {
                                         func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-                                            let POSTHOG_TOKEN = "<ph_project_token>"
+                                            let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
                                             let POSTHOG_HOST = "<ph_client_api_host>"
 
-                                            let config = PostHogConfig(apiKey: POSTHOG_TOKEN, host: POSTHOG_HOST)
+                                            let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
 
                                             // Enable session recording. Requires enabling in your project settings as well.
                                             // Default is false.

--- a/docs/onboarding/surveys/ios.tsx
+++ b/docs/onboarding/surveys/ios.tsx
@@ -27,7 +27,7 @@ function getSurveysIOSSteps(ctx: OnboardingComponentsContext): StepDefinition[] 
                                     let POSTHOG_PROJECT_TOKEN = "<ph_project_token>"
                                     // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
                                     let POSTHOG_HOST = "<ph_client_api_host>"
-                                    let config = PostHogConfig(apiKey: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST) 
+                                    let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
 
                                     // Surveys require iOS 15.0 or later
                                     if #available(iOS 15.0, *) {

--- a/docs/onboarding/web-analytics/ios.tsx
+++ b/docs/onboarding/web-analytics/ios.tsx
@@ -28,7 +28,7 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                     language: 'swift',
                                     file: 'AppDelegate.swift',
                                     code: dedent`
-                                        let config = PostHogConfig(apiKey: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
+                                        let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
                                         config.captureScreenViews = true
                                         PostHogSDK.shared.setup(config)
                                     `,

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/ios.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/ios.tsx
@@ -11,14 +11,14 @@ export interface iOSSetupProps {
 }
 
 function IOSInstallCocoaPodsSnippet(): JSX.Element {
-    return <CodeSnippet language={Language.Ruby}>{'pod "PostHog", "~> 3.0"'}</CodeSnippet>
+    return <CodeSnippet language={Language.Ruby}>{'pod "PostHog", "~> 3.56"'}</CodeSnippet>
 }
 
 function IOSInstallSPMSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.Swift}>
             {`dependencies: [
-  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0")
+  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.56.0")
 ]`}
         </CodeSnippet>
     )
@@ -57,7 +57,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let POSTHOG_PROJECT_TOKEN = "${currentTeam?.api_token}"
         let POSTHOG_HOST = "${apiHostOrigin()}"
 
-        let config = PostHogConfig(apiKey: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
+        let config = PostHogConfig(projectToken: POSTHOG_PROJECT_TOKEN, host: POSTHOG_HOST)
         ${configSection}
         PostHogSDK.shared.setup(config)
 


### PR DESCRIPTION
## Problem

The iOS onboarding snippets still used the older `apiKey:` initializer label and older SDK install version examples. The public docs were updated to use project token terminology, so the monorepo onboarding snippets should match.

## Changes

- Update iOS onboarding snippets to use `PostHogConfig(projectToken:)`.
- Rename the session replay onboarding token constant to `POSTHOG_PROJECT_TOKEN`.
- Update iOS CocoaPods install examples to `~> 3.56`, preserving the existing two-component Pod version style.
- Update iOS Swift Package Manager install examples to `from: "3.56.0"`, preserving the existing three-component SPM version style.

## How did you test this code?

- Ran `git diff --check`.
- Searched the affected iOS onboarding paths for old iOS patterns like `PostHogConfig(apiKey`, `POSTHOG_TOKEN`, old `~> 3.0` Pod snippets, and old `from: "3.0.0"` SPM snippets.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

This is a docs/onboarding snippet update.

## 🤖 LLM context

This PR was authored by an AI coding agent in the local repository checkout. The changes mirror the companion posthog.com docs update for iOS project token terminology and install versions.
