### PR TITLE
fix(integrations): use stripe apps oauth token endpoint

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1205,8 +1205,8 @@ class TestStripeIntegration:
         assert response.status_code == status.HTTP_201_CREATED
         mock_oauth_response.assert_called_once()
 
-    # Stripe's Connect-OAuth flow (used by stripe_api_access_type: oauth) doesn't sign
-    # the callback redirect — only the install-link OAuth mechanism emits install_signature.
+    # The Stripe Apps OAuth flow (used by stripe_api_access_type: oauth) doesn't sign the
+    # callback redirect — only the install-link OAuth mechanism emits install_signature.
     # The conflict guard is the defense-in-depth here, not signature verification.
     @pytest.mark.parametrize("include_install_signature", [True, False])
     @patch("posthog.api.integration.StripeIntegration")

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -560,7 +560,7 @@ class OauthIntegration:
             )
             return OauthConfig(
                 authorize_url=authorize_url,
-                token_url="https://connect.stripe.com/oauth/token",
+                token_url="https://api.stripe.com/v1/oauth/token",
                 client_id=settings.STRIPE_APP_CLIENT_ID,
                 client_secret=settings.STRIPE_APP_SECRET_KEY,
                 scope="",
@@ -647,6 +647,18 @@ class OauthIntegration:
                     "auth_code": params["code"],
                 },
                 headers={"Content-Type": "application/json"},
+            )
+        elif kind == "stripe":
+            # Stripe Apps OAuth authenticates with the developer secret key as HTTP Basic
+            # username and does not accept client_id/redirect_uri in the token-exchange body.
+            # Connect OAuth (client_id+client_secret in body) is a different system.
+            res = requests.post(
+                oauth_config.token_url,
+                auth=HTTPBasicAuth(oauth_config.client_secret, ""),
+                data={
+                    "code": params["code"],
+                    "grant_type": "authorization_code",
+                },
             )
         else:
             redirect_uri = OauthIntegration.redirect_uri(kind)
@@ -936,6 +948,16 @@ class OauthIntegration:
                     "refresh_token": self.integration.sensitive_config["refresh_token"],
                     "grant_type": "refresh_token",
                     "scope": oauth_config.scope,
+                },
+            )
+        elif self.integration.kind == "stripe":
+            # Stripe Apps OAuth: secret as HTTP Basic username, no client_id/client_secret in body.
+            res = requests.post(
+                oauth_config.token_url,
+                auth=HTTPBasicAuth(oauth_config.client_secret, ""),
+                data={
+                    "refresh_token": self.integration.sensitive_config["refresh_token"],
+                    "grant_type": "refresh_token",
                 },
             )
         else:

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -546,6 +546,59 @@ class TestOauthIntegrationModel(BaseTest):
 
         mock_reload.assert_called_once_with(self.team.id, [integration.id])
 
+    @patch("posthog.models.integration.requests.post")
+    def test_stripe_integration_from_oauth_response_uses_apps_endpoint_and_basic_auth(self, mock_post):
+        # Stripe Apps OAuth (api.stripe.com/v1/oauth/token) is a different system from
+        # Stripe Connect OAuth (connect.stripe.com/oauth/token): it authenticates the
+        # token exchange with HTTP Basic (secret as username, no password) and accepts
+        # only `code` + `grant_type` in the body. Codes minted by `marketplace.stripe.com`
+        # cannot be redeemed at the Connect endpoint.
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "access_token": "FAKE_ACCESS",
+            "refresh_token": "FAKE_REFRESH",
+            "stripe_user_id": "acct_123",
+            "account_name": "Test Account",
+            "expires_in": 3600,
+        }
+
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_test_clientid",
+            STRIPE_APP_SECRET_KEY="sk_test_secret",
+        ):
+            OauthIntegration.integration_from_oauth_response(
+                "stripe",
+                self.team.id,
+                self.user,
+                {"code": "ac_real_code"},
+            )
+
+        call = mock_post.call_args
+        assert call.args[0] == "https://api.stripe.com/v1/oauth/token"
+        assert call.kwargs["data"] == {"code": "ac_real_code", "grant_type": "authorization_code"}
+        assert call.kwargs["auth"].username == "sk_test_secret"
+        assert call.kwargs["auth"].password == ""
+
+    @patch("posthog.models.integration.reload_integrations_on_workers")
+    @patch("posthog.models.integration.requests.post")
+    def test_stripe_refresh_access_token_uses_apps_endpoint_and_basic_auth(self, mock_post, mock_reload):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"access_token": "REFRESHED", "expires_in": 1000}
+
+        integration = self.create_integration(kind="stripe", config={"expires_in": 1000})
+
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_test_clientid",
+            STRIPE_APP_SECRET_KEY="sk_test_secret",
+        ):
+            OauthIntegration(integration).refresh_access_token()
+
+        call = mock_post.call_args
+        assert call.args[0] == "https://api.stripe.com/v1/oauth/token"
+        assert call.kwargs["data"] == {"refresh_token": "REFRESH", "grant_type": "refresh_token"}
+        assert call.kwargs["auth"].username == "sk_test_secret"
+        assert call.kwargs["auth"].password == ""
+
 
 class TestGoogleCloudIntegrationModel(BaseTest):
     mock_keyfile = {

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -599,6 +599,8 @@ class TestOauthIntegrationModel(BaseTest):
         assert call.kwargs["auth"].username == "sk_test_secret"
         assert call.kwargs["auth"].password == ""
 
+        mock_reload.assert_called_once_with(self.team.id, [integration.id])
+
 
 class TestGoogleCloudIntegrationModel(BaseTest):
     mock_keyfile = {


### PR DESCRIPTION
## Problem

The Stripe integration's OAuth token-exchange has been hitting the wrong endpoint since it shipped. PR #49572 wired `kind="stripe"` token exchange against `https://connect.stripe.com/oauth/token` (Stripe **Connect** OAuth, used by platforms onboarding sub-accounts). But the authorize URL we use is `marketplace.stripe.com/oauth/v2/authorize`, which is **Stripe Apps OAuth**, a different system. Codes minted by `marketplace.stripe.com` cannot be redeemed at the Connect endpoint. Stripe responds:

```
{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}
```

The bug went unnoticed because `services/stripe-app/README.md` recommends a dev shortcut (`generate_stripe_app_tokens` + paste-into-Secret-Store UI) that skips the OAuth round-trip, so the wrong endpoint was never exercised. Stripe support flagged this in [the existing thread](https://posthog.slack.com/archives/C0AAZGWD83A/p1777225565897289?thread_ts=1777055363.703719&cid=C0AAZGWD83A):

> you are using Connect OAuth flow `https://connect.stripe.com/oauth/token` and not the correct endpoint for Stripe Apps. […] Then you exchange auth code for an access token as shown here https://docs.stripe.com/stripe-apps/api-authentication/oauth#obtain-access-token

## Changes

- `posthog/models/integration.py`
  - `token_url` for `kind="stripe"` switched from `connect.stripe.com/oauth/token` to `api.stripe.com/v1/oauth/token`
  - New `kind == "stripe"` branch in `integration_from_oauth_response` and `refresh_access_token` to use HTTP Basic auth (secret key as username, no password) and only `code`/`refresh_token` + `grant_type` in the body. Stripe Apps OAuth does not accept `client_id`/`client_secret`/`redirect_uri` form params, unlike Connect OAuth.
- `posthog/models/test/test_integration_model.py`: two new tests asserting the request shape (URL, basic-auth credentials, body) for both exchange and refresh.
- `posthog/api/test/test_integration.py`: corrected an inline comment that called this flow "Connect-OAuth" (it is Stripe Apps OAuth).

No new env vars. The existing `STRIPE_APP_CLIENT_ID` and `STRIPE_APP_SECRET_KEY` values carry over (the secret value is the same `sk_*` key whether used in body or HTTP Basic auth).

## How did you test this code?

I'm an agent. Both automated and manual round-trip checks below were actually executed.

**Automated**
- New unit tests in `posthog/models/test/test_integration_model.py`:
  - `test_stripe_integration_from_oauth_response_uses_apps_endpoint_and_basic_auth`
  - `test_stripe_refresh_access_token_uses_apps_endpoint_and_basic_auth`
- Full integration test suite: `pytest posthog/models/test/test_integration_model.py posthog/api/test/test_integration.py` — 135 passed.
- `ruff check` and `ruff format --check` pass on the three changed files.

**Manual end-to-end (run with the user)**
- A live Stripe install via `marketplace.stripe.com/oauth/v2/chnlink_.../authorize?client_id=ca_LAVHfa1Qgi...` succeeded against a local backend running this branch. Stripe redirected back to `/integrations/stripe/callback`, the backend exchanged the code at `api.stripe.com/v1/oauth/token`, and a row was persisted:
  ```
  Integration(id=4, kind='stripe', team_id=1, errors='',
    config={scope: 'stripe_apps', livemode: False, token_type: 'bearer',
            stripe_user_id: 'acct_1TPt3...', stripe_publishable_key: 'pk_test_...'},
    sensitive_keys=['id_token', 'access_token', 'refresh_token'])
  ```

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by Claude (Opus 4.7) in agent mode.
- Root-cause investigation chained from [PR #56373](https://github.com/PostHog/posthog/pull/56373) (marketplace install confirmation step) where end-to-end OAuth testing kept hitting `invalid_grant: Authorization code provided does not belong to you`. We initially assumed cred mismatch; running [the Stripe Apps OAuth doc](https://docs.stripe.com/stripe-apps/api-authentication/oauth#obtain-access-token) against the existing token URL identified the endpoint mismatch.
- Stripe Apps OAuth is intentionally a separate system from Connect OAuth even though both use authorization codes and refresh tokens. Connect OAuth accepts `client_id`+`client_secret` in body; Stripe Apps OAuth uses HTTP Basic with the secret only.
- Decision: kept the existing branch-on-`kind` pattern in `integration_from_oauth_response`/`refresh_access_token` (matching `reddit-ads`/`pinterest-ads`/`bing-ads`), instead of refactoring to a strategy object. Smaller change, easier to review.