### PR TITLE
fix(devbox): surface coder install and reachability failures

### DIFF
--- a/common/hogli/devbox/cli.py
+++ b/common/hogli/devbox/cli.py
@@ -29,6 +29,7 @@ from .coder import (
     delete_workspace,
     ensure_coder_authenticated,
     ensure_coder_installed,
+    ensure_coder_reachable,
     ensure_runtime_ready,
     ensure_tailscale_connected,
     ensure_tailscale_routes_accepted,
@@ -443,6 +444,7 @@ def devbox_setup(
     """Prepare this machine for Coder workspaces."""
     ensure_tailscale_connected("rerun `hogli devbox:setup`.")
     ensure_tailscale_routes_accepted()
+    ensure_coder_reachable()
     ensure_coder_installed(verbose=verbose)
     ensure_coder_authenticated()
     maybe_configure_ssh(configure_ssh=configure_ssh, verbose=verbose)

--- a/common/hogli/devbox/coder.py
+++ b/common/hogli/devbox/coder.py
@@ -293,6 +293,35 @@ def ensure_tailscale_routes_accepted() -> None:
         _fail("Failed to enable Tailscale subnet routes. Run manually: sudo tailscale set --accept-routes")
 
 
+def coder_reachable(timeout: float = 5.0) -> bool:
+    """Return whether the Coder deployment responds on /api/v2/buildinfo."""
+    coder_url = get_coder_url()
+    try:
+        resp = requests.get(f"{coder_url}/api/v2/buildinfo", timeout=timeout)
+    except requests.RequestException:
+        return False
+    return resp.ok
+
+
+def ensure_coder_reachable() -> None:
+    """Fail fast when the Coder deployment is not reachable.
+
+    Tailscale reporting ``BackendState=Running`` with ``--accept-routes`` does not
+    prove the subnet route to the Coder ALB is actually plumbed — DNS can resolve
+    and packets still blackhole. Probe the API directly so reachability failures
+    surface here instead of as a silent ``curl | sh`` no-op during install.
+    """
+    coder_url = get_coder_url()
+    if coder_reachable():
+        return
+    _fail(
+        f"Cannot reach {coder_url} over the tailnet.\n"
+        "Check that you're connected to the PostHog tailnet and that subnet routes are accepted:\n"
+        "  tailscale status   # verify peer is connected\n"
+        "  sudo tailscale set --accept-routes"
+    )
+
+
 def _config_ssh_args() -> list[str]:
     """Build the base args for ``coder config-ssh``, pinning the managed binary path."""
     args = ["coder", "config-ssh"]
@@ -365,7 +394,9 @@ def _install_coder_cli(*, verbose: bool = False) -> None:
     prefix = _MANAGED_CODER_DIR.parent
     prefix.mkdir(parents=True, exist_ok=True)
     install_url = shlex.quote(f"{coder_url}/install.sh")
-    cmd = f"curl -fsSL {install_url} | sh -s -- --prefix {shlex.quote(str(prefix))}"
+    # `set -o pipefail` so a curl failure fails the pipeline; otherwise `sh`
+    # exits 0 with empty stdin and we silently "install" nothing.
+    cmd = f"set -o pipefail; curl -fsSL {install_url} | sh -s -- --prefix {shlex.quote(str(prefix))}"
     result = subprocess.run(["sh", "-c", cmd], text=True, capture_output=not verbose)
     if result.returncode != 0:
         if not verbose:
@@ -381,6 +412,10 @@ def _install_coder_cli(*, verbose: bool = False) -> None:
             stripped = line.strip()
             if stripped:
                 click.echo(f"  {stripped}")
+
+    managed = _MANAGED_CODER_DIR / "coder"
+    if not managed.is_file():
+        _fail(f"Coder CLI install reported success but {managed} is missing.\nTry manually: {cmd}")
 
 
 def ensure_coder_installed(*, verbose: bool = False) -> None:
@@ -427,6 +462,9 @@ def ensure_coder_authenticated() -> None:
         click.echo("Coder login is ready.")
         return
 
+    if not coder_installed():
+        _fail(f"`coder` is not installed. {RUNTIME_SETUP_HINT}")
+
     coder_url = get_coder_url()
     click.echo(f"Logging in to {coder_url}...")
     result = _run(["coder", "login", coder_url])
@@ -438,6 +476,7 @@ def ensure_runtime_ready() -> None:
     """Verify runtime prerequisites without mutating host setup."""
     ensure_tailscale_connected()
     ensure_tailscale_routes_accepted()
+    ensure_coder_reachable()
 
     if not coder_installed():
         _fail(f"`coder` is not installed. {RUNTIME_SETUP_HINT}")

--- a/common/hogli/devbox/coder.py
+++ b/common/hogli/devbox/coder.py
@@ -395,9 +395,10 @@ def _install_coder_cli(*, verbose: bool = False) -> None:
     prefix.mkdir(parents=True, exist_ok=True)
     install_url = shlex.quote(f"{coder_url}/install.sh")
     # `set -o pipefail` so a curl failure fails the pipeline; otherwise `sh`
-    # exits 0 with empty stdin and we silently "install" nothing.
+    # exits 0 with empty stdin and we silently "install" nothing. Invoke via
+    # `bash` because `/bin/sh` is `dash` on Debian/Ubuntu and rejects `-o pipefail`.
     cmd = f"set -o pipefail; curl -fsSL {install_url} | sh -s -- --prefix {shlex.quote(str(prefix))}"
-    result = subprocess.run(["sh", "-c", cmd], text=True, capture_output=not verbose)
+    result = subprocess.run(["bash", "-c", cmd], text=True, capture_output=not verbose)
     if result.returncode != 0:
         if not verbose:
             click.echo(result.stdout or "")

--- a/common/hogli/tests/test_devbox.py
+++ b/common/hogli/tests/test_devbox.py
@@ -213,6 +213,7 @@ class TestCoderConfig:
     ) -> None:
         monkeypatch.setattr(coder, "ensure_tailscale_connected", lambda setup_hint=coder.RUNTIME_SETUP_HINT: None)
         monkeypatch.setattr(coder, "ensure_tailscale_routes_accepted", lambda: None)
+        monkeypatch.setattr(coder, "ensure_coder_reachable", lambda: None)
         monkeypatch.setattr(coder, "coder_installed", lambda: False)
 
         with pytest.raises(SystemExit):

--- a/common/hogli/tests/test_devbox.py
+++ b/common/hogli/tests/test_devbox.py
@@ -278,23 +278,74 @@ class TestCoderVersion:
     def test_ensure_coder_installed_uses_deployment_install_script(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        managed_dir = tmp_path / "bin"
         monkeypatch.setattr(coder, "coder_installed", lambda: False)
         monkeypatch.setattr(coder, "get_coder_url", lambda: "https://coder.example.com")
         monkeypatch.setattr(coder, "get_server_version", lambda: "1.0.0")
-        monkeypatch.setattr(coder, "_MANAGED_CODER_DIR", tmp_path / "bin")
+        monkeypatch.setattr(coder, "_MANAGED_CODER_DIR", managed_dir)
 
         captured_cmd: list[str] = []
 
         def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
             captured_cmd.extend(args)
+            managed_dir.mkdir(parents=True, exist_ok=True)
+            (managed_dir / "coder").touch()
             return subprocess.CompletedProcess(args, 0, "", "")
 
         monkeypatch.setattr(coder.subprocess, "run", fake_run)
 
         coder.ensure_coder_installed()
         full_cmd = " ".join(captured_cmd)
+        assert "set -o pipefail" in full_cmd
         assert "curl -fsSL https://coder.example.com/install.sh" in full_cmd
         assert f"--prefix {tmp_path}" in full_cmd
+
+    def test_ensure_coder_installed_fails_when_binary_missing_after_install(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(coder, "coder_installed", lambda: False)
+        monkeypatch.setattr(coder, "get_coder_url", lambda: "https://coder.example.com")
+        monkeypatch.setattr(coder, "get_server_version", lambda: "1.0.0")
+        monkeypatch.setattr(coder, "_MANAGED_CODER_DIR", tmp_path / "bin")
+
+        def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(coder.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit):
+            coder.ensure_coder_installed()
+
+    def test_ensure_coder_authenticated_fails_fast_when_not_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(coder, "coder_installed", lambda: False)
+        monkeypatch.setattr(coder, "get_coder_url", lambda: "https://coder.example.com")
+
+        def boom(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise AssertionError("should not invoke coder when not installed")
+
+        monkeypatch.setattr(coder.subprocess, "run", boom)
+
+        with pytest.raises(SystemExit):
+            coder.ensure_coder_authenticated()
+
+
+class TestCoderReachable:
+    """Test the Coder deployment reachability probe."""
+
+    def test_coder_reachable_returns_false_on_request_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(coder, "get_coder_url", lambda: "https://coder.example.com")
+
+        def boom(*a: object, **kw: object) -> object:
+            raise coder.requests.ConnectionError("blackholed")
+
+        monkeypatch.setattr(coder.requests, "get", boom)
+        assert coder.coder_reachable() is False
+
+    def test_ensure_coder_reachable_fails_when_unreachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(coder, "get_coder_url", lambda: "https://coder.example.com")
+        monkeypatch.setattr(coder, "coder_reachable", lambda: False)
+        with pytest.raises(SystemExit):
+            coder.ensure_coder_reachable()
 
 
 class TestWorkspaceNaming:
@@ -485,6 +536,7 @@ class TestDevboxCommands:
 
         monkeypatch.setattr(devbox_cli, "ensure_tailscale_connected", lambda setup_hint="": calls.append("tailscale"))
         monkeypatch.setattr(devbox_cli, "ensure_tailscale_routes_accepted", lambda: calls.append("routes"))
+        monkeypatch.setattr(devbox_cli, "ensure_coder_reachable", lambda: calls.append("reachable"))
         monkeypatch.setattr(devbox_cli, "ensure_coder_installed", lambda **kw: calls.append("install"))
         monkeypatch.setattr(devbox_cli, "ensure_coder_authenticated", lambda: calls.append("login"))
         monkeypatch.setattr(
@@ -524,6 +576,7 @@ class TestDevboxCommands:
         assert calls == [
             "tailscale",
             "routes",
+            "reachable",
             "install",
             "login",
             "ssh:False",
@@ -540,6 +593,7 @@ class TestDevboxCommands:
     ) -> None:
         monkeypatch.setattr(devbox_cli, "ensure_tailscale_connected", lambda setup_hint="": None)
         monkeypatch.setattr(devbox_cli, "ensure_tailscale_routes_accepted", lambda: None)
+        monkeypatch.setattr(devbox_cli, "ensure_coder_reachable", lambda: None)
         monkeypatch.setattr(devbox_cli, "ensure_coder_installed", lambda **kw: None)
         monkeypatch.setattr(devbox_cli, "ensure_coder_authenticated", lambda: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_ssh", lambda configure_ssh, **kw: None)
@@ -571,6 +625,7 @@ class TestDevboxCommands:
 
         monkeypatch.setattr(devbox_cli, "ensure_tailscale_connected", lambda setup_hint="": None)
         monkeypatch.setattr(devbox_cli, "ensure_tailscale_routes_accepted", lambda: None)
+        monkeypatch.setattr(devbox_cli, "ensure_coder_reachable", lambda: None)
         monkeypatch.setattr(devbox_cli, "ensure_coder_installed", lambda **kw: None)
         monkeypatch.setattr(devbox_cli, "ensure_coder_authenticated", lambda: None)
         monkeypatch.setattr(devbox_cli, "maybe_configure_ssh", lambda configure_ssh, **kw: None)


### PR DESCRIPTION
## Problem

`hogli devbox:setup` could silently no-op the Coder CLI install and then crash with a `FileNotFoundError` traceback exec'ing `coder`. Tailscale passing its `BackendState=Running` check did not prove the Coder ALB was actually reachable over the tailnet, so `curl https://coder.dev.posthog.dev/install.sh | sh` could hit a blackholed route, exit 0 (no `pipefail`), and leave no binary behind.

## Changes

- `_install_coder_cli`: prepend `set -o pipefail` so a `curl` failure fails the pipeline, and assert `~/.hogli/bin/coder` actually exists after the install reports success.
- New `coder_reachable()` / `ensure_coder_reachable()` probe against `/api/v2/buildinfo` with a clear tailnet/accept-routes hint on failure. Wired into `devbox_setup` and `ensure_runtime_ready` so reachability is validated before install and before every runtime command.
- `ensure_coder_authenticated`: guard on `coder_installed()` before exec'ing `coder login`, so a missing binary surfaces as a red `_fail` instead of a Python traceback.

## How did you test this code?

Agent-authored, no manual testing. Covered by unit tests in `common/hogli/tests/test_devbox.py`:

- install succeeds but binary missing -> `SystemExit`
- `ensure_coder_authenticated` exits cleanly when CLI isn't installed
- reachability probe returns `False` on `ConnectionError`
- `ensure_coder_reachable` exits when unreachable
- existing `devbox_setup` flow test updated to assert the new step ordering

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code. Fixes the failure mode where a silent `curl | sh` no-op (caused by tailnet unreachability or any other install-script issue) manifests downstream as an uninformative `FileNotFoundError: 'coder'`.