### PR TITLE
chore(ci): add visual review selection probe

### DIFF
--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -5,6 +5,7 @@
 // Isolation detection: products that declare a backend:contract-check script
 // (with narrowed inputs in their own turbo.json) are considered isolated —
 // they can be tested alone when only their non-contract files change.
+// Products changed by Turbo's Git affectedness query are selected for product tests.
 // Products without contract-check are non-isolated: any change in them
 // triggers the full test suite (all products + Django).
 //
@@ -16,7 +17,7 @@
 // Output: JSON on stdout: { matrix, run_legacy }
 //         Diagnostics on stderr
 
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 const fs = require('fs')
 
 const SMALL_THRESHOLD_SECONDS = 2 * 60
@@ -32,9 +33,18 @@ const DURATION_SAFETY_FACTOR = 2
 const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 
 const TURBO_EXEC_OPTS = { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: 50 * 1024 * 1024 }
+const TURBO_BIN = './node_modules/.bin/turbo'
+
+function runTurbo(args) {
+    return execFileSync(TURBO_BIN, args, TURBO_EXEC_OPTS)
+}
 
 function parseTurboTasks(raw) {
     return JSON.parse(raw).tasks.filter((t) => !/NONEXISTENT/.test(t.command))
+}
+
+function parseAffectedTasks(raw) {
+    return JSON.parse(raw).data.affectedTasks.items
 }
 
 function packageToProduct(pkg) {
@@ -45,14 +55,32 @@ function getIsolatedProducts(contractTasks) {
     return new Set(contractTasks.map((t) => packageToProduct(t.package)))
 }
 
-function getMissProducts(testTasks) {
-    return [
-        ...new Set(testTasks.filter((t) => t.cache?.status === 'MISS').map((t) => packageToProduct(t.package))),
-    ].sort()
+function getAffectedTaskProducts(tasks) {
+    return [...new Set(tasks.map((t) => packageToProduct(t.package.name)))].sort()
 }
 
 function getAllProducts(testTasks) {
     return [...new Set(testTasks.map((t) => packageToProduct(t.package)))].sort()
+}
+
+function affectedArgs(taskName) {
+    const args = ['query', 'affected', '--tasks', taskName]
+    if (process.env.TURBO_SCM_BASE) {
+        args.push('--base', process.env.TURBO_SCM_BASE)
+    }
+    if (process.env.TURBO_SCM_HEAD) {
+        args.push('--head', process.env.TURBO_SCM_HEAD)
+    }
+    return args
+}
+
+function logAffectedReasons(label, tasks) {
+    const reasons = {}
+    for (const task of tasks) {
+        const reason = task.reason?.__typename || 'Unknown'
+        reasons[reason] = (reasons[reason] || 0) + 1
+    }
+    console.error(`${label} affected reasons: ${JSON.stringify(reasons)}`)
 }
 
 function loadTestDurations() {
@@ -140,25 +168,24 @@ function buildMatrix(products, durations) {
 
 const legacyChanged = process.env.LEGACY_CHANGED === 'true'
 
-let testTasks, contractTasks
+let allTestTasks, affectedTestTasks, affectedContractTasks, contractTasks
 try {
-    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-    testTasks = parseTurboTasks(execSync('./node_modules/.bin/turbo run backend:test --dry-run=json', TURBO_EXEC_OPTS))
-    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-    contractTasks = parseTurboTasks(
-        execSync('./node_modules/.bin/turbo run backend:contract-check --dry-run=json', TURBO_EXEC_OPTS)
-    )
+    allTestTasks = parseTurboTasks(runTurbo(['run', 'backend:test', '--dry-run=json']))
+    if (!legacyChanged) {
+        console.error(`Turbo affected base: ${process.env.TURBO_SCM_BASE || '(default)'}`)
+        console.error(`Turbo affected head: ${process.env.TURBO_SCM_HEAD || '(default)'}`)
+        affectedTestTasks = parseAffectedTasks(runTurbo(affectedArgs('backend:test')))
+        affectedContractTasks = parseAffectedTasks(runTurbo(affectedArgs('backend:contract-check')))
+        contractTasks = parseTurboTasks(runTurbo(['run', 'backend:contract-check', '--dry-run=json']))
+    }
 } catch (e) {
-    console.error(`turbo dry-run failed: ${e.message}`)
+    console.error(`turbo discovery failed: ${e.message}`)
     if (e.stderr) {
         console.error(e.stderr.toString().slice(0, 1000))
     }
     process.exit(1)
 }
-const isolatedProducts = getIsolatedProducts(contractTasks)
-const allProducts = getAllProducts(testTasks)
-
-console.error(`Isolated products (have contract-check): ${JSON.stringify([...isolatedProducts].sort())}`)
+const allProducts = getAllProducts(allTestTasks)
 
 let products
 let runLegacy
@@ -168,31 +195,35 @@ if (legacyChanged) {
     products = allProducts
     runLegacy = true
 } else {
-    const missProducts = getMissProducts(testTasks)
-    const nonIsolatedMisses = missProducts.filter((p) => !isolatedProducts.has(p))
+    const isolatedProducts = getIsolatedProducts(contractTasks)
+    const affectedProducts = getAffectedTaskProducts(affectedTestTasks)
+    const nonIsolatedAffectedProducts = affectedProducts.filter((p) => !isolatedProducts.has(p))
 
-    if (nonIsolatedMisses.length > 0) {
+    console.error(`Isolated products (have contract-check): ${JSON.stringify([...isolatedProducts].sort())}`)
+    console.error(`Affected products: ${JSON.stringify(affectedProducts)}`)
+    logAffectedReasons('backend:test', affectedTestTasks)
+
+    if (nonIsolatedAffectedProducts.length > 0) {
         // Non-isolated product changed — must test everything
         console.error(
-            `Non-isolated products changed: ${JSON.stringify(nonIsolatedMisses)} — testing all products + Django`
+            `Non-isolated products changed: ${JSON.stringify(nonIsolatedAffectedProducts)} — testing all products + Django`
         )
         products = allProducts
         runLegacy = true
-    } else if (missProducts.length > 0) {
-        // Only isolated products changed — check contract-check cache for those specific products
-        const missProductSet = new Set(missProducts)
-        const contractMisses = contractTasks
-            .filter((t) => t.cache?.status === 'MISS')
-            .map((t) => packageToProduct(t.package))
-            .filter((p) => missProductSet.has(p))
-        if (contractMisses.length > 0) {
-            console.error(`Isolated product contracts changed: ${JSON.stringify(contractMisses)} — Django will run`)
+    } else if (affectedProducts.length > 0) {
+        // Only isolated products changed — check whether their contract surface was affected
+        const affectedProductSet = new Set(affectedProducts)
+        const affectedContracts = getAffectedTaskProducts(affectedContractTasks)
+            .filter((p) => affectedProductSet.has(p))
+        logAffectedReasons('backend:contract-check', affectedContractTasks)
+        if (affectedContracts.length > 0) {
+            console.error(`Isolated product contracts changed: ${JSON.stringify(affectedContracts)} — Django will run`)
             runLegacy = true
         } else {
             console.error('Only isolated product internals changed — Django can be skipped')
             runLegacy = false
         }
-        products = missProducts
+        products = affectedProducts
     } else {
         console.error('No product changes detected')
         products = []

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -133,8 +133,8 @@ jobs:
                         - 'docker/clickhouse/**'
                       legacy:
                         # Non-product backend code — when only products/ change,
-                        # turbo-discover diffs backend:test vs backend:contract-check
-                        # to detect isolated products and decide whether Django runs.
+                        # turbo-discover uses Turbo query affectedness to detect changed
+                        # products and decide whether Django runs.
                         # Everything from backend: EXCEPT products/**/backend/**/*
                         - 'ee/**/*'
                         - 'common/__init__.py'
@@ -236,7 +236,7 @@ jobs:
 
     # Fast pre-job: determines which products need testing and if Django should run
     # Only needs pnpm + node — no Python, Docker, or services
-    # Runs on depot for turbo remote cache access (cache status drives Django gating)
+    # Runs on depot to match the product-test runner environment
     turbo-discover:
         needs: changes
         if: needs.changes.outputs.backend == 'true'
@@ -249,6 +249,15 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1000
+                  filter: blob:none
+
+            - name: Fetch current PR base for Turbo affected diff
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
             - name: Setup pnpm
               uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -271,17 +280,16 @@ jobs:
                   # On pushes to master, always run everything.
                   # On PRs, use the path filter to detect legacy changes.
                   LEGACY_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.legacy }}
+                  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
+                  TURBO_SCM_HEAD: ${{ github.sha }}
               run: |
-                  # turbo-discover.js diffs backend:test vs backend:contract-check
-                  # to detect isolated products. Non-isolated product changes trigger
-                  # the full suite (all products + Django).
+                  # turbo-discover.js uses Turbo's Git affectedness to detect
+                  # changed products. Non-isolated product changes trigger the
+                  # full suite (all products + Django).
                   RESULT=$(node .github/scripts/turbo-discover.js)
                   echo "Result: $RESULT"
                   echo "matrix=$(echo "$RESULT" | jq -c '.matrix')" >> $GITHUB_OUTPUT
                   echo "run_legacy=$(echo "$RESULT" | jq -r '.run_legacy')" >> $GITHUB_OUTPUT
-
-                  # Keep contract-check remote cache warm for future runs
-                  ./node_modules/.bin/turbo run backend:contract-check --output-logs=errors-only 2>/dev/null || true
 
     # Runs product tests in parallel — one matrix job per group
     # Each job gets its own runner + Docker stack, so no shared DB conflicts

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "stylelint-config-standard-scss": "^11.1.0",
         "stylelint-order": "^6.0.4",
         "syncpack": "^13.0.4",
-        "turbo": "^2.4.2"
+        "turbo": "^2.9.6"
     },
     "optionalDependencies": {
         "fsevents": "^2.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
         specifier: ^13.0.4
         version: 13.0.4(typescript@5.9.3)
       turbo:
-        specifier: ^2.4.2
-        version: 2.4.2
+        specifier: ^2.9.6
+        version: 2.9.6
     optionalDependencies:
       fsevents:
         specifier: ^2.3.3
@@ -1826,7 +1826,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
+        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       jest-image-snapshot:
         specifier: ^6.4.0
         version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
@@ -3448,7 +3448,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
+        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -11651,6 +11651,36 @@ packages:
 
   '@tsconfig/node16@1.0.3':
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -22362,38 +22392,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.4.2:
-    resolution: {integrity: sha512-HFfemyWB60CJtEvVQj9yby5rkkWw9fLAdLtAPGtPQoU3tKh8t/uzCAZKso2aPVbib9vGUuGbPGoGpaRXdVhj5g==}
-    cpu: [x64]
-    os: [darwin]
-
-  turbo-darwin-arm64@2.4.2:
-    resolution: {integrity: sha512-uwSx1dsBSSFeEC0nxyx2O219FEsS/haiESaWwE9JI8mHkQK61s6w6fN2G586krKxyNam4AIxRltleL+O2Em94g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.4.2:
-    resolution: {integrity: sha512-Fy/uL8z/LAYcPbm7a1LwFnTY9pIi5FAi12iuHsgB7zHjdh4eeIKS2NIg4nroAmTcUTUZ0/cVTo4bDOCUcS3aKw==}
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.4.2:
-    resolution: {integrity: sha512-AEA0d8h5W/K6iiXfEgiNwWt0yqRL1NpBs8zQCLdc4/L7WeYeJW3sORWX8zt7xhutF/KW9gTm8ehKpiK6cCIsAA==}
-    cpu: [arm64]
-    os: [linux]
-
-  turbo-windows-64@2.4.2:
-    resolution: {integrity: sha512-CybtIZ9wRgnnNFVN9En9G+rxsO+mwU81fvW4RpE8BWyNEkhQ8J28qYf4PaimueMxGHHp/28i/G7Kcdn2GAWG0g==}
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.4.2:
-    resolution: {integrity: sha512-7V0yneVPL8Y3TgrkUIjw7Odmwu1tHnyIiPHFM7eFcA7U+H6hPXyCxge7nC3wOKfjhKCQqUm+Vf/k6kjmLz5G4g==}
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.4.2:
-    resolution: {integrity: sha512-Qxi0ioQCxMRUCcHKHZkTnYH8e7XCpNfg9QiJcyfWIc+ZXeaCjzV5rCGlbQlTXMAtI8qgfP8fZADv3CFtPwqdPQ==}
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
 
   tweetnacl@0.14.5:
@@ -35385,6 +35385,24 @@ snapshots:
 
   '@tsconfig/node16@1.0.3': {}
 
+  '@turbo/darwin-64@2.9.6':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.6':
+    optional: true
+
+  '@turbo/linux-64@2.9.6':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.6':
+    optional: true
+
+  '@turbo/windows-64@2.9.6':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.6':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -36410,7 +36428,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -49206,32 +49224,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo-darwin-64@2.4.2:
-    optional: true
-
-  turbo-darwin-arm64@2.4.2:
-    optional: true
-
-  turbo-linux-64@2.4.2:
-    optional: true
-
-  turbo-linux-arm64@2.4.2:
-    optional: true
-
-  turbo-windows-64@2.4.2:
-    optional: true
-
-  turbo-windows-arm64@2.4.2:
-    optional: true
-
-  turbo@2.4.2:
+  turbo@2.9.6:
     optionalDependencies:
-      turbo-darwin-64: 2.4.2
-      turbo-darwin-arm64: 2.4.2
-      turbo-linux-64: 2.4.2
-      turbo-linux-arm64: 2.4.2
-      turbo-windows-64: 2.4.2
-      turbo-windows-arm64: 2.4.2
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
 
   tweetnacl@0.14.5: {}
 

--- a/products/visual_review/backend/diffing.py
+++ b/products/visual_review/backend/diffing.py
@@ -19,7 +19,7 @@ from .ssim import compute_ssim
 
 logger = structlog.get_logger(__name__)
 
-# Two-tier classification thresholds:
+# Two-tier classification thresholds. Dummy CI-selection probe change.
 #
 # 1. Pixel diff ratio — fast path for obvious changes. Snapshots above
 #    this are immediately classified as CHANGED.

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,8 @@
 {
     "$schema": "https://turbo.build/schema.json",
-    "extends": ["//"],
+    "futureFlags": {
+        "affectedUsingTaskInputs": true
+    },
     "tasks": {
         "backend:test": {
             "inputs": [


### PR DESCRIPTION
## Problem

We need a small stacked PR to exercise the Turbo-query backend product discovery changes from #56263 with an isolated product implementation-only diff.

## Changes

- Add a no-op comment change in `products/visual_review/backend/diffing.py`.
- The changed file is outside the visual_review `backend:contract-check` inputs, so this should select visual-review product tests only and skip Django.

## How did you test this code?

As an agent, I ran:

```bash
LEGACY_CHANGED=false TURBO_SCM_BASE=webjunkie/turbo-affected-product-discover TURBO_SCM_HEAD=HEAD node .github/scripts/turbo-discover.js
git diff --check
```

The local discovery output was:

```text
Affected products: ["visual-review"]
backend:test affected reasons: {"TaskFileChanged":1}
backend:contract-check affected reasons: {}
Only isolated product internals changed — Django can be skipped
Run legacy (Django): false
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Implemented by Codex as a stacked draft PR on top of #56263. This is intentionally a dummy product implementation change to validate backend CI product selection behavior.