### PR TITLE
feat(query-performance-ai): add ClickHouse perf proxy API route

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -22,7 +22,7 @@ from posthog.rbac.user_access_control import (
     minimum_access_level,
     ordered_access_levels,
 )
-from posthog.scopes import API_SCOPE_OBJECTS, APIScopeObject, APIScopeObjectOrNotSupported
+from posthog.scopes import API_SCOPE_OBJECTS, INTERNAL_API_SCOPE_OBJECTS, APIScopeObject, APIScopeObjectOrNotSupported
 
 from ee.models.rbac.access_control import AccessControl
 from ee.models.rbac.role import Role
@@ -88,8 +88,9 @@ class AccessControlSerializer(serializers.ModelSerializer):
         return field_class, field_kwargs
 
     def validate_resource(self, resource):
-        if resource not in API_SCOPE_OBJECTS:
-            raise serializers.ValidationError("Invalid resource. Must be one of: {}".format(API_SCOPE_OBJECTS))
+        if resource not in API_SCOPE_OBJECTS or resource in INTERNAL_API_SCOPE_OBJECTS:
+            allowed = tuple(s for s in API_SCOPE_OBJECTS if s not in INTERNAL_API_SCOPE_OBJECTS)
+            raise serializers.ValidationError("Invalid resource. Must be one of: {}".format(allowed))
 
         return resource
 

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -21,6 +21,7 @@ export const API_SCOPES: APIScope[] = [
     { key: 'annotation', objectName: 'Annotation', objectPlural: 'annotations' },
     { key: 'approvals', objectName: 'Approvals', objectPlural: 'approvals' },
     { key: 'batch_export', objectName: 'Batch export', objectPlural: 'batch exports' },
+    // `clickhouse_test_cluster_perf` is omitted — see `INTERNAL_API_SCOPE_OBJECTS` in posthog/scopes.py.
     { key: 'cohort', objectName: 'Cohort', objectPlural: 'cohorts' },
     { key: 'comment', objectName: 'Comment', objectPlural: 'comments' },
     { key: 'customer_analytics', objectName: 'Customer analytics', objectPlural: 'customer analytics' },
@@ -245,9 +246,13 @@ export const getScopeDescription = (scope: string): string | undefined => {
     }
 
     const scopeObject = API_SCOPES.find((s) => s.key === object)
+    if (!scopeObject) {
+        // Unknown / hidden scope — call sites .filter(Boolean) the result.
+        return undefined
+    }
     const actionWord = action === 'write' ? 'Write' : 'Read'
 
-    return `${actionWord} access to ${scopeObject?.objectPlural ?? scope}`
+    return `${actionWord} access to ${scopeObject.objectPlural}`
 }
 
 export const getMinimumEquivalentScopes = (scopes: string[]): string[] => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5234,6 +5234,7 @@ export type APIScopeObject =
     | 'annotation'
     | 'approvals'
     | 'batch_export'
+    | 'clickhouse_test_cluster_perf'
     | 'cohort'
     | 'comment'
     | 'customer_analytics'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3027,6 +3027,8 @@ importers:
 
   products/product_tours: {}
 
+  products/query_performance_ai: {}
+
   products/replay:
     dependencies:
       '@posthog/icons':

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -5,6 +5,7 @@ from posthog.api import data_color_theme, hog_flow, hog_flow_template, metalytic
 from posthog.api.batch_imports import BatchImportViewSet
 from posthog.api.csp_reporting import CSPReportingViewSet
 from posthog.api.js_snippet import JsSnippetViewSet
+from posthog.api.query_performance_proxy import QueryPerformanceProxyViewSet
 from posthog.api.routing import DefaultRouterPlusPlus
 from posthog.api.sdk_doctor import SdkDoctorViewSet
 from posthog.api.wizard import http as wizard
@@ -739,6 +740,7 @@ router.register(r"dead_letter_queue", dead_letter_queue.DeadLetterQueueViewSet, 
 router.register(r"async_migrations", async_migration.AsyncMigrationsViewset, "async_migrations")
 router.register(r"instance_settings", instance_settings.InstanceSettingsViewset, "instance_settings")
 router.register(r"debug_ch_queries", debug_ch_queries.DebugCHQueries, "debug_ch_queries")
+router.register(r"query_performance_proxy", QueryPerformanceProxyViewSet, "query_performance_proxy")
 
 from posthog.api.action import ActionViewSet  # noqa: E402
 from posthog.api.cohort import CohortViewSet, LegacyCohortViewSet  # noqa: E402

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2943,6 +2943,15 @@ class TestOAuthAuthorizationServerMetadata(APIBaseTest):
         resource_scopes = [s for s in scopes if ":" in s]
         self.assertGreater(len(resource_scopes), 0, "Should have resource scopes like 'event_definition:read'")
 
+    def test_metadata_excludes_internal_scope_objects(self):
+        response = self.client.get("/.well-known/oauth-authorization-server")
+        metadata = response.json()
+        scopes = metadata["scopes_supported"]
+        for scope in scopes:
+            assert not scope.startswith("clickhouse_test_cluster_perf:"), (
+                f"Internal scope {scope} must not be advertised in OAuth metadata"
+            )
+
     def test_metadata_accessible_without_authentication(self):
         self.client.logout()
 

--- a/posthog/api/personal_api_key.py
+++ b/posthog/api/personal_api_key.py
@@ -23,7 +23,7 @@ from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, hash_key_value, mask_key_value
 from posthog.permissions import TimeSensitiveActionPermission
-from posthog.scopes import API_SCOPE_ACTIONS, API_SCOPE_OBJECTS
+from posthog.scopes import API_SCOPE_ACTIONS, API_SCOPE_OBJECTS, INTERNAL_API_SCOPE_OBJECTS
 from posthog.user_permissions import UserPermissions
 
 MAX_API_KEYS_PER_USER = 10  # Same as in scopes.tsx
@@ -84,6 +84,7 @@ class PersonalAPIKeySerializer(serializers.ModelSerializer):
             if (
                 len(scope_parts) != 2
                 or scope_parts[0] not in API_SCOPE_OBJECTS
+                or scope_parts[0] in INTERNAL_API_SCOPE_OBJECTS
                 or scope_parts[1] not in API_SCOPE_ACTIONS
             ):
                 raise serializers.ValidationError(f"Invalid scope: {scope}")

--- a/posthog/api/project_secret_api_key.py
+++ b/posthog/api/project_secret_api_key.py
@@ -21,7 +21,12 @@ from posthog.models.project_secret_api_key import ProjectSecretAPIKey
 from posthog.models.signals import mutable_receiver
 from posthog.models.utils import generate_random_token_secret, hash_key_value, mask_key_value
 from posthog.permissions import TeamMemberStrictManagementPermission, TimeSensitiveActionPermission
-from posthog.scopes import API_SCOPE_ACTIONS, API_SCOPE_OBJECTS, PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION
+from posthog.scopes import (
+    API_SCOPE_ACTIONS,
+    API_SCOPE_OBJECTS,
+    INTERNAL_API_SCOPE_OBJECTS,
+    PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION,
+)
 
 MAX_PROJECT_SECRET_API_KEYS_PER_TEAM = 10
 
@@ -65,6 +70,7 @@ class ProjectSecretAPIKeySerializer(serializers.ModelSerializer):
             if (
                 len(scope_parts) != 2
                 or scope_parts[0] not in API_SCOPE_OBJECTS
+                or scope_parts[0] in INTERNAL_API_SCOPE_OBJECTS
                 or scope_parts[1] not in API_SCOPE_ACTIONS
             ):
                 raise serializers.ValidationError(f"Invalid scope: {scope}")

--- a/posthog/api/query_performance_proxy.py
+++ b/posthog/api/query_performance_proxy.py
@@ -1,0 +1,78 @@
+"""OAuth-gated ClickHouse passthrough for query-performance autoresearch.
+
+Stub: route + M2M auth only. The execution layer that forwards SQL to the
+``autoresearch`` ClickHouse user will be added in a follow-up PR.
+"""
+
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.auth import OAuthAccessTokenAuthentication
+from posthog.permissions import APIScopePermission
+
+MAX_SQL_LENGTH = 64 * 1024
+
+
+class ExecuteTestClusterRequestSerializer(serializers.Serializer):
+    sql = serializers.CharField(max_length=MAX_SQL_LENGTH, help_text="ClickHouse SQL to run against the test cluster.")
+
+
+class ExecuteTestClusterResponseSerializer(serializers.Serializer):
+    result = serializers.ListField(
+        child=serializers.ListField(),
+        help_text="Rows returned, each as a positional list of canonicalized values.",
+    )
+    query_id = serializers.CharField(allow_null=True, help_text="ClickHouse query_id for this execution.")
+    elapsed_ms = serializers.FloatField(allow_null=True, help_text="Server-side elapsed time in milliseconds.")
+    rows_read = serializers.IntegerField(allow_null=True, help_text="Rows read from storage (scan-side).")
+    bytes_read = serializers.IntegerField(allow_null=True, help_text="Bytes read from storage (scan-side).")
+    rows_returned = serializers.IntegerField(help_text="Rows in the `result` payload.")
+
+
+_ACTION_SCOPES: dict[str, list[str]] = {
+    "execute_test": ["clickhouse_test_cluster_perf:read"],
+}
+
+
+class QueryPerformanceProxyViewSet(viewsets.ViewSet):
+    authentication_classes = [OAuthAccessTokenAuthentication]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "INTERNAL"
+
+    # Not project- or org-nested. Opts out of `scoped_teams` / `scoped_organizations`
+    # enforcement; see `APIScopePermission.check_team_and_org_permissions`.
+    dangerously_skip_scoped_team_enforcement = True
+
+    def dangerously_get_required_scopes(self, request: Request, view) -> list[str] | None:
+        return _ACTION_SCOPES.get(getattr(view, "action", "") or "")
+
+    @extend_schema(
+        request=ExecuteTestClusterRequestSerializer,
+        responses={200: ExecuteTestClusterResponseSerializer},
+        summary="Run a read-only query against the autoresearch test cluster",
+        description=(
+            "Stub for the autoresearch ClickHouse passthrough. Auth + scope are wired up; "
+            "execution lands in a follow-up PR. Currently returns an empty response."
+        ),
+    )
+    @action(detail=False, methods=["POST"], url_path="execute-test")
+    def execute_test(self, request: Request) -> Response:
+        serializer = ExecuteTestClusterRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(
+            {
+                "result": [],
+                "query_id": None,
+                "elapsed_ms": None,
+                "rows_read": None,
+                "bytes_read": None,
+                "rows_returned": 0,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -128,6 +128,14 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
         response = self.client.post("/api/personal_api_keys/", {"label": "test", "scopes": ["insight:invalid"]})
         assert response.status_code == 400
 
+    def test_rejects_internal_scope_objects(self):
+        response = self.client.post(
+            "/api/personal_api_keys/",
+            {"label": "test", "scopes": ["clickhouse_test_cluster_perf:read"]},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid scope: clickhouse_test_cluster_perf:read"
+
     def test_delete_personal_api_key(self):
         key = PersonalAPIKey.objects.create(
             label="Test",

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -493,7 +493,10 @@ class APIScopePermission(ScopeBasePermission):
 
         self.check_team_and_org_permissions(request, view)
 
-        if "*" in key_scopes:
+        # `*` is the "Full access to all scopes" consent option; INTERNAL viewsets
+        # are programmatic-only and must not be reachable via user-consented tokens.
+        scope_object = self._get_scope_object(request, view)
+        if "*" in key_scopes and scope_object != "INTERNAL":
             return True
 
         for required_scope in required_scopes:
@@ -511,6 +514,16 @@ class APIScopePermission(ScopeBasePermission):
 
     def check_team_and_org_permissions(self, request, view) -> None:
         scope_object = self._get_scope_object(request, view)
+
+        # Guard runs above the `user` early return so the misconfig still trips
+        # if someone sets the flag on a `scope_object = "user"` viewset.
+        skip_team_and_org = getattr(view, "dangerously_skip_scoped_team_enforcement", False)
+        if skip_team_and_org and scope_object != "INTERNAL":
+            raise RuntimeError(
+                f"`dangerously_skip_scoped_team_enforcement = True` is only allowed on viewsets with "
+                f"`scope_object = 'INTERNAL'`; {type(view).__name__} declares `scope_object = {scope_object!r}`."
+            )
+
         if scope_object == "user":
             return  # The /api/users/@me/ endpoint is exempt from team and org scoping
 
@@ -525,7 +538,12 @@ class APIScopePermission(ScopeBasePermission):
         else:
             raise ValueError("Unexpected authentication type")
 
-        if scoped_teams:
+        if scoped_teams and not skip_team_and_org:
+            # Views that aren't project-nested but still need to accept
+            # scoped_teams tokens can set `dangerously_skip_scoped_team_enforcement = True`
+            # and take on responsibility for their own per-team access. The
+            # flag is only honored on `scope_object = "INTERNAL"` views —
+            # anywhere else it's a config error and we fail loudly.
             try:
                 team = view.team
                 if team.id not in scoped_teams:
@@ -533,7 +551,9 @@ class APIScopePermission(ScopeBasePermission):
             except (KeyError, AttributeError):
                 raise PermissionDenied("API keys with scoped projects are only supported on project-based endpoints.")
 
-        if scoped_organizations:
+        if scoped_organizations and not skip_team_and_org:
+            # The flag also opts out of org enforcement — INTERNAL views aren't
+            # org-nested today, but adding nesting later must revisit the flag.
             try:
                 organization = get_organization_from_view(view)
                 if str(organization.id) not in scoped_organizations:

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -11,7 +11,7 @@ from rest_framework import serializers
 
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, OrganizationMembership, Team, User
-from posthog.scopes import API_SCOPE_OBJECTS, APIScopeObject
+from posthog.scopes import API_SCOPE_OBJECTS, INTERNAL_API_SCOPE_OBJECTS, APIScopeObject
 from posthog.settings import EE_AVAILABLE
 
 if TYPE_CHECKING:
@@ -280,7 +280,7 @@ def model_to_resource(model: Model) -> Optional[APIScopeObject]:
     if name == "customerjourney":
         return "customer_journey"
 
-    if name not in API_SCOPE_OBJECTS:
+    if name not in API_SCOPE_OBJECTS or name in INTERNAL_API_SCOPE_OBJECTS:
         return None
 
     return cast(APIScopeObject, name)

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -17,6 +17,7 @@ APIScopeObject = Literal[
     "approvals",
     "batch_export",
     "batch_import",
+    "clickhouse_test_cluster_perf",
     "cohort",
     "comment",
     "conversation",
@@ -103,6 +104,11 @@ APIScopeObjectOrNotSupported = Literal[
 API_SCOPE_OBJECTS: tuple[APIScopeObject, ...] = get_args(APIScopeObject)
 API_SCOPE_ACTIONS: tuple[APIScopeActions, ...] = get_args(APIScopeActions)
 
+# Scope objects minted programmatically only — never via the OAuth consent flow,
+# the personal-API-key UI, the CLI authorize page, or RBAC. Filtered out of
+# `get_scope_descriptions()` and rejected by every user-facing scope validator.
+INTERNAL_API_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset({"clickhouse_test_cluster_perf"})
+
 PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION: list[tuple[APIScopeObject, APIScopeActions]] = [("endpoint", "read")]
 
 
@@ -110,5 +116,6 @@ def get_scope_descriptions() -> dict[str, str]:
     return {
         f"{obj}:{action}": f"{action.capitalize()} access to {obj}"
         for obj in API_SCOPE_OBJECTS
+        if obj not in INTERNAL_API_SCOPE_OBJECTS
         for action in API_SCOPE_ACTIONS
     }

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -69,6 +69,7 @@ PRODUCTS_APPS = [
     "products.platform_features.backend.apps.PlatformFeaturesConfig",
     "products.streamlit_apps.backend.apps.StreamlitAppsConfig",
     "products.legal_documents.backend.apps.LegalDocumentsConfig",
+    "products.query_performance_ai.backend.apps.QueryPerformanceAiConfig",
 ]
 
 INSTALLED_APPS = [

--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -65,12 +65,13 @@ PosthogMcpScopes = McpScopePreset | list[str]
 MCP_SCOPE_PRESETS = ("read_only", "full")
 
 
-def resolve_scopes(scopes: PosthogMcpScopes = "read_only") -> list[str]:
+def resolve_scopes(scopes: PosthogMcpScopes = "read_only", *, include_internal_scopes: bool = True) -> list[str]:
+    internal = list(INTERNAL_SCOPES) if include_internal_scopes else []
     if isinstance(scopes, str):
         if scopes == "full":
-            return [*MCP_READ_SCOPES, *MCP_WRITE_SCOPES, *INTERNAL_SCOPES]
-        return [*MCP_READ_SCOPES, *INTERNAL_SCOPES]
-    return [*scopes, *INTERNAL_SCOPES]
+            return [*MCP_READ_SCOPES, *MCP_WRITE_SCOPES, *internal]
+        return [*MCP_READ_SCOPES, *internal]
+    return [*scopes, *internal]
 
 
 def has_write_scopes(scopes: PosthogMcpScopes) -> bool:
@@ -94,8 +95,14 @@ def get_array_app() -> OAuthApplication:
         raise RuntimeError(f"Array app not found for region {region} (client_id={client_id})") from err
 
 
-def create_oauth_access_token_for_user(user, team_id: int, *, scopes: PosthogMcpScopes = "read_only") -> str:
-    resolved = resolve_scopes(scopes)
+def create_oauth_access_token_for_user(
+    user,
+    team_id: int,
+    *,
+    scopes: PosthogMcpScopes = "read_only",
+    include_internal_scopes: bool = True,
+) -> str:
+    resolved = resolve_scopes(scopes, include_internal_scopes=include_internal_scopes)
     app = get_array_app()
     token_value = generate_random_oauth_access_token(None)
 

--- a/posthog/temporal/tests/test_oauth.py
+++ b/posthog/temporal/tests/test_oauth.py
@@ -29,6 +29,30 @@ class TestResolveScopes(SimpleTestCase):
             assert scope in resolve_scopes("full")
             assert scope in resolve_scopes(["feature_flag:read"])
 
+    def test_include_internal_scopes_false_drops_internal_scopes(self) -> None:
+        custom = ["clickhouse_test_cluster_perf:read"]
+        result = resolve_scopes(custom, include_internal_scopes=False)
+        assert result == custom
+        for scope in INTERNAL_SCOPES:
+            assert scope not in result
+
+    def test_include_internal_scopes_false_for_read_only_preset(self) -> None:
+        result = resolve_scopes("read_only", include_internal_scopes=False)
+        assert set(result) == set(MCP_READ_SCOPES)
+        for scope in INTERNAL_SCOPES:
+            assert scope not in result
+
+    def test_internal_scope_objects_disjoint_from_mcp_scope_lists(self) -> None:
+        from posthog.scopes import INTERNAL_API_SCOPE_OBJECTS
+
+        mcp_scope_objects: set[str] = {scope.split(":", 1)[0] for scope in [*MCP_READ_SCOPES, *MCP_WRITE_SCOPES]}
+        internal: set[str] = set(INTERNAL_API_SCOPE_OBJECTS)
+        overlap = internal & mcp_scope_objects
+        assert overlap == set(), (
+            f"{overlap} are in INTERNAL_API_SCOPE_OBJECTS and also in MCP_READ_SCOPES / MCP_WRITE_SCOPES; "
+            "a `read_only` MCP token would silently grant them."
+        )
+
 
 class TestHasWriteScopes(SimpleTestCase):
     @parameterized.expand(

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -607,6 +607,22 @@ class TestOAuthAccessTokenAPIScopePermission(BaseTest):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["detail"], "This action does not support Personal API Key access")
 
+    def test_forbids_wildcard_scope_for_internal_viewset(self):
+        """`*` does not satisfy INTERNAL viewsets — explicit scope required."""
+        self.access_token.scope = "*"
+        self.access_token.save()
+        response = self._do_request("/api/query_performance_proxy/execute-test/", method="POST")
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("clickhouse_test_cluster_perf:read", response.json()["detail"])
+
+    def test_allows_explicit_scope_for_internal_viewset(self):
+        self.access_token.scope = "clickhouse_test_cluster_perf:read"
+        self.access_token.save()
+        response = self._do_request(
+            "/api/query_performance_proxy/execute-test/", method="POST", data={"sql": "SELECT 1"}
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_allows_derived_scope_for_read(self):
         """OAuth token with feature_flag:read can read feature flags"""
         response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/")

--- a/products/query_performance_ai/backend/apps.py
+++ b/products/query_performance_ai/backend/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class QueryPerformanceAiConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "products.query_performance_ai.backend"
+    label = "query_performance_ai"

--- a/products/query_performance_ai/package.json
+++ b/products/query_performance_ai/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@posthog/products-query-performance-ai",
+    "scripts": {
+        "backend:test": "echo 'no backend tests yet'"
+    }
+}

--- a/products/query_performance_ai/product.yaml
+++ b/products/query_performance_ai/product.yaml
@@ -1,0 +1,3 @@
+name: Query performance AI
+owners:
+    - team-analytics-platform

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16116,6 +16116,41 @@ export namespace Schemas {
       AiTrace: '$ai_trace',
     } as const;
 
+    export interface ExecuteTestClusterRequest {
+      /**
+       * ClickHouse SQL to run against the test cluster.
+       * @maxLength 65536
+       */
+      sql: string;
+    }
+
+    export interface ExecuteTestClusterResponse {
+      /** Rows returned, each as a positional list of canonicalized values. */
+      result: unknown[][];
+      /**
+       * ClickHouse query_id for this execution.
+       * @nullable
+       */
+      query_id: string | null;
+      /**
+       * Server-side elapsed time in milliseconds.
+       * @nullable
+       */
+      elapsed_ms: number | null;
+      /**
+       * Rows read from storage (scan-side).
+       * @nullable
+       */
+      rows_read: number | null;
+      /**
+       * Bytes read from storage (scan-side).
+       * @nullable
+       */
+      bytes_read: number | null;
+      /** Rows in the `result` payload. */
+      rows_returned: number;
+    }
+
     /**
      * * `exit_on_conversion` - Conversion
     * `exit_on_trigger_not_matched` - Trigger Not Matched

--- a/tach.toml
+++ b/tach.toml
@@ -85,6 +85,7 @@ depends_on = [
     "products.notifications",
     "products.posthog_ai",
     "products.product_tours",
+    "products.query_performance_ai",
     "products.revenue_analytics",
     "products.signals",
     "products.slack_app",
@@ -362,6 +363,13 @@ path = "products.product_tours"
 depends_on = [
     "posthog",
     "products.surveys",
+]
+layer = "modules"
+
+[[modules]]
+path = "products.query_performance_ai"
+depends_on = [
+    "posthog",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem

Split out of #55641 

The main thing this adds is M2M token auth that is not associated with a team or user. This is so that we can mint a token and give it to the sandboxed research agent, to let it call back to the django app (for only this one specific route).

The new route (that is protected by M2M auth) will run a query on the test cluster. This is stubbed out in this PR, in a future PR this will have its own protections as to what it can do (i.e. query the test cluster and nothing else, see https://github.com/PostHog/posthog/pull/56236 for the restrictions put on this user).

## Changes

### Route + auth

- **POST `/api/query_performance_proxy/execute-test/`** — stub. Validates the request body (`ExecuteTestClusterRequestSerializer`) and returns an empty `ExecuteTestClusterResponseSerializer`-shaped payload. Auth-only for now so reviewers can sign off on the M2M plumbing in isolation.
- **`clickhouse_test_cluster_perf:read` scope** — uses the standard `:read` action verb. Hidden from every user-facing surface (see below) so a human user never sees or grants it.
- **`include_internal_scopes=False`** on `create_oauth_access_token_for_user` / `resolve_scopes`. Narrow-scope tokens (e.g. autoresearch) opt out of the implicit `task:write` + `llm_gateway:read` union that `INTERNAL_SCOPES` adds for MCP callers.

### Internal scope plumbing

New `INTERNAL_API_SCOPE_OBJECTS: frozenset[APIScopeObject]` set in `posthog/scopes.py` listing scope objects that are minted programmatically only. The set is consulted everywhere a scope can be advertised or validated:

- `get_scope_descriptions()` filters them out → DOT's `OAUTH2_PROVIDER["SCOPES"]` and the RFC 8414 `scopes_supported` metadata don't list them.
- `PersonalAPIKeySerializer.validate_scopes` rejects them.
- `ProjectSecretAPIKeySerializer.validate_scopes` rejects them.
- `AccessControlSerializer.validate_resource` (RBAC) rejects them.
- `model_to_resource` returns `None` for them.
- Frontend `API_SCOPES` omits them, which keeps them out of the personal-API-key picker, the CLI authorize page, the OAuth consent screen, and the `mcp_server` preset.

### Permission gates

- **`dangerously_skip_scoped_team_enforcement`** flag on `APIScopePermission` for non-project-nested viewsets. Gated to `scope_object = "INTERNAL"` — anywhere else it raises `RuntimeError`. The flag covers both `scoped_teams` and `scoped_organizations` enforcement: an INTERNAL view is org-agnostic by design, so the previously-silent `except ValueError: pass` org-check no-op is now an explicit opt-out.
- **`*` wildcard scope** no longer satisfies `scope_object == "INTERNAL"` viewsets. `*` is granted via the "Full access to all scopes" consent option, and a user clicking that on an unrelated OAuth app must not unwittingly grant access to programmatic-only endpoints.

### Scaffolding

- **`products.query_performance_ai`** — tach entry, `INSTALLED_APPS`, `AppConfig`, `product.yaml`, `package.json`. No endpoints in the product app yet; the proxy lives under `posthog/api/` with the other cross-cutting viewsets.

## How did you test this code?

Automated tests only (I'm an agent — no manual verification beyond the test suite):

- `posthog/test/test_permissions.py` — new `test_forbids_wildcard_scope_for_internal_viewset` (asserts `*` token gets 403 with "missing required scope") and `test_allows_explicit_scope_for_internal_viewset` (asserts the explicit `clickhouse_test_cluster_perf:read` token gets 200). Plus the existing 33 OAuth scope/permission tests still pass after the `*` gate change.
- `posthog/temporal/tests/test_oauth.py` — `test_include_internal_scopes_false_drops_internal_scopes`, `test_include_internal_scopes_false_for_read_only_preset`, and `test_internal_scope_objects_disjoint_from_mcp_scope_lists` (asserts `INTERNAL_API_SCOPE_OBJECTS` is disjoint from `MCP_READ_SCOPES + MCP_WRITE_SCOPES` so a `read_only` MCP token can't silently bundle an internal scope).
- `posthog/api/test/test_personal_api_keys.py::test_rejects_internal_scope_objects` — asserts personal API keys cannot mint internal scopes.
- `posthog/api/oauth/test_views.py::test_metadata_excludes_internal_scope_objects` — asserts the RFC 8414 `scopes_supported` metadata response excludes internal scopes.
- `uvx tach check` — clean.
- `ruff check` on touched files — clean.
- `hogli build:openapi` regenerated; the only diff in `services/mcp/src/api/generated.ts` is the two new schemas (`ExecuteTestClusterRequest`, `ExecuteTestClusterResponse`).

312 tests pass across `test_project_secret_api_keys`, `test_permissions`, `ee/api/rbac`, and `posthog/rbac/test`.

## Publish to changelog?

No.

## Docs update

No docs update.

## 🤖 Agent context

Authored by PostHog Code with @robbie-c. The viewset action is intentionally a stub — the body validation runs and the response shape is final, but the ClickHouse forwarding (caps, canonicalization, lock, error mapping) lands separately so reviewers can sign off on the auth/scope plumbing first.

Deferred to the follow-up PR (currently still in #55641):

- Proxy execution layer: `SyncClient` + `_QUERY_LOCK`, `_canonicalize_*`, `_run_autoresearch_query`, ClickHouse caps + error mapping, DEBUG/cloud guards, `Feature.AUTORESEARCH` query tag, `CLICKHOUSE_TEST_CLUSTER_*` Django settings (these settings live only in #56236 today).
- Per-token rate limiting (`throttle_classes`) and a body-size guard before serializer validation.
- Vendored pi-autoresearch tree, workspace templates, scripts, skills.
- `run_autoresearch_smoke` management command + Docker sandbox driver.
- `products/tasks/backend/services/{docker,modal}_sandbox.py` changes.
- `bin/start` autoresearch user env plumbing.

Depends on #56236 for the `autoresearch` ClickHouse user + CI env wiring. With the proxy execution gone from this PR there's no longer any settings overlap between the two — this PR can land in either order.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
