### PR TITLE
chore(experiments): rename experiment.py to views.py and update imports.

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -802,7 +802,7 @@ register_grandfathered_environment_nested_viewset(r"saved", SavedHeatmapViewSet,
 register_grandfathered_environment_nested_viewset(r"sessions", SessionViewSet, "environment_sessions", ["team_id"])
 
 if EE_AVAILABLE:
-    from products.experiments.backend.presentation.experiments import EnterpriseExperimentsViewSet
+    from products.experiments.backend.presentation.views import EnterpriseExperimentsViewSet
 
     from ee.clickhouse.views.experiment_holdouts import ExperimentHoldoutViewSet
     from ee.clickhouse.views.experiment_saved_metrics import ExperimentSavedMetricViewSet

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -38,7 +38,10 @@ from posthog.temporal.common.client import sync_connect
 from posthog.temporal.experiments.models import ExperimentTimeseriesRecalculationWorkflowInputs
 from posthog.user_permissions import UserPermissions
 
+# TODO: Route through facade instead of direct import
 from products.experiments.backend.experiment_service import ExperimentService
+
+# TODO: Route through facade instead of direct import
 from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentTimeseriesRecalculation,


### PR DESCRIPTION
## Problem

The presentation layer file is named `experiments.py` instead of following the standard views.py naming convention used across product backends.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR renames `products/experiments/backend/presentation/experiments.py` to `views.py` to align with the naming convention established in the product backend architecture. The file contains the `ViewSet`, so `views.py` is the more descriptive and conventional name. The data flow remains completely unchanged; the same `ViewSet` code is in the same place, just with a standardized filename. This also aligns with the `tach.toml` interface pattern that expects `backend\.presentation\.views.*` for `ViewSet` exports.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

<img width="249" height="152" alt="cat-type" src="https://github.com/user-attachments/assets/b349cc0e-d658-44db-8ff1-ffd1f159da0f" />


<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
