### PR TITLE
fix(marketing-analytics): hide cost per conversion at UTM drill-down levels

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTableLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTableLogic.ts
@@ -74,13 +74,22 @@ export const marketingAnalyticsTableLogic = kea<marketingAnalyticsTableLogicType
                           ]
                         : Object.values(MarketingAnalyticsBaseColumns).map((column) => column.toString())
 
+                // Cost per conversion only makes sense when the Cost metric exists at this level.
+                // At UTM drill-downs (medium/content/term) Cost is excluded because platform
+                // cost can't be attributed to a specific UTM value.
+                const costAvailable = !config.excludedBaseColumns.includes(MarketingAnalyticsBaseColumns.Cost)
+
                 const selectColumns = [
                     ...baseColumns,
                     ...conversionGoals
-                        .map((goal) => [
-                            goal.conversion_goal_name,
-                            `${MarketingAnalyticsConstants.CostPer} ${goal.conversion_goal_name}`,
-                        ])
+                        .map((goal) =>
+                            costAvailable
+                                ? [
+                                      goal.conversion_goal_name,
+                                      `${MarketingAnalyticsConstants.CostPer} ${goal.conversion_goal_name}`,
+                                  ]
+                                : [goal.conversion_goal_name]
+                        )
                         .flat(),
                 ].filter(isNotNil)
                 return selectColumns

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
@@ -12,6 +12,7 @@ import {
     IntegrationFilter,
     MARKETING_ANALYTICS_DRILL_DOWN_CONFIG,
     MARKETING_ANALYTICS_SCHEMA,
+    MarketingAnalyticsBaseColumns,
     MarketingAnalyticsConstants,
     MarketingAnalyticsDrillDownLevel,
     MarketingAnalyticsTableQuery,
@@ -241,6 +242,10 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                 // and the stale response data renders as raw JSON (no matching context.columns render fn).
                 const excludedColumns = new Set<string>(drillDownConfig.excludedBaseColumns)
 
+                // Same rule as marketingAnalyticsTableLogic: at UTM levels the Cost metric is excluded
+                // so cost-per-conversion for the draft goal must be excluded too.
+                const costAvailable = !drillDownConfig.excludedBaseColumns.includes(MarketingAnalyticsBaseColumns.Cost)
+
                 const columnsWithDraftConversionGoal = [
                     ...(marketingQuery?.select?.length ? marketingQuery.select : defaultColumns)
                         .filter((column) => !isDraftConversionGoalColumn(column, draftConversionGoal))
@@ -248,10 +253,12 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                         .filter((column) => column === groupingAlias || !excludedColumns.has(column))
                         .filter((column, index, arr) => arr.indexOf(column) === index),
                     ...(draftConversionGoal
-                        ? [
-                              draftConversionGoal.conversion_goal_name,
-                              `${MarketingAnalyticsConstants.CostPer} ${draftConversionGoal.conversion_goal_name}`,
-                          ]
+                        ? costAvailable
+                            ? [
+                                  draftConversionGoal.conversion_goal_name,
+                                  `${MarketingAnalyticsConstants.CostPer} ${draftConversionGoal.conversion_goal_name}`,
+                              ]
+                            : [draftConversionGoal.conversion_goal_name]
                         : []),
                 ]
                 const sortedColumns = getSortedColumnsByArray(columnsWithDraftConversionGoal, defaultColumns)

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
@@ -340,8 +340,14 @@ class ConversionGoalsAggregator:
 
         return columns
 
-    def get_coalesce_fallback_columns(self) -> dict[str, ast.Expr]:
-        """Get COALESCE columns that fall back to unified conversion goals for campaign/id/source"""
+    def get_coalesce_fallback_columns(self, campaign_costs_joined: bool = True) -> dict[str, ast.Expr]:
+        """Get COALESCE columns that fall back to unified conversion goals for campaign/id/source.
+
+        Args:
+            campaign_costs_joined: Whether the outer query joins with campaign_costs CTE.
+                When False (e.g. UTM levels that bypass campaign_costs), the COALESCE
+                only references the unified conversion goals side.
+        """
         level = self.config.drill_down_level
         group_by_fields = self.config.group_by_fields
 
@@ -363,23 +369,29 @@ class ConversionGoalsAggregator:
             }
             fallback = fallback_map[level]
             campaign_alias = self.config.get_campaign_column_alias()
-            campaign_args = [
-                ast.Call(
-                    name="nullif",
-                    args=[
-                        ast.Field(chain=self.config.get_campaign_cost_field_chain(campaign_field)),
-                        ast.Constant(value=""),
-                    ],
-                ),
-                ast.Call(
-                    name="nullif",
-                    args=[
-                        ast.Field(chain=self.config.get_unified_conversion_field_chain(campaign_field)),
-                        ast.Constant(value=""),
-                    ],
-                ),
-                ast.Constant(value=fallback),
-            ]
+            campaign_args: list[ast.Expr] = []
+            if campaign_costs_joined:
+                campaign_args.append(
+                    ast.Call(
+                        name="nullif",
+                        args=[
+                            ast.Field(chain=self.config.get_campaign_cost_field_chain(campaign_field)),
+                            ast.Constant(value=""),
+                        ],
+                    )
+                )
+            campaign_args.extend(
+                [
+                    ast.Call(
+                        name="nullif",
+                        args=[
+                            ast.Field(chain=self.config.get_unified_conversion_field_chain(campaign_field)),
+                            ast.Constant(value=""),
+                        ],
+                    ),
+                    ast.Constant(value=fallback),
+                ]
+            )
             return {
                 campaign_alias: ast.Alias(alias=campaign_alias, expr=ast.Call(name="coalesce", args=campaign_args)),
             }

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -279,9 +279,14 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
         else:
             all_columns = {str(k): v for k, v in BASE_COLUMN_MAPPING.items()}
 
-        # Add conversion goal columns using the aggregator
+        # Add conversion goal columns using the aggregator.
+        # "Cost per conversion" is only meaningful when the Cost metric exists at this
+        # drill-down level — at UTM levels (medium/content/term) Cost is excluded because
+        # we can't attribute platform cost to a specific UTM value, so cost-per-conversion
+        # must be hidden too.
         if conversion_aggregator:
-            conversion_columns = conversion_aggregator.get_conversion_goal_columns()
+            include_cost_per = MarketingAnalyticsBaseColumns.COST not in excluded
+            conversion_columns = conversion_aggregator.get_conversion_goal_columns(include_cost_per=include_cost_per)
             all_columns.update(conversion_columns)
 
         return all_columns
@@ -302,9 +307,30 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
     def _build_select_query(self, conversion_aggregator: Optional[ConversionGoalsAggregator] = None) -> ast.SelectQuery:
         """Build the complete SELECT query with base columns and conversion goal columns"""
         level = self.config.drill_down_level
+        is_utm_level = level in (
+            MarketingAnalyticsDrillDownLevel.MEDIUM,
+            MarketingAnalyticsDrillDownLevel.CONTENT,
+            MarketingAnalyticsDrillDownLevel.TERM,
+        )
 
         # Get conversion goal components
         conversion_columns_mapping = self._build_select_columns_mapping(conversion_aggregator)
+
+        # UTM levels have no cost data — bypass campaign_costs entirely and select directly
+        # from unified conversions. This avoids phantom rows from the FULL OUTER JOIN and
+        # keeps the query aligned with what's actually computable at UTM granularity.
+        if conversion_aggregator and is_utm_level:
+            coalesce_columns = conversion_aggregator.get_coalesce_fallback_columns(campaign_costs_joined=False)
+            for key, coalesce_col in coalesce_columns.items():
+                conversion_columns_mapping[key] = coalesce_col
+
+            return ast.SelectQuery(
+                select=list(conversion_columns_mapping.values()),
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=[UNIFIED_CONVERSION_GOALS_CTE_ALIAS]),
+                    alias=self.config.unified_conversion_goals_cte_alias,
+                ),
+            )
 
         # Create the FROM clause with base table
         from_clause = ast.JoinExpr(table=ast.Field(chain=[self.config.campaign_costs_cte_name]))
@@ -314,9 +340,6 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             if level in (
                 MarketingAnalyticsDrillDownLevel.CHANNEL,
                 MarketingAnalyticsDrillDownLevel.SOURCE,
-                MarketingAnalyticsDrillDownLevel.MEDIUM,
-                MarketingAnalyticsDrillDownLevel.CONTENT,
-                MarketingAnalyticsDrillDownLevel.TERM,
             ):
                 join_type = "FULL OUTER JOIN"
                 join_constraint = ast.JoinConstraint(

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -307,19 +307,18 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
     def _build_select_query(self, conversion_aggregator: Optional[ConversionGoalsAggregator] = None) -> ast.SelectQuery:
         """Build the complete SELECT query with base columns and conversion goal columns"""
         level = self.config.drill_down_level
-        is_utm_level = level in (
-            MarketingAnalyticsDrillDownLevel.MEDIUM,
-            MarketingAnalyticsDrillDownLevel.CONTENT,
-            MarketingAnalyticsDrillDownLevel.TERM,
+        # Same invariant as _build_select_columns_mapping: if Cost is excluded at this level,
+        # joining campaign_costs buys us nothing but phantom rows from the FULL OUTER JOIN.
+        bypass_campaign_costs = (
+            MarketingAnalyticsBaseColumns.COST in DRILL_DOWN_LEVEL_CONFIG[level]["excluded_base_columns"]
         )
 
         # Get conversion goal components
         conversion_columns_mapping = self._build_select_columns_mapping(conversion_aggregator)
 
-        # UTM levels have no cost data — bypass campaign_costs entirely and select directly
-        # from unified conversions. This avoids phantom rows from the FULL OUTER JOIN and
-        # keeps the query aligned with what's actually computable at UTM granularity.
-        if conversion_aggregator and is_utm_level:
+        # Bypass campaign_costs when cost isn't computable at this level — select directly
+        # from unified conversions to avoid phantom rows.
+        if conversion_aggregator and bypass_campaign_costs:
             coalesce_columns = conversion_aggregator.get_coalesce_fallback_columns(campaign_costs_joined=False)
             for key, coalesce_col in coalesce_columns.items():
                 conversion_columns_mapping[key] = coalesce_col

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py
@@ -434,6 +434,77 @@ class TestMarketingAnalyticsTableQueryRunner(ClickhouseTestMixin, BaseTest):
         assert result.columns is not None
         assert config_alias_in_columns(result.columns, DRILL_DOWN_LEVEL_CONFIG[level]["column_alias"])
 
+    @parameterized.expand(
+        [
+            (MarketingAnalyticsDrillDownLevel.CHANNEL, True),
+            (MarketingAnalyticsDrillDownLevel.SOURCE, True),
+            (MarketingAnalyticsDrillDownLevel.CAMPAIGN, True),
+            (MarketingAnalyticsDrillDownLevel.MEDIUM, False),
+            (MarketingAnalyticsDrillDownLevel.CONTENT, False),
+            (MarketingAnalyticsDrillDownLevel.TERM, False),
+        ]
+    )
+    def test_cost_per_conversion_only_emitted_when_cost_is_available(self, level, cost_per_expected):
+        """At UTM levels (medium/content/term) the Cost metric is excluded because platform
+        cost can't be attributed to a specific UTM value — so 'Cost per <goal>' must also be
+        excluded to avoid showing divisions against a meaningless cost."""
+        conversion_goal = self._create_test_conversion_goal(goal_id="utm_cost_goal")
+        query = MarketingAnalyticsTableQuery(
+            dateRange=self.default_date_range,
+            limit=DEFAULT_LIMIT,
+            offset=0,
+            properties=[],
+            drillDownLevel=level,
+            draftConversionGoal=conversion_goal,
+        )
+        runner = self._create_query_runner(query)
+
+        with patch.object(MarketingAnalyticsTableQueryRunner, "_get_marketing_source_adapters") as mock_get_adapters:
+            mock_get_adapters.return_value = []
+            ast_query = runner.to_query()
+
+        column_names = [col.alias if isinstance(col, ast.Alias) else str(col) for col in ast_query.select]
+        cost_per_column = f"Cost per {conversion_goal.conversion_goal_name}"
+
+        assert (cost_per_column in column_names) == cost_per_expected
+
+    @parameterized.expand(
+        [
+            (MarketingAnalyticsDrillDownLevel.MEDIUM,),
+            (MarketingAnalyticsDrillDownLevel.CONTENT,),
+            (MarketingAnalyticsDrillDownLevel.TERM,),
+        ]
+    )
+    def test_utm_levels_bypass_campaign_costs_join(self, level):
+        """UTM drill-down levels should not join against the campaign_costs CTE — there's no
+        meaningful cost to attribute at that granularity, and joining produces phantom rows
+        from the dummy cost group (see _build_campaign_cost_select for the UTM branch)."""
+        conversion_goal = self._create_test_conversion_goal(goal_id="utm_join_goal")
+        query = MarketingAnalyticsTableQuery(
+            dateRange=self.default_date_range,
+            limit=DEFAULT_LIMIT,
+            offset=0,
+            properties=[],
+            drillDownLevel=level,
+            draftConversionGoal=conversion_goal,
+        )
+        runner = self._create_query_runner(query)
+
+        with patch.object(MarketingAnalyticsTableQueryRunner, "_get_marketing_source_adapters") as mock_get_adapters:
+            mock_get_adapters.return_value = []
+            ast_query = runner.to_query()
+
+        # Walk the FROM clause and any chained next_joins, collecting referenced tables.
+        tables_in_from: list[str] = []
+        join_expr: ast.JoinExpr | None = ast_query.select_from
+        while join_expr is not None:
+            table = join_expr.table
+            if isinstance(table, ast.Field) and table.chain:
+                tables_in_from.append(str(table.chain[0]))
+            join_expr = join_expr.next_join
+
+        assert runner.config.campaign_costs_cte_name not in tables_in_from
+
 
 def config_alias_in_columns(columns: list, alias: str) -> bool:
     return any(str(col) == alias for col in columns)


### PR DESCRIPTION
## Problem

At UTM drill-down levels (medium / content / term) platform cost can't be attributed to a specific UTM value — a single campaign+source can generate events with multiple UTM values, so there's no principled way to split the reported ad spend. Because of that, the Cost metric column is already excluded at these levels via `DRILL_DOWN_LEVEL_CONFIG`.

However, two leaks made the table still show misleading data at those levels:

1. **Cost per conversion** (the dynamically named `Cost per <goal>` columns) was still being emitted, dividing `campaign_costs.total_cost` through a JOIN on `campaign_field = utm_value`. That JOIN almost never matches, so the value was usually NULL — and in the rare case a UTM value coincided with a campaign name, it was a meaningless number.
2. A phantom **"(none)" row** was showing up in the table: the `campaign_costs` CTE at UTM levels emits a dummy row keyed by `campaign_field = ""`, and the `FULL OUTER JOIN` with `unified_conversion_goals` left that row unmatched — producing an extra row with `(none)` in the grouping column and zero conversions when no events were missing a UTM value.

## Changes

**Backend** (`products/marketing_analytics/backend/hogql_queries/`):

- `marketing_analytics_table_query_runner.py` — derive `include_cost_per` from `excluded_base_columns`: if `Cost` is excluded at a drill-down level, `Cost per <goal>` must be excluded too. Centralises the invariant so any new drill-down level that excludes `Cost` gets correct behavior automatically.
- `marketing_analytics_table_query_runner.py` — at UTM levels, bypass the `campaign_costs` CTE entirely (FROM `unified_conversion_goals` directly, no join). There's no cost to join with at that granularity, so joining only produces phantom rows.
- `conversion_goals_aggregator.py` — `get_coalesce_fallback_columns` now accepts `campaign_costs_joined: bool`; when `False`, the COALESCE only references the unified conversions side.

**Frontend** (`frontend/src/scenes/web-analytics/.../logic/`):

- `marketingAnalyticsTableLogic.ts` — derive `costAvailable` from the drill-down config's `excludedBaseColumns` and skip `Cost per <goal>` from `defaultColumns` when not available. Keeps the requested `select` list aligned with what the backend emits.
- `marketingAnalyticsTilesLogic.ts` — same derivation for the draft conversion goal column.

## How did you test this code?

Automated tests only — I have not exercised this in a browser.

- Added parametrized tests in `test_marketing_analytics_table_query_runner.py`:
  - `test_cost_per_conversion_only_emitted_when_cost_is_available`: `Cost per <goal>` is present at CAMPAIGN/SOURCE/CHANNEL and absent at MEDIUM/CONTENT/TERM.
  - `test_utm_levels_bypass_campaign_costs_join`: at UTM levels the query's `select_from` chain does not reference `campaign_costs`.
- Full marketing_analytics backend suite passes (427/427).
- Ruff lint + format clean. TypeScript check for the touched files is clean (unrelated pre-existing errors exist elsewhere in the repo).

## Publish to changelog?

no