### PR TITLE
fix(insights): remove redundant tooltip around loading spinner

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -25,7 +25,6 @@ import { Link } from 'lib/lemon-ui/Link'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Splotch, SplotchColor } from 'lib/lemon-ui/Splotch'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
@@ -660,15 +659,10 @@ export function InsightMetaContent({
                 {title || <i>{fallbackTitle || 'Untitled'}</i>}
             </span>
             {(loading || loadingQueued) && (
-                <Tooltip
-                    title={loading ? 'This insight is loading results.' : 'This insight is waiting to load results.'}
-                    placement="top-end"
-                >
-                    <span className={clsx('text-sm font-medium ml-1.5', loading ? 'text-accent' : 'text-muted')}>
-                        <Spinner className="mr-1.5 text-base" textColored />
-                        {loading ? 'Loading' : 'Waiting to load'}
-                    </span>
-                </Tooltip>
+                <span className={clsx('text-sm font-medium ml-1.5', loading ? 'text-accent' : 'text-muted')}>
+                    <Spinner className="mr-1.5 text-base" textColored />
+                    {loading ? 'Loading' : 'Waiting to load'}
+                </span>
             )}
         </>
     )


### PR DESCRIPTION
## Problem

User-reported symptom: PostHog tabs with a dashboard open accumulate memory over time, especially when dashboards have auto-refresh enabled. Investigation traced the dominant per-refresh retention to a Tooltip wrapper around the loading spinner in each insight tile.

## Changes

Removed the `Tooltip` wrapped around the loading spinner in `InsightMeta.tsx` and dropped the now-unused import. The Tooltip's title ("This insight is loading results." / "This insight is waiting to load results.") was a verbose restatement of the visible text already rendered next to the spinner ("Loading" / "Waiting to load"), so there is no user-visible information loss.

Our `Tooltip` wraps `@base-ui/react/tooltip`, which retains the popup DOM after React unmount through internal refs. Every time a dashboard tile transitioned into its loading state and back, the Tooltip mount/unmount cycle leaked one popup subtree. On an 8-tile dashboard refreshing every 5 minutes, this was ~8 leaked subtrees per refresh per tab.

## How did you test this code?

This PR was authored by an agent. No manual QA was performed.

Automated measurement via CDP heap profiling and `Performance.getMetrics` on `/project/1/dashboard/1` in a truly-backgrounded tab, with 10 forced `refreshDashboardItems` calls between samples and `HeapProfiler.collectGarbage` called twice before each measurement:

| Metric | Before | After |
| --- | --- | --- |
| JS event listeners growth | +9 per refresh | **0 per refresh** (flat) |
| JS heap growth | +1.06 MB per refresh | +0.36 MB per refresh |
| DOM node growth | +237 per refresh | +244 per refresh (unchanged; remaining growth is `CSSTransition`-based and will be addressed separately) |

## Publish to changelog?

no

## Docs update

## 🤖 Agent context

Authored by PostHog Code (Claude) while investigating the browser-tab memory growth symptom. The investigation also produced offline tooling (heap-diff CLI, background-tab polling via CDP) that lives on a separate scratch branch and is not included in this PR. A follow-up will address the remaining per-refresh DOM retention, which is driven by `react-transition-group` `CSSTransition` + `nodeRef` + `unmountOnExit` in `LemonTableLoader` and the parent `CardMeta` Transition — same pattern as the Popover retention documented earlier.

Human review required; the Tooltip removal is a minor visual change (loss of a verbose hover tooltip on the loading indicator).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*