### PR TITLE
fix(oauth-proxy): hash KV keys to survive long OAuth state values

### DIFF
--- a/services/oauth-proxy/src/lib/kv.ts
+++ b/services/oauth-proxy/src/lib/kv.ts
@@ -16,6 +16,16 @@ const CALLBACK_PREFIX = 'callback:'
 const REGION_SELECTION_TTL = 3600
 const CALLBACK_TTL = 3600
 
+// Cloudflare KV caps key names at 512 bytes. Callers may pass opaque values
+// (notably the OAuth `state` parameter) that exceed that limit, so we derive
+// a bounded cache key via SHA-256 before hitting KV.
+export async function hashKey(raw: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw))
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+}
+
 export async function getClientMapping(kv: KVNamespace, proxyClientId: string): Promise<ClientMapping | null> {
     const data = await kv.get(`${CLIENT_PREFIX}${proxyClientId}`, 'json')
     return data as ClientMapping | null
@@ -26,7 +36,7 @@ export async function putClientMapping(kv: KVNamespace, proxyClientId: string, m
 }
 
 export async function getRegionSelection(kv: KVNamespace, key: string): Promise<Region | null> {
-    const data = await kv.get(`${REGION_PREFIX}${key}`)
+    const data = await kv.get(`${REGION_PREFIX}${await hashKey(key)}`)
     if (data === 'us' || data === 'eu') {
         return data
     }
@@ -34,15 +44,15 @@ export async function getRegionSelection(kv: KVNamespace, key: string): Promise<
 }
 
 export async function putRegionSelection(kv: KVNamespace, key: string, region: Region): Promise<void> {
-    await kv.put(`${REGION_PREFIX}${key}`, region, {
+    await kv.put(`${REGION_PREFIX}${await hashKey(key)}`, region, {
         expirationTtl: REGION_SELECTION_TTL,
     })
 }
 
 export async function putCallbackRedirectUri(kv: KVNamespace, key: string, redirectUri: string): Promise<void> {
-    await kv.put(`${CALLBACK_PREFIX}${key}`, redirectUri, { expirationTtl: CALLBACK_TTL })
+    await kv.put(`${CALLBACK_PREFIX}${await hashKey(key)}`, redirectUri, { expirationTtl: CALLBACK_TTL })
 }
 
 export async function getCallbackRedirectUri(kv: KVNamespace, key: string): Promise<string | null> {
-    return kv.get(`${CALLBACK_PREFIX}${key}`)
+    return kv.get(`${CALLBACK_PREFIX}${await hashKey(key)}`)
 }

--- a/services/oauth-proxy/tests/authorize.test.ts
+++ b/services/oauth-proxy/tests/authorize.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleAuthorize } from '@/handlers/authorize'
+import { hashKey } from '@/lib/kv'
 
 import { createMockKV, mockKVGet } from './helpers'
 
@@ -128,21 +129,53 @@ describe('handleAuthorize', () => {
 
         const putCalls = vi.mocked(mockKV.put).mock.calls
 
+        const stateHash = await hashKey('abc123')
+        const clientHash = await hashKey('us_id')
+
         // Region selection stored by both state and client_id
-        const regionByState = putCalls.find(([key]) => (key as string) === 'region:abc123')
-        const regionByClient = putCalls.find(([key]) => (key as string) === 'region:us_id')
+        const regionByState = putCalls.find(([key]) => (key as string) === `region:${stateHash}`)
+        const regionByClient = putCalls.find(([key]) => (key as string) === `region:${clientHash}`)
         expect(regionByState).toBeTruthy()
         expect(regionByState![1]).toBe('eu')
         expect(regionByClient).toBeTruthy()
         expect(regionByClient![1]).toBe('eu')
 
         // Callback redirect_uri stored by both state and client_id
-        const callbackByState = putCalls.find(([key]) => (key as string) === 'callback:abc123')
-        const callbackByClient = putCalls.find(([key]) => (key as string) === 'callback:us_id')
+        const callbackByState = putCalls.find(([key]) => (key as string) === `callback:${stateHash}`)
+        const callbackByClient = putCalls.find(([key]) => (key as string) === `callback:${clientHash}`)
         expect(callbackByState).toBeTruthy()
         expect(callbackByState![1]).toBe('http://localhost:3000/callback')
         expect(callbackByClient).toBeTruthy()
         expect(callbackByClient![1]).toBe('http://localhost:3000/callback')
+    })
+
+    it('writes bounded-length KV keys even for very large state values', async () => {
+        const mapping = {
+            us_client_id: 'us_id',
+            eu_client_id: 'eu_id',
+            redirect_uris: ['http://localhost:3000/callback'],
+            created_at: Date.now(),
+        }
+        mockKVGet(mockKV, (_key: string, type?: unknown) => {
+            if (type === 'json') {
+                return Promise.resolve(mapping)
+            }
+            return Promise.resolve(null)
+        })
+
+        // A JWT-shaped state well above Cloudflare's 512-byte KV key limit.
+        const longState = 'x'.repeat(2000)
+        const request = new Request(
+            `https://oauth.posthog.com/oauth/authorize/?client_id=us_id&redirect_uri=http://localhost:3000/callback&response_type=code&state=${longState}&_region=us`
+        )
+        const response = await handleAuthorize(request, mockKV)
+
+        expect(response.status).toBe(302)
+        const putCalls = vi.mocked(mockKV.put).mock.calls
+        expect(putCalls.length).toBeGreaterThan(0)
+        for (const [key] of putCalls) {
+            expect((key as string).length).toBeLessThanOrEqual(512)
+        }
     })
 
     it('passes redirect_uri through without interception for legacy clients (no stored redirect_uris)', async () => {

--- a/services/oauth-proxy/tests/callback.test.ts
+++ b/services/oauth-proxy/tests/callback.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleCallback } from '@/handlers/callback'
+import { hashKey } from '@/lib/kv'
 
 import { createMockKV, mockKVGet } from './helpers'
 
@@ -12,8 +13,9 @@ beforeEach(() => {
 
 describe('handleCallback', () => {
     it('redirects to original redirect_uri with code and state', async () => {
+        const stateHash = await hashKey('test_state_123')
         mockKVGet(mockKV, (key: string) => {
-            if (key === 'callback:test_state_123') {
+            if (key === `callback:${stateHash}`) {
                 return Promise.resolve('http://localhost:3000/callback')
             }
             return Promise.resolve(null)
@@ -48,8 +50,9 @@ describe('handleCallback', () => {
     })
 
     it('forwards error params to client redirect_uri', async () => {
+        const stateHash = await hashKey('err_state')
         mockKVGet(mockKV, (key: string) => {
-            if (key === 'callback:err_state') {
+            if (key === `callback:${stateHash}`) {
                 return Promise.resolve('http://localhost:3000/callback')
             }
             return Promise.resolve(null)

--- a/services/oauth-proxy/tests/token.test.ts
+++ b/services/oauth-proxy/tests/token.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleToken } from '@/handlers/token'
+import { hashKey } from '@/lib/kv'
 
 import { createMockKV, mockKVGet, mockKVGetValue } from './helpers'
 
@@ -12,8 +13,9 @@ beforeEach(() => {
 
 describe('handleToken', () => {
     it('proxies to the correct region when region is stored in KV by client_id', async () => {
+        const clientHash = await hashKey('proxy_client_123')
         mockKVGet(mockKV, (key: string, type?: unknown) => {
-            if (key === 'region:proxy_client_123') {
+            if (key === `region:${clientHash}`) {
                 return Promise.resolve('us')
             }
             if (key === 'client:proxy_client_123' && type === 'json') {
@@ -56,11 +58,12 @@ describe('handleToken', () => {
     })
 
     it('rewrites redirect_uri when callback was intercepted by the proxy', async () => {
+        const clientHash = await hashKey('proxy_client_456')
         mockKVGet(mockKV, (key: string, type?: unknown) => {
-            if (key === 'region:proxy_client_456') {
+            if (key === `region:${clientHash}`) {
                 return Promise.resolve('eu')
             }
-            if (key === 'callback:proxy_client_456') {
+            if (key === `callback:${clientHash}`) {
                 return Promise.resolve('http://localhost:3000/callback')
             }
             if (key === 'client:proxy_client_456' && type === 'json') {
@@ -102,11 +105,12 @@ describe('handleToken', () => {
     })
 
     it('rewrites client_secret for confidential clients', async () => {
+        const clientHash = await hashKey('proxy_client_789')
         mockKVGet(mockKV, (key: string, type?: unknown) => {
-            if (key === 'region:proxy_client_789') {
+            if (key === `region:${clientHash}`) {
                 return Promise.resolve('eu')
             }
-            if (key === 'callback:proxy_client_789') {
+            if (key === `callback:${clientHash}`) {
                 return Promise.resolve('https://claude.ai/api/mcp/auth_callback')
             }
             if (key === 'client:proxy_client_789' && type === 'json') {


### PR DESCRIPTION
## Problem

`GET /oauth/authorize/` on `oauth.posthog.com` returns
`{"error":"server_error","error_description":"An internal error occurred"}`
when the OAuth `state` value is long enough that the KV key the proxy writes
exceeds Cloudflare Workers KV's **512-byte key-name limit**
([docs](https://developers.cloudflare.com/kv/platform/limits/)).

`services/oauth-proxy/src/handlers/authorize.ts` uses `state` verbatim as KV
key material (`region:<state>`, `callback:<state>`). OAuth 2.0 treats `state`
as opaque with no length cap, so spec-legal clients that encode a signed JWT
into `state` overflow the limit, `kv.put` rejects, and the top-level catch in
`src/index.ts` surfaces the failure as `server_error`.

## Changes

- Add `hashKey(raw)` in `services/oauth-proxy/src/lib/kv.ts` that returns a
  SHA-256 hex digest (64 chars) via `crypto.subtle.digest`.
- Apply it inside the four state/client-id keyed helpers so every KV key
  the proxy writes stays well under 512 bytes. Write and read sides remain
  automatically symmetric — no handler changes.
- The client-visible `state` round-trips unchanged on the callback URL.

### Deploy-time note

In-flight authorizations have un-hashed KV entries with a 1-hour TTL. After
deploy, lookups hash the key and miss, so affected flows need one restart.
Self-heals as the TTL drains.

## How did you test this code?

- `pnpm test --run` in `services/oauth-proxy/` — 33/33 pass, including a new
  regression test that drives a 2000-byte `state` and asserts every KV key
  stays ≤ 512 bytes.
- `pnpm typecheck` / `oxlint` / `oxfmt` — clean on changed files.
- **Not manually verified** against live `wrangler dev` / staging — agent-
  authored PR. Suggested smoke: `wrangler dev` locally, curl
  `/oauth/authorize/` with a >512-byte `state`, confirm 302 rather than 500.

## Publish to changelog?

no

## Docs update

_No docs change — internal infrastructure fix._

## 🤖 LLM context

Authored by Claude (Opus 4.7) via Claude Code. Diagnosed from a user-reported
`server_error` response: the response body is a verbatim match for the catch
in `src/index.ts`, the URL's `_region=us` placed the throw in
`redirectToRegionalAuthorize`, and the `state` value measured 664 bytes
against the 512-byte KV key-name limit. Fix moves the bounded-key derivation
inside the KV helpers so both sides stay symmetric by construction.