### PR TITLE
feat(logs): switch to stateless bucketed alert evaluation

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -123,7 +123,20 @@ class AlertCheckQuery:
         return AlertCheckCountResult(count=count, query_duration_ms=duration_ms)
 
     def execute_bucketed(self, interval_minutes: int, *, limit: int = 10_000) -> list[BucketedCount]:
-        """Return time-bucketed counts for preview charts."""
+        """Return time-bucketed counts.
+
+        Used by the simulate preview chart and (as of the stateless eval refactor)
+        the production alert evaluator, which derives its N-of-M window directly
+        from the bucket sequence. Operational contract callers depend on:
+
+        - Buckets returned in ASC (oldest-first) order; alert eval reverses to get
+          newest-first for the state machine.
+        - `limit` bounds the row count to `evaluation_periods` for the eval path
+          (preview path uses MAX_SIMULATE_BUCKETS).
+        - Bucket boundaries are aligned to `toStartOfInterval(…, interval_minutes)`
+          from midnight UTC — pass cadence-aligned `date_from`/`date_to` so each
+          returned bucket holds a full `interval_minutes` of data.
+        """
         self._tag()
 
         # Wrapping in toStartOfMinute() lets ClickHouse match the projection's
@@ -237,11 +250,18 @@ def fetch_live_logs_checkpoint(team: Team) -> dt.datetime | None:
     return checkpoint
 
 
-def resolve_alert_date_to(now: dt.datetime, checkpoint: dt.datetime | None) -> dt.datetime:
-    """Anchor `date_to` on the checkpoint when fresh, else fall back to `now`."""
-    if checkpoint is None or (now - checkpoint) > CHECKPOINT_MAX_STALENESS:
-        return now
-    return min(now, checkpoint)
+def resolve_alert_date_to(nca: dt.datetime, checkpoint: dt.datetime | None) -> dt.datetime:
+    """Anchor `date_to` on the alert's scheduled `next_check_at`, clamped to the
+    ingestion checkpoint when the checkpoint is fresh enough.
+
+    Anchoring on `next_check_at` (not wall-clock-now) is what makes the query
+    window deterministic across retries and immune to scheduler lag — two evals
+    of the same alert at different actual eval times produce the same `date_to`
+    and thus the same query.
+    """
+    if checkpoint is None or (nca - checkpoint) > CHECKPOINT_MAX_STALENESS:
+        return nca
+    return min(nca, checkpoint)
 
 
 def is_projection_eligible(filters: dict) -> bool:

--- a/products/logs/backend/alert_utils.py
+++ b/products/logs/backend/alert_utils.py
@@ -11,15 +11,16 @@ def advance_next_check_at(
     """Schedule-relative advancement, snapped to the canonical cadence grid.
 
     The scheduler cron fires every minute. A sub-minute offset on the returned
-    NCA (e.g. 12:05:30) makes the cron skip a full tick waiting for it — the
-    alert is picked up at 12:06:00, ~30s late, every cycle. Snapping to the
-    cadence grid (every 5-min alert lands on :00/:05/:10/..., every 10-min on
-    :00/:10/:20/..., etc.) eliminates that lag AND aligns every alert sharing
-    a cadence onto the same canonical grid regardless of when it was created.
+    `next_check_at` (e.g. 12:05:30) makes the cron skip a full tick waiting for
+    it — the alert is picked up at 12:06:00, ~30s late, every cycle. Snapping
+    to the cadence grid (every 5-min alert lands on :00/:05/:10/..., every
+    10-min on :00/:10/:20/..., etc.) eliminates that lag AND aligns every alert
+    sharing a cadence onto the same canonical grid regardless of when it was
+    created.
 
-    Any drifted NCA — sub-minute drift OR minute-level offset (e.g. legacy
-    alerts on a per-creation-time grid) — self-heals to canonical on its next
-    return. Existing alerts heal lazily, one transient short-gap each (the
+    Any drifted `next_check_at` — sub-minute drift OR minute-level offset (e.g.
+    legacy alerts on a per-creation-time grid) — self-heals to canonical on its
+    next return. Existing alerts heal lazily, one transient short-gap each (the
     state machine handles the brief overlap window via N-of-M dedup).
 
     Inter-eval gaps are exactly `check_interval_minutes` in steady state. The

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -118,8 +118,14 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
         self.next_check_at = None
         return ["next_check_at"]
 
-    def to_snapshot(self) -> AlertSnapshot:
-        """Capture the fields the state machine reads for a transition decision."""
+    def to_snapshot(self, recent_events_breached: tuple[bool, ...] | None = None) -> AlertSnapshot:
+        """Capture the fields the state machine reads for a transition decision.
+
+        `recent_events_breached` lets the caller pass in the M-of-N window directly
+        (e.g. derived from a single bucketed CH query). When omitted, falls back to
+        reading historical CHECK rows via `get_recent_breaches` — kept for back-compat
+        with code paths that haven't switched to the bucketed eval yet.
+        """
         from products.logs.backend.alert_state_machine import AlertSnapshot, AlertState
 
         return AlertSnapshot(
@@ -130,7 +136,9 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
             last_notified_at=self.last_notified_at,
             snooze_until=self.snooze_until,
             consecutive_failures=self.consecutive_failures,
-            recent_events_breached=self.get_recent_breaches(),
+            recent_events_breached=recent_events_breached
+            if recent_events_breached is not None
+            else self.get_recent_breaches(),
         )
 
     def get_recent_breaches(self) -> tuple[bool, ...]:

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -5,7 +5,7 @@ import dataclasses
 from datetime import UTC, datetime, timedelta
 
 from django.db import transaction
-from django.db.models import F, Q
+from django.db.models import Q
 
 import structlog
 import temporalio.activity
@@ -14,7 +14,12 @@ from posthog.cdp.internal_events import InternalEventEvent, produce_internal_eve
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
 
-from products.logs.backend.alert_check_query import AlertCheckQuery, fetch_live_logs_checkpoint, resolve_alert_date_to
+from products.logs.backend.alert_check_query import (
+    AlertCheckQuery,
+    BucketedCount,
+    fetch_live_logs_checkpoint,
+    resolve_alert_date_to,
+)
 from products.logs.backend.alert_error_classifier import (
     AlertErrorCode,
     classify as classify_alert_error,
@@ -29,7 +34,7 @@ from products.logs.backend.alert_state_machine import (
 )
 from products.logs.backend.alert_utils import advance_next_check_at
 from products.logs.backend.logs_url_params import build_logs_url_params
-from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
+from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
@@ -43,6 +48,34 @@ from products.logs.backend.temporal.metrics import (
 )
 
 logger = structlog.get_logger(__name__)
+
+
+def _derive_breaches(
+    buckets: list[BucketedCount],
+    threshold_count: int,
+    threshold_operator: str,
+    evaluation_periods: int,
+) -> tuple[bool, ...]:
+    """Map ASC-ordered bucketed CH counts to a newest-first breach tuple of length M.
+
+    CH's `GROUP BY` only emits buckets that have data. The state machine needs M
+    data points regardless of how sparse the underlying log volume is — so we
+    pad the result to `evaluation_periods` with the implicit count=0 outcome:
+    `False` for `above` (0 < threshold), `True` for `below` (0 < threshold given
+    the model's min_value=1 validator).
+
+    Without this pad, a `below` alert on a truly silent service would never
+    fire — CH returns no buckets, the breach tuple is empty, and the N-of-M
+    evaluator never sees the implicit "count is below threshold" signal.
+    """
+    if threshold_operator == "above":
+        actual = tuple(b.count > threshold_count for b in reversed(buckets))
+        missing_breach = False
+    else:
+        actual = tuple(b.count < threshold_count for b in reversed(buckets))
+        missing_breach = True
+    pad = (missing_breach,) * max(0, evaluation_periods - len(actual))
+    return actual + pad
 
 
 @dataclasses.dataclass(frozen=True)
@@ -182,32 +215,49 @@ def _evaluate_single_alert(
     *,
     checkpoint: datetime | None = None,
 ) -> None:
-    """Run the ClickHouse query, apply state machine, persist, and emit events for a single alert."""
+    """Run the ClickHouse query, apply state machine, persist, and emit events for a single alert.
+
+    Stateless eval: a single bucketed CH query returns the last M counts; the
+    N-of-M evaluator decides from those buckets directly. Anchored on
+    `next_check_at` so two evals at different actual eval times produce the
+    same query.
+    """
     start_time = time.perf_counter()
     original_next_check_at = alert.next_check_at
 
-    date_to = resolve_alert_date_to(now, checkpoint)
-    date_from = date_to - timedelta(minutes=alert.window_minutes)
+    # First-run alerts (`next_check_at` still null after enable) anchor on `now`;
+    # from the second eval onward, `next_check_at` is set and idempotence holds.
+    nca = alert.next_check_at if alert.next_check_at is not None else now
+    date_to = resolve_alert_date_to(nca, checkpoint)
+    # Each bucket represents one historical "what the alert query would have
+    # returned" — window_minutes of data. M buckets cover M * window_minutes total.
+    date_from = date_to - timedelta(minutes=alert.window_minutes * alert.evaluation_periods)
 
     check_result: CheckResult
+    recent_breaches: tuple[bool, ...] = ()
     error_category: AlertErrorCode | None = None
     try:
-        query_result = AlertCheckQuery(
+        query_start = time.perf_counter()
+        buckets = AlertCheckQuery(
             team=alert.team,
             alert=alert,
             date_from=date_from,
             date_to=date_to,
-        ).execute()
-        threshold_breached = (
-            query_result.count > alert.threshold_count
-            if alert.threshold_operator == "above"
-            else query_result.count < alert.threshold_count
-        )
+        ).execute_bucketed(interval_minutes=alert.window_minutes, limit=alert.evaluation_periods)
+        query_duration_ms = int((time.perf_counter() - query_start) * 1000)
+
+        # execute_bucketed returns ASC (oldest first); state machine wants newest first.
+        # Buckets that are entirely empty are absent from the result, so a sparse window
+        # naturally produces a shorter breaches tuple — same behavior as today's
+        # get_recent_breaches when fewer than M CHECK rows exist.
+        breaches = _derive_breaches(buckets, alert.threshold_count, alert.threshold_operator, alert.evaluation_periods)
+        latest_count = buckets[-1].count if buckets else 0
         check_result = CheckResult(
-            result_count=query_result.count,
-            threshold_breached=threshold_breached,
-            query_duration_ms=query_result.query_duration_ms,
+            result_count=latest_count,
+            threshold_breached=breaches[0] if breaches else False,
+            query_duration_ms=query_duration_ms,
         )
+        recent_breaches = breaches[1:]
     except Exception as e:
         classified = classify_alert_error(e)
         error_category = classified.code
@@ -227,7 +277,7 @@ def _evaluate_single_alert(
             is_transient_error=classified.is_transient,
         )
 
-    outcome = evaluate_alert_check(alert.to_snapshot(), check_result, now)
+    outcome = evaluate_alert_check(alert.to_snapshot(recent_events_breached=recent_breaches), check_result, now)
 
     # Attempt Kafka delivery BEFORE committing state transition.
     # If delivery fails and we needed to notify, keep old state so the
@@ -244,16 +294,22 @@ def _evaluate_single_alert(
     committed_state = committed_outcome.new_state
 
     state_before = alert.state
+    state_changed = state_before != committed_state.value
+    is_error = outcome.error_message is not None
     with transaction.atomic():
-        LogsAlertEvent.objects.create(
-            alert=alert,
-            result_count=check_result.result_count,
-            threshold_breached=check_result.threshold_breached,
-            state_before=state_before,
-            state_after=committed_state.value,
-            error_message=outcome.error_message,
-            query_duration_ms=check_result.query_duration_ms,
-        )
+        # Stateless eval: write a CHECK row only on state transition or eval error.
+        # Steady-state same-state evals don't write — the N-of-M evaluator gets its
+        # window from the bucketed CH query, not from PG.
+        if state_changed or is_error:
+            LogsAlertEvent.objects.create(
+                alert=alert,
+                result_count=check_result.result_count,
+                threshold_breached=check_result.threshold_breached,
+                state_before=state_before,
+                state_after=committed_state.value,
+                error_message=outcome.error_message,
+                query_duration_ms=check_result.query_duration_ms,
+            )
 
         # All state/consecutive_failures writes go through apply_outcome —
         # single source of truth, enforced by the semgrep rule.
@@ -271,30 +327,6 @@ def _evaluate_single_alert(
             update_fields.append("last_notified_at")
 
         alert.save(update_fields=update_fields)
-
-    # Per-alert cap on non-event rows, enforced inline so the table stays bounded between
-    # daily cleanup runs. Errored rows and state transitions survive (event-retention task).
-    # Best-effort and deliberately outside the transaction above: a missed check would skew
-    # the alert's N-of-M window, a missed prune just leaves one extra row that the next
-    # tick's prune will mop up. Prefer the eventual-consistency failure mode.
-    # Upper-bound the slice so a one-time backlog (e.g. first deploy, or a disabled alert
-    # that accumulated rows) doesn't materialize thousands of IDs in one tick — subsequent
-    # ticks finish the job.
-    try:
-        prunable_ids = list(
-            LogsAlertEvent.objects.filter(
-                alert=alert,
-                kind=LogsAlertEvent.Kind.CHECK,
-                error_message__isnull=True,
-                state_before=F("state_after"),
-            )
-            .order_by("-created_at")
-            .values_list("id", flat=True)[MAX_EVALUATION_PERIODS : MAX_EVALUATION_PERIODS + 500]
-        )
-        if prunable_ids:
-            LogsAlertEvent.objects.filter(id__in=prunable_ids).delete()
-    except Exception:
-        logger.exception("Failed to prune non-event rows", alert_id=str(alert.id))
 
     stats["checked"] += 1
 

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -305,6 +305,299 @@ class TestAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
         assert isinstance(result, list)
         assert len(result) > 0
 
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_count_placement(self):
+        # Seeds five logs at known timestamps spanning two 5-min buckets
+        # ([10:00, 10:05) and [10:05, 10:10)) and asserts the per-bucket counts
+        # are placed correctly. Catches timezone / boundary off-by-one bugs that
+        # would shift counts by one bucket while preserving the total.
+        rows = [
+            {
+                "uuid": f"{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "bucket_placement_test",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 10:00:30",  # bucket [10:00, 10:05)
+                    "2025-12-16 10:01:00",  # bucket [10:00, 10:05)
+                    "2025-12-16 10:04:59",  # bucket [10:00, 10:05)
+                    "2025-12-16 10:05:00",  # bucket [10:05, 10:10)
+                    "2025-12-16 10:09:59",  # bucket [10:05, 10:10)
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["bucket_placement_test"]})
+        result = AlertCheckQuery(
+            team=self.team,
+            alert=alert,
+            date_from=datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        assert len(result) == 2
+        bucket_a, bucket_b = result
+        assert bucket_a.count == 3
+        assert bucket_b.count == 2
+        # Bucket boundary alignment: starts of [10:00, 10:05) and [10:05, 10:10)
+        assert bucket_a.timestamp.replace(tzinfo=UTC) == datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC)
+        assert bucket_b.timestamp.replace(tzinfo=UTC) == datetime(2025, 12, 16, 10, 5, 0, tzinfo=UTC)
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_sum_equals_single_count(self):
+        # Same WHERE clause, same date range, just GROUP BY in one path. If any
+        # rows fall through bucket boundaries (e.g. a half-open interval bug
+        # in toStartOfInterval), the sum would diverge from the single count.
+        alert = self._make_alert(filters={"serviceNames": ["argo-rollouts"]})
+        query = self._make_query(alert)
+
+        single = query.execute()
+        bucketed = query.execute_bucketed(interval_minutes=5)
+
+        assert sum(b.count for b in bucketed) == single.count
+
+    @freeze_time("2025-12-16T11:00:00Z")
+    def test_bucketed_count_matches_python_histogram_across_random_inputs(self):
+        # Stress test the actual ClickHouse bucketing: seed N logs at random
+        # timestamps with a unique service name, run execute_bucketed, then
+        # bucket the same timestamps in python and assert per-bucket equality.
+        # Catches: bucket alignment math, half-open boundary handling, sub-second
+        # bucketing, edge cases at hour/minute crossings.
+        import random as _random
+
+        rng = _random.Random(42)  # deterministic seed; trial output reproducible
+        base = datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC)
+        range_seconds = 2 * 3600  # 2-hour window covering hour boundary
+
+        # Generate all trials' inputs upfront, then batch-INSERT all rows in one
+        # CH round-trip. Service-name uniqueness keeps trials isolated at query time.
+        trials = []
+        all_rows: list[dict] = []
+        for trial in range(15):
+            n_logs = rng.randint(5, 200)
+            offsets_seconds = [rng.randint(0, range_seconds - 1) for _ in range(n_logs)]
+            bucket_minutes = rng.choice([1, 5, 10, 15, 30])
+            service_name = f"hist_stress_test_{trial}"
+            trials.append((service_name, offsets_seconds, bucket_minutes))
+            all_rows.extend(
+                {
+                    "uuid": f"hist-{trial}-{i}",
+                    "team_id": self.team.id,
+                    "timestamp": (base + dt.timedelta(seconds=off)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    "body": "",
+                    "severity_text": "info",
+                    "severity_number": 9,
+                    "service_name": service_name,
+                    "resource_attributes": {},
+                    "attributes_map_str": {},
+                }
+                for i, off in enumerate(offsets_seconds)
+            )
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in all_rows))
+
+        for service_name, offsets_seconds, bucket_minutes in trials:
+            alert = self._make_alert(filters={"serviceNames": [service_name]})
+            result = AlertCheckQuery(
+                team=self.team,
+                alert=alert,
+                date_from=base,
+                date_to=base + dt.timedelta(seconds=range_seconds),
+            ).execute_bucketed(interval_minutes=bucket_minutes, limit=10_000)
+
+            expected: dict[datetime, int] = {}
+            for off in offsets_seconds:
+                ts = base + dt.timedelta(seconds=off)
+                total_minutes = ts.hour * 60 + ts.minute
+                floored = (total_minutes // bucket_minutes) * bucket_minutes
+                bucket_key = ts.replace(hour=floored // 60, minute=floored % 60, second=0, microsecond=0)
+                expected[bucket_key] = expected.get(bucket_key, 0) + 1
+
+            actual = {
+                (b.timestamp.replace(tzinfo=UTC) if b.timestamp.tzinfo is None else b.timestamp): b.count
+                for b in result
+            }
+            assert actual == expected, (
+                f"service={service_name} n_logs={len(offsets_seconds)} bucket_minutes={bucket_minutes}\n"
+                f"actual:   {sorted(actual.items())}\n"
+                f"expected: {sorted(expected.items())}"
+            )
+
+    @freeze_time("2025-12-17T01:00:00Z")
+    def test_bucketed_count_correct_across_midnight_boundary(self):
+        # Cadence-grid bucketing anchors at midnight UTC — buckets that span
+        # the day rollover must land in the right slot.
+        rows = [
+            {
+                "uuid": f"mid-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "midnight_test",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 23:55:00.000000",  # bucket [23:55, 24:00)
+                    "2025-12-16 23:59:59.999999",  # bucket [23:55, 24:00)
+                    "2025-12-17 00:00:00.000000",  # bucket [00:00, 00:05)
+                    "2025-12-17 00:04:59.999999",  # bucket [00:00, 00:05)
+                    "2025-12-17 00:05:00.000000",  # bucket [00:05, 00:10)
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["midnight_test"]})
+        result = AlertCheckQuery(
+            team=self.team,
+            alert=alert,
+            date_from=datetime(2025, 12, 16, 23, 50, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 17, 0, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        actual = {b.timestamp.replace(tzinfo=UTC): b.count for b in result}
+        expected = {
+            datetime(2025, 12, 16, 23, 55, 0, tzinfo=UTC): 2,
+            datetime(2025, 12, 17, 0, 0, 0, tzinfo=UTC): 2,
+            datetime(2025, 12, 17, 0, 5, 0, tzinfo=UTC): 1,
+        }
+        assert actual == expected
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_subsecond_precision_at_boundaries(self):
+        # DateTime64(6) precision: a log at :04:59.999999 is in [10:00, 10:05);
+        # one at :05:00.000000 is in [10:05, 10:10). Boundary ownership matters
+        # because rounding errors here would silently mis-bucket logs.
+        rows = [
+            {
+                "uuid": f"sub-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "subsecond_test",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 10:04:59.999999",  # bucket [10:00, 10:05)
+                    "2025-12-16 10:05:00.000000",  # bucket [10:05, 10:10)
+                    "2025-12-16 10:05:00.000001",  # bucket [10:05, 10:10)
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["subsecond_test"]})
+        result = AlertCheckQuery(
+            team=self.team,
+            alert=alert,
+            date_from=datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        actual = {b.timestamp.replace(tzinfo=UTC): b.count for b in result}
+        expected = {
+            datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC): 1,
+            datetime(2025, 12, 16, 10, 5, 0, tzinfo=UTC): 2,
+        }
+        assert actual == expected
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_excludes_log_at_exact_date_to(self):
+        # Half-open [date_from, date_to) — a log timestamped exactly at date_to
+        # must be excluded. Catches an off-by-one if anyone changes < to <=.
+        rows = [
+            {
+                "uuid": f"bnd-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "boundary_test",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 10:09:59.999999",  # included
+                    "2025-12-16 10:10:00.000000",  # exactly date_to → excluded
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["boundary_test"]})
+        result = AlertCheckQuery(
+            team=self.team,
+            alert=alert,
+            date_from=datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        actual = {b.timestamp.replace(tzinfo=UTC): b.count for b in result}
+        # Only the .999999 log should be counted; the .000000 log is at date_to and excluded.
+        assert actual == {datetime(2025, 12, 16, 10, 5, 0, tzinfo=UTC): 1}
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_sparse_data_returns_only_populated_buckets(self):
+        # CH GROUP BY only emits buckets that have data. This is the contract
+        # downstream callers (the activity, the simulate fill helper) depend on:
+        # if you query 50 minutes of data and only 3 buckets have logs, you get
+        # 3 BucketedCount rows back, not 10.
+        rows = [
+            {
+                "uuid": f"sparse-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "sparse_test",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 09:00:00.000000",  # bucket [09:00, 09:05)
+                    "2025-12-16 09:25:00.000000",  # bucket [09:25, 09:30)
+                    "2025-12-16 09:45:00.000000",  # bucket [09:45, 09:50)
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["sparse_test"]})
+        result = AlertCheckQuery(
+            team=self.team,
+            alert=alert,
+            date_from=datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 9, 50, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        # Only 3 populated buckets returned, not 10. Each has count=1.
+        assert len(result) == 3
+        assert [b.count for b in result] == [1, 1, 1]
+        assert [b.timestamp.replace(tzinfo=UTC) for b in result] == [
+            datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC),
+            datetime(2025, 12, 16, 9, 25, 0, tzinfo=UTC),
+            datetime(2025, 12, 16, 9, 45, 0, tzinfo=UTC),
+        ]
+
     def test_team_mismatch_raises(self):
         from posthog.models import Organization, Team
 
@@ -366,28 +659,28 @@ class TestFetchLiveLogsCheckpoint(APIBaseTest):
 
 
 class TestResolveAlertDateTo(unittest.TestCase):
-    NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    NEXT_CHECK_AT = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
 
-    def test_none_checkpoint_returns_now(self):
-        assert resolve_alert_date_to(self.NOW, None) == self.NOW
+    def test_none_checkpoint_returns_next_check_at(self):
+        assert resolve_alert_date_to(self.NEXT_CHECK_AT, None) == self.NEXT_CHECK_AT
 
     def test_fresh_checkpoint_in_past_is_used(self):
-        checkpoint = self.NOW - dt.timedelta(seconds=30)
-        assert resolve_alert_date_to(self.NOW, checkpoint) == checkpoint
+        checkpoint = self.NEXT_CHECK_AT - dt.timedelta(seconds=30)
+        assert resolve_alert_date_to(self.NEXT_CHECK_AT, checkpoint) == checkpoint
 
-    def test_checkpoint_equal_to_now_is_used(self):
-        assert resolve_alert_date_to(self.NOW, self.NOW) == self.NOW
+    def test_checkpoint_equal_to_next_check_at_is_used(self):
+        assert resolve_alert_date_to(self.NEXT_CHECK_AT, self.NEXT_CHECK_AT) == self.NEXT_CHECK_AT
 
-    def test_future_checkpoint_is_clamped_to_now(self):
-        checkpoint = self.NOW + dt.timedelta(seconds=60)
-        assert resolve_alert_date_to(self.NOW, checkpoint) == self.NOW
+    def test_future_checkpoint_is_clamped_to_next_check_at(self):
+        checkpoint = self.NEXT_CHECK_AT + dt.timedelta(seconds=60)
+        assert resolve_alert_date_to(self.NEXT_CHECK_AT, checkpoint) == self.NEXT_CHECK_AT
 
-    def test_stale_checkpoint_beyond_threshold_falls_back_to_now(self):
+    def test_stale_checkpoint_beyond_threshold_falls_back_to_next_check_at(self):
         # The "quiet partition pins min() backwards" case — must not strand spikes
         # on active partitions in the past.
-        checkpoint = self.NOW - CHECKPOINT_MAX_STALENESS - dt.timedelta(seconds=1)
-        assert resolve_alert_date_to(self.NOW, checkpoint) == self.NOW
+        checkpoint = self.NEXT_CHECK_AT - CHECKPOINT_MAX_STALENESS - dt.timedelta(seconds=1)
+        assert resolve_alert_date_to(self.NEXT_CHECK_AT, checkpoint) == self.NEXT_CHECK_AT
 
     def test_checkpoint_exactly_at_threshold_is_still_used(self):
-        checkpoint = self.NOW - CHECKPOINT_MAX_STALENESS
-        assert resolve_alert_date_to(self.NOW, checkpoint) == checkpoint
+        checkpoint = self.NEXT_CHECK_AT - CHECKPOINT_MAX_STALENESS
+        assert resolve_alert_date_to(self.NEXT_CHECK_AT, checkpoint) == checkpoint

--- a/products/logs/backend/test/test_alert_utils.py
+++ b/products/logs/backend/test/test_alert_utils.py
@@ -78,7 +78,7 @@ class TestAdvanceNextCheckAt(TestCase):
                 datetime(2026, 3, 19, 12, 15, tzinfo=UTC),
             ),
             (
-                # Drifted NCA from a first-run that landed at :30 of a minute.
+                # Drifted next_check_at from a first-run that landed at :30 of a minute.
                 # Floor-snap pulls it back onto the canonical 5-min grid (12:10),
                 # not forward to 12:11 — alert lives on :00/:05/:10/... going forward.
                 "drifted_nca_self_heals_to_canonical_grid",
@@ -88,10 +88,10 @@ class TestAdvanceNextCheckAt(TestCase):
                 datetime(2026, 3, 19, 12, 10, tzinfo=UTC),
             ),
             (
-                # User changes cadence from 5min to 1min mid-flight. NCA was
-                # drifted at :30 — floor lands on the canonical 1-min grid
+                # User changes cadence from 5min to 1min mid-flight. next_check_at
+                # was drifted at :30 — floor lands on the canonical 1-min grid
                 # but at 12:16:00, which equals `now`. Bump by one interval
-                # (1 min) to ensure strict-future NCA → 12:17.
+                # (1 min) to ensure strict-future next_check_at → 12:17.
                 "cadence_change_self_heals",
                 datetime(2026, 3, 19, 12, 15, 30, tzinfo=UTC),
                 1,
@@ -180,8 +180,9 @@ class TestAdvanceNextCheckAtProperties(TestCase):
     def test_result_is_minute_aligned_and_strictly_future(
         self, cadence: int, drift: timedelta, lag_seconds: int
     ) -> None:
-        # For any drifted NCA + any lag, the returned NCA must be on a whole
-        # minute boundary AND strictly > now (no tight-loop re-pickup).
+        # For any drifted next_check_at + any lag, the returned next_check_at
+        # must be on a whole minute boundary AND strictly > now (no tight-loop
+        # re-pickup).
         current = _anchor + drift
         now = current + timedelta(seconds=lag_seconds)
         result = advance_next_check_at(current, cadence, now)
@@ -207,9 +208,9 @@ class TestAdvanceNextCheckAtProperties(TestCase):
         self, cadence: int, lag_a_seconds: int, lag_b_seconds: int
     ) -> None:
         # Once an alert is on the canonical grid (steady state), eval-time
-        # jitter within the same sub-minute window must produce the same NCA.
-        # If this property fails, scheduler lag would accumulate and push
-        # subsequent evals further out each cycle.
+        # jitter within the same sub-minute window must produce the same
+        # next_check_at. If this property fails, scheduler lag would accumulate
+        # and push subsequent evals further out each cycle.
         #
         # Note: this is the production-realistic case — cron pickup constrains
         # `now` to minute-boundary + epsilon, and steady-state alerts are
@@ -223,7 +224,7 @@ class TestAdvanceNextCheckAtProperties(TestCase):
         result_a = advance_next_check_at(current, cadence, now_a)
         result_b = advance_next_check_at(current, cadence, now_b)
         assert result_a == result_b, (
-            f"cadence={cadence}: sub-minute lag jitter shifted NCA: "
+            f"cadence={cadence}: sub-minute lag jitter shifted next_check_at: "
             f"lag_a={lag_a_seconds}s → {result_a}, lag_b={lag_b_seconds}s → {result_b}"
         )
 
@@ -242,12 +243,12 @@ class TestAdvanceNextCheckAtProperties(TestCase):
         current = advance_next_check_at(current, cadence, current + timedelta(seconds=1))
         # Run forward and assert constant gap.
         for _ in range(15):
-            next_nca = advance_next_check_at(current, cadence, current)
-            gap = next_nca - current
+            next_check = advance_next_check_at(current, cadence, current)
+            gap = next_check - current
             assert gap == timedelta(minutes=cadence), (
-                f"cadence={cadence}: gap {gap} drifted from configured {cadence}min at NCA {current}"
+                f"cadence={cadence}: gap {gap} drifted from configured {cadence}min at next_check_at {current}"
             )
-            current = next_nca
+            current = next_check
 
     @given(
         cadence=st.sampled_from([1, 2, 3, 5, 6, 10, 12, 15, 20, 30, 60]),  # divisors of 60
@@ -259,16 +260,16 @@ class TestAdvanceNextCheckAtProperties(TestCase):
         self, cadence: int, starting_minute: int, drift: timedelta
     ) -> None:
         # For cadences that divide 60, the canonical grid is well-defined
-        # (e.g. 5-min alerts → :00, :05, :10). After one heal cycle, NCA's
-        # minute-of-hour must be a multiple of cadence — REGARDLESS of the
-        # starting minute. (Earlier version of this test used a fixed anchor
-        # at minute 0, which trivially satisfies `0 % cadence == 0` and missed
-        # the minute-level-drift case entirely.)
+        # (e.g. 5-min alerts → :00, :05, :10). After one heal cycle,
+        # next_check_at's minute-of-hour must be a multiple of cadence —
+        # REGARDLESS of the starting minute. (Earlier version of this test
+        # used a fixed anchor at minute 0, which trivially satisfies
+        # `0 % cadence == 0` and missed the minute-level-drift case entirely.)
         current = _anchor.replace(minute=starting_minute) + drift
         result = advance_next_check_at(current, cadence, current + timedelta(seconds=1))
         assert result.minute % cadence == 0, (
             f"cadence={cadence} (divisor of 60) starting_minute={starting_minute} drift={drift} "
-            f"produced off-grid NCA {result} (minute={result.minute}, mod={result.minute % cadence})"
+            f"produced off-grid next_check_at {result} (minute={result.minute}, mod={result.minute % cadence})"
         )
 
     @given(
@@ -281,15 +282,16 @@ class TestAdvanceNextCheckAtProperties(TestCase):
         self, cadence: int, drift: timedelta, downtime_minutes: int
     ) -> None:
         # After arbitrary downtime, the catch-up arithmetic must not produce
-        # an NCA wildly in the future or far in the past — it should land in
-        # (now, now + cadence + 1 minute] (the +1 minute is the snap-bump
-        # ceiling). This guards the skip-forward math against off-by-N bugs.
+        # a next_check_at wildly in the future or far in the past — it should
+        # land in (now, now + cadence + 1 minute] (the +1 minute is the snap-
+        # bump ceiling). This guards the skip-forward math against off-by-N
+        # bugs.
         current = _anchor + drift
         now = current + timedelta(minutes=downtime_minutes)
         result = advance_next_check_at(current, cadence, now)
         assert now < result, f"result {result} <= now {now}"
         assert result <= now + timedelta(minutes=cadence + 1), (
-            f"cadence={cadence} downtime={downtime_minutes}min produced runaway NCA: "
+            f"cadence={cadence} downtime={downtime_minutes}min produced runaway next_check_at: "
             f"now={now}, result={result}, gap={result - now}"
         )
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -1,24 +1,47 @@
+import json
 import datetime as dt
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
+import unittest
 from freezegun import freeze_time
-from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import MagicMock, patch
 
-from django.db.models import F
-
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
 from parameterized import parameterized
 
+from posthog.clickhouse.client import sync_execute
 from posthog.errors import QueryErrorCategory
 
-from products.logs.backend.alert_check_query import AlertCheckCountResult
+from products.logs.backend.alert_check_query import BucketedCount
 from products.logs.backend.alert_state_machine import AlertState, NotificationAction
-from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
-from products.logs.backend.temporal.activities import CheckAlertsOutput, _check_alerts_sync, _evaluate_single_alert
+from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
+from products.logs.backend.temporal.activities import (
+    CheckAlertsOutput,
+    _check_alerts_sync,
+    _derive_breaches,
+    _evaluate_single_alert,
+)
 
 
 def _make_stats() -> dict[str, int]:
     return {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+
+
+def _mock_buckets(mock_query_cls: MagicMock, counts: list[int]) -> None:
+    """Set execute_bucketed to return BucketedCount entries (oldest-first, ASC order).
+
+    `counts[0]` is the oldest bucket, `counts[-1]` is the newest. The activity
+    reverses this internally so the state-machine sees breaches newest-first.
+    """
+    base = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+    mock_query_cls.return_value.execute_bucketed.return_value = [
+        BucketedCount(timestamp=base + timedelta(minutes=i * 5), count=c) for i, c in enumerate(counts)
+    ]
 
 
 class TestCheckAlertsSync(APIBaseTest):
@@ -91,7 +114,7 @@ class TestCheckAlertsSync(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     def test_picks_up_due_alert(self, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         self._make_alert()
         result = _check_alerts_sync()
         assert result.alerts_checked == 1
@@ -99,7 +122,7 @@ class TestCheckAlertsSync(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     def test_picks_up_null_next_check_at(self, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         self._make_alert(next_check_at=None)
         result = _check_alerts_sync()
         assert result.alerts_checked == 1
@@ -114,7 +137,7 @@ class TestCheckAlertsSync(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     def test_clickhouse_error_records_errored_check(self, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = RuntimeError("boom")
+        mock_query_cls.return_value.execute_bucketed.side_effect = RuntimeError("boom")
         self._make_alert()
         result = _check_alerts_sync()
         # ClickHouse error is caught inside _evaluate_single_alert, alert is still "checked"
@@ -141,7 +164,7 @@ class TestCheckAlertsSync(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     def test_records_alerts_active_gauge(self, _name, seed_alerts, expected_count, mock_query_cls, mock_record_gauge):
         if seed_alerts:
-            mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+            _mock_buckets(mock_query_cls, [5])
             self._make_alert()
             self._make_alert(name="Second")
             # Disabled and snoozed alerts should not count toward the gauge.
@@ -165,7 +188,7 @@ class TestCheckAlertsSync(APIBaseTest):
     ):
         checkpoint = datetime(2025, 1, 1, 0, 0, 30, tzinfo=UTC)
         mock_fetch_checkpoint.return_value = checkpoint
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         self._make_alert()
         self._make_alert(name="Second")
 
@@ -199,7 +222,7 @@ class TestCheckAlertsSync(APIBaseTest):
     def test_checkpoint_fetch_failure_falls_back_to_wall_clock(
         self, mock_query_cls, _mock_fetch, mock_record_lag, mock_unavailable
     ):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         self._make_alert()
 
         result = _check_alerts_sync()
@@ -242,7 +265,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_threshold_breached_transitions_to_firing(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -260,7 +283,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_threshold_not_breached_stays_not_firing(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -276,8 +299,19 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_steady_state_writes_no_alert_event(self, _mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [5])  # below threshold → stays NOT_FIRING
+        alert = self._make_alert()
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        assert LogsAlertEvent.objects.filter(alert=alert).count() == 0
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_creates_event_row(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=250)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -289,14 +323,16 @@ class TestEvaluateSingleAlert(APIBaseTest):
         assert check.threshold_breached is True
         assert check.state_before == "not_firing"
         assert check.state_after == "firing"
-        assert check.query_duration_ms == 250
+        # Stateless eval times the bucketed CH call via perf_counter — exact value
+        # depends on real clock (mocked CH returns instantly, so duration is tiny).
+        assert check.query_duration_ms is not None and check.query_duration_ms >= 0
         assert check.error_message is None
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_advances_next_check_at(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(next_check_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC))
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -309,68 +345,6 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
-    def test_inline_cap_trims_oldest_non_event_rows(self, _mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
-        alert = self._make_alert()
-
-        # Seed MAX_EVALUATION_PERIODS non-event rows (the allowed headroom).
-        for _ in range(MAX_EVALUATION_PERIODS):
-            LogsAlertEvent.objects.create(
-                alert=alert, threshold_breached=False, state_before="not_firing", state_after="not_firing"
-            )
-        # Seed an event row the activity should never touch.
-        errored = LogsAlertEvent.objects.create(
-            alert=alert,
-            threshold_breached=False,
-            state_before="not_firing",
-            state_after="not_firing",
-            error_message="Old CH timeout",
-        )
-
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
-
-        # Cap is MAX_EVALUATION_PERIODS + the new check that was just inserted.
-        non_event_count = LogsAlertEvent.objects.filter(
-            alert=alert, error_message__isnull=True, state_before=F("state_after")
-        ).count()
-        assert non_event_count == MAX_EVALUATION_PERIODS
-        # The errored row survives the cap — events are retention-managed, not count-managed.
-        assert LogsAlertEvent.objects.filter(pk=errored.pk).exists()
-
-    @parameterized.expand([(k.value, k) for k in LogsAlertEvent.Kind if k != LogsAlertEvent.Kind.CHECK])
-    @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
-    def test_inline_prune_leaves_non_check_kinds_alone(self, _name, non_check_kind, _mock_produce, mock_query_cls):
-        # Control-plane rows are excluded from the prune candidate set by `kind=CHECK`.
-        # Without that filter, a hypothetical non-CHECK row with state_before=state_after
-        # would match the legacy "non-event" filter and get trimmed along with OK rows.
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
-        alert = self._make_alert()
-
-        for _ in range(MAX_EVALUATION_PERIODS + 5):
-            LogsAlertEvent.objects.create(
-                alert=alert,
-                kind=LogsAlertEvent.Kind.CHECK,
-                threshold_breached=False,
-                state_before="not_firing",
-                state_after="not_firing",
-            )
-        control = LogsAlertEvent.objects.create(
-            alert=alert,
-            kind=non_check_kind,
-            threshold_breached=False,
-            state_before="not_firing",
-            state_after="not_firing",
-        )
-
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
-
-        assert LogsAlertEvent.objects.filter(pk=control.pk).exists()
-
-    @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
     @patch(
         "products.logs.backend.alert_error_classifier.classify_query_error",
         return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
@@ -379,7 +353,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         # Force the classifier to treat this as a performance error so the assertion
         # doesn't depend on whether the raw message hits one of the shared classifier's
         # recognized shapes.
-        mock_query_cls.return_value.execute.side_effect = Exception(
+        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         alert = self._make_alert()
@@ -399,7 +373,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_emit_event_uses_team_distinct_id(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -413,7 +387,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_last_notified_at_set_after_kafka_success(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -428,7 +402,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_last_notified_at_not_set_on_kafka_failure(self, mock_capture, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -451,7 +425,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_threshold_operators(self, _name, operator, count, should_fire, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=count, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [count])
         alert = self._make_alert(threshold_operator=operator, threshold_count=10)
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -472,13 +446,13 @@ class TestEvaluateSingleAlert(APIBaseTest):
     def test_resolution_emits_resolved_event(self, mock_produce, mock_query_cls):
         alert = self._make_alert(state=LogsAlertConfiguration.State.FIRING)
         # First check breached to create an event row for get_recent_breaches
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         mock_produce.reset_mock()
 
         # Second check not breached — should resolve
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [0])
         stats = _make_stats()
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
 
@@ -492,7 +466,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_cooldown_suppresses_notification(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert(
             state=LogsAlertConfiguration.State.FIRING,
             cooldown_minutes=60,
@@ -511,22 +485,25 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_n_of_m_requires_multiple_breaches_to_fire(self, mock_produce, mock_query_cls):
+        # Stateless eval: a single bucketed query returns the M-bucket history.
+        # State machine derives the N-of-M decision from those buckets directly.
+        # Buckets are oldest-first; the activity reverses internally.
         alert = self._make_alert(evaluation_periods=3, datapoints_to_alarm=2)
 
-        # First check: breached but 1-of-3 not enough
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        # 1-of-3 breach (newest=breach, older two ok) → not enough
+        _mock_buckets(mock_query_cls, [0, 0, 50])
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
-        # Second check: not breached, 1-of-3 still not enough
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
+        # 1-of-3 still (oldest breach, newer two ok) → not enough
+        _mock_buckets(mock_query_cls, [50, 0, 0])
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
-        # Third check: breached, now 2-of-3 — should fire
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        # 2-of-3 (oldest ok, two newer breach) → fire
+        _mock_buckets(mock_query_cls, [0, 50, 50])
         stats = _make_stats()
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC), stats)
         alert.refresh_from_db()
@@ -542,7 +519,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             threshold_count=5,
             filters={"severityLevels": ["error"], "serviceNames": ["api-server"]},
         )
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=10, query_duration_ms=50)
+        _mock_buckets(mock_query_cls, [10])
 
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
@@ -564,7 +541,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             window_minutes=10,
             filters={"severityLevels": ["error"]},
         )
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=10, query_duration_ms=50)
+        _mock_buckets(mock_query_cls, [10])
 
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
@@ -578,7 +555,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_resolution_within_cooldown_suppresses_resolved_event(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [0])
         alert = self._make_alert(
             state=LogsAlertConfiguration.State.FIRING,
             cooldown_minutes=60,
@@ -649,7 +626,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             consecutive_failures=initial_failures,
             state=initial_state,
         )
-        mock_query_cls.return_value.execute.side_effect = Exception(
+        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
 
@@ -680,7 +657,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_state_transition_counter_fires_on_state_change(self, _mock_produce, mock_query_cls, mock_transition):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
 
         _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
@@ -692,7 +669,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_state_transition_counter_silent_when_state_unchanged(self, _mock_produce, mock_query_cls, mock_transition):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         self._make_alert()
 
         _evaluate_single_alert(
@@ -722,9 +699,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_notif_failures,
     ):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(
-            count=result_count, query_duration_ms=100
-        )
+        _mock_buckets(mock_query_cls, [result_count])
         self._make_alert(state=initial_state)
 
         _evaluate_single_alert(
@@ -738,7 +713,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_notification_failures_silent_on_success(self, _mock_produce, mock_query_cls, mock_notif_failures):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [50])
         self._make_alert()
 
         _evaluate_single_alert(
@@ -767,7 +742,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_check_errors,
     ):
-        mock_query_cls.return_value.execute.side_effect = Exception("boom")
+        mock_query_cls.return_value.execute_bucketed.side_effect = Exception("boom")
         self._make_alert()
 
         with patch(
@@ -785,7 +760,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_check_errors_counter_silent_on_success(self, _mock_produce, mock_query_cls, mock_check_errors):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         self._make_alert()
 
         _evaluate_single_alert(
@@ -798,7 +773,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_query_uses_checkpoint_as_date_to_when_in_past(self, _mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(window_minutes=5)
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         checkpoint = datetime(2025, 1, 1, 0, 0, 30, tzinfo=UTC)  # 30s behind now
@@ -814,7 +789,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_query_uses_now_when_checkpoint_is_in_future(self, _mock_produce, mock_query_cls):
         # Defensive case: if clocks are skewed so checkpoint > now, don't query the future.
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(window_minutes=5)
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         checkpoint = datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC)  # 60s ahead of now
@@ -829,7 +804,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_query_uses_now_when_checkpoint_is_none(self, _mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(window_minutes=5)
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
@@ -846,7 +821,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         # Quiet partitions pin min(max_observed_timestamp) backwards. If that's older than
         # CHECKPOINT_MAX_STALENESS we must ignore the checkpoint — otherwise a spike of
         # errors on an active partition would never appear in the window.
-        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(window_minutes=5)
         now = datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC)
         stale_checkpoint = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)  # 1 hour behind now
@@ -857,11 +832,40 @@ class TestEvaluateSingleAlert(APIBaseTest):
         assert kwargs["date_to"] == now
         assert kwargs["date_from"] == now - dt.timedelta(minutes=5)
 
+    @parameterized.expand(
+        [
+            # M=1/window=5 covered by `test_query_uses_now_when_checkpoint_is_none` above.
+            ("M=3_window=5", 5, 3, 15),
+            ("M=10_window=5", 5, 10, 50),
+            ("M=3_window=10", 10, 3, 30),
+            ("M=10_window=60_worst_case", 60, 10, 600),
+        ]
+    )
+    @freeze_time("2025-01-01T05:00:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_date_from_scales_with_window_times_evaluation_periods(
+        self, _name, window_minutes, evaluation_periods, expected_range_minutes, _mock_produce, mock_query_cls
+    ):
+        _mock_buckets(mock_query_cls, [0])
+        alert = self._make_alert(
+            window_minutes=window_minutes,
+            evaluation_periods=evaluation_periods,
+            datapoints_to_alarm=1,
+        )
+        now = datetime(2025, 1, 1, 5, 0, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=None)
+
+        kwargs = mock_query_cls.call_args.kwargs
+        assert kwargs["date_to"] == now
+        assert kwargs["date_from"] == now - dt.timedelta(minutes=expected_range_minutes)
+
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_errored_notification_emitted_on_first_error(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = Exception(
+        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         alert = self._make_alert()
@@ -886,7 +890,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_errored_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        mock_query_cls.return_value.execute_bucketed.side_effect = RuntimeError("CH down")
         alert = self._make_alert()
         now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
@@ -910,7 +914,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = Exception(
+        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         # 4 prior failures — one more pushes consecutive_failures to MAX (5) → BROKEN.
@@ -961,7 +965,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_notif_failures,
     ):
-        mock_query_cls.return_value.execute.side_effect = Exception(
+        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         self._make_alert(state=initial_state, consecutive_failures=initial_failures)
@@ -975,3 +979,317 @@ class TestEvaluateSingleAlert(APIBaseTest):
             )
 
         mock_notif_failures.assert_called_once_with(expected_action)
+
+
+class TestDeriveBreachesProperties(unittest.TestCase):
+    """Property-based coverage of `_derive_breaches`.
+
+    The activity's bucket → state-machine seam: takes ASC-ordered CH buckets,
+    applies the threshold predicate, returns a newest-first breach tuple. Pure
+    function so we can exercise the full input space without DB or mocks.
+    """
+
+    @given(
+        bucket_counts=st.lists(st.integers(min_value=0, max_value=10_000), min_size=0, max_size=10),
+        threshold=st.integers(min_value=1, max_value=5_000),
+        operator=st.sampled_from(["above", "below"]),
+    )
+    @settings(max_examples=500, deadline=None)
+    def test_length_preserved_when_no_padding_needed(
+        self, bucket_counts: list[int], threshold: int, operator: str
+    ) -> None:
+        # When evaluation_periods == len(buckets), no pad fires; result length
+        # matches input. Padding behavior covered by a separate property below.
+        buckets = [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=c) for c in bucket_counts]
+        result = _derive_breaches(buckets, threshold, operator, len(buckets))
+        assert len(result) == len(buckets)
+
+    @given(
+        bucket_counts=st.lists(st.integers(min_value=0, max_value=10_000), min_size=1, max_size=10),
+        threshold=st.integers(min_value=1, max_value=5_000),
+        operator=st.sampled_from(["above", "below"]),
+    )
+    @settings(max_examples=500, deadline=None)
+    def test_newest_first_ordering(self, bucket_counts: list[int], threshold: int, operator: str) -> None:
+        # The first element of the returned tuple corresponds to the LAST bucket
+        # in the ASC input — i.e., the newest. State machine reads window
+        # newest-first, so getting this wrong silently flips N-of-M decisions.
+        buckets = [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=c) for c in bucket_counts]
+        result = _derive_breaches(buckets, threshold, operator, len(buckets))
+        newest_breach = buckets[-1].count > threshold if operator == "above" else buckets[-1].count < threshold
+        assert result[0] == newest_breach
+
+    @given(
+        bucket_counts=st.lists(st.integers(min_value=0, max_value=10_000), min_size=1, max_size=10),
+        threshold=st.integers(min_value=1, max_value=5_000),
+        operator=st.sampled_from(["above", "below"]),
+    )
+    @settings(max_examples=500, deadline=None)
+    def test_breach_count_matches_threshold_predicate_when_no_padding(
+        self, bucket_counts: list[int], threshold: int, operator: str
+    ) -> None:
+        # When the bucket list is already M long, no padding fires and the
+        # breach count exactly matches the count of inputs satisfying the
+        # threshold predicate. Catches drop / duplicate bugs.
+        buckets = [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=c) for c in bucket_counts]
+        result = _derive_breaches(buckets, threshold, operator, len(buckets))
+        if operator == "above":
+            expected_count = sum(1 for c in bucket_counts if c > threshold)
+        else:
+            expected_count = sum(1 for c in bucket_counts if c < threshold)
+        assert sum(result) == expected_count
+
+    @given(
+        bucket_counts=st.lists(st.integers(min_value=1, max_value=10_000), min_size=1, max_size=10),
+        threshold=st.integers(min_value=1, max_value=10_000),
+    )
+    @settings(max_examples=300, deadline=None)
+    def test_above_and_below_are_complementary_at_strict_inequality(
+        self, bucket_counts: list[int], threshold: int
+    ) -> None:
+        # `above` = count > threshold; `below` = count < threshold. For any count
+        # ≠ threshold, exactly one of the two is True. Sum of breach counts across
+        # the two operators equals the number of buckets that aren't EQ to threshold.
+        buckets = [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=c) for c in bucket_counts]
+        above = _derive_breaches(buckets, threshold, "above", len(buckets))
+        below = _derive_breaches(buckets, threshold, "below", len(buckets))
+        not_equal = sum(1 for c in bucket_counts if c != threshold)
+        assert sum(above) + sum(below) == not_equal
+
+    @given(
+        bucket_counts=st.lists(st.integers(min_value=0, max_value=10_000), min_size=0, max_size=5),
+        threshold=st.integers(min_value=1, max_value=5_000),
+        m_extra=st.integers(min_value=1, max_value=8),
+    )
+    @settings(max_examples=300, deadline=None)
+    def test_padding_fills_to_evaluation_periods_with_correct_implicit_breach(
+        self, bucket_counts: list[int], threshold: int, m_extra: int
+    ) -> None:
+        # When `evaluation_periods > len(buckets)`, the result is padded to length
+        # M with the implicit count=0 outcome:
+        #   - above: pad = False (0 is not above threshold)
+        #   - below: pad = True (0 is below threshold, given threshold >= 1)
+        # This is the load-bearing fix for `below` alerts on silent services —
+        # without it, an empty bucket list yields no breaches and silence detection
+        # would never fire.
+        m = len(bucket_counts) + m_extra
+        buckets = [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=c) for c in bucket_counts]
+
+        above = _derive_breaches(buckets, threshold, "above", m)
+        below = _derive_breaches(buckets, threshold, "below", m)
+
+        assert len(above) == m
+        assert len(below) == m
+        # The trailing `m_extra` entries are pure padding.
+        assert above[len(buckets) :] == (False,) * m_extra
+        assert below[len(buckets) :] == (True,) * m_extra
+
+
+class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
+    """End-to-end coverage of `_evaluate_single_alert` against real ClickHouse.
+
+    Sibling tests above mock `execute_bucketed` and verify the activity's logic
+    in isolation. This class drives the full hot path — bucketed CH query →
+    activity reverses → state machine → PG state update — against seeded log
+    data, catching seam bugs (ASC/DESC handling, BucketedCount tzinfo, threshold
+    sign) that mocked-bucket tests can't see.
+    """
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_breach_against_real_clickhouse_fires_alert(self, _mock_produce):
+        # Five logs at 10:30 with a unique service. next_check_at=10:33,
+        # window=5, M=1 → activity's query window is [10:28, 10:33), capturing
+        # all five.
+        rows = [
+            {
+                "uuid": f"e2e-{i}",
+                "team_id": self.team.id,
+                "timestamp": "2025-12-16 10:30:00",
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "e2e_eval_test",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i in range(5)
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(
+            filters={"serviceNames": ["e2e_eval_test"]},
+            next_check_at=datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC),
+        )
+        stats = _make_stats()
+
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), stats)
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        assert stats["checked"] == 1
+        assert stats["fired"] == 1
+
+    def _seed_logs(self, service_name: str, timestamps: list[str]) -> None:
+        rows = [
+            {
+                "uuid": f"{service_name}-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": service_name,
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(timestamps)
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "E2E Test Alert",
+            "threshold_count": 2,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "evaluation_periods": 1,
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    @freeze_time("2025-12-16T10:25:00Z")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_n_of_m_progression_across_three_consecutive_evals(self, _mock_produce):
+        # Real-CH version of the N-of-M progression test. M=3 N=2 over 5-min buckets.
+        # Three consecutive evals at next_check_at 10:15, 10:20, 10:25, each
+        # shifting the query window by one bucket. Bucket counts are designed
+        # so the breach pattern progresses NOT_FIRING → FIRING → NOT_FIRING
+        # (resolve).
+        # Bucket counts (above threshold=100):
+        #   :00 = 50  (no breach)
+        #   :05 = 50  (no breach)
+        #   :10 = 200 (breach)
+        #   :15 = 200 (breach)
+        #   :20 = 50  (no breach)
+        # Cycle 1 (next_check_at 10:15): buckets [:00, :05, :10] → 1-of-3 → not_firing
+        # Cycle 2 (next_check_at 10:20): buckets [:05, :10, :15] → 2-of-3 newest=breach → fire
+        # Cycle 3 (next_check_at 10:25): newest bucket = :20 (no breach) → resolve from FIRING
+        bucket_volumes = {
+            "2025-12-16 10:00:30.000000": 50,
+            "2025-12-16 10:05:30.000000": 50,
+            "2025-12-16 10:10:30.000000": 200,
+            "2025-12-16 10:15:30.000000": 200,
+            "2025-12-16 10:20:30.000000": 50,
+        }
+        self._seed_logs(
+            "n_of_m_progression",
+            [ts for ts, count in bucket_volumes.items() for _ in range(count)],
+        )
+
+        alert = self._make_alert(
+            filters={"serviceNames": ["n_of_m_progression"]},
+            threshold_count=100,
+            evaluation_periods=3,
+            datapoints_to_alarm=2,
+            next_check_at=datetime(2025, 12, 16, 10, 15, 0, tzinfo=UTC),
+        )
+
+        # Cycle 1: 1-of-3 breach → stays NOT_FIRING
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 15, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+
+        # Cycle 2: 2-of-3 breach AND newest is a breach → fire
+        alert.next_check_at = datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC)
+        alert.save(update_fields=["next_check_at"])
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+
+        # Cycle 3: newest bucket (:20) is no-breach → resolve (immediate from FIRING)
+        alert.next_check_at = datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC)
+        alert.save(update_fields=["next_check_at"])
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+
+    @freeze_time("2025-12-16T10:25:00Z")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_cooldown_suppresses_resolve_notification_within_window(self, mock_produce):
+        # Alert fires at next_check_at #1, resolve attempted at next_check_at #2
+        # within cooldown_minutes → state transitions to NOT_FIRING but
+        # NotificationAction.RESOLVE is suppressed (no produce call). Tests
+        # cooldown timing across two real CH-backed evals.
+        self._seed_logs(
+            "cooldown_test",
+            ["2025-12-16 10:18:00.000000"] * 10,  # logs only in cycle 1's window
+        )
+
+        alert = self._make_alert(
+            filters={"serviceNames": ["cooldown_test"]},
+            cooldown_minutes=30,  # cooldown longer than the 5-min interval between cycles
+            next_check_at=datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC),
+        )
+
+        # Cycle 1: fires (10 logs at :18 in [10:15, 10:20)) → fire notification, sets last_notified_at
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        assert mock_produce.call_count == 1
+
+        # Cycle 2: no logs in the new window [10:20, 10:25) → resolve attempted,
+        # but cooldown=30min suppresses the dispatch (only 5 min since fire).
+        alert.next_check_at = datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC)
+        alert.save(update_fields=["next_check_at"])
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING  # state still transitions
+        assert mock_produce.call_count == 1  # but no second notification dispatched
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_below_operator_fires_on_truly_silent_service(self, _mock_produce):
+        # Pre-PR behavior: `execute()` always runs, returns count=0 for a silent
+        # service, so `0 < threshold` evaluates True → breach → fires.
+        # Post-PR risk: `execute_bucketed()` returns NO buckets for a silent
+        # service (CH GROUP BY only emits buckets with data). If the activity
+        # treats absent buckets as "no breach", `below` alerts on truly silent
+        # services would silently never fire — exactly the case the [TEST] Web
+        # Service Silent prod alert is built to catch.
+        alert = self._make_alert(
+            filters={"serviceNames": ["truly_silent_service_no_logs"]},
+            threshold_count=1,
+            threshold_operator="below",
+            next_check_at=datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC),
+        )
+
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), _make_stats())
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING, (
+            "below operator on a silent service must fire — count=0 satisfies count<threshold"
+        )
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_first_run_with_null_nca_anchors_on_now(self, _mock_produce):
+        # Alert created with next_check_at=None (first eval after enable). The
+        # activity falls back to `now` as the anchor; the query window is
+        # [now - window*M, now) and breach detection still works.
+        self._seed_logs(
+            "null_nca_test",
+            ["2025-12-16 10:30:00.000000"] * 5,  # logs at :30, captured by [10:28, 10:33)
+        )
+
+        alert = self._make_alert(
+            filters={"serviceNames": ["null_nca_test"]},
+            next_check_at=None,  # first run
+        )
+
+        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), _make_stats())
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        assert alert.next_check_at is not None  # activity advanced it


### PR DESCRIPTION
## Problem

Alert evaluation runs a single ClickHouse count per check and stores the result in a Postgres `LogsAlertEvent` (CHECK kind) row. The N-of-M evaluator reads the last M historical rows back from Postgres on every tick to reconstruct its decision window.

This means:

- Two Postgres round-trips per alert tick (insert the new row, read the last M-1).
- An inline pruning loop on every eval to keep the table bounded.
- Query windows anchored on wall-clock `now`, so scheduler lag varies the window edges across retries - small overlaps/gaps at the boundary.

## Changes

- Single `execute_bucketed` call returns the M-bucket history in one query; N-of-M decision derives directly from the buckets — no Postgres reads.
- `resolve_alert_date_to` now anchors on the alert's `next_check_at` (NCA), not `now`. Two evals at different actual eval times produce the same query.
- `to_snapshot(recent_events_breached=...)` accepts the M-of-N window directly; the historical PG read is preserved as a fallback.
- CHECK rows are written only on state transition or eval error. Steady-state same-state evals don't touch Postgres.
- Inline prune block deleted (no rows to prune on the hot path).

using the good ol' strangler fig method - `get_recent_breaches`, `MAX_EVALUATION_PERIODS`, and the `LogsAlertCheck` shell are no longer used after this PR; a follow-up will remove them once the new path has proven itself.

After this PR, LogsAlertEvent is an audit trail of meaningful events only: state transitions, eval errors, and user-initiated control actions (reset/enable/disable/snooze/threshold_change). Steady-state per-tick OK rows are no longer written.

## How did you test this code?

all tests pass. Activity tests refactored to mock `execute_bucketed` via a new `_mock_buckets` helper.

Prod ClickHouse cost measured against the `Contour Errors` alert (team 2) - ran EXPLAIN on the live pods

|  | Time range | Wall clock | Bytes |
| --- | ---:| ---:| ---:|
| Today's eval (single 5-min count) | 5 min | 1\.297 s | 8\.18 MB |
| Stateless (10 × 5-min buckets) | 50 min | 1\.366 s | 8\.90 MB |

**1\.05× cost for a 10× wider time range.** The PK on `(team_id, service_name, severity_text, timestamp)` prunes ~99.7% of granules upstream; only the downstream timestamp skip scales with the time range, and operates on the already-tiny working set. Worst-case configuration (M=10 × window=60 = 10 hr of data) extrapolates to ~3.7 s - within 3× of baseline.

## Publish to changelog?

no