### PR TITLE
fix(integrations): accept stateless stripe marketplace install callback

### DIFF
--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -245,7 +245,10 @@ export const integrationsLogic = kea<integrationsLogicType>([
             // Stripe marketplace installs redirect here without a PostHog-minted state —
             // Stripe initiates OAuth itself on install (stripe_api_access_type: oauth). Skip
             // the CSRF state check; the code is still validated server-side via Stripe exchange.
-            const isStripeMarketplaceInstall = resolvedKind === 'stripe' && !state && !!stripe_user_id && !!code
+            // resolvedKind is typed as IntegrationKind which doesn't list 'stripe' in the enum,
+            // but the URL route (`/integrations/:kind/callback`) passes it through verbatim.
+            const isStripeMarketplaceInstall =
+                (resolvedKind as string) === 'stripe' && !state && !!stripe_user_id && !!code
 
             try {
                 if (!isStripeMarketplaceInstall && token !== getCookie('ph_oauth_state')) {

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -229,7 +229,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
             }
         },
         handleOauthCallback: async ({ kind, searchParams }) => {
-            const { state, code, error, stripe_user_id, account_id, user_id } = searchParams
+            const { state, code, error, stripe_user_id, account_id, user_id, install_signature } = searchParams
             const { next, token, source, server_id, kind: stateKind } = fromParamsGivenUrl(state)
             // slack-posthog-code reuses /integrations/slack/callback as its approved redirect URI,
             // so the real kind is carried in OAuth state and takes precedence over the URL path.
@@ -259,7 +259,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
                     const integration = await api.integrations.create({
                         kind: resolvedKind,
                         config: isStripeMarketplaceInstall
-                            ? { code, stripe_user_id, account_id, user_id }
+                            ? { code, stripe_user_id, account_id, user_id, install_signature }
                             : { state, code },
                     })
 

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -229,7 +229,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
             }
         },
         handleOauthCallback: async ({ kind, searchParams }) => {
-            const { state, code, error } = searchParams
+            const { state, code, error, stripe_user_id, account_id, user_id } = searchParams
             const { next, token, source, server_id, kind: stateKind } = fromParamsGivenUrl(state)
             // slack-posthog-code reuses /integrations/slack/callback as its approved redirect URI,
             // so the real kind is carried in OAuth state and takes precedence over the URL path.
@@ -242,8 +242,13 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 return
             }
 
+            // Stripe marketplace installs redirect here without a PostHog-minted state —
+            // Stripe initiates OAuth itself on install (stripe_api_access_type: oauth). Skip
+            // the CSRF state check; the code is still validated server-side via Stripe exchange.
+            const isStripeMarketplaceInstall = resolvedKind === 'stripe' && !state && !!stripe_user_id && !!code
+
             try {
-                if (token !== getCookie('ph_oauth_state')) {
+                if (!isStripeMarketplaceInstall && token !== getCookie('ph_oauth_state')) {
                     throw new Error('Invalid state token')
                 }
 
@@ -253,7 +258,9 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 } else {
                     const integration = await api.integrations.create({
                         kind: resolvedKind,
-                        config: { state, code },
+                        config: isStripeMarketplaceInstall
+                            ? { code, stripe_user_id, account_id, user_id }
+                            : { state, code },
                     })
 
                     // Add the integration ID to the replaceUrl so that the landing page can use it

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -355,6 +355,10 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                         .exists()
                     )
                     if conflicting:
+                        capture_exception(
+                            Exception("Stripe marketplace callback rejected: conflicting integration"),
+                            {"team_id": team_id, "stripe_user_id": stripe_user_id},
+                        )
                         raise ValidationError(
                             "A different Stripe account is already connected to this team. Disconnect it first.",
                             code="stripe_integration_conflict",

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 
+import stripe
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -58,6 +59,28 @@ from posthog.permissions import (
 )
 from posthog.rate_limit import GitHubRepositoryRefreshThrottle
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+
+
+def _verify_stripe_install_signature(state: str, user_id: str, account_id: str, install_signature: str) -> bool:
+    """Verify Stripe Apps marketplace install signature.
+
+    Stripe signs the redirect with HMAC over the JSON object {state, user_id, account_id}
+    in that exact key order using the app's signing secret. Without this check, a forged
+    callback URL could link an attacker's Stripe account onto a victim's PostHog team.
+
+    See: https://docs.stripe.com/stripe-apps/install-links-oauth
+    """
+    if not install_signature or not settings.STRIPE_SIGNING_SECRET:
+        return False
+    payload = json.dumps(
+        {"state": state, "user_id": user_id, "account_id": account_id},
+        separators=(",", ":"),
+    )
+    try:
+        stripe.WebhookSignature.verify_header(payload, install_signature, settings.STRIPE_SIGNING_SECRET)
+        return True
+    except stripe.SignatureVerificationError:
+        return False
 
 
 def _ensure_oauth_token_valid(instance: Integration) -> None:
@@ -342,13 +365,33 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
 
         elif validated_data["kind"] in OauthIntegration.supported_kinds:
             # Stripe marketplace installs redirect to /integrations/stripe/callback without
-            # a PostHog-minted CSRF state token. Before exchanging the code, reject the
-            # request if a different Stripe account is already linked — prevents a forged
-            # code from relinking an attacker's account onto a victim's team.
+            # a PostHog-minted CSRF state token — Stripe drives the OAuth flow itself. Stripe
+            # signs the redirect with `install_signature` over {state, user_id, account_id};
+            # verify it before exchanging the code so a forged URL can't link an attacker's
+            # account onto a victim's team. Conflict check is defense-in-depth on top.
             if validated_data["kind"] == "stripe":
-                stripe_user_id = validated_data["config"].get("stripe_user_id")
-                state = validated_data["config"].get("state")
+                config = validated_data["config"]
+                stripe_user_id = config.get("stripe_user_id")
+                state = config.get("state")
                 if stripe_user_id and not state:
+                    install_signature = config.get("install_signature") or ""
+                    user_id = config.get("user_id") or ""
+                    account_id = config.get("account_id") or ""
+                    if not _verify_stripe_install_signature(
+                        state="",
+                        user_id=user_id,
+                        account_id=account_id,
+                        install_signature=install_signature,
+                    ):
+                        capture_exception(
+                            Exception("Stripe marketplace callback rejected: invalid install_signature"),
+                            {"team_id": team_id, "stripe_user_id": stripe_user_id},
+                        )
+                        raise ValidationError(
+                            "Stripe install signature could not be verified.",
+                            code="stripe_install_signature_invalid",
+                        )
+
                     conflicting = (
                         Integration.objects.filter(team_id=team_id, kind="stripe")
                         .exclude(integration_id=stripe_user_id)

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -341,6 +341,25 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
             return instance
 
         elif validated_data["kind"] in OauthIntegration.supported_kinds:
+            # Stripe marketplace installs redirect to /integrations/stripe/callback without
+            # a PostHog-minted CSRF state token. Before exchanging the code, reject the
+            # request if a different Stripe account is already linked — prevents a forged
+            # code from relinking an attacker's account onto a victim's team.
+            if validated_data["kind"] == "stripe":
+                stripe_user_id = validated_data["config"].get("stripe_user_id")
+                state = validated_data["config"].get("state")
+                if stripe_user_id and not state:
+                    conflicting = (
+                        Integration.objects.filter(team_id=team_id, kind="stripe")
+                        .exclude(integration_id=stripe_user_id)
+                        .exists()
+                    )
+                    if conflicting:
+                        raise ValidationError(
+                            "A different Stripe account is already connected to this team. Disconnect it first.",
+                            code="stripe_integration_conflict",
+                        )
+
             try:
                 instance = OauthIntegration.integration_from_oauth_response(
                     validated_data["kind"], team_id, request.user, validated_data["config"]

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -77,7 +77,8 @@ def _verify_stripe_install_signature(state: str, user_id: str, account_id: str, 
         separators=(",", ":"),
     )
     try:
-        stripe.WebhookSignature.verify_header(payload, install_signature, settings.STRIPE_SIGNING_SECRET)
+        # 300s tolerance matches the agentic-provisioning HMAC check at ee/api/agentic_provisioning/signature.py.
+        stripe.WebhookSignature.verify_header(payload, install_signature, settings.STRIPE_SIGNING_SECRET, tolerance=300)
         return True
     except stripe.SignatureVerificationError:
         return False

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1137,6 +1137,113 @@ class TestStripeIntegration:
 
         assert response.status_code == status.HTTP_201_CREATED
 
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_marketplace_callback_without_state_succeeds(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        created_integration = self._create_stripe_integration()
+        mock_oauth_response.return_value = created_integration
+        mock_instance = MagicMock()
+        MockStripeIntegration.return_value = mock_instance
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {
+                    "code": "oauth_code_123",
+                    "stripe_user_id": "acct_123",
+                    "account_id": "acct_123",
+                    "user_id": "usr_abc",
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_instance.write_posthog_secrets.assert_called_once_with(self.team.pk, self.user)
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_marketplace_callback_rejects_when_different_stripe_account_connected(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        self._create_stripe_integration()
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {
+                    "code": "oauth_code_999",
+                    "stripe_user_id": "acct_999",
+                    "account_id": "acct_999",
+                    "user_id": "usr_xyz",
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "stripe_integration_conflict" in response.content.decode()
+        mock_oauth_response.assert_not_called()
+        MockStripeIntegration.assert_not_called()
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_marketplace_callback_allows_reinstall_of_same_stripe_account(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        existing = self._create_stripe_integration()
+        mock_oauth_response.return_value = existing
+        mock_instance = MagicMock()
+        MockStripeIntegration.return_value = mock_instance
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {
+                    "code": "oauth_code_123",
+                    "stripe_user_id": "acct_123",
+                    "account_id": "acct_123",
+                    "user_id": "usr_abc",
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_oauth_response.assert_called_once()
+
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_stripe_oauth_exchange_failure_returns_error(
+        self, mock_oauth_response, stripe_settings, client: HttpClient
+    ):
+        mock_oauth_response.side_effect = Exception("Stripe returned invalid_grant")
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {
+                    "code": "ac_invalid",
+                    "stripe_user_id": "acct_123",
+                    "account_id": "acct_123",
+                    "user_id": "usr_abc",
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code >= 400
+        assert not Integration.objects.filter(team_id=self.team.pk, kind="stripe").exists()
+
 
 class TestStripeIntegrationOAuthTokens:
     @pytest.fixture(autouse=True)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1,3 +1,7 @@
+import hmac
+import json
+import time
+import hashlib
 from datetime import timedelta
 
 import pytest
@@ -1101,13 +1105,8 @@ class TestStripeIntegration:
         self, state: str, user_id: str, account_id: str, secret: str = "whsec_test_signing"
     ) -> str:
         """Build a valid t=...,v1=... header for a marketplace install callback."""
-        import hmac
-        import json as _json
-        import time as _time
-        import hashlib
-
-        ts = int(_time.time())
-        payload = _json.dumps(
+        ts = int(time.time())
+        payload = json.dumps(
             {"state": state, "user_id": user_id, "account_id": account_id},
             separators=(",", ":"),
         )
@@ -1236,55 +1235,48 @@ class TestStripeIntegration:
         assert response.status_code == status.HTTP_201_CREATED
         mock_instance.write_posthog_secrets.assert_called_once_with(self.team.pk, self.user)
 
-    @patch("posthog.api.integration.StripeIntegration")
-    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
-    def test_marketplace_callback_rejects_missing_install_signature(
-        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
-    ):
-        client.force_login(self.user)
-        response = client.post(
-            f"/api/environments/{self.team.pk}/integrations",
-            {
-                "kind": "stripe",
-                "config": {
-                    "code": "oauth_code_123",
-                    "stripe_user_id": "acct_123",
-                    "account_id": "acct_123",
-                    "user_id": "usr_abc",
-                },
-            },
-            content_type="application/json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "stripe_install_signature_invalid" in response.content.decode()
-        mock_oauth_response.assert_not_called()
-        MockStripeIntegration.assert_not_called()
-
+    @pytest.mark.parametrize(
+        "scenario,build_signature",
+        [
+            ("missing", lambda self: None),
+            (
+                "forged",
+                lambda self: self._make_install_signature(
+                    state="", user_id="usr_abc", account_id="acct_123", secret="wrong_secret"
+                ),
+            ),
+        ],
+    )
     @patch("posthog.api.integration.StripeIntegration")
     @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
     def test_marketplace_callback_rejects_invalid_install_signature(
-        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+        self,
+        mock_oauth_response,
+        MockStripeIntegration,
+        scenario,
+        build_signature,
+        stripe_settings,
+        client: HttpClient,
     ):
-        forged = self._make_install_signature(state="", user_id="usr_abc", account_id="acct_123", secret="wrong_secret")
+        config = {
+            "code": "oauth_code_123",
+            "stripe_user_id": "acct_123",
+            "account_id": "acct_123",
+            "user_id": "usr_abc",
+        }
+        sig = build_signature(self)
+        if sig is not None:
+            config["install_signature"] = sig
+
         client.force_login(self.user)
         response = client.post(
             f"/api/environments/{self.team.pk}/integrations",
-            {
-                "kind": "stripe",
-                "config": {
-                    "code": "oauth_code_123",
-                    "stripe_user_id": "acct_123",
-                    "account_id": "acct_123",
-                    "user_id": "usr_abc",
-                    "install_signature": forged,
-                },
-            },
+            {"kind": "stripe", "config": config},
             content_type="application/json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "stripe_install_signature_invalid" in response.content.decode()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, scenario
+        assert "stripe_install_signature_invalid" in response.content.decode(), scenario
         mock_oauth_response.assert_not_called()
         MockStripeIntegration.assert_not_called()
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1139,6 +1139,56 @@ class TestStripeIntegration:
 
     @patch("posthog.api.integration.StripeIntegration")
     @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_posthog_initiated_oauth_with_state_still_works(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        created_integration = self._create_stripe_integration()
+        mock_oauth_response.return_value = created_integration
+        mock_instance = MagicMock()
+        MockStripeIntegration.return_value = mock_instance
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {"kind": "stripe", "config": {"state": "next=/foo&token=abc123", "code": "oauth_code_123"}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_instance.write_posthog_secrets.assert_called_once_with(self.team.pk, self.user)
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_posthog_initiated_oauth_ignores_marketplace_conflict_guard(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        self._create_stripe_integration()
+        new_integration = Integration(
+            team=self.team,
+            kind="stripe",
+            integration_id="acct_999",
+            config={},
+            sensitive_config={},
+        )
+        mock_oauth_response.return_value = new_integration
+        mock_instance = MagicMock()
+        MockStripeIntegration.return_value = mock_instance
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {"state": "next=/foo&token=abc123", "code": "oauth_code_999"},
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_oauth_response.assert_called_once()
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
     def test_marketplace_callback_without_state_succeeds(
         self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
     ):

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1094,7 +1094,26 @@ class TestStripeIntegration:
     def stripe_settings(self, settings):
         settings.STRIPE_APP_CLIENT_ID = "ca_test123"
         settings.STRIPE_APP_SECRET_KEY = "sk_test_secret"
+        settings.STRIPE_SIGNING_SECRET = "whsec_test_signing"
         return settings
+
+    def _make_install_signature(
+        self, state: str, user_id: str, account_id: str, secret: str = "whsec_test_signing"
+    ) -> str:
+        """Build a valid t=...,v1=... header for a marketplace install callback."""
+        import hmac
+        import json as _json
+        import time as _time
+        import hashlib
+
+        ts = int(_time.time())
+        payload = _json.dumps(
+            {"state": state, "user_id": user_id, "account_id": account_id},
+            separators=(",", ":"),
+        )
+        signed = f"{ts}.{payload}".encode()
+        digest = hmac.new(secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
+        return f"t={ts},v1={digest}"
 
     @patch("posthog.api.integration.StripeIntegration")
     @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
@@ -1197,6 +1216,31 @@ class TestStripeIntegration:
         mock_instance = MagicMock()
         MockStripeIntegration.return_value = mock_instance
 
+        sig = self._make_install_signature(state="", user_id="usr_abc", account_id="acct_123")
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {
+                    "code": "oauth_code_123",
+                    "stripe_user_id": "acct_123",
+                    "account_id": "acct_123",
+                    "user_id": "usr_abc",
+                    "install_signature": sig,
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_instance.write_posthog_secrets.assert_called_once_with(self.team.pk, self.user)
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_marketplace_callback_rejects_missing_install_signature(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
         client.force_login(self.user)
         response = client.post(
             f"/api/environments/{self.team.pk}/integrations",
@@ -1212,8 +1256,37 @@ class TestStripeIntegration:
             content_type="application/json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
-        mock_instance.write_posthog_secrets.assert_called_once_with(self.team.pk, self.user)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "stripe_install_signature_invalid" in response.content.decode()
+        mock_oauth_response.assert_not_called()
+        MockStripeIntegration.assert_not_called()
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_marketplace_callback_rejects_invalid_install_signature(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        forged = self._make_install_signature(state="", user_id="usr_abc", account_id="acct_123", secret="wrong_secret")
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "stripe",
+                "config": {
+                    "code": "oauth_code_123",
+                    "stripe_user_id": "acct_123",
+                    "account_id": "acct_123",
+                    "user_id": "usr_abc",
+                    "install_signature": forged,
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "stripe_install_signature_invalid" in response.content.decode()
+        mock_oauth_response.assert_not_called()
+        MockStripeIntegration.assert_not_called()
 
     @patch("posthog.api.integration.StripeIntegration")
     @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
@@ -1222,6 +1295,7 @@ class TestStripeIntegration:
     ):
         self._create_stripe_integration()
 
+        sig = self._make_install_signature(state="", user_id="usr_xyz", account_id="acct_999")
         client.force_login(self.user)
         response = client.post(
             f"/api/environments/{self.team.pk}/integrations",
@@ -1232,6 +1306,7 @@ class TestStripeIntegration:
                     "stripe_user_id": "acct_999",
                     "account_id": "acct_999",
                     "user_id": "usr_xyz",
+                    "install_signature": sig,
                 },
             },
             content_type="application/json",
@@ -1252,6 +1327,7 @@ class TestStripeIntegration:
         mock_instance = MagicMock()
         MockStripeIntegration.return_value = mock_instance
 
+        sig = self._make_install_signature(state="", user_id="usr_abc", account_id="acct_123")
         client.force_login(self.user)
         response = client.post(
             f"/api/environments/{self.team.pk}/integrations",
@@ -1262,6 +1338,7 @@ class TestStripeIntegration:
                     "stripe_user_id": "acct_123",
                     "account_id": "acct_123",
                     "user_id": "usr_abc",
+                    "install_signature": sig,
                 },
             },
             content_type="application/json",
@@ -1276,6 +1353,7 @@ class TestStripeIntegration:
     ):
         mock_oauth_response.side_effect = Exception("Stripe returned invalid_grant")
 
+        sig = self._make_install_signature(state="", user_id="usr_abc", account_id="acct_123")
         client.force_login(self.user)
         response = client.post(
             f"/api/environments/{self.team.pk}/integrations",
@@ -1286,12 +1364,13 @@ class TestStripeIntegration:
                     "stripe_user_id": "acct_123",
                     "account_id": "acct_123",
                     "user_id": "usr_abc",
+                    "install_signature": sig,
                 },
             },
             content_type="application/json",
         )
 
-        assert response.status_code >= 400
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert not Integration.objects.filter(team_id=self.team.pk, kind="stripe").exists()
 
 

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 
 from django.core import mail
 from django.core.cache import cache
+from django.test import override_settings
 from django.utils.timezone import now
 
 from parameterized import parameterized
@@ -1522,6 +1523,9 @@ class TestOrganizationInviteRateLimits(APIBaseTest):
             )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    # Bump the session-sensitive action threshold past the 8-hour test window so
+    # TimeSensitiveActionPermission doesn't 403 the later iterations under freeze_time.
+    @override_settings(SESSION_SENSITIVE_ACTIONS_AGE=24 * 60 * 60)
     @patch("posthog.rate_limit.OrganizationInviteBurstThrottle.rate", new="1000/hour")
     @patch("posthog.rate_limit.OrganizationInviteSustainedThrottle.rate", new="3/day")
     def test_sustained_limit_caps_invites_over_longer_window(self, _rate_limit_enabled_mock):


### PR DESCRIPTION
## Problem

The PostHog Stripe App is listed on marketplace.stripe.com. When a merchant installs it, Stripe itself initiates an OAuth flow (via `stripe_api_access_type: oauth` in the app manifest) and redirects the merchant's browser to `/integrations/stripe/callback?code=...&stripe_user_id=...&install_signature=...`. Unlike PostHog-initiated "Connect Stripe" flows, there is no PostHog-minted `ph_oauth_state` cookie because PostHog didn't start the handshake — Stripe did.

The existing frontend callback handler unconditionally rejected callbacks whose `state.token` didn't match the `ph_oauth_state` cookie, so every marketplace-originated install threw `Invalid state token`, showed "Something went wrong. Please try again.", and never POSTed the integration to the backend. That meant `IntegrationSerializer.create → write_posthog_secrets` never fired, and the `posthog_*` secrets the Stripe App reads to authenticate with PostHog were never written to Stripe's Secret Store. Result: the app on marketplace installs looked permanently disconnected.

<!-- Closes #ISSUE_ID -->

## Changes

**Frontend (`integrationsLogic.ts`)** — detect Stripe marketplace-initiated callbacks (`kind === 'stripe' && !state && !!stripe_user_id && !!code`) and skip the `ph_oauth_state` CSRF check for that path. Forward `stripe_user_id`, `account_id`, `user_id`, and `install_signature` to the backend in `config`. PostHog-initiated Stripe flow is unchanged.

**Backend (`posthog/api/integration.py`)** — two layers of protection take the place of the absent CSRF cookie:
1. **Verify Stripe's `install_signature` HMAC** over `{state, user_id, account_id}` using `STRIPE_SIGNING_SECRET` and `stripe.WebhookSignature.verify_header`. Stripe signs every install redirect with the app's signing secret ([docs](https://docs.stripe.com/stripe-apps/install-links-oauth)) — this is the cryptographic proof that Stripe itself drove the redirect for *this* user/account, not an attacker. Reject with 400 / `stripe_install_signature_invalid` if missing or invalid.
2. **Defense-in-depth conflict guard** — reject with 400 / `stripe_integration_conflict` if a different Stripe account is already connected on the team (still allows same-account re-install). Both rejections emit `capture_exception` for observability.

**Tests (`posthog/api/test/test_integration.py`)** — 8 new cases covering: marketplace happy path (with valid sig), missing signature reject, forged signature reject, conflict reject (different acct), same-account re-install allow, OAuth exchange failure, and explicit regression tests for the stateful PostHog-initiated path so the existing flow is provably unaffected by the new branch.

## How did you test this code?

Agent-authored. All testing below was run by the agent — no human manual testing performed.

**Automated:**
- `pytest posthog/api/test/test_integration.py::TestStripeIntegration` — 13/13 pass.
- `ruff check` + `ruff format` + lint-staged hooks pass.

**Local reproduction (Chrome MCP against a PostHog sandbox):**
- Pre-fix: navigating to `/integrations/stripe/callback?code=ac_fake&stripe_user_id=acct_FAKE&account_id=acct_FAKE&user_id=usr_FAKE` while logged in produced "Something went wrong" toast, redirect to `/settings/project-integrations`, and **zero** POSTs to `/api/environments/.../integrations/`.
- Post-fix (same URL): **POST** fires to `/api/environments/.../integrations/` → 400 with `stripe_install_signature_invalid` (correct rejection — fake URL has no valid Stripe signature).
- Tested signature-rejection path locally; valid-signature happy path is exercised by automated tests using a hand-rolled HMAC.

End-to-end validation against a real Stripe marketplace install will happen on staging after deploy (see "Notes for reviewers" below).

## Publish to changelog?

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

- Tooling: Claude Code (Opus 4.7, 1M context). The user (@Brooker) directed the investigation, validated findings against a separate adversarial reviewer, and approved scope expansions.
- Investigation trail: prod log queries (PostHog MCP `query-logs`) confirmed marketplace installs hit `/integrations/stripe/callback` (browser-side, frontend throws before backend POST) — *not* `/api/agentic/oauth/token`, which handles Stripe Projects provisioning, a separate flow. Initial fix attempt was scoped to only "skip the state check"; pre-PR review surfaced that `install_signature` is the cryptographic primitive Stripe provides for exactly this CSRF gap, and the fix was widened to verify it.
- Key decisions:
  - Skip the state check *only* for the narrow marketplace-install shape; PostHog-initiated stripe stays gated by the existing cookie check.
  - Cryptographic verification of `install_signature` is the primary defense; team-conflict guard is layered on top to prevent surprises if signature verification has edge cases we haven't seen yet.
  - Bound the cost of the `state=""` assumption: Stripe docs are explicit about marketplace installs not carrying state, and the signed payload is `{state, user_id, account_id}` with `state` as `""` for unattributed installs. If real Stripe traffic shows otherwise, the verification will reject and we'll see it in `capture_exception` immediately.

**Notes for reviewers:**
- Real-Stripe E2E confirmation will happen post-deploy: install Stripe App 1.2.3 (already in Stripe's Test mode channel) on a test Stripe account, complete the marketplace install, watch for an integration to land + secrets to write to Stripe's Secret Store. Pre-deploy, we can't see real `install_signature` values.
- The Stripe App manifest version bump to 1.2.3 (with `FALLBACK_CONSTANTS` to defend against missing manifest constants) is *not* in this PR — that lives in `services/stripe-app/` and is being shipped separately.