### PR TITLE
fix: remove unused ThresholdMode.LEGACY that causes KeyError

### DIFF
--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -121,7 +121,7 @@ def is_stale_filter(
     return is_stale(team, filter.date_to, interval, last_refresh)
 
 
-# enum legacy, default, lazy
+# enum default, lazy, ai
 class ThresholdMode(Enum):
     DEFAULT = "default"
     LAZY = "lazy"

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -123,7 +123,6 @@ def is_stale_filter(
 
 # enum legacy, default, lazy
 class ThresholdMode(Enum):
-    LEGACY = "legacy"
     DEFAULT = "default"
     LAZY = "lazy"
     AI = "ai"


### PR DESCRIPTION
Closes #56405

## Problem

`ThresholdMode.LEGACY` is defined in the `ThresholdMode` enum but is **never added** to `staleness_threshold_map`. Any call to `cache_target_age()` or `is_stale()` with `mode=ThresholdMode.LEGACY` would raise a `KeyError` at runtime:

```python
def cache_target_age(interval, last_refresh, mode=ThresholdMode.DEFAULT):
    if interval not in staleness_threshold_map[mode]:  # KeyError if mode=LEGACY!
```

A code search confirms `ThresholdMode.LEGACY` is never referenced anywhere in the codebase.

## Fix

Remove the unused `LEGACY` enum member from `ThresholdMode` to prevent potential `KeyError` crashes and avoid future misuse of an undefined threshold mode.