### PR TITLE
chore(ci): collect pytest-testmon coverage data as CI artifacts

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1232,6 +1232,30 @@ jobs:
               shell: bash
               run: echo "PYTEST_ARGS=--snapshot-update --snapshot-warn-unused" >> $GITHUB_ENV
 
+            # Testmon: per-shard coverage database that lets PRs skip tests whose
+            # source dependencies haven't changed since the last master run.
+            # Skipped for compat runs (different CH version, need all tests).
+            - name: Restore testmon coverage database
+              if: ${{ !matrix.compat }}
+              uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+              with:
+                  path: .testmondata
+                  key: testmon-django-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}-${{ github.sha }}
+                  restore-keys: |
+                      testmon-django-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}-
+
+            - name: Set testmon flags
+              if: ${{ !matrix.compat }}
+              shell: bash
+              run: |
+                  if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+                    # Collect coverage without filtering — builds the baseline for PR runs
+                    echo "TESTMON_ARGS=--testmon-noselect" >> $GITHUB_ENV
+                  else
+                    # Filter: only run tests whose covered files changed vs the master baseline
+                    echo "TESTMON_ARGS=--testmon" >> $GITHUB_ENV
+                  fi
+
             # Tests
             - name: Log test environment diagnostics
               if: ${{ needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' }}
@@ -1284,7 +1308,8 @@ jobs:
                       --reruns 2 --reruns-delay 1 \
                       -r fEsxX \
                       --junitxml=junit-core.xml \
-                      $PYTEST_ARGS
+                      $PYTEST_ARGS \
+                      $TESTMON_ARGS
                   exit_code=$?
                   set -e
                   if [ $exit_code -eq 5 ]; then
@@ -1338,7 +1363,8 @@ jobs:
                       --reruns 2 --reruns-delay 1 \
                       -r fEsxX \
                       --junitxml=junit-temporal.xml \
-                      $PYTEST_ARGS
+                      $PYTEST_ARGS \
+                      $TESTMON_ARGS
                   exit_code=$?
                   set -e
                   if [ $exit_code -eq 5 ]; then
@@ -1363,6 +1389,15 @@ jobs:
                   path: .test_durations
                   include-hidden-files: true
                   retention-days: 2
+
+            - name: Save testmon coverage database
+              # Persist the coverage database on master so PRs can restore it for test selection.
+              # Not saved on PRs to avoid polluting the master baseline.
+              if: ${{ github.ref == 'refs/heads/master' && !matrix.compat }}
+              uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+              with:
+                  path: .testmondata
+                  key: testmon-django-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}-${{ github.sha }}
 
             - name: Verify new snapshots for flakiness
               # Only in UPDATE mode - CHECK mode doesn't update snapshots

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -410,7 +410,7 @@ jobs:
                       --reuse-db
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations --durations-path ../../.test_durations' || '' }}
-                      ${{ github.ref == 'refs/heads/master' && '--testmon-noselect' || '' }}
+                      ${{ (github.ref == 'refs/heads/master' || contains(github.head_ref, 'testmon') || contains(github.ref_name, 'testmon')) && '--testmon-noselect' || '' }}
               run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
 
             - name: Upload timing data
@@ -424,7 +424,7 @@ jobs:
 
             - name: Upload testmon coverage databases
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-              if: ${{ github.ref == 'refs/heads/master' }}
+              if: ${{ github.ref == 'refs/heads/master' || contains(github.head_ref, 'testmon') || contains(github.ref_name, 'testmon') }}
               with:
                   name: testmon-Products-${{ strategy.job-index }}
                   path: products/**/.testmondata
@@ -1248,8 +1248,8 @@ jobs:
             # --testmon-noselect runs all tests normally but records which source
             # files each test depends on. The resulting .testmondata is uploaded
             # as an artifact so we can inspect it before wiring up PR filtering.
-            - name: Enable testmon coverage collection (master only)
-              if: ${{ github.ref == 'refs/heads/master' && !matrix.compat }}
+            - name: Enable testmon coverage collection
+              if: ${{ (github.ref == 'refs/heads/master' || contains(github.head_ref, 'testmon') || contains(github.ref_name, 'testmon')) && !matrix.compat }}
               shell: bash
               run: echo "TESTMON_ARGS=--testmon-noselect" >> $GITHUB_ENV
 
@@ -1388,7 +1388,7 @@ jobs:
                   retention-days: 2
 
             - name: Upload testmon coverage database
-              if: ${{ github.ref == 'refs/heads/master' && !matrix.compat }}
+              if: ${{ (github.ref == 'refs/heads/master' || contains(github.head_ref, 'testmon') || contains(github.ref_name, 'testmon')) && !matrix.compat }}
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: testmon-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1232,29 +1232,14 @@ jobs:
               shell: bash
               run: echo "PYTEST_ARGS=--snapshot-update --snapshot-warn-unused" >> $GITHUB_ENV
 
-            # Testmon: per-shard coverage database that lets PRs skip tests whose
-            # source dependencies haven't changed since the last master run.
-            # Skipped for compat runs (different CH version, need all tests).
-            - name: Restore testmon coverage database
-              if: ${{ !matrix.compat }}
-              uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-              with:
-                  path: .testmondata
-                  key: testmon-django-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}-${{ github.sha }}
-                  restore-keys: |
-                      testmon-django-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}-
-
-            - name: Set testmon flags
-              if: ${{ !matrix.compat }}
+            # Testmon: collect per-test coverage data on master for analysis.
+            # --testmon-noselect runs all tests normally but records which source
+            # files each test depends on. The resulting .testmondata is uploaded
+            # as an artifact so we can inspect it before wiring up PR filtering.
+            - name: Enable testmon coverage collection (master only)
+              if: ${{ github.ref == 'refs/heads/master' && !matrix.compat }}
               shell: bash
-              run: |
-                  if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-                    # Collect coverage without filtering — builds the baseline for PR runs
-                    echo "TESTMON_ARGS=--testmon-noselect" >> $GITHUB_ENV
-                  else
-                    # Filter: only run tests whose covered files changed vs the master baseline
-                    echo "TESTMON_ARGS=--testmon" >> $GITHUB_ENV
-                  fi
+              run: echo "TESTMON_ARGS=--testmon-noselect" >> $GITHUB_ENV
 
             # Tests
             - name: Log test environment diagnostics
@@ -1390,14 +1375,15 @@ jobs:
                   include-hidden-files: true
                   retention-days: 2
 
-            - name: Save testmon coverage database
-              # Persist the coverage database on master so PRs can restore it for test selection.
-              # Not saved on PRs to avoid polluting the master baseline.
+            - name: Upload testmon coverage database
               if: ${{ github.ref == 'refs/heads/master' && !matrix.compat }}
-              uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
+                  name: testmon-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}
                   path: .testmondata
-                  key: testmon-django-${{ matrix.segment }}-poe${{ matrix.person-on-events && '1' || '0' }}-g${{ matrix.group }}-${{ github.sha }}
+                  include-hidden-files: true
+                  if-no-files-found: ignore
+                  retention-days: 7
 
             - name: Verify new snapshots for flakiness
               # Only in UPDATE mode - CHECK mode doesn't update snapshots

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -404,11 +404,13 @@ jobs:
               env:
                   # --reuse-db: keep the test database between sequential product runs to avoid
                   # ClickHouse drop/create race conditions with ReplicatedMergeTree ZK metadata.
-                  # On master, also collect timing data for pytest-split sharding.
+                  # On master, also collect timing data for pytest-split sharding and testmon
+                  # coverage data (--testmon-noselect runs all tests but records per-test deps).
                   PYTEST_ADDOPTS: >-
                       --reuse-db
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations --durations-path ../../.test_durations' || '' }}
+                      ${{ github.ref == 'refs/heads/master' && '--testmon-noselect' || '' }}
               run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
 
             - name: Upload timing data
@@ -419,6 +421,16 @@ jobs:
                   path: .test_durations
                   include-hidden-files: true
                   retention-days: 2
+
+            - name: Upload testmon coverage databases
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: ${{ github.ref == 'refs/heads/master' }}
+              with:
+                  name: testmon-Products-${{ strategy.job-index }}
+                  path: products/**/.testmondata
+                  include-hidden-files: true
+                  if-no-files-found: ignore
+                  retention-days: 7
 
             - name: Verify new snapshots for flakiness
               if: ${{ always() && needs.detect-snapshot-mode.outputs.mode == 'update' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 __emails__
 __pycache__/
 .coverage
+.testmondata
 .dlt
 .dmypy.json
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ dev = [
     "pytest-icdiff~=0.9",
     "pytest-mock~=3.15.1",
     "pytest-split~=0.10.0",
+    "pytest-testmon~=2.2.0",
     "pytest-timeout~=2.4.0",
     "pytest-xdist~=3.8.0",
     "python-dateutil~=2.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-17T13:14:51.221452705Z"
+exclude-newer = "2026-04-19T11:03:09.269288831Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -5210,6 +5210,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-split" },
+    { name = "pytest-testmon" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-dateutil" },
@@ -5466,6 +5467,7 @@ dev = [
     { name = "pytest-mock", specifier = "~=3.15.1" },
     { name = "pytest-rerunfailures", specifier = "~=16.1" },
     { name = "pytest-split", specifier = "~=0.10.0" },
+    { name = "pytest-testmon", specifier = "~=2.2.0" },
     { name = "pytest-timeout", specifier = "~=2.4.0" },
     { name = "pytest-xdist", specifier = "~=3.8.0" },
     { name = "python-dateutil", specifier = "~=2.9.0" },
@@ -6204,6 +6206,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/d7/e30ba44adf83f15aee3f636daea54efadf735769edc0f0a7d98163f61038/pytest_split-0.10.0.tar.gz", hash = "sha256:adf80ba9fef7be89500d571e705b4f963dfa05038edf35e4925817e6b34ea66f", size = 13903, upload-time = "2024-10-16T15:45:19.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/a7/cad88e9c1109a5c2a320d608daa32e5ee008ccbc766310f54b1cd6b3d69c/pytest_split-0.10.0-py3-none-any.whl", hash = "sha256:466096b086a7147bcd423c6e6c2e57fc62af1c5ea2e256b4ed50fc030fc3dddc", size = 11961, upload-time = "2024-10-16T15:45:18.289Z" },
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

We want to understand which tests cover which source files before wiring up test selection. This is the data-collection phase: gather `pytest-testmon` coverage databases from CI runs so we can inspect them and decide whether coverage-based filtering is worth enabling on PRs.

## Changes

- **`pyproject.toml` / `uv.lock`**: adds `pytest-testmon~=2.2.0` to dev deps
- **`.gitignore`**: adds `.testmondata` (the SQLite coverage database testmon writes)
- **`ci-backend.yml`** — on master **or any branch whose name contains `testmon`**:
  - Django job (Core, Core POE, Temporal — all non-compat shards): runs with `--testmon-noselect`, which executes all tests normally but records per-test source-file dependencies. Uploads one artifact per shard (`testmon-{segment}-poe{0|1}-g{N}`, 7-day retention).
  - Turbo-tests (product tests): injects `--testmon-noselect` via `PYTEST_ADDOPTS`, uploads `products/**/.testmondata` as `testmon-Products-{index}`.

No change to PR runs — zero overhead on the normal dev workflow.

The branch-name escape hatch (`contains(github.head_ref, 'testmon')`) lets us collect data from this PR itself without waiting for a merge to master.

## How did you test this code?

Agent-authored. The workflow YAML was linted by the existing `bin/hogli format:yaml` pre-commit hook (passed). No manual CI run yet — the PR itself will exercise the branch-name condition.

## Publish to changelog?

No

## Docs update

No

## 🤖 Agent context

Authored by Claude (claude-sonnet-4-6) via Claude Code. Session: https://claude.ai/code/session_01WzDtQJqRzBL3Bn1ZjeazXc

Key decisions:
- Collection only (no PR filtering) — validate data quality first before committing to the filtering half
- Per-shard artifacts for the django matrix so coverage maps stay small and attributable
- Compat runs excluded — they need all tests regardless of source changes (different ClickHouse version)
- `--testmon-noselect` injected via `PYTEST_ADDOPTS` for turbo-tests (pytest reads it automatically, no turbo config changes needed)
- Branch-name trigger uses both `github.head_ref` (PR events) and `github.ref_name` (push events) to cover both cases


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzDtQJqRzBL3Bn1ZjeazXc)_