### PR TITLE
feat(llma): emit prometheus metrics from ai_events resolver

### DIFF
--- a/posthog/hogql_queries/ai/ai_table_resolver.py
+++ b/posthog/hogql_queries/ai/ai_table_resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import posthoganalytics
+from prometheus_client import Counter, Histogram
 
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
@@ -10,6 +11,19 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
 from posthog.hogql_queries.ai.ai_column_rewriter import rewrite_expr_for_events_table, rewrite_query_for_events_table
 from posthog.hogql_queries.ai.ai_property_rewriter import rewrite_expr_for_ai_events_table
+
+AI_EVENTS_QUERY_TOTAL = Counter(
+    "posthog_ai_events_query_total",
+    "LLM analytics queries routed by execute_with_ai_events_fallback, by read-path source.",
+    labelnames=["source"],
+)
+
+AI_EVENTS_QUERY_DURATION_SECONDS = Histogram(
+    "posthog_ai_events_query_duration_seconds",
+    "Wall-clock duration of LLM analytics query executions, by read-path source. Used to compare dedicated_table vs shared_table latency.",
+    labelnames=["source"],
+    buckets=(0.025, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+)
 
 if TYPE_CHECKING:
     from posthog.hogql.constants import LimitContext
@@ -63,7 +77,8 @@ def execute_with_ai_events_fallback(
         if is_ai_events_enabled(team):
             tag_queries(ai_query_source="dedicated_table")
             ai_placeholders = {k: rewrite_expr_for_ai_events_table(v) for k, v in placeholders.items()}
-            result = execute_hogql_query(query=query, placeholders=ai_placeholders, **kwargs)
+            with AI_EVENTS_QUERY_DURATION_SECONDS.labels(source="dedicated_table").time():
+                result = execute_hogql_query(query=query, placeholders=ai_placeholders, **kwargs)
             # Fallback: if ai_events returned no rows, re-run on the shared events table.
             # This handles the rollout window where older data may only exist in the shared
             # table. Only ~4% of queries fall outside the dedicated table's 30-day TTL
@@ -71,14 +86,20 @@ def execute_with_ai_events_fallback(
             # the fallback fires rarely. Legitimately-empty queries do incur a redundant
             # second round-trip — acceptable during rollout, removed when the flag is retired.
             if result.results:
+                AI_EVENTS_QUERY_TOTAL.labels(source="dedicated_table").inc()
                 return result
             tag_queries(ai_query_source="shared_table_fallback")
+            AI_EVENTS_QUERY_TOTAL.labels(source="shared_table_fallback").inc()
+            fallback_source = "shared_table_fallback"
         else:
             tag_queries(ai_query_source="shared_table")
+            AI_EVENTS_QUERY_TOTAL.labels(source="shared_table").inc()
+            fallback_source = "shared_table"
 
         events_query = rewrite_query_for_events_table(query)
         events_placeholders = {k: rewrite_expr_for_events_table(v) for k, v in placeholders.items()}
-        return execute_hogql_query(query=events_query, placeholders=events_placeholders, **kwargs)
+        with AI_EVENTS_QUERY_DURATION_SECONDS.labels(source=fallback_source).time():
+            return execute_hogql_query(query=events_query, placeholders=events_placeholders, **kwargs)
 
 
 # Canonical Python list. Node.js mirror: nodejs/src/ingestion/ai/process-ai-event.ts

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -29,6 +29,21 @@
             "readOnlyHint": true
         }
     },
+    "experiment-get-all": {
+        "description": "DEPRECATED: renamed to experiment-list. This alias forwards to experiment-list and will be removed. Call experiment-list directly with the same arguments.",
+        "category": "Experiments",
+        "feature": "experiments",
+        "summary": "Deprecated alias for experiment-list.",
+        "title": "Get all experiments (deprecated)",
+        "required_scopes": ["experiment:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "insight-query": {
         "description": "Execute a saved insight's query and return results. THIS IS THE ONLY WAY TO RETRIEVE INSIGHT RESULTS — the insights-list, insight-get, insight-create, and insight-update tools all return metadata and query definitions but never the actual data. Call insight-query whenever the user asks to see, analyze, summarize, or compare data from a saved insight, and immediately after creating or updating an insight if they want to verify the output. Supports two output formats: 'optimized' (default) returns a human-readable summary from server-side formatters ideal for analysis, while 'json' returns the raw query results.",
         "category": "Insights & analytics",


### PR DESCRIPTION
## Problem

The `ai-events-table-rollout` flag flip is happening this week (Mon for Team 2,
Tue fleet-wide). Until now there was no Prometheus visibility into which read
path the resolver was choosing or how fast each path executes — the cutover
dashboard was relying on querying ClickHouse `system.query_log` through
Grafana's CH datasource, which doesn't reach the relevant cluster.

This adds the symmetric instrumentation other PostHog dashboards use
(`person_dualwrite_*`, `recording_blob_ingestion_v2_*`, `llma_eval_*`) so the
cutover dashboard can be 100% Prom-backed.

## Changes

`posthog/hogql_queries/ai/ai_table_resolver.py`:

- `posthog_ai_events_query_total{source}` — Counter, increments at each
  routing-decision point (`dedicated_table` / `shared_table_fallback` /
  `shared_table`).
- `posthog_ai_events_query_duration_seconds{source}` — Histogram, observes
  wall-clock duration of `execute_hogql_query` per path. Buckets at
  25ms / 100ms / 250ms / 500ms / 1s / 2.5s / 5s / 10s / 30s — sized for trace
  point lookups (current shared-table p95 in the ~1s range, dedicated
  expected ~100ms).

The Counter and Histogram have intentionally different semantics: the Counter
only increments on a routing outcome (e.g. `dedicated_table` only when results
are returned), while the Histogram observes every execution. The ~4% gap is
the "empty-result fallback" rate — useful to keep visible.

## How did you test this code?

I'm an agent (Claude Code). Automated only:

- `hogli test posthog/hogql_queries/ai/test/test_ai_table_resolver.py` — 9/9 pass
- `ruff check` + `ruff format` — clean

No manual testing performed.

## Publish to changelog?

no

## 🤖 Agent context

- Author: Claude Code session with @carlos-marchal-ph, in support of the
  `ai_events` migration cutover dashboard ("AI events table" in the
  Synced/LLMA Grafana folder, uid `dffk2stzu6p4aoc`).
- Discovery process: scoped multiple PostHog dashboards (Persons Dual-Writes,
  Session Recording V2, LLMA Evals) — all are Prom-backed via Counter +
  Histogram. Initial dashboard attempt to query CH `system.query_log` via
  Grafana's CH datasource failed (cluster routing not configured); this PR
  unblocks the Prom-native rebuild.
- Bucket selection follows the convention from
  `events_pipeline_step_ms_bucket` and `ingestion_outputs_latency_seconds_bucket`.
- Key decision: kept the Counter alongside the auto-emitted Histogram
  `_count` series because they capture different semantics (routing outcomes
  vs raw execution count).