### PR TITLE
fix: Pass min_ingested_timestamp to snowflake tests

### DIFF
--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -368,6 +368,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
     """
     model = BatchExportModel(name="events", schema=None)
     table_name = f"test_insert_activity_table_remove_{ateam.pk}"
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
 
     await _run_activity(
         activity_environment=activity_environment,
@@ -380,6 +381,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
         table_name=table_name,
         batch_export_model=model,
         sort_key="event",
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
     snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
@@ -412,6 +414,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
         table_name=table_name,
         batch_export_model=model,
         sort_key="event",
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
     snowflake_cursor.execute(list_query)
@@ -679,6 +682,7 @@ async def test_insert_into_snowflake_activity_handles_uppercased_columns(
     table_name = f"test_insert_activity_{model.name}_table_handle_uppercased_{ateam.pk}"
 
     sort_key = "uuid" if model.name == "events" else "person_id"
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
     await _run_activity(
         activity_environment=activity_environment,
         snowflake_cursor=snowflake_cursor,
@@ -690,6 +694,7 @@ async def test_insert_into_snowflake_activity_handles_uppercased_columns(
         table_name=table_name,
         batch_export_model=model,
         sort_key=sort_key,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
     uppercase_columns = ["team_id"]
@@ -716,6 +721,7 @@ async def test_insert_into_snowflake_activity_handles_uppercased_columns(
         batch_export_model=model,
         sort_key=sort_key,
         uppercase_columns=uppercase_columns,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 
@@ -740,6 +746,7 @@ async def test_insert_into_snowflake_activity_handles_extra_columns_in_destinati
     """
     table_name = f"test_insert_activity_{model.name}_handles_extra_columns_{ateam.pk}"
 
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
     await _run_activity(
         activity_environment=activity_environment,
         snowflake_cursor=snowflake_cursor,
@@ -751,6 +758,7 @@ async def test_insert_into_snowflake_activity_handles_extra_columns_in_destinati
         table_name=table_name,
         batch_export_model=model,
         sort_key="uuid",
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
     snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
@@ -768,4 +776,5 @@ async def test_insert_into_snowflake_activity_handles_extra_columns_in_destinati
         batch_export_model=model,
         sort_key="uuid",
         extra_fields={"extra_column": "test"},
+        min_ingested_timestamp=min_ingested_timestamp,
     )


### PR DESCRIPTION
## Problem

We started sending `snowflake_ingested_at` but our tests are failing as they are not passing `min_ingested_timestamp`.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Pass `min_ingested_timestamp`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran tests

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
