### PR TITLE
fix(cohorts): read event date from payload in precalculated_events MV

### DIFF
--- a/posthog/clickhouse/migrations/0243_fix_precalculated_events_date.py
+++ b/posthog/clickhouse/migrations/0243_fix_precalculated_events_date.py
@@ -1,0 +1,58 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.precalculated_events.sql import (
+    KAFKA_PRECALCULATED_EVENTS_TABLE_SQL,
+    KAFKA_PRECALCULATED_EVENTS_WS_TABLE_SQL,
+    PRECALCULATED_EVENTS_KAFKA_TABLE,
+    PRECALCULATED_EVENTS_MV,
+    PRECALCULATED_EVENTS_MV_SQL,
+    PRECALCULATED_EVENTS_WS_KAFKA_TABLE,
+    PRECALCULATED_EVENTS_WS_MV,
+    PRECALCULATED_EVENTS_WS_MV_SQL,
+)
+
+# The precalculated_events materialized view was deriving `date` from `toDate(_timestamp)`,
+# where `_timestamp` is the Kafka ingestion time. That broke backfills: events inserted by the
+# temporal backfill workflow always ended up with `date = today`, regardless of the event's
+# actual date.
+#
+# Fix: add the `date` column to the Kafka engine tables (MSK + WarpStream) so the producer's
+# `date` field is read, and update the MVs to prefer the incoming date, falling back to
+# `toDate(_timestamp)` when unset (realtime path still works unchanged).
+#
+# The sharded target table is unchanged; only the Kafka engine tables and MVs are recreated.
+
+operations = [
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {PRECALCULATED_EVENTS_MV}",
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {PRECALCULATED_EVENTS_WS_MV}",
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {PRECALCULATED_EVENTS_KAFKA_TABLE}",
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {PRECALCULATED_EVENTS_WS_KAFKA_TABLE}",
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        KAFKA_PRECALCULATED_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        KAFKA_PRECALCULATED_EVENTS_WS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        PRECALCULATED_EVENTS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        PRECALCULATED_EVENTS_WS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+]

--- a/posthog/clickhouse/migrations/0243_fix_precalculated_events_date.py
+++ b/posthog/clickhouse/migrations/0243_fix_precalculated_events_date.py
@@ -1,3 +1,4 @@
+from posthog import settings
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.precalculated_events.sql import (
@@ -16,13 +17,21 @@ from posthog.models.precalculated_events.sql import (
 # temporal backfill workflow always ended up with `date = today`, regardless of the event's
 # actual date.
 #
-# Fix: add the `date` column to the Kafka engine tables (MSK + WarpStream) so the producer's
-# `date` field is read, and update the MVs to prefer the incoming date, falling back to
-# `toDate(_timestamp)` when unset (realtime path still works unchanged).
+# Fix: add a Nullable(Date) `date` column to the Kafka engine tables so the producer's `date`
+# field is read, and update the MVs to prefer the incoming date, falling back to
+# `toDate(_timestamp)` when absent (realtime path still works unchanged).
 #
 # The sharded target table is unchanged; only the Kafka engine tables and MVs are recreated.
+#
+# CLOUD-ONLY (WS): non-cloud environments (CI, dev, hobby) have a single ClickHouse node where
+# both the MSK and WS materialized views consume the same Kafka topic and write to the same
+# target, causing double-ingest. WS objects are only recreated in cloud; in non-cloud they are
+# dropped (if present) and not recreated.
+
+_is_cloud = settings.CLOUD_DEPLOYMENT in ("US", "EU", "DEV")
 
 operations = [
+    # Drop MVs first so the Kafka tables can be recreated without a brief double-write window.
     run_sql_with_exceptions(
         f"DROP TABLE IF EXISTS {PRECALCULATED_EVENTS_MV}",
         node_roles=[NodeRole.INGESTION_MEDIUM],
@@ -39,20 +48,28 @@ operations = [
         f"DROP TABLE IF EXISTS {PRECALCULATED_EVENTS_WS_KAFKA_TABLE}",
         node_roles=[NodeRole.INGESTION_MEDIUM],
     ),
+    # Recreate MSK objects on all environments.
     run_sql_with_exceptions(
         KAFKA_PRECALCULATED_EVENTS_TABLE_SQL(),
-        node_roles=[NodeRole.INGESTION_MEDIUM],
-    ),
-    run_sql_with_exceptions(
-        KAFKA_PRECALCULATED_EVENTS_WS_TABLE_SQL(),
         node_roles=[NodeRole.INGESTION_MEDIUM],
     ),
     run_sql_with_exceptions(
         PRECALCULATED_EVENTS_MV_SQL(),
         node_roles=[NodeRole.INGESTION_MEDIUM],
     ),
-    run_sql_with_exceptions(
-        PRECALCULATED_EVENTS_WS_MV_SQL(),
-        node_roles=[NodeRole.INGESTION_MEDIUM],
-    ),
-]
+] + (
+    [
+        # WarpStream path is cloud-only: recreating it in non-cloud double-ingests because
+        # the warpstream_calculated_events named collection points at the same Kafka hosts.
+        run_sql_with_exceptions(
+            KAFKA_PRECALCULATED_EVENTS_WS_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_MEDIUM],
+        ),
+        run_sql_with_exceptions(
+            PRECALCULATED_EVENTS_WS_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_MEDIUM],
+        ),
+    ]
+    if _is_cloud
+    else []
+)

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0242_warpstream_person_distinct_id_overrides_kafka_engine
+0243_fix_precalculated_events_date

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -583,7 +583,7 @@
   CREATE TABLE IF NOT EXISTS kafka_precalculated_events
   (
       team_id Int64,
-      date Date,
+      date Nullable(Date),
       distinct_id String,
       person_id UUID,
       condition String,
@@ -2297,7 +2297,7 @@
   CREATE TABLE IF NOT EXISTS kafka_precalculated_events
   (
       team_id Int64,
-      date Date,
+      date Nullable(Date),
       distinct_id String,
       person_id UUID,
       condition String,
@@ -3299,7 +3299,7 @@
   CREATE MATERIALIZED VIEW IF NOT EXISTS precalculated_events_mv TO writable_precalculated_events
   AS SELECT
       team_id,
-      if(date = toDate('1970-01-01'), toDate(_timestamp), date) AS date,
+      ifNull(date, toDate(_timestamp)) AS date,
       distinct_id,
       person_id,
       condition,

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -583,6 +583,7 @@
   CREATE TABLE IF NOT EXISTS kafka_precalculated_events
   (
       team_id Int64,
+      date Date,
       distinct_id String,
       person_id UUID,
       condition String,
@@ -2296,6 +2297,7 @@
   CREATE TABLE IF NOT EXISTS kafka_precalculated_events
   (
       team_id Int64,
+      date Date,
       distinct_id String,
       person_id UUID,
       condition String,
@@ -3297,7 +3299,7 @@
   CREATE MATERIALIZED VIEW IF NOT EXISTS precalculated_events_mv TO writable_precalculated_events
   AS SELECT
       team_id,
-      toDate(_timestamp) AS date,
+      if(date = toDate('1970-01-01'), toDate(_timestamp), date) AS date,
       distinct_id,
       person_id,
       condition,

--- a/posthog/models/precalculated_events/sql.py
+++ b/posthog/models/precalculated_events/sql.py
@@ -96,7 +96,7 @@ def KAFKA_PRECALCULATED_EVENTS_TABLE_SQL():
 CREATE TABLE IF NOT EXISTS {table_name}
 (
     team_id Int64,
-    date Date,
+    date Nullable(Date),
     distinct_id String,
     person_id UUID,
     condition String,
@@ -115,7 +115,7 @@ def PRECALCULATED_EVENTS_MV_SQL():
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} TO {writable_table_name}
 AS SELECT
     team_id,
-    if(date = toDate('1970-01-01'), toDate(_timestamp), date) AS date,
+    ifNull(date, toDate(_timestamp)) AS date,
     distinct_id,
     person_id,
     condition,
@@ -148,7 +148,7 @@ def KAFKA_PRECALCULATED_EVENTS_WS_TABLE_SQL():
 CREATE TABLE IF NOT EXISTS {table_name}
 (
     team_id Int64,
-    date Date,
+    date Nullable(Date),
     distinct_id String,
     person_id UUID,
     condition String,
@@ -171,7 +171,7 @@ def PRECALCULATED_EVENTS_WS_MV_SQL():
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} TO {writable_table_name}
 AS SELECT
     team_id,
-    if(date = toDate('1970-01-01'), toDate(_timestamp), date) AS date,
+    ifNull(date, toDate(_timestamp)) AS date,
     distinct_id,
     person_id,
     condition,

--- a/posthog/models/precalculated_events/sql.py
+++ b/posthog/models/precalculated_events/sql.py
@@ -96,6 +96,7 @@ def KAFKA_PRECALCULATED_EVENTS_TABLE_SQL():
 CREATE TABLE IF NOT EXISTS {table_name}
 (
     team_id Int64,
+    date Date,
     distinct_id String,
     person_id UUID,
     condition String,
@@ -114,7 +115,7 @@ def PRECALCULATED_EVENTS_MV_SQL():
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} TO {writable_table_name}
 AS SELECT
     team_id,
-    toDate(_timestamp) AS date,
+    if(date = toDate('1970-01-01'), toDate(_timestamp), date) AS date,
     distinct_id,
     person_id,
     condition,
@@ -147,6 +148,7 @@ def KAFKA_PRECALCULATED_EVENTS_WS_TABLE_SQL():
 CREATE TABLE IF NOT EXISTS {table_name}
 (
     team_id Int64,
+    date Date,
     distinct_id String,
     person_id UUID,
     condition String,
@@ -169,7 +171,7 @@ def PRECALCULATED_EVENTS_WS_MV_SQL():
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} TO {writable_table_name}
 AS SELECT
     team_id,
-    toDate(_timestamp) AS date,
+    if(date = toDate('1970-01-01'), toDate(_timestamp), date) AS date,
     distinct_id,
     person_id,
     condition,


### PR DESCRIPTION
## Problem

The `backfill_precalculated_events` temporal workflow was producing `precalculated_events` rows whose `date` column was always equal to the backfill run date, instead of the event's actual date.

Root cause: the workflow sends `"date": <event_date>` in the Kafka payload (`posthog/temporal/messaging/backfill_precalculated_events_workflow.py:329`), but the `kafka_precalculated_events` engine table (and its WarpStream sibling) had no `date` column — so ClickHouse silently dropped the field. The materialized view then computed `toDate(_timestamp) AS date`, where `_timestamp` is the Kafka ingestion time, so every backfilled row landed with `date = today`.

## Changes

- Add `date Date` to `kafka_precalculated_events` and `kafka_precalculated_events_ws`.
- Update both MVs to read the incoming `date`, falling back to `toDate(_timestamp)` when unset — keeps the realtime Node.js path (which doesn't send `date`) working unchanged.
- New migration `0243_fix_precalculated_events_date.py` drops and recreates both Kafka tables and both MVs on `INGESTION_MEDIUM`. Sharded target table is untouched.
- Regenerated the ClickHouse schema snapshot.

No data migration — existing `precalculated_events` rows with the wrong date will be corrected by re-running the backfill workflow.

## How did you test this code?

Agent-authored. I did not run manual tests. Verified automatically: `ruff check` and `ruff format --check` on the modified Python files pass, and I confirmed the generated DDL by importing the SQL functions and printing their output. The snapshot file was updated to match the new schema.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Changes are limited to the ClickHouse schema for `precalculated_events` — the producer was already sending the correct data, so no application code was touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*