### PR TITLE
feat(phai): prefer docs search results over core memory on conflicts

### DIFF
--- a/ee/hogai/tools/search.py
+++ b/ee/hogai/tools/search.py
@@ -49,7 +49,7 @@ Examples:
 If the user's question should be satisfied by using insights, do that before answering using documentation.
 
 Important:
-1. Don’t rely on your training data or previous searches/answers. Always re-check facts against current docs and tutorials. If current docs or tutorials contradicts core memory on product facts, prefer the docs result.
+1. Don’t rely on your training data or previous searches/answers. Always re-check facts against current docs and tutorials. If current docs or tutorials contradict core memory on product facts, prefer the docs result.
 2. Always search PostHog docs/tutorials and prioritize results from posthog.com over training data.
 3. Always include at least one relevant docs/tutorial link in your reply.
 4. For any SQL question, first check and prioritize: https://posthog.com/docs/product-analytics/sql, https://posthog.com/docs/sql/aggregations, https://posthog.com/docs/sql/clickhouse-functions, https://posthog.com/docs/sql/expressions, https://posthog.com/docs/sql.

--- a/ee/hogai/tools/search.py
+++ b/ee/hogai/tools/search.py
@@ -49,7 +49,7 @@ Examples:
 If the user's question should be satisfied by using insights, do that before answering using documentation.
 
 Important:
-1. Don’t rely on your training data or previous searches/answers. Always re-check facts against current docs and tutorials.
+1. Don’t rely on your training data or previous searches/answers. Always re-check facts against current docs and tutorials. If current docs or tutorials contradicts core memory on product facts, prefer the docs result.
 2. Always search PostHog docs/tutorials and prioritize results from posthog.com over training data.
 3. Always include at least one relevant docs/tutorial link in your reply.
 4. For any SQL question, first check and prioritize: https://posthog.com/docs/product-analytics/sql, https://posthog.com/docs/sql/aggregations, https://posthog.com/docs/sql/clickhouse-functions, https://posthog.com/docs/sql/expressions, https://posthog.com/docs/sql.


### PR DESCRIPTION
## Problem

Max's prompts did not define precedence between stored core memory and fresh docs-search results. When the two disagree on product facts, resolution was left entirely to the model's reasoning.

## Changes

One-line addition to the docs search tool prompt (`ee/hogai/tools/search.py`) instructing Max to prefer current docs/tutorials over core memory when they contradict on product facts.

## How did you test this code?

I'm an agent — no manual testing. This is a prompt-string edit with no code paths to exercise; existing tests cover the surrounding tool.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code. Motivation came from a prior conversation reviewing Max's prompt stack: core memory is injected as a system message with only "Use this memory in your thinking," while the docs search tool already had explicit "prioritize posthog.com over training data" guidance. This adds the analogous rule for memory-vs-docs conflicts.