### PR TITLE
feat(devex): add Standard Schema adapter for kea-forms with Zod validation

### DIFF
--- a/frontend/src/lib/forms/standard-schema/StandardSchema.stories.tsx
+++ b/frontend/src/lib/forms/standard-schema/StandardSchema.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useValues } from 'kea'
+import { kea, path } from 'kea'
+import { Form, forms } from 'kea-forms'
+import { z } from 'zod'
+
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { standardSchemaToKeaErrors } from './standardSchema'
+
+const SCHEMA_SOURCE = `z.object({
+    repository: z.object({
+        fullName: z.string().trim().min(1, 'Repository name is required'),
+        baselinePaths: z.record(
+            z.string().trim().min(1, 'Run type is required'),
+            z.string().trim().min(1, 'Path is required')
+        ),
+    }),
+})`
+
+const WIRING_SOURCE = `// 1. Define your Zod schema
+const schema = z.object({ ... })
+
+// 2. In your kea logic, wire it into forms()
+forms(() => ({
+    myForm: {
+        defaults: { ... },
+
+        // Validate → returns kea-compatible error map
+        errors: (values) =>
+            standardSchemaToKeaErrors(schema, values),
+
+        // Submit → parse first, get typed output
+        submit: async (values) => {
+            const parsed = parseWithStandardSchema(schema, values)
+            if (!parsed.success) { return }
+            // parsed.data is fully typed + transformed
+            await api.save(parsed.data)
+        },
+    },
+}))
+
+// 3. In your component, use <Form> + <LemonField> as normal
+<Form logic={myLogic} formKey="myForm" enableFormOnSubmit>
+    <LemonField name="repository.fullName" label="Name">
+        <LemonInput />
+    </LemonField>
+</Form>`
+
+interface StandardSchemaStoryFormValues {
+    repository: {
+        fullName: string
+        baselinePaths: Record<string, string>
+    }
+}
+
+const standardSchemaStorySchema = z.object({
+    repository: z.object({
+        fullName: z.string().trim().min(1, 'Repository name is required'),
+        baselinePaths: z.record(
+            z.string().trim().min(1, 'Run type is required'),
+            z.string().trim().min(1, 'Path is required')
+        ),
+    }),
+})
+
+const standardSchemaStoryLogic = kea([
+    path(['lib', 'forms', 'standardSchema', 'stories']),
+    forms(() => ({
+        standardSchemaStoryForm: {
+            defaults: {
+                repository: {
+                    fullName: '',
+                    baselinePaths: {
+                        storybook: '',
+                    },
+                },
+            } as StandardSchemaStoryFormValues,
+            errors: (values) => standardSchemaToKeaErrors(standardSchemaStorySchema, values),
+            submit: async () => {
+                // no-op for demo
+            },
+        },
+    })),
+])
+
+function CodeBlock({ code, title }: { code: string; title: string }): JSX.Element {
+    return (
+        <div>
+            <div className="text-xs font-semibold text-muted mb-1">{title}</div>
+            <pre className="text-xs bg-bg-3000 rounded p-3 overflow-x-auto font-mono whitespace-pre leading-relaxed">
+                {code.trim()}
+            </pre>
+        </div>
+    )
+}
+
+function LiveErrorInspector(): JSX.Element {
+    const { standardSchemaStoryFormErrors, standardSchemaStoryFormTouched } = useValues(standardSchemaStoryLogic)
+
+    return (
+        <div>
+            <div className="text-xs font-semibold text-muted mb-1">Live kea-forms error state</div>
+            <pre className="text-xs bg-bg-3000 rounded p-3 overflow-x-auto font-mono whitespace-pre leading-relaxed">
+                {JSON.stringify(
+                    {
+                        errors: standardSchemaStoryFormErrors,
+                        touched: standardSchemaStoryFormTouched,
+                    },
+                    null,
+                    2
+                )}
+            </pre>
+        </div>
+    )
+}
+
+const meta: Meta = {
+    title: 'Forms/Standard Schema Adapter',
+    parameters: {
+        docs: {
+            description: {
+                component: `
+The Standard Schema adapter bridges any schema library that implements the
+[Standard Schema](https://github.com/standard-schema/standard-schema) spec
+(Zod, Valibot, ArkType) into kea-forms.
+
+**Two helpers:**
+
+- \`standardSchemaToKeaErrors(schema, values)\` — validates and returns a kea-compatible \`DeepPartialMap\` error object. Use in the \`errors\` callback.
+- \`parseWithStandardSchema(schema, values)\` — validates and returns either \`{ success: true, data }\` with the parsed + transformed output, or \`{ success: false, errors }\`. Use in \`submit\` to get typed, coerced values (e.g. trimmed strings).
+
+**Benefits over manual validation:**
+
+- Schema is the single source of truth for both validation and data transformation
+- Zod schemas can extend the generated API schemas from \`api.zod.ts\`
+- Error paths (nested objects, arrays, records) are mapped automatically
+`,
+            },
+        },
+    },
+}
+
+export default meta
+
+type Story = StoryObj
+
+export const ZodShowcase: Story = {
+    render: () => {
+        return (
+            <div className="flex gap-6 items-start max-w-4xl">
+                <div className="flex-1 min-w-0 space-y-4">
+                    <Form logic={standardSchemaStoryLogic} formKey="standardSchemaStoryForm" enableFormOnSubmit>
+                        <div className="space-y-4">
+                            <LemonField name="repository.fullName" label="Repository full name">
+                                <LemonInput placeholder="posthog/posthog" />
+                            </LemonField>
+
+                            <LemonField name="repository.baselinePaths.storybook" label="Storybook baseline file path">
+                                <LemonInput placeholder=".storybook/snapshots.yml" />
+                            </LemonField>
+
+                            <div className="flex justify-end">
+                                <LemonButton type="primary" htmlType="submit">
+                                    Validate
+                                </LemonButton>
+                            </div>
+                        </div>
+                    </Form>
+
+                    <LiveErrorInspector />
+                </div>
+
+                <div className="flex-1 min-w-0 space-y-4">
+                    <CodeBlock title="Zod schema" code={SCHEMA_SOURCE} />
+                    <CodeBlock title="How to wire into kea-forms" code={WIRING_SOURCE} />
+                </div>
+            </div>
+        )
+    },
+}

--- a/frontend/src/lib/forms/standard-schema/index.ts
+++ b/frontend/src/lib/forms/standard-schema/index.ts
@@ -1,0 +1,10 @@
+export {
+    parseWithStandardSchema,
+    standardSchemaToKeaErrors,
+    type ParseWithStandardSchemaResult,
+    type StandardSchemaErrorResult,
+    type StandardSchemaIssue,
+    type StandardSchemaResult,
+    type StandardSchemaSuccessResult,
+    type StandardSchemaV1,
+} from './standardSchema'

--- a/frontend/src/lib/forms/standard-schema/standardSchema.test.ts
+++ b/frontend/src/lib/forms/standard-schema/standardSchema.test.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+
+import { parseWithStandardSchema, standardSchemaToKeaErrors } from './standardSchema'
+
+describe('standardSchema adapter', () => {
+    const schema = z.object({
+        repository: z.object({
+            fullName: z.string().trim().min(1, 'Repository name is required'),
+            baselinePaths: z.record(
+                z.string().trim().min(1, 'Run type is required'),
+                z.string().trim().min(1, 'Path is required')
+            ),
+        }),
+        entries: z.array(
+            z.object({
+                name: z.string().trim().min(1, 'Name is required'),
+            })
+        ),
+    })
+
+    it('maps nested object and array paths into kea errors', () => {
+        const errors = standardSchemaToKeaErrors(schema, {
+            repository: {
+                fullName: '',
+                baselinePaths: {
+                    storybook: '',
+                },
+            },
+            entries: [{ name: '' }],
+        })
+
+        expect(errors).toEqual({
+            repository: {
+                fullName: 'Repository name is required',
+                baselinePaths: {
+                    storybook: 'Path is required',
+                },
+            },
+            entries: {
+                0: {
+                    name: 'Name is required',
+                },
+            },
+        })
+    })
+
+    it('returns parsed values on success', () => {
+        const parsed = parseWithStandardSchema(schema, {
+            repository: {
+                fullName: ' posthog/posthog ',
+                baselinePaths: {
+                    storybook: ' .storybook/snapshots.yml ',
+                },
+            },
+            entries: [{ name: ' smoke ' }],
+        })
+
+        expect(parsed).toEqual({
+            success: true,
+            data: {
+                repository: {
+                    fullName: 'posthog/posthog',
+                    baselinePaths: {
+                        storybook: '.storybook/snapshots.yml',
+                    },
+                },
+                entries: [{ name: 'smoke' }],
+            },
+        })
+    })
+})

--- a/frontend/src/lib/forms/standard-schema/standardSchema.ts
+++ b/frontend/src/lib/forms/standard-schema/standardSchema.ts
@@ -1,0 +1,156 @@
+import type { DeepPartialMap, ValidationErrorType } from 'kea-forms'
+
+type StandardSchemaPathSegment =
+    | PropertyKey
+    | {
+          key?: PropertyKey
+      }
+
+export interface StandardSchemaIssue {
+    message: string
+    path?: ReadonlyArray<StandardSchemaPathSegment>
+}
+
+export interface StandardSchemaSuccessResult<Output> {
+    value: Output
+    issues?: undefined
+}
+
+export interface StandardSchemaErrorResult {
+    issues: ReadonlyArray<StandardSchemaIssue>
+    value?: undefined
+}
+
+export type StandardSchemaResult<Output> = StandardSchemaSuccessResult<Output> | StandardSchemaErrorResult
+
+export interface StandardSchemaV1<Input, Output> {
+    '~standard': {
+        validate: (value: Input) => StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>
+    }
+}
+
+export type ParseWithStandardSchemaResult<Input, Output> =
+    | {
+          success: true
+          data: Output
+      }
+    | {
+          success: false
+          errors: DeepPartialMap<Input, ValidationErrorType>
+      }
+
+function getPathKey(segment: StandardSchemaPathSegment): PropertyKey | undefined {
+    if (typeof segment === 'object' && segment !== null && 'key' in segment) {
+        return segment.key
+    }
+    return segment
+}
+
+function appendIssueToErrors(
+    errors: Record<PropertyKey, unknown>,
+    path: ReadonlyArray<StandardSchemaPathSegment>,
+    message: string
+): void {
+    let current: Record<PropertyKey, unknown> = errors
+
+    if (path.length === 0) {
+        const currentRootError = current._error
+        if (Array.isArray(currentRootError)) {
+            current._error = [...currentRootError, message]
+        } else if (typeof currentRootError === 'string') {
+            current._error = [currentRootError, message]
+        } else {
+            current._error = message
+        }
+        return
+    }
+
+    for (let index = 0; index < path.length; index++) {
+        const key = getPathKey(path[index])
+
+        if (key === undefined) {
+            continue
+        }
+
+        const isLeaf = index === path.length - 1
+
+        if (isLeaf) {
+            const existingValue = current[key]
+            if (Array.isArray(existingValue)) {
+                current[key] = [...existingValue, message]
+            } else if (typeof existingValue === 'string') {
+                current[key] = [existingValue, message]
+            } else {
+                current[key] = message
+            }
+            return
+        }
+
+        const next = current[key]
+        if (typeof next === 'object' && next !== null && !Array.isArray(next)) {
+            current = next as Record<PropertyKey, unknown>
+            continue
+        }
+
+        const newBranch: Record<PropertyKey, unknown> = {}
+        current[key] = newBranch
+        current = newBranch
+    }
+}
+
+function issuesToKeaErrors<Input>(
+    issues: ReadonlyArray<StandardSchemaIssue>
+): DeepPartialMap<Input, ValidationErrorType> {
+    const errors: Record<PropertyKey, unknown> = {}
+
+    for (const issue of issues) {
+        appendIssueToErrors(errors, issue.path ?? [], issue.message)
+    }
+
+    return errors as DeepPartialMap<Input, ValidationErrorType>
+}
+
+function validateSync<Input, Output>(
+    schema: StandardSchemaV1<Input, Output>,
+    values: Input
+): StandardSchemaResult<Output> {
+    const result = schema['~standard'].validate(values)
+
+    if (result instanceof Promise) {
+        throw new Error('Standard Schema adapter currently supports sync validation only')
+    }
+
+    return result
+}
+
+export function standardSchemaToKeaErrors<Input, Output>(
+    schema: StandardSchemaV1<Input, Output>,
+    values: Input
+): DeepPartialMap<Input, ValidationErrorType> {
+    const result = validateSync(schema, values)
+
+    if (!('issues' in result) || !result.issues?.length) {
+        return {} as DeepPartialMap<Input, ValidationErrorType>
+    }
+
+    return issuesToKeaErrors<Input>(result.issues)
+}
+
+export function parseWithStandardSchema<Input, Output>(
+    schema: StandardSchemaV1<Input, Output>,
+    values: Input
+): ParseWithStandardSchemaResult<Input, Output> {
+    const result = validateSync(schema, values)
+
+    if ('issues' in result && result.issues?.length) {
+        return {
+            success: false,
+            errors: issuesToKeaErrors<Input>(result.issues),
+        }
+    }
+
+    return {
+        success: true,
+        data: result.value,
+    }
+}

--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -1,10 +1,12 @@
 import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
 
 import { IconArrowRight, IconCopy, IconGear, IconGithub, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -197,52 +199,53 @@ function RepoCard({ repo }: { repo: RepoApi }): JSX.Element {
 }
 
 function RepoEditForm(): JSX.Element {
-    const { formValues, saving, hasChanges } = useValues(visualReviewSettingsSceneLogic)
-    const { setFormField, saveRepo, cancelEdit } = useActions(visualReviewSettingsSceneLogic)
+    const { repoFormSubmitting, hasChanges } = useValues(visualReviewSettingsSceneLogic)
+    const { cancelEdit } = useActions(visualReviewSettingsSceneLogic)
 
     return (
-        <div className="border-2 border-primary rounded-lg p-4 space-y-4">
-            <div>
-                <label className="block text-sm font-medium mb-1">Baseline file paths</label>
-                <p className="text-muted text-xs mb-1.5">Where baseline hashes are stored for each run type.</p>
-                <BaselinePathEditor
-                    paths={formValues.baseline_file_paths}
-                    onChange={(paths) => setFormField('baseline_file_paths', paths)}
-                />
-            </div>
-
-            <div>
-                <LemonSwitch
-                    checked={formValues.enable_pr_comments}
-                    onChange={(checked) => setFormField('enable_pr_comments', checked)}
-                    label="Post PR comments"
-                    bordered
-                />
-                <p className="text-muted text-xs mt-1">
-                    Post a comment on pull requests when visual changes are detected, prompting reviewers to approve.
-                </p>
-            </div>
-
-            <div className="flex gap-2 pt-2">
-                <LemonButton
-                    type="primary"
-                    size="small"
-                    onClick={saveRepo}
-                    loading={saving}
-                    disabledReason={!hasChanges ? 'No changes' : undefined}
+        <Form logic={visualReviewSettingsSceneLogic} formKey="repoForm" enableFormOnSubmit>
+            <div className="border-2 border-primary rounded-lg p-4 space-y-4">
+                <LemonField
+                    name="baseline_file_paths"
+                    label="Baseline file paths"
+                    help="Where baseline hashes are stored for each run type."
                 >
-                    Save
-                </LemonButton>
-                <LemonButton type="secondary" size="small" onClick={cancelEdit}>
-                    Cancel
-                </LemonButton>
+                    {({ value, onChange }) => <BaselinePathEditor paths={value} onChange={onChange} />}
+                </LemonField>
+
+                <LemonField name="enable_pr_comments">
+                    {({ value, onChange }) => (
+                        <div>
+                            <LemonSwitch checked={value} onChange={onChange} label="Post PR comments" bordered />
+                            <p className="text-muted text-xs mt-1">
+                                Post a comment on pull requests when visual changes are detected, prompting reviewers to
+                                approve.
+                            </p>
+                        </div>
+                    )}
+                </LemonField>
+
+                <div className="flex gap-2 pt-2">
+                    <LemonButton
+                        type="primary"
+                        size="small"
+                        htmlType="submit"
+                        loading={repoFormSubmitting}
+                        disabledReason={!hasChanges ? 'No changes' : undefined}
+                    >
+                        Save
+                    </LemonButton>
+                    <LemonButton type="secondary" size="small" onClick={cancelEdit}>
+                        Cancel
+                    </LemonButton>
+                </div>
             </div>
-        </div>
+        </Form>
     )
 }
 
 function AddRepoDropdown(): JSX.Element {
-    const { availableRepos, existingRepoNames, saving, githubManageAccessUrl } =
+    const { availableRepos, existingRepoNames, reposLoading, githubManageAccessUrl } =
         useValues(visualReviewSettingsSceneLogic)
     const { addRepo } = useActions(visualReviewSettingsSceneLogic)
     const { githubRepositoriesLoading } = useValues(integrationsLogic)
@@ -262,7 +265,7 @@ function AddRepoDropdown(): JSX.Element {
     return (
         <LemonSelect
             placeholder="Add a repository..."
-            loading={saving}
+            loading={reposLoading}
             options={[
                 {
                     options:

--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { Form } from 'kea-forms'
+import { Form, Group } from 'kea-forms'
 
 import { IconArrowRight, IconCopy, IconGear, IconGithub, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
@@ -85,20 +85,27 @@ function BaselinePathEditor({ paths, onChange }: BaselinePathEditorProps): JSX.E
     return (
         <div className="space-y-2">
             {entries.map(([key, value], index) => (
-                <div key={index} className="flex gap-2 items-center">
+                <div key={index} className="flex gap-2 items-start">
                     <LemonInput
                         value={key}
                         onChange={(newKey) => updateKey(key, newKey)}
                         placeholder="Run type (e.g. storybook)"
                         className="flex-1"
                     />
-                    <LemonInput
-                        value={value}
-                        onChange={(newValue) => updateValue(key, newValue)}
-                        placeholder="Path (e.g. .snapshots.yml)"
-                        className="flex-[2]"
+                    <LemonField name={key} className="flex-[2]">
+                        <LemonInput
+                            value={value}
+                            onChange={(newValue) => updateValue(key, newValue)}
+                            placeholder="Path (e.g. .snapshots.yml)"
+                        />
+                    </LemonField>
+                    <LemonButton
+                        icon={<IconTrash />}
+                        type="secondary"
+                        size="small"
+                        className="mt-1"
+                        onClick={() => removeEntry(key)}
                     />
-                    <LemonButton icon={<IconTrash />} type="secondary" size="small" onClick={() => removeEntry(key)} />
                 </div>
             ))}
             <LemonButton icon={<IconPlus />} type="secondary" size="small" onClick={addEntry}>
@@ -205,12 +212,17 @@ function RepoEditForm(): JSX.Element {
     return (
         <Form logic={visualReviewSettingsSceneLogic} formKey="repoForm" enableFormOnSubmit>
             <div className="border-2 border-primary rounded-lg p-4 space-y-4">
-                <LemonField.Pure label="Baseline file paths" help="Where baseline hashes are stored for each run type.">
-                    <BaselinePathEditor
-                        paths={repoForm.baseline_file_paths}
-                        onChange={(paths) => setRepoFormValue('baseline_file_paths', paths)}
-                    />
-                </LemonField.Pure>
+                <Group name="baseline_file_paths">
+                    <LemonField.Pure
+                        label="Baseline file paths"
+                        help="Where baseline hashes are stored for each run type."
+                    >
+                        <BaselinePathEditor
+                            paths={repoForm.baseline_file_paths}
+                            onChange={(paths) => setRepoFormValue('baseline_file_paths', paths)}
+                        />
+                    </LemonField.Pure>
+                </Group>
 
                 <LemonField name="enable_pr_comments">
                     {({ value, onChange }) => (

--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { Form, Group } from 'kea-forms'
+import { Form } from 'kea-forms'
 
 import { IconArrowRight, IconCopy, IconGear, IconGithub, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
@@ -54,10 +54,11 @@ function GitHubConnectPrompt(): JSX.Element {
 
 interface BaselinePathEditorProps {
     paths: Record<string, string>
+    errors?: Record<string, string>
     onChange: (paths: Record<string, string>) => void
 }
 
-function BaselinePathEditor({ paths, onChange }: BaselinePathEditorProps): JSX.Element {
+function BaselinePathEditor({ paths, errors, onChange }: BaselinePathEditorProps): JSX.Element {
     const entries = Object.entries(paths)
 
     const addEntry = (): void => {
@@ -85,27 +86,30 @@ function BaselinePathEditor({ paths, onChange }: BaselinePathEditorProps): JSX.E
     return (
         <div className="space-y-2">
             {entries.map(([key, value], index) => (
-                <div key={index} className="flex gap-2 items-start">
-                    <LemonInput
-                        value={key}
-                        onChange={(newKey) => updateKey(key, newKey)}
-                        placeholder="Run type (e.g. storybook)"
-                        className="flex-1"
-                    />
-                    <LemonField name={key} className="flex-[2]">
+                <div key={index}>
+                    <div className="flex gap-2 items-center">
+                        <LemonInput
+                            value={key}
+                            onChange={(newKey) => updateKey(key, newKey)}
+                            placeholder="Run type (e.g. storybook)"
+                            className="flex-1"
+                            status={errors?.[key] ? 'danger' : undefined}
+                        />
                         <LemonInput
                             value={value}
                             onChange={(newValue) => updateValue(key, newValue)}
                             placeholder="Path (e.g. .snapshots.yml)"
+                            className="flex-[2]"
+                            status={errors?.[key] ? 'danger' : undefined}
                         />
-                    </LemonField>
-                    <LemonButton
-                        icon={<IconTrash />}
-                        type="secondary"
-                        size="small"
-                        className="mt-1"
-                        onClick={() => removeEntry(key)}
-                    />
+                        <LemonButton
+                            icon={<IconTrash />}
+                            type="secondary"
+                            size="small"
+                            onClick={() => removeEntry(key)}
+                        />
+                    </div>
+                    {errors?.[key] && typeof errors[key] === 'string' ? <LemonField.Error error={errors[key]} /> : null}
                 </div>
             ))}
             <LemonButton icon={<IconPlus />} type="secondary" size="small" onClick={addEntry}>
@@ -206,23 +210,21 @@ function RepoCard({ repo }: { repo: RepoApi }): JSX.Element {
 }
 
 function RepoEditForm(): JSX.Element {
-    const { repoForm, repoFormSubmitting, hasChanges } = useValues(visualReviewSettingsSceneLogic)
+    const { repoForm, repoFormErrors, repoFormSubmitting, hasChanges } = useValues(visualReviewSettingsSceneLogic)
     const { setRepoFormValue, cancelEdit } = useActions(visualReviewSettingsSceneLogic)
+
+    const pathErrors = repoFormErrors?.baseline_file_paths as Record<string, string> | undefined
 
     return (
         <Form logic={visualReviewSettingsSceneLogic} formKey="repoForm" enableFormOnSubmit>
             <div className="border-2 border-primary rounded-lg p-4 space-y-4">
-                <Group name="baseline_file_paths">
-                    <LemonField.Pure
-                        label="Baseline file paths"
-                        help="Where baseline hashes are stored for each run type."
-                    >
-                        <BaselinePathEditor
-                            paths={repoForm.baseline_file_paths}
-                            onChange={(paths) => setRepoFormValue('baseline_file_paths', paths)}
-                        />
-                    </LemonField.Pure>
-                </Group>
+                <LemonField.Pure label="Baseline file paths" help="Where baseline hashes are stored for each run type.">
+                    <BaselinePathEditor
+                        paths={repoForm.baseline_file_paths}
+                        errors={pathErrors}
+                        onChange={(paths) => setRepoFormValue('baseline_file_paths', paths)}
+                    />
+                </LemonField.Pure>
 
                 <LemonField name="enable_pr_comments">
                     {({ value, onChange }) => (

--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -199,19 +199,18 @@ function RepoCard({ repo }: { repo: RepoApi }): JSX.Element {
 }
 
 function RepoEditForm(): JSX.Element {
-    const { repoFormSubmitting, hasChanges } = useValues(visualReviewSettingsSceneLogic)
-    const { cancelEdit } = useActions(visualReviewSettingsSceneLogic)
+    const { repoForm, repoFormSubmitting, hasChanges } = useValues(visualReviewSettingsSceneLogic)
+    const { setRepoFormValue, cancelEdit } = useActions(visualReviewSettingsSceneLogic)
 
     return (
         <Form logic={visualReviewSettingsSceneLogic} formKey="repoForm" enableFormOnSubmit>
             <div className="border-2 border-primary rounded-lg p-4 space-y-4">
-                <LemonField
-                    name="baseline_file_paths"
-                    label="Baseline file paths"
-                    help="Where baseline hashes are stored for each run type."
-                >
-                    {({ value, onChange }) => <BaselinePathEditor paths={value} onChange={onChange} />}
-                </LemonField>
+                <LemonField.Pure label="Baseline file paths" help="Where baseline hashes are stored for each run type.">
+                    <BaselinePathEditor
+                        paths={repoForm.baseline_file_paths}
+                        onChange={(paths) => setRepoFormValue('baseline_file_paths', paths)}
+                    />
+                </LemonField.Pure>
 
                 <LemonField name="enable_pr_comments">
                     {({ value, onChange }) => (

--- a/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
@@ -1,7 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
-import { z } from 'zod'
 
 import { parseWithStandardSchema, standardSchemaToKeaErrors } from 'lib/forms/standard-schema'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -22,22 +21,7 @@ export interface RepoFormValues {
     enable_pr_comments: boolean
 }
 
-const baselinePathKey = z
-    .string()
-    .trim()
-    .min(1, 'Run type is required')
-    .regex(/^[a-z][a-z0-9_-]*$/i, 'Run type must be alphanumeric (e.g. storybook, playwright)')
-
-const baselinePathValue = z
-    .string()
-    .trim()
-    .min(1, 'Path is required')
-    .regex(/\.\w+$/, 'Path must include a file extension (e.g. .yml)')
-
-const repoFormSchema = VisualReviewReposPartialUpdateBody.extend({
-    baseline_file_paths: z.record(baselinePathKey, baselinePathValue).default({}),
-    enable_pr_comments: z.boolean().default(false),
-})
+const repoFormSchema = VisualReviewReposPartialUpdateBody
 
 const EMPTY_FORM: RepoFormValues = {
     baseline_file_paths: {},

--- a/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
@@ -22,10 +22,20 @@ export interface RepoFormValues {
     enable_pr_comments: boolean
 }
 
+const baselinePathKey = z
+    .string()
+    .trim()
+    .min(1, 'Run type is required')
+    .regex(/^[a-z][a-z0-9_-]*$/i, 'Run type must be alphanumeric (e.g. storybook, playwright)')
+
+const baselinePathValue = z
+    .string()
+    .trim()
+    .min(1, 'Path is required')
+    .regex(/\.\w+$/, 'Path must include a file extension (e.g. .yml)')
+
 const repoFormSchema = VisualReviewReposPartialUpdateBody.extend({
-    baseline_file_paths: z
-        .record(z.string().trim().min(1, 'Run type is required'), z.string().trim().min(1, 'Path is required'))
-        .default({}),
+    baseline_file_paths: z.record(baselinePathKey, baselinePathValue).default({}),
     enable_pr_comments: z.boolean().default(false),
 })
 

--- a/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
@@ -23,7 +23,9 @@ export interface RepoFormValues {
 }
 
 const repoFormSchema = VisualReviewReposPartialUpdateBody.extend({
-    baseline_file_paths: z.record(z.string().min(1), z.string().min(1)).default({}),
+    baseline_file_paths: z
+        .record(z.string().min(1, 'Run type is required'), z.string().min(1, 'Path is required'))
+        .default({}),
     enable_pr_comments: z.boolean().default(false),
 })
 

--- a/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
@@ -1,6 +1,9 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
+import { z } from 'zod'
 
+import { parseWithStandardSchema, standardSchemaToKeaErrors } from 'lib/forms/standard-schema'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
@@ -11,12 +14,20 @@ import type { GitHubRepoApi } from 'products/integrations/frontend/generated/api
 
 import { visualReviewReposCreate, visualReviewReposList, visualReviewReposPartialUpdate } from '../generated/api'
 import type { PatchedUpdateRepoRequestInputApi, RepoApi } from '../generated/api.schemas'
+import { VisualReviewReposPartialUpdateBody } from '../generated/api.zod'
 import type { visualReviewSettingsSceneLogicType } from './visualReviewSettingsSceneLogicType'
 
 export interface RepoFormValues {
     baseline_file_paths: Record<string, string>
     enable_pr_comments: boolean
 }
+
+const repoFormSchema = VisualReviewReposPartialUpdateBody.extend({
+    baseline_file_paths: z
+        .record(z.string().trim().min(1, 'Run type is required'), z.string().trim().min(1, 'Path is required'))
+        .default({}),
+    enable_pr_comments: z.boolean().default(false),
+})
 
 const EMPTY_FORM: RepoFormValues = {
     baseline_file_paths: {},
@@ -41,7 +52,6 @@ export const visualReviewSettingsSceneLogic = kea<visualReviewSettingsSceneLogic
     actions({
         editRepo: (repoId: string) => ({ repoId }),
         cancelEdit: true,
-        setFormField: (field: keyof RepoFormValues, value: RepoFormValues[keyof RepoFormValues]) => ({ field, value }),
         addRepo: (githubRepo: GitHubRepoApi) => ({ githubRepo }),
         saveRepo: true,
     }),
@@ -67,24 +77,39 @@ export const visualReviewSettingsSceneLogic = kea<visualReviewSettingsSceneLogic
                 loadReposSuccess: () => null,
             },
         ],
-        formValues: [
-            EMPTY_FORM as RepoFormValues,
-            {
-                cancelEdit: () => EMPTY_FORM,
-                setFormField: (state, { field, value }) => ({ ...state, [field]: value }),
-                loadReposSuccess: () => EMPTY_FORM,
-            },
-        ],
-        saving: [
-            false,
-            {
-                saveRepo: () => true,
-                addRepo: () => true,
-                loadReposSuccess: () => false,
-                loadReposFailure: () => false,
-            },
-        ],
     }),
+
+    forms(({ actions, values }) => ({
+        repoForm: {
+            defaults: EMPTY_FORM,
+            errors: (values) => standardSchemaToKeaErrors(repoFormSchema, values),
+            submit: async (formValues) => {
+                try {
+                    const parsed = parseWithStandardSchema(repoFormSchema, formValues)
+                    if (!parsed.success) {
+                        return
+                    }
+                    if (values.editingRepoId) {
+                        const updates: PatchedUpdateRepoRequestInputApi = {
+                            baseline_file_paths: parsed.data.baseline_file_paths,
+                            enable_pr_comments: parsed.data.enable_pr_comments,
+                        }
+                        await visualReviewReposPartialUpdate(
+                            String(values.currentProjectId),
+                            values.editingRepoId,
+                            updates
+                        )
+                        lemonToast.success('Settings saved')
+                    }
+
+                    actions.loadRepos()
+                } catch {
+                    lemonToast.error('Failed to save')
+                    actions.loadReposFailure('Save failed')
+                }
+            },
+        },
+    })),
 
     selectors({
         editingRepo: [
@@ -97,15 +122,15 @@ export const visualReviewSettingsSceneLogic = kea<visualReviewSettingsSceneLogic
             },
         ],
         hasChanges: [
-            (s) => [s.formValues, s.editingRepo],
-            (formValues, editingRepo): boolean => {
+            (s) => [s.repoForm, s.editingRepo],
+            (repoForm, editingRepo): boolean => {
                 if (!editingRepo) {
                     return false
                 }
                 return (
-                    JSON.stringify(formValues.baseline_file_paths) !==
+                    JSON.stringify(repoForm.baseline_file_paths) !==
                         JSON.stringify(editingRepo.baseline_file_paths || {}) ||
-                    formValues.enable_pr_comments !== editingRepo.enable_pr_comments
+                    repoForm.enable_pr_comments !== editingRepo.enable_pr_comments
                 )
             },
         ],
@@ -169,10 +194,14 @@ export const visualReviewSettingsSceneLogic = kea<visualReviewSettingsSceneLogic
         editRepo: ({ repoId }) => {
             const repo = values.repos.find((r) => r.id === repoId)
             if (repo) {
-                const form = formValuesFromRepo(repo)
-                actions.setFormField('baseline_file_paths', form.baseline_file_paths)
-                actions.setFormField('enable_pr_comments', form.enable_pr_comments)
+                actions.setRepoFormValues(formValuesFromRepo(repo))
             }
+        },
+        cancelEdit: () => {
+            actions.resetRepoForm()
+        },
+        saveRepo: () => {
+            actions.submitRepoForm()
         },
         addRepo: async ({ githubRepo }) => {
             try {
@@ -185,25 +214,6 @@ export const visualReviewSettingsSceneLogic = kea<visualReviewSettingsSceneLogic
             } catch {
                 lemonToast.error('Failed to add repo')
                 actions.loadReposFailure('Add failed')
-            }
-        },
-        saveRepo: async () => {
-            try {
-                const { editingRepoId, formValues } = values
-
-                if (editingRepoId) {
-                    const updates: PatchedUpdateRepoRequestInputApi = {
-                        baseline_file_paths: formValues.baseline_file_paths,
-                        enable_pr_comments: formValues.enable_pr_comments,
-                    }
-                    await visualReviewReposPartialUpdate(String(values.currentProjectId), editingRepoId, updates)
-                    lemonToast.success('Settings saved')
-                }
-
-                actions.loadRepos()
-            } catch {
-                lemonToast.error('Failed to save')
-                actions.loadReposFailure('Save failed')
             }
         },
     })),

--- a/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSettingsSceneLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
+import { z } from 'zod'
 
 import { parseWithStandardSchema, standardSchemaToKeaErrors } from 'lib/forms/standard-schema'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -21,7 +22,10 @@ export interface RepoFormValues {
     enable_pr_comments: boolean
 }
 
-const repoFormSchema = VisualReviewReposPartialUpdateBody
+const repoFormSchema = VisualReviewReposPartialUpdateBody.extend({
+    baseline_file_paths: z.record(z.string().min(1), z.string().min(1)).default({}),
+    enable_pr_comments: z.boolean().default(false),
+})
 
 const EMPTY_FORM: RepoFormValues = {
     baseline_file_paths: {},


### PR DESCRIPTION
## Problem

kea-forms validation requires manually building error objects field by field. No way to use schema validation libraries like Zod, and no way to leverage the generated Zod schemas from `api.zod.ts`. Developers end up writing repetitive validation logic that drifts from the API contract.

## Changes

**Standard Schema adapter** (`lib/forms/standard-schema/`)
- Bridges any [Standard Schema](https://github.com/standard-schema/standard-schema)-compatible library (Zod, Valibot, ArkType) into kea-forms
- `standardSchemaToKeaErrors(schema, values)` — for the `errors` callback, returns kea-compatible error map
- `parseWithStandardSchema(schema, values)` — for submit handlers, returns typed+transformed output
- Handles nested objects, arrays, and record paths automatically
- Storybook story with live error inspector and wiring documentation

**Visual review settings** (proof of concept)
- Converted repo edit form to use `<Form>` + `<LemonField>` with the adapter
- Extends the generated `VisualReviewReposPartialUpdateBody` Zod schema with form-level requirements (generated PATCH schemas have `.nullish()` on all fields)
- Per-entry inline validation errors on the baseline paths record editor

## How did you test this code?

Unit tests for the adapter (`standardSchema.test.ts`) covering nested objects, arrays, and records. Manually tested the visual review settings form — validation errors show inline on invalid entries, submit is blocked when errors exist.

## 🤖 Agent context

Co-authored with Claude Code. Key decisions: generated PATCH schemas need `.extend()` for form validation since PATCH fields are inherently optional. Record editors (key-value pairs) don't fit `Group`+`LemonField` cleanly because renaming keys isn't a simple field update — errors are passed down manually instead, matching the feature flag variant pattern.