### PR TITLE
chore(frontend): report top chunks after PostHog App build

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -288,6 +288,48 @@ function getChunks(result) {
     return chunks
 }
 
+function formatMegabytes(bytes) {
+    return `${(bytes / 1_000_000).toFixed(2)} MB`
+}
+
+function shortenInputPath(inputPath) {
+    const pnpmMatch = inputPath.match(/node_modules\/\.pnpm\/([^/]+)\/node_modules\/(.+)$/)
+    if (pnpmMatch) {
+        const pkg = pnpmMatch[1].replace(/_.*$/, '')
+        return `${pkg} (${pnpmMatch[2]})`
+    }
+    return inputPath
+}
+
+export function reportTopChunks(outputs, { topChunks = 10, topContributors = 5, label = 'chunks' } = {}) {
+    if (!outputs) {
+        return
+    }
+    const chunkEntries = Object.entries(outputs)
+        .filter(([outputPath]) => /\/chunk-[A-Z0-9]+\.js$/.test(outputPath))
+        .sort((a, b) => b[1].bytes - a[1].bytes)
+        .slice(0, topChunks)
+    if (chunkEntries.length === 0) {
+        return
+    }
+    const lines = [`Top ${chunkEntries.length} ${label} by uncompressed size:`]
+    for (const [outputPath, output] of chunkEntries) {
+        const inputCount = Object.keys(output.inputs || {}).length
+        lines.push(
+            `  ${formatMegabytes(output.bytes).padStart(9)}  ${path.basename(outputPath)}  (${inputCount} inputs)`
+        )
+        const contributors = Object.entries(output.inputs || {})
+            .sort((a, b) => b[1].bytesInOutput - a[1].bytesInOutput)
+            .slice(0, topContributors)
+        for (const [inputPath, info] of contributors) {
+            lines.push(
+                `               ${formatMegabytes(info.bytesInOutput).padStart(9)}  ${shortenInputPath(inputPath)}`
+            )
+        }
+    }
+    console.info(lines.join('\n'))
+}
+
 export async function buildInParallel(configs, { onBuildStart, onBuildComplete } = {}) {
     try {
         await Promise.all(

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -10,6 +10,7 @@ import {
     copySnappyWASMFile,
     createHashlessEntrypoints,
     isDev,
+    reportTopChunks,
     startDevServer,
 } from '@posthog/esbuilder'
 
@@ -113,6 +114,9 @@ await buildInParallel(
                 if (!isDev && Object.keys(entrypoints).length === 0) {
                     console.error('Could not get entrypoint for bundle "PostHog App."')
                     throw new Error('Could not get entrypoint for bundle "PostHog App."')
+                }
+                if (!isDev) {
+                    reportTopChunks(buildResponse.outputs, { label: 'PostHog App chunks' })
                 }
                 writeIndexHtml(chunks, entrypoints)
             }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
