### PR TITLE
chore(ai): teach exploring-autocapture-events skill the canonical $autocapture properties

### DIFF
--- a/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
+++ b/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
@@ -124,7 +124,9 @@ Each step in a `FunnelsQuery` / `TrendsQuery` is an `EventsNode` (or `ActionsNod
 
 Two distinct property `type` values matter — they are not interchangeable:
 
-- **`type: "element"`** — keys: `selector`, `tag_name`, `text`, `href`. Matched against the parsed `elements_chain`. `selector` only supports the `exact` operator; the others also accept `is_set`, `is_not_set`, and `icontains`.
+- **`type: "element"`** — keys: `selector`, `tag_name`, `text`, `href`. Matched against the parsed `elements_chain`. Operator support is split:
+  - `selector` and `tag_name` only support `exact` and `is_not` — anything else raises `NotImplementedError` in the query compiler (`posthog/hogql/property.py`).
+  - `text` and `href` accept the full string operator set (`exact`, `is_not`, `icontains`, `not_icontains`, `regex`, `not_regex`, `is_set`, `is_not_set`).
 - **`type: "event"`** — keys: any of the canonical autocapture properties (`$event_type`, `$el_text`, `$current_url`) or anything else on the event. Standard event-property operators (`exact`, `icontains`, `regex`, etc.).
 
 Example funnel from clicking one button to clicking another:

--- a/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
+++ b/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Guides exploration of $autocapture events captured by posthog-js to understand user interactions,
   find CSS selectors (especially data-attr attributes), evaluate selector uniqueness, query matching
   clicks ad-hoc, and create actions. Use when the user asks about autocapture data, wants to find
-  what users are clicking, needs to build actions from click events, or asks about elements_chain.
-  Only applies to projects using posthog-js autocapture.
+  what users are clicking, needs to build actions from click events, asks about elements_chain,
+  wants to build a trend or funnel filtered by clicks or other autocapture interactions, asks which
+  properties autocapture sends, or asks how to filter $autocapture events. Only applies to projects
+  using posthog-js autocapture.
 ---
 
 # Exploring autocapture events
@@ -30,6 +32,20 @@ The `events` table provides fast access to common element fields without parsing
 | `elements_chain_elements` | Array(String) | Useful tag names: a, button, input, select, textarea, label                                            |
 
 Use materialized columns for exploration queries whenever possible — they avoid regex parsing.
+
+## Canonical autocapture properties
+
+Every `$autocapture` event from posthog-js ships with a fixed set of properties.
+Do not query the schema to "look them up" — they are these:
+
+| Property          | Examples                          | Notes                                                       |
+| ----------------- | --------------------------------- | ----------------------------------------------------------- |
+| `$event_type`     | `click`, `submit`, `change`       | the kind of interaction                                     |
+| `$el_text`        | `Sign up`, `Submit`               | text of the clicked element                                 |
+| `$current_url`    | `https://app.example.com/pricing` | page the interaction happened on                            |
+| `$elements_chain` | semicolon-separated chain         | parsed via the `elements_chain*` materialized columns above |
+
+Standard event properties (`$browser`, `$os`, `$device_type`, etc.) are also present.
 
 ## Workflow
 
@@ -101,7 +117,58 @@ If the selector alone is not unique enough, layer on additional filters:
 Re-run the uniqueness check after each refinement.
 Only include filters that are needed — fewer filters means more resilience to minor DOM changes.
 
-### 6. Use in ad-hoc queries
+### 6. Filter autocapture inside an insight query
+
+When the user wants a funnel, trend, or other insight, the filter shape is different from HogQL.
+Each step in a `FunnelsQuery` / `TrendsQuery` is an `EventsNode` (or `ActionsNode`) with `event: "$autocapture"` and a `properties` array.
+
+Two distinct property `type` values matter — they are not interchangeable:
+
+- **`type: "element"`** — keys: `selector`, `tag_name`, `text`, `href`. Matched against the parsed `elements_chain`. `selector` only supports the `exact` operator; the others also accept `is_set`, `is_not_set`, and `icontains`.
+- **`type: "event"`** — keys: any of the canonical autocapture properties (`$event_type`, `$el_text`, `$current_url`) or anything else on the event. Standard event-property operators (`exact`, `icontains`, `regex`, etc.).
+
+Example funnel from clicking one button to clicking another:
+
+```json
+{
+  "kind": "FunnelsQuery",
+  "series": [
+    {
+      "kind": "EventsNode",
+      "event": "$autocapture",
+      "properties": [
+        {
+          "type": "element",
+          "key": "selector",
+          "value": ["[data-attr=\"autocapture-series-save-as-action-banner-shown\"]"],
+          "operator": "exact"
+        }
+      ]
+    },
+    {
+      "kind": "EventsNode",
+      "event": "$autocapture",
+      "properties": [
+        {
+          "type": "element",
+          "key": "selector",
+          "value": ["[data-attr=\"autocapture-save-as-action\"]"],
+          "operator": "exact"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Two things easy to get wrong:
+
+- `value` is an array even when matching a single selector
+- The selector string includes the `[data-attr="..."]` wrapper — it is a CSS selector, not a bare attribute value
+
+Decision rule: prefer an action (`ActionsNode` referencing an existing action — see Step 8) when the interaction will be referenced more than once; inline `type: "element"` / `type: "event"` filters when it's a one-off insight; raw HogQL (Step 7) when joining across events or doing custom aggregations.
+
+### 7. Use in ad-hoc queries
 
 The discovered selector can be used directly in HogQL without creating an action.
 
@@ -152,7 +219,7 @@ FROM (
 
 For recurring analysis, prefer creating an action (next step) or using `posthog:query-trends` / `posthog:query-funnel` with the action.
 
-### 7. Create an action
+### 8. Create an action
 
 Actions are the durable version of ad-hoc selector queries.
 Once the criteria uniquely identify the interaction, create an action using `posthog:action-create`.
@@ -198,5 +265,4 @@ WHERE matchesAction('Clicked checkout button')
 - Use `LIMIT` generously when sampling `elements_chain` — the strings can be long
 - The `elements_chain =~` operator matches CSS selectors as regex internally;
   prefer materialized columns when possible for performance
-- `$autocapture` events also carry standard properties like `$current_url`, `$browser`, `$os`
 - This workflow only applies to posthog-js — other SDKs do not capture elements


### PR DESCRIPTION
## Problem

When a user asked posthog-ai "funnel from data-attr autocapture-series-save-as-action-banner-shown to data-attr autocapture-save-as-action using autocapture events", the agent committed to "I'll look up the autocapture event properties to confirm the right property name for data-attr filtering", called `read_taxonomy`, hit `ClickHouseQueryMemoryLimitExceeded`, and burned 232s + $0.24 across four models trying to recover. `$autocapture` ships with a small fixed set of properties — looking them up at runtime is wasted work and, in this case, fails outright on a high-volume event.

The existing `exploring-autocapture-events` skill never named those properties (it jumps straight into `elements_chain*` materialized columns) and didn't trigger on funnel/trend creation phrasing.

## Changes

Three edits to `products/product_analytics/skills/exploring-autocapture-events/SKILL.md`:

- **Frontmatter description** broadened so the skill triggers on "build a trend or funnel filtered by clicks", "which properties does autocapture send", and "how to filter `$autocapture`".
- **New "Canonical autocapture properties" section** (cheat sheet) names `$event_type`, `$el_text`, `$current_url`, `$elements_chain` with examples and an explicit "Do not query the schema to look them up".
- **New step 6 "Filter autocapture inside an insight query"** distinguishes `type: "element"` (selector / tag_name / text / href; `selector` is exact-only) from `type: "event"` (the canonical props; standard operators), with a verbatim `FunnelsQuery` JSON taken from the failing user's intended output. Calls out the easy-to-miss bits — `value` is an array, the selector string wraps `[data-attr="..."]`. Existing HogQL workflow renumbered to step 7 and action creation to step 8. Also drops a now-redundant `$current_url` tip from the Tips section.

## How did you test this code?

I'm an agent. No automated tests exist for skill content. Verification I actually performed:

- Re-read the file end-to-end after edits; frontmatter description stays under the 1024-char limit and the file is 269 lines (well under the 500-line skill cap).
- Cross-checked the canonical-properties cheat sheet against `posthog/taxonomy/taxonomy.py` (`$event_type` lines 842–846, `$el_text` lines 1051–1055).
- Cross-checked the JSON example by URL-decoding a real `FunnelsQuery` URL the user provided from `us.posthog.com/project/2`; the `series[].properties[]` shape (`type: "element"`, `key: "selector"`, `value` as array, `operator: "exact"`) matches.

## Publish to changelog?

no

## 🤖 Agent context

- Authored end-to-end by PostHog Code agent (Opus 4.7); human in the loop for direction and approval.
- Triggering session: posthog-ai chat `2c2ed72c-7518-4ad4-85aa-8dc3c8ab923e` -> trace `96548f37-cc2e-45b1-a370-32f0850dee0b` (LangGraph, product_analytics mode). Trace shows 25+ pipeline steps carrying the "I'll look up..." commitment, then a `read_taxonomy` failure with `ClickHouseQueryMemoryLimitExceeded`.
- Key decisions:
  - Extend the existing skill rather than create a sibling one (user choice).
  - Cover both insight query nodes and HogQL surfaces equally (user choice).
  - Use the user-supplied real `FunnelsQuery` URL as the verbatim JSON example, including its quirks (array-typed `value`, full CSS selector wrapper).
- Scope intentionally excludes the underlying `read_taxonomy` OOM on `$autocapture` — that is a separate tool-level bug. This change only ensures the agent does not need to call `read_taxonomy` for autocapture in the first place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*