### PR TITLE
chore(web-analytics): Sort Page Report URLs by view count

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -388,6 +388,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_WIZARD_PROMINENCE: 'onboarding-wizard-prominence', // owner: #team-growth multivariate=control,wizard-hero,wizard-tab,wizard-only
     OWNER_ONLY_BILLING: 'owner-only-billing', // owner: @pawelcebula #team-billing
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics
+    PAGE_REPORTS_RANKED_URL_SEARCH: 'page-reports-ranked-url-search', // owner: @jordanm-posthog #team-web-analytics
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     PHAI_PLAN_MODE: 'phai-plan-mode', // owner: #team-posthog-ai

--- a/frontend/src/scenes/web-analytics/PageReports.tsx
+++ b/frontend/src/scenes/web-analytics/PageReports.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { FilterBar } from 'lib/components/FilterBar'
 import { XRayHog2 } from 'lib/components/hedgehogs'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 
 import { pageReportsLogic } from './pageReportsLogic'
@@ -27,13 +28,23 @@ function NoUrlSelectedMessage(): JSX.Element {
 }
 
 export function PageReportsFilters({ tabs }: { tabs: JSX.Element }): JSX.Element {
-    const { pagesUrls, pageUrl, isLoading, dateFilter } = useValues(pageReportsLogic)
+    const { pagesUrls, pageUrl, isLoading, dateFilter, pageUrlSearchTerm, featureFlags } = useValues(pageReportsLogic)
     const { setPageUrl, setPageUrlSearchTerm, loadPages, setDates } = useActions(pageReportsLogic)
+
+    const rankedSearchEnabled = !!featureFlags[FEATURE_FLAGS.PAGE_REPORTS_RANKED_URL_SEARCH]
 
     const options = pagesUrls.map((option: { url: string }) => ({
         key: option.url,
         label: option.url,
     }))
+
+    const emptyStateComponent = rankedSearchEnabled ? (
+        <div className="text-muted-alt px-3 py-2 text-xs">
+            {pageUrlSearchTerm
+                ? `No pages match "${pageUrlSearchTerm}". Press Enter to analyze it as a custom URL.`
+                : 'No pageviews in the selected date range. Paste a URL to analyze it anyway.'}
+        </div>
+    ) : undefined
 
     return (
         <FilterBar
@@ -55,6 +66,7 @@ export function PageReportsFilters({ tabs }: { tabs: JSX.Element }): JSX.Element
                         onInputChange={(val: string) => setPageUrlSearchTerm(val)}
                         data-attr="page-reports-url-search"
                         onFocus={() => loadPages('')}
+                        emptyStateComponent={emptyStateComponent}
                     />
                 </div>
             }

--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -14,6 +14,7 @@ import {
     WebAnalyticsPropertyFilters,
     WebPageURLSearchQuery,
     WebStatsBreakdown,
+    WebStatsTableQuery,
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import {
@@ -41,6 +42,7 @@ import {
     WebTileLayout,
     parseWebAnalyticsURL,
 } from './common'
+import { PROPERTY_PATHNAME } from './constants'
 import type { pageReportsLogicType } from './pageReportsLogicType'
 import { webAnalyticsLogic } from './webAnalyticsLogic'
 
@@ -210,16 +212,47 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
             {
                 loadPagesUrls: async ({ searchTerm }: { searchTerm: string }, breakpoint) => {
                     await breakpoint(100) // debounce the typing
+                    const dateRange = {
+                        date_from: values.dateFilter.dateFrom,
+                        date_to: values.dateFilter.dateTo,
+                    }
+
+                    if (values.featureFlags[FEATURE_FLAGS.PAGE_REPORTS_RANKED_URL_SEARCH]) {
+                        const response = await api.query<WebStatsTableQuery>(
+                            setLatestVersionsOnQuery({
+                                kind: NodeKind.WebStatsTableQuery,
+                                breakdownBy: WebStatsBreakdown.Page,
+                                includeHost: true,
+                                dateRange,
+                                properties: searchTerm
+                                    ? [
+                                          {
+                                              type: PropertyFilterType.Event,
+                                              key: PROPERTY_PATHNAME,
+                                              operator: PropertyOperator.IContains,
+                                              value: searchTerm,
+                                          },
+                                      ]
+                                    : [],
+                                limit: 100,
+                                tags: WEB_ANALYTICS_DEFAULT_QUERY_TAGS,
+                            })
+                        )
+                        breakpoint()
+                        return (response.results ?? []).flatMap((row): PageURLSearchResult[] => {
+                            const url = Array.isArray(row) ? row[0] : null
+                            return typeof url === 'string' && url ? [{ url }] : []
+                        })
+                    }
+
                     const response = await api.query<WebPageURLSearchQuery>(
                         setLatestVersionsOnQuery({
                             kind: NodeKind.WebPageURLSearchQuery,
                             searchTerm: searchTerm,
                             stripQueryParams: true,
-                            dateRange: {
-                                date_from: values.dateFilter.dateFrom,
-                                date_to: values.dateFilter.dateTo,
-                            },
+                            dateRange,
                             properties: [],
+                            tags: WEB_ANALYTICS_DEFAULT_QUERY_TAGS,
                         })
                     )
                     breakpoint() // ensure that if more typing has happened since we sent the request, we don't update the state
@@ -732,7 +765,7 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
         ],
     },
 
-    listeners: ({ actions }) => ({
+    listeners: ({ actions, values }) => ({
         setPageUrlSearchTerm: ({ searchTerm }) => {
             actions.loadPages(searchTerm)
         },
@@ -741,6 +774,11 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
         },
         loadPages: ({ searchTerm }) => {
             actions.loadPagesUrls({ searchTerm })
+        },
+        setDates: () => {
+            if (values.featureFlags[FEATURE_FLAGS.PAGE_REPORTS_RANKED_URL_SEARCH]) {
+                actions.loadPages(values.pageUrlSearchTerm)
+            }
         },
     }),
 


### PR DESCRIPTION
## Problem
The current listing logic for page report URLs returns up to 100 distinct URLs from the selected date range ordered alphabetically, with no weighting by visit volume. High-traffic pages can fall off the list behind alphabetically earlier long-tail URLs, and the ordering doesn't reflect what users likely care about.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Swap the dropdown's data source to the same ranked query that powers the Top paths tile, so pages are ordered by visitors with pre-aggregated tables used when available. The list now also refreshes when the date range changes and shows a more helpful empty-state message.
<img width="672" height="135" alt="image" src="https://github.com/user-attachments/assets/17133d58-da77-4134-81f6-95691164c1ad" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally tested 
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
