### PR TITLE
feat(insights): render trend lines in TrendsLineChart

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -444,6 +444,18 @@ snapshots:
         hash: v1.k794b7964.61cfe187b6ffb1afbbe249728e25564b649d867594361c942f272177a30a2512.DcZXxZ_ile6MrnQzOW4qcytPJNg_6XmoWp0quap7xyc
     components-hogcharts-referenceline--vertical-reference-lines--light:
         hash: v1.k794b7964.57e8def3f05c5ce3e99c0683e22615bdb04488249dc65b8ea0b7478a4808a94f.4_lE_Bg7_SUhLYhtKvMXD_yFzvqdBbC9npoDyMjFVbA
+    components-hogcharts-trendlines--multi-series-with-trend-lines--dark:
+        hash: v1.k794b7964.78033802ebf740d7ab89be2be4f2193c43a14966c0402026bd45dddbb4269396.RUWWv6pYa_wo0a1Usu3f62Wk4EvQ0rGgPfKIf3UQJDc
+    components-hogcharts-trendlines--multi-series-with-trend-lines--light:
+        hash: v1.k794b7964.ba1dd4a8fa2093e58823dbeaccea10509d588023fae750089fcd3caed6e05de2.dH5SqXb2RXB8MCVqO-0Z5rVWBUlFUbA0hlXuZjzgyao
+    components-hogcharts-trendlines--trend-line-with-incomplete-period--dark:
+        hash: v1.k794b7964.04241a23b9362ec83f80d010699220a08fbc9d3904718780fc6abf26d4a0dd4c.eUPFh_Gb0JsPkx0jz0HMEkNi0srWCh7faDntW1Uv-28
+    components-hogcharts-trendlines--trend-line-with-incomplete-period--light:
+        hash: v1.k794b7964.71a62e5f098e7ff225ee1a222242e60eafd0bceda1316b1af89254bd5fa845de.dy66a2lxQ9B2eVXUo_rUqpMSCuO24AAAiFx2LPVcD1Q
+    components-hogcharts-trendlines--with-trend-line--dark:
+        hash: v1.k794b7964.da7509fa2d50594b97da227743df5d6c8dc2fba68319cdb63e0c0a783a9e8a56.VyeZQIl63pbC3dTu5fIiBCqjLA97n2KDMSesUBp-3yc
+    components-hogcharts-trendlines--with-trend-line--light:
+        hash: v1.k794b7964.276799f30320d0d543bbad2ab88ae343d86e5bc2b6deb8e64db0c27b96beab8a.54U0eAaXpU1eM76JrzJxGfYdtTlQ3nPCHmTuv_lgwjc
     components-hogcharts-valuelabels--dual-y-axes--dark:
         hash: v1.k794b7964.90610149a5326e633baa49e9873a88386caf9d74956025d507a5acb091f4e9f6.aovJ-42i8bFRGXdJhTjYGV2tAekmSMSl2SUTDIurqN4
     components-hogcharts-valuelabels--dual-y-axes--light:
@@ -3719,7 +3731,7 @@ snapshots:
     scenes-app-experiments--experiment-with-funnel-metric--light:
         hash: v1.k794b7964.f305aeb1f57f2b5067d6ae0b812f75a63f88cf5c40d15caa863bc805664d5375.mY8pmFLkdB5pzrPDozUDx4CgAHJa6pFcvQH41UDz_FE
     scenes-app-experiments--experiment-with-legacy-funnels-query--dark:
-        hash: v1.k794b7964.644aff531876ec747a85c5099e7ddbb60ffbfd7e4f4ed28662a5146af0a26843.GYAVO2-jhLe_UkKQOnYr9myeAypZvqUiZRv5wDGbeI4
+        hash: v1.k794b7964.e395675ce6eb10390482d4523e21d63081cafdcc768e231306b83a5071f44e47.1sUPKo3i-J7YjYoUn5t_lYE1YNk-9GEVApXwLAs6Dno
     scenes-app-experiments--experiment-with-legacy-funnels-query--light:
         hash: v1.k794b7964.fabdc62ca5cb61aca244403b553abe1ffd659a21ff593b2b168d82f05239b411.7-3vcjv_cV7Ztuez1Q_QtUQoB7ZO-HkLQmATqkcUR8k
     scenes-app-experiments--experiment-with-legacy-trends-query--dark:
@@ -4285,7 +4297,7 @@ snapshots:
     scenes-app-insights-user-paths--user-paths-edit--dark:
         hash: v1.k794b7964.49cb94ded5400950ff52cfcf899a91644a5fc52315f3e3d1994c1e550b8b97aa.RY6xnm8QoMji88whvowfUqINH60aaqwoKVYiDeNgH4o
     scenes-app-insights-user-paths--user-paths-edit--light:
-        hash: v1.k794b7964.18c85f4016b260304fd26e08f6aa9b89edd3be6cf557e6218b5939c343647783.62fMBIDorfURbvudXkFEdLaZp2Tg_5JH0AtCAp77k9I
+        hash: v1.k794b7964.91454a843bd2caaa6df0eb2b179262413dcfa5d5e4204be87032fd51f59cb18f.uLjnPAzYscHzKxTzxisjDnufL-2VWnoxX-utYI3VKYw
     scenes-app-insights-worldmap--default--dark:
         hash: v1.k794b7964.6c0d91b07e971d6e0efdefe4974c303232f4fb96b3746ebfbf5aa7f460ed80ee.QIP22_VR42_X3gh1ObltZBoE5ExnX6jLulV5BQojNfA
     scenes-app-insights-worldmap--default--light:

--- a/frontend/src/lib/hog-charts/TrendLines.stories.tsx
+++ b/frontend/src/lib/hog-charts/TrendLines.stories.tsx
@@ -85,7 +85,7 @@ export const MultiSeriesWithTrendLines: Story = {
     },
 }
 
-export const TrendLineWithIncompleteperiod: Story = {
+export const TrendLineWithIncompletePeriod: Story = {
     render: () => {
         const theme = buildTheme()
         // First 5 buckets show a steady climb (fit target); last 2 are artificially low

--- a/frontend/src/lib/hog-charts/TrendLines.stories.tsx
+++ b/frontend/src/lib/hog-charts/TrendLines.stories.tsx
@@ -1,0 +1,111 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { buildTheme } from 'lib/charts/utils/theme'
+import { LineChart } from 'lib/hog-charts'
+import type { LineChartConfig, Series } from 'lib/hog-charts'
+import { trendLine } from 'lib/statistics'
+
+const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const CONFIG: LineChartConfig = {
+    showGrid: true,
+    showCrosshair: false,
+}
+
+function Stage({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ height: 280, width: 480, display: 'flex', flexDirection: 'column' }}>{children}</div>
+    )
+}
+
+function trendLineOverlay(parent: Series, fitUpTo?: number): Series {
+    return {
+        key: `${parent.key}__trendline`,
+        label: parent.label,
+        color: parent.color,
+        yAxisId: parent.yAxisId,
+        data: trendLine(parent.data, fitUpTo),
+        dashPattern: [6, 4],
+        pointRadius: 0,
+        hideFromTooltip: true,
+    }
+}
+
+const meta: Meta = {
+    title: 'Components/HogCharts/TrendLines',
+    parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const WithTrendLine: Story = {
+    render: () => {
+        const theme = buildTheme()
+        const base: Series = {
+            key: 'visits',
+            label: 'Visits',
+            color: 'var(--brand-blue)',
+            data: [20, 35, 28, 60, 45, 70, 52],
+            pointRadius: 3,
+        }
+        const series: Series[] = [base, trendLineOverlay(base)]
+        return (
+            <Stage>
+                <LineChart series={series} labels={LABELS} config={CONFIG} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const MultiSeriesWithTrendLines: Story = {
+    render: () => {
+        const theme = buildTheme()
+        const visits: Series = {
+            key: 'visits',
+            label: 'Visits',
+            color: 'var(--brand-blue)',
+            data: [40, 42, 44, 43, 55, 57, 66],
+            pointRadius: 3,
+        }
+        const signups: Series = {
+            key: 'signups',
+            label: 'Signups',
+            color: 'var(--brand-red)',
+            data: [38, 36, 30, 32, 28, 22, 18],
+            pointRadius: 3,
+        }
+        const series: Series[] = [visits, signups, trendLineOverlay(visits), trendLineOverlay(signups)]
+        return (
+            <Stage>
+                <LineChart series={series} labels={LABELS} config={CONFIG} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const TrendLineWithIncompleteperiod: Story = {
+    render: () => {
+        const theme = buildTheme()
+        // First 5 buckets show a steady climb (fit target); last 2 are artificially low
+        // because the period is still in progress — they'd pull the slope down if included.
+        const data = [20, 25, 35, 40, 50, 15, 8]
+        const dashedFromIndex = 5
+
+        const base: Series = {
+            key: 'visits',
+            label: 'Visits',
+            color: 'var(--brand-blue)',
+            data,
+            pointRadius: 3,
+            dashedFromIndex,
+        }
+        const series: Series[] = [base, trendLineOverlay(base, dashedFromIndex)]
+        return (
+            <Stage>
+                <LineChart series={series} labels={LABELS} config={CONFIG} theme={theme} />
+            </Stage>
+        )
+    },
+}

--- a/frontend/src/lib/statistics.test.ts
+++ b/frontend/src/lib/statistics.test.ts
@@ -53,10 +53,13 @@ describe('statistics', () => {
             expect(result.map((n) => n.toFixed(2))).toEqual(['1.00', '2.00', '3.00', '4.00', '5.00'])
         })
 
-        it('falls back to full fit when fitUpTo is less than 2', () => {
-            const values = [1, 2, 3, 4, 5]
+        it('falls back to 2-point fit when fitUpTo is less than 2', () => {
+            // First two points give slope -9; a full fit would give a different slope.
+            // Math.max(2, ...) clamps degenerate fitUpTo to 2, not the full length.
+            const values = [10, 1, 2, 3, 4]
             const result = trendLine(values, 1)
-            expect(result.map((n) => n.toFixed(2))).toEqual(['1.00', '2.00', '3.00', '4.00', '5.00'])
+            // m = (1-10)/(1-0) = -9, b = 10  ->  y = -9x + 10
+            expect(result.map((n) => n.toFixed(2))).toEqual(['10.00', '1.00', '-8.00', '-17.00', '-26.00'])
         })
     })
 

--- a/frontend/src/lib/statistics.test.ts
+++ b/frontend/src/lib/statistics.test.ts
@@ -44,6 +44,20 @@ describe('statistics', () => {
             const result = trendLine(values)
             expect(result).toEqual([10])
         })
+
+        it('fits only up to fitUpTo and extrapolates past it', () => {
+            // Clean slope of 1 on first 3 points; tail is artificially flat and would
+            // drag the fit down if included.
+            const values = [1, 2, 3, 10, 10]
+            const result = trendLine(values, 3)
+            expect(result.map((n) => n.toFixed(2))).toEqual(['1.00', '2.00', '3.00', '4.00', '5.00'])
+        })
+
+        it('falls back to full fit when fitUpTo is less than 2', () => {
+            const values = [1, 2, 3, 4, 5]
+            const result = trendLine(values, 1)
+            expect(result.map((n) => n.toFixed(2))).toEqual(['1.00', '2.00', '3.00', '4.00', '5.00'])
+        })
     })
 
     describe('movingAverage', () => {

--- a/frontend/src/lib/statistics.test.ts
+++ b/frontend/src/lib/statistics.test.ts
@@ -54,11 +54,8 @@ describe('statistics', () => {
         })
 
         it('falls back to 2-point fit when fitUpTo is less than 2', () => {
-            // First two points give slope -9; a full fit would give a different slope.
-            // Math.max(2, ...) clamps degenerate fitUpTo to 2, not the full length.
             const values = [10, 1, 2, 3, 4]
             const result = trendLine(values, 1)
-            // m = (1-10)/(1-0) = -9, b = 10  ->  y = -9x + 10
             expect(result.map((n) => n.toFixed(2))).toEqual(['10.00', '1.00', '-8.00', '-17.00', '-26.00'])
         })
     })

--- a/frontend/src/lib/statistics.ts
+++ b/frontend/src/lib/statistics.ts
@@ -33,8 +33,8 @@ export function ciRanges(values: number[], ci: number = 0.95): [number[], number
  * @param fitUpTo - If provided, the regression is fit only on `values.slice(0, fitUpTo)`;
  *                  the returned array still spans the full length (extrapolated past
  *                  the cutoff). Useful for excluding in-progress/partial tails that
- *                  would skew the slope. Clamped to >= 2 so degenerate values fall
- *                  back to fitting on all points.
+ *                  would skew the slope. When `fitUpTo < 2` the regression falls back
+ *                  to using the first two points (the minimum for linear regression).
  */
 export function trendLine(values: number[], fitUpTo?: number): number[] {
     const n = values.length

--- a/frontend/src/lib/statistics.ts
+++ b/frontend/src/lib/statistics.ts
@@ -25,13 +25,25 @@ export function ciRanges(values: number[], ci: number = 0.95): [number[], number
     return [lower, upper]
 }
 
-export function trendLine(values: number[]): number[] {
+/**
+ * Computes y = m*x + b via linear regression and returns the fitted line evaluated
+ * at every x in `values`.
+ *
+ * @param values - The series to fit against.
+ * @param fitUpTo - If provided, the regression is fit only on `values.slice(0, fitUpTo)`;
+ *                  the returned array still spans the full length (extrapolated past
+ *                  the cutoff). Useful for excluding in-progress/partial tails that
+ *                  would skew the slope. Clamped to >= 2 so degenerate values fall
+ *                  back to fitting on all points.
+ */
+export function trendLine(values: number[], fitUpTo?: number): number[] {
     const n = values.length
     if (n < 2) {
         return values
     }
 
-    const coordinates: [number, number][] = values.map((y, x) => [x, y])
+    const fitEnd = fitUpTo != null ? Math.max(2, Math.min(fitUpTo, n)) : n
+    const coordinates: [number, number][] = values.slice(0, fitEnd).map((y, x) => [x, y])
     const { m, b } = linearRegression(coordinates)
 
     return values.map((_, x) => m * x + b)

--- a/frontend/src/lib/statistics.ts
+++ b/frontend/src/lib/statistics.ts
@@ -25,17 +25,6 @@ export function ciRanges(values: number[], ci: number = 0.95): [number[], number
     return [lower, upper]
 }
 
-/**
- * Computes y = m*x + b via linear regression and returns the fitted line evaluated
- * at every x in `values`.
- *
- * @param values - The series to fit against.
- * @param fitUpTo - If provided, the regression is fit only on `values.slice(0, fitUpTo)`;
- *                  the returned array still spans the full length (extrapolated past
- *                  the cutoff). Useful for excluding in-progress/partial tails that
- *                  would skew the slope. When `fitUpTo < 2` the regression falls back
- *                  to using the first two points (the minimum for linear regression).
- */
 export function trendLine(values: number[], fitUpTo?: number): number[] {
     const n = values.length
     if (n < 2) {

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_Y_AXIS_ID, LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, PointClickData, Series } from 'lib/hog-charts'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { ReferenceLines } from 'lib/hog-charts/overlays/ReferenceLine'
-import { movingAverage } from 'lib/statistics'
+import { movingAverage, trendLine } from 'lib/statistics'
 import { hexToRGBA } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -60,6 +60,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         incompletenessOffsetFromEnd,
         showMovingAverage,
         movingAverageIntervals,
+        showTrendLines,
     } = useValues(trendsDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
@@ -98,14 +99,17 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                     order: r.action?.order ?? r.id,
                     filter: r.filter,
                 }
+                const baseColor = getTrendsColor(r)
+                const displayColor = r.compare_label === 'previous' ? hexToRGBA(baseColor, 0.5) : baseColor
+                const hidden = getTrendsHidden(r)
                 const mainSeries: Series<TrendsSeriesMeta> = {
                     key: `${r.id}`,
                     label: r.label ?? '',
                     data: r.data,
-                    color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
+                    color: displayColor,
                     fillArea: display === ChartDisplayType.ActionsAreaGraph,
                     dashedFromIndex,
-                    hidden: getTrendsHidden(r),
+                    hidden,
                     yAxisId,
                     meta,
                 }
@@ -121,13 +125,30 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                         key: `${r.id}-ma`,
                         label: `${r.label ?? ''} (Moving avg)`,
                         data: movingAverage(r.data, movingAverageIntervals),
-                        color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
+                        color: displayColor,
                         fillArea: false,
                         dashPattern: [10, 3],
                         pointRadius: 0,
                         hideFromTooltip: true,
                         yAxisId,
                         meta,
+                    })
+                }
+
+                // Fit excludes the in-progress tail (dashedFromIndex..end) so the flat
+                // partial bucket doesn't drag the slope down. Dimmed so the dashed
+                // overlay reads as subordinate to the series line — at full intensity
+                // the two colors visually compete, especially on a dark background.
+                if (showTrendLines && !hidden) {
+                    series.push({
+                        key: `${r.id}__trendline`,
+                        label: r.label ?? '',
+                        data: trendLine(r.data, dashedFromIndex),
+                        color: hexToRGBA(baseColor, 0.5),
+                        yAxisId,
+                        dashPattern: [6, 4],
+                        pointRadius: 0,
+                        hideFromTooltip: true,
                     })
                 }
 
@@ -143,6 +164,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
             showMultipleYAxes,
             showMovingAverage,
             movingAverageIntervals,
+            showTrendLines,
         ]
     )
 


### PR DESCRIPTION
## Problem

The new hog-charts `TrendsLineChartD3` component doesn't render trend lines (linear regression overlays), so enabling "Show trend line" has no effect when the hog-charts flag is on.

## Changes

- Extend `trendLine()` in `lib/statistics.ts` with an optional `fitUpTo` parameter so the regression can be fit on only the non-incomplete portion of a series while still emitting a full-length line.
- Wire `showTrendLines` from `trendsDataLogic` through `TrendsLineChartD3` to append a dashed derived series per visible parent series, matching the legacy Chart.js behavior.
- Add Storybook stories for single/multi-series trend lines and incomplete-period handling.
- Add unit tests for the new `fitUpTo` parameter.

## How did you test this code?

- New unit tests for `trendLine()` with `fitUpTo`
- Storybook stories covering single series, multi-series, and incomplete period cases

## Publish to changelog?

no

## 🤖 LLM context

Authored by an agent via PostHog Code. Key design points:
- Regression uses the existing `linearRegression` from `simple-statistics` (same source as the prior `trendLine`) — no new dependency.
- `dashedFromIndex` from the adapter's existing in-progress computation doubles as the `fitUpTo` cutoff, mirroring the `trendoffset: incompletenessOffsetFromEnd` behavior of `chartjs-plugin-trendline` in `LineGraph.tsx`.
- Hidden base series are intentionally skipped so toggling a legend item also hides its trendline.