### PR TITLE
chore(replay): use AI purple for summarize-recording button

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -298,11 +298,11 @@ const RecordingSummaryIcon = memo(function RecordingSummaryIcon({
             type="tertiary"
             size="xxsmall"
             noPadding
-            icon={<IconPlusSmall className="text-[var(--warning)] text-lg" />}
+            icon={<IconPlusSmall className="text-ai text-lg" />}
             tooltip="Summarize this recording"
             aria-label="Summarize this recording"
             data-attr="summarize-recording-from-list"
-            className="shrink-0 border border-dashed border-[var(--warning)] text-[var(--warning)] hover:bg-[var(--warning)]/10 mb-1"
+            className="shrink-0 border border-dashed border-ai text-ai hover:bg-ai/10 mb-1"
             onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()


### PR DESCRIPTION
## Problem

The "Summarize this recording" button in the session-recording playlist preview was using the warning-yellow palette (dashed yellow border, yellow plus icon, yellow hover fill). It's an AI affordance, so it should match the rest of PostHog's AI surfaces (Max, IconSparkles, Nav chat icon) which already use the AI purple colour token.

## Changes

- `frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx` — swap `text-[var(--warning)]` / `border-[var(--warning)]` / `hover:bg-[var(--warning)]/10` for the existing `text-ai` / `border-ai` / `hover:bg-ai/10` tokens (backed by `var(--color-ai)`). Same tokens are already used in `MaxTool.tsx:85` and the AI nav (`Nav.tsx:89`), so we're reusing — not adding — colour vocabulary.
- No behaviour change. The existing `data-attr=\"summarize-recording-from-list\"` and `tooltip=\"Summarize this recording\"` are untouched. The summarising spinner and `IconAIText` (summary-present) branches are unchanged.

## How did you test this code?

I'm an agent. I did not run a dev server or visually verify in a browser. The change is className-only and relies on `text-ai` / `border-ai` / `bg-ai/10` utilities being valid (they're already used elsewhere in the repo). A human reviewer should confirm by opening a session-recording playlist with \`REPLAY_VIDEO_BASED_SUMMARIZATION\` enabled and a recording that has no summary yet — the button should render in AI purple instead of warning yellow.

## Publish to changelog?

no

## Docs update

Not applicable.

## 🤖 Agent context

- Agent: PostHog Code (Claude Opus 4.7).
- Task brief originally asked for a \`data-attr\` and a tooltip on the summarize/show-summary button. On inspection both already exist (\`data-attr=\"summarize-recording-from-list\"\` on the LemonButton, and \`<Tooltip title={summaryOutcome.description}>\` on the \`IconAIText\` summary-present icon). The user redirected to a colour change only — that's all this PR does.
- Decision: reused existing \`text-ai\` / \`border-ai\` / \`bg-ai\` Tailwind tokens rather than introducing a new palette, to match \`MaxTool.tsx\` and the AI nav. Kept hover opacity at \`/10\` (same as the previous warning variant).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*