### PR TITLE
feat(cdp): Add function_id label to rate-limited counter

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-events.consumer.ts
@@ -138,7 +138,7 @@ export class CdpEventsConsumer<
                 try {
                     const rateLimit = rateLimits[index][1]
                     if (rateLimit.isRateLimited) {
-                        counterRateLimited.labels({ kind: 'hog_function' }).inc()
+                        counterRateLimited.labels({ kind: 'hog_function', function_id: item.functionId }).inc()
                         // NOTE: We don't return here as we are just monitoring this feature currently
                         // this.hogFunctionMonitoringService.queueAppMetric(
                         //     {
@@ -294,7 +294,7 @@ export class CdpEventsConsumer<
                 try {
                     const rateLimit = rateLimits[index][1]
                     if (rateLimit.isRateLimited) {
-                        counterRateLimited.labels({ kind: 'hog_flow' }).inc()
+                        counterRateLimited.labels({ kind: 'hog_flow', function_id: item.functionId }).inc()
                         this.hogFunctionMonitoringService.queueAppMetric(
                             {
                                 team_id: item.teamId,

--- a/nodejs/src/cdp/consumers/metrics.ts
+++ b/nodejs/src/cdp/consumers/metrics.ts
@@ -9,7 +9,7 @@ export const counterParseError = new Counter({
 export const counterRateLimited = new Counter({
     name: 'cdp_function_rate_limited',
     help: 'A function invocation was rate limited',
-    labelNames: ['kind'],
+    labelNames: ['kind', 'function_id'],
 })
 
 export const counterHogFunctionStateOnEvent = new Counter({


### PR DESCRIPTION
## Problem

The `cdp_function_rate_limited` Prometheus counter only has a `kind` label (`hog_function` or `hog_flow`), so Grafana can't tell which specific hog function or workflow is being rate limited. App metrics give this info in ClickHouse, but there is no equivalent visibility in the ops dashboards where we already track CDP health.

## Changes

- Add `function_id` to `counterRateLimited.labelNames` in `nodejs/src/cdp/consumers/metrics.ts`.
- Pass `function_id: item.functionId` from both call sites in `cdp-events.consumer.ts` (hog function path and hog flow path).

Cardinality stays bounded because the counter only increments on rate-limited invocations, so the label set grows only to functions that have actually been rate limited during a pod's lifetime.

## How did you test this code?

Just extending existing counter

## Publish to changelog?

No