### PR TITLE
fix(surveys): expose runtime translation contract

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -90,6 +90,16 @@ CACHE_TIMEOUT_SECONDS = 300
 
 ALLOWED_LINK_URL_SCHEMES = ["https", "mailto"]
 EMAIL_REGEX = r"^mailto:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+# Keep this in sync with SurveyAPISerializer's public runtime contract.
+# Root survey description is intentionally excluded because customers have used it for internal notes.
+SURVEY_API_TRANSLATION_FIELDS = frozenset(
+    [
+        "name",
+        "thankYouMessageHeader",
+        "thankYouMessageDescription",
+        "thankYouMessageCloseButtonText",
+    ]
+)
 FIELDS_NOT_APPLICABLE_TO_EXTERNAL_SURVEYS = [
     "linked_flag_id",
     "targeting_flag_filters",
@@ -2606,6 +2616,26 @@ class SurveyAPIActionSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+def get_survey_api_translations(translations: Any) -> dict[str, dict[str, str]] | None:
+    if not isinstance(translations, dict):
+        return None
+
+    safe_translations: dict[str, dict[str, str]] = {}
+    for language, translation in translations.items():
+        if not isinstance(language, str) or not isinstance(translation, dict):
+            continue
+
+        safe_translation = {
+            field: value
+            for field, value in translation.items()
+            if field in SURVEY_API_TRANSLATION_FIELDS and isinstance(value, str)
+        }
+        if safe_translation:
+            safe_translations[language] = safe_translation
+
+    return safe_translations or None
+
+
 class SurveyAPISerializer(serializers.ModelSerializer):
     """
     Serializer for the exposed /api/surveys endpoint, to be used in posthog-js and for headless APIs.
@@ -2616,6 +2646,7 @@ class SurveyAPISerializer(serializers.ModelSerializer):
     internal_targeting_flag_key = serializers.CharField(source="internal_targeting_flag.key", read_only=True)
     conditions = serializers.SerializerMethodField(method_name="get_conditions")
     enable_partial_responses = serializers.BooleanField(read_only=True)
+    translations = serializers.SerializerMethodField(method_name="get_translations")
 
     class Meta:
         model = Survey
@@ -2640,12 +2671,25 @@ class SurveyAPISerializer(serializers.ModelSerializer):
             "current_iteration_start_date",
             "schedule",
             "enable_partial_responses",
+            "translations",
         ]
         read_only_fields = fields
 
     @extend_schema_field(serializers.DictField(allow_null=True))
     def get_conditions(self, survey: Survey):
         return get_survey_conditions_with_actions(survey, SurveyAPIActionSerializer)
+
+    @extend_schema_field(
+        serializers.DictField(child=serializers.DictField(child=serializers.CharField()), allow_null=True)
+    )
+    def get_translations(self, survey: Survey) -> dict[str, dict[str, str]] | None:
+        return get_survey_api_translations(survey.translations)
+
+    def to_representation(self, instance: Survey) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        if data.get("translations") is None:
+            data.pop("translations", None)
+        return data
 
 
 def get_surveys_opt_in(team: Team) -> bool:

--- a/products/surveys/backend/api/test/test_external_surveys.py
+++ b/products/surveys/backend/api/test/test_external_surveys.py
@@ -1,3 +1,4 @@
+import re
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -173,6 +174,61 @@ class TestExternalSurveys(APIBaseTest):
         # Description should not be in the response
         assert "SENSITIVE" not in response.content.decode()
         assert "Internal team feedback" not in response.content.decode()
+
+    def test_safe_translations_are_exposed_without_survey_description(self):
+        survey = self.create_external_survey(
+            description="SENSITIVE: Internal default description",
+            translations={
+                "es": {
+                    "name": "Encuesta traducida",
+                    "description": "SENSITIVE: Internal translated description",
+                    "thankYouMessageHeader": "Gracias",
+                    "thankYouMessageDescription": "Agradecemos tus comentarios",
+                    "thankYouMessageCloseButtonText": "Cerrar",
+                },
+                "fr": {
+                    "description": "SENSITIVE: Description interne uniquement",
+                },
+            },
+            questions=[
+                {
+                    "id": str(uuid.uuid4()),
+                    "type": "open",
+                    "question": "What do you think of our product?",
+                    "description": "Question description",
+                    "translations": {
+                        "es": {
+                            "question": "¿Qué opinas de nuestro producto?",
+                            "description": "Descripción de la pregunta",
+                        }
+                    },
+                }
+            ],
+        )
+
+        response = self.client.get(f"/external_surveys/{survey.id}/")
+        assert response.status_code == 200
+
+        content = response.content.decode()
+        assert "SENSITIVE" not in content
+
+        survey_match = re.search(r'<script[^>]*id="survey-data"[^>]*>(.*?)</script>', content, re.DOTALL)
+        assert survey_match is not None
+
+        survey_data = json.loads(survey_match.group(1))
+        assert "description" not in survey_data
+        assert survey_data["translations"] == {
+            "es": {
+                "name": "Encuesta traducida",
+                "thankYouMessageHeader": "Gracias",
+                "thankYouMessageDescription": "Agradecemos tus comentarios",
+                "thankYouMessageCloseButtonText": "Cerrar",
+            }
+        }
+        assert survey_data["questions"][0]["translations"]["es"] == {
+            "question": "¿Qué opinas de nuestro producto?",
+            "description": "Descripción de la pregunta",
+        }
 
     # FUNCTIONALITY TESTS
 

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -23,6 +23,7 @@ from django.core.cache import cache
 from django.test.client import Client
 
 from nanoid import generate
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.test.test_personal_api_keys import PersonalAPIKeysBaseTest
@@ -4460,6 +4461,81 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
                 assert "description" not in survey, f"Description field should not be present in survey: {survey}"
 
             assert len(surveys) == 2
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "es": {
+                        "name": "Encuesta traducida",
+                        "description": "Internal translated description",
+                        "thankYouMessageHeader": "Gracias",
+                        "thankYouMessageDescription": "Agradecemos tus comentarios",
+                        "thankYouMessageCloseButtonText": "Cerrar",
+                    },
+                    "fr": {
+                        "description": "Description interne uniquement",
+                    },
+                },
+                {
+                    "es": {
+                        "name": "Encuesta traducida",
+                        "thankYouMessageHeader": "Gracias",
+                        "thankYouMessageDescription": "Agradecemos tus comentarios",
+                        "thankYouMessageCloseButtonText": "Cerrar",
+                    }
+                },
+            ),
+            (
+                {
+                    "fr": {
+                        "description": "Description interne uniquement",
+                    },
+                },
+                None,
+            ),
+            (None, None),
+        ],
+    )
+    def test_list_surveys_exposes_only_safe_translations(
+        self, translations: dict[str, dict[str, str]] | None, expected_translations: dict[str, dict[str, str]] | None
+    ):
+        Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Survey with translations",
+            description="Internal default description",
+            type="popover",
+            questions=[
+                {
+                    "type": "open",
+                    "question": "What's a survey?",
+                    "description": "Question description",
+                    "translations": {
+                        "es": {
+                            "question": "¿Qué es una encuesta?",
+                            "description": "Descripción de la pregunta",
+                        }
+                    },
+                }
+            ],
+            translations=translations,
+        )
+        self.client.logout()
+
+        response = self._get_surveys()
+        assert response.status_code == status.HTTP_200_OK
+
+        survey = response.json()["surveys"][0]
+        assert "description" not in survey
+        if expected_translations is None:
+            assert "translations" not in survey
+        else:
+            assert survey["translations"] == expected_translations
+        assert survey["questions"][0]["translations"]["es"] == {
+            "question": "¿Qué es una encuesta?",
+            "description": "Descripción de la pregunta",
+        }
 
     def test_list_surveys_uses_hypercache(self):
         # TODO: Currently RemoteConfig uses this to decide whether to return surveys or not


### PR DESCRIPTION
## Problem

Survey translations can be saved by the product API, but the runtime survey payload used by `posthog-js` and hosted surveys does not expose root translation fields.

The runtime serializer also intentionally excludes root `description` because customers have used it for internal notes. Translated root descriptions need the same privacy boundary.

Related to #42154.

## Changes

Add a filtered runtime `translations` field to `SurveyAPISerializer`.

The exposed runtime translation contract includes only fields needed for rendering:

- `name`
- `thankYouMessageHeader`
- `thankYouMessageDescription`
- `thankYouMessageCloseButtonText`

Root translated `description` is intentionally excluded. If a survey has no runtime-safe root translations, the field is omitted so existing no-translation payloads remain backwards compatible.

Added coverage for both runtime consumers:

- `/api/surveys/`
- `/external_surveys/<id>/` hosted survey payload

## How did you test this code?

Agent-authored change.

Ran successfully:

```bash
ruff check products/surveys/backend/api/survey.py products/surveys/backend/api/test/test_survey.py products/surveys/backend/api/test/test_external_surveys.py

git diff --check HEAD -- products/surveys/backend/api/survey.py products/surveys/backend/api/test/test_survey.py products/surveys/backend/api/test/test_external_surveys.py
```

The focused Django tests were added but local execution did not complete because the local test DB/service initialization stalled after collection:

```bash
flox activate -- bash -c "./bin/hogli test products/surveys/backend/api/test/test_survey.py::TestSurveysAPIList::test_list_surveys_includes_safe_translations_without_description products/surveys/backend/api/test/test_external_surveys.py::TestExternalSurveys::test_safe_translations_are_exposed_without_survey_description"
```

CI should be treated as the merge gate for the Django test run.

## Publish to changelog?

no

## Docs update

No docs update needed for this backend runtime contract patch.

## 🤖 Agent context

Implemented by Codex in a local agent session.

Key decisions:

- Preserve the existing runtime privacy boundary by excluding root translated `description` from public survey payloads.
- Keep the payload additive only when runtime-safe translations exist, so surveys without translations keep the same response shape.
- Add tests for both SDK and hosted-survey consumers so the contract can be used by the companion `posthog-js` work.