### PR TITLE
fix(logs): snap alert NextCheckAt timestamps to the canonical cadence grid

### DIFF
--- a/products/logs/backend/alert_utils.py
+++ b/products/logs/backend/alert_utils.py
@@ -8,17 +8,58 @@ def advance_next_check_at(
     check_interval_minutes: int,
     now: datetime,
 ) -> datetime:
-    """Schedule-relative advancement. Skips forward past now if multiple intervals elapsed."""
+    """Schedule-relative advancement, snapped to the canonical cadence grid.
+
+    The scheduler cron fires every minute. A sub-minute offset on the returned
+    NCA (e.g. 12:05:30) makes the cron skip a full tick waiting for it — the
+    alert is picked up at 12:06:00, ~30s late, every cycle. Snapping to the
+    cadence grid (every 5-min alert lands on :00/:05/:10/..., every 10-min on
+    :00/:10/:20/..., etc.) eliminates that lag AND aligns every alert sharing
+    a cadence onto the same canonical grid regardless of when it was created.
+
+    Any drifted NCA — sub-minute drift OR minute-level offset (e.g. legacy
+    alerts on a per-creation-time grid) — self-heals to canonical on its next
+    return. Existing alerts heal lazily, one transient short-gap each (the
+    state machine handles the brief overlap window via N-of-M dedup).
+
+    Inter-eval gaps are exactly `check_interval_minutes` in steady state. The
+    only "shorter than cadence" gaps are (1) creation-to-first-eval and (2)
+    the one-time heal cycle for a previously-drifted alert. Both are
+    cosmetic — alert eval windows tile correctly because they're anchored
+    on `date_to`, not on prior eval time.
+    """
     if check_interval_minutes <= 0:
         raise ValueError(f"check_interval_minutes must be positive, got {check_interval_minutes}")
     interval = timedelta(minutes=check_interval_minutes)
 
     if current_next_check_at is None:
-        return now + interval
+        next_at = now + interval
+    else:
+        next_at = current_next_check_at + interval
+        if next_at <= now:
+            elapsed = (now - next_at).total_seconds()
+            intervals_to_skip = int(elapsed // interval.total_seconds()) + 1
+            next_at += interval * intervals_to_skip
 
-    next_at = current_next_check_at + interval
-    if next_at <= now:
-        elapsed = (now - next_at).total_seconds()
-        intervals_to_skip = int(elapsed // interval.total_seconds()) + 1
-        next_at += interval * intervals_to_skip
-    return next_at
+    # Bump by full interval (not 1 cadence-grid slot upward) when the floor
+    # lands at/before `now`, so the alert stays on its canonical cadence grid.
+    snapped = _floor_to_cadence_grid(next_at, check_interval_minutes)
+    if snapped <= now:
+        snapped += interval
+    return snapped
+
+
+def _floor_to_cadence_grid(t: datetime, cadence_minutes: int) -> datetime:
+    """Floor to the previous cadence-grid slot, anchored at midnight of `t`.
+
+    For divisors of 60 (1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60), this is
+    "every cadence minutes within the hour" — the grid an operator expects
+    (5-min alerts on :00/:05/:10, 15-min on :00/:15/:30/:45, etc.). Cadences
+    > 60 that divide 1440 (90, 120, 240, 360, 480, 720, 1440) also tile
+    cleanly. Cadences that divide neither 60 nor 1440 (e.g. 7, 11, 100) get
+    a discontinuity at midnight where the grid re-anchors — fine in practice
+    because alert UI almost certainly constrains cadence to common values.
+    """
+    total_minutes = t.hour * 60 + t.minute
+    floored_minutes = (total_minutes // cadence_minutes) * cadence_minutes
+    return t.replace(hour=floored_minutes // 60, minute=floored_minutes % 60, second=0, microsecond=0)

--- a/products/logs/backend/test/test_alert_utils.py
+++ b/products/logs/backend/test/test_alert_utils.py
@@ -3,9 +3,32 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from unittest import TestCase
 
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
 from parameterized import parameterized
 
 from products.logs.backend.alert_utils import advance_next_check_at
+
+# Strategies for property tests below.
+# Cadences span the realistic range: 1 minute (tightest), through hourly (60),
+# and sample non-divisors of 60 to surface bugs that only appear off the
+# canonical grid.
+_cadence_minutes = st.sampled_from([1, 2, 3, 5, 7, 10, 11, 15, 30, 60])
+_anchor = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)
+# Sub-minute drift (any second + microsecond within a minute) — exercises both
+# floor-passes-through and floor-lands-at-now branches of the snap helper.
+_subminute_drift = st.builds(
+    timedelta,
+    seconds=st.integers(min_value=0, max_value=59),
+    microseconds=st.integers(min_value=0, max_value=999_999),
+)
+# Eval-lag axis: from "evaluated exactly on schedule" through "well past one
+# cadence" (forces the skip-forward path). Capped at a few hours to keep the
+# search space tractable while still covering long-downtime catch-up.
+_lag_seconds = st.integers(min_value=0, max_value=3 * 3600)
 
 
 class TestAdvanceNextCheckAt(TestCase):
@@ -54,6 +77,79 @@ class TestAdvanceNextCheckAt(TestCase):
                 datetime(2026, 3, 19, 12, 12, tzinfo=UTC),
                 datetime(2026, 3, 19, 12, 15, tzinfo=UTC),
             ),
+            (
+                # Drifted NCA from a first-run that landed at :30 of a minute.
+                # Floor-snap pulls it back onto the canonical 5-min grid (12:10),
+                # not forward to 12:11 — alert lives on :00/:05/:10/... going forward.
+                "drifted_nca_self_heals_to_canonical_grid",
+                datetime(2026, 3, 19, 12, 5, 30, tzinfo=UTC),
+                5,
+                datetime(2026, 3, 19, 12, 6, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 10, tzinfo=UTC),
+            ),
+            (
+                # User changes cadence from 5min to 1min mid-flight. NCA was
+                # drifted at :30 — floor lands on the canonical 1-min grid
+                # but at 12:16:00, which equals `now`. Bump by one interval
+                # (1 min) to ensure strict-future NCA → 12:17.
+                "cadence_change_self_heals",
+                datetime(2026, 3, 19, 12, 15, 30, tzinfo=UTC),
+                1,
+                datetime(2026, 3, 19, 12, 16, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 17, tzinfo=UTC),
+            ),
+            (
+                # Sub-second precision rounds down to the floor minute, then
+                # checked against now. 12:01:00 > 12:00:30, so no bump.
+                "subsecond_drift_snaps_down",
+                datetime(2026, 3, 19, 12, 0, 0, 500_000, tzinfo=UTC),
+                1,
+                datetime(2026, 3, 19, 12, 0, 30, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 1, tzinfo=UTC),
+            ),
+            (
+                # Drift survives the skip-forward path too. After catch-up,
+                # next_at = 12:10:30; floor = 12:10:00, which equals `now` →
+                # bump by 1 min → 12:11.
+                "skip_forward_with_drifted_input_self_heals",
+                datetime(2026, 3, 19, 12, 0, 30, tzinfo=UTC),
+                1,
+                datetime(2026, 3, 19, 12, 10, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 11, tzinfo=UTC),
+            ),
+            (
+                # First-run with creation drift lands on the canonical 5-min
+                # grid (12:05) — gap to first eval is 4:37, slightly less than
+                # cadence. Subsequent evals are exactly 5 min apart on :05 grid.
+                "first_run_with_drifted_now_lands_on_canonical_grid",
+                None,
+                5,
+                datetime(2026, 3, 19, 12, 0, 23, 456_000, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 5, tzinfo=UTC),
+            ),
+            (
+                # Bump edge case: drifted current + on-time eval at minute
+                # boundary. next_at=12:05:30, floor=12:05:00 == now, bump by
+                # full interval (5 min) to keep canonical-grid alignment →
+                # 12:10. Bumping by 1 min instead would produce 12:06 and
+                # leave the alert off-grid forever.
+                "floor_at_now_bumps_by_full_interval_not_one_minute",
+                datetime(2026, 3, 19, 12, 0, 30, tzinfo=UTC),
+                5,
+                datetime(2026, 3, 19, 12, 5, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 10, tzinfo=UTC),
+            ),
+            (
+                # Regression pin for the cadence-floor's hour-overflow math:
+                # next_at=13:03 produces total_minutes=13*60+3, floor to 13:00.
+                # The general "heals to canonical" property is proved by the
+                # property test below; this case pins the cross-hour arithmetic.
+                "minute_drifted_nca_heals_across_hour_boundary",
+                datetime(2026, 3, 19, 12, 58, tzinfo=UTC),
+                5,
+                datetime(2026, 3, 19, 12, 58, 30, tzinfo=UTC),
+                datetime(2026, 3, 19, 13, 0, tzinfo=UTC),
+            ),
         ]
     )
     def test_advance_next_check_at(
@@ -66,6 +162,136 @@ class TestAdvanceNextCheckAt(TestCase):
     ) -> None:
         result = advance_next_check_at(current_next_check_at, interval_minutes, now)
         assert result == expected, f"Expected {expected}, got {result}"
+
+
+class TestAdvanceNextCheckAtProperties(TestCase):
+    """Property-based tests over the full input space.
+
+    The parameterized cases above pin specific behaviors; these prove the
+    invariants hold for *all* combinations of cadence, eval timing, and drift.
+    """
+
+    @given(
+        cadence=_cadence_minutes,
+        drift=_subminute_drift,
+        lag_seconds=_lag_seconds,
+    )
+    @settings(max_examples=500, deadline=None)
+    def test_result_is_minute_aligned_and_strictly_future(
+        self, cadence: int, drift: timedelta, lag_seconds: int
+    ) -> None:
+        # For any drifted NCA + any lag, the returned NCA must be on a whole
+        # minute boundary AND strictly > now (no tight-loop re-pickup).
+        current = _anchor + drift
+        now = current + timedelta(seconds=lag_seconds)
+        result = advance_next_check_at(current, cadence, now)
+        assert result.second == 0 and result.microsecond == 0, f"unaligned: {result}"
+        assert result > now, f"result {result} not strictly > now {now}"
+
+    @given(cadence=_cadence_minutes, lag_seconds=_lag_seconds)
+    @settings(max_examples=300, deadline=None)
+    def test_first_run_result_is_minute_aligned_and_strictly_future(self, cadence: int, lag_seconds: int) -> None:
+        # Same invariants for the current=None first-run path.
+        now = _anchor + timedelta(seconds=lag_seconds)
+        result = advance_next_check_at(None, cadence, now)
+        assert result.second == 0 and result.microsecond == 0, f"unaligned: {result}"
+        assert result > now, f"result {result} not strictly > now {now}"
+
+    @given(
+        cadence=_cadence_minutes,
+        lag_a_seconds=st.integers(min_value=0, max_value=55),
+        lag_b_seconds=st.integers(min_value=0, max_value=55),
+    )
+    @settings(max_examples=300, deadline=None)
+    def test_subminute_lag_on_aligned_current_does_not_compound(
+        self, cadence: int, lag_a_seconds: int, lag_b_seconds: int
+    ) -> None:
+        # Once an alert is on the canonical grid (steady state), eval-time
+        # jitter within the same sub-minute window must produce the same NCA.
+        # If this property fails, scheduler lag would accumulate and push
+        # subsequent evals further out each cycle.
+        #
+        # Note: this is the production-realistic case — cron pickup constrains
+        # `now` to minute-boundary + epsilon, and steady-state alerts are
+        # already grid-aligned by the time they're being evaluated. The
+        # transient case (drifted current with `now` straddling next_at's
+        # floor) can produce a one-cadence difference, but cron timing makes
+        # it unreachable in practice.
+        current = _anchor  # aligned
+        now_a = current + timedelta(seconds=lag_a_seconds)
+        now_b = current + timedelta(seconds=lag_b_seconds)
+        result_a = advance_next_check_at(current, cadence, now_a)
+        result_b = advance_next_check_at(current, cadence, now_b)
+        assert result_a == result_b, (
+            f"cadence={cadence}: sub-minute lag jitter shifted NCA: "
+            f"lag_a={lag_a_seconds}s → {result_a}, lag_b={lag_b_seconds}s → {result_b}"
+        )
+
+    @given(
+        cadence=st.sampled_from([1, 2, 3, 5, 6, 10, 12, 15, 20, 30, 60]),  # divisors of 60
+        drift=_subminute_drift,
+    )
+    @settings(max_examples=300, deadline=None)
+    def test_steady_state_gap_equals_cadence_after_first_heal(self, cadence: int, drift: timedelta) -> None:
+        # Whatever the starting drift, by the second eval onward every inter-
+        # eval gap must equal exactly the configured cadence. This is the
+        # property that distinguishes "self-healing schedule" from "alert
+        # drifts forever once misaligned."
+        current = _anchor + drift
+        # First heal — pulls onto a minute boundary.
+        current = advance_next_check_at(current, cadence, current + timedelta(seconds=1))
+        # Run forward and assert constant gap.
+        for _ in range(15):
+            next_nca = advance_next_check_at(current, cadence, current)
+            gap = next_nca - current
+            assert gap == timedelta(minutes=cadence), (
+                f"cadence={cadence}: gap {gap} drifted from configured {cadence}min at NCA {current}"
+            )
+            current = next_nca
+
+    @given(
+        cadence=st.sampled_from([1, 2, 3, 5, 6, 10, 12, 15, 20, 30, 60]),  # divisors of 60
+        starting_minute=st.integers(min_value=0, max_value=59),
+        drift=_subminute_drift,
+    )
+    @settings(max_examples=500, deadline=None)
+    def test_divisor_cadences_land_on_canonical_grid_after_one_heal(
+        self, cadence: int, starting_minute: int, drift: timedelta
+    ) -> None:
+        # For cadences that divide 60, the canonical grid is well-defined
+        # (e.g. 5-min alerts → :00, :05, :10). After one heal cycle, NCA's
+        # minute-of-hour must be a multiple of cadence — REGARDLESS of the
+        # starting minute. (Earlier version of this test used a fixed anchor
+        # at minute 0, which trivially satisfies `0 % cadence == 0` and missed
+        # the minute-level-drift case entirely.)
+        current = _anchor.replace(minute=starting_minute) + drift
+        result = advance_next_check_at(current, cadence, current + timedelta(seconds=1))
+        assert result.minute % cadence == 0, (
+            f"cadence={cadence} (divisor of 60) starting_minute={starting_minute} drift={drift} "
+            f"produced off-grid NCA {result} (minute={result.minute}, mod={result.minute % cadence})"
+        )
+
+    @given(
+        cadence=_cadence_minutes,
+        drift=_subminute_drift,
+        downtime_minutes=st.integers(min_value=1, max_value=180),
+    )
+    @settings(max_examples=200, deadline=None)
+    def test_long_downtime_catch_up_lands_within_one_cadence_of_now(
+        self, cadence: int, drift: timedelta, downtime_minutes: int
+    ) -> None:
+        # After arbitrary downtime, the catch-up arithmetic must not produce
+        # an NCA wildly in the future or far in the past — it should land in
+        # (now, now + cadence + 1 minute] (the +1 minute is the snap-bump
+        # ceiling). This guards the skip-forward math against off-by-N bugs.
+        current = _anchor + drift
+        now = current + timedelta(minutes=downtime_minutes)
+        result = advance_next_check_at(current, cadence, now)
+        assert now < result, f"result {result} <= now {now}"
+        assert result <= now + timedelta(minutes=cadence + 1), (
+            f"cadence={cadence} downtime={downtime_minutes}min produced runaway NCA: "
+            f"now={now}, result={result}, gap={result - now}"
+        )
 
     def test_next_check_is_always_in_the_future(self) -> None:
         now = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)


### PR DESCRIPTION
## Problem

Alert scheduling had a sub-minute drift bug: when `advance_next_check_at` returned a timestamp with a non-zero seconds component (e.g. `12:05:30`), the scheduler cron (which fires every minute) would skip a full tick waiting for it, causing the alert to be picked up ~30 seconds late every single cycle. Additionally, alerts created at different times would land on different per-creation-time grids, meaning two 5-minute alerts could fire at `:02/:07/:12` and `:04/:09/:14` instead of sharing the canonical `:00/:05/:10` grid.

## Changes

**`advance_next_check_at` now snaps the returned NCA to the cadence grid:**

- After computing the next timestamp (including skip-forward catch-up for downtime), the result is floored to the nearest cadence-grid slot anchored at midnight (e.g. 5-min alerts always land on `:00/:05/:10/:15/...`).
- If the floored value is at or before `now`, it bumps forward by a full cadence interval (not just one minute) to preserve grid alignment.
- Previously-drifted alerts self-heal on their next evaluation — one transient short gap, then steady-state cadence-exact intervals forever after.

**New `_floor_to_cadence_grid` helper:**

- Floors a datetime to the previous cadence-grid slot anchored at midnight of that day.
- Works correctly for all divisors of 60 (1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60) and divisors of 1440 (90, 120, 240, 360, 480, 720, 1440). Non-divisors re-anchor at midnight, which is acceptable given UI constraints on cadence values.

## How did you test this code?

Extended the test suite with both parameterized regression cases and property-based tests using Hypothesis:

**New parameterized cases** pin specific behaviors:
- Drifted NCA self-heals to canonical grid
- Cadence change mid-flight self-heals
- Sub-second drift snaps down correctly
- Skip-forward path with drifted input self-heals
- First-run with drifted `now` lands on canonical grid
- Floor-at-now bumps by full interval (not one minute) to stay on-grid
- Cross-hour boundary arithmetic

**Property-based tests** (500–300 examples each) prove invariants over the full input space:
- Result is always minute-aligned and strictly in the future
- First-run path satisfies the same invariants
- Sub-minute eval-time jitter on an already-aligned alert produces identical NCA (no compounding drift)
- Steady-state inter-eval gap equals exactly the configured cadence after the first heal
- Divisor-of-60 cadences land on the canonical grid after one heal, regardless of starting minute
- Long-downtime catch-up lands within `(now, now + cadence + 1 minute]` (guards skip-forward off-by-N)

## Publish to changelog?

No