### PR TITLE
fix(visual-review): raise pixel diff threshold to reduce noise during beta

### DIFF
--- a/products/visual_review/backend/diffing.py
+++ b/products/visual_review/backend/diffing.py
@@ -28,7 +28,7 @@ logger = structlog.get_logger(__name__)
 #    a measurable structural shift that SSIM catches.
 #
 # Only when both are below threshold is the snapshot reclassified as UNCHANGED.
-PIXEL_DIFF_THRESHOLD_PERCENT = 1.0
+PIXEL_DIFF_THRESHOLD_PERCENT = 2.5
 SSIM_DISSIMILARITY_THRESHOLD = 0.01  # 1% structural difference
 
 


### PR DESCRIPTION
## Problem

During beta, the 1% pixel diff threshold flags too many false positives from font anti-aliasing, sub-pixel rendering, and scrollbar jitter — especially on small components. Data shows 33% of all CHANGED snapshots are in the 1-2% band, and every human-tolerated diff maxed out at 2.3%.

## Changes

Raise `PIXEL_DIFF_THRESHOLD_PERCENT` from 1.0 to 2.5. SSIM safety net stays at 1% dissimilarity — it still catches real structural changes on tall pages where pixel ratio gets diluted.

## How did you test this code?

Queried tolerated hash data and CHANGED snapshot distributions to validate the threshold choice. All human-tolerated diffs with recorded percentages fall within the 1.1-2.3% range, confirming 2.5% covers known noise. SSIM at 1% continues to guard against diluted-but-real changes.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code assisted with data analysis and threshold reasoning. Human-driven decision on the threshold value based on the data.