### PR TITLE
chore(ci): add roll-up job for required sandbox image check

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -225,3 +225,39 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: |
                       BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
+
+    # Single required status check for branch protection. Add future sandbox
+    # image jobs to `needs` here rather than reconfiguring GitHub.
+    sandbox_base_image_check:
+        needs: [changes, build_skills, sandbox_base_build]
+        name: Sandbox Base Image Pass
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: always()
+        permissions: {}
+        steps:
+            - name: Check all sandbox image jobs
+              run: |
+                  # Fail if change detection itself failed
+                  if [[ "${{ needs.changes.result }}" == "failure" ]]; then
+                    echo "Change detection job failed."
+                    exit 1
+                  fi
+
+                  # Pass if build wasn't required (no relevant changes, no dispatch, no label)
+                  if [[ "${{ needs.build_skills.result }}" == "skipped" && "${{ needs.sandbox_base_build.result }}" == "skipped" ]]; then
+                    echo "Sandbox image build was skipped (no relevant changes)."
+                    exit 0
+                  fi
+
+                  if [[ "${{ needs.build_skills.result }}" != "success" && "${{ needs.build_skills.result }}" != "skipped" ]]; then
+                    echo "Agent skills build failed."
+                    exit 1
+                  fi
+
+                  if [[ "${{ needs.sandbox_base_build.result }}" != "success" && "${{ needs.sandbox_base_build.result }}" != "skipped" ]]; then
+                    echo "Sandbox base image build failed."
+                    exit 1
+                  fi
+
+                  echo "All sandbox image checks passed."


### PR DESCRIPTION
## Problem

We need our docker image for sandbox to be reliably built, let's make this required. 
