### PR TITLE
fix(mcp): build client profile after awaiting flag resolution

### DIFF
--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -477,12 +477,6 @@ export class MCP extends McpAgent<Env> {
         // registration decisions with an undefined client name.
         this._seedClientInfoFromProps()
 
-        const clientProfile = new MCPClientProfile({
-            clientName: this._mcpClientName,
-            clientVersion: this._mcpClientVersion,
-            consumer: this.requestProperties.mcpConsumer,
-        })
-
         // Start feature flag resolution in parallel with cache seeding
         const flagPromise = this.resolveVersionFlag()
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
@@ -520,6 +514,13 @@ export class MCP extends McpAgent<Env> {
             toolFlagsPromise,
             singleExecPromise,
         ])
+
+        const clientProfile = new MCPClientProfile({
+            clientName: this._mcpClientName,
+            clientVersion: this._mcpClientVersion,
+            consumer: this.requestProperties.mcpConsumer,
+        })
+
         // Restrict single-exec mode to coding agents only — Cursor and other clients that
         // render `structuredContent` in their UI need the full per-tool roster, not the
         // wrapped CLI. `_mcpClientName` is seeded from request properties at the top of


### PR DESCRIPTION
## Problem

On reconnection, `_seedClientInfoFromProps()` correctly wrote the current
request's client name onto `this._mcpClientName`. But subsequent requests
reading the single-exec decision saw the wrong value because
`MCPClientProfile` was being constructed *before* the flag-resolution
`Promise.all` settled — the profile captured whatever `_mcpClientName`
held at that earlier point, not the value reflecting the request props
used by the rest of `init()`.

The symptom was that `useSingleExec` could flip between connections even
though the seeded client info and flag were stable.

## Changes

Move the `MCPClientProfile` construction to after
`await Promise.all([flagPromise, toolFlagsPromise, singleExecPromise])`,
so it reads the client fields at the same boundary where the flags are
consumed. Order of side effects in `init()` is otherwise unchanged.

## How did you test this code?

I'm an agent — I have not exercised this against a running worker. A
targeted test covering the reconnect → subsequent-request ordering is
incoming in a follow-up.

## Publish to changelog?

do not publish to changelog

## 🤖 LLM context

Authored by Claude. Change is a small reordering inside `MCPAgent.init()`
in `services/mcp/src/mcp.ts`. No behavior changes outside of when the
`MCPClientProfile` is instantiated relative to the flag-resolution
`Promise.all`.