### PR TITLE
chore(frontend): make type-only imports of lib/Chart explicit

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -3,7 +3,7 @@ import { useMemo, useRef, useState } from 'react'
 
 import { Popover } from '@posthog/lemon-ui'
 
-import { ScaleOptions, TooltipModel } from 'lib/Chart'
+import type { ScaleOptions, TooltipModel } from 'lib/Chart'
 import { getColorVar } from 'lib/colors'
 import { useChart } from 'lib/hooks/useChart'
 import { useEventListener } from 'lib/hooks/useEventListener'

--- a/frontend/src/scenes/data-pipelines/legacy-plugins/PipelineNodeMetrics.tsx
+++ b/frontend/src/scenes/data-pipelines/legacy-plugins/PipelineNodeMetrics.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { IconCalendar, IconCollapse, IconExpand, IconInfo } from '@posthog/icons'
 import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
 
-import { ChartDataset } from 'lib/Chart'
+import type { ChartDataset } from 'lib/Chart'
 import { getColorVar } from 'lib/colors'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -2,7 +2,7 @@ import { actions, afterMount, connect, kea, listeners, path, props, selectors } 
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
-import { ChartDataset as ChartJsDataset } from 'lib/Chart'
+import type { ChartDataset as ChartJsDataset } from 'lib/Chart'
 import { getSeriesColor } from 'lib/colors'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { hexToRGBA, pluralize } from 'lib/utils'

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup } from '@testing-library/react'
 
-import { ChartEvent, InteractionItem } from 'lib/Chart'
+import type { ChartEvent, InteractionItem } from 'lib/Chart'
 
 import { NodeKind, TrendsQueryResponse } from '~/queries/schema/schema-general'
 import {

--- a/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
@@ -1,4 +1,4 @@
-import { TooltipItem } from 'lib/Chart'
+import type { TooltipItem } from 'lib/Chart'
 import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 import { GraphDataset } from '~/types'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,7 +8,7 @@ import { LogLevel } from '@posthog/rrweb-plugin-console-record'
 import { eventWithTime } from '@posthog/rrweb-types'
 
 import { PaginatedResponse } from 'lib/api'
-import { ChartDataset, ChartType, InteractionItem } from 'lib/Chart'
+import type { ChartDataset, ChartType, InteractionItem } from 'lib/Chart'
 import { AlertType } from 'lib/components/Alerts/types'
 import { CommonFilters, HeatmapFilters, HeatmapFixedPositionMode } from 'lib/components/heatmaps/types'
 import { HedgehogActorOptions } from 'lib/components/HedgehogMode/types'


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
