### PR TITLE
feat(signals): skip recordings whose rasterize has failed too many times

### DIFF
--- a/ee/hogai/videos/session_moments.py
+++ b/ee/hogai/videos/session_moments.py
@@ -11,7 +11,7 @@ import structlog
 from google.genai import Client
 from google.genai.errors import APIError
 from google.genai.types import Blob, Content, Part, VideoMetadata
-from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
+from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttributes, WorkflowIDReusePolicy
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.user import User
@@ -19,6 +19,7 @@ from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.storage import object_storage
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.client import async_connect
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.rasterize_recording.types import RasterizeRecordingInputs
 
 from products.llm_analytics.backend.providers.gemini import GeminiProvider
@@ -162,6 +163,12 @@ class SessionMomentsLLMAnalyzer:
                 retry_policy=RetryPolicy(maximum_attempts=int(TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
                 execution_timeout=timedelta(minutes=30),
+                search_attributes=TypedSearchAttributes(
+                    search_attributes=[
+                        SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=self.team_id),
+                        SearchAttributePair(key=POSTHOG_SESSION_RECORDING_ID_KEY, value=self.session_id),
+                    ]
+                ),
             )
             # Return the asset ID for later retrieval
             return exported_asset.id

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -14,7 +14,7 @@ from loginas.utils import is_impersonated_session
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.request import Request
-from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
+from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttributes, WorkflowIDReusePolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
@@ -28,6 +28,7 @@ from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.common.client import async_connect
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 from posthog.temporal.session_replay.rasterize_recording.types import RasterizeRecordingInputs
 
@@ -227,6 +228,8 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
 
                 logger.info("starting_rasterize_recording_workflow", asset_id=instance.id)
 
+                session_recording_id = instance.export_context.get("session_recording_id")
+
                 async def _start():
                     client = await async_connect()
                     await client.execute_workflow(
@@ -237,6 +240,12 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                         retry_policy=RetryPolicy(maximum_attempts=int(TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
                         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
                         execution_timeout=timedelta(hours=1),
+                        search_attributes=TypedSearchAttributes(
+                            search_attributes=[
+                                SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team.id),
+                                SearchAttributePair(key=POSTHOG_SESSION_RECORDING_ID_KEY, value=session_recording_id),
+                            ]
+                        ),
                     )
 
                 try:

--- a/posthog/temporal/common/search_attributes.py
+++ b/posthog/temporal/common/search_attributes.py
@@ -14,6 +14,7 @@ POSTHOG_DAG_ID_KEY = SearchAttributeKey.for_keyword("PostHogDagId")
 # Tags a Temporal schedule so a namespace-wide reconciler can find its own schedules
 # without scanning every schedule in the namespace.
 POSTHOG_SCHEDULE_TYPE_KEY = SearchAttributeKey.for_keyword("PostHogScheduleType")
+POSTHOG_SESSION_RECORDING_ID_KEY = SearchAttributeKey.for_keyword("PostHogSessionRecordingId")
 
 # Registry of all custom search attributes PostHog registers in Temporal.
 # This is the single source of truth — the register_temporal_search_attributes
@@ -23,4 +24,5 @@ POSTHOG_SEARCH_ATTRIBUTES: list[SearchAttributeKey] = [
     POSTHOG_ORG_ID_KEY,
     POSTHOG_DAG_ID_KEY,
     POSTHOG_SCHEDULE_TYPE_KEY,
+    POSTHOG_SESSION_RECORDING_ID_KEY,
 ]

--- a/posthog/temporal/session_replay/session_summary/summarize_session.py
+++ b/posthog/temporal/session_replay/session_summary/summarize_session.py
@@ -25,7 +25,7 @@ from posthog.redis import get_client
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.client import async_connect
-from posthog.temporal.common.search_attributes import POSTHOG_TEAM_ID_KEY
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.rasterize_recording.types import RasterizeRecordingInputs
 from posthog.temporal.session_replay.session_summary.activities import (
     CaptureTimingInputs,
@@ -562,6 +562,12 @@ async def ensure_llm_single_session_summary(
             retry_policy=RetryPolicy(maximum_attempts=int(settings.TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
             id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             execution_timeout=timedelta(minutes=30),
+            search_attributes=TypedSearchAttributes(
+                search_attributes=[
+                    SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=video_inputs.team_id),
+                    SearchAttributePair(key=POSTHOG_SESSION_RECORDING_ID_KEY, value=video_inputs.session_id),
+                ]
+            ),
         )
 
     # Activity 2: Upload full video to Gemini (single upload)

--- a/posthog/temporal/session_replay/summarization_sweep/activities.py
+++ b/posthog/temporal/session_replay/summarization_sweep/activities.py
@@ -1,13 +1,19 @@
+import re
+from collections import Counter
+
 import structlog
 from temporalio import activity
 
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.sync import database_sync_to_async, database_sync_to_async_pool
+from posthog.temporal.common.client import async_connect
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY
 from posthog.temporal.session_replay.summarization_sweep.constants import (
     CH_QUERY_MAX_EXECUTION_SECONDS,
     SCHEDULE_ID_PREFIX,
     SCHEDULE_TYPE,
+    STUCK_RASTERIZE_THRESHOLD,
     WORKFLOW_NAME,
 )
 from posthog.temporal.session_replay.summarization_sweep.models import (
@@ -63,6 +69,43 @@ def _load_team_user_and_sessions(team_id: int, lookback_minutes: int) -> tuple[T
     return team, session_ids, _select_summarization_user(team)
 
 
+# Session ids land here from ClickHouse and originate at SDK clients. Rejecting anything
+# outside this shape keeps untrusted input out of the Temporal visibility query string.
+_SAFE_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,100}$")
+
+
+async def _stuck_session_ids(session_ids: list[str]) -> set[str]:
+    if not session_ids:
+        return set()
+    safe_ids = [sid for sid in session_ids if _SAFE_SESSION_ID_RE.match(sid)]
+    if len(safe_ids) < len(session_ids):
+        logger.warning(
+            "summarization_sweep.unsafe_session_id_dropped",
+            count=len(session_ids) - len(safe_ids),
+        )
+    if not safe_ids:
+        return set()
+    try:
+        client = await async_connect()
+        ids_clause = ",".join(f'"{sid}"' for sid in safe_ids)
+        query = (
+            f'WorkflowType = "rasterize-recording" '
+            f'AND ExecutionStatus IN ("Failed", "TimedOut") '
+            f"AND {POSTHOG_SESSION_RECORDING_ID_KEY.name} IN ({ids_clause})"
+        )
+        failures: Counter[str] = Counter()
+        async for wf in client.list_workflows(query=query):
+            for pair in wf.typed_search_attributes:
+                if pair.key.name == POSTHOG_SESSION_RECORDING_ID_KEY.name:
+                    failures[pair.value] += 1
+                    break
+        return {sid for sid, n in failures.items() if n >= STUCK_RASTERIZE_THRESHOLD}
+    except Exception as exc:
+        # Degrade to dispatching normally rather than blocking summarization.
+        logger.warning("summarization_sweep.stuck_query_failed", error=str(exc))
+        return set()
+
+
 @activity.defn
 async def find_sessions_for_team_activity(inputs: FindSessionsInput) -> FindSessionsResult:
     """Surfaces `team_disabled=True` so the workflow can tear down its own schedule."""
@@ -85,6 +128,8 @@ async def find_sessions_for_team_activity(inputs: FindSessionsInput) -> FindSess
         extra_summary_context=None,
     )
     sessions_to_summarize = [sid for sid in session_ids if not existing_summaries.get(sid)][: inputs.max_sessions]
+    stuck = await _stuck_session_ids(sessions_to_summarize)
+    sessions_to_summarize = [sid for sid in sessions_to_summarize if sid not in stuck]
 
     return FindSessionsResult(
         team_id=inputs.team_id,

--- a/posthog/temporal/session_replay/summarization_sweep/constants.py
+++ b/posthog/temporal/session_replay/summarization_sweep/constants.py
@@ -15,6 +15,9 @@ SESSION_LOOKBACK_MINUTES = 30
 
 MAX_SESSIONS_PER_TEAM = 10
 
+# Stops the redispatch loop on recordings the rasterizer can't process.
+STUCK_RASTERIZE_THRESHOLD = 3
+
 CH_QUERY_MAX_EXECUTION_SECONDS = 180
 
 # Must exceed FIND_ACTIVITY_TIMEOUT + child-start fan-out. Children are

--- a/posthog/temporal/session_replay/summarization_sweep/workflow.py
+++ b/posthog/temporal/session_replay/summarization_sweep/workflow.py
@@ -15,7 +15,7 @@ from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttri
 from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.search_attributes import POSTHOG_TEAM_ID_KEY
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.summarization_sweep.constants import (
     FIND_ACTIVITY_TIMEOUT,
     MAX_SESSIONS_PER_TEAM,
@@ -166,7 +166,10 @@ class SummarizeTeamSessionsWorkflow(PostHogWorkflow):
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                 task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
                 search_attributes=TypedSearchAttributes(
-                    search_attributes=[SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team_id)]
+                    search_attributes=[
+                        SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team_id),
+                        SearchAttributePair(key=POSTHOG_SESSION_RECORDING_ID_KEY, value=session_id),
+                    ]
                 ),
                 # Covers all three retry attempts + backoff (10m + 15m + 15m) with headroom.
                 execution_timeout=timedelta(minutes=45),

--- a/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
@@ -290,3 +290,151 @@ async def test_list_enabled_teams_filters_ai_consent(activity_environment, organ
     result = await activity_environment.run(list_enabled_teams_activity)
     assert t_consented.id in result
     assert t_revoked.id not in result
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_find_sessions_skips_recordings_with_too_many_failures(activity_environment, organization, team):
+    from posthog.models.user import User
+
+    await sync_to_async(enable_signal_source)(team)
+    user = await sync_to_async(User.objects.create_and_join)(organization, "skip@posthog.com", "pw", "Skip")
+    try:
+        candidate_ids = ["good-1", "stuck-2", "good-3"]
+        with (
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.fetch_recent_session_ids",
+                return_value=candidate_ids,
+            ),
+            patch(
+                "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
+                return_value={},
+            ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities._stuck_session_ids",
+                return_value={"stuck-2"},
+            ),
+        ):
+            result = await activity_environment.run(
+                find_sessions_for_team_activity,
+                FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+            )
+        assert sorted(result.session_ids) == ["good-1", "good-3"]
+    finally:
+        await sync_to_async(user.delete)()
+
+
+@pytest.mark.asyncio
+async def test_stuck_session_ids_returns_empty_for_empty_input():
+    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+
+    result = await _stuck_session_ids([])
+    assert result == set()
+
+
+@pytest.mark.asyncio
+async def test_stuck_session_ids_thresholds_failures():
+    from unittest.mock import AsyncMock, MagicMock
+
+    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+    from posthog.temporal.session_replay.summarization_sweep.constants import STUCK_RASTERIZE_THRESHOLD
+
+    def _make_wf(session_id: str):
+        attr_key = MagicMock()
+        attr_key.name = "PostHogSessionRecordingId"
+        pair = MagicMock()
+        pair.key = attr_key
+        pair.value = session_id
+        wf = MagicMock()
+        wf.typed_search_attributes = [pair]
+        return wf
+
+    class _AsyncIter:
+        def __init__(self, items):
+            self._items = items
+
+        def __aiter__(self):
+            self._iter = iter(self._items)
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    # Three failures for "stuck", one for "transient", none for "fresh"
+    workflows = [_make_wf("stuck")] * STUCK_RASTERIZE_THRESHOLD + [_make_wf("transient")]
+    client = MagicMock()
+    client.list_workflows = MagicMock(return_value=_AsyncIter(workflows))
+    with patch(
+        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
+        AsyncMock(return_value=client),
+    ):
+        result = await _stuck_session_ids(["stuck", "transient", "fresh"])
+    assert result == {"stuck"}
+
+
+@pytest.mark.asyncio
+async def test_stuck_session_ids_swallows_temporal_errors():
+    from unittest.mock import AsyncMock
+
+    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+
+    with patch(
+        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
+        AsyncMock(side_effect=RuntimeError("temporal unavailable")),
+    ):
+        result = await _stuck_session_ids(["a", "b"])
+    # Degrade gracefully — better to dispatch and risk a retry than block summarization.
+    assert result == set()
+
+
+@pytest.mark.asyncio
+async def test_stuck_session_ids_rejects_unsafe_session_ids():
+    from unittest.mock import AsyncMock, MagicMock
+
+    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+
+    client = MagicMock()
+    captured_query: list[str] = []
+
+    class _AsyncIter:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    def _list_workflows(query: str):
+        captured_query.append(query)
+        return _AsyncIter()
+
+    client.list_workflows = _list_workflows
+    unsafe_ids = ['evil") OR (true', "back\\slash", "with space", "with;semi"]
+    safe_id = "019dbfc3-27b0-74fb-8ee3-5b500a7b9074"
+    with patch(
+        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
+        AsyncMock(return_value=client),
+    ):
+        await _stuck_session_ids([*unsafe_ids, safe_id])
+    assert len(captured_query) == 1
+    for bad in unsafe_ids:
+        assert bad not in captured_query[0]
+    assert safe_id in captured_query[0]
+
+
+@pytest.mark.asyncio
+async def test_stuck_session_ids_skips_query_when_all_unsafe():
+    from unittest.mock import AsyncMock, MagicMock
+
+    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+
+    client = MagicMock()
+    client.list_workflows = MagicMock(side_effect=AssertionError("must not query Temporal"))
+    with patch(
+        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
+        AsyncMock(return_value=client),
+    ):
+        result = await _stuck_session_ids(['"', "x y"])
+    assert result == set()


### PR DESCRIPTION
## Problem

Some recordings break the rasterizer deterministically (corrupt snapshot, ffmpeg edge case). The summarization sweep keeps redispatching them every 5 min for the full 30 min lookback because `summaries_exist` only catches *completed* summaries — not failed ones.

In a 4h window after #55724 we observed ~480 of 482 EU rasterize failures coming from 12 stuck recordings, and ~200 of 208 US failures from 9 stuck recordings.

## Changes

- New `PostHogSessionRecordingId` keyword search attribute.
- `summarize-session` and every `rasterize-recording` start (sweep, manual export, AI moments pipeline) tag themselves with it.
- `find_sessions_for_team_activity` queries Temporal visibility for prior `Failed`/`TimedOut` rasterize executions per candidate session and skips any with `STUCK_RASTERIZE_THRESHOLD = 3` or more. Wrapped in try/except so a Temporal blip falls back to dispatching normally.

Query latency measured against prod-us: **~48 ms** for an IN-clause with 10 indexed values.

## ⚠️ Pre-merge step

`PostHogSessionRecordingId` must be registered in both production namespaces **before this is merged**. Workflow starts with an unregistered search attribute will be rejected by Temporal Cloud, breaking summarization, manual video exports, and the AI session-moments pipeline.

```bash
kctl --context prod -n temporal-worker-session-replay exec deploy/temporal-worker-session-replay -- \
  python manage.py register_temporal_search_attributes --namespace posthog-prod-us.usz2o
kctl --context prod-eu -n temporal-worker-session-replay exec deploy/temporal-worker-session-replay -- \
  python manage.py register_temporal_search_attributes --namespace posthog-prod-eu.usz2o
```

## How did you test this code?

I'm an agent. Added unit tests for the dedup path, threshold logic, empty-input short-circuit, and graceful degradation on Temporal errors. All 31 sweep tests pass locally.

## Publish to changelog?

no

## Docs update

No docs impact.