### PR TITLE
fix(tasks): enforce sandbox environment access

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -72,6 +72,7 @@ from .serializers import (
     TaskRunCreateRequestSchemaSerializer,
     TaskRunCreateRequestSerializer,
     TaskRunDetailSerializer,
+    TaskRunErrorResponseSerializer,
     TaskRunRelayMessageRequestSerializer,
     TaskRunRelayMessageResponseSerializer,
     TaskRunSessionLogsQuerySerializer,
@@ -507,6 +508,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         request_serializer=TaskRunCreateRequestSerializer,
         responses={
             200: OpenApiResponse(response=TaskSerializer, description="Task with updated latest run"),
+            400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid task run payload"),
             404: OpenApiResponse(description="Task not found"),
         },
         summary="Run task",
@@ -521,6 +523,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         pending_user_message = request.validated_data.get("pending_user_message")
         pending_user_artifact_ids = request.validated_data.get("pending_user_artifact_ids") or []
         sandbox_environment_id = request.validated_data.get("sandbox_environment_id")
+        sandbox_environment_id_supplied_by_user = sandbox_environment_id is not None
         pr_authorship_mode = request.validated_data.get("pr_authorship_mode")
         run_source = request.validated_data.get("run_source")
         signal_report_id = request.validated_data.get("signal_report_id")
@@ -615,22 +618,27 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             return Response({"detail": "github_user_token is required for user-authored cloud runs"}, status=400)
 
         if sandbox_environment_id is not None:
-            sandbox_environment = SandboxEnvironment.objects.filter(id=sandbox_environment_id, team=task.team).first()
-            if not sandbox_environment:
-                return Response({"detail": "Invalid sandbox_environment_id"}, status=400)
-
-            extra_state = extra_state or {}
-            extra_state["sandbox_environment_id"] = str(sandbox_environment.id)
-
-            logger.info(
-                "Applying sandbox environment to task run",
-                extra={
-                    "task_id": str(task.id),
-                    "sandbox_environment_id": str(sandbox_environment.id),
-                    "sandbox_environment_name": sandbox_environment.name,
-                    "network_access_level": sandbox_environment.network_access_level,
-                },
+            sandbox_environment = SandboxEnvironment.get_accessible_for_task(
+                environment_id=sandbox_environment_id,
+                team=task.team,
+                task_created_by_id=task.created_by_id,
             )
+            if sandbox_environment is None:
+                if sandbox_environment_id_supplied_by_user:
+                    return Response({"detail": "Invalid sandbox_environment_id"}, status=400)
+            else:
+                extra_state = extra_state or {}
+                extra_state["sandbox_environment_id"] = str(sandbox_environment.id)
+
+                logger.info(
+                    "Applying sandbox environment to task run",
+                    extra={
+                        "task_id": str(task.id),
+                        "sandbox_environment_id": str(sandbox_environment.id),
+                        "sandbox_environment_name": sandbox_environment.name,
+                        "network_access_level": sandbox_environment.network_access_level,
+                    },
+                )
 
         staged_artifacts: list[dict[str, Any]] = []
         if pending_user_artifact_ids:
@@ -757,7 +765,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         request_serializer=TaskRunBootstrapCreateRequestSerializer,
         responses={
             201: OpenApiResponse(response=TaskRunDetailSerializer, description="Created task run"),
-            400: OpenApiResponse(response=ErrorResponseSerializer, description="Invalid task run payload"),
+            400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid task run payload"),
         },
         summary="Create task run",
         description="Create a new run for a specific task without starting execution.",
@@ -823,8 +831,12 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
         if sandbox_environment_id is not None:
-            sandbox_environment = SandboxEnvironment.objects.filter(id=sandbox_environment_id, team=task.team).first()
-            if not sandbox_environment:
+            sandbox_environment = SandboxEnvironment.get_accessible_for_task(
+                environment_id=sandbox_environment_id,
+                team=task.team,
+                task_created_by_id=task.created_by_id,
+            )
+            if sandbox_environment is None:
                 return Response({"detail": "Invalid sandbox_environment_id"}, status=status.HTTP_400_BAD_REQUEST)
 
             extra_state = extra_state or {}

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -620,7 +620,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if sandbox_environment_id is not None:
             sandbox_environment = SandboxEnvironment.get_accessible_for_task(
                 environment_id=sandbox_environment_id,
-                team=task.team,
+                team_id=task.team_id,
                 task_created_by_id=task.created_by_id,
             )
             if sandbox_environment is None:
@@ -833,7 +833,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if sandbox_environment_id is not None:
             sandbox_environment = SandboxEnvironment.get_accessible_for_task(
                 environment_id=sandbox_environment_id,
-                team=task.team,
+                team_id=task.team_id,
                 task_created_by_id=task.created_by_id,
             )
             if sandbox_environment is None:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -281,10 +281,13 @@ class Task(DeletedMetaFields, models.Model):
             if not github_integration and not is_public_sandbox_repo(repository):
                 raise ValueError(f"Team {team.id} does not have a GitHub integration")
 
-        sandbox_env = None
         if sandbox_environment_id is not None:
-            sandbox_env = SandboxEnvironment.objects.filter(id=sandbox_environment_id, team=team).first()
-            if not sandbox_env:
+            sandbox_env = SandboxEnvironment.get_accessible_for_task(
+                environment_id=sandbox_environment_id,
+                team=team,
+                task_created_by_id=user_id,
+            )
+            if sandbox_env is None:
                 raise ValueError(f"Invalid sandbox_environment_id: {sandbox_environment_id}")
 
         task = Task.objects.create(
@@ -521,14 +524,11 @@ class TaskRun(models.Model):
         env_id = (self.state or {}).get("sandbox_environment_id")
         if not env_id:
             return None
-        env = SandboxEnvironment.objects.filter(id=env_id, team_id=self.team_id).first()
-        if not env:
-            return None
-        if env.private:
-            task_user_id = self.task.created_by_id
-            if not task_user_id or env.created_by_id != task_user_id:
-                return None
-        return env
+        return SandboxEnvironment.get_accessible_for_task(
+            environment_id=env_id,
+            team=self.team,
+            task_created_by_id=self.task.created_by_id,
+        )
 
     def prepare_for_cloud_handoff(self) -> None:
         """
@@ -1035,6 +1035,29 @@ class SandboxEnvironment(UUIDModel):
         indexes = [
             models.Index(fields=["team", "created_by"]),
         ]
+
+    def is_accessible_for_task_creator(self, task_created_by_id: int | None) -> bool:
+        if not self.private:
+            return True
+        return task_created_by_id is not None and self.created_by_id == task_created_by_id
+
+    @classmethod
+    def get_accessible_for_task(
+        cls,
+        *,
+        environment_id: str | uuid.UUID,
+        team: Team,
+        task_created_by_id: int | None,
+    ) -> Optional["SandboxEnvironment"]:
+        try:
+            environment = cls.objects.filter(id=environment_id, team=team).first()
+        except (ValidationError, ValueError):
+            return None
+        if environment is None:
+            return None
+        if not environment.is_accessible_for_task_creator(task_created_by_id):
+            return None
+        return environment
 
     def __str__(self):
         return self.name

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -281,6 +281,7 @@ class Task(DeletedMetaFields, models.Model):
             if not github_integration and not is_public_sandbox_repo(repository):
                 raise ValueError(f"Team {team.id} does not have a GitHub integration")
 
+        sandbox_env = None
         if sandbox_environment_id is not None:
             sandbox_env = SandboxEnvironment.get_accessible_for_task(
                 environment_id=sandbox_environment_id,

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -284,7 +284,7 @@ class Task(DeletedMetaFields, models.Model):
         if sandbox_environment_id is not None:
             sandbox_env = SandboxEnvironment.get_accessible_for_task(
                 environment_id=sandbox_environment_id,
-                team=team,
+                team_id=team.id,
                 task_created_by_id=user_id,
             )
             if sandbox_env is None:
@@ -526,7 +526,7 @@ class TaskRun(models.Model):
             return None
         return SandboxEnvironment.get_accessible_for_task(
             environment_id=env_id,
-            team=self.team,
+            team_id=self.team_id,
             task_created_by_id=self.task.created_by_id,
         )
 
@@ -1046,11 +1046,11 @@ class SandboxEnvironment(UUIDModel):
         cls,
         *,
         environment_id: str | uuid.UUID,
-        team: Team,
+        team_id: int,
         task_created_by_id: int | None,
     ) -> Optional["SandboxEnvironment"]:
         try:
-            environment = cls.objects.filter(id=environment_id, team=team).first()
+            environment = cls.objects.filter(id=environment_id, team_id=team_id).first()
         except (ValidationError, ValueError):
             return None
         if environment is None:

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -423,6 +423,19 @@ class ErrorResponseSerializer(serializers.Serializer):
     error = serializers.CharField(help_text="Error message")
 
 
+class TaskRunErrorResponseSerializer(serializers.Serializer):
+    detail = serializers.CharField(required=False, help_text="Human-readable validation error")
+    error = serializers.CharField(required=False, help_text="Human-readable error message")
+    type = serializers.CharField(required=False, help_text="Machine-readable error type")
+    code = serializers.CharField(required=False, help_text="Machine-readable error code")
+    attr = serializers.CharField(required=False, help_text="Request field associated with the error")
+    missing_artifact_ids = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Artifact ids that could not be resolved for the run",
+    )
+
+
 class AgentListResponseSerializer(serializers.Serializer):
     results = AgentDefinitionSerializer(many=True, help_text="Array of available agent definitions")
 

--- a/products/tasks/backend/temporal/conftest.py
+++ b/products/tasks/backend/temporal/conftest.py
@@ -152,6 +152,7 @@ def task_context(test_task, test_task_run) -> TaskProcessingContext:
         github_integration_id=test_task.github_integration_id,
         repository=test_task.repository,
         distinct_id=test_task.created_by.distinct_id or "test-distinct-id",
+        task_created_by_id=test_task.created_by_id,
     )
 
 

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -8,7 +8,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.models import SandboxEnvironment, SandboxSnapshot, Task, TaskRun
+from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
 from products.tasks.backend.services.sandbox import (
     Sandbox,
@@ -172,9 +172,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
 
         sandbox_environment = None
         if ctx.sandbox_environment_id:
-            sandbox_environment = SandboxEnvironment.objects.filter(
-                id=ctx.sandbox_environment_id, team=task.team
-            ).first()
+            sandbox_environment = ctx.get_sandbox_environment()
             if sandbox_environment and sandbox_environment.environment_variables:
                 skipped_keys: list[str] = []
                 added_keys = 0

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -8,7 +8,7 @@ from temporalio import activity
 from posthog.models import Team
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.models import SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.temporal.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.temporal.observability import emit_agent_log, log_with_activity_context
 from products.tasks.backend.temporal.process_task.utils import format_allowed_domains_for_log
@@ -35,6 +35,7 @@ class TaskProcessingContext:
     github_integration_id: int | None
     repository: str | None
     distinct_id: str
+    task_created_by_id: int | None = None
     create_pr: bool = True
     pr_loop_enabled: bool = False
     state: dict | None = None
@@ -78,14 +79,15 @@ class TaskProcessingContext:
         return value if isinstance(value, str) else None
 
     def get_sandbox_environment(self):
-        """Resolve the SandboxEnvironment, team-scoped via the TaskRun model."""
-        from products.tasks.backend.models import TaskRun
-
-        try:
-            task_run = TaskRun.objects.select_related("task").get(id=self.run_id)
-            return task_run.get_sandbox_environment()
-        except TaskRun.DoesNotExist:
+        """Resolve the SandboxEnvironment, team-scoped and respecting privacy."""
+        sandbox_environment_id = self.sandbox_environment_id
+        if not sandbox_environment_id:
             return None
+        return SandboxEnvironment.get_accessible_for_task(
+            environment_id=sandbox_environment_id,
+            team_id=self.team_id,
+            task_created_by_id=self.task_created_by_id,
+        )
 
     @property
     def branch(self) -> str | None:
@@ -200,6 +202,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         github_integration_id=task.github_integration_id,
         repository=task.repository,
         distinct_id=distinct_id,
+        task_created_by_id=task.created_by_id,
         create_pr=input.create_pr,
         pr_loop_enabled=pr_loop_enabled,
         state=state,

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -8,7 +8,7 @@ from temporalio import activity
 from posthog.models import Team
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.models import SandboxEnvironment, Task, TaskRun
+from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.temporal.observability import emit_agent_log, log_with_activity_context
 from products.tasks.backend.temporal.process_task.utils import format_allowed_domains_for_log
@@ -145,12 +145,14 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
     allowed_domains: list[str] | None = None
 
     if sandbox_environment_id:
-        sandbox_environment = SandboxEnvironment.objects.filter(id=sandbox_environment_id, team=task.team).first()
+        sandbox_environment = task_run.get_sandbox_environment()
         if sandbox_environment is None:
             raise TaskInvalidStateError(
-                f"Sandbox environment {sandbox_environment_id} not found for team {task.team_id}",
+                f"Sandbox environment {sandbox_environment_id} not accessible for team {task.team_id}",
                 {"sandbox_environment_id": sandbox_environment_id, "team_id": task.team_id},
-                cause=RuntimeError(f"Sandbox environment {sandbox_environment_id} does not exist"),
+                cause=RuntimeError(
+                    f"Sandbox environment {sandbox_environment_id} does not exist or is not accessible to the task creator"
+                ),
             )
         else:
             sandbox_environment_name = sandbox_environment.name

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -8,7 +8,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.models import SandboxEnvironment, SandboxSnapshot, Task, TaskRun
+from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.services.agentsh import ENV_FILE
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
 from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
@@ -146,7 +146,7 @@ def _build_environment_variables(
 
     sandbox_environment = None
     if ctx.sandbox_environment_id:
-        sandbox_environment = SandboxEnvironment.objects.filter(id=ctx.sandbox_environment_id, team=task.team).first()
+        sandbox_environment = ctx.get_sandbox_environment()
         if sandbox_environment and sandbox_environment.environment_variables:
             skipped_keys: list[str] = []
             added_keys = 0

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_sandbox_for_repository.py
@@ -29,6 +29,7 @@ class TestGetSandboxForRepositoryActivity:
             github_integration_id=github_integration.id,
             repository=test_task.repository,
             distinct_id=test_task.created_by.distinct_id or "test-user-id",
+            task_created_by_id=test_task.created_by_id,
         )
 
     @pytest.mark.django_db

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -5,8 +5,10 @@ from django.core.exceptions import ValidationError
 
 from asgiref.sync import async_to_sync
 
+from posthog.models import OrganizationMembership, User
+
 from products.tasks.backend.models import SandboxEnvironment, Task
-from products.tasks.backend.temporal.exceptions import TaskNotFoundError
+from products.tasks.backend.temporal.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
@@ -105,6 +107,33 @@ class TestGetTaskProcessingContextActivity:
         assert result.sandbox_environment_id == str(sandbox_environment.id)
         assert result.sandbox_environment_name == "Restricted env"
         assert result.allowed_domains == ["example.com"]
+
+    @pytest.mark.django_db
+    def test_get_task_processing_context_rejects_other_users_private_sandbox_environment(
+        self, activity_environment, test_task
+    ):
+        other_user = User.objects.create_user(
+            email="victim@example.com",
+            first_name="Victim",
+            password="password",
+        )
+        OrganizationMembership.objects.create(
+            user=other_user,
+            organization_id=test_task.team.organization_id,
+        )
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=test_task.team,
+            created_by=other_user,
+            name="Victim's private env",
+            private=True,
+            environment_variables={"SECRET_KEY": "secret_value"},
+        )
+        task_run = test_task.create_run(extra_state={"sandbox_environment_id": str(sandbox_environment.id)})
+
+        input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
+
+        with pytest.raises(TaskInvalidStateError):
+            async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_inject_fresh_tokens_on_resume.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_inject_fresh_tokens_on_resume.py
@@ -3,10 +3,14 @@ from unittest.mock import MagicMock, patch
 
 from asgiref.sync import async_to_sync
 
+from posthog.models import OrganizationMembership, User
+
+from products.tasks.backend.models import SandboxEnvironment
 from products.tasks.backend.services.agentsh import ENV_FILE
 from products.tasks.backend.services.sandbox import ExecutionResult
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
     InjectFreshTokensOnResumeInput,
+    _build_environment_variables,
     inject_fresh_tokens_on_resume,
 )
 
@@ -131,3 +135,47 @@ class TestInjectFreshTokensOnResumeActivity:
             )
 
         assert sandbox.write_file.call_count == 1
+
+    def test_build_environment_variables_ignores_other_users_private_sandbox_environment(
+        self, task_context, test_task, test_task_run
+    ):
+        other_user = User.objects.create_user(
+            email="victim@example.com",
+            first_name="Victim",
+            password="password",
+        )
+        OrganizationMembership.objects.create(
+            user=other_user,
+            organization_id=test_task.team.organization_id,
+        )
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=test_task.team,
+            created_by=other_user,
+            name="Victim's private env",
+            private=True,
+            environment_variables={"SECRET_KEY": "secret_value"},
+        )
+        state = {"sandbox_environment_id": str(sandbox_environment.id)}
+        test_task_run.state = state
+        test_task_run.save(update_fields=["state"])
+        task_context.state = state
+
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.provision_sandbox.get_sandbox_api_url",
+                return_value="https://sandbox.example.com",
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.provision_sandbox.get_sandbox_jwt_public_key",
+                return_value="jwt-public-key",
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.provision_sandbox.get_git_identity_env_vars",
+                return_value={},
+            ),
+        ):
+            environment_variables = _build_environment_variables(task_context, test_task, "", "oauth_new")
+
+        assert environment_variables["POSTHOG_PERSONAL_API_KEY"] == "oauth_new"
+        assert environment_variables["POSTHOG_API_URL"] == "https://sandbox.example.com"
+        assert "SECRET_KEY" not in environment_variables

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -135,6 +135,15 @@ class BaseTaskAPITest(TestCase):
             origin_product=Task.OriginProduct.USER_CREATED,
         )
 
+    def create_organization_user(self, email_prefix: str = "other") -> User:
+        user = User.objects.create_user(
+            email=f"{email_prefix}-{uuid.uuid4()}@example.com",
+            first_name="Other",
+            password="password",
+        )
+        self.organization.members.add(user)
+        return user
+
     def create_automation(
         self,
         name="Daily PRs",
@@ -361,7 +370,13 @@ class TestTaskAPI(BaseTaskAPITest):
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_persists_sandbox_environment_id(self, mock_workflow):
-        task = self.create_task()
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Test Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
         sandbox_environment = SandboxEnvironment.objects.create(
             team=self.team,
             created_by=self.user,
@@ -380,6 +395,71 @@ class TestTaskAPI(BaseTaskAPITest):
         run_id = response.json()["latest_run"]["id"]
         task_run = TaskRun.objects.get(id=run_id)
         self.assertEqual(task_run.state["sandbox_environment_id"], str(sandbox_environment.id))
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_other_users_private_sandbox_environment(self, mock_workflow):
+        other_user = self.create_organization_user("victim")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Test Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=other_user,
+            name="Victim's private env",
+            private=True,
+            environment_variables={"SECRET_KEY": "secret_value"},
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"sandbox_environment_id": str(sandbox_environment.id)},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Invalid sandbox_environment_id")
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_drops_inaccessible_inherited_sandbox_environment_id(self, mock_workflow):
+        other_user = self.create_organization_user("victim")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Test Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=other_user,
+            name="Victim's private env",
+            private=True,
+            environment_variables={"SECRET_KEY": "secret_value"},
+        )
+        previous_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"sandbox_environment_id": str(sandbox_environment.id)},
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"resume_from_run_id": str(previous_run.id)},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        self.assertEqual(run.state["resume_from_run_id"], str(previous_run.id))
+        self.assertNotIn("sandbox_environment_id", run.state)
         mock_workflow.assert_called_once()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
@@ -526,6 +606,38 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(task_run.state["reasoning_effort"], "high")
         self.assertEqual(task_run.state["initial_permission_mode"], "auto")
         self.assertEqual(task_run.state["run_source"], "manual")
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_create_run_endpoint_rejects_other_users_private_sandbox_environment(self, mock_workflow):
+        other_user = self.create_organization_user("victim")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Test Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=other_user,
+            name="Victim's private env",
+            private=True,
+            environment_variables={"SECRET_KEY": "secret_value"},
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {
+                "environment": "cloud",
+                "sandbox_environment_id": str(sandbox_environment.id),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Invalid sandbox_environment_id")
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
@@ -4917,6 +5029,7 @@ class TestSandboxEnvironmentAPI(BaseTaskAPITest):
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_run_task_stores_sandbox_environment_id_in_state(self, mock_workflow):
         task = self.create_task()
+        task.created_by = self.user
         task.repository = "org/repo"
         task.github_integration = Integration.objects.create(team=self.team, kind="github")
         task.save()

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -127,9 +127,10 @@ class BaseTaskAPITest(TestCase):
 
         self.mock_feature_flag.side_effect = check_flag
 
-    def create_task(self, title="Test Task"):
+    def create_task(self, title="Test Task", created_by: User | None = None):
         return Task.objects.create(
             team=self.team,
+            created_by=created_by,
             title=title,
             description="Test Description",
             origin_product=Task.OriginProduct.USER_CREATED,
@@ -370,13 +371,7 @@ class TestTaskAPI(BaseTaskAPITest):
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_persists_sandbox_environment_id(self, mock_workflow):
-        task = Task.objects.create(
-            team=self.team,
-            created_by=self.user,
-            title="Test Task",
-            description="Test Description",
-            origin_product=Task.OriginProduct.USER_CREATED,
-        )
+        task = self.create_task(created_by=self.user)
         sandbox_environment = SandboxEnvironment.objects.create(
             team=self.team,
             created_by=self.user,
@@ -397,16 +392,22 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(task_run.state["sandbox_environment_id"], str(sandbox_environment.id))
         mock_workflow.assert_called_once()
 
+    @parameterized.expand(
+        [
+            ("run_endpoint", "run", {"sandbox_environment_id": "{sandbox_environment_id}"}),
+            (
+                "create_run_endpoint",
+                "runs",
+                {"environment": "cloud", "sandbox_environment_id": "{sandbox_environment_id}"},
+            ),
+        ]
+    )
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_rejects_other_users_private_sandbox_environment(self, mock_workflow):
+    def test_run_endpoints_reject_other_users_private_sandbox_environment(
+        self, _name, endpoint, payload_template, mock_workflow
+    ):
         other_user = self.create_organization_user("victim")
-        task = Task.objects.create(
-            team=self.team,
-            created_by=self.user,
-            title="Test Task",
-            description="Test Description",
-            origin_product=Task.OriginProduct.USER_CREATED,
-        )
+        task = self.create_task(created_by=self.user)
         sandbox_environment = SandboxEnvironment.objects.create(
             team=self.team,
             created_by=other_user,
@@ -414,10 +415,14 @@ class TestTaskAPI(BaseTaskAPITest):
             private=True,
             environment_variables={"SECRET_KEY": "secret_value"},
         )
+        payload = {
+            key: str(sandbox_environment.id) if value == "{sandbox_environment_id}" else value
+            for key, value in payload_template.items()
+        }
 
         response = self.client.post(
-            f"/api/projects/@current/tasks/{task.id}/run/",
-            {"sandbox_environment_id": str(sandbox_environment.id)},
+            f"/api/projects/@current/tasks/{task.id}/{endpoint}/",
+            payload,
             format="json",
         )
 
@@ -429,13 +434,7 @@ class TestTaskAPI(BaseTaskAPITest):
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_drops_inaccessible_inherited_sandbox_environment_id(self, mock_workflow):
         other_user = self.create_organization_user("victim")
-        task = Task.objects.create(
-            team=self.team,
-            created_by=self.user,
-            title="Test Task",
-            description="Test Description",
-            origin_product=Task.OriginProduct.USER_CREATED,
-        )
+        task = self.create_task(created_by=self.user)
         sandbox_environment = SandboxEnvironment.objects.create(
             team=self.team,
             created_by=other_user,
@@ -606,38 +605,6 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(task_run.state["reasoning_effort"], "high")
         self.assertEqual(task_run.state["initial_permission_mode"], "auto")
         self.assertEqual(task_run.state["run_source"], "manual")
-        mock_workflow.assert_not_called()
-
-    @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_create_run_endpoint_rejects_other_users_private_sandbox_environment(self, mock_workflow):
-        other_user = self.create_organization_user("victim")
-        task = Task.objects.create(
-            team=self.team,
-            created_by=self.user,
-            title="Test Task",
-            description="Test Description",
-            origin_product=Task.OriginProduct.USER_CREATED,
-        )
-        sandbox_environment = SandboxEnvironment.objects.create(
-            team=self.team,
-            created_by=other_user,
-            name="Victim's private env",
-            private=True,
-            environment_variables={"SECRET_KEY": "secret_value"},
-        )
-
-        response = self.client.post(
-            f"/api/projects/@current/tasks/{task.id}/runs/",
-            {
-                "environment": "cloud",
-                "sandbox_environment_id": str(sandbox_environment.id),
-            },
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json()["detail"], "Invalid sandbox_environment_id")
-        self.assertFalse(TaskRun.objects.filter(task=task).exists())
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -1337,6 +1337,10 @@ class TestTaskRunGetSandboxEnvironment(TestCase):
         run = self._create_run(uuid.uuid4())
         self.assertIsNone(run.get_sandbox_environment())
 
+    def test_returns_none_for_malformed_environment_id(self):
+        run = self._create_run("not-a-uuid")
+        self.assertIsNone(run.get_sandbox_environment())
+
 
 class TestCodeInvite(TestCase):
     def test_auto_generates_code_on_save(self):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -577,6 +577,21 @@ export type TaskRunCreateRequestSchemaApi =
     | CodexTaskRunCreateSchemaApi
     | TaskRunResumeRequestSchemaApi
 
+export interface TaskRunErrorResponseApi {
+    /** Human-readable validation error */
+    detail?: string
+    /** Human-readable error message */
+    error?: string
+    /** Machine-readable error type */
+    type?: string
+    /** Machine-readable error code */
+    code?: string
+    /** Request field associated with the error */
+    attr?: string
+    /** Artifact ids that could not be resolved for the run */
+    missing_artifact_ids?: string[]
+}
+
 /**
  * * `plan` - plan
  * `context` - context

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -35951,6 +35951,21 @@ export namespace Schemas {
 
     export type TaskRunCreateRequestSchema = ClaudeTaskRunCreateSchema | CodexTaskRunCreateSchema | TaskRunResumeRequestSchema;
 
+    export interface TaskRunErrorResponse {
+      /** Human-readable validation error */
+      detail?: string;
+      /** Human-readable error message */
+      error?: string;
+      /** Machine-readable error type */
+      type?: string;
+      /** Machine-readable error code */
+      code?: string;
+      /** Request field associated with the error */
+      attr?: string;
+      /** Artifact ids that could not be resolved for the run */
+      missing_artifact_ids?: string[];
+    }
+
     export interface TaskRunRelayMessageRequest {
       /** @maxLength 10000 */
       text: string;


### PR DESCRIPTION
## Problem

private sandbox environments should only be usable by the task creator who owns them. Task run creation paths accepted a sandbox environment id as long as it belonged to the same team, which made the access check inconsistent with the model-level resolver.
let's enforce ownership.

## Changes

- added resolver that enforces team ownership and private environment creator ownership.
- added regression coverage 
