### PR TITLE
feat(taxonomy): add $element_viewed event

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2906,6 +2906,11 @@
             "description": "A user has clicked on something that is probably not clickable.",
             "label": "Dead click"
         },
+        "$element_viewed": {
+            "description": "When an element wrapped in `<PostHogCaptureOnViewed>` becomes visible in the viewport.",
+            "ignored_in_assistant": true,
+            "label": "Element viewed"
+        },
         "$exception": {
             "description": "An unexpected error or unhandled exception in your application.",
             "label": "Exception"

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_suggested_questions_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_suggested_questions_query_runner.ambr
@@ -4,7 +4,7 @@
   SELECT events.event AS event,
          count() AS count
   FROM events
-  WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$element_viewed', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
   GROUP BY events.event
   ORDER BY count DESC, events.event ASC
   LIMIT 501

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
@@ -4,7 +4,7 @@
   SELECT events.event AS event,
          count() AS count
   FROM events
-  WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, minus(now64(6, 'UTC'), toIntervalDay(30))), notIn(events.event, ['$pageleave', '$autocapture', '$$heatmap', '$copy_autocapture', '$set', '$opt_in', '$feature_flag_called', '$feature_view', '$feature_interaction', '$element_viewed', '$capture_metrics', '$create_alias', '$merge_dangerously', '$groupidentify']))
   GROUP BY events.event
   ORDER BY count DESC, events.event ASC
   LIMIT 501

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -172,6 +172,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "When a user interacts with a feature.",
             "ignored_in_assistant": True,  # Specific to posthog-js/react, niche
         },
+        "$element_viewed": {
+            "label": "Element viewed",
+            "description": "When an element wrapped in `<PostHogCaptureOnViewed>` becomes visible in the viewport.",
+            "ignored_in_assistant": True,  # Specific to posthog-js/react, niche
+        },
         "$feature_enrollment_update": {
             "label": "Feature enrollment",
             "description": "When a user enrolls with a feature.",


### PR DESCRIPTION
## Problem

`@posthog/react` v1.9.0 emits `$element_viewed` from its `<PostHogCaptureOnViewed>` component when a wrapped element scrolls into view. The event has no entry in `posthog/taxonomy/taxonomy.py`, so the PostHog UI displays it as a raw event name with no label or description in places like the TaxonomicFilter and insight builders. The sibling React-only events (`$feature_view`, `$feature_interaction`) already have taxonomy entries — this brings parity.

## Changes

- Add `$element_viewed` to the `events` dict in `posthog/taxonomy/taxonomy.py` next to the existing posthog-react events, marked `ignored_in_assistant: True` to mirror them.
- Regenerate `frontend/src/taxonomy/core-filter-definitions-by-group.json` via `pnpm run taxonomy:build`.

## How did you test this code?

I'm an agent. Automated tests run:

- `hogli test posthog/taxonomy/` — 4 passed.
- Confirmed `pnpm run taxonomy:build` produced a clean JSON diff containing only the new entry.

No manual UI verification.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Investigated which `$`-prefixed events `@posthog/react` actually emits by reading the installed package's compiled output, cross-referenced against `posthog/taxonomy/taxonomy.py`, and found `$element_viewed` was the only one missing. Human review required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*