### PR TITLE
fix(cloud-agent): rename cloud-run gauge label to avoid pushgateway collision

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -496,29 +496,32 @@ def capture_task_run_state_metrics() -> None:
 
     try:
         with pushed_metrics_registry("tasks_run_state") as registry:
+            # NOTE: the label is named `run_environment` (not `environment`) to avoid collision with the
+            # deployment-environment label applied by the pushgateway scrape target, which would otherwise
+            # clobber the TaskRun.Environment value on ingest.
             runs_in_status_gauge = Gauge(
                 "posthog_tasks_runs_in_status",
-                "Number of open TaskRun rows by status, origin_product, and environment.",
+                "Number of open TaskRun rows by status, origin_product, and run_environment.",
                 registry=registry,
-                labelnames=["status", "origin_product", "environment"],
+                labelnames=["status", "origin_product", "run_environment"],
             )
             oldest_age_gauge = Gauge(
                 "posthog_tasks_oldest_open_run_age_seconds",
-                "Age (seconds) of the oldest TaskRun still in a given non-terminal status, by origin_product and environment.",
+                "Age (seconds) of the oldest TaskRun still in a given non-terminal status, by origin_product and run_environment.",
                 registry=registry,
-                labelnames=["status", "origin_product", "environment"],
+                labelnames=["status", "origin_product", "run_environment"],
             )
             runs_created_1h_gauge = Gauge(
                 "posthog_tasks_runs_created_1h",
-                "Number of TaskRun rows created in the last hour, by origin_product and environment.",
+                "Number of TaskRun rows created in the last hour, by origin_product and run_environment.",
                 registry=registry,
-                labelnames=["origin_product", "environment"],
+                labelnames=["origin_product", "run_environment"],
             )
             runs_terminal_1h_gauge = Gauge(
                 "posthog_tasks_runs_terminal_1h",
-                "Number of TaskRun rows that reached a terminal status in the last hour, by status, origin_product, and environment.",
+                "Number of TaskRun rows that reached a terminal status in the last hour, by status, origin_product, and run_environment.",
                 registry=registry,
-                labelnames=["status", "origin_product", "environment"],
+                labelnames=["status", "origin_product", "run_environment"],
             )
 
             counts = (
@@ -530,7 +533,7 @@ def capture_task_run_state_metrics() -> None:
                 runs_in_status_gauge.labels(
                     status=row["status"],
                     origin_product=row["task__origin_product"] or "unknown",
-                    environment=row["environment"],
+                    run_environment=row["environment"],
                 ).set(row["count"])
 
             oldest = (
@@ -544,7 +547,7 @@ def capture_task_run_state_metrics() -> None:
                 oldest_age_gauge.labels(
                     status=row["status"],
                     origin_product=row["task__origin_product"] or "unknown",
-                    environment=row["environment"],
+                    run_environment=row["environment"],
                 ).set(age_seconds)
 
             created_1h = (
@@ -555,7 +558,7 @@ def capture_task_run_state_metrics() -> None:
             for row in created_1h:
                 runs_created_1h_gauge.labels(
                     origin_product=row["task__origin_product"] or "unknown",
-                    environment=row["environment"],
+                    run_environment=row["environment"],
                 ).set(row["count"])
 
             # Terminal runs: approximated by updated_at since completed_at can be null for FAILED/CANCELLED
@@ -572,7 +575,7 @@ def capture_task_run_state_metrics() -> None:
                 runs_terminal_1h_gauge.labels(
                     status=row["status"],
                     origin_product=row["task__origin_product"] or "unknown",
-                    environment=row["environment"],
+                    run_environment=row["environment"],
                 ).set(row["count"])
 
     except Exception as err:

--- a/posthog/tasks/test/test_task_run_state_metrics.py
+++ b/posthog/tasks/test/test_task_run_state_metrics.py
@@ -73,21 +73,21 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_in_status",
-                {"status": "queued", "origin_product": "slack", "environment": "cloud"},
+                {"status": "queued", "origin_product": "slack", "run_environment": "cloud"},
             )
             == 2
         )
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_in_status",
-                {"status": "in_progress", "origin_product": "user_created", "environment": "cloud"},
+                {"status": "in_progress", "origin_product": "user_created", "run_environment": "cloud"},
             )
             == 1
         )
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_in_status",
-                {"status": "in_progress", "origin_product": "user_created", "environment": "local"},
+                {"status": "in_progress", "origin_product": "user_created", "run_environment": "local"},
             )
             == 1
         )
@@ -107,7 +107,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_in_status",
-                {"status": status.value, "origin_product": "slack", "environment": "cloud"},
+                {"status": status.value, "origin_product": "slack", "run_environment": "cloud"},
             )
             is None
         )
@@ -125,7 +125,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
 
         age = registry.get_sample_value(
             "posthog_tasks_oldest_open_run_age_seconds",
-            {"status": "queued", "origin_product": "slack", "environment": "cloud"},
+            {"status": "queued", "origin_product": "slack", "run_environment": "cloud"},
         )
         assert age is not None
         # Oldest run was ~30 minutes ago; allow generous slack for test timing.
@@ -147,14 +147,14 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_created_1h",
-                {"origin_product": "slack", "environment": "cloud"},
+                {"origin_product": "slack", "run_environment": "cloud"},
             )
             == 2
         )
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_created_1h",
-                {"origin_product": "user_created", "environment": "cloud"},
+                {"origin_product": "user_created", "run_environment": "cloud"},
             )
             == 1
         )
@@ -172,14 +172,14 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_terminal_1h",
-                {"status": "completed", "origin_product": "slack", "environment": "cloud"},
+                {"status": "completed", "origin_product": "slack", "run_environment": "cloud"},
             )
             == 2
         )
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_terminal_1h",
-                {"status": "failed", "origin_product": "user_created", "environment": "cloud"},
+                {"status": "failed", "origin_product": "user_created", "run_environment": "cloud"},
             )
             == 1
         )
@@ -196,7 +196,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_oldest_open_run_age_seconds",
-                {"status": "not_started", "origin_product": "slack", "environment": "cloud"},
+                {"status": "not_started", "origin_product": "slack", "run_environment": "cloud"},
             )
             is None
         )
@@ -204,7 +204,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_runs_in_status",
-                {"status": "not_started", "origin_product": "slack", "environment": "cloud"},
+                {"status": "not_started", "origin_product": "slack", "run_environment": "cloud"},
             )
             == 1
         )


### PR DESCRIPTION
## Problem

follow-up to #56160. The cloud-run state gauges added in that PR are being scraped by Prometheus, but the dashboard panels that filter by `environment="cloud"` all show "no data", let's fix 