### PR TITLE
fix(logs): track alert checkpoint unavailability via counter, not -1 sentinel

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -32,6 +32,7 @@ from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.metrics import (
     increment_check_errors,
+    increment_checkpoint_unavailable,
     increment_checks_total,
     increment_notification_failures,
     increment_state_transition,
@@ -90,9 +91,12 @@ def _check_alerts_sync() -> CheckAlertsOutput:
             logger.exception("Failed to fetch logs ingestion checkpoint; falling back to wall-clock")
 
     try:
-        record_checkpoint_lag(now, checkpoint)
+        if checkpoint is None:
+            increment_checkpoint_unavailable()
+        else:
+            record_checkpoint_lag(now, checkpoint)
     except Exception:
-        logger.exception("Failed to record checkpoint lag gauge")
+        logger.exception("Failed to record checkpoint metric")
 
     stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
 

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -118,19 +118,23 @@ def record_alerts_active(count: int) -> None:
     gauge.set(count)
 
 
-def record_checkpoint_lag(now: dt.datetime, checkpoint: dt.datetime | None) -> None:
-    # Emits -1 when checkpoint is None — dashboards/alerts must treat negative as
-    # "unavailable", not a real lag value.
+def record_checkpoint_lag(now: dt.datetime, checkpoint: dt.datetime) -> None:
     meter = get_metric_meter()
     gauge = meter.create_gauge(
         "logs_alerting_ingestion_checkpoint_lag_seconds",
         "Wall-clock age of the logs-ingestion checkpoint used to anchor alert windows",
     )
-    if checkpoint is None:
-        gauge.set(-1)
-        return
     lag_seconds = max(0, int((now - checkpoint).total_seconds()))
     gauge.set(lag_seconds)
+
+
+def increment_checkpoint_unavailable() -> None:
+    meter = get_metric_meter()
+    counter = meter.create_counter(
+        "logs_alerting_checkpoint_unavailable_total",
+        "Cycles where the logs-ingestion checkpoint could not be resolved (no alerts due, or fetch failure)",
+    )
+    counter.add(1)
 
 
 def record_check_duration(duration_ms: int) -> None:

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -35,6 +35,7 @@ class TestCheckAlertsSync(APIBaseTest):
         self.addCleanup(checkpoint_patch.stop)
         for target in (
             "products.logs.backend.temporal.activities.record_checkpoint_lag",
+            "products.logs.backend.temporal.activities.increment_checkpoint_unavailable",
             "products.logs.backend.temporal.activities.record_alerts_active",
         ):
             p = patch(target)
@@ -177,23 +178,27 @@ class TestCheckAlertsSync(APIBaseTest):
         assert checkpoint_arg == checkpoint
 
     @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_checkpoint_unavailable")
     @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
     @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_skips_checkpoint_fetch_when_no_due_alerts(self, _mock_query_cls, mock_fetch_checkpoint, mock_record_lag):
+    def test_skips_checkpoint_fetch_when_no_due_alerts(
+        self, _mock_query_cls, mock_fetch_checkpoint, mock_record_lag, mock_unavailable
+    ):
         _check_alerts_sync()
 
         mock_fetch_checkpoint.assert_not_called()
-        # Still record the gauge with None so the sentinel fires (pipeline unavailable-ish).
-        mock_record_lag.assert_called_once()
-        _now, checkpoint_arg = mock_record_lag.call_args.args
-        assert checkpoint_arg is None
+        mock_record_lag.assert_not_called()
+        mock_unavailable.assert_called_once()
 
     @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_checkpoint_unavailable")
     @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
     @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint", side_effect=RuntimeError("CH down"))
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_checkpoint_fetch_failure_falls_back_to_wall_clock(self, mock_query_cls, _mock_fetch, mock_record_lag):
+    def test_checkpoint_fetch_failure_falls_back_to_wall_clock(
+        self, mock_query_cls, _mock_fetch, mock_record_lag, mock_unavailable
+    ):
         mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
         self._make_alert()
 
@@ -201,9 +206,8 @@ class TestCheckAlertsSync(APIBaseTest):
 
         # Alert still evaluated — failed checkpoint fetch must not block alerting.
         assert result.alerts_checked == 1
-        mock_record_lag.assert_called_once()
-        _now, checkpoint_arg = mock_record_lag.call_args.args
-        assert checkpoint_arg is None
+        mock_record_lag.assert_not_called()
+        mock_unavailable.assert_called_once()
 
 
 class TestEvaluateSingleAlert(APIBaseTest):

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -12,6 +12,7 @@ from products.logs.backend.temporal.metrics import (
     ExecutionTimeRecorder,
     LogsAlertingMetricsInterceptor,
     increment_check_errors,
+    increment_checkpoint_unavailable,
     increment_checks_total,
     increment_notification_failures,
     increment_state_transition,
@@ -150,16 +151,20 @@ class TestRecordCheckpointLag:
         assert name == "logs_alerting_ingestion_checkpoint_lag_seconds"
         mock_gauge.set.assert_called_once_with(expected)
 
+
+class TestIncrementCheckpointUnavailable:
     @patch("products.logs.backend.temporal.metrics.get_metric_meter")
-    def test_sentinel_when_checkpoint_none(self, mock_get_meter: MagicMock):
+    def test_increments_counter(self, mock_get_meter: MagicMock):
         mock_meter = MagicMock()
-        mock_gauge = MagicMock()
-        mock_meter.create_gauge.return_value = mock_gauge
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
         mock_get_meter.return_value = mock_meter
 
-        record_checkpoint_lag(dt.datetime(2025, 1, 1, 0, 0, 0), None)
+        increment_checkpoint_unavailable()
 
-        mock_gauge.set.assert_called_once_with(-1)
+        (name, _description), _ = mock_meter.create_counter.call_args
+        assert name == "logs_alerting_checkpoint_unavailable_total"
+        mock_counter.add.assert_called_once_with(1)
 
 
 class TestRecordCheckDuration:


### PR DESCRIPTION
## Problem

The checkpoint lag metric used a sentinel value of `-1` to signal that the ingestion checkpoint was unavailable. This is a poor metric design - a gauge with a magic negative value requires special-casing in every dashboard and alert rule, and conflates two distinct signals (real lag vs. unavailability) into a single metric.

## Changes

Replaced the `-1` sentinel pattern with a dedicated counter metric:

- `record_checkpoint_lag` now only accepts a non-`None` checkpoint and records real lag values
- A new `increment_checkpoint_unavailable` counter (`logs_alerting_checkpoint_unavailable_total`) is incremented whenever the checkpoint cannot be resolved (no alerts due, or fetch failure)
- Call sites in `_check_alerts_sync` now branch explicitly: record lag when checkpoint is present, increment the unavailable counter otherwise

## How did you test this code?

Automated tests were updated to reflect the new behavior:

- `test_skips_checkpoint_fetch_when_no_due_alerts` now asserts `record_checkpoint_lag` is not called and `increment_checkpoint_unavailable` is called once
- `test_checkpoint_fetch_failure_falls_back_to_wall_clock` asserts the same branching behavior on fetch failure
- `TestIncrementCheckpointUnavailable` replaces the old `test_sentinel_when_checkpoint_none` test, verifying the counter name and that `add(1)` is called

## Publish to changelog?

No