### PR TITLE
fix(data-warehouse): show sources without a feature flag in new-source list

### DIFF
--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -76,13 +76,13 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                 // A source gated behind a feature flag should be hidden entirely when the flag
                 // isn't enabled for the user — regardless of its releaseStatus.
                 const visibleConnectors = connectors.filter((connector: SourceConfig) => {
-                    if (connector.featureFlag === undefined) {
+                    if (!connector.featureFlag) {
                         return true
                     }
                     return !!featureFlags[connector.featureFlag as FeatureFlagKey]
                 })
                 const managed = visibleConnectors.map((connector: SourceConfig): HogFunctionTemplateType => {
-                    const featureFlagDefined = connector.featureFlag !== undefined
+                    const featureFlagDefined = !!connector.featureFlag
                     const featureFlagRaw = featureFlags[connector.featureFlag as FeatureFlagKey]
                     let featureFlagValue: boolean | undefined = undefined
                     if (featureFlagDefined && featureFlagRaw !== undefined) {


### PR DESCRIPTION
## Problem

At `/project/:id/pipeline/new/source` the list collapsed to just self-managed sources (Azure, Cloudflare R2, GCS, S3) plus Supabase — the ~140 managed sources (Stripe, Hubspot, Postgres, MySQL, Snowflake, BigQuery, …) all disappeared.

Introduced by #56203 2 hours ago. The new filter in `nonHogFunctionTemplatesLogic.tsx` checked `connector.featureFlag === undefined`, but backend `SourceConfig.featureFlag` is `str | None = None` and pydantic `model_dump()` serializes missing values as `null`. `null !== undefined`, so every source without an explicit feature flag fell through and got dropped. Only Plain, Slack, and Supabase declare a `featureFlag`, hence why Supabase (whose flag the user had) was the lone managed source to survive.

## Changes

Nullish check instead of `=== undefined` — `null` and `undefined` both now count as "no flag". Two call sites in `frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx`.

## How did you test this code?

I'm an agent. I did not run the UI or tests — only static analysis of the data flow from `SourceRegistry.get_all_sources()` → `wizard` endpoint → `availableSourcesLogic` → `sourceWizardLogic.connectors` → the broken filter.

Suggested manual verification before merge:
- Visit `/project/:id/pipeline/new/source`, confirm full managed catalogue renders.
- Toggle `supabase-dwh` / `slack-dwh` / `dwh_plain` off locally, confirm those sources hide (the original #56203 intent).

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) at Daniel's direction. Root-cause analysis only — no manual UI testing performed. Requires human review.