### PR TITLE
fix: Fail if azure blob export fails due to auth error

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -245,10 +245,18 @@ class AzureBlobConsumer(Consumer):
         manifest_content = json.dumps({"files": self.files_uploaded}, indent=2)
 
         blob_client = self.container_client.get_blob_client(manifest_key)
-        await blob_client.upload_blob(
-            manifest_content.encode("utf-8"),
-            overwrite=True,
-        )
+
+        try:
+            await blob_client.upload_blob(
+                manifest_content.encode("utf-8"),
+                overwrite=True,
+            )
+        except HttpResponseError as exc:
+            if exc.error is not None and exc.error.code == "AuthorizationFailure":
+                raise MissingRequiredPermissionsError()
+            else:
+                raise
+
         self.logger.info("Manifest uploaded", manifest_key=manifest_key, file_count=len(self.files_uploaded))
 
 

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -4,6 +4,7 @@ import dataclasses
 
 from django.conf import settings
 
+from azure.core.exceptions import HttpResponseError
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient, ExponentialRetry
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
@@ -40,12 +41,12 @@ from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_
 from products.batch_exports.backend.temporal.utils import handle_non_retryable_errors
 
 NON_RETRYABLE_ERROR_TYPES = (
-    "ResourceNotFoundError",
-    "ClientAuthenticationError",
     "AzureBlobIntegrationError",
     "AzureBlobIntegrationNotFoundError",
-    "UnsupportedFileFormatError",
+    "ClientAuthenticationError",
+    "MissingRequiredPermissionsErrorResourceNotFoundError",
     "UnsupportedCompressionError",
+    "UnsupportedFileFormatError",
 )
 
 FILE_FORMAT_EXTENSIONS = {
@@ -85,6 +86,13 @@ class AzureBlobIntegrationNotFoundError(Exception):
             super().__init__(f"Azure Blob integration ID not provided for team '{team_id}'")
         else:
             super().__init__(f"Azure Blob integration with ID '{integration_id}' not found for team '{team_id}'")
+
+
+class MissingRequiredPermissionsError(Exception):
+    """Raised when missing required permissions in Azure Blob."""
+
+    def __init__(self):
+        super().__init__("Missing required permissions to run this batch export")
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -211,11 +219,17 @@ class AzureBlobConsumer(Consumer):
 
         self.logger.debug("Blob upload started", blob_key=blob_key, size_bytes=len(self.current_buffer))
 
-        await blob_client.upload_blob(
-            bytes(self.current_buffer),
-            overwrite=True,
-            max_concurrency=self.max_concurrency,
-        )
+        try:
+            await blob_client.upload_blob(
+                bytes(self.current_buffer),
+                overwrite=True,
+                max_concurrency=self.max_concurrency,
+            )
+        except HttpResponseError as exc:
+            if exc.error is not None and exc.error.code == "AuthorizationFailure":
+                raise MissingRequiredPermissionsError()
+            else:
+                raise
 
         self.logger.debug("Blob upload completed", blob_key=blob_key)
         self.files_uploaded.append(blob_key)

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -44,7 +44,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "AzureBlobIntegrationError",
     "AzureBlobIntegrationNotFoundError",
     "ClientAuthenticationError",
-    "MissingRequiredPermissionsErrorResourceNotFoundError",
+    "MissingRequiredPermissionsError",
+    "ResourceNotFoundError",
     "UnsupportedCompressionError",
     "UnsupportedFileFormatError",
 )


### PR DESCRIPTION
## Problem

Azure blob batch exports can raise an `HttpResponseError` if upload_blob fails due to authentication errors.

We should handle specifically AuthenticationFailures by re-raising a non-retryable exception.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Raise a missing permissions error on AuthenticationFailure.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
