### PR TITLE
chore: add devex soft ownership for openapi tooling files

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -168,3 +168,8 @@ tools/pr-approval-agent/ @PostHog/team-devex
 tools/phrocs/ @PostHog/team-devex
 greptile.json @PostHog/team-devex
 docs/published/developing-locally.md @PostHog/team-devex
+
+# OpenAPI / drf-spectacular tooling - owned by @PostHog/team-devex
+posthog/api/documentation.py @PostHog/team-devex
+posthog/api/mixins.py @PostHog/team-devex
+posthog/management/commands/find_enum_collisions.py @PostHog/team-devex

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -173,3 +173,6 @@ docs/published/developing-locally.md @PostHog/team-devex
 posthog/api/documentation.py @PostHog/team-devex
 posthog/api/mixins.py @PostHog/team-devex
 posthog/management/commands/find_enum_collisions.py @PostHog/team-devex
+
+# Visual Review - owned by @PostHog/team-devex
+products/visual_review/** @PostHog/team-devex


### PR DESCRIPTION
## Problem

Several devex-owned files and products had no soft ownership assigned, meaning PRs touching them don't automatically request a review from the team responsible for maintaining them.

## Changes

Adds `@PostHog/team-devex` as soft owner for the following in `.github/CODEOWNERS-soft`:

**OpenAPI / drf-spectacular tooling:**
- `posthog/api/documentation.py` — custom drf-spectacular hooks, `AutoSchema` subclass, preprocessing/postprocessing hooks that drive OpenAPI generation
- `posthog/api/mixins.py` — `validated_request` decorator, the primary primitive for annotating views with OpenAPI schemas
- `posthog/management/commands/find_enum_collisions.py` — tooling for diagnosing OpenAPI enum naming collisions and generating `ENUM_NAME_OVERRIDES` suggestions

**Visual Review product:**
- `products/visual_review/**` — CI visual regression testing tool (screenshot diffing, GitHub Check integration, baseline-in-git workflow); not previously listed in either CODEOWNERS file

`common/hogli/` is already covered by an existing devex entry. `posthog/settings/web.py` (contains `SPECTACULAR_SETTINGS`) was left out as it is too broad.

## How did you test this code?

Agent-authored. No automated tests exist for CODEOWNERS-soft entries. Verified by reading the file after editing.

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by Claude Code (claude-sonnet-4-6) in session https://claude.ai/code/session_01B2nERJmf2yxT1FDMqPx4Bb. Task was to add `@PostHog/team-devex` soft ownership for `documentation.py`, identify other OpenAPI tooling candidates, and add Visual Review product ownership. OpenAPI candidates found by searching for files importing `drf_spectacular` and referencing `AutoSchema`. Visual Review confirmed as devex-owned from its README (CI visual regression tooling with no other team assigned).