### PR TITLE
feat(replay): warn in filter panel when past product analytics limit

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3382,6 +3382,14 @@ snapshots:
         hash: v1.k794b7964.1556cdea89987c215a8c45a29ca3527164ce3d0d80214541c83b118753831d15.X2t4FVZwJiCZdBYl5-VswsG1DWxClF5jFe6rhBHuVYU
     replay-tabs-home-failure--not-found--light:
         hash: v1.k794b7964.d543024ba562e1364dc547cd1310125c8558a103cc126e343815ecdadb85e996.HC_NcrA2Nx-HCKzyqfZm36sVHJeNZ3cqrkEEi8cZ8qg
+    replay-tabs-home-filters-banner--product-analytics-over-limit--dark:
+        hash: v1.k794b7964.2615ae79f5367c6fac2b12a7a6c2ff7f3dd70110821ae02cca38f267600c0089.x8Fvnj-ztskcXE6yGpjKFvaPVQKT4aioH_55vj1P6HM
+    replay-tabs-home-filters-banner--product-analytics-over-limit--light:
+        hash: v1.k794b7964.cce46931ff5a525be825c3f76e45ce81583771d2b794ee6403cb06c15f7c35f0.XpZVC-MpYMGl09G-aJPD_ckaSqWRkmZUrPFSANu4wE8
+    replay-tabs-home-filters-banner--product-analytics-under-limit--dark:
+        hash: v1.k794b7964.bb59e56971ab9b3c10adebebf9053f4c484e666cfc91fb482c2d31bfb6c59daa.Z_D5pZx9r215_va-T1Jd6CYRb5v9rIvoQKjGM0QXkZs
+    replay-tabs-home-filters-banner--product-analytics-under-limit--light:
+        hash: v1.k794b7964.461a6456f8ef27c27ebb6b7436dc7b3e6bcd67ff0200da7a8e3dd5464ded7b65.6Ss4mfXakgzxF0lmKrOtIuPZHGvFuUQm3SUN1CvKAu0
     replay-tabs-home-success--filters-expanded--dark:
         hash: v1.k794b7964.da116250fd9441fdbc634c5eb1ae42148482c6e6495fd4781eec7bacde68a862.yRf-_7VEW1y9LHjjRGoZBfl9AeEfBmkseu1h0wuP43E
     replay-tabs-home-success--filters-expanded--light:

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -612,6 +612,14 @@ export const billingLogic = kea<billingLogicType>([
             (s) => [s.billing],
             (billing: BillingType | null): boolean => billing?.is_annual_plan_customer || false,
         ],
+        isProductOverUsageLimit: [
+            (s) => [s.billing],
+            (billing: BillingType | null): ((productKey: ProductKey) => boolean) =>
+                (productKey: ProductKey): boolean => {
+                    const product = billing?.products?.find((p) => p.type === productKey)
+                    return (product?.percentage_usage ?? 0) > 1
+                },
+        ],
         billingPeriodUTC: [
             (s) => [s.billing],
             (billing: BillingType | null): BillingPeriod => ({

--- a/frontend/src/scenes/session-recordings/filters/ProductAnalyticsOverLimitBanner.tsx
+++ b/frontend/src/scenes/session-recordings/filters/ProductAnalyticsOverLimitBanner.tsx
@@ -1,0 +1,41 @@
+import { useValues } from 'kea'
+
+import { LemonBanner, Link } from '@posthog/lemon-ui'
+import { PostHogCaptureOnViewed } from '@posthog/react'
+
+import { billingLogic } from 'scenes/billing/billingLogic'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+export function ProductAnalyticsOverLimitBanner(): JSX.Element | null {
+    const { isProductOverUsageLimit } = useValues(billingLogic)
+
+    if (!isProductOverUsageLimit(ProductKey.PRODUCT_ANALYTICS)) {
+        return null
+    }
+
+    return (
+        <PostHogCaptureOnViewed name="replay-filters-pa-over-limit-banner-shown">
+            <LemonBanner
+                type="warning"
+                className="mx-2 mt-2"
+                action={{
+                    children: 'Increase billing limit',
+                    to: urls.organizationBilling([ProductKey.PRODUCT_ANALYTICS]),
+                    'data-attr': 'replay-filters-pa-over-limit-banner-cta',
+                }}
+            >
+                Session recordings are filtered using your events. While you're over the Product analytics limit, new
+                events aren't processed — so recent recordings may not show up when you filter.{' '}
+                <Link
+                    to="https://posthog.com/docs/session-replay/troubleshooting#unable-to-filter-by-user-or-page-properties"
+                    target="_blank"
+                >
+                    Learn more
+                </Link>
+                .
+            </LemonBanner>
+        </PostHogCaptureOnViewed>
+    )
+}

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
@@ -1,0 +1,67 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { combineUrl } from 'kea-router'
+
+import { App } from 'scenes/App'
+import recordingEventsJson from 'scenes/session-recordings/__mocks__/recording_events_query'
+import { recordingPlaylists } from 'scenes/session-recordings/__mocks__/recording_playlists'
+import { recordings } from 'scenes/session-recordings/__mocks__/recordings'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+import { billingJson } from '~/mocks/fixtures/_billing'
+
+const billingJsonWithProductAnalyticsOverLimit = {
+    ...billingJson,
+    products: billingJson.products.map((product) =>
+        product.type === 'product_analytics' ? { ...product, percentage_usage: 1.5 } : product
+    ),
+}
+
+const meta: Meta = {
+    component: App,
+    title: 'Replay/Tabs/Home/Filters Banner',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2023-02-01',
+        pageUrl: combineUrl(urls.replay(), { showFilters: true }).url,
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/stats': () => [200, { users_on_product: 42, active_recordings: 7 }],
+                '/api/projects/:team_id/session_recording_playlists': recordingPlaylists,
+                '/api/environments/:team_id/session_recordings': (req) => {
+                    const version = req.url.searchParams.get('version')
+                    return [200, { has_next: false, results: recordings, version }]
+                },
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': recordingEventsJson,
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const ProductAnalyticsOverLimit: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/billing/': () => [200, billingJsonWithProductAnalyticsOverLimit],
+            },
+        }),
+    ],
+}
+
+export const ProductAnalyticsUnderLimit: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/billing/': () => [200, billingJson],
+            },
+        }),
+    ],
+}

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -27,6 +27,7 @@ import {
     LemonTab,
     LemonTabs,
     LemonTag,
+    Link,
     Popover,
 } from '@posthog/lemon-ui'
 
@@ -47,6 +48,7 @@ import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
 import { SettingsMenu } from 'scenes/session-recordings/components/PanelSettings'
 import { TimestampFormatToLabel } from 'scenes/session-recordings/utils'
+import { urls } from 'scenes/urls'
 
 import { actionsModel } from '~/models/actionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
@@ -582,10 +584,25 @@ const ReplayFiltersTab = ({
     return (
         <div className={clsx('relative bg-surface-primary w-full h-full', className)}>
             {isPastProductAnalyticsLimit && (
-                <LemonBanner type="warning" className="mx-2 mt-2">
+                <LemonBanner
+                    type="warning"
+                    className="mx-2 mt-2"
+                    action={{
+                        children: 'Increase billing limit',
+                        to: urls.organizationBilling([ProductKey.PRODUCT_ANALYTICS]),
+                        'data-attr': 'replay-filters-pa-over-limit-banner-cta',
+                    }}
+                >
                     You're past your usage limit for product analytics. Some session recording filtering relies on the
                     processing of events; recently recorded sessions might not be visible when you filter even though
-                    they've been recorded.
+                    they've been recorded.{' '}
+                    <Link
+                        to="https://posthog.com/docs/session-replay/troubleshooting#unable-to-filter-by-user-or-page-properties"
+                        target="_blank"
+                    >
+                        Learn more
+                    </Link>
+                    .
                 </LemonBanner>
             )}
             {appliedSavedFilter && (

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -541,9 +541,8 @@ const ReplayFiltersTab = ({
     )
     const { setActiveFilterTab } = useActions(playlistFiltersLogic)
 
-    const { billing } = useValues(billingLogic)
-    const productAnalyticsProduct = billing?.products?.find((p) => p.type === ProductKey.PRODUCT_ANALYTICS)
-    const isPastProductAnalyticsLimit = (productAnalyticsProduct?.percentage_usage ?? 0) > 1
+    const { isProductOverUsageLimit } = useValues(billingLogic)
+    const isPastProductAnalyticsLimit = isProductOverUsageLimit(ProductKey.PRODUCT_ANALYTICS)
 
     useEffect(() => {
         if (!pendingFilterApplication) {

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -27,7 +27,6 @@ import {
     LemonTab,
     LemonTabs,
     LemonTag,
-    Link,
     Popover,
 } from '@posthog/lemon-ui'
 
@@ -39,22 +38,19 @@ import { isCommentTextFilter, isUniversalGroupFilterLike } from 'lib/components/
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
-import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
-import { billingLogic } from 'scenes/billing/billingLogic'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
 import { SettingsMenu } from 'scenes/session-recordings/components/PanelSettings'
 import { TimestampFormatToLabel } from 'scenes/session-recordings/utils'
-import { urls } from 'scenes/urls'
 
 import { actionsModel } from '~/models/actionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
-import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
+import { NodeKind } from '~/queries/schema/schema-general'
 import {
     PropertyOperator,
     RecordingUniversalFilters,
@@ -73,6 +69,7 @@ import {
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
 import { CurrentFilterIndicator } from './CurrentFilterIndicator'
 import { DurationFilter } from './DurationFilter'
+import { ProductAnalyticsOverLimitBanner } from './ProductAnalyticsOverLimitBanner'
 import { SavedFilters } from './SavedFilters'
 
 function HideRecordingsMenu(): JSX.Element {
@@ -543,9 +540,6 @@ const ReplayFiltersTab = ({
     )
     const { setActiveFilterTab } = useActions(playlistFiltersLogic)
 
-    const { isProductOverUsageLimit } = useValues(billingLogic)
-    const isPastProductAnalyticsLimit = isProductOverUsageLimit(ProductKey.PRODUCT_ANALYTICS)
-
     useEffect(() => {
         if (!pendingFilterApplication) {
             return
@@ -583,28 +577,7 @@ const ReplayFiltersTab = ({
 
     return (
         <div className={clsx('relative bg-surface-primary w-full h-full', className)}>
-            {isPastProductAnalyticsLimit && (
-                <LemonBanner
-                    type="warning"
-                    className="mx-2 mt-2"
-                    action={{
-                        children: 'Increase billing limit',
-                        to: urls.organizationBilling([ProductKey.PRODUCT_ANALYTICS]),
-                        'data-attr': 'replay-filters-pa-over-limit-banner-cta',
-                    }}
-                >
-                    You're past your usage limit for product analytics. Some session recording filtering relies on the
-                    processing of events; recently recorded sessions might not be visible when you filter even though
-                    they've been recorded.{' '}
-                    <Link
-                        to="https://posthog.com/docs/session-replay/troubleshooting#unable-to-filter-by-user-or-page-properties"
-                        target="_blank"
-                    >
-                        Learn more
-                    </Link>
-                    .
-                </LemonBanner>
-            )}
+            <ProductAnalyticsOverLimitBanner />
             {appliedSavedFilter && (
                 <div className="border-b px-2 py-3 flex flex-wrap items-center gap-2">
                     <div className="flex items-center gap-2 min-w-0 flex-1 basis-3/5">

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -583,7 +583,7 @@ const ReplayFiltersTab = ({
     return (
         <div className={clsx('relative bg-surface-primary w-full h-full', className)}>
             {isPastProductAnalyticsLimit && (
-                <LemonBanner type="error" className="mx-2 mt-2">
+                <LemonBanner type="warning" className="mx-2 mt-2">
                     You're past your usage limit for product analytics. Some session recording filtering relies on the
                     processing of events; recently recorded sessions might not be visible when you filter even though
                     they've been recorded.

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -38,9 +38,11 @@ import { isCommentTextFilter, isUniversalGroupFilterLike } from 'lib/components/
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
+import { billingLogic } from 'scenes/billing/billingLogic'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
 import { SettingsMenu } from 'scenes/session-recordings/components/PanelSettings'
@@ -50,7 +52,7 @@ import { actionsModel } from '~/models/actionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import {
     PropertyOperator,
     RecordingUniversalFilters,
@@ -539,6 +541,10 @@ const ReplayFiltersTab = ({
     )
     const { setActiveFilterTab } = useActions(playlistFiltersLogic)
 
+    const { billing } = useValues(billingLogic)
+    const productAnalyticsProduct = billing?.products?.find((p) => p.type === ProductKey.PRODUCT_ANALYTICS)
+    const isPastProductAnalyticsLimit = (productAnalyticsProduct?.percentage_usage ?? 0) > 1
+
     useEffect(() => {
         if (!pendingFilterApplication) {
             return
@@ -576,6 +582,13 @@ const ReplayFiltersTab = ({
 
     return (
         <div className={clsx('relative bg-surface-primary w-full h-full', className)}>
+            {isPastProductAnalyticsLimit && (
+                <LemonBanner type="error" className="mx-2 mt-2">
+                    You're past your usage limit for product analytics. Some session recording filtering relies on the
+                    processing of events; recently recorded sessions might not be visible when you filter even though
+                    they've been recorded.
+                </LemonBanner>
+            )}
             {appliedSavedFilter && (
                 <div className="border-b px-2 py-3 flex flex-wrap items-center gap-2">
                     <div className="flex items-center gap-2 min-w-0 flex-1 basis-3/5">


### PR DESCRIPTION
## Problem

When an org goes past their product analytics usage limit, the global red banner explains usage is exceeded but doesn't say _why_ session recording filtering can suddenly look broken. Several session recording filters (event-based filters, autocapture, person/session properties) depend on processed events. When ingestion is throttled by the product analytics quota, recordings still get captured but those filters can silently hide them — confusing users who expected those recordings to show up.

## Changes

- Add an in-context red `LemonBanner` at the top of the session replay filters panel (`ReplayFiltersTab`) in `RecordingsUniversalFiltersEmbed.tsx`.
- Only renders when the org's `product_analytics` product has `percentage_usage > 1`, mirroring the trigger used by the global banner in `billingLogic`.
- New Storybook entry under `Replay/Tabs/Home/Filters Banner` with over-limit and under-limit stories so the banner can be reviewed visually.

Banner copy:

> You're past your usage limit for product analytics. Some session recording filtering relies on the processing of events; recently recorded sessions might not be visible when you filter even though they've been recorded.

## How did you test this code?

I'm an agent (PostHog Code). No manual browser testing was performed.

- Added a Storybook story (\`ProductAnalyticsOverLimit\` / \`ProductAnalyticsUnderLimit\`) so a human reviewer can verify the banner visually under both states.
- Reviewed the trigger condition against \`billingLogic.tsx\` lines 869-882 to confirm it uses the same \`percentage_usage > 1\` threshold the global banner uses.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored via PostHog Code. The change is small and localized to one component plus a new story file. Self-hosted is safe — \`billing\` is undefined there, optional chaining short-circuits to false.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*