### PR TITLE
fix(logs): align simulate eval cadence with alert cadence

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -51,6 +51,9 @@ MAX_ALERTS_PER_TEAM = 20
 MAX_SIMULATE_LOOKBACK_DAYS = 30
 MAX_SIMULATE_BUCKETS = 15_000
 STATE_TIMELINE_LOOKBACK_HOURS = 24
+# Mirrors LogsAlertConfiguration.check_interval_minutes' default — kept here so
+# the simulate endpoint evaluates at the same cadence production runs at.
+DEFAULT_CHECK_INTERVAL_MINUTES = 5
 _SENTINEL: Final = object()
 _NOT_ANNOTATED: Final = object()
 
@@ -955,18 +958,17 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             alert=fake_alert,
             date_from=date_from_dt,
             date_to=date_to_dt,
-        ).execute_bucketed(interval_minutes=1, limit=MAX_SIMULATE_BUCKETS)
+        ).execute_bucketed(interval_minutes=DEFAULT_CHECK_INTERVAL_MINUTES, limit=MAX_SIMULATE_BUCKETS)
 
-        # Fill gaps so every minute has a count (0 if no logs)
-        minute_buckets = _fill_empty_buckets(sparse_buckets, date_from_dt, date_to_dt, 1)
+        cadence_buckets = _fill_empty_buckets(sparse_buckets, date_from_dt, date_to_dt, DEFAULT_CHECK_INTERVAL_MINUTES)
 
-        # Compute rolling window sum: for each minute, sum the preceding window_minutes of counts.
-        # Simulate samples at minute granularity for a dense preview chart; real alerts evaluate
-        # less frequently (see LogsAlertConfiguration.check_interval_minutes, currently 5m).
-        counts = [b.count for b in minute_buckets]
+        # ALLOWED_WINDOW_MINUTES is bounded below by DEFAULT_CHECK_INTERVAL_MINUTES,
+        # so integer division here is always >= 1.
+        buckets_per_window = window_minutes // DEFAULT_CHECK_INTERVAL_MINUTES
+        counts = [b.count for b in cadence_buckets]
         rolling_counts: list[int] = []
         for i in range(len(counts)):
-            window_start = max(0, i - window_minutes + 1)
+            window_start = max(0, i - buckets_per_window + 1)
             rolling_counts.append(sum(counts[window_start : i + 1]))
 
         threshold = data["threshold_count"]
@@ -991,7 +993,7 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         fire_count = 0
         resolve_count = 0
 
-        for i, bucket in enumerate(minute_buckets):
+        for i, bucket in enumerate(cadence_buckets):
             window_count = rolling_counts[i]
             breached = window_count > threshold if is_above else window_count < threshold
             check = CheckResult(result_count=window_count, threshold_breached=breached)

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1202,15 +1202,16 @@ class TestLogsAlertAPI(APIBaseTest):
         defaults.update(overrides)
         return defaults
 
-    def _mock_minute_buckets(self, minute_counts: list[tuple[int, int]]) -> list[BucketedCount]:
-        """Create 1-minute buckets. minute_counts is [(offset_minutes, count), ...]."""
+    def _mock_cadence_buckets(self, offset_counts: list[tuple[int, int]]) -> list[BucketedCount]:
+        """Create cadence-aligned buckets. `offset_counts` is [(offset_minutes_from_base, count), ...].
+        Offsets should be multiples of the simulate cadence (5 min) to land on bucket boundaries."""
         base = datetime(2025, 12, 16, 10, 0, tzinfo=UTC)
-        return [BucketedCount(timestamp=base + timedelta(minutes=m), count=c) for m, c in minute_counts]
+        return [BucketedCount(timestamp=base + timedelta(minutes=m), count=c) for m, c in offset_counts]
 
     @freeze_time("2025-12-16T10:30:00Z")
     @patch("products.logs.backend.alerts_api.AlertCheckQuery")
     def test_simulate_returns_response_shape(self, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_minute_buckets([(0, 50), (1, 20)])
+        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_cadence_buckets([(0, 50), (5, 20)])
 
         response = self.client.post(self._simulate_url(), self._simulate_payload(), format="json")
         assert response.status_code == status.HTTP_200_OK
@@ -1228,8 +1229,8 @@ class TestLogsAlertAPI(APIBaseTest):
     @freeze_time("2025-12-16T10:30:00Z")
     @patch("products.logs.backend.alerts_api.AlertCheckQuery")
     def test_simulate_fills_empty_minutes(self, mock_query_cls):
-        # Two data points 10 minutes apart — should fill 1-min gaps between them
-        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_minute_buckets([(0, 50), (10, 200)])
+        # Two data points 10 minutes apart — should fill 5-min cadence gaps between them
+        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_cadence_buckets([(0, 50), (10, 200)])
 
         response = self.client.post(
             self._simulate_url(),
@@ -1243,14 +1244,16 @@ class TestLogsAlertAPI(APIBaseTest):
     @parameterized.expand(
         [
             (
+                # Single cadence bucket above threshold → fires once.
                 "fires",
-                [(0, 40), (1, 40), (2, 40)],
+                [(0, 150)],
                 {"threshold_count": 100, "threshold_operator": "above", "window_minutes": 5},
                 {"min_fire_count": 1},
             ),
             (
+                # Bucket at cadence 0 fires; cadence 5 (5 min later) drops to 0 → resolves.
                 "fires_and_resolves",
-                [(0, 40), (1, 40), (2, 40)],
+                [(0, 150), (5, 0)],
                 {"threshold_count": 100, "threshold_operator": "above", "window_minutes": 5},
                 {"min_fire_count": 1, "min_resolve_count": 1},
             ),
@@ -1259,7 +1262,7 @@ class TestLogsAlertAPI(APIBaseTest):
     @freeze_time("2025-12-16T10:30:00Z")
     @patch("products.logs.backend.alerts_api.AlertCheckQuery")
     def test_simulate_rolling_window(self, _name, buckets, payload_overrides, expected, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_minute_buckets(buckets)
+        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_cadence_buckets(buckets)
 
         response = self.client.post(
             self._simulate_url(),
@@ -1275,14 +1278,11 @@ class TestLogsAlertAPI(APIBaseTest):
     @freeze_time("2025-12-16T10:30:00Z")
     @patch("products.logs.backend.alerts_api.AlertCheckQuery")
     def test_simulate_n_of_m_delays_firing(self, mock_query_cls):
-        # window=5, 2-of-3 N-of-M. A spike at minute 0 pushes rolling sum above threshold
-        # for minutes 0-4. At minute 0 there's only one evaluation, so N=2 isn't met and
-        # the alert stays not_firing; by minute 1 there are two consecutive breaches,
-        # satisfying 2-of-3 -> fires. This is the "N-of-M delays firing past first breach"
-        # invariant; with window=5 the delay is one tick rather than two.
-        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_minute_buckets(
-            [(0, 150), (1, 50), (2, 150)]
-        )
+        # window=5, 2-of-3 N-of-M. Cadence-spaced buckets at minute 0 and 5 each have
+        # 150 logs (above threshold=100). At cadence 0 only 1-of-3 has breached, so
+        # alert stays not_firing. At cadence 5 there are 2 consecutive breaches,
+        # satisfying 2-of-3 -> fires. Demonstrates "N-of-M delays firing past first breach".
+        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_cadence_buckets([(0, 150), (5, 150)])
 
         response = self.client.post(
             self._simulate_url(),
@@ -1297,9 +1297,9 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         data = response.json()
         data_buckets = [b for b in data["buckets"] if b["count"] > 0]
-        # Minute 0: rolling=150 breached, but only 1 evaluation -> not_firing
+        # Cadence 0: 150 breached, 1-of-3 -> not_firing
         assert data_buckets[0]["state"] == "not_firing"
-        # Minute 1: rolling=200 breached, 2 consecutive breaches met N=2 -> fires
+        # Cadence 5: 150 breached, 2-of-3 satisfied -> fires
         assert data_buckets[1]["state"] == "firing"
         assert data_buckets[1]["notification"] == "fire"
 
@@ -1309,7 +1309,7 @@ class TestLogsAlertAPI(APIBaseTest):
         # window=5, cooldown=15 min. Two spikes 10 minutes apart: first fires at minute 0,
         # rolling sum drops below threshold at minute 5 (spike falls out of window) -> resolves,
         # second spike at minute 10 would re-fire but cooldown from minute 0 fire suppresses it.
-        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_minute_buckets([(0, 200), (10, 200)])
+        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_cadence_buckets([(0, 200), (10, 200)])
 
         response = self.client.post(
             self._simulate_url(),
@@ -1369,7 +1369,7 @@ class TestLogsAlertAPI(APIBaseTest):
     @freeze_time("2025-12-16T10:30:00Z")
     @patch("products.logs.backend.alerts_api.AlertCheckQuery")
     def test_simulate_echoes_threshold_config(self, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_minute_buckets([(0, 10)])
+        mock_query_cls.return_value.execute_bucketed.return_value = self._mock_cadence_buckets([(0, 10)])
 
         response = self.client.post(
             self._simulate_url(),


### PR DESCRIPTION
## Problem

The logs alert simulate endpoint was evaluating at 1-minute granularity, which didn't match the 5-minute cadence that production alerts actually run at. This caused the preview chart and state transitions (fire/resolve) to be inconsistent with real alert behavior — particularly for N-of-M alerts, where the number of evaluation ticks within a window directly affects when firing conditions are met.

## Changes

The simulate endpoint now uses `DEFAULT_CHECK_INTERVAL_MINUTES` (5 minutes, mirroring `LogsAlertConfiguration.check_interval_minutes`) as the bucket interval instead of 1 minute. The rolling window calculation is updated to work in units of cadence buckets (`window_minutes // DEFAULT_CHECK_INTERVAL_MINUTES`) rather than raw minutes, so the aggregation logic correctly reflects how many cadence ticks fall within the alert's window.

Tests are updated to use cadence-aligned bucket offsets (e.g. `(0, 150), (5, 150)` instead of per-minute offsets) and comments clarify the expected behavior at each cadence tick.

## How did you test this code?

Existing unit tests in `test_alerts_api.py` were updated to reflect the new cadence-based bucketing and cover:
- A single cadence bucket above threshold firing once
- A fire followed by a resolve when the next cadence bucket drops to zero
- N-of-M delay behavior: first cadence tick breaches but doesn't satisfy N=2, second tick satisfies 2-of-3 and fires

## Publish to changelog?

No