### PR TITLE
fix(hobby): run batch exports on dedicated temporal worker

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -381,6 +381,25 @@ services:
             - seaweedfs
             - temporal
 
+    temporal-django-batch-worker:
+        command: ./bin/temporal-django-worker --task-queue=batch-exports-task-queue
+        extends:
+            file: docker-compose.base.yml
+            service: temporal-django-worker
+        logging: *default-logging
+        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        environment:
+            SITE_URL: https://$DOMAIN
+            SECRET_KEY: $POSTHOG_SECRET
+        depends_on:
+            - db
+            - redis7
+            - clickhouse
+            - kafka
+            - objectstorage
+            - seaweedfs
+            - temporal
+
     cyclotron-janitor:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
## Problem

Self-hosted (hobby) deploys schedule batch-export workflows but they never run. PostHog ships exactly one Temporal worker on hobby (`temporal-django-worker`) and that worker polls the default `general-purpose-task-queue`. Batch exports run on `batch-exports-task-queue` (`settings.BATCH_EXPORTS_TASK_QUEUE` in `posthog/settings/temporal.py`). Per `posthog/temporal/README.md`, "a worker can only listen to a single queue", so batch-export workflows enqueue and then sit indefinitely with no worker to pick them up. Reported in #55167.

Closes #55167

## Changes

`docker-compose.hobby.yml`: add a second Temporal worker service `temporal-django-batch-worker` that runs `./bin/temporal-django-worker --task-queue=batch-exports-task-queue`. It extends `temporal-django-worker` from `docker-compose.base.yml` so it inherits `TEMPORAL_HOST: temporal` and the shared worker environment, and uses the same logging, image, env (`SITE_URL`, `SECRET_KEY`), and `depends_on` as the existing hobby worker block.

The bin script is invoked directly because it forwards args to `manage.py start_temporal_worker`, which already supports `--task-queue` (`posthog/management/commands/start_temporal_worker.py`).

The existing `temporal-django-worker` service is untouched, so the default-queue workflows it currently runs are unaffected.

## How did you test this code?

Agent-authored. The author is an agent (Claude Code orchestrating Codex CLI for the implementation). No manual hobby-stack deploy was performed. Verification:

- `docker compose -f docker-compose.hobby.yml -f docker-compose.base.yml config` parses without YAML errors (only the expected `REGISTRY_URL`/`POSTHOG_APP_TAG`/`DOMAIN`/`POSTHOG_SECRET`/`ENCRYPTION_SALT_KEYS` env-var-not-set warnings, which the deploy supplies).
- The `--task-queue` argument is parsed by `start_temporal_worker.add_arguments` (line 332 in `posthog/management/commands/start_temporal_worker.py`).
- `_task_queue_specs` (line 152 in the same file) registers the `batch-exports-task-queue` -> `BATCH_EXPORTS_WORKFLOWS` + `BATCH_EXPORTS_ACTIVITIES` mapping, so a worker bound to that queue picks up batch-export workflows.

A maintainer with hobby compose access can verify end-to-end by:
1. `docker compose -f docker-compose.hobby.yml up`
2. Scheduling a batch export to any destination
3. Observing the run completes (the issue reporter offered to test).

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tools: Claude Code (Opus 4.7) orchestrating Codex CLI (gpt-5.3-codex, medium reasoning) for the implementation. Claude reviewed the diff, validated YAML, and authored the commit/PR body.
- Key decisions:
  - Used `./bin/temporal-django-worker` directly rather than the `/compose/temporal-django-worker` wrapper because the wrapper does not forward `--task-queue` args.
  - Extended the base `temporal-django-worker` so the new service inherits `TEMPORAL_HOST: temporal` and the shared worker env. Same depends_on as the existing hobby worker.
  - Did NOT modify `web` / `worker` services for `TEMPORAL_HOST` (the original issue mentions this); the inherited `*worker_env` already carries it on every service that extends `*worker`, and adding it on top would just be redundant. If you want web/worker overrides too I can do them in a follow-up.
- Aware of the contributor offer in the issue thread - if Roy_Mathew already has a PR open let me know and I'll close this one.
- Agent-authored. Requires human review before merge. No self-merge.
