### PR TITLE
chore(flags): add per-product label to Prometheus recorder

### DIFF
--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -240,39 +240,33 @@ mod tests {
     use super::{build_prometheus_builder, normalize_unmatched_path};
 
     #[test]
-    fn test_product_global_label_is_emitted() {
-        let recorder = build_prometheus_builder(Some("feature_flags".to_string())).build_recorder();
-        let handle = recorder.handle();
-        metrics::with_local_recorder(&recorder, || {
-            metrics::counter!("test_counter_with_product").increment(1);
-        });
-        let rendered = handle.render();
-        assert!(
-            rendered.contains("test_counter_with_product"),
-            "rendered metrics missing the counter we just incremented:\n{rendered}"
-        );
-        assert!(
-            rendered.contains("product=\"feature_flags\""),
-            "rendered metrics missing product label:\n{rendered}"
-        );
-    }
-
-    #[test]
-    fn test_no_product_label_when_none() {
-        let recorder = build_prometheus_builder(None).build_recorder();
-        let handle = recorder.handle();
-        metrics::with_local_recorder(&recorder, || {
-            metrics::counter!("test_counter_without_product").increment(1);
-        });
-        let rendered = handle.render();
-        assert!(
-            rendered.contains("test_counter_without_product"),
-            "rendered metrics missing the counter we just incremented:\n{rendered}"
-        );
-        assert!(
-            !rendered.contains("product=\""),
-            "rendered metrics unexpectedly contain product label:\n{rendered}"
-        );
+    fn test_product_global_label_emission() {
+        let cases: &[(&'static str, Option<&'static str>)] = &[
+            ("test_counter_with_product", Some("feature_flags")),
+            ("test_counter_without_product", None),
+        ];
+        for &(counter_name, product) in cases {
+            let recorder = build_prometheus_builder(product.map(str::to_string)).build_recorder();
+            let handle = recorder.handle();
+            metrics::with_local_recorder(&recorder, || {
+                metrics::counter!(counter_name).increment(1);
+            });
+            let rendered = handle.render();
+            assert!(
+                rendered.contains(counter_name),
+                "missing counter {counter_name}:\n{rendered}"
+            );
+            match product {
+                Some(p) => assert!(
+                    rendered.contains(&format!("product=\"{p}\"")),
+                    "missing product label {p}:\n{rendered}"
+                ),
+                None => assert!(
+                    !rendered.contains("product=\""),
+                    "unexpected product label:\n{rendered}"
+                ),
+            }
+        }
     }
 
     #[test]

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -4,7 +4,7 @@ use axum::{
     body::Body, extract::MatchedPath, http::Request, middleware::Next, response::IntoResponse,
     routing::get, Router,
 };
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::PrometheusBuilder;
 use std::sync::OnceLock;
 
 type LabelFilterFn =
@@ -61,10 +61,6 @@ fn install_metrics_routes(router: Router, product: Option<String>) -> Router {
             get(move || std::future::ready(recorder_handle.render())),
         )
         .layer(axum::middleware::from_fn(track_metrics))
-}
-
-pub fn setup_metrics_recorder() -> PrometheusHandle {
-    build_prometheus_builder(None).install_recorder().unwrap()
 }
 
 fn build_prometheus_builder(product: Option<String>) -> PrometheusBuilder {

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -33,8 +33,27 @@ pub async fn serve(router: Router, bind: &str) -> Result<(), std::io::Error> {
 }
 
 /// Add the prometheus endpoint and middleware to a router, should be called last.
+/// Use [`setup_metrics_routes_for_product`] when you want a `product` global
+/// label for cost attribution.
 pub fn setup_metrics_routes(router: Router) -> Router {
-    let recorder_handle = setup_metrics_recorder();
+    install_metrics_routes(router, None)
+}
+
+/// Like [`setup_metrics_routes`], but emits a static `product="<value>"` global
+/// label on every metric for per-product cost attribution (see
+/// <https://posthog.com/handbook/product/per-product-cost-margin-analysis>),
+/// so metrics can be grouped across services without depending on metric-name
+/// prefixes or K8s topology labels. Use a snake_case product slug matching
+/// the Python `posthog.clickhouse.query_tagging.Product` enum values — e.g.
+/// `feature_flags`, `experiments`, `product_analytics`.
+pub fn setup_metrics_routes_for_product(router: Router, product: impl Into<String>) -> Router {
+    install_metrics_routes(router, Some(product.into()))
+}
+
+fn install_metrics_routes(router: Router, product: Option<String>) -> Router {
+    let recorder_handle = build_prometheus_builder(product)
+        .install_recorder()
+        .unwrap();
 
     router
         .route(
@@ -45,15 +64,19 @@ pub fn setup_metrics_routes(router: Router) -> Router {
 }
 
 pub fn setup_metrics_recorder() -> PrometheusHandle {
+    build_prometheus_builder(None).install_recorder().unwrap()
+}
+
+fn build_prometheus_builder(product: Option<String>) -> PrometheusBuilder {
     const BUCKETS: &[f64] = &[
         1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
     ];
 
-    PrometheusBuilder::new()
-        .set_buckets(BUCKETS)
-        .unwrap()
-        .install_recorder()
-        .unwrap()
+    let mut builder = PrometheusBuilder::new().set_buckets(BUCKETS).unwrap();
+    if let Some(product) = product {
+        builder = builder.add_global_label("product", product);
+    }
+    builder
 }
 
 /// Normalize an unmatched path to its first segment to avoid high-cardinality
@@ -214,7 +237,43 @@ impl<'a> TimingGuardLabels<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_unmatched_path;
+    use super::{build_prometheus_builder, normalize_unmatched_path};
+
+    #[test]
+    fn test_product_global_label_is_emitted() {
+        let recorder = build_prometheus_builder(Some("feature_flags".to_string())).build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            metrics::counter!("test_counter_with_product").increment(1);
+        });
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("test_counter_with_product"),
+            "rendered metrics missing the counter we just incremented:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("product=\"feature_flags\""),
+            "rendered metrics missing product label:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_no_product_label_when_none() {
+        let recorder = build_prometheus_builder(None).build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            metrics::counter!("test_counter_without_product").increment(1);
+        });
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("test_counter_without_product"),
+            "rendered metrics missing the counter we just incremented:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("product=\""),
+            "rendered metrics unexpectedly contain product label:\n{rendered}"
+        );
+    }
 
     #[test]
     fn test_normalize_unmatched_path() {

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -18,7 +18,7 @@ use common_cookieless::CookielessManager;
 use common_geoip::GeoIpClient;
 use common_hypercache::HyperCacheReader;
 use common_metrics::inc;
-use common_metrics::{setup_metrics_recorder, track_metrics};
+use common_metrics::setup_metrics_routes_for_product;
 use common_redis::Client as RedisClient;
 use health::{readiness_handler, HealthRegistry};
 use metrics::gauge;
@@ -298,7 +298,6 @@ pub fn router(
         .merge(flags_router)
         .layer(TraceLayer::new_for_http())
         .layer(cors)
-        .layer(axum::middleware::from_fn(track_metrics))
         .with_state(state);
 
     // Don't install metrics unless asked to
@@ -306,8 +305,7 @@ pub fn router(
     // In other words, only turn these on in production
     if config.enable_metrics {
         common_metrics::set_label_filter(team_id_label_filter(config.team_ids_to_track.clone()));
-        let recorder_handle = setup_metrics_recorder();
-        router.route("/metrics", get(move || ready(recorder_handle.render())))
+        setup_metrics_routes_for_product(router, "feature_flags")
     } else {
         router
     }

--- a/rust/hypercache-server/src/router.rs
+++ b/rust/hypercache-server/src/router.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use common_cache::NegativeCache;
 use common_hypercache::HyperCacheReader;
-use common_metrics::{setup_metrics_recorder, track_metrics};
+use common_metrics::setup_metrics_routes;
 use health::readiness_handler;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
@@ -80,12 +80,10 @@ pub fn router(
         .merge(app_router)
         .layer(TraceLayer::new_for_http())
         .layer(cors)
-        .layer(axum::middleware::from_fn(track_metrics))
         .with_state(state);
 
     if *config.enable_metrics {
-        let recorder_handle = setup_metrics_recorder();
-        router.route("/metrics", get(move || ready(recorder_handle.render())))
+        setup_metrics_routes(router)
     } else {
         router
     }


### PR DESCRIPTION
## Problem

PostHog's Rust services emit Prometheus metrics, but there hasn't been a consistent way to group cost/usage by product across services. Per-product attribution previously had to rely on metric-name prefixes or K8s topology labels, both of which are fragile. This PR introduces a static `product` global label so cost-attribution dashboards can group cleanly across services. See the [per-product cost margin analysis handbook](https://posthog.com/handbook/product/per-product-cost-margin-analysis) for context.

I updated the feature-flags crate to use this and specify a product, but I didn't update all the other services.

## Changes

- New helper `setup_metrics_routes_for_product(router, product)` in `common-metrics`. Threads a `product` global label through the Prometheus recorder via `add_global_label`, applying to every metric the service emits — including HTTP request metrics from `track_metrics`.
- `feature-flags` adopts the new helper with the slug `"feature_flags"` (matches the Python `posthog.clickhouse.query_tagging.Product` enum).
- `hypercache-server` migrates from its hand-wired `setup_metrics_recorder` + manual `track_metrics` layer to the existing `setup_metrics_routes` helper. No product label since it's a shared service; this consolidates with the pattern already used by `embedding-worker`, `cymbal`, `cyclotron-janitor`, and others.
- `setup_metrics_routes_for_product` accepts `impl Into<String>` rather than `&'static str` so future callers can drive the label from config (matches the precedent in `rust/capture/src/prometheus.rs`).

**Side effect:** `/metrics` scrape requests now appear as `http_requests_total{path="/metrics"}` for both services, matching every other service that uses the helper. Dashboards or alerts that aggregate by `path` without filtering `/metrics` will see a small new slice; cardinality impact is one series per replica.

## How did you test this code?

- Two new unit tests in `rust/common/metrics/src/lib.rs` verify the global label appears when set (`test_product_global_label_is_emitted`) and is absent when not (`test_no_product_label_when_none`). Both pin a positive assertion that the test counter is rendered so a regression that broke recorder construction can't slip past.
- Manual end-to-end smoke test: ran `feature-flags` locally with `ENABLE_METRICS=true`, made `/flags` requests, scraped `/metrics`. Confirmed every series carries `product="feature_flags"` (including `http_requests_total` from the `track_metrics` middleware), and `/metrics` itself shows up in `http_requests_total` as expected.
- `cargo build`, `cargo test -p common-metrics`, and `cargo clippy -p common-metrics --all-targets -- -D warnings` all clean.

## Publish to changelog?

no