### PR TITLE
fix: rate limit invite endpoint and reject URLs in org names and invite messages

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -1,3 +1,4 @@
+import re
 import dataclasses
 from functools import cached_property
 from typing import Any, Union, cast
@@ -155,6 +156,11 @@ class OrganizationSerializer(
                 "required": False,
             },  # slug is not required here as it's generated automatically for new organizations
         }
+
+    def validate_name(self, name: str) -> str:
+        if re.search(r"https?://", name, re.IGNORECASE):
+            raise serializers.ValidationError("Organization name cannot contain URLs.")
+        return name
 
     def validate_logo_media_id(self, value: UploadedMedia | None) -> UploadedMedia | None:
         if value is None:

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta
 from typing import Any, Optional, cast
 from uuid import UUID
@@ -25,8 +26,11 @@ from posthog.permissions import (
     TimeSensitiveActionPermission,
     UserCanInvitePermission,
 )
+from posthog.rate_limit import OrganizationInviteBurstThrottle, OrganizationInviteSustainedThrottle
 from posthog.rbac.user_access_control import UserAccessControl, ordered_access_levels
 from posthog.tasks.email import send_invite
+
+URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
 
 
 class OrganizationInviteManager:
@@ -136,6 +140,11 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
 
     def validate_target_email(self, email: str):
         return EmailNormalizer.normalize(email)
+
+    def validate_message(self, message: str) -> str:
+        if message and URL_PATTERN.search(message):
+            raise exceptions.ValidationError("Invite messages cannot contain URLs.")
+        return message
 
     def validate_level(self, level: int) -> int:
         # Validate that the user can't invite someone with a higher permission level than their own
@@ -303,6 +312,7 @@ class OrganizationInviteViewSet(
     queryset = OrganizationInvite.objects.all()
     lookup_field = "id"
     ordering = "-created_at"
+    throttle_classes = [OrganizationInviteBurstThrottle, OrganizationInviteSustainedThrottle]
 
     def dangerously_get_permissions(self):
         if self.action in ["create", "bulk", "update", "partial_update"]:

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -141,6 +141,11 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
     def validate_target_email(self, email: str):
         return EmailNormalizer.normalize(email)
 
+    def validate_first_name(self, value: str) -> str:
+        if value and URL_PATTERN.search(value):
+            raise exceptions.ValidationError("Name cannot contain URLs.")
+        return value
+
     def validate_message(self, message: str) -> str:
         if message and URL_PATTERN.search(message):
             raise exceptions.ValidationError("Invite messages cannot contain URLs.")

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -1,3 +1,4 @@
+import re
 import json
 import uuid as uuid_module
 from typing import Any, Optional, Union, cast
@@ -123,6 +124,16 @@ class SignupSerializer(serializers.Serializer):
             # To log in, a user just needs to attempt sign up with an email that's already in use
             fields.pop("password")
         return fields
+
+    def validate_organization_name(self, value: str) -> str:
+        if re.search(r"https?://", value, re.IGNORECASE):
+            raise exceptions.ValidationError("Organization name cannot contain URLs.")
+        return value
+
+    def validate_first_name(self, value: str) -> str:
+        if re.search(r"https?://", value, re.IGNORECASE):
+            raise exceptions.ValidationError("Name cannot contain URLs.")
+        return value
 
     def validate_password(self, value):
         if value is not None and value != "":
@@ -603,6 +614,11 @@ class SocialSignupSerializer(serializers.Serializer):
     referral_source_ai_prompt: serializers.Field = serializers.CharField(
         max_length=1000, required=False, allow_blank=True, default=""
     )
+
+    def validate_organization_name(self, value: str) -> str:
+        if re.search(r"https?://", value, re.IGNORECASE):
+            raise exceptions.ValidationError("Organization name cannot contain URLs.")
+        return value
 
     def create(self, validated_data, **kwargs):
         request = self.context["request"]

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -348,6 +348,11 @@ class UserSerializer(serializers.ModelSerializer):
             for invite in invites
         ]
 
+    def validate_first_name(self, value: str) -> str:
+        if re.search(r"https?://", value, re.IGNORECASE):
+            raise serializers.ValidationError("Name cannot contain URLs.")
+        return value
+
     def validate_set_current_organization(self, value: str) -> Organization:
         try:
             organization = Organization.objects.get(id=value)

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -761,6 +761,20 @@ class CodeInviteThrottle(UserRateThrottle):
     rate = "20000/hour"
 
 
+class OrganizationInviteBurstThrottle(UserRateThrottle):
+    """Per-user burst rate limit for sending organization invites."""
+
+    scope = "organization_invite_burst"
+    rate = "10/minute"
+
+
+class OrganizationInviteSustainedThrottle(UserRateThrottle):
+    """Per-user sustained rate limit for sending organization invites."""
+
+    scope = "organization_invite_sustained"
+    rate = "200/day"
+
+
 class RunSavedQueryRateThrottle(PersonalApiKeyRateThrottle):
     # Rate limit running a saved query per saved query per team.
     # Prevents agents from running the same query repeatedly without reason.


### PR DESCRIPTION
## Problem

Attackers are abusing the organization invite flow to send phishing emails at scale from PostHog's legitimate email domain (`hey@posthog.com`). The attack works by:

1. Creating an org with a name containing a phishing URL (e.g. `"GET A BONUS, CLICK HERE 👉 https://malicious-site.com 👈"`)
2. Setting the invite `message` field to additional phishing content
3. Using the invite API to send emails to arbitrary addresses — the phishing content is embedded in legitimate PostHog invite emails

This was able to scale to ~76k emails because the invite endpoint had **no rate limiting** and **no content validation** on user-controlled fields that appear in emails.

## Changes

### Rate limiting
- Added `OrganizationInviteBurstThrottle` (10/minute per user) and `OrganizationInviteSustainedThrottle` (200/day per user) to `OrganizationInviteViewSet`

### URL validation
- **Organization name**: Reject names containing `https?://` URLs in `OrganizationSerializer`, `SignupSerializer`, and `SocialSignupSerializer`
- **Invite message**: Reject messages containing URLs in `OrganizationInviteSerializer`
- **First name**: Reject first names containing URLs in `SignupSerializer` (also injected into email subjects)

## How did you test this code?

This PR was authored by an agent. The changes were validated by:
- Python syntax verification on all modified files
- Lint and format checks passed via pre-commit hooks
- Type checking passed via `ty check`
- Regex validation tested manually for URL detection edge cases

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR responding to an active phishing abuse incident. The attack vector was identified by tracing the invite email flow from the API endpoint through the Celery task to the Django email template, confirming that org name and invite message are rendered unsanitized (though HTML-escaped) in invite emails.