### PR TITLE
feat: Resolve best seat across orgs and remove team_id from plan cache

### DIFF
--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -22,10 +22,13 @@ from posthog.models.user import User
 from ee.billing.billing_manager import build_billing_token
 from ee.settings import BILLING_SERVICE_URL
 
+# Duplicated in services/llm-gateway/src/llm_gateway/services/plan_resolver.py
 PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
 
 
 def _seat_priority(seat: dict[str, Any]) -> tuple[bool, int]:
+    # Tuple comparison: active (True > False) takes precedence, then tier.
+    # So active-free (True, 1) beats canceled-pro (False, 2).
     active = seat.get("status") == "active"
     plan_key = seat.get("plan_key") or ""
     if any(plan_key.startswith(p) for p in PRO_PLAN_PREFIXES):
@@ -240,7 +243,13 @@ class SeatViewSet(viewsets.ViewSet):
         return self._forward_response(resp)
 
     def _retrieve_best_seat(self, request: Request) -> Response:
-        """Return the highest-tier seat across all the user's orgs."""
+        """Return the highest-tier seat across all the user's orgs.
+
+        For single-org users this is a direct pass-through. For multi-org
+        users, billing requests fan out in parallel via ThreadPoolExecutor
+        (capped at 5 workers) and the best seat is selected by
+        ``_seat_priority``.
+        """
         user = cast(User, request.user)
         distinct_id = str(user.distinct_id)
         query_params = self._filtered_query_params(request)
@@ -258,10 +267,10 @@ class SeatViewSet(viewsets.ViewSet):
                 return Response({"detail": "No license found"}, status=status.HTTP_400_BAD_REQUEST)
             resp = self._billing_request("GET", f"/api/v2/seats/{distinct_id}/", headers, query_params=query_params)
             drf_resp = self._forward_response(resp)
-            if 200 <= drf_resp.status_code < 300 and isinstance(drf_resp.data, dict):
-                drf_resp.data["organization_id"] = str(org.id)
-                drf_resp.data["organization_name"] = org.name
-            return drf_resp
+            if not 200 <= drf_resp.status_code < 300 or not isinstance(drf_resp.data, dict):
+                return drf_resp
+            data = {**drf_resp.data, "organization_id": str(org.id), "organization_name": org.name}
+            return Response(data)
 
         def fetch_seat(org: Organization) -> tuple[Organization, dict[str, Any]] | None:
             headers = self._get_billing_headers_for_org(user, org)

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -25,13 +25,14 @@ from ee.settings import BILLING_SERVICE_URL
 PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
 
 
-def _seat_priority(seat: dict[str, Any]) -> int:
+def _seat_priority(seat: dict[str, Any]) -> tuple[bool, int]:
+    active = seat.get("status") == "active"
     plan_key = seat.get("plan_key") or ""
     if any(plan_key.startswith(p) for p in PRO_PLAN_PREFIXES):
-        return 2
+        return (active, 2)
     if plan_key:
-        return 1
-    return 0
+        return (active, 1)
+    return (active, 0)
 
 
 logger = structlog.get_logger(__name__)
@@ -262,24 +263,18 @@ class SeatViewSet(viewsets.ViewSet):
             if not headers:
                 return None
             resp = self._billing_request("GET", f"/api/v2/seats/{distinct_id}/", headers, query_params=query_params)
-            if resp is None or not resp.ok:
+            drf_resp = self._forward_response(resp)
+            if not 200 <= drf_resp.status_code < 300 or not isinstance(drf_resp.data, dict):
                 return None
-            try:
-                data = resp.json()
-                return data.get("seat", data) if isinstance(data, dict) else None
-            except ValueError:
-                return None
+            return drf_resp.data
 
         seats: list[dict[str, Any]] = []
         with ThreadPoolExecutor(max_workers=min(len(orgs), 5)) as pool:
             futures = {pool.submit(fetch_seat, org): org for org in orgs}
             for future in as_completed(futures):
-                try:
-                    seat = future.result()
-                    if seat:
-                        seats.append(seat)
-                except Exception:
-                    logger.exception("Failed to fetch seat for org", org_id=str(futures[future].id))
+                seat = future.result()
+                if seat:
+                    seats.append(seat)
 
         if not seats:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -1,4 +1,5 @@
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, cast
 
 import requests
@@ -13,13 +14,25 @@ from rest_framework.response import Response
 
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.cloud_utils import get_cached_instance_license
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.user import User
 
 # TODO: Centralize billing proxy through BillingManager (ee/billing/) to avoid
 # duplicating auth header construction and keep all billing communication in one place
 from ee.billing.billing_manager import build_billing_token
 from ee.settings import BILLING_SERVICE_URL
+
+PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
+
+
+def _seat_priority(seat: dict[str, Any]) -> int:
+    plan_key = seat.get("plan_key") or ""
+    if any(plan_key.startswith(p) for p in PRO_PLAN_PREFIXES):
+        return 2
+    if plan_key:
+        return 1
+    return 0
+
 
 logger = structlog.get_logger(__name__)
 
@@ -59,17 +72,22 @@ class SeatViewSet(viewsets.ViewSet):
 
     def _get_billing_headers(self, request: Request) -> dict[str, str] | None:
         user = cast(User, request.user)
-        license = get_cached_instance_license()
         org = user.organization
-        if not org or not license:
+        if not org:
+            return None
+        return self._get_billing_headers_for_org(user, org)
+
+    def _get_billing_headers_for_org(self, user: User, org: Organization) -> dict[str, str] | None:
+        license = get_cached_instance_license()
+        if not license:
             return None
         try:
             token = build_billing_token(license, org, user)
         except NotAuthenticated:
-            logger.warning("User not a member of their current organization", user_id=user.id)
+            logger.warning("User not a member of organization", user_id=user.id, org_id=str(org.id))
             return None
         except Exception:
-            logger.exception("Failed to build billing token", user_id=user.id)
+            logger.exception("Failed to build billing token", user_id=user.id, org_id=str(org.id))
             return None
         return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
@@ -195,9 +213,17 @@ class SeatViewSet(viewsets.ViewSet):
         return self._forward_response(resp)
 
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
-        """GET /api/seats/me/ -> GET /api/v2/seats/{distinct_id}/?product_key="""
+        """GET /api/seats/me/ -> GET /api/v2/seats/{distinct_id}/?product_key=
+
+        Pass ``?best=true`` to resolve the highest-tier seat across all
+        the user's organizations (only supported for ``pk=me``).
+        """
         if pk != "me":
             self._require_admin(request)
+
+        use_best = request.query_params.get("best", "").lower() == "true"
+        if use_best and pk == "me":
+            return self._retrieve_best_seat(request)
 
         headers = self._get_billing_headers(request)
         if not headers:
@@ -211,6 +237,55 @@ class SeatViewSet(viewsets.ViewSet):
             query_params=self._filtered_query_params(request),
         )
         return self._forward_response(resp)
+
+    def _retrieve_best_seat(self, request: Request) -> Response:
+        """Return the highest-tier seat across all the user's orgs."""
+        user = cast(User, request.user)
+        distinct_id = str(user.distinct_id)
+        query_params = self._filtered_query_params(request)
+
+        memberships = OrganizationMembership.objects.filter(user=user).select_related("organization")
+        orgs = [m.organization for m in memberships if m.organization is not None]
+
+        if not orgs:
+            return Response({"detail": "No organization found"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if len(orgs) == 1:
+            headers = self._get_billing_headers_for_org(user, orgs[0])
+            if not headers:
+                return Response({"detail": "No license found"}, status=status.HTTP_400_BAD_REQUEST)
+            resp = self._billing_request("GET", f"/api/v2/seats/{distinct_id}/", headers, query_params=query_params)
+            return self._forward_response(resp)
+
+        def fetch_seat(org: Organization) -> dict[str, Any] | None:
+            headers = self._get_billing_headers_for_org(user, org)
+            if not headers:
+                return None
+            resp = self._billing_request("GET", f"/api/v2/seats/{distinct_id}/", headers, query_params=query_params)
+            if resp is None or not resp.ok:
+                return None
+            try:
+                data = resp.json()
+                return data.get("seat", data) if isinstance(data, dict) else None
+            except ValueError:
+                return None
+
+        seats: list[dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=min(len(orgs), 5)) as pool:
+            futures = {pool.submit(fetch_seat, org): org for org in orgs}
+            for future in as_completed(futures):
+                try:
+                    seat = future.result()
+                    if seat:
+                        seats.append(seat)
+                except Exception:
+                    logger.exception("Failed to fetch seat for org", org_id=str(futures[future].id))
+
+        if not seats:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        best = max(seats, key=_seat_priority)
+        return Response(best)
 
     def partial_update(self, request: Request, pk: str | None = None) -> Response:
         """PATCH /api/seats/me/ -> PATCH /api/v2/seats/{distinct_id}/"""

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -252,13 +252,18 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "No organization found"}, status=status.HTTP_400_BAD_REQUEST)
 
         if len(orgs) == 1:
-            headers = self._get_billing_headers_for_org(user, orgs[0])
+            org = orgs[0]
+            headers = self._get_billing_headers_for_org(user, org)
             if not headers:
                 return Response({"detail": "No license found"}, status=status.HTTP_400_BAD_REQUEST)
             resp = self._billing_request("GET", f"/api/v2/seats/{distinct_id}/", headers, query_params=query_params)
-            return self._forward_response(resp)
+            drf_resp = self._forward_response(resp)
+            if 200 <= drf_resp.status_code < 300 and isinstance(drf_resp.data, dict):
+                drf_resp.data["organization_id"] = str(org.id)
+                drf_resp.data["organization_name"] = org.name
+            return drf_resp
 
-        def fetch_seat(org: Organization) -> dict[str, Any] | None:
+        def fetch_seat(org: Organization) -> tuple[Organization, dict[str, Any]] | None:
             headers = self._get_billing_headers_for_org(user, org)
             if not headers:
                 return None
@@ -266,20 +271,22 @@ class SeatViewSet(viewsets.ViewSet):
             drf_resp = self._forward_response(resp)
             if not 200 <= drf_resp.status_code < 300 or not isinstance(drf_resp.data, dict):
                 return None
-            return drf_resp.data
+            return (org, drf_resp.data)
 
-        seats: list[dict[str, Any]] = []
+        results: list[tuple[Organization, dict[str, Any]]] = []
         with ThreadPoolExecutor(max_workers=min(len(orgs), 5)) as pool:
             futures = {pool.submit(fetch_seat, org): org for org in orgs}
             for future in as_completed(futures):
-                seat = future.result()
-                if seat:
-                    seats.append(seat)
+                result = future.result()
+                if result:
+                    results.append(result)
 
-        if not seats:
+        if not results:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        best = max(seats, key=_seat_priority)
+        best_org, best = max(results, key=lambda r: _seat_priority(r[1]))
+        best["organization_id"] = str(best_org.id)
+        best["organization_name"] = best_org.name
         return Response(best)
 
     def partial_update(self, request: Request, pk: str | None = None) -> Response:

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -1,5 +1,6 @@
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
 from typing import Any, cast
 
 import requests
@@ -26,16 +27,21 @@ from ee.settings import BILLING_SERVICE_URL
 PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
 
 
-def _seat_priority(seat: dict[str, Any]) -> tuple[bool, int]:
-    # Tuple comparison: active (True > False) takes precedence, then tier.
-    # So active-free (True, 1) beats canceled-pro (False, 2).
+def _seat_priority(seat: dict[str, Any]) -> tuple[bool, int, float]:
+    # Tuple comparison: active (True > False) first, then tier, then
+    # earliest created_at wins ties (oldest seat is the stable pick).
     active = seat.get("status") == "active"
     plan_key = seat.get("plan_key") or ""
+    created_at = seat.get("created_at") or ""
+    try:
+        ts = datetime.fromisoformat(created_at).timestamp()
+    except (ValueError, TypeError):
+        ts = float("inf")
     if any(plan_key.startswith(p) for p in PRO_PLAN_PREFIXES):
-        return (active, 2)
+        return (active, 2, -ts)
     if plan_key:
-        return (active, 1)
-    return (active, 0)
+        return (active, 1, -ts)
+    return (active, 0, -ts)
 
 
 logger = structlog.get_logger(__name__)

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -277,7 +277,11 @@ class SeatViewSet(viewsets.ViewSet):
         with ThreadPoolExecutor(max_workers=min(len(orgs), 5)) as pool:
             futures = {pool.submit(fetch_seat, org): org for org in orgs}
             for future in as_completed(futures):
-                result = future.result()
+                try:
+                    result = future.result()
+                except Exception:
+                    logger.warning("fetch_seat_failed", org_id=str(futures[future].id))
+                    continue
                 if result:
                     results.append(result)
 

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -436,9 +436,7 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
     def test_best_ignored_for_non_me_pk(self, _mock_token, mock_request, _mock_license):
         mock_request.return_value = _billing_response({"seat": MOCK_SEAT})
         self._auth_as_admin()
-        response = self.client.get(
-            f"/api/seats/{self.user.distinct_id}/?product_key=posthog_code&best=true"
-        )
+        response = self.client.get(f"/api/seats/{self.user.distinct_id}/?product_key=posthog_code&best=true")
         assert response.status_code == status.HTTP_200_OK
         assert mock_request.call_count == 1
 

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 
 from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated
 from rest_framework.test import APIClient
 
 from posthog.models import Organization, OrganizationMembership, Team, User
@@ -496,6 +497,28 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["plan_key"] == "posthog-code-free-20260301"
         assert response.json()["status"] == "active"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_future_exception_handled_gracefully(self, _mock_token, mock_request, _mock_license):
+        mock_request.side_effect = [
+            RuntimeError("connection reset"),
+            _billing_response({"seat": MOCK_PRO_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-200-20260301"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token")
+    def test_partial_header_failure_returns_available_seat(self, mock_token, mock_request, _mock_license):
+        mock_token.side_effect = [NotAuthenticated("no member"), MOCK_BILLING_TOKEN]
+        mock_request.return_value = _billing_response({"seat": MOCK_FREE_SEAT})
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-free-20260301"
 
 
 @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -386,6 +386,8 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
         response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["plan_key"] == "posthog-code-free-20260301"
+        assert response.json()["organization_id"] == str(self.organization.id)
+        assert response.json()["organization_name"] == "Test Org"
 
     @patch("products.tasks.backend.seat_api.requests.request")
     @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
@@ -398,6 +400,7 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
         response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["plan_key"] == "posthog-code-200-20260301"
+        assert "organization_id" in response.json()
 
     @patch("products.tasks.backend.seat_api.requests.request")
     @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -329,6 +329,160 @@ class TestSeatAPIResponseUnwrapping(BaseSeatAPITest):
         assert response.json() == payload
 
 
+MOCK_FREE_SEAT = {
+    "id": "seat_free",
+    "user_distinct_id": "user-abc",
+    "product_key": "posthog_code",
+    "plan_key": "posthog-code-free-20260301",
+    "status": "active",
+    "end_reason": None,
+    "created_at": "2026-04-01T00:00:00Z",
+    "active_until": None,
+    "active_from": "2026-04-01T00:00:00Z",
+}
+
+MOCK_PRO_SEAT = {
+    "id": "seat_pro",
+    "user_distinct_id": "user-abc",
+    "product_key": "posthog_code",
+    "plan_key": "posthog-code-200-20260301",
+    "status": "active",
+    "end_reason": None,
+    "created_at": "2026-04-01T00:00:00Z",
+    "active_until": None,
+    "active_from": "2026-04-01T00:00:00Z",
+}
+
+MOCK_PRO_V2_SEAT = {
+    "id": "seat_pro_v2",
+    "user_distinct_id": "user-abc",
+    "product_key": "posthog_code",
+    "plan_key": "posthog-code-pro-200-20260422",
+    "status": "active",
+    "end_reason": None,
+    "created_at": "2026-04-01T00:00:00Z",
+    "active_until": None,
+    "active_from": "2026-04-01T00:00:00Z",
+}
+
+
+@patch("products.tasks.backend.seat_api.get_cached_instance_license", return_value=MagicMock())
+class TestSeatAPIBestPlan(BaseSeatAPITest):
+    """``best=true`` returns the highest-tier seat across all orgs."""
+
+    org2: ClassVar[Organization]
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.org2 = Organization.objects.create(name="Second Org")
+        cls.org2.members.add(cls.user)
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_single_org_returns_that_seat(self, _mock_token, mock_request, _mock_license):
+        mock_request.return_value = _billing_response({"seat": MOCK_FREE_SEAT})
+        self._auth_as_admin()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-free-20260301"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_multi_org_returns_pro_over_free(self, _mock_token, mock_request, _mock_license):
+        mock_request.side_effect = [
+            _billing_response({"seat": MOCK_FREE_SEAT}),
+            _billing_response({"seat": MOCK_PRO_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-200-20260301"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_multi_org_returns_pro_regardless_of_order(self, _mock_token, mock_request, _mock_license):
+        mock_request.side_effect = [
+            _billing_response({"seat": MOCK_PRO_SEAT}),
+            _billing_response({"seat": MOCK_FREE_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-200-20260301"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_all_billing_failures_returns_404(self, _mock_token, mock_request, _mock_license):
+        mock_request.return_value = _billing_response({"error": "fail"}, status_code=500, ok=False)
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_partial_failure_returns_best_available(self, _mock_token, mock_request, _mock_license):
+        mock_request.side_effect = [
+            _billing_response({"error": "fail"}, status_code=500, ok=False),
+            _billing_response({"seat": MOCK_PRO_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-200-20260301"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_best_ignored_for_non_me_pk(self, _mock_token, mock_request, _mock_license):
+        mock_request.return_value = _billing_response({"seat": MOCK_SEAT})
+        self._auth_as_admin()
+        response = self.client.get(
+            f"/api/seats/{self.user.distinct_id}/?product_key=posthog_code&best=true"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_request.call_count == 1
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_without_best_param_does_single_call(self, _mock_token, mock_request, _mock_license):
+        mock_request.return_value = _billing_response({"seat": MOCK_SEAT})
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code")
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_request.call_count == 1
+
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_no_orgs_returns_400(self, _mock_token, _mock_license):
+        self.client.force_authenticate(self.external_user)
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_pro_v2_prefix_recognized(self, _mock_token, mock_request, _mock_license):
+        mock_request.side_effect = [
+            _billing_response({"seat": MOCK_FREE_SEAT}),
+            _billing_response({"seat": MOCK_PRO_V2_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-pro-200-20260422"
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_no_plan_key_loses_to_free(self, _mock_token, mock_request, _mock_license):
+        no_plan_seat = {**MOCK_FREE_SEAT, "plan_key": None, "id": "seat_none"}
+        mock_request.side_effect = [
+            _billing_response({"seat": no_plan_seat}),
+            _billing_response({"seat": MOCK_FREE_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-free-20260301"
+
+
 @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
 @patch("products.tasks.backend.seat_api.get_cached_instance_license", return_value=MagicMock())
 class TestSeatAPIKeyAccess(BaseSeatAPITest):

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -520,6 +520,20 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["plan_key"] == "posthog-code-free-20260301"
 
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_same_tier_picks_oldest_seat(self, _mock_token, mock_request, _mock_license):
+        newer_pro = {**MOCK_PRO_SEAT, "id": "seat_newer", "created_at": "2026-06-01T00:00:00Z"}
+        older_pro = {**MOCK_PRO_SEAT, "id": "seat_older", "created_at": "2026-03-01T00:00:00Z"}
+        mock_request.side_effect = [
+            _billing_response({"seat": newer_pro}),
+            _billing_response({"seat": older_pro}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == "seat_older"
+
 
 @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
 @patch("products.tasks.backend.seat_api.get_cached_instance_license", return_value=MagicMock())

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -482,6 +482,20 @@ class TestSeatAPIBestPlan(BaseSeatAPITest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["plan_key"] == "posthog-code-free-20260301"
 
+    @patch("products.tasks.backend.seat_api.requests.request")
+    @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+    def test_active_free_beats_canceled_pro(self, _mock_token, mock_request, _mock_license):
+        canceled_pro = {**MOCK_PRO_SEAT, "status": "canceled", "id": "seat_canceled_pro"}
+        mock_request.side_effect = [
+            _billing_response({"seat": canceled_pro}),
+            _billing_response({"seat": MOCK_FREE_SEAT}),
+        ]
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code&best=true")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["plan_key"] == "posthog-code-free-20260301"
+        assert response.json()["status"] == "active"
+
 
 @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
 @patch("products.tasks.backend.seat_api.get_cached_instance_license", return_value=MagicMock())

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -48,7 +48,7 @@ async def get_usage(
     user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
 ) -> UsageResponse:
     runner: ThrottleRunner = request.app.state.throttle_runner
-    plan_info = await resolve_plan_info(request, user.user_id, product, team_id=user.team_id)
+    plan_info = await resolve_plan_info(request, user.user_id, product)
 
     context = ThrottleContext(
         user=user,
@@ -91,5 +91,5 @@ async def invalidate_plan_cache(
     if product != POSTHOG_CODE_PRODUCT:
         raise HTTPException(status_code=404, detail="Plan cache not available for this product")
     plan_resolver: PlanResolver = request.app.state.plan_resolver
-    await plan_resolver.invalidate(user.user_id, team_id=user.team_id)
+    await plan_resolver.invalidate(user.user_id)
     return {"ok": True}

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -149,7 +149,7 @@ class Settings(BaseSettings):
     default_fallback_cost_usd: float = 0.01
 
     posthog_api_base_url: str = "https://us.posthog.com"
-    plan_cache_ttl: int = 300  # 5 minutes
+    plan_cache_ttl: int = 900  # 15 minutes
     billing_period_days: int = 30
 
     @field_validator("product_cost_limits", mode="before")

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -158,7 +158,7 @@ async def enforce_throttles(
     else:
         end_user_id = await _extract_end_user_id_from_body(request)
 
-    plan_info = await resolve_plan_info(request, user.user_id, product, team_id=user.team_id)
+    plan_info = await resolve_plan_info(request, user.user_id, product)
 
     context = ThrottleContext(
         user=user,

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -196,9 +196,8 @@ class _UserCostThrottleBase(CostThrottle):
     def _get_cache_key(self, context: ThrottleContext) -> str:
         if not context.end_user_id:
             return ""
-        team_id = context.user.team_id or 0
         team_mult = self._get_team_multiplier(context)
-        base = f"cost:user:{self.scope}:{context.product}:{context.end_user_id}:t{team_id}"
+        base = f"cost:user:{self.scope}:{context.product}:{context.end_user_id}"
         if team_mult == 1:
             return base
         return f"{base}:tm{team_mult}"

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -44,8 +44,8 @@ class PlanInfo:
     billing_period: BillingPeriod | None = None
 
 
-def _redis_key(user_id: int, team_id: int | None) -> str:
-    return f"{PLAN_CACHE_PREFIX}:{user_id}:{team_id or 0}"
+def _redis_key(user_id: int) -> str:
+    return f"{PLAN_CACHE_PREFIX}:{user_id}"
 
 
 def is_pro_plan(plan_key: str | None) -> bool:
@@ -89,7 +89,6 @@ async def resolve_plan_info(
     request: Request,
     user_id: int,
     product: str,
-    team_id: int | None = None,
 ) -> PlanInfo:
     """Resolve plan info, returning safe defaults on failure."""
     if product != POSTHOG_CODE_PRODUCT:
@@ -101,7 +100,6 @@ async def resolve_plan_info(
         return await plan_resolver.get_plan(
             user_id=user_id,
             auth_header=auth_header,
-            team_id=team_id,
         )
     except Exception:
         logger.warning("plan_resolve_failed", user_id=user_id)
@@ -117,26 +115,20 @@ class PlanResolver:
         self._redis = redis
         self._http = http_client
 
-    async def invalidate(self, user_id: int, team_id: int | None = None) -> None:
-        """Invalidate the plan cache for a specific (user, team) pair.
-
-        Only deletes the entry for the given team_id. Entries cached under
-        other team_ids are left to expire naturally via TTL since reads are
-        always scoped to the current team's key.
-        """
+    async def invalidate(self, user_id: int) -> None:
         if not self._redis:
             return
         try:
-            await self._redis.delete(_redis_key(user_id, team_id))
+            await self._redis.delete(_redis_key(user_id))
         except Exception:
             logger.debug("plan_cache_invalidate_failed", user_id=user_id)
 
-    async def get_plan(self, user_id: int, auth_header: str, team_id: int | None = None) -> PlanInfo:
+    async def get_plan(self, user_id: int, auth_header: str) -> PlanInfo:
         """Return the user's plan info, using cache when available."""
         if not auth_header:
             return PlanInfo(plan_key=None, seat_created_at=None)
 
-        cached = await self._get_cached(user_id, team_id)
+        cached = await self._get_cached(user_id)
         if cached is not None:
             return cached
 
@@ -146,18 +138,18 @@ class PlanResolver:
             logger.warning("seat_fetch_failed", user_id=user_id, exc_info=True)
             return PlanInfo(plan_key=None, seat_created_at=None)
 
-        await self._set_cached(user_id, plan_key, seat_created_at, billing_period, team_id)
+        await self._set_cached(user_id, plan_key, seat_created_at, billing_period)
         return PlanInfo(
             plan_key=plan_key,
             seat_created_at=seat_created_at,
             billing_period=billing_period,
         )
 
-    async def _get_cached(self, user_id: int, team_id: int | None = None) -> PlanInfo | None:
+    async def _get_cached(self, user_id: int) -> PlanInfo | None:
         if not self._redis:
             return None
         try:
-            val = await self._redis.get(_redis_key(user_id, team_id))
+            val = await self._redis.get(_redis_key(user_id))
             if val is not None:
                 data = json.loads(val.decode())
                 plan_key = data.get("plan_key") or None
@@ -178,7 +170,6 @@ class PlanResolver:
         plan_key: str | None,
         seat_created_at: str | None,
         billing_period: BillingPeriod | None = None,
-        team_id: int | None = None,
     ) -> None:
         if not self._redis:
             return
@@ -192,7 +183,7 @@ class PlanResolver:
                     "interval": billing_period.interval,
                 }
             data = json.dumps(payload)
-            await self._redis.set(_redis_key(user_id, team_id), data, ex=ttl)
+            await self._redis.set(_redis_key(user_id), data, ex=ttl)
         except Exception:
             logger.debug("plan_cache_write_failed", user_id=user_id)
 
@@ -209,7 +200,7 @@ class PlanResolver:
         url = f"{settings.posthog_api_base_url.rstrip('/')}/api/seats/me/"
         resp = await self._http.get(
             url,
-            params={"product_key": POSTHOG_CODE_PRODUCT},
+            params={"product_key": POSTHOG_CODE_PRODUCT, "best": "true"},
             headers={"Authorization": auth_header},
             timeout=2.0,
         )

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -27,6 +27,7 @@ logger = structlog.get_logger(__name__)
 
 POSTHOG_CODE_PRODUCT = "posthog_code"
 PLAN_CACHE_PREFIX = f"plan:{POSTHOG_CODE_PRODUCT}"
+# Duplicated in products/tasks/backend/seat_api.py
 PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
 
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -234,7 +234,7 @@ class TestUserCostBurstThrottle:
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_burst:posthog_code:42:t1"
+        assert key == "cost:user:user_cost_burst:posthog_code:42"
 
     @pytest.mark.asyncio
     async def test_different_users_have_separate_limits(self) -> None:
@@ -309,7 +309,7 @@ class TestUserCostSustainedThrottle:
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_free_plan(self) -> None:
@@ -327,7 +327,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
 
     @pytest.mark.asyncio
     async def test_cache_key_period_increments_after_period_days(self) -> None:
@@ -345,7 +345,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:1"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
 
     def test_cache_key_uses_billing_period_start_over_seat_created_at(self) -> None:
         from datetime import UTC, datetime, timedelta
@@ -364,7 +364,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
 
     def test_cache_key_falls_back_to_seat_created_at_without_billing_period(self) -> None:
         from datetime import UTC, datetime, timedelta
@@ -382,7 +382,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:1"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_pro_plan(self) -> None:
@@ -400,7 +400,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42:t1:period:0"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
 
 
 class TestBurstSustainedInteraction:
@@ -596,7 +596,7 @@ class TestCostRateLimiterRedisIntegration:
 
         mock_redis.eval.assert_called_once()
         call_args = mock_redis.eval.call_args
-        assert "ratelimit:cost:user:user_cost_burst:posthog_code:1:t1" in call_args[0]
+        assert "ratelimit:cost:user:user_cost_burst:posthog_code:1" in call_args[0]
 
     @pytest.mark.asyncio
     async def test_redis_get_current_returns_accumulated_cost(self) -> None:
@@ -668,7 +668,7 @@ class TestTeamRateLimitMultipliers:
 
         key = throttle._get_cache_key(context)
         assert ":tm" not in key
-        assert key == "cost:user:user_cost_burst:posthog_code:1:t99"
+        assert key == "cost:user:user_cost_burst:posthog_code:1"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -682,7 +682,7 @@ class TestTeamRateLimitMultipliers:
         context = make_context(user=user, product="posthog_code")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_burst:posthog_code:1:t2:tm10"
+        assert key == "cost:user:user_cost_burst:posthog_code:1:tm10"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -1054,8 +1054,8 @@ class TestRateLimitPoisoningPrevention:
         victim_key = throttle._get_cache_key(victim_ctx)
 
         assert attacker_key != victim_key
-        assert ":999:" in attacker_key
-        assert ":42:" in victim_key
+        assert ":999" in attacker_key
+        assert ":42" in victim_key
 
 
 class TestPlanAwareThrottling:

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -148,7 +148,7 @@ class TestPlanResolver:
 
         resolver_with_redis._http.get.assert_called_once_with(
             "https://app.posthog.com/api/seats/me/",
-            params={"product_key": "posthog_code"},
+            params={"product_key": "posthog_code", "best": "true"},
             headers={"Authorization": "Bearer phx_test"},
             timeout=2.0,
         )

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -230,7 +230,7 @@ class TestUsageEndpoint:
         )
         assert response.status_code == 200
         assert response.json() == {"ok": True}
-        app.state.plan_resolver.invalidate.assert_called_once_with(42, team_id=1)
+        app.state.plan_resolver.invalidate.assert_called_once_with(42)
 
     def test_invalidate_plan_cache_404_for_other_product(self, authenticated_usage_client: TestClient) -> None:
         response = authenticated_usage_client.post(


### PR DESCRIPTION
## Problem

Users with a pro plan in one org were getting free-tier rate limits when using PostHog Code in a different org. The plan cache and rate limit buckets were keyed by (user_id, team_id), so the gateway resolved the plan for whichever team the request happened to come from, not the user's best plan across all their orgs. This meant multi-org users had to be on a pro plan in every org to get pro limits everywhere.

This PR adds a ?best=true parameter to GET /api/seats/me/ that resolves the highest-tier active seat across all the user's organizations, removes team_id from the plan cache and rate limit cache keys so users get a single plan resolution and a single rate limit bucket regardless of which org they're working in.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

**NOTE:** Plan resolution is cached in Redis with a 15-minute TTL, so the cross-org seat lookup doesn't happen on every request.

1. LLM gateway receives a request → calls resolve_plan_info(user_id, product) (no more team_id)
2. PlanResolver._fetch_plan calls GET /api/seats/me/?product_key=posthog_code&best=true
3. Django SeatViewSet.retrieve sees best=true → calls _retrieve_best_seat
4. _retrieve_best_seat fans out across all the user's orgs, picks the highest-tier active seat
5. The plan_key from the best seat flows back → cached in Redis keyed by user_id alone (no team_id)
6. Rate limit cache keys are now cost:user:{scope}:{product}:{end_user_id} (no :t{team_id})

## How did you test this code?

Manually

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->