### PR TITLE
fix(experiments/mcp): Improve MCP schemas for common agent issues

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, cast
 from django.conf import settings
 from django.db.models import Prefetch, QuerySet
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from pydantic import RootModel as PydanticRootModel
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -843,6 +843,30 @@ class EnterpriseExperimentsViewSet(
             }
         )
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="metric_uuid",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "UUID of the metric to fetch timeseries for. Available on each metric in the "
+                    "experiment's metrics array."
+                ),
+                required=True,
+            ),
+            OpenApiParameter(
+                name="fingerprint",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Fingerprint of the metric configuration. Available alongside metric_uuid on "
+                    "each metric in the experiment's metrics array."
+                ),
+                required=True,
+            ),
+        ],
+    )
     @action(methods=["GET"], detail=True, required_scopes=["experiment:read"])
     def timeseries_results(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         experiment = self.get_object()

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -763,3 +763,14 @@ export type ExperimentsListParams = {
      */
     offset?: number
 }
+
+export type ExperimentsTimeseriesResultsRetrieveParams = {
+    /**
+     * Fingerprint of the metric configuration. Available alongside metric_uuid on each metric in the experiment's metrics array.
+     */
+    fingerprint: string
+    /**
+     * UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array.
+     */
+    metric_uuid: string
+}

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -17,6 +17,7 @@ import type {
     ExperimentSavedMetricApi,
     ExperimentSavedMetricsListParams,
     ExperimentsListParams,
+    ExperimentsTimeseriesResultsRetrieveParams,
     PaginatedExperimentHoldoutListApi,
     PaginatedExperimentListApi,
     PaginatedExperimentSavedMetricListApi,
@@ -695,16 +696,33 @@ This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate d
 on serializer methods and converts them into proper HTTP 409 Conflict responses with
 change request details.
  */
-export const getExperimentsTimeseriesResultsRetrieveUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/experiments/${id}/timeseries_results/`
+export const getExperimentsTimeseriesResultsRetrieveUrl = (
+    projectId: string,
+    id: number,
+    params: ExperimentsTimeseriesResultsRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/experiments/${id}/timeseries_results/?${stringifiedParams}`
+        : `/api/projects/${projectId}/experiments/${id}/timeseries_results/`
 }
 
 export const experimentsTimeseriesResultsRetrieve = async (
     projectId: string,
     id: number,
+    params: ExperimentsTimeseriesResultsRetrieveParams,
     options?: RequestInit
 ): Promise<void> => {
-    return apiMutator<void>(getExperimentsTimeseriesResultsRetrieveUrl(projectId, id), {
+    return apiMutator<void>(getExperimentsTimeseriesResultsRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
     })

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -367,29 +367,20 @@
             },
             "required": ["name", "feature_flag_key"]
         },
-        "ExperimentDeleteSchema": {
-            "type": "object",
-            "properties": {
-                "experimentId": {
-                    "type": "number",
-                    "description": "The ID of the experiment to delete"
-                }
-            },
-            "required": ["experimentId"]
-        },
         "ExperimentResultsGetSchema": {
             "type": "object",
             "properties": {
-                "experimentId": {
+                "id": {
                     "type": "number",
                     "description": "The ID of the experiment to get comprehensive results for"
                 },
                 "refresh": {
-                    "type": "boolean",
-                    "description": "Force refresh of results instead of using cached values"
+                    "default": false,
+                    "description": "Force refresh of results instead of using cached values. Defaults to false.",
+                    "type": "boolean"
                 }
             },
-            "required": ["experimentId", "refresh"]
+            "required": ["id"]
         },
         "ExperimentUpdateInputSchema": {
             "type": "object",

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -254,6 +254,19 @@ export class ApiClient {
                         throw new Error(`Validation error: ${detail}${attr}`)
                     }
 
+                    if (response.status === 404) {
+                        const experimentMatch = /\/experiments\/(\d+)/.exec(url)
+                        if (experimentMatch) {
+                            const experimentId = experimentMatch[1]
+                            console.error(`[API] Experiment ${experimentId} not found on ${method} ${url}`)
+                            throw new Error(
+                                `Experiment ${experimentId} not found in this project. ` +
+                                    `If the id is correct, the experiment may belong to a different project — ` +
+                                    `call experiment-list to see experiments accessible with your current API key and project, or switch-project first.`
+                            )
+                        }
+                    }
+
                     console.error(`[API] Request failed on ${method} ${url}: ${response.status} ${response.statusText}`)
                     throw new Error(
                         `Request failed:\nURL: ${method} ${url}\nStatus Code: ${response.status} (${response.statusText})\nError Message: ${errorText}`

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -41330,6 +41330,17 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type ExperimentsTimeseriesResultsRetrieveParams = {
+    /**
+     * Fingerprint of the metric configuration. Available alongside metric_uuid on each metric in the experiment's metrics array.
+     */
+    fingerprint: string;
+    /**
+     * UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array.
+     */
+    metric_uuid: string;
+    };
+
     export type ExportsListParams = {
     /**
      * Number of results to return per page.

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -3570,6 +3570,19 @@ export const ExperimentsTimeseriesResultsRetrieveParams = /* @__PURE__ */ zod.ob
         ),
 })
 
+export const ExperimentsTimeseriesResultsRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    fingerprint: zod
+        .string()
+        .describe(
+            "Fingerprint of the metric configuration. Available alongside metric_uuid on each metric in the experiment's metrics array."
+        ),
+    metric_uuid: zod
+        .string()
+        .describe(
+            "UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array."
+        ),
+})
+
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
 

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -41,12 +41,12 @@ export const DocumentationSearchSchema = z.object({
 })
 
 export const ExperimentResultsGetSchema = z.object({
-    experimentId: z.number().describe('The ID of the experiment to get comprehensive results for'),
-    refresh: z.boolean().describe('Force refresh of results instead of using cached values'),
-})
-
-export const ExperimentDeleteSchema = z.object({
-    experimentId: z.number().describe('The ID of the experiment to delete'),
+    id: z.number().describe('The ID of the experiment to get comprehensive results for'),
+    refresh: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('Force refresh of results instead of using cached values. Defaults to false.'),
 })
 
 /**

--- a/services/mcp/src/tools/experiments/getResults.ts
+++ b/services/mcp/src/tools/experiments/getResults.ts
@@ -24,7 +24,7 @@ export const getResultsHandler: ToolBase<typeof schema, Result>['handler'] = asy
     const projectId = await context.stateManager.getProjectId()
 
     const result = await context.api.experiments({ projectId }).getMetricResults({
-        experimentId: params.experimentId,
+        experimentId: params.id,
         refresh: params.refresh,
     })
 
@@ -42,7 +42,7 @@ export const getResultsHandler: ToolBase<typeof schema, Result>['handler'] = asy
             secondaryMetricsResults,
             exposures,
         }),
-        `/experiments/${params.experimentId}`
+        `/experiments/${params.id}`
     )
 }
 

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -21,6 +21,7 @@ import {
     ExperimentsShipVariantCreateBody,
     ExperimentsShipVariantCreateParams,
     ExperimentsTimeseriesResultsRetrieveParams,
+    ExperimentsTimeseriesResultsRetrieveQueryParams,
 } from '@/generated/experiments/api'
 import { withUiApp } from '@/resources/ui-apps'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
@@ -375,18 +376,9 @@ const experimentReset = (): ToolBase<typeof ExperimentResetSchema, WithPostHogUr
         },
     })
 
-const ExperimentTimeseriesResultsSchema = ExperimentsTimeseriesResultsRetrieveParams.omit({ project_id: true }).extend({
-    metric_uuid: z
-        .string()
-        .describe(
-            "UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array (each metric has a `uuid` field)."
-        ),
-    fingerprint: z
-        .string()
-        .describe(
-            "Fingerprint of the metric configuration. Available alongside `metric_uuid` on each metric in the experiment's metrics array."
-        ),
-})
+const ExperimentTimeseriesResultsSchema = ExperimentsTimeseriesResultsRetrieveParams.omit({ project_id: true }).extend(
+    ExperimentsTimeseriesResultsRetrieveQueryParams.shape
+)
 
 const experimentTimeseriesResults = (): ToolBase<typeof ExperimentTimeseriesResultsSchema, unknown> =>
     withUiApp('experiment-results', {
@@ -398,8 +390,8 @@ const experimentTimeseriesResults = (): ToolBase<typeof ExperimentTimeseriesResu
                 method: 'GET',
                 path: `/api/projects/${encodeURIComponent(String(projectId))}/experiments/${encodeURIComponent(String(params.id))}/timeseries_results/`,
                 query: {
-                    metric_uuid: params.metric_uuid,
                     fingerprint: params.fingerprint,
+                    metric_uuid: params.metric_uuid,
                 },
             })
             return result

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -375,7 +375,18 @@ const experimentReset = (): ToolBase<typeof ExperimentResetSchema, WithPostHogUr
         },
     })
 
-const ExperimentTimeseriesResultsSchema = ExperimentsTimeseriesResultsRetrieveParams.omit({ project_id: true })
+const ExperimentTimeseriesResultsSchema = ExperimentsTimeseriesResultsRetrieveParams.omit({ project_id: true }).extend({
+    metric_uuid: z
+        .string()
+        .describe(
+            "UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array (each metric has a `uuid` field)."
+        ),
+    fingerprint: z
+        .string()
+        .describe(
+            "Fingerprint of the metric configuration. Available alongside `metric_uuid` on each metric in the experiment's metrics array."
+        ),
+})
 
 const experimentTimeseriesResults = (): ToolBase<typeof ExperimentTimeseriesResultsSchema, unknown> =>
     withUiApp('experiment-results', {
@@ -386,6 +397,10 @@ const experimentTimeseriesResults = (): ToolBase<typeof ExperimentTimeseriesResu
             const result = await context.api.request<unknown>({
                 method: 'GET',
                 path: `/api/projects/${encodeURIComponent(String(projectId))}/experiments/${encodeURIComponent(String(params.id))}/timeseries_results/`,
+                query: {
+                    metric_uuid: params.metric_uuid,
+                    fingerprint: params.fingerprint,
+                },
             })
             return result
         },

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -505,7 +505,7 @@ describe('Experiments', { concurrent: false }, () => {
             // Try to get metric results for draft experiment
             await expect(
                 getResultsTool.handler(context, {
-                    experimentId: experiment.id,
+                    id: experiment.id,
                     refresh: false,
                 })
             ).rejects.toThrow(/has not started yet/)
@@ -545,7 +545,7 @@ describe('Experiments', { concurrent: false }, () => {
             // Test with refresh=true (will still fail for draft, but tests parameter handling)
             await expect(
                 getResultsTool.handler(context, {
-                    experimentId: experiment.id,
+                    id: experiment.id,
                     refresh: true,
                 })
             ).rejects.toThrow(/has not started yet/)
@@ -733,7 +733,7 @@ describe('Experiments', { concurrent: false }, () => {
             // Test get metric results
             await expect(
                 getResultsTool.handler(context, {
-                    experimentId: invalidId,
+                    id: invalidId,
                     refresh: false,
                 })
             ).rejects.toThrow()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-results-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-results-get.json
@@ -1,15 +1,16 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "experimentId": {
+        "id": {
             "description": "The ID of the experiment to get comprehensive results for",
             "type": "number"
         },
         "refresh": {
-            "description": "Force refresh of results instead of using cached values",
+            "default": false,
+            "description": "Force refresh of results instead of using cached values. Defaults to false.",
             "type": "boolean"
         }
     },
-    "required": ["experimentId", "refresh"],
+    "required": ["id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-timeseries-results.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-timeseries-results.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "fingerprint": {
-            "description": "Fingerprint of the metric configuration. Available alongside `metric_uuid` on each metric in the experiment's metrics array.",
+            "description": "Fingerprint of the metric configuration. Available alongside metric_uuid on each metric in the experiment's metrics array.",
             "type": "string"
         },
         "id": {
@@ -10,10 +10,10 @@
             "type": "number"
         },
         "metric_uuid": {
-            "description": "UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array (each metric has a `uuid` field).",
+            "description": "UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array.",
             "type": "string"
         }
     },
-    "required": ["id", "metric_uuid", "fingerprint"],
+    "required": ["id", "fingerprint", "metric_uuid"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-timeseries-results.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-timeseries-results.json
@@ -1,11 +1,19 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "fingerprint": {
+            "description": "Fingerprint of the metric configuration. Available alongside `metric_uuid` on each metric in the experiment's metrics array.",
+            "type": "string"
+        },
         "id": {
             "description": "A unique integer value identifying this experiment.",
             "type": "number"
+        },
+        "metric_uuid": {
+            "description": "UUID of the metric to fetch timeseries for. Available on each metric in the experiment's metrics array (each metric has a `uuid` field).",
+            "type": "string"
         }
     },
-    "required": ["id"],
+    "required": ["id", "metric_uuid", "fingerprint"],
     "type": "object"
 }


### PR DESCRIPTION
## Problem

Trace monitoring surfaced 4 LLM failure modes in the experiment MCP tools — pre-existing schema gaps and a vague 404 response:

- `experiment-results-get` rejected payloads missing `refresh`, even though every layer below the schema defaults it to `false`
- `experiment-results-get` used `experimentId` while every other experiment tool uses `id`, leading LLMs to guess the wrong param name
- `experiment-timeseries-results` had `metric_uuid` and `fingerprint` undocumented in the tool schema
- Any 404 on `/experiments/{id}/` returned a bare "Not Found" with no hint that the id might belong to another project

## Changes

- `refresh` is now optional on `experiment-results-get` with `default(false)`
- Renamed `experiment-results-get`'s `experimentId` param to `id` to match every other experiment tool
- Declared `metric_uuid` and `fingerprint` on `experiment-timeseries-results` — `@extend_schema` on the viewset (so the next OpenAPI regen picks them up) plus an explicit MCP schema extension for immediate effect
- 404s on `/experiments/{id}/` now return concrete next actions (`experiment-list`, `switch-project`) instead of a bare "Not Found"
- Removed the unused hand-written `ExperimentDeleteSchema` (shadowed by the generated equivalent)

## How did you test this code?

- A few new test cases
- Comparing local with production:

| # | Fix | Prompt | Local (fixed) | Production (pre-fix) |
|---|---|---|---|---|
| 1 | `refresh` optional on `experiment-results-get` | "Check results of experiment 1375" | `{ id: 1375 }` → passes Zod, backend returns `Experiment "New signup process" has not started yet` (1375 is a draft; call cleared every layer) | `{ experimentId: 362437 }` → `MCP -32602: expected boolean at path ["refresh"], received undefined` |
| 2 | `experimentId` → `id` on `experiment-results-get` | "Pull up metric results for experiment 1375" | `{ id: 1375 }` → schema accepts, runs to backend (same "has not started" as 1.) | `{ experiment_id: "79376" }` (model guessed snake_case) → `expected number at path ["experimentId"], received undefined` |
| 3 | `metric_uuid` + `fingerprint` declared on `experiment-timeseries-results` | "Show day-by-day timeseries for experiment 1375's primary metric" | Model reads `metrics[0].uuid` + `fingerprint` from `experiment-get`, then `{ id, metric_uuid, fingerprint }` → passes Zod, backend returns `has not been started yet` | `{ id: <n> }` (params weren't in schema) → backend `Validation error: metric_uuid query parameter is required` |
| 4 | Friendlier 404 envelope for `/experiments/{id}` | "Duplicate experiment 99999999" (nonexistent id) | `Experiment 99999999 not found in this project. If the id is correct, the experiment may belong to a different project — call experiment-list…, or switch-project first.` | Bare `404 Not Found` (`{"type":"invalid_request","code":"not_found","detail":"Not found."}`)  |