### PR TITLE
fix(stripe-app): add CSP trailing slashes and fallback for environment.constants

### DIFF
--- a/services/stripe-app/src/constants.ts
+++ b/services/stripe-app/src/constants.ts
@@ -18,12 +18,11 @@ const FALLBACK_CONSTANTS: AppConstants = {
     POSTHOG_NEW_SOURCE_URL: 'https://app.posthog.com/data-warehouse/new-source?kind=Stripe',
 }
 
-// `stripe apps upload` server-canonicalises the manifest by adding a
-// `declarations` block alongside the existing top-level `constants`. With a
-// `declarations` block present the SDK reads `declarations.constants` and
-// finds nothing, so `environment.constants` is undefined at runtime. Fall
-// back to the hardcoded values when that happens. Reproduced on CLI 1.40.0
-// and 1.40.8. See https://github.com/PostHog/posthog/pull/56404.
+// Must match the `constants` block in stripe-app.json.
+// `stripe apps upload` (apps plugin <1.15.32) server-canonicalises the manifest
+// by adding a `declarations` block that causes the SDK to ignore top-level
+// `constants` at runtime, making `environment.constants` undefined. Fall back
+// to these hardcoded values when that happens. See PR #56404.
 export function getConstants(environment: ExtensionContextValue['environment']): AppConstants {
     return (environment?.constants as unknown as AppConstants | undefined) ?? FALLBACK_CONSTANTS
 }

--- a/services/stripe-app/src/constants.ts
+++ b/services/stripe-app/src/constants.ts
@@ -11,8 +11,21 @@ export interface AppConstants {
     POSTHOG_NEW_SOURCE_URL: string
 }
 
+const FALLBACK_CONSTANTS: AppConstants = {
+    POSTHOG_US_BASE_URL: 'https://us.posthog.com',
+    POSTHOG_EU_BASE_URL: 'https://eu.posthog.com',
+    POSTHOG_DASHBOARD_URL: 'https://app.posthog.com',
+    POSTHOG_NEW_SOURCE_URL: 'https://app.posthog.com/data-warehouse/new-source?kind=Stripe',
+}
+
+// `stripe apps upload` server-canonicalises the manifest by adding a
+// `declarations` block alongside the existing top-level `constants`. With a
+// `declarations` block present the SDK reads `declarations.constants` and
+// finds nothing, so `environment.constants` is undefined at runtime. Fall
+// back to the hardcoded values when that happens. Reproduced on CLI 1.40.0
+// and 1.40.8. See https://github.com/PostHog/posthog/pull/56404.
 export function getConstants(environment: ExtensionContextValue['environment']): AppConstants {
-    return environment.constants as unknown as AppConstants
+    return (environment?.constants as unknown as AppConstants | undefined) ?? FALLBACK_CONSTANTS
 }
 
 export { BrandIcon }

--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,8 +2,95 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "icon": "./assets/logomark.png",
+    "declarations": {
+        "distribution_type": "public",
+        "stripe_api_access_type": "oauth",
+        "sandbox_install_compatible": true,
+        "stripe_api_access": {
+            "permissions": [
+                {
+                    "permission": "secret_write",
+                    "purpose": "Store PostHog OAuth tokens securely"
+                },
+                {
+                    "permission": "balance_transaction_source_read",
+                    "purpose": "Read balance transactions for data syncing"
+                },
+                {
+                    "permission": "charge_read",
+                    "purpose": "Read charges and refunds for data syncing"
+                },
+                {
+                    "permission": "customer_read",
+                    "purpose": "Read customers for data syncing"
+                },
+                {
+                    "permission": "dispute_read",
+                    "purpose": "Read disputes for data syncing"
+                },
+                {
+                    "permission": "payout_read",
+                    "purpose": "Read payouts for data syncing"
+                },
+                {
+                    "permission": "product_read",
+                    "purpose": "Read products for data syncing"
+                },
+                {
+                    "permission": "credit_note_read",
+                    "purpose": "Read credit notes for data syncing"
+                },
+                {
+                    "permission": "invoice_read",
+                    "purpose": "Read invoices and invoice items for data syncing"
+                },
+                {
+                    "permission": "plan_read",
+                    "purpose": "Read prices/plans for data syncing"
+                },
+                {
+                    "permission": "subscription_read",
+                    "purpose": "Read subscriptions for data syncing"
+                },
+                {
+                    "permission": "application_fee_read",
+                    "purpose": "Read application fees for data syncing"
+                },
+                {
+                    "permission": "transfer_read",
+                    "purpose": "Read transfers for data syncing"
+                },
+                {
+                    "permission": "connected_account_read",
+                    "purpose": "Read connected accounts for data syncing"
+                },
+                {
+                    "permission": "payment_method_read",
+                    "purpose": "Read payment methods for data syncing"
+                },
+                {
+                    "permission": "provisioning_account_request_write",
+                    "purpose": "Allows PostHog Stripe app to create and sign in to PostHog accounts."
+                }
+            ]
+        },
+        "allowed_redirect_uris": [
+            "https://us.posthog.com/integrations/stripe/callback",
+            "https://eu.posthog.com/integrations/stripe/callback",
+            "https://app.posthog.com/integrations/stripe/callback"
+        ],
+        "post_install_action": {
+            "type": "onboarding"
+        },
+        "constants": {
+            "POSTHOG_DASHBOARD_URL": "https://app.posthog.com",
+            "POSTHOG_EU_BASE_URL": "https://eu.posthog.com",
+            "POSTHOG_NEW_SOURCE_URL": "https://app.posthog.com/data-warehouse/new-source?kind=Stripe",
+            "POSTHOG_US_BASE_URL": "https://us.posthog.com"
+        }
+    },
     "provisioning": {
         "base_url": "https://us.posthog.com/api/agentic/",
         "oauth_scopes": [
@@ -46,88 +133,5 @@
             "purpose": "Connect to PostHog API to populate the UI with PostHog data"
         }
     },
-    "extensions": null,
-    "permissions": [
-        {
-            "permission": "secret_write",
-            "purpose": "Store PostHog OAuth tokens securely"
-        },
-        {
-            "permission": "balance_transaction_source_read",
-            "purpose": "Read balance transactions for data syncing"
-        },
-        {
-            "permission": "charge_read",
-            "purpose": "Read charges and refunds for data syncing"
-        },
-        {
-            "permission": "customer_read",
-            "purpose": "Read customers for data syncing"
-        },
-        {
-            "permission": "dispute_read",
-            "purpose": "Read disputes for data syncing"
-        },
-        {
-            "permission": "payout_read",
-            "purpose": "Read payouts for data syncing"
-        },
-        {
-            "permission": "product_read",
-            "purpose": "Read products for data syncing"
-        },
-        {
-            "permission": "credit_note_read",
-            "purpose": "Read credit notes for data syncing"
-        },
-        {
-            "permission": "invoice_read",
-            "purpose": "Read invoices and invoice items for data syncing"
-        },
-        {
-            "permission": "plan_read",
-            "purpose": "Read prices/plans for data syncing"
-        },
-        {
-            "permission": "subscription_read",
-            "purpose": "Read subscriptions for data syncing"
-        },
-        {
-            "permission": "application_fee_read",
-            "purpose": "Read application fees for data syncing"
-        },
-        {
-            "permission": "transfer_read",
-            "purpose": "Read transfers for data syncing"
-        },
-        {
-            "permission": "connected_account_read",
-            "purpose": "Read connected accounts for data syncing"
-        },
-        {
-            "permission": "payment_method_read",
-            "purpose": "Read payment methods for data syncing"
-        },
-        {
-            "permission": "provisioning_account_request_write",
-            "purpose": "Allows PostHog Stripe app to create and sign in to PostHog accounts."
-        }
-    ],
-    "post_install_action": {
-        "type": "onboarding"
-    },
-    "constants": {
-        "POSTHOG_DASHBOARD_URL": "https://app.posthog.com",
-        "POSTHOG_EU_BASE_URL": "https://eu.posthog.com",
-        "POSTHOG_NEW_SOURCE_URL": "https://app.posthog.com/data-warehouse/new-source?kind=Stripe",
-        "POSTHOG_US_BASE_URL": "https://us.posthog.com"
-    },
-    "allowed_redirect_uris": [
-        "https://us.posthog.com/integrations/stripe/callback",
-        "https://eu.posthog.com/integrations/stripe/callback",
-        "https://app.posthog.com/integrations/stripe/callback"
-    ],
-    "distribution_type": "public",
-    "stripe_api_access_type": "oauth",
-    "sandbox_install_compatible": true
+    "extensions": null
 }

--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,95 +2,8 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "1.2.6",
+    "version": "1.2.9",
     "icon": "./assets/logomark.png",
-    "declarations": {
-        "distribution_type": "public",
-        "stripe_api_access_type": "oauth",
-        "sandbox_install_compatible": true,
-        "stripe_api_access": {
-            "permissions": [
-                {
-                    "permission": "secret_write",
-                    "purpose": "Store PostHog OAuth tokens securely"
-                },
-                {
-                    "permission": "balance_transaction_source_read",
-                    "purpose": "Read balance transactions for data syncing"
-                },
-                {
-                    "permission": "charge_read",
-                    "purpose": "Read charges and refunds for data syncing"
-                },
-                {
-                    "permission": "customer_read",
-                    "purpose": "Read customers for data syncing"
-                },
-                {
-                    "permission": "dispute_read",
-                    "purpose": "Read disputes for data syncing"
-                },
-                {
-                    "permission": "payout_read",
-                    "purpose": "Read payouts for data syncing"
-                },
-                {
-                    "permission": "product_read",
-                    "purpose": "Read products for data syncing"
-                },
-                {
-                    "permission": "credit_note_read",
-                    "purpose": "Read credit notes for data syncing"
-                },
-                {
-                    "permission": "invoice_read",
-                    "purpose": "Read invoices and invoice items for data syncing"
-                },
-                {
-                    "permission": "plan_read",
-                    "purpose": "Read prices/plans for data syncing"
-                },
-                {
-                    "permission": "subscription_read",
-                    "purpose": "Read subscriptions for data syncing"
-                },
-                {
-                    "permission": "application_fee_read",
-                    "purpose": "Read application fees for data syncing"
-                },
-                {
-                    "permission": "transfer_read",
-                    "purpose": "Read transfers for data syncing"
-                },
-                {
-                    "permission": "connected_account_read",
-                    "purpose": "Read connected accounts for data syncing"
-                },
-                {
-                    "permission": "payment_method_read",
-                    "purpose": "Read payment methods for data syncing"
-                },
-                {
-                    "permission": "provisioning_account_request_write",
-                    "purpose": "Allows PostHog Stripe app to create and sign in to PostHog accounts."
-                }
-            ]
-        },
-        "allowed_redirect_uris": [
-            "https://us.posthog.com/integrations/stripe/callback",
-            "https://eu.posthog.com/integrations/stripe/callback",
-            "https://app.posthog.com/integrations/stripe/callback"
-        ],
-        "post_install_action": {
-            "type": "onboarding"
-        },
-        "constants": {
-            "POSTHOG_DASHBOARD_URL": "https://app.posthog.com",
-            "POSTHOG_EU_BASE_URL": "https://eu.posthog.com",
-            "POSTHOG_NEW_SOURCE_URL": "https://app.posthog.com/data-warehouse/new-source?kind=Stripe",
-            "POSTHOG_US_BASE_URL": "https://us.posthog.com"
-        }
-    },
     "provisioning": {
         "base_url": "https://us.posthog.com/api/agentic/",
         "oauth_scopes": [
@@ -133,5 +46,88 @@
             "purpose": "Connect to PostHog API to populate the UI with PostHog data"
         }
     },
-    "extensions": null
+    "extensions": null,
+    "permissions": [
+        {
+            "permission": "secret_write",
+            "purpose": "Store PostHog OAuth tokens securely"
+        },
+        {
+            "permission": "balance_transaction_source_read",
+            "purpose": "Read balance transactions for data syncing"
+        },
+        {
+            "permission": "charge_read",
+            "purpose": "Read charges and refunds for data syncing"
+        },
+        {
+            "permission": "customer_read",
+            "purpose": "Read customers for data syncing"
+        },
+        {
+            "permission": "dispute_read",
+            "purpose": "Read disputes for data syncing"
+        },
+        {
+            "permission": "payout_read",
+            "purpose": "Read payouts for data syncing"
+        },
+        {
+            "permission": "product_read",
+            "purpose": "Read products for data syncing"
+        },
+        {
+            "permission": "credit_note_read",
+            "purpose": "Read credit notes for data syncing"
+        },
+        {
+            "permission": "invoice_read",
+            "purpose": "Read invoices and invoice items for data syncing"
+        },
+        {
+            "permission": "plan_read",
+            "purpose": "Read prices/plans for data syncing"
+        },
+        {
+            "permission": "subscription_read",
+            "purpose": "Read subscriptions for data syncing"
+        },
+        {
+            "permission": "application_fee_read",
+            "purpose": "Read application fees for data syncing"
+        },
+        {
+            "permission": "transfer_read",
+            "purpose": "Read transfers for data syncing"
+        },
+        {
+            "permission": "connected_account_read",
+            "purpose": "Read connected accounts for data syncing"
+        },
+        {
+            "permission": "payment_method_read",
+            "purpose": "Read payment methods for data syncing"
+        },
+        {
+            "permission": "provisioning_account_request_write",
+            "purpose": "Allows PostHog Stripe app to create and sign in to PostHog accounts."
+        }
+    ],
+    "post_install_action": {
+        "type": "onboarding"
+    },
+    "constants": {
+        "POSTHOG_DASHBOARD_URL": "https://app.posthog.com",
+        "POSTHOG_EU_BASE_URL": "https://eu.posthog.com",
+        "POSTHOG_NEW_SOURCE_URL": "https://app.posthog.com/data-warehouse/new-source?kind=Stripe",
+        "POSTHOG_US_BASE_URL": "https://us.posthog.com"
+    },
+    "allowed_redirect_uris": [
+        "https://us.posthog.com/integrations/stripe/callback",
+        "https://eu.posthog.com/integrations/stripe/callback",
+        "https://app.posthog.com/integrations/stripe/callback"
+    ],
+    "distribution_type": "public",
+    "stripe_api_access_type": "oauth",
+    "sandbox_install_compatible": true
 }

--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,7 +2,7 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "1.2.1",
+    "version": "1.2.5",
     "icon": "./assets/logomark.png",
     "provisioning": {
         "base_url": "https://us.posthog.com/api/agentic/",
@@ -42,7 +42,7 @@
             }
         ],
         "content_security_policy": {
-            "connect-src": ["https://us.posthog.com/api", "https://eu.posthog.com/api"],
+            "connect-src": ["https://us.posthog.com/api/", "https://eu.posthog.com/api/"],
             "purpose": "Connect to PostHog API to populate the UI with PostHog data"
         }
     },


### PR DESCRIPTION
## Problem

Two bugs in the published Stripe app, both flagged in the production app's DevTools console:

### 1. CSP `connect-src` blocks every API call

Per the [CSP3 spec](https://www.w3.org/TR/CSP3/#match-url-to-source-expression), source expressions without a trailing slash match only the literal resource. `https://us.posthog.com/api` matches `/api` and nothing else - it does not match `/api/projects/.../query/`. Every API call from the dashboard app is blocked:

```
Fetch API cannot load https://us.posthog.com/api/projects/398176/query/.
Refused to connect because it violates the document's Content Security Policy.
```

Affects all published versions (1.0.0, 1.1.0, 1.2.0, 1.2.1).

### 2. `environment.constants` undefined at runtime (1.2.5+)

`stripe apps upload` server-canonicalises the manifest on every upload by adding a `declarations` block (with `distribution_type`, `stripe_api_access`, `stripe_api_access_type`, `sandbox_install_compatible`) while leaving `constants` at the top level. With a `declarations` block present the SDK reads `declarations.constants` and finds nothing, so `environment.constants` is undefined at runtime and every view crashes when `getConstants` returns it:

```
[Extension com.posthog.stripe] Cannot read properties of undefined (reading 'POSTHOG_NEW_SOURCE_URL')
```

Reproduced on CLI 1.40.0 and 1.40.8 (so it is server-side, not a CLI version issue). Tested four upload variants - flat v1 manifest, clean v2 manifest with constants inside `declarations`, `--force`, upgraded CLI - all produce the same broken hybrid manifest server-side. Filed with the Stripe team in Slack as a suspected regression (1.2.1 currently in Live works; 1.2.5+ all broken).

## Changes

1. Add trailing `/` to both `connect-src` entries so source expressions match subpaths.
2. Make `getConstants` fall back to hardcoded URLs when `environment.constants` is undefined. Existing call sites unchanged. If Stripe ever fixes the upload canonicalization, the manifest constants take over again.
3. Keep the manifest in flat v1 form (rolled back the v2 migration attempt earlier on this branch). Server canonicalises on its own; we do not need to fight it.
4. Bump `version` 1.2.1 → 1.2.9. Stripe treats published version numbers as immutable; 1.2.5 / 1.2.6 / 1.2.7 / 1.2.8 are all consumed (broken External test channel uploads from the debugging session).

## How did you test this code?

Authored by Claude (Opus 4.7).

- CSP path-match behavior verified against the linked CSP3 spec.
- `environment.constants` regression reproduced across four upload variants and two CLI versions; root cause traced to server-side manifest canonicalization.
- Manual verification after upload: install 1.2.9 in the Stripe Dashboard and confirm (a) the dashboard renders without `getConstants` crashing and (b) Events / Experiments / Feature flags / Web overview / Customer journeys tabs load PostHog data instead of failing with "Failed to fetch".

There are no automated tests for `services/stripe-app/stripe-app.json` or the Stripe app source.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by Claude (Opus 4.7, 1M context).
- Both bugs were diagnosed from the production app's DevTools console.
- An earlier commit on this branch attempted a full v1 → v2 manifest migration (moving fields into `declarations`); that approach failed because the upload server silently dropped `constants` and `post_install_action` when declared inside `declarations`. The fallback approach in `getConstants` is more robust and minimal.