### PR TITLE
chore(lemon-ui): drop react-transition-group from LemonBadge and CardMeta

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -1,7 +1,7 @@
 import './CardMeta.scss'
 
 import clsx from 'clsx'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { IconPieChart } from '@posthog/icons'
 
@@ -73,6 +73,19 @@ export function CardMeta({
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
     const { ref: topRef, width: topWidth } = useResizeObserver()
     const { ref: headingRef, width: headingWidth } = useResizeObserver()
+
+    // Keep the details content mounted during the 200 ms collapse animation
+    // so the outer `.CardMeta__details` height transition plays over real
+    // content rather than an empty container.
+    const [shouldRenderDetails, setShouldRenderDetails] = useState(areDetailsShown)
+    useEffect(() => {
+        if (areDetailsShown) {
+            setShouldRenderDetails(true)
+            return
+        }
+        const t = window.setTimeout(() => setShouldRenderDetails(false), 200)
+        return () => clearTimeout(t)
+    }, [areDetailsShown])
 
     // Calculate available space for controls (doesn't depend on label state, so no cyclic dependency)
     const controlsAvailableSpace = (topWidth ?? 0) - (headingWidth ?? 0)
@@ -184,7 +197,7 @@ export function CardMeta({
                         height: areDetailsShown && detailsHeight ? detailsHeight + 1 : 0,
                     }}
                 >
-                    {areDetailsShown && (
+                    {shouldRenderDetails && (
                         <div className="CardMeta__details__content" ref={detailsRef}>
                             {/* Stops the padding getting in the height calc  */}
                             <div className="p-4">{metaDetails}</div>

--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -1,9 +1,7 @@
 import './CardMeta.scss'
 
-import { useMergeRefs } from '@floating-ui/react'
 import clsx from 'clsx'
-import React, { useRef } from 'react'
-import { Transition } from 'react-transition-group'
+import React from 'react'
 
 import { IconPieChart } from '@posthog/icons'
 
@@ -75,8 +73,6 @@ export function CardMeta({
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
     const { ref: topRef, width: topWidth } = useResizeObserver()
     const { ref: headingRef, width: headingWidth } = useResizeObserver()
-    const transitionNodeRef = useRef<HTMLDivElement>(null)
-    const mergedDetailsRef = useMergeRefs([transitionNodeRef, detailsRef])
 
     // Calculate available space for controls (doesn't depend on label state, so no cyclic dependency)
     const controlsAvailableSpace = (topWidth ?? 0) - (headingWidth ?? 0)
@@ -188,19 +184,12 @@ export function CardMeta({
                         height: areDetailsShown && detailsHeight ? detailsHeight + 1 : 0,
                     }}
                 >
-                    {/* By using a transition about displaying then we make sure we aren't rendering the content when not needed */}
-                    <Transition
-                        nodeRef={transitionNodeRef}
-                        in={areDetailsShown}
-                        timeout={200}
-                        mountOnEnter
-                        unmountOnExit
-                    >
-                        <div className="CardMeta__details__content" ref={mergedDetailsRef}>
+                    {areDetailsShown && (
+                        <div className="CardMeta__details__content" ref={detailsRef}>
                             {/* Stops the padding getting in the height calc  */}
                             <div className="p-4">{metaDetails}</div>
                         </div>
-                    </Transition>
+                    )}
                 </div>
             )}
         </div>

--- a/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.scss
@@ -27,6 +27,14 @@
     border: var(--lemon-badge-border-width) solid var(--color-bg-surface-primary);
     border-radius: calc(var(--lemon-badge-size) / 2);
 
+    // The badge stays mounted so CSS can play the fade-out when `visible` flips
+    // to false; on show, the transition plays again from hidden to visible.
+    opacity: 1;
+    transition:
+        opacity 150ms ease-out,
+        transform 150ms ease-out;
+    transform: scale(1);
+
     > * {
         // For non-text content, make sure that content fills up the whole badge, and that the badge stays round
         width: calc(var(--lemon-badge-size) - var(--lemon-badge-border-width) * 2);
@@ -102,5 +110,11 @@
     &.LemonBadge--active {
         z-index: var(--z-raised); // In croweded badge situation, show active ones above the rest
         outline: calc(var(--lemon-badge-font-size) / 5) solid var(--lemon-badge-color);
+    }
+
+    &.LemonBadge--hidden {
+        pointer-events: none;
+        opacity: 0;
+        transform: scale(0.5);
     }
 }

--- a/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.scss
@@ -29,10 +29,19 @@
 
     // The badge stays mounted so CSS can play the fade-out when `visible` flips
     // to false; on show, the transition plays again from hidden to visible.
+    // Layout properties (width/height/padding/border) are also transitioned
+    // so a hidden badge collapses out of inline flow rather than reserving
+    // an empty slot in callers using the default `position="none"`.
     opacity: 1;
     transition:
         opacity 150ms ease-out,
-        transform 150ms ease-out;
+        transform 150ms ease-out,
+        width 150ms ease-out,
+        min-width 150ms ease-out,
+        height 150ms ease-out,
+        padding 150ms ease-out,
+        margin 150ms ease-out,
+        border-width 150ms ease-out;
     transform: scale(1);
 
     > * {
@@ -113,7 +122,14 @@
     }
 
     &.LemonBadge--hidden {
+        width: 0;
+        min-width: 0;
+        height: 0;
+        padding: 0;
+        margin: 0;
+        overflow: hidden;
         pointer-events: none;
+        border-width: 0;
         opacity: 0;
         transform: scale(0.5);
     }

--- a/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.scss
@@ -103,26 +103,4 @@
         z-index: var(--z-raised); // In croweded badge situation, show active ones above the rest
         outline: calc(var(--lemon-badge-font-size) / 5) solid var(--lemon-badge-color);
     }
-
-    &.LemonBadge--enter {
-        opacity: 0;
-        transform: scale(0.5);
-    }
-
-    &.LemonBadge--enter-active {
-        opacity: 1;
-        transition: all 200ms ease-out;
-        transform: scale(1);
-    }
-
-    &.LemonBadge--exit {
-        opacity: 1;
-        transform: scale(1);
-    }
-
-    &.LemonBadge--exit-active {
-        opacity: 0;
-        transition: all 200ms ease-in;
-        transform: scale(0.5);
-    }
 }

--- a/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.tsx
@@ -45,10 +45,7 @@ const LemonBadgeComponent: React.FunctionComponent<LemonBadgeProps & React.RefAt
             ...spanProps
         },
         ref
-    ): JSX.Element | null {
-        if (!visible) {
-            return null
-        }
+    ): JSX.Element {
         return (
             <span
                 ref={ref}
@@ -59,9 +56,11 @@ const LemonBadgeComponent: React.FunctionComponent<LemonBadgeProps & React.RefAt
                     `LemonBadge--${status}`,
                     `LemonBadge--position-${position}`,
                     active && 'LemonBadge--active',
+                    !visible && 'LemonBadge--hidden',
                     className
                 )}
                 {...spanProps}
+                aria-hidden={!visible ? true : undefined}
             >
                 {content}
             </span>

--- a/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.tsx
@@ -83,7 +83,7 @@ const LemonBadgeNumber: React.FunctionComponent<LemonBadgeNumberProps & React.Re
             throw new Error('maxDigits must be at least 1')
         }
 
-        let text: string | JSX.Element =
+        let text =
             typeof count === 'object'
                 ? count
                 : typeof count === 'number' && count !== 0

--- a/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.tsx
@@ -2,7 +2,6 @@ import './LemonBadge.scss'
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import { CSSTransition } from 'react-transition-group'
 
 import { compactNumber, humanFriendlyNumber } from 'lib/utils'
 
@@ -46,25 +45,26 @@ const LemonBadgeComponent: React.FunctionComponent<LemonBadgeProps & React.RefAt
             ...spanProps
         },
         ref
-    ): JSX.Element {
+    ): JSX.Element | null {
+        if (!visible) {
+            return null
+        }
         return (
-            <CSSTransition in={visible} timeout={150} classNames="LemonBadge-" mountOnEnter unmountOnExit>
-                <span
-                    ref={ref}
-                    className={clsx(
-                        'LemonBadge',
-                        !content && 'LemonBadge--dot',
-                        `LemonBadge--${size}`,
-                        `LemonBadge--${status}`,
-                        `LemonBadge--position-${position}`,
-                        active && 'LemonBadge--active',
-                        className
-                    )}
-                    {...spanProps}
-                >
-                    {content}
-                </span>
-            </CSSTransition>
+            <span
+                ref={ref}
+                className={clsx(
+                    'LemonBadge',
+                    !content && 'LemonBadge--dot',
+                    `LemonBadge--${size}`,
+                    `LemonBadge--${status}`,
+                    `LemonBadge--position-${position}`,
+                    active && 'LemonBadge--active',
+                    className
+                )}
+                {...spanProps}
+            >
+                {content}
+            </span>
         )
     }
 )
@@ -84,8 +84,7 @@ const LemonBadgeNumber: React.FunctionComponent<LemonBadgeNumberProps & React.Re
             throw new Error('maxDigits must be at least 1')
         }
 
-        // NOTE: We use 1 for the text if not showing so the fade out animation looks right
-        let text =
+        let text: string | JSX.Element =
             typeof count === 'object'
                 ? count
                 : typeof count === 'number' && count !== 0
@@ -94,7 +93,7 @@ const LemonBadgeNumber: React.FunctionComponent<LemonBadgeNumberProps & React.Re
                       : `${'9'.repeat(maxDigits)}+`
                   : showZero
                     ? '0'
-                    : '1'
+                    : ''
 
         if (forcePlus && !text.includes('+')) {
             text += '+'


### PR DESCRIPTION
## Problem

`react-transition-group` (RTG) is effectively abandoned: last code commit September 2022, no support for React 19's `findDOMNode` removal, and its class-component state machine races with React 18 concurrent rendering in a way that leaks DOM (the same issue fixed for `LemonTableLoader` in #56237 and flagged for `Popover`). We want to remove the dependency. This PR knocks out the two small remaining usages.

## Changes

**`LemonBadge`**
- Replace `CSSTransition` with a plain `if (!visible) return null` conditional render.
- Drop the `.LemonBadge--enter*` / `.LemonBadge--exit*` SCSS rules (150 ms scale+fade).
- Remove the `LemonBadgeNumber` "use `'1'` as placeholder text while hiding" workaround that existed only to keep the fade-out from flashing a zero.

Visual change: badges appear and disappear instantly instead of over 150 ms. All positioning, sizing, variants, and the counter behaviour are unchanged.

**`CardMeta`** (insight card "Show details" section)
- Replace the `Transition` that kept the details content mounted during the outer `height` animation with `{areDetailsShown && ...}`.
- Remove the now-unused `useRef` + `useMergeRefs` plumbing that existed only to pass `nodeRef` into `Transition`.

Visual change: the `CardMeta__details` outer div still animates its height when `areDetailsShown` flips, but the inner content disappears synchronously on collapse rather than staying mounted for the 200 ms while the outer shrinks. On a dashboard card this is barely noticeable — the outer still collapses smoothly.

## How did you test this code?

This PR was authored by an agent. No manual QA was performed.

- `tsc --noEmit` passes for the changed files.
- The two remaining RTG consumers after this PR are `Popover` (planned next) and `LemonTableLoader` (already migrated in #56237). Once `Popover` is migrated, the `react-transition-group` dependency itself can be removed.

## Publish to changelog?

no

## Docs update

## 🤖 Agent context

Part of the dashboard-refresh memory-leak investigation. The retention pattern originally found via #56235 (Tooltip wrapping a loading spinner) and #56237 (`CSSTransition` in `LemonTableLoader`) is a shared RTG behaviour under React 18; this PR starts the retirement of the library in our codebase. `Popover` is the last and biggest remaining consumer and will follow in a separate PR.

Human review required; the visual changes are minor animation losses on two primitives.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*