### PR TITLE
fix: Temporal logging with new AIOProducer

### DIFF
--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Any, Optional
 
 from freezegun import freeze_time
-from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory
+from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory, TickingDateTimeFactory
 from posthog.test.base import APIBaseTest, QueryMatchingTest
 
 from rest_framework import status
@@ -126,7 +126,7 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         notebook_short_id: str,
         notebook_version: int,
         the_user: User,
-        frozen_time: FrozenDateTimeFactory | StepTickTimeFactory,
+        frozen_time: FrozenDateTimeFactory | StepTickTimeFactory | TickingDateTimeFactory,
     ) -> int:
         self.client.force_login(the_user)
         for created_insight_id in created_insights[:7]:

--- a/posthog/api/test/test_my_notifications.py
+++ b/posthog/api/test/test_my_notifications.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Any, Optional
 
 from freezegun import freeze_time
-from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory
+from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory, TickingDateTimeFactory
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest
 
 from rest_framework import status
@@ -129,7 +129,7 @@ class TestMyNotifications(APIBaseTest, QueryMatchingTest):
         notebook_short_id: str,
         notebook_version: int,
         the_user: User,
-        frozen_time: FrozenDateTimeFactory | StepTickTimeFactory,
+        frozen_time: FrozenDateTimeFactory | StepTickTimeFactory | TickingDateTimeFactory,
     ) -> int:
         self.client.force_login(the_user)
         for created_insight_id in created_insights[:7]:

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -12,7 +12,8 @@ import os
 import json
 import asyncio
 import threading
-from collections.abc import Callable
+import contextlib
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Optional
@@ -332,6 +333,28 @@ class _KafkaProducer:
         self.producer.flush()
 
 
+@contextlib.contextmanager
+def ensure_loop(loop: asyncio.AbstractEventLoop | None) -> Iterator[asyncio.AbstractEventLoop]:
+    """Ensure an asyncio event loop is available.
+
+    `AIOProducer` requires a running loop when initializing, so we ensure one exists or
+    we set the `loop` provided.
+    """
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # We are being called from a sync context, must provide event loop
+        if loop is None or not loop.is_running():
+            raise
+
+        asyncio.set_event_loop(loop)
+        yield loop
+
+        asyncio.set_event_loop(None)
+    else:
+        yield running_loop
+
+
 class _AsyncKafkaProducer:
     producer: AIOProducer
     _closed: bool
@@ -340,12 +363,13 @@ class _AsyncKafkaProducer:
         self,
         kafka_hosts: list[str] | str | None = None,
         kafka_security_protocol: str | None = None,
-        sasl_mechanism: Optional[str] = None,
-        sasl_user: Optional[str] = None,
-        sasl_password: Optional[str] = None,
+        sasl_mechanism: str | None = None,
+        sasl_user: str | None = None,
+        sasl_password: str | None = None,
         max_request_size: int | None = None,
         compression_type: str | None = None,
-        producer_settings: Optional[dict[str, Any]] = None,
+        producer_settings: dict[str, Any] | None = None,
+        loop: asyncio.AbstractEventLoop | None = None,
     ):
         default_profile = settings.KAFKA_PROFILES["default"]
         if kafka_security_protocol is None:
@@ -386,7 +410,9 @@ class _AsyncKafkaProducer:
         if max_request_size:
             config["message.max.bytes"] = max_request_size
 
-        self.producer = AIOProducer(config)
+        with ensure_loop(loop):
+            self.producer = AIOProducer(config)
+
         self._closed = False
 
     @staticmethod

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -425,7 +425,6 @@ class _AsyncKafkaProducer:
         data: Any,
         key: Any = None,
         value_serializer: Callable[[Any], Any] | None = None,
-        headers: list[tuple[str, str | bytes]] | None = None,
     ) -> asyncio.Future[Any]:
         if not value_serializer:
             value_serializer = self.json_serializer
@@ -433,17 +432,11 @@ class _AsyncKafkaProducer:
         if key is not None:
             if not isinstance(key, bytes):
                 key = str(key).encode("utf-8")
-        encoded_headers: list[tuple[str, str | bytes | None]] | None = (
-            [(h[0], h[1] if isinstance(h[1], bytes) else h[1].encode("utf-8")) for h in headers]
-            if headers is not None
-            else None
-        )
 
         future = await self.producer.produce(
             topic=topic,
             value=b,
             key=key,
-            headers=encoded_headers,
         )
         return future
 

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -343,14 +343,18 @@ def ensure_loop(loop: asyncio.AbstractEventLoop | None) -> Iterator[asyncio.Abst
     try:
         running_loop = asyncio.get_running_loop()
     except RuntimeError:
-        # We are being called from a sync context, must provide event loop
+        # We are being called from a sync context, a running event loop must be provided
         if loop is None or not loop.is_running():
             raise
 
         asyncio.set_event_loop(loop)
-        yield loop
 
-        asyncio.set_event_loop(None)
+        try:
+            yield loop
+        finally:
+            # We landed here because there is no event loop running in the current
+            # thread. So, we restore it back to None.
+            asyncio.set_event_loop(None)
     else:
         yield running_loop
 

--- a/posthog/kafka_client/routing.py
+++ b/posthog/kafka_client/routing.py
@@ -16,6 +16,7 @@ Two lifecycle shapes:
   AIOProducer — caching would leave later callers with a closed instance.
 """
 
+import asyncio
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from threading import Lock
@@ -178,7 +179,9 @@ def _build_sync_producer(profile: KafkaClusterProfile) -> _KafkaProducer:
     )
 
 
-def _build_async_producer(profile: KafkaClusterProfile) -> _AsyncKafkaProducer:
+def _build_async_producer(
+    profile: KafkaClusterProfile, /, loop: asyncio.AbstractEventLoop | None = None
+) -> _AsyncKafkaProducer:
     p = settings.KAFKA_PROFILES[profile.value]
     producer_settings = p.producer_settings
     return _AsyncKafkaProducer(
@@ -190,6 +193,7 @@ def _build_async_producer(profile: KafkaClusterProfile) -> _AsyncKafkaProducer:
         max_request_size=producer_settings.get("max_request_size"),
         compression_type=producer_settings.get("compression_type"),
         producer_settings=producer_settings,
+        loop=loop,
     )
 
 
@@ -257,6 +261,7 @@ def new_async_producer(
     *,
     profile: Optional[KafkaClusterProfile] = None,
     topic: Optional[str] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> _AsyncKafkaProducer:
     """Construct a fresh async producer the caller fully owns.
 
@@ -265,7 +270,7 @@ def new_async_producer(
     it. For per-call work prefer `async_producer_scope`.
     """
     resolved = resolve_profile_name(topic=topic, profile=profile)
-    return _build_async_producer(resolved)
+    return _build_async_producer(resolved, loop=loop)
 
 
 def flush_all_producers(timeout: Optional[float] = None) -> None:

--- a/posthog/kafka_client/test/test_routing.py
+++ b/posthog/kafka_client/test/test_routing.py
@@ -44,7 +44,7 @@ def _mock_kafka_backend():
             sync_producers[profile] = MagicMock(name=f"sync_producer[{profile}]")
         return sync_producers[profile]
 
-    def async_factory(profile: KafkaClusterProfile) -> MagicMock:
+    def async_factory(profile: KafkaClusterProfile, loop=None) -> MagicMock:
         producer = MagicMock(name=f"async_producer[{profile}]")
         producer.flush = mock.AsyncMock()
         producer.close = mock.AsyncMock()
@@ -252,7 +252,7 @@ class AsyncProducerScopeTest(TestCase):
 class NewAsyncProducerTest(TestCase):
     def test_returns_fresh_instance_per_call(self):
         with _mock_kafka_backend() as (_, async_build):
-            async_build.side_effect = lambda profile: MagicMock(name=f"fresh[{profile}]")
+            async_build.side_effect = lambda profile, loop: MagicMock(name=f"fresh[{profile}]")
             first = new_async_producer(profile=KafkaClusterProfile.DEFAULT)
             second = new_async_producer(profile=KafkaClusterProfile.DEFAULT)
         self.assertIsNot(first, second)

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -682,24 +682,30 @@ class KafkaLogProducerFromQueueAsync:
     async def produce(self, msg: bytes):
         """Produce messages to configured topic and key.
 
-        We catch any exceptions so as to continue processing the queue even if the broker is unavailable
-        or we fail to produce for whatever other reason. We log the failure to not fail silently.
-        """
-        fut = await self.producer.produce(
-            topic=self.topic,
-            data=msg,
-            key=self.key,
-            value_serializer=lambda v: v,
-        )
-        fut.add_done_callback(self.mark_queue_done)
+        We catch any exceptions so as to continue processing the queue even if the
+        broker is unavailable we fail to produce for whatever other reason. We log the
+        failure to not fail silently.
 
+        Note that `self.producer.produce` may not immediately produce a message, nor do
+        we wait for the message to be fully produced here. Whether a message is produced
+        depends on the underlying producer's `batch_size` a `buffer_timeout`. To force a
+        message to be produced, call `flush()`.
+        """
         try:
-            await fut
+            fut = await self.producer.produce(
+                topic=self.topic,
+                data=msg,
+                key=self.key,
+                value_serializer=lambda v: v,
+            )
+            fut.add_done_callback(self.mark_queue_done)
+
         except Exception:
             self.logger.exception("Failed to produce log to Kafka topic %s", self.topic)
             self.logger.debug("Message that couldn't be produced to Kafka topic %s: %s", self.topic, msg)
 
     async def flush(self):
+        """Flush underlying producer, effectively producing any messages in the batch."""
         try:
             await self.producer.flush()
         except Exception:

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -698,11 +698,12 @@ class KafkaLogProducerFromQueueAsync:
                 key=self.key,
                 value_serializer=lambda v: v,
             )
-            fut.add_done_callback(self.mark_queue_done)
-
         except Exception:
+            self.mark_queue_done()
             self.logger.exception("Failed to produce log to Kafka topic %s", self.topic)
             self.logger.debug("Message that couldn't be produced to Kafka topic %s: %s", self.topic, msg)
+        else:
+            fut.add_done_callback(self.mark_queue_done)
 
     async def flush(self):
         """Flush underlying producer, effectively producing any messages in the batch."""

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -654,7 +654,7 @@ class KafkaLogProducerFromQueueAsync:
         self.queue = queue
         self.topic = topic
         self.key = key
-        self.producer = producer if producer is not None else new_async_producer(topic=topic)
+        self.producer = producer if producer is not None else new_async_producer(topic=topic, loop=loop)
         self.logger = structlog.get_logger("posthog.temporal.common.logger.KafkaLogProducerFromQueueAsync")
 
     async def listen(self):

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -475,6 +475,7 @@ def configure_logger(
     cache_logger_on_first_use: bool = True,
     loop: asyncio.AbstractEventLoop | None = None,
     file: typing.TextIO | None = None,
+    raise_on_producer_error: bool = False,
 ) -> None:
     """Configure a structlog for Temporal workflows.
 
@@ -501,6 +502,9 @@ def configure_logger(
         cache_logger_on_first_use: Set whether to cache logger for performance.
             Should always be `True` except in tests.
         loop: The loop where the aforementioned tasks will run on.
+        raise_on_producer_error: Raise any producer startup errors when `True`,
+            otherwise only log them. Set to `False` as in production environments, we
+            prefer only logging as most products can survive without logs.
     """
     base_processors: list[structlog.types.Processor] = [
         structlog.stdlib.add_log_level,
@@ -567,7 +571,10 @@ def configure_logger(
     )
 
     if log_producer is None:
-        if loop is not None:
+        if log_producer_error is not None:
+            if raise_on_producer_error:
+                raise log_producer_error
+
             logger = structlog.get_logger()
             logger.error("Failed to initialize log producer", exc_info=log_producer_error)
         return

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -484,13 +484,22 @@ def log_entries_table():
     sync_execute(TRUNCATE_LOG_ENTRIES_TABLE_SQL)
 
 
+async def wait_for_queue_entries(queue):
+    iterations = 0
+    while not queue.entries:
+        await asyncio.sleep(0)
+
+        iterations += 1
+        if iterations > 10:
+            raise TimeoutError("Timedout waiting for logs")
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "activity_environment",
     ACTIVITY_INFOS,
     indirect=True,
 )
-@freezegun.freeze_time("2024-01-01 00:00:00")
 @pytest.mark.parametrize("log_capture", [False], indirect=True)
 async def test_logger_produces_to_kafka_from_activity(activity_environment, producer, queue, log_entries_table):
     """Test whether our log entries logger produces messages to Kafka.
@@ -538,10 +547,11 @@ async def test_logger_produces_to_kafka_from_activity(activity_environment, prod
     )
 
     for activity in activities:
-        if fut := activity_environment.run(activity):
-            await fut
+        with freezegun.freeze_time("2024-01-01 00:00:00", real_asyncio=True):
+            if fut := activity_environment.run(activity):
+                await fut
 
-        await producer.flush()
+        await wait_for_queue_entries(queue)
 
         assert len(queue.entries) == 2 or len(queue.entries) == 4
 
@@ -550,6 +560,8 @@ async def test_logger_produces_to_kafka_from_activity(activity_environment, prod
 
         entries_captured = len(producer.entries)
         assert entries_captured == 2 or entries_captured == 4
+
+        await producer.flush()
 
         for _ in range(len(producer.entries)):
             entry = producer.entries.pop(0)
@@ -644,7 +656,7 @@ async def test_logger_produces_to_log_queue_from_workflow(queue):
 
     iterations = 0
     while not queue.entries:
-        await asyncio.sleep(1)
+        await asyncio.sleep(0)
 
         iterations += 1
         if iterations > 10:
@@ -666,7 +678,6 @@ async def test_logger_produces_to_log_queue_from_workflow(queue):
 
 
 @pytest.mark.django_db
-@freezegun.freeze_time("2024-01-01 00:00:00")
 @pytest.mark.parametrize("log_capture", [False], indirect=True)
 async def test_logger_produces_to_kafka_from_workflow(producer, queue, log_entries_table):
     """Test whether our log entries logger produces messages to Kafka.
@@ -691,15 +702,16 @@ async def test_logger_produces_to_kafka_from_workflow(producer, queue, log_entri
             activities=[],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            await workflow_environment.client.execute_workflow(
-                TestWorkflow.run,
-                id=workflow_id,
-                task_queue=task_queue,
-                retry_policy=RetryPolicy(maximum_attempts=1),
-                execution_timeout=dt.timedelta(seconds=5),
-            )
+            with freezegun.freeze_time("2024-01-01 00:00:00", real_asyncio=True):
+                await workflow_environment.client.execute_workflow(
+                    TestWorkflow.run,
+                    id=workflow_id,
+                    task_queue=task_queue,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=5),
+                )
 
-    await producer.flush()
+    await wait_for_queue_entries(queue)
 
     assert len(queue.entries) == 2
 
@@ -708,6 +720,8 @@ async def test_logger_produces_to_kafka_from_workflow(producer, queue, log_entri
 
     entries_captured = len(producer.entries)
     assert entries_captured == 2
+
+    await producer.flush()
 
     log_source, log_source_id = resolve_log_source("external-data-job", workflow_id)
 

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -165,6 +165,7 @@ async def configure_logger_auto(log_capture, queue, producer):
             producer=producer,
             cache_logger_on_first_use=False,
             loop=loop,
+            raise_on_producer_error=True,
         )
 
     yield

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -564,9 +564,6 @@ async def test_logger_produces_to_kafka_from_activity(activity_environment, prod
 
             assert entry["topic"] == KAFKA_LOG_ENTRIES
             assert entry["key"] is None
-            assert entry["partition"] is None
-            assert entry["timestamp_ms"] is None
-            assert entry["headers"] is None
 
             log_dict = json.loads(entry["value"].decode("utf-8"))
 
@@ -736,9 +733,6 @@ async def test_logger_produces_to_kafka_from_workflow(producer, queue, log_entri
 
         assert entry["topic"] == KAFKA_LOG_ENTRIES
         assert entry["key"] is None
-        assert entry["partition"] is None
-        assert entry["timestamp_ms"] is None
-        assert entry["headers"] is None
 
         log_dict = json.loads(entry["value"].decode("utf-8"))
 

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -93,12 +93,12 @@ class CaptureKafkaProducer:
     """Wrap a `_AsyncKafkaProducer` to captures calls to `produce`."""
 
     def __init__(self, *args, topic: str, loop: asyncio.AbstractEventLoop, **kwargs):
-        self.entries = []
+        self.entries: list[dict[str, str | bytes]] = []
         self.producer: _AsyncKafkaProducer = new_async_producer(topic=topic, loop=loop)
         self._is_closed = False
 
     async def produce(self, *, topic, data, key=None, value_serializer=None):
-        """Append an entry and delegate to aiokafka.AIOKafkaProducer."""
+        """Append an entry and delegate to `_AsyncKafkaProducer`."""
         if value_serializer is not None:
             data = value_serializer(data)
 

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -1,5 +1,4 @@
 import json
-import time
 import uuid
 import random
 import asyncio
@@ -491,6 +490,7 @@ def log_entries_table():
     ACTIVITY_INFOS,
     indirect=True,
 )
+@freezegun.freeze_time("2024-01-01 00:00:00")
 @pytest.mark.parametrize("log_capture", [False], indirect=True)
 async def test_logger_produces_to_kafka_from_activity(activity_environment, producer, queue, log_entries_table):
     """Test whether our log entries logger produces messages to Kafka.
@@ -538,18 +538,10 @@ async def test_logger_produces_to_kafka_from_activity(activity_environment, prod
     )
 
     for activity in activities:
-        with freezegun.freeze_time("2023-11-03 10:00:00.123123"):
-            if fut := activity_environment.run(activity):
-                await fut
+        if fut := activity_environment.run(activity):
+            await fut
 
-        iterations = 0
-        while not queue.entries:
-            # Let the loop run so messages have a chance to be inserted
-            await asyncio.sleep(1)
-
-            iterations += 1
-            if iterations > 10:
-                raise TimeoutError("Timedout waiting for logs")
+        await producer.flush()
 
         assert len(queue.entries) == 2 or len(queue.entries) == 4
 
@@ -573,11 +565,9 @@ async def test_logger_produces_to_kafka_from_activity(activity_environment, prod
             assert log_dict["log_source_id"] == log_source_id
             assert log_dict["message"] == "Hi! This is an external info log from an activity"
             assert log_dict["team_id"] == team_id_producer_counter
-            assert log_dict["timestamp"] == "2023-11-03 10:00:00.123123"
+            assert log_dict["timestamp"] == "2024-01-01 00:00:00.000000"
 
             team_id_producer_counter += 1
-
-        await producer.flush()
 
         results = sync_execute(
             f"SELECT instance_id, level, log_source, log_source_id, message, team_id, timestamp FROM {log_entries_table} WHERE instance_id = '{activity_environment.info.workflow_run_id}' ORDER BY team_id ASC"
@@ -602,7 +592,7 @@ async def test_logger_produces_to_kafka_from_activity(activity_environment, prod
             assert row[3] == log_source_id
             assert row[4] == "Hi! This is an external info log from an activity"
             assert row[5] == team_id_row_counter
-            assert row[6].isoformat() == "2023-11-03T10:00:00.123123+00:00"
+            assert row[6].isoformat() == "2024-01-01T00:00:00+00:00"
             team_id_row_counter += 1
 
         sync_execute(f"TRUNCATE {log_entries_table}")
@@ -709,14 +699,7 @@ async def test_logger_produces_to_kafka_from_workflow(producer, queue, log_entri
                 execution_timeout=dt.timedelta(seconds=5),
             )
 
-    iterations = 0
-    while not queue.entries:
-        # Let the loop run so messages have a chance to be inserted
-        await asyncio.sleep(1)
-
-        iterations += 1
-        if iterations > 10:
-            raise TimeoutError("Timedout waiting for logs")
+    await producer.flush()
 
     assert len(queue.entries) == 2
 
@@ -744,20 +727,17 @@ async def test_logger_produces_to_kafka_from_workflow(producer, queue, log_entri
         assert log_dict["team_id"] == FIRST_WORKFLOW_TEAM_ID + i
         assert log_dict["timestamp"] == "2024-01-01 00:00:00.000000"
 
-    await producer.flush()
+    results = sync_execute(
+        f"SELECT instance_id, level, log_source, log_source_id, message, team_id, timestamp FROM {log_entries_table} ORDER BY team_id ASC"
+    )
 
     iterations = 0
-
-    while True:
+    while not len(results) == entries_captured:
         # It may take a bit for CH to ingest.
+        await asyncio.sleep(1)
         results = sync_execute(
             f"SELECT instance_id, level, log_source, log_source_id, message, team_id, timestamp FROM {log_entries_table} ORDER BY team_id ASC"
         )
-
-        if len(results) == entries_captured:
-            break
-        else:
-            time.sleep(1)
 
         iterations += 1
         if iterations > 10:

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -13,7 +13,6 @@ import freezegun
 from django.conf import settings
 from django.test import override_settings
 
-import aiokafka
 import structlog
 import pytest_asyncio
 import temporalio.testing
@@ -30,6 +29,8 @@ from posthog.clickhouse.log_entries import (
     LOG_ENTRIES_TABLE_MV_SQL,
     TRUNCATE_LOG_ENTRIES_TABLE_SQL,
 )
+from posthog.kafka_client.client import _AsyncKafkaProducer
+from posthog.kafka_client.routing import new_async_producer
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 from posthog.temporal.common.logger import BACKGROUND_LOGGER_TASKS, configure_logger, resolve_log_source
 
@@ -90,26 +91,14 @@ async def queue():
 
 
 class CaptureKafkaProducer:
-    """A test producer matching the `_AsyncKafkaProducer` surface that captures calls to `produce`."""
+    """Wrap a `_AsyncKafkaProducer` to captures calls to `produce`."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, topic: str, loop: asyncio.AbstractEventLoop, **kwargs):
         self.entries = []
-        self._producer: None | aiokafka.AIOKafkaProducer = None
+        self.producer: _AsyncKafkaProducer = new_async_producer(topic=topic, loop=loop)
         self._is_closed = False
 
-    @property
-    def producer(self) -> aiokafka.AIOKafkaProducer:
-        if self._producer is None:
-            self._producer = aiokafka.AIOKafkaProducer(
-                bootstrap_servers=[*settings.KAFKA_PROFILES["default"].hosts, "localhost:9092"],
-                security_protocol=settings.KAFKA_PROFILES["default"].security_protocol or "PLAINTEXT",
-                acks="all",
-                request_timeout_ms=1000000,
-                api_version="2.5.0",
-            )
-        return self._producer
-
-    async def produce(self, *, topic, data, key=None, value_serializer=None, headers=None):
+    async def produce(self, *, topic, data, key=None, value_serializer=None):
         """Append an entry and delegate to aiokafka.AIOKafkaProducer."""
         if value_serializer is not None:
             data = value_serializer(data)
@@ -119,26 +108,18 @@ class CaptureKafkaProducer:
                 "topic": topic,
                 "value": data,
                 "key": key,
-                # `_AsyncKafkaProducer.produce` doesn't expose partition/timestamp_ms;
-                # kept as None so assertions from the prior aiokafka-based fixture still hold.
-                "partition": None,
-                "timestamp_ms": None,
-                "headers": headers,
             }
         )
-        if not self._is_closed and self._producer is None:
-            await self.producer.start()
-        return await self.producer.send(topic, data, key, headers=headers)
+        return await self.producer.produce(topic, data, key, value_serializer=lambda v: v)
 
     async def flush(self, timeout=None):
-        if self._producer is not None:
-            await self._producer.flush()
+        await self.producer.flush()
 
     async def close(self):
         if self._is_closed:
             return
-        if self._producer is not None:
-            await self._producer.stop()
+
+        await self.producer.close()
         self._is_closed = True
 
     @property
@@ -153,7 +134,9 @@ async def producer():
     After usage, we ensure the producer was closed to avoid leaking/warnings.
     """
     loop = asyncio.get_running_loop()
-    producer = CaptureKafkaProducer(bootstrap_servers=settings.KAFKA_PROFILES["default"].hosts, loop=loop)
+    producer = CaptureKafkaProducer(
+        topic=KAFKA_LOG_ENTRIES, bootstrap_servers=settings.KAFKA_PROFILES["default"].hosts, loop=loop
+    )
 
     yield producer
 

--- a/posthog/test/test_database_healthcheck.py
+++ b/posthog/test/test_database_healthcheck.py
@@ -34,7 +34,7 @@ class TestDatabaseHealthcheck(TestCase):
 
             self.healthcheck.is_postgres_connected_check.reset_mock()
             # 30 seconds later
-            frozen_time.tick(delta=30)  # type: ignore
+            frozen_time.tick(delta=30)
 
             self.assertTrue(self.healthcheck.is_connected())
             self.healthcheck.is_postgres_connected_check.assert_called_once()
@@ -43,7 +43,7 @@ class TestDatabaseHealthcheck(TestCase):
             self.assertEqual(self.healthcheck.last_check, 53648641)
 
             # 30 seconds later
-            frozen_time.tick(delta=30)  # type: ignore
+            frozen_time.tick(delta=30)
             self.healthcheck.is_postgres_connected_check = mock.MagicMock(return_value=False)  # type: ignore
 
             self.assertFalse(self.healthcheck.is_connected())
@@ -72,7 +72,7 @@ class TestDatabaseHealthcheck(TestCase):
             self.assertEqual(self.healthcheck.last_check, 53648640)
 
             # 30 seconds later
-            frozen_time.tick(delta=30)  # type: ignore
+            frozen_time.tick(delta=30)
 
             self.assertTrue(self.healthcheck.is_connected())
             self.healthcheck.is_postgres_connected_check.assert_called_once()

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -3,7 +3,7 @@ import datetime
 import concurrent.futures
 
 import pytest
-from freezegun import config, configure, freeze_time  # type: ignore
+from freezegun import config, configure, freeze_time
 from posthog.test.base import (
     APIBaseTest,
     BaseTest,

--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -47,7 +47,7 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
     # Skip `transformers` when freezegun walks sys.modules: it has a broken
     # lazy-import path that crashes `getattr`, leaving a partial monkey-patch
     # on `time.time` that poisons the whole process.
-    freezegun.configure(extend_ignore_list=["transformers"])  # type: ignore[attr-defined]
+    freezegun.configure(extend_ignore_list=["transformers"])
 
     from posthog.schema import HogQLFilters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ dev = [
     "fakeredis[lua]==2.23.3",
     "hypothesis~=6.151.9",
     "pytest-rerunfailures~=16.1",
-    "freezegun==1.2.2",
+    "freezegun==1.5.5",
     "grpcio-tools~=1.71.0",
     "protoletariat~=3.3.10",
     "ipython~=9.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,6 @@ dev = [
     "types-aiobotocore~=2.22.0",
     "types-boto3[essential]==1.37.6",
     "types-croniter~=6.0.0",
-    "types-freezegun==1.1.10",
     "types-markdown==3.3.9",
     "types-paramiko==3.4.0.20240423",
     "types-pymysql==1.1.0.20240524",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-16T07:27:37.174126Z"
+exclude-newer = "2026-04-17T12:53:23.844001817Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2265,14 +2265,14 @@ wheels = [
 
 [[package]]
 name = "freezegun"
-version = "1.2.2"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/97/002ac49ec52858538b4aa6f6831f83c2af562c17340bdf6043be695f39ac/freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446", size = 30670, upload-time = "2022-08-12T12:24:08.735Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/cd/ba1c8319c002727ccfa03049127218d1767232a77219924d03ba170e0601/freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f", size = 17062, upload-time = "2022-08-12T12:24:06.364Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
 ]
 
 [[package]]
@@ -5439,7 +5439,7 @@ dev = [
     { name = "djangorestframework-stubs", specifier = "~=3.16.0" },
     { name = "faker", specifier = "==17.5.0" },
     { name = "fakeredis", extras = ["lua"], specifier = "==2.23.3" },
-    { name = "freezegun", specifier = "==1.2.2" },
+    { name = "freezegun", specifier = "==1.5.5" },
     { name = "granian", extras = ["uvloop", "reload", "pname"], specifier = "==2.5.5" },
     { name = "grpcio-tools", specifier = "~=1.71.0" },
     { name = "hypothesis", specifier = "~=6.151.9" },

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-17T12:53:23.844001817Z"
+exclude-newer = "2026-04-17T13:14:51.221452705Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -5224,7 +5224,6 @@ dev = [
     { name = "types-aiobotocore" },
     { name = "types-boto3", extra = ["essential"] },
     { name = "types-croniter" },
-    { name = "types-freezegun" },
     { name = "types-markdown" },
     { name = "types-paramiko" },
     { name = "types-pymysql" },
@@ -5480,7 +5479,6 @@ dev = [
     { name = "types-aiobotocore", specifier = "~=2.22.0" },
     { name = "types-boto3", extras = ["essential"], specifier = "==1.37.6" },
     { name = "types-croniter", specifier = "~=6.0.0" },
-    { name = "types-freezegun", specifier = "==1.1.10" },
     { name = "types-markdown", specifier = "==3.3.9" },
     { name = "types-paramiko", specifier = "==3.4.0.20240423" },
     { name = "types-pymysql", specifier = "==1.1.0.20240524" },
@@ -7773,15 +7771,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/ac/7b26a9b19cc2b137293b14af71402ba83d13674c208b141474b6887465ae/types_croniter-6.0.0.20250809.tar.gz", hash = "sha256:c829295d4d65eaddcfafec905b0fbab59e72c3c91ee934a4d504dcafad79ff95", size = 11745, upload-time = "2025-08-09T03:14:10.729Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/99/e8e40592fbecb6671b32e4dab4cca2a1d4fa7d5b2f54aece134ccb42e839/types_croniter-6.0.0.20250809-py3-none-any.whl", hash = "sha256:d9f53f3e837eb6af509e2090fd2f5bb29b38425dd78f77d7b3bf37ccd2b2bf93", size = 9712, upload-time = "2025-08-09T03:14:09.966Z" },
-]
-
-[[package]]
-name = "types-freezegun"
-version = "1.1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/0d/2a0485b7f693437570da1b005cbc06748252d24a5a24e521a0bcf4f8912e/types-freezegun-1.1.10.tar.gz", hash = "sha256:cb3a2d2eee950eacbaac0673ab50499823365ceb8c655babb1544a41446409ec", size = 2861, upload-time = "2022-06-09T09:19:19.568Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/48/3380ecdafe5646f4e9e31814297073aeb6929c474212377189cbee228b50/types_freezegun-1.1.10-py3-none-any.whl", hash = "sha256:fadebe72213e0674036153366205038e1f95c8ca96deb4ef9b71ddc15413543e", size = 2904, upload-time = "2022-06-09T09:19:17.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problems

There are many:

### Missing running loop for AIOProducer

Confluent's AIOProducer requires a loop when initializing, which it
gets by calling asyncio.get_running_loop(). This means we need to be in an async context to initialize AIOProducer, which we are not: We pass a loop from the runner instead.

### Invalid headers argument passed to AIOProducer

Confluent's AIOProducer does not support a headers keyword argument to
produce: It will raise a RuntimeError just if the argument is
present (even if it's set to None). So, we should not pass one.

### Tests are not updated

Tests are still using the old aiokafka producer. This
makes them kind of pointless: They were not asserting the behavior of
the logging pipeline with the new producer, which behaves differently
to the old aiokafka producer. They are just asserting that the code before https://github.com/PostHog/posthog/pull/54702 works, which it does naturally!

### Freeze gun breaks AIOProducer

Freeze gun messes with AIOProducer's timeout function. This requires a new version of freezegun to allow asyncio event loops to run normally.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

### Missing running loop for AIOProducer

Now passing a loop down from the runner, and using a context manager to set it if necessary.

### Invalid headers argument passed to AIOProducer

I've removed the invalid argument. AFAIK it's not used.

### Tests are not updated

I've updated the tests to work with the new producer rather than the old aiokafka.

### Freeze gun breaks AIOProducer

I've updated the freezegun version.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests updated, all passing.

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
