### PR TITLE
fix(revenue-analytics): correct customer analytics link in deprecation notice

### DIFF
--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -67,7 +67,7 @@ export function RevenueAnalyticsScene(): JSX.Element {
                     {enabledFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] ? (
                         <Link to={urls.customerAnalytics()}>Customer analytics</Link>
                     ) : (
-                        <Link to={urls.earlyAccessFeatures()}>Customer analytics (early access)</Link>
+                        <Link to={urls.settings('user-feature-previews')}>Customer analytics (early access)</Link>
                     )}
                     .
                 </LemonBanner>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The deprecation notice at the top of the Revenue Analytics page links "Customer analytics" to the Early access features management page (where users build and launch their own early access features) instead of the User feature previews settings page (where users toggle PostHog feature previews like Customer analytics).

## Changes

Updated the link in the Revenue Analytics deprecation banner to point to `urls.settings('user-feature-previews')` instead of `urls.earlyAccessFeatures()` when the Customer Analytics feature flag is not enabled.

## How did you test this code?

This is a single-line link fix. The change updates the URL from `/project/:id/early_access_features` to `/project/:id/settings/user-feature-previews`, which matches the pattern used elsewhere in the codebase (AccountMenu, FeaturePreviewSceneGate, etc.).

## Publish to changelog?

no

## Docs update

N/A - no docs update needed

## 🤖 Agent context

Agent: Cursor Cloud Agent
Session: Slack-reported issue
Key decision: Changed from `urls.earlyAccessFeatures()` to `urls.settings('user-feature-previews')` to match the correct destination for toggling PostHog feature previews.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1777050442159069?thread_ts=1777050442.159069&cid=D0ACMC57HDE)

<div><a href="https://cursor.com/agents/bc-90fbc518-f798-572c-a889-ffd05e4f656c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90fbc518-f798-572c-a889-ffd05e4f656c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

