### PR TITLE
chore(flags): consolidate warm-flags-cache into feature-flags crate and ship image

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -35,6 +35,12 @@
   dockerfile: ./rust/Dockerfile
   project: vglf58qgzw
 
+- image: flags-cache-warmer
+  bin: warm-flags-cache
+  dockerfile: ./rust/Dockerfile
+  project: vglf58qgzw
+  features: warm-flags-cache
+
 - image: batch-import-worker
   dockerfile: ./rust/Dockerfile
   project: 4ppc15q4bv

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -152,7 +152,8 @@ jobs:
                   build-args: |
                       SCCACHE_LOG=debug
                       SCCACHE_NO_DAEMON=1
-                      BIN=${{ matrix.image }}
+                      BIN=${{ matrix.bin || matrix.image }}
+                      BUILD_FEATURES=${{ matrix.features || '' }}
                   secrets: |
                       SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
                       SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -68,6 +68,9 @@ jobs:
                     - release: feature-flags
                       digest_key: feature-flags
                       values_key: image
+                    - release: flags-cache-jumphost
+                      digest_key: flags-cache-warmer
+                      values_key: image
                     - release: batch-import-worker
                       digest_key: batch-import-worker
                       values_key: image

--- a/bin/rust-jumphost
+++ b/bin/rust-jumphost
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Shell into the flags-cache-jumphost pod. The jumphost is a long-lived
+# `sleep infinity` deployment that ships the warm-flags-cache binary on
+# PATH so ops can run it ad-hoc against an environment's Postgres / Redis
+# / S3.
+#
+# Prerequisites:
+#   - kubectl context already pointed at the target cluster (e.g.
+#     `kubectl config use-context posthog-dev`).
+#   - The flags-cache-jumphost deployment exists in $KUBE_NAMESPACE.
+#
+# Usage:
+#   bin/rust-jumphost                  # drops into bash
+#   KUBE_NAMESPACE=posthog bin/rust-jumphost
+#
+# Inside the pod:
+#   warm-flags-cache --help
+#   warm-flags-cache --team-ids <id> --no-stagger
+
+set -euo pipefail
+
+NAMESPACE="${KUBE_NAMESPACE:-posthog}"
+
+exec kubectl exec -it "deploy/flags-cache-jumphost" -n "$NAMESPACE" -- bash

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -783,3 +783,7 @@ environment:
         bin_script: warm-flags-cache
         description: 'Warm the feature-flags hypercache against the local dev environment (requires ./bin/start running)'
         hidden: true
+    flags:jumphost:
+        bin_script: rust-jumphost
+        description: 'Shell into the flags-cache-jumphost pod (uses $KUBE_NAMESPACE, defaults to posthog)'
+        hidden: true

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,6 +7,7 @@ ENV RUSTC_WRAPPER=sccache SCCACHE_LOG=debug SCCACHE_DIR=/sccache
 FROM base AS planner
 WORKDIR /app
 ARG BIN
+ARG BUILD_FEATURES=""
 ENV PROTO_ROOT=../proto
 
 COPY . .
@@ -15,6 +16,7 @@ RUN cargo chef prepare --recipe-path recipe.json --bin $BIN
 FROM base AS builder
 WORKDIR /app
 ARG BIN
+ARG BUILD_FEATURES=""
 ENV PROTO_ROOT=../proto
 
 # Ensure working C compile setup (not installed by default in arm64 images)
@@ -27,7 +29,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
-    cargo chef cook --release --recipe-path recipe.json --bin $BIN && \
+    cargo chef cook --release --recipe-path recipe.json --bin $BIN ${BUILD_FEATURES:+--features $BUILD_FEATURES} && \
     sccache --show-stats
 
 COPY . .
@@ -41,7 +43,7 @@ RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
         export SCCACHE_WEBDAV_TOKEN=$(cat /run/secrets/SCCACHE_WEBDAV_TOKEN); \
     fi && \
     SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
-    cargo build --release --bin $BIN && \
+    cargo build --release --bin $BIN ${BUILD_FEATURES:+--features $BUILD_FEATURES} && \
     sccache --show-stats
 
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
## Problem

The `warm-flags-cache` binary (consolidated into the `feature-flags` crate in #56106) needs to be published as an image and deployed as a one-off pod (`flags-cache-jumphost`) that mirrors the feature-flags service environment. Ops also need a one-line wrapper to shell into that pod.

## Changes

- Add a `BUILD_FEATURES` build-arg to `rust/Dockerfile` and forward it from the shared image-build workflow per matrix entry, so feature-gated bins can be built without affecting other images.
- Add a `flags-cache-warmer` entry to `.github/rust-images.yml` with `features: warm-flags-cache`. The image name is a noun to match siblings like `*-worker`; the cargo bin stays `warm-flags-cache` (verb form), decoupled via a new optional `bin:` matrix field that defaults to `image`.
- Add `flags-cache-jumphost` to the deploy matrix in `rust-docker-build.yml` so the new digest is dispatched to charts on master merges. No-ops until the matching chart release lands.
- Add `bin/rust-jumphost`, a small wrapper around `kubectl exec -it deploy/flags-cache-jumphost -- bash`. Namespace defaults to `posthog`, overridable via `KUBE_NAMESPACE`; the caller's kubectl context selects the cluster.

## How did you test this code?

Verification will happen via CI on this PR and on the matching chart release. The `bin/rust-jumphost` wrapper can't be exercised until the chart release creates the deployment.

## Publish to changelog?

no
