### PR TITLE
fix(replay): Always clean up Gemini file uploads

### DIFF
--- a/posthog/temporal/session_replay/session_summary/activities/a2_upload_video_to_gemini.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a2_upload_video_to_gemini.py
@@ -44,7 +44,16 @@ MAX_PROCESSING_WAIT_SECONDS = 300
 async def upload_video_to_gemini_activity(
     inputs: VideoSummarySingleSessionInputs, asset_id: int
 ) -> UploadVideoToGeminiOutput:
-    """Upload full video to Gemini for analysis and return file reference with duration, plus team name"""
+    """Upload full video to Gemini for analysis and return file reference with duration, plus team name.
+
+    If the activity fails any time after ``files.upload`` succeeded (e.g. the processing poll
+    times out or the final state isn't ``ACTIVE``), the orphaned Gemini file is deleted in a
+    ``finally`` block. Without this, Temporal's activity-level retries would upload a fresh
+    file on each attempt while the previous ones sit in Gemini storage for the full 48h TTL.
+    """
+    uploaded_file_name: str | None = None
+    raw_client: RawGenAIClient | None = None
+    succeeded = False
     try:
         # Fetch team name once here to avoid fetching it 100+ times in parallel segment analysis
         team_name = (await Team.objects.only("name").aget(id=inputs.team_id)).name
@@ -82,6 +91,8 @@ async def upload_video_to_gemini_activity(
             uploaded_file = await sync_to_async(raw_client.files.upload, thread_sensitive=False)(
                 file=tmp_file.name, config=types.UploadFileConfig(mime_type=asset.export_format)
             )
+            if uploaded_file.name:
+                uploaded_file_name = uploaded_file.name
             # Wait for file to be ready
             wait_start_time = time.time()
             while uploaded_file.state and uploaded_file.state.name == "PROCESSING":
@@ -106,6 +117,8 @@ async def upload_video_to_gemini_activity(
                 uploaded_file = await sync_to_async(raw_client.files.get, thread_sensitive=False)(
                     name=uploaded_file.name
                 )
+                if uploaded_file.name:
+                    uploaded_file_name = uploaded_file.name
             final_state_name = uploaded_file.state.name if uploaded_file.state else None
             if final_state_name != "ACTIVE":
                 raise RuntimeError(f"File processing failed. State: {final_state_name}")
@@ -127,7 +140,7 @@ async def upload_video_to_gemini_activity(
             )
             # Extract inactivity periods from export_context if available to avoid analyzing inactive segments
             inactivity_periods = asset.export_context.get("inactivity_periods") if asset.export_context else None
-            return UploadVideoToGeminiOutput(
+            result = UploadVideoToGeminiOutput(
                 uploaded_video=uploaded_video,
                 team_name=team_name,
                 # Converting to use proper types in calculations
@@ -137,6 +150,8 @@ async def upload_video_to_gemini_activity(
                     else [ReplayInactivityPeriod.model_validate(p) for p in inactivity_periods]
                 ),
             )
+            succeeded = True
+            return result
 
     except Exception as e:
         logger.exception(
@@ -145,3 +160,24 @@ async def upload_video_to_gemini_activity(
             signals_type="session-summaries",
         )
         raise
+    finally:
+        # If we uploaded a file but the activity didn't return it successfully (raise,
+        # cancellation, etc.), delete the orphan so Temporal retries don't stack up files
+        # in Gemini storage. Best-effort: failures here are logged but never swallow the
+        # original exception.
+        if not succeeded and uploaded_file_name and raw_client is not None:
+            try:
+                await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=uploaded_file_name)
+                logger.info(
+                    f"Deleted orphaned Gemini file {uploaded_file_name} for session {inputs.session_id}",
+                    gemini_file_name=uploaded_file_name,
+                    session_id=inputs.session_id,
+                    signals_type="session-summaries",
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to delete orphaned Gemini file {uploaded_file_name} for session {inputs.session_id}",
+                    gemini_file_name=uploaded_file_name,
+                    session_id=inputs.session_id,
+                    signals_type="session-summaries",
+                )

--- a/posthog/temporal/session_replay/session_summary/activities/a8_cleanup_gemini_file.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a8_cleanup_gemini_file.py
@@ -13,17 +13,42 @@ from google.genai import Client as RawGenAIClient
 logger = structlog.get_logger(__name__)
 
 
+def _is_not_found_error(exc: BaseException) -> bool:
+    """Best-effort check for a 404 / 'not found' error from the Gemini files API.
+
+    The google-genai SDK raises ``google.genai.errors.ClientError`` with a ``code`` of 404
+    when the file does not exist. We also match on message text as a fallback in case the
+    SDK changes its error surface.
+    """
+    code = getattr(exc, "code", None) or getattr(exc, "status_code", None)
+    if code == 404:
+        return True
+    msg = str(exc).lower()
+    return "not found" in msg or "404" in msg
+
+
 @temporalio.activity.defn
 async def cleanup_gemini_file_activity(gemini_file_name: str, session_id: str) -> None:
     """Delete an uploaded file from Gemini.
 
-    Raises on failure so Temporal retries the activity — the workflow's ``RetryPolicy``
-    controls total attempts.
+    Raises on unexpected failures so Temporal retries the activity — the workflow's
+    ``RetryPolicy`` controls total attempts. A 404 (file already gone, e.g. because a
+    prior attempt succeeded but the worker crashed before acknowledging it) is treated
+    as success so retries don't propagate a spurious error once the post-condition is
+    already satisfied.
     """
     raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
     try:
         await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=gemini_file_name)
-    except Exception:
+    except Exception as e:
+        if _is_not_found_error(e):
+            logger.info(
+                f"Gemini file {gemini_file_name} already gone for session {session_id} — treating as cleaned up",
+                gemini_file_name=gemini_file_name,
+                session_id=session_id,
+                signals_type="session-summaries",
+            )
+            return
         logger.exception(
             f"Failed to delete Gemini file {gemini_file_name} for session {session_id} — will be retried",
             gemini_file_name=gemini_file_name,

--- a/posthog/temporal/session_replay/session_summary/activities/a8_cleanup_gemini_file.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a8_cleanup_gemini_file.py
@@ -15,20 +15,25 @@ logger = structlog.get_logger(__name__)
 
 @temporalio.activity.defn
 async def cleanup_gemini_file_activity(gemini_file_name: str, session_id: str) -> None:
-    """Delete an uploaded file from Gemini. Best-effort: logs failures but never raises."""
+    """Delete an uploaded file from Gemini.
+
+    Raises on failure so Temporal retries the activity — the workflow's ``RetryPolicy``
+    controls total attempts.
+    """
+    raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
     try:
-        raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
         await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=gemini_file_name)
-        logger.info(
-            f"Deleted Gemini file {gemini_file_name} for session {session_id}",
-            gemini_file_name=gemini_file_name,
-            session_id=session_id,
-            signals_type="session-summaries",
-        )
     except Exception:
         logger.exception(
-            f"Failed to delete Gemini file {gemini_file_name} for session {session_id}",
+            f"Failed to delete Gemini file {gemini_file_name} for session {session_id} — will be retried",
             gemini_file_name=gemini_file_name,
             session_id=session_id,
             signals_type="session-summaries",
         )
+        raise
+    logger.info(
+        f"Deleted Gemini file {gemini_file_name} for session {session_id}",
+        gemini_file_name=gemini_file_name,
+        session_id=session_id,
+        signals_type="session-summaries",
+    )

--- a/posthog/temporal/session_replay/session_summary/summarize_session.py
+++ b/posthog/temporal/session_replay/session_summary/summarize_session.py
@@ -575,16 +575,18 @@ async def ensure_llm_single_session_summary(
     team_name = upload_result["team_name"]
     inactivity_periods = upload_result["inactivity_periods"]
 
-    # Calculate segment specs based on video duration and activity periods
-    segment_specs = calculate_video_segment_specs(
-        video_duration=uploaded_video.duration,
-        chunk_duration=SESSION_VIDEO_CHUNK_DURATION_S,
-        inputs=inputs,
-        inactivity_periods=inactivity_periods,
-    )
-
-    # Activity 8 (cleanup) must run even if activities 3-7 fail
+    # Activity 8 (cleanup) must run even if anything after the upload fails, including
+    # video segment planning — ``calculate_video_segment_specs`` can raise on missing or
+    # invalid inactivity data and previously left orphaned files in Gemini storage.
     try:
+        # Calculate segment specs based on video duration and activity periods
+        segment_specs = calculate_video_segment_specs(
+            video_duration=uploaded_video.duration,
+            chunk_duration=SESSION_VIDEO_CHUNK_DURATION_S,
+            inputs=inputs,
+            inactivity_periods=inactivity_periods,
+        )
+
         # Activity 3: Analyze all segments in parallel (max 100 concurrent to limit blast radius)
         _set_phase(progress, "analyzing_segments")
         if progress is not None:
@@ -713,13 +715,22 @@ async def ensure_llm_single_session_summary(
             retry_policy=retry_policy,
         )
     finally:
-        # Activity 8: Delete uploaded video from Gemini to free storage quota
+        # Activity 8: Delete uploaded video from Gemini to free storage quota.
+        # ``asyncio.shield`` keeps the cleanup activity running even if the workflow is
+        # cancelled, and the higher retry count ensures transient delete failures don't
+        # leave the 20 GB project quota pinned until the 48h TTL kicks in.
         _set_phase(progress, "cleanup")
-        await temporalio.workflow.execute_activity(
-            cleanup_gemini_file_activity,
-            args=(uploaded_video.gemini_file_name, inputs.session_id),
-            start_to_close_timeout=timedelta(seconds=30),
-            retry_policy=RetryPolicy(maximum_attempts=2),
+        await asyncio.shield(
+            temporalio.workflow.execute_activity(
+                cleanup_gemini_file_activity,
+                args=(uploaded_video.gemini_file_name, inputs.session_id),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=5,
+                    initial_interval=timedelta(seconds=2),
+                    maximum_interval=timedelta(seconds=30),
+                ),
+            )
         )
 
 


### PR DESCRIPTION
## Problem

We just exhausted our Gemini file-upload quota (20 GB). Uploaded session replay videos have a 48h TTL, but it looks like either have had too many in flight, or their cleanup wasn't complete. Let's assume the latter for now, which means we need to tighten up cleanup. 


## Changes

Three changes:
- `summarize_session.py`: moving `calculate_video_segment_specs` inside the `try` as the only piece outside of it, wrap the cleanup activity in `asyncio.shield` so it completes under workflow cancellation, and bump cleanup retries from 2 to 5
- `a2_upload_video_to_gemini.py`: also deleting the file if the upload activity itself fails, which we didn't do before
- `a8_cleanup_gemini_file.py`: raise on failure so Temporal's retry policy actually kicks in.

This shouldn't be leaving any gaps now.
