### PR TITLE
refactor: Make new_async_producer async as it requires an event loop

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -343,8 +343,8 @@ def ensure_loop(loop: asyncio.AbstractEventLoop | None) -> Iterator[asyncio.Abst
     try:
         running_loop = asyncio.get_running_loop()
     except RuntimeError:
-        # We are being called from a sync context, a running event loop must be provided
-        if loop is None or not loop.is_running():
+        # We are being called from a sync context, an event loop must be provided
+        if loop is None:
             raise
 
         asyncio.set_event_loop(loop)

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -12,8 +12,7 @@ import os
 import json
 import asyncio
 import threading
-import contextlib
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Optional
@@ -333,32 +332,6 @@ class _KafkaProducer:
         self.producer.flush()
 
 
-@contextlib.contextmanager
-def ensure_loop(loop: asyncio.AbstractEventLoop | None) -> Iterator[asyncio.AbstractEventLoop]:
-    """Ensure an asyncio event loop is available.
-
-    `AIOProducer` requires a running loop when initializing, so we ensure one exists or
-    we set the `loop` provided.
-    """
-    try:
-        running_loop = asyncio.get_running_loop()
-    except RuntimeError:
-        # We are being called from a sync context, an event loop must be provided
-        if loop is None:
-            raise
-
-        asyncio.set_event_loop(loop)
-
-        try:
-            yield loop
-        finally:
-            # We landed here because there is no event loop running in the current
-            # thread. So, we restore it back to None.
-            asyncio.set_event_loop(None)
-    else:
-        yield running_loop
-
-
 class _AsyncKafkaProducer:
     producer: AIOProducer
     _closed: bool
@@ -414,8 +387,7 @@ class _AsyncKafkaProducer:
         if max_request_size:
             config["message.max.bytes"] = max_request_size
 
-        with ensure_loop(loop):
-            self.producer = AIOProducer(config)
+        self.producer = AIOProducer(config)
 
         self._closed = False
 

--- a/posthog/kafka_client/routing.py
+++ b/posthog/kafka_client/routing.py
@@ -16,7 +16,6 @@ Two lifecycle shapes:
   AIOProducer — caching would leave later callers with a closed instance.
 """
 
-import asyncio
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from threading import Lock
@@ -180,7 +179,7 @@ def _build_sync_producer(profile: KafkaClusterProfile) -> _KafkaProducer:
 
 
 def _build_async_producer(
-    profile: KafkaClusterProfile, /, loop: asyncio.AbstractEventLoop | None = None
+    profile: KafkaClusterProfile,
 ) -> _AsyncKafkaProducer:
     p = settings.KAFKA_PROFILES[profile.value]
     producer_settings = p.producer_settings
@@ -193,7 +192,6 @@ def _build_async_producer(
         max_request_size=producer_settings.get("max_request_size"),
         compression_type=producer_settings.get("compression_type"),
         producer_settings=producer_settings,
-        loop=loop,
     )
 
 
@@ -257,20 +255,22 @@ async def async_producer_scope(
         await producer.close()
 
 
-def new_async_producer(
+async def new_async_producer(
     *,
     profile: Optional[KafkaClusterProfile] = None,
     topic: Optional[str] = None,
-    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> _AsyncKafkaProducer:
     """Construct a fresh async producer the caller fully owns.
 
     For long-lived consumers (e.g. the Temporal logger daemon) where the
     producer outlives any single scope. The caller is responsible for closing
     it. For per-call work prefer `async_producer_scope`.
+
+    This function is async as the underlying producer requires a running
+    event loop.
     """
     resolved = resolve_profile_name(topic=topic, profile=profile)
-    return _build_async_producer(resolved, loop=loop)
+    return _build_async_producer(resolved)
 
 
 def flush_all_producers(timeout: Optional[float] = None) -> None:

--- a/posthog/kafka_client/test/test_routing.py
+++ b/posthog/kafka_client/test/test_routing.py
@@ -44,7 +44,7 @@ def _mock_kafka_backend():
             sync_producers[profile] = MagicMock(name=f"sync_producer[{profile}]")
         return sync_producers[profile]
 
-    def async_factory(profile: KafkaClusterProfile, loop=None) -> MagicMock:
+    def async_factory(profile: KafkaClusterProfile) -> MagicMock:
         producer = MagicMock(name=f"async_producer[{profile}]")
         producer.flush = mock.AsyncMock()
         producer.close = mock.AsyncMock()
@@ -251,10 +251,12 @@ class AsyncProducerScopeTest(TestCase):
 
 class NewAsyncProducerTest(TestCase):
     def test_returns_fresh_instance_per_call(self):
+        import asyncio
+
         with _mock_kafka_backend() as (_, async_build):
-            async_build.side_effect = lambda profile, loop: MagicMock(name=f"fresh[{profile}]")
-            first = new_async_producer(profile=KafkaClusterProfile.DEFAULT)
-            second = new_async_producer(profile=KafkaClusterProfile.DEFAULT)
+            async_build.side_effect = lambda profile: MagicMock(name=f"fresh[{profile}]")
+            first = asyncio.run(new_async_producer(profile=KafkaClusterProfile.DEFAULT))
+            second = asyncio.run(new_async_producer(profile=KafkaClusterProfile.DEFAULT))
         self.assertIsNot(first, second)
         self.assertEqual(async_build.call_count, 2)
 

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -530,8 +530,8 @@ class Command(BaseCommand):
 
         with asyncio.Runner() as runner:
             loop = runner.get_loop()
-
             configure_logger(loop=loop)
+
             logger = LOGGER.bind(
                 host=temporal_host,
                 port=temporal_port,

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -538,7 +538,9 @@ def configure_logger(
     else:
         try:
             log_producer = KafkaLogProducerFromQueueAsync(
-                queue=log_queue, topic=KAFKA_LOG_ENTRIES, producer=producer, loop=loop
+                queue=log_queue,
+                topic=KAFKA_LOG_ENTRIES,
+                producer=producer,
             )
         except Exception as e:
             # Skip putting logs in queue if we don't have a producer that can consume the queue.
@@ -652,17 +654,20 @@ class KafkaLogProducerFromQueueAsync:
         self,
         queue: asyncio.Queue[bytes],
         topic: str = KAFKA_LOG_ENTRIES,
-        key: str | None = None,
         producer: "_AsyncKafkaProducer | None" = None,
-        loop: None | asyncio.AbstractEventLoop = None,
+        key: str | None = None,
     ):
-        from posthog.kafka_client.routing import new_async_producer
-
         self.queue = queue
         self.topic = topic
         self.key = key
-        self.producer = producer if producer is not None else new_async_producer(topic=topic, loop=loop)
+        self._producer = producer
         self.logger = structlog.get_logger("posthog.temporal.common.logger.KafkaLogProducerFromQueueAsync")
+
+    @property
+    def producer(self) -> "_AsyncKafkaProducer":
+        if self._producer is None:
+            raise ValueError("Producer not initialized")
+        return self._producer
 
     async def listen(self):
         """Listen to messages in queue and produce them to Kafka as they come.
@@ -670,6 +675,11 @@ class KafkaLogProducerFromQueueAsync:
         This is designed to be ran as an asyncio.Task, as it will wait forever for the queue
         to have messages.
         """
+        from posthog.kafka_client.routing import new_async_producer
+
+        if self._producer is None:
+            self._producer = await new_async_producer(topic=self.topic)
+
         try:
             while True:
                 msg = await self.queue.get()

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -29,7 +29,6 @@ from posthog.clickhouse.log_entries import (
     TRUNCATE_LOG_ENTRIES_TABLE_SQL,
 )
 from posthog.kafka_client.client import _AsyncKafkaProducer
-from posthog.kafka_client.routing import new_async_producer
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 from posthog.temporal.common.logger import BACKGROUND_LOGGER_TASKS, configure_logger, resolve_log_source
 
@@ -92,9 +91,9 @@ async def queue():
 class CaptureKafkaProducer:
     """Wrap a `_AsyncKafkaProducer` to captures calls to `produce`."""
 
-    def __init__(self, *args, topic: str, loop: asyncio.AbstractEventLoop, **kwargs):
+    def __init__(self, *args, topic: str, producer: _AsyncKafkaProducer, **kwargs):
         self.entries: list[dict[str, str | bytes]] = []
-        self.producer: _AsyncKafkaProducer = new_async_producer(topic=topic, loop=loop)
+        self.producer: _AsyncKafkaProducer = producer
         self._is_closed = False
 
     async def produce(self, *, topic, data, key=None, value_serializer=None):
@@ -132,9 +131,11 @@ async def producer():
 
     After usage, we ensure the producer was closed to avoid leaking/warnings.
     """
-    loop = asyncio.get_running_loop()
+    from posthog.kafka_client.routing import new_async_producer
+
+    kafka_producer = await new_async_producer(topic=KAFKA_LOG_ENTRIES)
     producer = CaptureKafkaProducer(
-        topic=KAFKA_LOG_ENTRIES, bootstrap_servers=settings.KAFKA_PROFILES["default"].hosts, loop=loop
+        topic=KAFKA_LOG_ENTRIES, bootstrap_servers=settings.KAFKA_PROFILES["default"].hosts, producer=kafka_producer
     )
 
     yield producer


### PR DESCRIPTION
## Problem

In #56172 I tried to fix the logging pipeline using `AIOProducer` by passing the loop returned by asyncio.Runner to the kafka producer. Unfortunately, that loop is lazily initialized, so we can't check it's running, and nor can `AIOProducer`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Since AIOProducer requires a running event loop, the constructor must be async to force callers to call it from an async context.

The logging library has then been updated to delay initializing the producer until the listen task starts running.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests updated, ran, all passing.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Nothing, agents are useless on this one. Spin around for ages wasting tokens.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
