### PR TITLE
fix(insights): clarify paths hover styling vs dropoff red

### DIFF
--- a/frontend/src/scenes/paths/Paths.tsx
+++ b/frontend/src/scenes/paths/Paths.tsx
@@ -4,6 +4,7 @@ import { useActions, useValues } from 'kea'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
+import { lightenDarkenColor } from 'lib/utils'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -67,12 +68,12 @@ export function Paths(): JSX.Element {
     )
 
     useLayoutEffect(() => {
+        const hasActive = activeIndices.linkIndices.size > 0
         canvasRef.current?.querySelectorAll<SVGPathElement>('path[id^="path-"]').forEach((el) => {
             const pathIndex = Number(el.id.replace('path-', ''))
-            el.setAttribute(
-                'stroke',
-                activeIndices.linkIndices.has(pathIndex) ? 'var(--paths-link-hover)' : 'var(--paths-link)'
-            )
+            const isActive = activeIndices.linkIndices.has(pathIndex)
+            el.setAttribute('stroke', isActive ? 'var(--paths-link-hover)' : 'var(--paths-link)')
+            el.setAttribute('stroke-opacity', hasActive ? (isActive ? '0.85' : '0.15') : '0.35')
         })
     }, [activeIndices])
 
@@ -156,7 +157,7 @@ export function Paths(): JSX.Element {
                         '--paths-node': theme?.['preset-1'] || '#000000',
                         '--paths-node-start-or-end': theme?.['preset-2'] || '#000000',
                         '--paths-link': theme?.['preset-1'] || '#000000',
-                        '--paths-link-hover': theme?.['preset-2'] || '#000000',
+                        '--paths-link-hover': lightenDarkenColor(theme?.['preset-1'] || '#000000', -20),
                         '--paths-dropoff': 'rgba(220,53,69,0.7)',
                     } as React.CSSProperties
                 }

--- a/frontend/src/scenes/paths/renderPaths.ts
+++ b/frontend/src/scenes/paths/renderPaths.ts
@@ -114,11 +114,11 @@ const appendPathLinks = (svg: any, links: SankeyLink<PathNodeData, {}>[], handle
         .data(links)
         .join('g')
         .attr('stroke', 'var(--paths-link)')
-        .attr('opacity', 0.35)
 
     link.append('path')
         .attr('d', sankeyLinkHorizontal())
         .attr('id', (d: PathNodeData) => `path-${d.index}`)
+        .attr('stroke-opacity', 0.35)
         .attr('stroke-width', (d: PathNodeData) => {
             return Math.max(1, d.width)
         })

--- a/frontend/src/scenes/paths/renderPaths.ts
+++ b/frontend/src/scenes/paths/renderPaths.ts
@@ -146,6 +146,7 @@ const appendPathLinks = (svg: any, links: SankeyLink<PathNodeData, {}>[], handle
             return roundedRect(0, 0, 30, _height, Math.min(25, _height), false, true, false, false)
         })
         .attr('fill', 'url(#dropoff-gradient)')
+        .attr('fill-opacity', 0.35)
         .attr('stroke-width', 0)
         .attr('transform', (data: PathNodeData) => {
             return (


### PR DESCRIPTION
## Problem

In the User Paths insight, hovered links were tinted with `theme.preset-2` (a magenta/purple). Rendered at 0.35 opacity over a light background it read as pinkish-red — visually competing with the red dropoff gradient (`rgba(220,53,69,0.7)`). Users couldn't easily tell apart "this link is hovered" from "this is a drop-off."

The hover effect was also subtle: only the stroke color changed; the link group's opacity stayed at 0.35 across active and inactive paths, so hover was a hue shift rather than emphasis.

## Changes

- `frontend/src/scenes/paths/Paths.tsx`: rebind `--paths-link-hover` from `theme.preset-2` to `lightenDarkenColor(theme.preset-1, -20)` — same family as the link color, just darker. This matches the existing approach in `paths-v2`. Update the `useLayoutEffect` to also drive per-link `stroke-opacity`: hovered active paths jump to 0.85, non-active paths dim to 0.15, idle stays 0.35.
- `frontend/src/scenes/paths/renderPaths.ts`: move opacity from the parent `<g>` (where it would multiply with child opacity in SVG) onto each `<path>` via `stroke-opacity`, so the hover effect can override per-path.

The dropoff gradient is unchanged — red still means loss.

## How did you test this code?

I'm an agent (PostHog Code). I did not run the app locally — `pnpm typescript:check` failed in this environment due to a pre-existing TS5101/TS5107 deprecation flag and `node_modules` were not installed. Changes are small and self-contained; relying on CI for typecheck/lint/snapshots. A human reviewer should verify the visual change in the User Paths insight.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by PostHog Code (Claude). Session covered two paths-insight UX issues; this PR addresses issue 1 (hover color confusion). Issue 2 (URL autocomplete ordering) is being scoped separately. Key decision: rebind the hover CSS variable instead of editing every consumer, so `PathNodeCard`'s active-state border and shadow continue to track the same token.