### PR TITLE
fix(internal_stage): rename local test function and improve object st…

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -70,8 +70,12 @@ from products.batch_exports.backend.temporal.utils import set_status_to_running_
 LOGGER = get_write_only_logger()
 
 
-def _is_local_or_test() -> bool:
+def _is_local_dev_or_test() -> bool:
     return settings.DEBUG or settings.TEST
+
+
+def _uses_object_storage_endpoint() -> bool:
+    return _is_local_dev_or_test() or not settings.CLOUD_DEPLOYMENT
 
 
 def _get_s3_endpoint_url() -> str:
@@ -80,7 +84,7 @@ def _get_s3_endpoint_url() -> str:
     When running the stack locally, MinIO runs in Docker but the Temporal workers run outside, so we need to pass in
     localhost URL rather than the hostname of the container.
     """
-    if _is_local_or_test():
+    if _is_local_dev_or_test():
         return "http://localhost:19000"
     return settings.BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT
 
@@ -91,7 +95,7 @@ def _get_s3_credentials() -> tuple[str | None, str | None]:
     If keyless S3 auth is enabled, we use no credentials as the IAM role will be used to authenticate.
     Otherwise, we use the credentials from the object storage settings.
     """
-    use_keyless_s3_auth = not _is_local_or_test()
+    use_keyless_s3_auth = not _uses_object_storage_endpoint()
     if use_keyless_s3_auth:
         aws_access_key_id = None
         aws_secret_access_key = None
@@ -453,7 +457,7 @@ def _get_clickhouse_s3_staging_folder_url(folder: str) -> str:
     bucket = settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET
     region = settings.BATCH_EXPORT_OBJECT_STORAGE_REGION
     # in these environments this will be a URL for MinIO
-    if _is_local_or_test():
+    if _uses_object_storage_endpoint():
         base_url = f"{settings.BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT}/{bucket}/"
     else:
         base_url = f"https://{bucket}.s3.{region}.amazonaws.com/"

--- a/products/batch_exports/backend/tests/test_internal_stage_storage_config.py
+++ b/products/batch_exports/backend/tests/test_internal_stage_storage_config.py
@@ -30,7 +30,7 @@ def _get_test_s3_staging_folder_url() -> str:
     [
         (None, False, False),
         (None, True, False),
-        ("E2E", False, True),
+        (None, False, True),
     ],
 )
 def test_internal_stage_uses_object_storage_endpoint_for_self_hosted_local_and_test(
@@ -52,7 +52,7 @@ def test_internal_stage_uses_object_storage_endpoint_for_self_hosted_local_and_t
         assert _get_s3_credentials() == (OBJECT_STORAGE_ACCESS_KEY_ID, OBJECT_STORAGE_SECRET_ACCESS_KEY)
 
 
-@pytest.mark.parametrize("cloud_deployment", ["DEV", "US", "EU"])
+@pytest.mark.parametrize("cloud_deployment", ["DEV", "US", "EU", "E2E"])
 def test_internal_stage_uses_aws_s3_for_cloud(cloud_deployment: str) -> None:
     with override_settings(
         CLOUD_DEPLOYMENT=cloud_deployment,

--- a/products/batch_exports/backend/tests/test_internal_stage_storage_config.py
+++ b/products/batch_exports/backend/tests/test_internal_stage_storage_config.py
@@ -1,0 +1,78 @@
+import pytest
+
+from django.test.utils import override_settings
+
+from products.batch_exports.backend.temporal.pipeline.internal_stage import (
+    _get_s3_credentials,
+    _get_s3_endpoint_url,
+    get_s3_staging_folder,
+)
+
+OBJECT_STORAGE_ENDPOINT = "http://objectstorage:19000"
+OBJECT_STORAGE_BUCKET = "posthog-test"
+OBJECT_STORAGE_REGION = "us-east-2"
+OBJECT_STORAGE_ACCESS_KEY_ID = "object-storage-key"
+OBJECT_STORAGE_SECRET_ACCESS_KEY = "object-storage-secret"
+EXPECTED_STAGE_FOLDER = "batch-exports/batch-export/2026-01-01-2026-01-02/attempt_1"
+
+
+def _get_test_s3_staging_folder_url() -> str:
+    return get_s3_staging_folder(
+        batch_export_id="batch-export",
+        data_interval_start="2026-01-01",
+        data_interval_end="2026-01-02",
+        attempt_number=1,
+    ).url
+
+
+@pytest.mark.parametrize(
+    ("cloud_deployment", "is_debug", "is_test"),
+    [
+        (None, False, False),
+        (None, True, False),
+        ("E2E", False, True),
+    ],
+)
+def test_internal_stage_uses_object_storage_endpoint_for_self_hosted_local_and_test(
+    cloud_deployment: str | None, is_debug: bool, is_test: bool
+) -> None:
+    with override_settings(
+        CLOUD_DEPLOYMENT=cloud_deployment,
+        DEBUG=is_debug,
+        TEST=is_test,
+        BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT=OBJECT_STORAGE_ENDPOINT,
+        BATCH_EXPORT_INTERNAL_STAGING_BUCKET=OBJECT_STORAGE_BUCKET,
+        OBJECT_STORAGE_ACCESS_KEY_ID=OBJECT_STORAGE_ACCESS_KEY_ID,
+        OBJECT_STORAGE_SECRET_ACCESS_KEY=OBJECT_STORAGE_SECRET_ACCESS_KEY,
+    ):
+        assert (
+            _get_test_s3_staging_folder_url()
+            == f"{OBJECT_STORAGE_ENDPOINT}/{OBJECT_STORAGE_BUCKET}/{EXPECTED_STAGE_FOLDER}"
+        )
+        assert _get_s3_credentials() == (OBJECT_STORAGE_ACCESS_KEY_ID, OBJECT_STORAGE_SECRET_ACCESS_KEY)
+
+
+@pytest.mark.parametrize("cloud_deployment", ["DEV", "US", "EU"])
+def test_internal_stage_uses_aws_s3_for_cloud(cloud_deployment: str) -> None:
+    with override_settings(
+        CLOUD_DEPLOYMENT=cloud_deployment,
+        DEBUG=False,
+        TEST=False,
+        BATCH_EXPORT_OBJECT_STORAGE_REGION=OBJECT_STORAGE_REGION,
+        BATCH_EXPORT_INTERNAL_STAGING_BUCKET=OBJECT_STORAGE_BUCKET,
+    ):
+        assert (
+            _get_test_s3_staging_folder_url()
+            == f"https://{OBJECT_STORAGE_BUCKET}.s3.{OBJECT_STORAGE_REGION}.amazonaws.com/{EXPECTED_STAGE_FOLDER}"
+        )
+        assert _get_s3_credentials() == (None, None)
+
+
+def test_s3_endpoint_url_self_hosted_uses_configured_endpoint_not_localhost() -> None:
+    with override_settings(
+        CLOUD_DEPLOYMENT=None,
+        DEBUG=False,
+        TEST=False,
+        BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT=OBJECT_STORAGE_ENDPOINT,
+    ):
+        assert _get_s3_endpoint_url() == OBJECT_STORAGE_ENDPOINT


### PR DESCRIPTION
## Problem

Batch exports fail on hobby self-hosted deployments with `INVALID_ACCESS_KEY_ID` because `_get_clickhouse_s3_staging_folder_url` in `internal_stage.py` chose between a MinIO URL and an AWS S3 URL based on `_is_local_or_test()` (which is just `DEBUG or TEST`). Hobby runs with `DEBUG=False`/`TEST=False` but stores data in MinIO, so it fell into the AWS branch and produced `https://<bucket>.s3.<region>.amazonaws.com/...`. ClickHouse then tried to authenticate against AWS using the configured MinIO credentials and the run failed.

Closes #55168

## Changes

  - Renamed `_is_local_or_test` → `_is_local_dev_or_test`. Behavior unchanged; only the name is more explicit. `_get_s3_endpoint_url` continues to use it because that helper's purpose is detecting "Temporal worker is running outside Docker" (true for local dev, false for hobby), which is orthogonal to which S3 backend we're talking to.
  - Added `_uses_object_storage_endpoint()`, which returns true when we should target the configured object-storage endpoint with explicit access keys instead of AWS S3 with IAM. The condition is `_is_local_dev_or_test() or not settings.CLOUD_DEPLOYMENT` — `CLOUD_DEPLOYMENT` being unset is the documented signal for self-hosted deployments per its setting docstring.
  - Switched `_get_s3_credentials` and `_get_clickhouse_s3_staging_folder_url` to the new predicate. Hobby and other self-hosted deployments now produce `{BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT}/{bucket}/{folder}` and pass explicit MinIO credentials. Cloud (`US`/`EU`/`DEV`) is unchanged: AWS-hostname URL with keyless IAM auth.


## How did you test this code?

Automated tests added at `products/batch_exports/backend/tests/test_internal_stage_storage_config.py` (placed outside `tests/temporal/` to avoid the package-scoped autouse ClickHouse fixture — these are pure config tests)

No manual reproduction against a live hobby compose stack — relying on the unit-test matrix to pin the routing behavior. Happy to do a manual run if a maintainer would like that before merge.

## Publish to changelog?

No

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

  ## 🤖 Agent context

  - Tooling: Claude Code (Opus 4.7), authored end-to-end with my review and direction at each step (predicate split vs. one-line widening, naming, test placement, edge-case matrix).
  - Key decisions:
    - Kept `_is_local_dev_or_test` as a behavior-preserving rename rather than widening it, so `_get_s3_endpoint_url` keeps its existing semantics for hobby.
    - Named the new predicate `_uses_object_storage_endpoint` rather than `_uses_minio_*` to avoid baking a vendor name into the API surface.
    - Test file lives at `products/batch_exports/backend/tests/test_internal_stage_storage_config.py` (not under `tests/temporal/`) because the temporal package's autouse fixture pulls in ClickHouse, which these pure-config tests don't need.