### PR TITLE
revert: pilot git diff path filters (#55830)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -79,7 +79,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   list-files: 'escape'
                   filters: |
                       backend:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -57,7 +57,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   filters: |
                       dagster:
                         # --- DAG code itself ---

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -71,6 +71,7 @@ jobs:
             shouldRun: ${{ steps.changes.outputs.shouldRun || 'true' }}
             oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
         steps:
+            # For pull requests it's not necessary to check out the code
             - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: changes
               if: github.event_name != 'push' # Run all tests on master push

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -36,7 +36,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   filters: |
                       frontend:
                         # Avoid running frontend tests for irrelevant changes

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -30,7 +30,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   filters: |
                       mcp:
                         # MCP service and per-product tool/UI-app configs

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -30,7 +30,6 @@ jobs:
             - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: filter
               with:
-                  token: ''
                   filters: |
                       node_files:
                         - 'nodejs/**'

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -43,7 +43,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   filters: |
                       nodejs:
                         - .github/workflows/ci-nodejs.yml

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -34,7 +34,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   filters: |
                       python:
                         - 'pyproject.toml'

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -39,7 +39,6 @@ jobs:
               id: filter
               if: github.event_name != 'push' # Run all tests on master push
               with:
-                  token: ''
                   filters: |
                       rust:
                         # Avoid running rust tests for irrelevant changes


### PR DESCRIPTION
## Problem

PR #55830 switched eight workflows to dorny/paths-filter's `token: ''` (git diff) mode to avoid API rate-limit failures. Spot checks on two post-merge PRs show a correctness regression: when a PR's base is behind master, the filter detects master-drift files the PR never touched.

| PR | `pulls/N/files` | filter "Detected" | false positives | filter job |
|---|---|---|---|---|
| #56189 | 13 | 53 | +40 | [ci-backend](https://github.com/PostHog/posthog/actions/runs/24895812908/job/72900214251) |
| #56041 | 6 | 740 | +734 | [ci-python](https://github.com/PostHog/posthog/actions/runs/24895799260/job/72900137330) |

The #56189 log shows `Change detection 9300c972..df4fb379` — that range includes every commit that landed on master since `pull_request.base.sha` (9300c972). This wrongly set `migrations=true` because `posthog/migrations/1118_subscriptiondelivery_change_summary.py` from an unrelated PR had landed on master. The old API mode returned only the PR's own changes, so filters stayed tight regardless of base staleness.

Rate-limit fix worked; path-filter efficiency did not. Reverting while we design a better fix (compute local merge-base and pass as `base` input, or keep API mode with retry/backoff).

## Changes

Clean revert of #55830 (0c104d2). Nine workflow files, +1/-8.

## How did you test this code?

- `git diff HEAD^ HEAD --stat` confirms single-commit inverse
- `git diff --check`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 LLM context

Authored by an LLM agent. Regression was caught via live post-merge filter-log inspection on three PRs; two showed false-positive detection tied to stale `pull_request.base.sha`.