### PR TITLE
feat(roles): add github mapping

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AttachGitHubTeamModal.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AttachGitHubTeamModal.tsx
@@ -1,0 +1,89 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonModal, LemonSelect } from '@posthog/lemon-ui'
+
+import { githubRoleMappingsLogic, getIntegrationAccountName } from './githubRoleMappingsLogic'
+
+export function AttachGitHubTeamModal({
+    roleId,
+    canEditRoles,
+}: {
+    roleId: string
+    canEditRoles: boolean | null
+}): JSX.Element {
+    const logic = githubRoleMappingsLogic({ roleId })
+    const {
+        externalReferenceModalOpen,
+        selectedGithubIntegrationId,
+        selectedGithubTeamId,
+        organizationGithubIntegrations,
+        availableGithubTeams,
+        noTeamsHelpText,
+        canAttachSelectedGithubTeam,
+    } = useValues(logic)
+    const {
+        closeExternalReferenceModal,
+        setSelectedGithubIntegrationId,
+        setSelectedGithubTeamId,
+        attachSelectedGithubTeam,
+    } = useActions(logic)
+
+    return (
+        <LemonModal
+            isOpen={externalReferenceModalOpen}
+            onClose={closeExternalReferenceModal}
+            title="Attach GitHub team"
+            maxWidth={560}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={closeExternalReferenceModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={attachSelectedGithubTeam}
+                        disabledReason={
+                            !canEditRoles
+                                ? 'You cannot edit this'
+                                : availableGithubTeams.length === 0
+                                  ? 'No unattached GitHub teams available'
+                                  : !canAttachSelectedGithubTeam
+                                    ? 'Select an integration and team to attach'
+                                    : undefined
+                        }
+                    >
+                        Attach
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="deprecated-space-y-3">
+                <LemonSelect
+                    value={selectedGithubIntegrationId}
+                    onChange={(value) => {
+                        setSelectedGithubIntegrationId(value)
+                        setSelectedGithubTeamId(null)
+                    }}
+                    options={organizationGithubIntegrations.map((integration) => ({
+                        value: integration.id,
+                        label: getIntegrationAccountName(integration) || `Integration ${integration.id}`,
+                    }))}
+                    placeholder="Select GitHub organization"
+                    fullWidth
+                />
+                <LemonSelect
+                    value={selectedGithubTeamId}
+                    onChange={setSelectedGithubTeamId}
+                    options={availableGithubTeams.map((team) => ({
+                        value: team.id,
+                        label: `${team.name} (${team.slug})`,
+                    }))}
+                    placeholder="Select GitHub team"
+                    disabledReason={availableGithubTeams.length === 0 ? noTeamsHelpText : undefined}
+                    fullWidth
+                />
+                {availableGithubTeams.length === 0 && <div className="text-xs text-muted">{noTeamsHelpText}</div>}
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/GitHubRoleMappings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/GitHubRoleMappings.tsx
@@ -1,0 +1,66 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { IconGithub } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { AttachGitHubTeamModal } from './AttachGitHubTeamModal'
+import { githubRoleMappingsLogic } from './githubRoleMappingsLogic'
+import { GitHubRoleMappingsTable } from './GitHubRoleMappingsTable'
+
+export function GitHubRoleMappings({
+    roleId,
+    canEditRoles,
+}: {
+    roleId: string
+    canEditRoles: boolean | null
+}): JSX.Element | null {
+    const logic = githubRoleMappingsLogic({ roleId })
+    const { organizationGithubIntegrations, githubReferencesForRole } = useValues(logic)
+    const { openExternalReferenceModal, deleteRoleExternalReference } = useActions(logic)
+
+    return (
+        <div className="rounded border border-border p-3 deprecated-space-y-2">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <IconGithub fontSize="18" />
+                    <h4 className="mb-0 text-sm font-semibold">GitHub</h4>
+                </div>
+                {organizationGithubIntegrations.length > 0 ? (
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={openExternalReferenceModal}
+                        disabledReason={!canEditRoles ? 'You cannot edit this' : undefined}
+                    >
+                        Attach GitHub team
+                    </LemonButton>
+                ) : (
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={() => router.actions.push(urls.settings('environment-integrations'))}
+                    >
+                        GitHub connection
+                    </LemonButton>
+                )}
+            </div>
+
+            <div className="text-xs text-muted">
+                Use GitHub teams from organization installations to map external roles.
+            </div>
+
+            <GitHubRoleMappingsTable
+                references={githubReferencesForRole}
+                canEditRoles={canEditRoles}
+                onDelete={deleteRoleExternalReference}
+            />
+
+            {organizationGithubIntegrations.length > 0 ? (
+                <AttachGitHubTeamModal roleId={roleId} canEditRoles={canEditRoles} />
+            ) : null}
+        </div>
+    )
+}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/GitHubRoleMappingsTable.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/GitHubRoleMappingsTable.tsx
@@ -1,0 +1,51 @@
+import { LemonButton, LemonTable } from '@posthog/lemon-ui'
+
+import type { RoleExternalReferenceApi } from 'products/integrations/frontend/generated/api.schemas'
+
+export function GitHubRoleMappingsTable({
+    references,
+    canEditRoles,
+    onDelete,
+}: {
+    references: RoleExternalReferenceApi[]
+    canEditRoles: boolean | null
+    onDelete: (id: string) => void
+}): JSX.Element | null {
+    if (references.length === 0) {
+        return null
+    }
+
+    return (
+        <LemonTable
+            columns={[
+                {
+                    title: 'Team',
+                    key: 'provider_role_name',
+                    render: (_, reference: RoleExternalReferenceApi) => reference.provider_role_name,
+                },
+                {
+                    title: 'Slug',
+                    key: 'provider_role_slug',
+                    render: (_, reference: RoleExternalReferenceApi) => reference.provider_role_slug || '-',
+                },
+                {
+                    key: 'actions',
+                    width: 0,
+                    render: (_, reference: RoleExternalReferenceApi) => (
+                        <LemonButton
+                            type="tertiary"
+                            size="small"
+                            status="danger"
+                            disabledReason={!canEditRoles ? 'You cannot edit this' : undefined}
+                            onClick={() => onDelete(reference.id)}
+                        >
+                            Remove
+                        </LemonButton>
+                    ),
+                },
+            ]}
+            dataSource={references}
+            embedded
+        />
+    )
+}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
@@ -9,6 +9,7 @@ import {
     LemonDialog,
     LemonInput,
     LemonInputSelect,
+    LemonSelect,
     LemonTable,
     LemonTableColumns,
     LemonTag,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
@@ -10,6 +10,7 @@ import {
     LemonInput,
     LemonInputSelect,
     LemonSelect,
+    LemonModal,
     LemonTable,
     LemonTableColumns,
     LemonTag,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
@@ -9,8 +9,6 @@ import {
     LemonDialog,
     LemonInput,
     LemonInputSelect,
-    LemonModal,
-    LemonSelect,
     LemonTable,
     LemonTableColumns,
     LemonTag,
@@ -22,6 +20,7 @@ import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { usersLemonSelectOptions } from 'lib/components/UserSelectItem'
 import { OrganizationMembershipLevel } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { fullName } from 'lib/utils'
@@ -31,6 +30,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature, RoleType } from '~/types'
 
+import { GitHubRoleMappings } from './GitHubRoleMappings'
 import { roleAccessControlLogic } from './roleAccessControlLogic'
 
 export function RolesAccessControls(): JSX.Element {
@@ -146,6 +146,7 @@ export function RolesAccessControls(): JSX.Element {
 
 function RoleDetails({ roleId }: { roleId: string }): JSX.Element | null {
     const { user } = useValues(userLogic)
+    const githubRoleMappingsEnabled = useFeatureFlag('ROLE_EXTERNAL_REFERENCE_UI')
     const { sortedMembers, roles, canEditRoles } = useValues(roleAccessControlLogic)
     const { addMembersToRole, removeMemberFromRole } = useActions(roleAccessControlLogic)
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
@@ -267,6 +268,8 @@ function RoleDetails({ roleId }: { roleId: string }): JSX.Element | null {
                 ]}
                 dataSource={role.members}
             />
+
+            {githubRoleMappingsEnabled && <GitHubRoleMappings roleId={role.id} canEditRoles={canEditRoles} />}
         </div>
     )
 }

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/githubRoleMappingsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/githubRoleMappingsLogic.ts
@@ -1,0 +1,325 @@
+import { actions, afterMount, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import {
+    integrationsList,
+    roleExternalReferencesCreate,
+    roleExternalReferencesDestroy,
+    roleExternalReferencesList,
+} from 'products/integrations/frontend/generated/api'
+import type {
+    IntegrationConfigApi,
+    RoleExternalReferenceApi,
+} from 'products/integrations/frontend/generated/api.schemas'
+
+export type GitHubTeamType = {
+    id: number
+    slug: string
+    name: string
+}
+
+type GitHubTeamsResponse = {
+    teams: GitHubTeamType[]
+    has_more: boolean
+}
+
+function getIntegrationAccountType(integration: IntegrationConfigApi): string | null {
+    if (!integration.config || typeof integration.config !== 'object') {
+        return null
+    }
+
+    const account = (integration.config as Record<string, unknown>).account
+    if (!account || typeof account !== 'object') {
+        return null
+    }
+
+    const accountType = (account as Record<string, unknown>).type
+    return typeof accountType === 'string' ? accountType : null
+}
+
+export function getIntegrationAccountName(integration: IntegrationConfigApi): string | null {
+    if (!integration.config || typeof integration.config !== 'object') {
+        return null
+    }
+
+    const account = (integration.config as Record<string, unknown>).account
+    if (!account || typeof account !== 'object') {
+        return null
+    }
+
+    const accountName = (account as Record<string, unknown>).name
+    return typeof accountName === 'string' ? accountName : null
+}
+
+export const githubRoleMappingsLogic = kea([
+    path(['scenes', 'accessControl', 'githubRoleMappingsLogic']),
+    props({} as { roleId: string }),
+    connect(() => ({
+        values: [teamLogic, ['currentProjectId'], organizationLogic, ['currentOrganization']],
+    })),
+    actions({
+        openExternalReferenceModal: true,
+        closeExternalReferenceModal: true,
+        setSelectedGithubIntegrationId: (integrationId: number | null) => ({ integrationId }),
+        setSelectedGithubTeamId: (teamId: number | null) => ({ teamId }),
+        attachSelectedGithubTeam: true,
+        createGitHubRoleExternalReference: (payload: {
+            roleId: string
+            providerOrganizationId: string
+            team: GitHubTeamType
+        }) => ({ payload }),
+        deleteRoleExternalReference: (referenceId: string) => ({ referenceId }),
+    }),
+    reducers({
+        externalReferenceModalOpen: [
+            false,
+            {
+                openExternalReferenceModal: () => true,
+                closeExternalReferenceModal: () => false,
+                createGitHubRoleExternalReferenceSuccess: () => false,
+            },
+        ],
+        selectedGithubIntegrationId: [
+            null as number | null,
+            {
+                setSelectedGithubIntegrationId: (_, { integrationId }) => integrationId,
+            },
+        ],
+        selectedGithubTeamId: [
+            null as number | null,
+            {
+                setSelectedGithubTeamId: (_, { teamId }) => teamId,
+                closeExternalReferenceModal: () => null,
+                createGitHubRoleExternalReferenceSuccess: () => null,
+                setSelectedGithubIntegrationId: () => null,
+            },
+        ],
+        githubTeamsError: [
+            null as string | null,
+            {
+                loadGithubTeams: () => null,
+                loadGithubTeamsSuccess: () => null,
+                loadGithubTeamsFailure: (_, { errorObject }) => {
+                    const detail = (errorObject as Record<string, unknown> | undefined)?.detail
+                    return typeof detail === 'string' ? detail : 'Failed to load GitHub teams'
+                },
+            },
+        ],
+    }),
+    loaders(({ values }) => ({
+        roleExternalReferences: [
+            [] as RoleExternalReferenceApi[],
+            {
+                loadRoleExternalReferences: async () => {
+                    const organizationId = values.currentOrganization?.id
+                    if (!organizationId) {
+                        return []
+                    }
+                    const response = await roleExternalReferencesList(organizationId, {
+                        provider: 'github',
+                        limit: 1000,
+                    })
+                    return response.results
+                },
+                createGitHubRoleExternalReference: async ({ payload }) => {
+                    const organizationId = values.currentOrganization?.id
+                    if (!organizationId) {
+                        throw new Error('Organization not found')
+                    }
+                    await roleExternalReferencesCreate(organizationId, {
+                        provider: 'github',
+                        provider_organization_id: payload.providerOrganizationId,
+                        provider_role_id: String(payload.team.id),
+                        provider_role_slug: payload.team.slug,
+                        provider_role_name: payload.team.name.trim() || payload.team.slug,
+                        role: payload.roleId,
+                    })
+                    const response = await roleExternalReferencesList(organizationId, {
+                        provider: 'github',
+                        limit: 1000,
+                    })
+                    return response.results
+                },
+                deleteRoleExternalReference: async ({ referenceId }) => {
+                    const organizationId = values.currentOrganization?.id
+                    if (!organizationId) {
+                        throw new Error('Organization not found')
+                    }
+                    await roleExternalReferencesDestroy(organizationId, referenceId)
+                    return values.roleExternalReferences.filter((reference) => reference.id !== referenceId)
+                },
+            },
+        ],
+        githubIntegrations: [
+            [] as IntegrationConfigApi[],
+            {
+                loadGithubIntegrations: async () => {
+                    const response = await integrationsList(String(values.currentProjectId), { limit: 200 })
+                    return response.results.filter((integration) => integration.kind === 'github')
+                },
+            },
+        ],
+        githubTeams: [
+            [] as GitHubTeamType[],
+            {
+                loadGithubTeams: async ({ integrationId, search }: { integrationId: number; search: string }) => {
+                    const response = await api.get<GitHubTeamsResponse>(
+                        `api/projects/${values.currentProjectId}/integrations/${integrationId}/github_teams/?search=${encodeURIComponent(search)}&limit=100&offset=0`
+                    )
+                    return response.teams
+                        .filter(
+                            (team): team is GitHubTeamType =>
+                                typeof team.id === 'number' &&
+                                typeof team.slug === 'string' &&
+                                typeof team.name === 'string'
+                        )
+                        .map((team) => ({ id: team.id, slug: team.slug, name: team.name.trim() || team.slug }))
+                },
+            },
+        ],
+    })),
+    selectors(({ props }) => ({
+        organizationGithubIntegrations: [
+            (s) => [s.githubIntegrations],
+            (githubIntegrations: IntegrationConfigApi[]): IntegrationConfigApi[] =>
+                githubIntegrations.filter(
+                    (integration) => getIntegrationAccountType(integration)?.toLowerCase() === 'organization'
+                ),
+        ],
+        githubReferencesForRole: [
+            (s) => [s.roleExternalReferences],
+            (roleExternalReferences: RoleExternalReferenceApi[]): RoleExternalReferenceApi[] =>
+                roleExternalReferences.filter((reference) => reference.role === props.roleId),
+        ],
+        selectedGithubIntegration: [
+            (s) => [s.organizationGithubIntegrations, s.selectedGithubIntegrationId],
+            (integrations: IntegrationConfigApi[], integrationId: number | null): IntegrationConfigApi | null =>
+                integrations.find((integration) => integration.id === integrationId) ?? null,
+        ],
+        selectedGithubIntegrationAccountName: [
+            (s) => [s.selectedGithubIntegration],
+            (integration: IntegrationConfigApi | null): string | null =>
+                integration ? getIntegrationAccountName(integration) : null,
+        ],
+        availableGithubTeams: [
+            (s) => [s.roleExternalReferences, s.githubTeams, s.selectedGithubIntegrationAccountName],
+            (
+                roleExternalReferences: RoleExternalReferenceApi[],
+                githubTeams: GitHubTeamType[],
+                selectedGithubIntegrationAccountName: string | null
+            ): GitHubTeamType[] => {
+                const mappedGithubTeamIds = new Set(
+                    roleExternalReferences
+                        .filter((reference) =>
+                            selectedGithubIntegrationAccountName
+                                ? reference.provider_organization_id === selectedGithubIntegrationAccountName
+                                : true
+                        )
+                        .map((reference) => reference.provider_role_id)
+                )
+                return githubTeams.filter((team) => !mappedGithubTeamIds.has(String(team.id)))
+            },
+        ],
+        selectedGithubTeam: [
+            (s) => [s.availableGithubTeams, s.selectedGithubTeamId],
+            (teams: GitHubTeamType[], selectedGithubTeamId: number | null): GitHubTeamType | null =>
+                teams.find((team) => team.id === selectedGithubTeamId) ?? null,
+        ],
+        noTeamsHelpText: [
+            (s) => [
+                s.githubTeamsError,
+                s.selectedGithubIntegration,
+                s.selectedGithubIntegrationAccountName,
+                s.githubTeams,
+            ],
+            (
+                githubTeamsError: string | null,
+                selectedGithubIntegration: IntegrationConfigApi | null,
+                selectedGithubIntegrationAccountName: string | null,
+                githubTeams: GitHubTeamType[]
+            ): string => {
+                if (githubTeamsError) {
+                    return `Could not load teams for ${selectedGithubIntegrationAccountName || 'this integration'}: ${githubTeamsError}`
+                }
+                if (!selectedGithubIntegration) {
+                    return 'Select a GitHub organization integration to load teams.'
+                }
+                if (githubTeams.length === 0) {
+                    return `No teams were returned for ${selectedGithubIntegrationAccountName || 'this integration'}. The installation might not have team access.`
+                }
+                return 'All fetched teams are already mapped to a role.'
+            },
+        ],
+        canAttachSelectedGithubTeam: [
+            (s) => [s.selectedGithubIntegration, s.selectedGithubTeam],
+            (
+                selectedGithubIntegration: IntegrationConfigApi | null,
+                selectedGithubTeam: GitHubTeamType | null
+            ): boolean => !!selectedGithubIntegration && !!selectedGithubTeam,
+        ],
+    })),
+    listeners(({ actions, values, props }) => ({
+        openExternalReferenceModal: () => {
+            if (values.selectedGithubIntegrationId) {
+                actions.loadGithubTeams({ integrationId: values.selectedGithubIntegrationId, search: '' })
+            }
+        },
+        setSelectedGithubIntegrationId: ({ integrationId }) => {
+            if (integrationId) {
+                actions.loadGithubTeams({ integrationId, search: '' })
+            }
+        },
+        attachSelectedGithubTeam: () => {
+            if (!values.selectedGithubIntegration || !values.selectedGithubTeam) {
+                return
+            }
+
+            const providerOrganizationId = getIntegrationAccountName(values.selectedGithubIntegration)
+            if (!providerOrganizationId) {
+                return
+            }
+
+            actions.createGitHubRoleExternalReference({
+                roleId: props.roleId,
+                providerOrganizationId,
+                team: values.selectedGithubTeam,
+            })
+        },
+        loadGithubIntegrationsSuccess: ({ githubIntegrations }) => {
+            const defaultIntegration = githubIntegrations.find(
+                (integration) => getIntegrationAccountType(integration)?.toLowerCase() === 'organization'
+            )
+            actions.setSelectedGithubIntegrationId(defaultIntegration?.id ?? null)
+        },
+        loadGithubTeamsFailure: ({ errorObject }) => {
+            const detail = (errorObject as Record<string, unknown> | undefined)?.detail
+            lemonToast.error(
+                typeof detail === 'string' ? `Load github teams failed: ${detail}` : 'Load github teams failed'
+            )
+        },
+        createGitHubRoleExternalReferenceSuccess: () => {
+            lemonToast.success('GitHub team attached to role')
+            actions.closeExternalReferenceModal()
+        },
+        createGitHubRoleExternalReferenceFailure: ({ errorObject }) => {
+            const detail = (errorObject as Record<string, unknown> | undefined)?.detail
+            lemonToast.error(typeof detail === 'string' ? detail : 'Failed to attach GitHub team')
+        },
+        deleteRoleExternalReferenceSuccess: () => {
+            lemonToast.success('External reference removed')
+        },
+        deleteRoleExternalReferenceFailure: () => {
+            lemonToast.error('Failed to remove external reference')
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadRoleExternalReferences()
+        actions.loadGithubIntegrations()
+    }),
+])

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/roleAccessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/roleAccessControlLogic.ts
@@ -97,7 +97,6 @@ export const roleAccessControlLogic = kea<roleAccessControlLogicType>([
                 },
             },
         ],
-
         resourceAccessControls: [
             null as AccessControlResponseType | null,
             {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -178,6 +178,7 @@ export const FEATURE_FLAGS = {
     METALYTICS: 'metalytics', // owner: #team-platform-features, used to allow companies to see (meta) analytics on access to a specific page
     PERSON_PROPERTY_INCIDENT_ANNOTATION_JAN_2026: 'person-property-incident-annotation-jan-2026', // owner: #team-platform-features, shows system annotation for Jan 6-7 2026 person property incident
     REPLAY_EXCLUDE_FROM_HIDE_RECORDINGS_MENU: 'replay-exclude-from-hide-recordings-menu', // owner: #team-replay, used to exclude what other people are seeing in Replay
+    ROLE_EXTERNAL_REFERENCE_UI: 'role_external_reference_ui', // owner: #team-error-tracking, controls GitHub role external reference mapping UI
     SHOW_UPGRADE_TO_MANAGED_ACCOUNT: 'show-upgrade-to-managed-account', // owner: #team-billing, used to give free accounts a way to force upgrade to managed account
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-ingestion, used to disable webhooks for certain companies
 

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -35,6 +35,7 @@ from posthog.models.integration import (
     EmailIntegration,
     FirebaseIntegration,
     GitHubIntegration,
+    GitHubIntegrationError,
     GitLabIntegration,
     GoogleAdsIntegration,
     GoogleCloudIntegration,
@@ -750,7 +751,10 @@ class IntegrationViewSet(
         offset = query_serializer.validated_data["offset"]
 
         github = GitHubIntegration(self.get_object())
-        teams, has_more = github.list_teams(search=search, limit=limit, offset=offset)
+        try:
+            teams, has_more = github.list_teams(search=search, limit=limit, offset=offset)
+        except GitHubIntegrationError as err:
+            raise ValidationError(str(err)) from err
 
         return Response({"teams": teams, "has_more": has_more})
 

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -129,6 +129,41 @@ class GitHubReposRefreshResponseSerializer(serializers.Serializer):
     repositories = GitHubRepoSerializer(many=True, help_text="The refreshed repository cache.")
 
 
+class GitHubTeamSerializer(serializers.Serializer):
+    id = serializers.IntegerField(help_text="GitHub team numeric identifier.")
+    slug = serializers.CharField(help_text="GitHub team slug.")
+    name = serializers.CharField(help_text="GitHub team display name.")
+
+
+class GitHubTeamsQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="Optional case-insensitive team name or slug search query.",
+    )
+    limit = serializers.IntegerField(
+        required=False,
+        default=100,
+        min_value=1,
+        max_value=500,
+        help_text="Maximum number of teams to return per request (max 500).",
+    )
+    offset = serializers.IntegerField(
+        required=False,
+        default=0,
+        min_value=0,
+        help_text="Number of teams to skip before returning results.",
+    )
+
+
+class GitHubTeamsResponseSerializer(serializers.Serializer):
+    teams = GitHubTeamSerializer(
+        many=True, help_text="List of GitHub teams available to the installation organization."
+    )
+    has_more = serializers.BooleanField(help_text="Whether more teams are available beyond this page.")
+
+
 class GitHubBranchesQuerySerializer(serializers.Serializer):
     repo = serializers.CharField(help_text="Repository in owner/repo format")
     search = serializers.CharField(
@@ -375,6 +410,7 @@ class IntegrationViewSet(
         "retrieve",
         "github_repos",
         "github_branches",
+        "github_teams",
     ]
     scope_object_write_actions = ["create", "update", "partial_update", "patch", "destroy", "refresh_github_repos"]
     permission_classes = [TeamMemberStrictManagementPermission]
@@ -700,6 +736,23 @@ class IntegrationViewSet(
         )
 
         return Response({"repositories": repositories})
+
+    @extend_schema(
+        parameters=[GitHubTeamsQuerySerializer],
+        responses={200: GitHubTeamsResponseSerializer},
+    )
+    @action(methods=["GET"], detail=True, url_path="github_teams")
+    def github_teams(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        query_serializer = GitHubTeamsQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        search = query_serializer.validated_data["search"]
+        limit = query_serializer.validated_data["limit"]
+        offset = query_serializer.validated_data["offset"]
+
+        github = GitHubIntegration(self.get_object())
+        teams, has_more = github.list_teams(search=search, limit=limit, offset=offset)
+
+        return Response({"teams": teams, "has_more": has_more})
 
     @extend_schema(
         parameters=[GitHubBranchesQuerySerializer],

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -745,6 +745,64 @@ class TestIntegrationAPIKeyAccess:
         assert data["has_more"] is False
         mock_list_repos.assert_called_once_with(search="posthog", limit=1, offset=1)
 
+    @patch("posthog.models.integration.GitHubIntegration.list_teams")
+    def test_github_teams_with_scope_succeeds(self, mock_list_teams, client: HttpClient):
+        mock_list_teams.return_value = (
+            [
+                {"id": 1, "slug": "frontend-team", "name": "Frontend Team"},
+                {"id": 2, "slug": "platform", "name": "Platform"},
+            ],
+            False,
+        )
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
+        )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_teams/",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["teams"]) == 2
+        assert data["teams"][0]["slug"] == "frontend-team"
+        assert data["has_more"] is False
+        mock_list_teams.assert_called_once_with(search="", limit=100, offset=0)
+
+    @patch("posthog.models.integration.GitHubIntegration.list_teams")
+    def test_github_teams_passes_search_limit_offset(self, mock_list_teams, client: HttpClient):
+        mock_list_teams.return_value = (
+            [
+                {"id": 1, "slug": "frontend-team", "name": "Frontend Team"},
+            ],
+            True,
+        )
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
+        )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_teams/?search=front&limit=10&offset=20",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["teams"][0]["name"] == "Frontend Team"
+        assert data["has_more"] is True
+        mock_list_teams.assert_called_once_with(search="front", limit=10, offset=20)
+
     @patch("posthog.models.integration.GitHubIntegration.sync_repository_cache")
     def test_refresh_github_repos_with_write_scope_succeeds(self, mock_sync_repository_cache, client: HttpClient):
         mock_sync_repository_cache.return_value = [

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -17,6 +17,7 @@ from posthog.models.integration import (
     PRIVATE_CHANNEL_WITHOUT_ACCESS,
     EmailIntegration,
     GitHubIntegration,
+    GitHubIntegrationError,
     Integration,
     SlackIntegration,
     StripeIntegration,
@@ -745,15 +746,58 @@ class TestIntegrationAPIKeyAccess:
         assert data["has_more"] is False
         mock_list_repos.assert_called_once_with(search="posthog", limit=1, offset=1)
 
+    @pytest.mark.parametrize(
+        "query_string,mock_return,expected_call",
+        [
+            (
+                "",
+                (
+                    [
+                        {"id": 1, "slug": "frontend-team", "name": "Frontend Team"},
+                        {"id": 2, "slug": "platform", "name": "Platform"},
+                    ],
+                    False,
+                ),
+                {"search": "", "limit": 100, "offset": 0},
+            ),
+            (
+                "?search=front&limit=10&offset=20",
+                (
+                    [
+                        {"id": 1, "slug": "frontend-team", "name": "Frontend Team"},
+                    ],
+                    True,
+                ),
+                {"search": "front", "limit": 10, "offset": 20},
+            ),
+        ],
+    )
     @patch("posthog.models.integration.GitHubIntegration.list_teams")
-    def test_github_teams_with_scope_succeeds(self, mock_list_teams, client: HttpClient):
-        mock_list_teams.return_value = (
-            [
-                {"id": 1, "slug": "frontend-team", "name": "Frontend Team"},
-                {"id": 2, "slug": "platform", "name": "Platform"},
-            ],
-            False,
+    def test_github_teams(self, mock_list_teams, query_string, mock_return, expected_call, client: HttpClient):
+        mock_list_teams.return_value = mock_return
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
         )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_teams/{query_string}",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["teams"] == mock_return[0]
+        assert data["has_more"] is mock_return[1]
+        mock_list_teams.assert_called_once_with(**expected_call)
+
+    @patch("posthog.models.integration.GitHubIntegration.list_teams")
+    def test_github_teams_errors_return_400(self, mock_list_teams, client: HttpClient):
+        mock_list_teams.side_effect = GitHubIntegrationError("GitHubIntegration: list_teams failed")
 
         key_value = "test_key_123"
         PersonalAPIKey.objects.create(
@@ -768,40 +812,8 @@ class TestIntegrationAPIKeyAccess:
             HTTP_AUTHORIZATION=f"Bearer {key_value}",
         )
 
-        assert response.status_code == status.HTTP_200_OK
-        data = response.json()
-        assert len(data["teams"]) == 2
-        assert data["teams"][0]["slug"] == "frontend-team"
-        assert data["has_more"] is False
-        mock_list_teams.assert_called_once_with(search="", limit=100, offset=0)
-
-    @patch("posthog.models.integration.GitHubIntegration.list_teams")
-    def test_github_teams_passes_search_limit_offset(self, mock_list_teams, client: HttpClient):
-        mock_list_teams.return_value = (
-            [
-                {"id": 1, "slug": "frontend-team", "name": "Frontend Team"},
-            ],
-            True,
-        )
-
-        key_value = "test_key_123"
-        PersonalAPIKey.objects.create(
-            label="Test Key",
-            user=self.user,
-            secure_value=hash_key_value(key_value),
-            scopes=["integration:read"],
-        )
-
-        response = client.get(
-            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_teams/?search=front&limit=10&offset=20",
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        data = response.json()
-        assert data["teams"][0]["name"] == "Frontend Team"
-        assert data["has_more"] is True
-        mock_list_teams.assert_called_once_with(search="front", limit=10, offset=20)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "GitHubIntegration: list_teams failed"
 
     @patch("posthog.models.integration.GitHubIntegration.sync_repository_cache")
     def test_refresh_github_repos_with_write_scope_succeeds(self, mock_sync_repository_cache, client: HttpClient):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2286,6 +2286,10 @@ class GitHubIntegration:
 
     def list_teams(self, *, search: str = "", limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], bool]:
         """List GitHub teams for the integration account organization with bounded API calls."""
+        account_type = dot_get(self.integration.config, "account.type", "")
+        if isinstance(account_type, str) and account_type.lower() == "user":
+            return [], False
+
         organization = dot_get(self.integration.config, "account.name", "")
         if not organization:
             return [], False
@@ -2315,6 +2319,8 @@ class GitHubIntegration:
                 f"https://api.github.com/orgs/{organization}/teams?page={page}&per_page={per_page}"
             )
             if response is None or response.status_code != 200:
+                if response is not None and response.status_code == 404:
+                    return [], False
                 logger.warning(
                     "GitHubIntegration: list_teams failed",
                     integration_id=self.integration.id,

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2284,6 +2284,62 @@ class GitHubIntegration:
             return False
         return response.status_code == 200
 
+    def list_teams(self, *, search: str = "", limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], bool]:
+        """List GitHub teams for the integration account organization with local pagination."""
+        organization = dot_get(self.integration.config, "account.name", "")
+        if not organization:
+            return [], False
+
+        teams: list[dict[str, Any]] = []
+        page = 1
+        per_page = 100
+
+        while True:
+            response = self._installation_authenticated_get(
+                f"https://api.github.com/orgs/{organization}/teams?page={page}&per_page={per_page}"
+            )
+            if response is None or response.status_code != 200:
+                logger.warning(
+                    "GitHubIntegration: list_teams failed",
+                    integration_id=self.integration.id,
+                    organization=organization,
+                    status_code=response.status_code if response is not None else None,
+                )
+                raise GitHubIntegrationError("GitHubIntegration: list_teams failed")
+
+            body = response.json()
+            if not isinstance(body, list):
+                logger.warning(
+                    "GitHubIntegration: list_teams invalid payload",
+                    integration_id=self.integration.id,
+                    organization=organization,
+                )
+                raise GitHubIntegrationError("GitHubIntegration: list_teams invalid payload")
+
+            for team in body:
+                if not isinstance(team, dict):
+                    continue
+                team_id = team.get("id")
+                slug = team.get("slug")
+                name = team.get("name")
+                if not isinstance(team_id, int) or not isinstance(slug, str) or not isinstance(name, str):
+                    continue
+                teams.append({"id": team_id, "slug": slug, "name": name})
+
+            if len(body) < per_page:
+                break
+            page += 1
+
+        search_lower = search.lower().strip()
+        if search_lower:
+            teams = [
+                team for team in teams if search_lower in team["slug"].lower() or search_lower in team["name"].lower()
+            ]
+
+        sliced = teams[offset : offset + limit]
+        has_more = len(teams) > offset + limit
+        return sliced, has_more
+
     def get_commit_author_info(self, repository: str, sha: str) -> GitHubCommitAuthor | None:
         """Resolve a commit SHA to author metadata via the GitHub API."""
         response = self._installation_authenticated_get(f"https://api.github.com/repos/{repository}/commits/{sha}")

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2285,16 +2285,32 @@ class GitHubIntegration:
         return response.status_code == 200
 
     def list_teams(self, *, search: str = "", limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], bool]:
-        """List GitHub teams for the integration account organization with local pagination."""
+        """List GitHub teams for the integration account organization with bounded API calls."""
         organization = dot_get(self.integration.config, "account.name", "")
         if not organization:
             return [], False
 
-        teams: list[dict[str, Any]] = []
-        page = 1
         per_page = 100
+        search_lower = search.lower().strip()
 
-        while True:
+        if search_lower:
+            # GitHub's org teams endpoint does not support server-side search.
+            # Keep calls bounded and filter locally.
+            max_pages = 10
+            first_page = 1
+            last_page = max_pages
+            start = offset
+            end = offset + limit
+        else:
+            requested = limit + 1
+            first_page = offset // per_page + 1
+            last_page = (offset + requested) // per_page + 1
+            start = offset % per_page
+            end = start + requested
+
+        teams: list[dict[str, Any]] = []
+
+        for page in range(first_page, last_page + 1):
             response = self._installation_authenticated_get(
                 f"https://api.github.com/orgs/{organization}/teams?page={page}&per_page={per_page}"
             )
@@ -2328,17 +2344,18 @@ class GitHubIntegration:
 
             if len(body) < per_page:
                 break
-            page += 1
 
-        search_lower = search.lower().strip()
         if search_lower:
             teams = [
                 team for team in teams if search_lower in team["slug"].lower() or search_lower in team["name"].lower()
             ]
+            sliced = teams[offset : offset + limit]
+            has_more = len(teams) > offset + limit
+            return sliced, has_more
 
-        sliced = teams[offset : offset + limit]
-        has_more = len(teams) > offset + limit
-        return sliced, has_more
+        window = teams[start:end]
+        has_more = len(window) > limit
+        return window[:limit], has_more
 
     def get_commit_author_info(self, repository: str, sha: str) -> GitHubCommitAuthor | None:
         """Resolve a commit SHA to author metadata via the GitHub API."""

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2295,12 +2295,12 @@ class GitHubIntegration:
 
         if search_lower:
             # GitHub's org teams endpoint does not support server-side search.
-            # Keep calls bounded and filter locally.
+            # Keep calls bounded and shift the fetch window by offset.
             max_pages = 10
-            first_page = 1
-            last_page = max_pages
-            start = offset
-            end = offset + limit
+            first_page = offset // per_page + 1
+            last_page = first_page + max_pages - 1
+            start = 0
+            end = limit + 1
         else:
             requested = limit + 1
             first_page = offset // per_page + 1
@@ -2349,9 +2349,6 @@ class GitHubIntegration:
             teams = [
                 team for team in teams if search_lower in team["slug"].lower() or search_lower in team["name"].lower()
             ]
-            sliced = teams[offset : offset + limit]
-            has_more = len(teams) > offset + limit
-            return sliced, has_more
 
         window = teams[start:end]
         has_more = len(window) > limit

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -287,6 +287,22 @@ export interface GitHubReposRefreshResponseApi {
     repositories: GitHubRepoApi[]
 }
 
+export interface GitHubTeamApi {
+    /** GitHub team numeric identifier. */
+    id: number
+    /** GitHub team slug. */
+    slug: string
+    /** GitHub team display name. */
+    name: string
+}
+
+export interface GitHubTeamsResponseApi {
+    /** List of GitHub teams available to the installation organization. */
+    teams: GitHubTeamApi[]
+    /** Whether more teams are available beyond this page. */
+    has_more: boolean
+}
+
 export type RoleExternalReferencesListParams = {
     /**
      * Number of results to return per page.
@@ -369,6 +385,24 @@ export type IntegrationsGithubReposRetrieveParams = {
     offset?: number
     /**
      * Optional case-insensitive repository name search query.
+     */
+    search?: string
+}
+
+export type IntegrationsGithubTeamsRetrieveParams = {
+    /**
+     * Maximum number of teams to return per request (max 500).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number
+    /**
+     * Number of teams to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number
+    /**
+     * Optional case-insensitive team name or slug search query.
      */
     search?: string
 }

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -12,9 +12,11 @@ import type {
     GitHubBranchesResponseApi,
     GitHubReposRefreshResponseApi,
     GitHubReposResponseApi,
+    GitHubTeamsResponseApi,
     IntegrationConfigApi,
     IntegrationsGithubBranchesRetrieveParams,
     IntegrationsGithubReposRetrieveParams,
+    IntegrationsGithubTeamsRetrieveParams,
     IntegrationsListParams,
     OrganizationIntegrationApi,
     PaginatedIntegrationConfigListApi,
@@ -406,6 +408,38 @@ export const integrationsGithubReposRefreshCreate = async (
     return apiMutator<GitHubReposRefreshResponseApi>(getIntegrationsGithubReposRefreshCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
+    })
+}
+
+export const getIntegrationsGithubTeamsRetrieveUrl = (
+    projectId: string,
+    id: number,
+    params?: IntegrationsGithubTeamsRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/integrations/${id}/github_teams/?${stringifiedParams}`
+        : `/api/projects/${projectId}/integrations/${id}/github_teams/`
+}
+
+export const integrationsGithubTeamsRetrieve = async (
+    projectId: string,
+    id: number,
+    params?: IntegrationsGithubTeamsRetrieveParams,
+    options?: RequestInit
+): Promise<GitHubTeamsResponseApi> => {
+    return apiMutator<GitHubTeamsResponseApi>(getIntegrationsGithubTeamsRetrieveUrl(projectId, id, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -126,3 +126,6 @@ tools:
     role-external-references-lookup-retrieve:
         operation: role_external_references_lookup_retrieve
         enabled: false
+    integrations-github-teams-retrieve:
+        operation: integrations_github_teams_retrieve
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17720,6 +17720,22 @@ export namespace Schemas {
       has_more: boolean;
     }
 
+    export interface GitHubTeam {
+      /** GitHub team numeric identifier. */
+      id: number;
+      /** GitHub team slug. */
+      slug: string;
+      /** GitHub team display name. */
+      name: string;
+    }
+
+    export interface GitHubTeamsResponse {
+      /** List of GitHub teams available to the installation organization. */
+      teams: GitHubTeam[];
+      /** Whether more teams are available beyond this page. */
+      has_more: boolean;
+    }
+
     export interface GitProviderFileLinkResolveResponse {
       /** Whether a matching file URL was found. */
       found: boolean;
@@ -38256,6 +38272,24 @@ export namespace Schemas {
     search?: string;
     };
 
+    export type EnvironmentsIntegrationsGithubTeamsRetrieveParams = {
+    /**
+     * Maximum number of teams to return per request (max 500).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Number of teams to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number;
+    /**
+     * Optional case-insensitive team name or slug search query.
+     */
+    search?: string;
+    };
+
     export type EnvironmentsLogsAlertsListParams = {
     /**
      * Number of results to return per page.
@@ -42438,6 +42472,24 @@ export namespace Schemas {
     offset?: number;
     /**
      * Optional case-insensitive repository name search query.
+     */
+    search?: string;
+    };
+
+    export type IntegrationsGithubTeamsRetrieveParams = {
+    /**
+     * Maximum number of teams to return per request (max 500).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Number of teams to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number;
+    /**
+     * Optional case-insensitive team name or slug search query.
      */
     search?: string;
     };


### PR DESCRIPTION
## Problem

Organization roles currently lack a dedicated way to map roles to GitHub teams for external references. This makes setup harder and forces manual workflows.

## Changes

- add a dedicated GitHub role mappings section in role details
- split GitHub mapping concerns into dedicated kea logic and components
- support lazy team loading when opening the attach modal
- prevent selecting teams already mapped to any role for the same GitHub org install
- improve empty/error states for installation issues vs no teams returned
- show a GitHub connection button when no organization GitHub integration is present
- gate the UI behind FEATURE_FLAGS.ROLE_EXTERNAL_REFERENCE_UI

## How did you test this code?

- exercised the role details flow locally
- validated attach modal states (no integration, no teams, already mapped, load error)
- verified create/remove mapping flows and duplicate-prevention behavior
- fixed runtime regression by restoring LemonSelect import

Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.

## Publish to changelog?

no

## Docs update

No docs update needed.

## LLM context

Implemented with agent support. Split UI into smaller components and moved derived state + attach flow into kea selectors/listeners to reduce prop drilling and keep modal state in logic.

