### PR TITLE
chore(revenue-analytics): fix product stage

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -260,7 +260,7 @@ export const SchemasTab = ({ id }: SchemasTabProps): JSX.Element => {
                         <LemonButton
                             type="primary"
                             className="mt-2"
-                            tooltip="This source is feeding data into our Revenue analytics product - currently in beta."
+                            tooltip="This source is feeding data into our Revenue analytics product - currently in alpha."
                             onClick={() => {
                                 addProductIntentForCrossSell({
                                     from: ProductKey.DATA_WAREHOUSE,
@@ -271,8 +271,8 @@ export const SchemasTab = ({ id }: SchemasTabProps): JSX.Element => {
                             }}
                         >
                             See data in Revenue analytics
-                            <LemonTag className="ml-2" type="warning" size="small">
-                                BETA
+                            <LemonTag className="ml-2" type="danger" size="small">
+                                ALPHA
                             </LemonTag>
                         </LemonButton>
                     </div>


### PR DESCRIPTION
## Problem

Revenue Analytics is in alpha, not beta.

## Changes

Fix where it appears as Beta in the PostHog UI. Additionally, most commonly Alpha stages appear as a danger `LemonTag`, so updated this too.

## How did you test this code?

Manual

## Publish to changelog?

No