### PR TITLE
feat(logs): allow matching attributes on value when filtering

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
@@ -181,6 +181,29 @@ describe('taxonomicPropertyFilterLogic', () => {
             logic.actions.selectItem(group, undefined)
             expect(setFilterSpy).not.toHaveBeenCalled()
         })
+
+        it('pre-fills the filter value when the row matched on a property value', () => {
+            selectAndExpect(
+                TaxonomicFilterGroupType.EventProperties,
+                'user.email',
+                PropertyFilterType.Event,
+                {
+                    key: 'user.email',
+                    type: PropertyFilterType.Event,
+                    value: ['frank@posthog.com'],
+                    operator: PropertyOperator.Exact,
+                },
+                { matchedOn: 'value', matchedValue: 'frank@posthog.com' }
+            )
+        })
+
+        it('does not pre-fill the value when the row matched on key', () => {
+            const group = logic.values.taxonomicGroups.find((g) => g.type === TaxonomicFilterGroupType.EventProperties)!
+            logic.actions.selectItem(group, 'user.email', PropertyFilterType.Event, {
+                matchedOn: 'key',
+            })
+            expect(setFilterSpy).toHaveBeenCalledWith(0, expect.objectContaining({ key: 'user.email', value: null }))
+        })
     })
 
     it('restores a complete property filter from a recent filter item', async () => {

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
@@ -182,7 +182,8 @@ describe('taxonomicPropertyFilterLogic', () => {
             expect(setFilterSpy).not.toHaveBeenCalled()
         })
 
-        it('pre-fills the filter value when the row matched on a property value', () => {
+        // The full matchedOn/matchedValue matrix is covered in utils.test.ts.
+        it('forwards matchedValue to the new filter when the row matched on value', () => {
             selectAndExpect(
                 TaxonomicFilterGroupType.EventProperties,
                 'user.email',
@@ -195,14 +196,6 @@ describe('taxonomicPropertyFilterLogic', () => {
                 },
                 { matchedOn: 'value', matchedValue: 'frank@posthog.com' }
             )
-        })
-
-        it('does not pre-fill the value when the row matched on key', () => {
-            const group = logic.values.taxonomicGroups.find((g) => g.type === TaxonomicFilterGroupType.EventProperties)!
-            logic.actions.selectItem(group, 'user.email', PropertyFilterType.Event, {
-                matchedOn: 'key',
-            })
-            expect(setFilterSpy).toHaveBeenCalledWith(0, expect.objectContaining({ key: 'user.email', value: null }))
         })
     })
 

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -28,7 +28,6 @@ import {
     EventPropertyFilter,
     FlagPropertyFilter,
     PropertyFilterType,
-    PropertyFilterValue,
     PropertyOperator,
 } from '~/types'
 
@@ -165,7 +164,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                     propertyKey,
                     propertyType,
                     taxonomicGroup,
-                    values.describeProperty
+                    values.describeProperty,
+                    item
                 )
 
                 // Add cohort name if this is a cohort filter
@@ -183,13 +183,6 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                 if (propertyType === PropertyFilterType.EventMetadata && item.id.startsWith('$group_')) {
                     const eventMetadataFilter = filter as EventMetadataPropertyFilter
                     eventMetadataFilter.label = item.name
-                }
-
-                // If the row was surfaced because the search matched on a property *value*
-                // (rather than a key), pre-fill the filter with that value so the user
-                // doesn't need to retype what they just searched for.
-                if (item?.matchedOn === 'value' && typeof item?.matchedValue === 'string' && item.matchedValue) {
-                    ;(filter as AnyPropertyFilter & { value?: PropertyFilterValue }).value = [item.matchedValue]
                 }
 
                 props.setFilter(props.filterIndex, filter)

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -28,6 +28,7 @@ import {
     EventPropertyFilter,
     FlagPropertyFilter,
     PropertyFilterType,
+    PropertyFilterValue,
     PropertyOperator,
 } from '~/types'
 
@@ -182,6 +183,13 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                 if (propertyType === PropertyFilterType.EventMetadata && item.id.startsWith('$group_')) {
                     const eventMetadataFilter = filter as EventMetadataPropertyFilter
                     eventMetadataFilter.label = item.name
+                }
+
+                // If the row was surfaced because the search matched on a property *value*
+                // (rather than a key), pre-fill the filter with that value so the user
+                // doesn't need to retype what they just searched for.
+                if (item?.matchedOn === 'value' && typeof item?.matchedValue === 'string' && item.matchedValue) {
+                    ;(filter as AnyPropertyFilter & { value?: PropertyFilterValue }).value = [item.matchedValue]
                 }
 
                 props.setFilter(props.filterIndex, filter)

--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -387,4 +387,45 @@ describe('createDefaultPropertyFilter()', () => {
         )
         expect(result).toEqual(expect.objectContaining({ operator: PropertyOperator.IsNot }))
     })
+
+    it('pre-fills value from selectedItem.matchedValue when matchedOn is "value"', () => {
+        const result = createDefaultPropertyFilter(
+            null,
+            'user.email',
+            'log_attribute' as PropertyFilterType,
+            makeGroup('log_attributes' as TaxonomicFilterGroupType),
+            noopDescribeProperty,
+            { matchedOn: 'value', matchedValue: 'frank@posthog.com' }
+        )
+        expect(result).toEqual(
+            expect.objectContaining({
+                key: 'user.email',
+                value: ['frank@posthog.com'],
+                operator: PropertyOperator.Exact,
+            })
+        )
+    })
+
+    it('does not pre-fill value when matchedOn is "key"', () => {
+        const result = createDefaultPropertyFilter(
+            null,
+            'user.email',
+            'log_attribute' as PropertyFilterType,
+            makeGroup('log_attributes' as TaxonomicFilterGroupType),
+            noopDescribeProperty,
+            { matchedOn: 'key', matchedValue: 'frank@posthog.com' }
+        )
+        expect(result).toEqual(expect.objectContaining({ key: 'user.email', value: null }))
+    })
+
+    it('does not pre-fill value when selectedItem is omitted', () => {
+        const result = createDefaultPropertyFilter(
+            null,
+            'user.email',
+            'log_attribute' as PropertyFilterType,
+            makeGroup('log_attributes' as TaxonomicFilterGroupType),
+            noopDescribeProperty
+        )
+        expect(result).toEqual(expect.objectContaining({ key: 'user.email', value: null }))
+    })
 })

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -550,12 +550,19 @@ export function isEmptyProperty(property: AnyPropertyFilter): boolean {
     )
 }
 
+/** Subset of TaxonomicFilter result-item fields that influence default-filter creation. */
+type SelectedTaxonomicItem = {
+    matchedOn?: string
+    matchedValue?: string
+}
+
 export function createDefaultPropertyFilter(
     filter: AnyPropertyFilter | null,
     propertyKey: string | number,
     propertyType: PropertyFilterType,
     taxonomicGroup: TaxonomicFilterGroup,
-    describeProperty: propertyDefinitionsModelType['values']['describeProperty']
+    describeProperty: propertyDefinitionsModelType['values']['describeProperty'],
+    selectedItem?: SelectedTaxonomicItem | null
 ): AnyPropertyFilter {
     if (propertyType === PropertyFilterType.Cohort) {
         const operator =
@@ -609,11 +616,20 @@ export function createDefaultPropertyFilter(
         PropertyOperator.Exact
 
     const isGroupNameFilter = taxonomicGroup.type.startsWith(TaxonomicFilterGroupType.GroupNamesPrefix)
+    // When the row was surfaced because the search matched a property *value* (not the key),
+    // pre-fill the filter with that value so the user doesn't have to retype it. Operator
+    // defaults above are multi-select (Exact), so wrap in an array.
+    const matchedValue =
+        selectedItem?.matchedOn === 'value' &&
+        typeof selectedItem.matchedValue === 'string' &&
+        selectedItem.matchedValue
+            ? selectedItem.matchedValue
+            : null
     // :TRICKY: When we have a GroupNamesPrefix taxonomic filter, selecting the group name
     // is the equivalent of selecting a property value
     const property: AnyPropertyFilter = {
         key: isGroupNameFilter ? '$group_key' : propertyKey.toString(),
-        value: isGroupNameFilter ? propertyKey.toString() : null,
+        value: isGroupNameFilter ? propertyKey.toString() : matchedValue ? [matchedValue] : null,
         operator,
         type: propertyType as AnyPropertyFilter['type'] as any, // bad | pipe chain :(
         group_type_index: taxonomicGroup.groupTypeIndex,

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -107,6 +107,20 @@ const staleIndicator = (parsedLastSeen: dayjs.Dayjs | null): JSX.Element => {
     )
 }
 
+const valueMatchIndicator = (matchedValue: string): JSX.Element => {
+    return (
+        <Tooltip title={<>Matched on value: "{matchedValue}"</>}>
+            <span
+                aria-label="Matched on value"
+                data-attr="taxonomic-value-match-indicator"
+                className="text-tertiary opacity-60 ml-1 flex items-center"
+            >
+                <IconSearch />
+            </span>
+        </Tooltip>
+    )
+}
+
 const unusedIndicator = (eventNames: string[]): JSX.Element => {
     return (
         <Tooltip
@@ -243,19 +257,40 @@ const renderItemContents = ({
             {isUnusedEventProperty && unusedIndicator(eventNames)}
         </>
     ) : (
-        <div className="taxonomic-list-row-contents min-w-0">
-            {listGroupType === TaxonomicFilterGroupType.Elements ? (
-                <PropertyKeyInfo value={item.name ?? ''} disablePopover className="w-full" type={listGroupType} />
-            ) : (
-                <>
-                    {icon}
-                    <span className="truncate" title={itemGroup.getName?.(item) || item.name || ''}>
-                        {itemGroup.getName?.(item) || item.name || ''}
-                    </span>
-                </>
-            )}
-        </div>
+        <>
+            <div className="taxonomic-list-row-contents min-w-0">
+                {listGroupType === TaxonomicFilterGroupType.Elements ? (
+                    <PropertyKeyInfo value={item.name ?? ''} disablePopover className="w-full" type={listGroupType} />
+                ) : (
+                    <>
+                        {icon}
+                        <span className="truncate" title={itemGroup.getName?.(item) || item.name || ''}>
+                            {itemGroup.getName?.(item) || item.name || ''}
+                        </span>
+                    </>
+                )}
+            </div>
+            {(() => {
+                const matchedValue = getMatchedValue(item)
+                return matchedValue ? valueMatchIndicator(matchedValue) : null
+            })()}
+        </>
     )
+}
+
+function getMatchedValue(item: TaxonomicDefinitionTypes): string | null {
+    if (typeof item !== 'object' || item === null) {
+        return null
+    }
+    const candidate = item as unknown as { matchedOn?: string; matchedValue?: string }
+    if (
+        candidate.matchedOn === 'value' &&
+        typeof candidate.matchedValue === 'string' &&
+        candidate.matchedValue.length > 0
+    ) {
+        return candidate.matchedValue
+    }
+    return null
 }
 
 const selectedItemHasPopover = (

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -107,16 +107,22 @@ const staleIndicator = (parsedLastSeen: dayjs.Dayjs | null): JSX.Element => {
     )
 }
 
+const VALUE_MATCH_MAX_LENGTH = 30
+
 const valueMatchIndicator = (matchedValue: string): JSX.Element => {
+    const truncated =
+        matchedValue.length > VALUE_MATCH_MAX_LENGTH
+            ? matchedValue.slice(0, VALUE_MATCH_MAX_LENGTH) + '…'
+            : matchedValue
     return (
         <Tooltip title={<>Matched on value: "{matchedValue}"</>}>
-            <span
+            <LemonTag
                 aria-label="Matched on value"
                 data-attr="taxonomic-value-match-indicator"
-                className="text-tertiary opacity-60 ml-1 flex items-center"
+                className="ml-1 max-w-[12rem] truncate"
             >
-                <IconSearch />
-            </span>
+                {truncated}
+            </LemonTag>
         </Tooltip>
     )
 }

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1017,4 +1017,81 @@ describe('TaxonomicFilter', () => {
             }
         )
     })
+
+    describe('log attribute value-match indicator', () => {
+        const mockLogAttributes = {
+            results: [
+                { name: 'service.name', propertyFilterType: 'log_resource_attribute', matchedOn: 'key' },
+                { name: 'k8s.pod.name', propertyFilterType: 'log_resource_attribute', matchedOn: 'key' },
+                {
+                    name: 'k8s.deployment.name',
+                    propertyFilterType: 'log_resource_attribute',
+                    matchedOn: 'value',
+                    matchedValue: 'argo-rollouts-dashboard',
+                },
+            ],
+            count: 3,
+        }
+
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                    '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                    '/api/projects/:team/actions': { results: [] },
+                    '/api/environments/:team/logs/attributes': mockLogAttributes,
+                },
+                post: {
+                    '/api/environments/:team/query': { results: [] },
+                },
+            })
+        })
+
+        it('renders the value-match indicator only on rows matched by value', async () => {
+            renderFilter({ taxonomicGroupTypes: [TaxonomicFilterGroupType.LogResourceAttributes] })
+
+            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'argo')
+
+            await waitFor(() => {
+                expect(screen.getByText('k8s.deployment.name')).toBeInTheDocument()
+            })
+
+            const indicators = screen.queryAllByLabelText('Matched on value')
+            expect(indicators).toHaveLength(1)
+            const indicator = indicators[0]
+            const row = indicator.closest('.taxonomic-list-row, [data-attr*="prop-filter"]') ?? indicator.parentElement
+            expect(row?.textContent).toContain('k8s.deployment.name')
+            expect(row?.textContent).not.toContain('service.name')
+        })
+
+        it('orders key matches above value matches in the rendered list', async () => {
+            renderFilter({ taxonomicGroupTypes: [TaxonomicFilterGroupType.LogResourceAttributes] })
+
+            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'argo')
+
+            await waitFor(() => {
+                expect(screen.getAllByText('service.name').length).toBeGreaterThan(0)
+            })
+
+            // Anchor on the row data-attr so we ignore tooltips / titles that duplicate the text.
+            const rowText = (name: string): string =>
+                Array.from(document.querySelectorAll('[data-attr^="prop-filter-log_resource_attributes-"]'))
+                    .find((el) => el.textContent?.includes(name))
+                    ?.getAttribute('data-attr') ?? ''
+
+            const serviceIdx = rowText('service.name')
+            const podIdx = rowText('k8s.pod.name')
+            const deploymentIdx = rowText('k8s.deployment.name')
+            expect(serviceIdx).not.toBe('')
+            expect(podIdx).not.toBe('')
+            expect(deploymentIdx).not.toBe('')
+            // data-attr ends with the row index; key matches (0,1) come before value matches (2)
+            expect(parseInt(serviceIdx.split('-').pop() as string)).toBeLessThan(
+                parseInt(deploymentIdx.split('-').pop() as string)
+            )
+            expect(parseInt(podIdx.split('-').pop() as string)).toBeLessThan(
+                parseInt(deploymentIdx.split('-').pop() as string)
+            )
+        })
+    })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1059,6 +1059,8 @@ describe('TaxonomicFilter', () => {
             const indicators = screen.queryAllByLabelText('Matched on value')
             expect(indicators).toHaveLength(1)
             const indicator = indicators[0]
+            // Badge shows the (possibly truncated) matched value
+            expect(indicator.textContent).toContain('argo-rollouts-dashboard')
             const row = indicator.closest('.taxonomic-list-row, [data-attr*="prop-filter"]') ?? indicator.parentElement
             expect(row?.textContent).toContain('k8s.deployment.name')
             expect(row?.textContent).not.toContain('service.name')

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -899,6 +899,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         type: TaxonomicFilterGroupType.LogAttributes,
                         endpoint: combineUrl(`api/environments/${projectId}/logs/attributes`, {
                             attribute_type: 'log',
+                            search_values: 'true',
                             ...endpointFilters,
                         }).url,
                         valuesEndpoint: (key) =>
@@ -917,6 +918,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         type: TaxonomicFilterGroupType.LogResourceAttributes,
                         endpoint: combineUrl(`api/environments/${projectId}/logs/attributes`, {
                             attribute_type: 'resource',
+                            search_values: 'true',
                             ...endpointFilters,
                         }).url,
                         valuesEndpoint: (key) =>

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -24,6 +24,10 @@ import { DataWarehouseTableForInsight } from 'products/data_warehouse/frontend/t
 export interface SimpleOption {
     name: string
     propertyFilterType?: PropertyFilterType
+    /** When the search query matched a value rather than a key, this is set to 'value'. Otherwise 'key' or omitted. */
+    matchedOn?: 'key' | 'value'
+    /** Sample value that matched the search — only set when matchedOn === 'value'. */
+    matchedValue?: string
 }
 
 export interface QuickFilterItem {

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.test.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.test.ts
@@ -120,6 +120,52 @@ describe('universalFiltersLogic', () => {
         })
     })
 
+    it('addGroupFilter pre-fills value when search matched on a property value', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.addGroupFilter(
+                { type: TaxonomicFilterGroupType.PersonProperties } as TaxonomicFilterGroup,
+                'user.email',
+                { matchedOn: 'value', matchedValue: 'frank@posthog.com' } as any
+            )
+        }).toMatchValues({
+            filterGroup: {
+                ...defaultFilter,
+                values: [
+                    ...defaultFilter.values,
+                    {
+                        key: 'user.email',
+                        value: ['frank@posthog.com'],
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Person,
+                    },
+                ],
+            },
+        })
+    })
+
+    it('addGroupFilter does not pre-fill value when search matched on key', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.addGroupFilter(
+                { type: TaxonomicFilterGroupType.PersonProperties } as TaxonomicFilterGroup,
+                'user.email',
+                { matchedOn: 'key' } as any
+            )
+        }).toMatchValues({
+            filterGroup: {
+                ...defaultFilter,
+                values: [
+                    ...defaultFilter.values,
+                    {
+                        key: 'user.email',
+                        value: null,
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Person,
+                    },
+                ],
+            },
+        })
+    })
+
     it('addGroupFilter', async () => {
         const property = {
             key: 'property_key',

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.test.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.test.ts
@@ -143,29 +143,6 @@ describe('universalFiltersLogic', () => {
         })
     })
 
-    it('addGroupFilter does not pre-fill value when search matched on key', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.addGroupFilter(
-                { type: TaxonomicFilterGroupType.PersonProperties } as TaxonomicFilterGroup,
-                'user.email',
-                { matchedOn: 'key' } as any
-            )
-        }).toMatchValues({
-            filterGroup: {
-                ...defaultFilter,
-                values: [
-                    ...defaultFilter.values,
-                    {
-                        key: 'user.email',
-                        value: null,
-                        operator: PropertyOperator.Exact,
-                        type: PropertyFilterType.Person,
-                    },
-                ],
-            },
-        })
-    })
-
     it('addGroupFilter', async () => {
         const property = {
             key: 'property_key',

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -110,7 +110,13 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
         addGroupFilter: (
             taxonomicGroup: TaxonomicFilterGroup,
             propertyKey: TaxonomicFilterValue,
-            item: { propertyFilterType?: PropertyFilterType; name?: string; key?: string }
+            item: {
+                propertyFilterType?: PropertyFilterType
+                name?: string
+                key?: string
+                matchedOn?: string
+                matchedValue?: string
+            }
         ) => ({
             taxonomicGroup,
             propertyKey,

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -327,19 +327,9 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
                         propertyKey,
                         propertyType,
                         taxonomicGroup,
-                        values.describeProperty
+                        values.describeProperty,
+                        item
                     )
-
-                    // If the row was surfaced because the search matched on a value rather
-                    // than a key, pre-fill the filter with that value so the user doesn't
-                    // have to retype what they just searched for.
-                    const matchedValue =
-                        item && (item as { matchedOn?: string; matchedValue?: string }).matchedOn === 'value'
-                            ? (item as { matchedValue?: string }).matchedValue
-                            : undefined
-                    if (matchedValue) {
-                        ;(newPropertyFilter as { value?: unknown }).value = [matchedValue]
-                    }
 
                     newValues.push(newPropertyFilter)
                 } else {

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -329,6 +329,18 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
                         taxonomicGroup,
                         values.describeProperty
                     )
+
+                    // If the row was surfaced because the search matched on a value rather
+                    // than a key, pre-fill the filter with that value so the user doesn't
+                    // have to retype what they just searched for.
+                    const matchedValue =
+                        item && (item as { matchedOn?: string; matchedValue?: string }).matchedOn === 'value'
+                            ? (item as { matchedValue?: string }).matchedValue
+                            : undefined
+                    if (matchedValue) {
+                        ;(newPropertyFilter as { value?: unknown }).value = [matchedValue]
+                    }
+
                     newValues.push(newPropertyFilter)
                 } else {
                     const entityType = taxonomicFilterGroupTypeToEntityType(taxonomicGroup.type)

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22330,6 +22330,29 @@
             "required": ["type", "artifact_id"],
             "type": "object"
         },
+        "LogAttributeResult": {
+            "additionalProperties": false,
+            "properties": {
+                "matchedOn": {
+                    "description": "Whether this row matched the search by attribute key or by attribute value.",
+                    "enum": ["key", "value"],
+                    "type": "string"
+                },
+                "matchedValue": {
+                    "description": "Sample value that matched the search — only set when matchedOn is 'value'.",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "propertyFilterType": {
+                    "description": "Either 'log_attribute' or 'log_resource_attribute'.",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "propertyFilterType", "matchedOn"],
+            "type": "object"
+        },
         "LogAttributesQuery": {
             "additionalProperties": false,
             "properties": {
@@ -22361,6 +22384,10 @@
                 },
                 "search": {
                     "type": "string"
+                },
+                "searchValues": {
+                    "description": "When true, the search query also matches attribute values (not just keys).",
+                    "type": "boolean"
                 },
                 "serviceNames": {
                     "items": {
@@ -22413,7 +22440,7 @@
                 },
                 "results": {
                     "items": {
-                        "type": "object"
+                        "$ref": "#/definitions/LogAttributeResult"
                     },
                     "type": "array"
                 },
@@ -30964,7 +30991,7 @@
                         },
                         "results": {
                             "items": {
-                                "type": "object"
+                                "$ref": "#/definitions/LogAttributeResult"
                             },
                             "type": "array"
                         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2918,14 +2918,26 @@ export interface LogAttributesQuery extends DataNode<LogAttributesQueryResponse>
     limit?: integer
     offset?: integer
     search?: string
+    /** When true, the search query also matches attribute values (not just keys). */
+    searchValues?: boolean
     severityLevels?: LogSeverityLevel[]
     filterGroup?: PropertyGroupFilter
     serviceNames?: string[]
     attributeType: string
 }
 
+export interface LogAttributeResult {
+    name: string
+    /** Either 'log_attribute' or 'log_resource_attribute'. */
+    propertyFilterType: string
+    /** Whether this row matched the search by attribute key or by attribute value. */
+    matchedOn: 'key' | 'value'
+    /** Sample value that matched the search — only set when matchedOn is 'value'. */
+    matchedValue?: string
+}
+
 export interface LogAttributesQueryResponse extends AnalyticsQueryResponseBase {
-    results: Record<string, any>[]
+    results: LogAttributeResult[]
     count: number
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2797,6 +2797,27 @@ class LoadingBlock(BaseModel):
     type: Literal["loading"] = "loading"
 
 
+class MatchedOn(StrEnum):
+    KEY = "key"
+    VALUE = "value"
+
+
+class LogAttributeResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    matchedOn: MatchedOn = Field(
+        ...,
+        description=("Whether this row matched the search by attribute key or by attribute value."),
+    )
+    matchedValue: str | None = Field(
+        default=None,
+        description=("Sample value that matched the search — only set when matchedOn is 'value'."),
+    )
+    name: str
+    propertyFilterType: str = Field(..., description="Either 'log_attribute' or 'log_resource_attribute'.")
+
+
 class LogPropertyFilterType(StrEnum):
     LOG = "log"
     LOG_ATTRIBUTE = "log_attribute"
@@ -14816,7 +14837,7 @@ class LogAttributesQueryResponse(BaseModel):
     resolved_date_range: ResolvedDateRangeResponse | None = Field(
         default=None, description="The date range used for the query"
     )
-    results: list[dict[str, Any]]
+    results: list[LogAttributeResult]
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -16909,7 +16930,7 @@ class QueryResponseAlternative76(BaseModel):
     resolved_date_range: ResolvedDateRangeResponse | None = Field(
         default=None, description="The date range used for the query"
     )
-    results: list[dict[str, Any]]
+    results: list[LogAttributeResult]
     timings: list[QueryTiming] | None = Field(
         default=None,
         description=("Measured timings for different parts of the query generation process"),
@@ -20711,6 +20732,10 @@ class LogAttributesQuery(BaseModel):
     offset: int | None = None
     response: LogAttributesQueryResponse | None = None
     search: str | None = None
+    searchValues: bool | None = Field(
+        default=None,
+        description=("When true, the search query also matches attribute values (not just keys)."),
+    )
     serviceNames: list[str] | None = None
     severityLevels: list[LogSeverityLevel] | None = None
     tags: QueryLogTags | None = None

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -151,6 +151,11 @@ class _LogPropertyFilterSerializer(serializers.Serializer):
 
 class _LogsAttributesQuerySerializer(serializers.Serializer):
     search = serializers.CharField(required=False, help_text="Search filter for attribute names")
+    search_values = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="When true, the search query also matches attribute values (not just keys). Each result indicates whether it matched on key or value.",
+    )
     attribute_type = serializers.ChoiceField(
         choices=["log", "resource"],
         required=False,
@@ -441,6 +446,15 @@ class _LogAttributeEntrySerializer(serializers.Serializer):
     propertyFilterType = serializers.CharField(
         help_text='Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering.',
     )
+    matchedOn = serializers.ChoiceField(
+        choices=["key", "value"],
+        help_text='How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.',
+    )
+    matchedValue = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text='Sample matching value — only set when matchedOn is "value".',
+    )
 
 
 class _LogsAttributesResponseSerializer(serializers.Serializer):
@@ -718,6 +732,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def attributes(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         search = request.GET.get("search", "")
+        search_values = request.GET.get("search_values", "false").lower() == "true"
         limit = request.GET.get("limit", 100)
         offset = request.GET.get("offset", 0)
 
@@ -756,6 +771,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             dateRange=dateRange,
             attributeType=attributeType,
             search=search,
+            searchValues=search_values,
             limit=limit,
             offset=offset,
             serviceNames=serviceNames,
@@ -765,7 +781,13 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         runner = LogAttributesQueryRunner(team=self.team, query=query)
 
         result = runner.calculate()
-        return Response({"results": result.results, "count": result.count}, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "results": [r.model_dump(exclude_none=True) for r in result.results],
+                "count": result.count,
+            },
+            status=status.HTTP_200_OK,
+        )
 
     @extend_schema(parameters=[_LogsValuesQuerySerializer], responses={200: _LogsValuesResponseSerializer})
     @action(detail=False, methods=["GET"], required_scopes=["logs:read"])

--- a/products/logs/backend/log_attributes_query_runner.py
+++ b/products/logs/backend/log_attributes_query_runner.py
@@ -197,7 +197,7 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
                 )
             )
 
-        total_count = response.results[0][1] + self.query.offset
+        total_count = response.results[0][1] + (self.query.offset or 0)
         return LogAttributesQueryResponse(results=formatted_results, count=total_count)
 
     def _format_value_search_response(self, response, property_filter_type: str) -> LogAttributesQueryResponse:
@@ -222,7 +222,7 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
         # show a "load more" affordance, so an exact count isn't required.
         return LogAttributesQueryResponse(
             results=formatted_results,
-            count=len(formatted_results) + self.query.offset,
+            count=len(formatted_results) + (self.query.offset or 0),
         )
 
     @cached_property

--- a/products/logs/backend/log_attributes_query_runner.py
+++ b/products/logs/backend/log_attributes_query_runner.py
@@ -20,6 +20,11 @@ from products.logs.backend.logs_query_runner import LogsQueryRunnerMixin
 # filters to narrow things down (and will likely have to anyway if we're returning thousands of attributes)
 MAX_READ_BYTES = 5_000_000_000
 
+# Value-search probes attribute_value with ILIKE %search%, which scans far more rows than
+# the key-only path. Require a meaningfully specific term so short prefixes (e.g. "id")
+# don't trigger an expensive scan.
+MIN_VALUE_SEARCH_LENGTH = 4
+
 
 class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse], LogsQueryRunnerMixin):
     query: LogAttributesQuery
@@ -46,7 +51,9 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
         return self._to_query_keys_only()
 
     def _should_search_values(self) -> bool:
-        return bool(self.query.searchValues) and bool(self.query.search)
+        if not self.query.searchValues or not self.query.search:
+            return False
+        return len(self.query.search) >= MIN_VALUE_SEARCH_LENGTH
 
     def _to_query_keys_only(self) -> ast.SelectQuery:
         query = parse_select(

--- a/products/logs/backend/log_attributes_query_runner.py
+++ b/products/logs/backend/log_attributes_query_runner.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from zoneinfo import ZoneInfo
 
-from posthog.schema import IntervalType, LogAttributesQuery, LogAttributesQueryResponse
+from posthog.schema import IntervalType, LogAttributeResult, LogAttributesQuery, LogAttributesQueryResponse, MatchedOn
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
@@ -41,6 +41,14 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
         )
 
     def to_query(self) -> ast.SelectQuery:
+        if self._should_search_values():
+            return self._to_query_with_value_search()
+        return self._to_query_keys_only()
+
+    def _should_search_values(self) -> bool:
+        return bool(self.query.searchValues) and bool(self.query.search)
+
+    def _to_query_keys_only(self) -> ast.SelectQuery:
         query = parse_select(
             """
             SELECT
@@ -60,6 +68,72 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
                 ORDER BY lower(attribute_key) = lower({exact}) DESC, has(splitByNonAlpha(lower(attribute_key)), lower({exact})) DESC, sum(attribute_count) desc, attribute_key asc
                 OFFSET {offset}
             )
+            """,
+            placeholders={
+                "search": ast.Constant(value=f"%{self.query.search}%"),
+                "exact": ast.Constant(value=self.query.search),
+                "attributeType": ast.Constant(value=self.query.attributeType),
+                "limit": ast.Constant(value=self.query.limit),
+                "offset": ast.Constant(value=self.query.offset),
+                "where": self.where(),
+                **self.query_date_range.to_placeholders(),
+            },
+        )
+
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+    def _to_query_with_value_search(self) -> ast.SelectQuery:
+        # UNION ALL of two branches:
+        #   (1) keys whose name matches the search
+        #   (2) keys whose values match the search but whose name does NOT match
+        # The NOT-ILIKE on the value branch dedupes — a key never appears twice.
+        # match_type lets the outer ORDER BY put key matches above value matches.
+        query = parse_select(
+            """
+            SELECT
+                attribute_key,
+                match_type,
+                sample_value,
+                total_count
+            FROM (
+                SELECT
+                    attribute_key,
+                    'key' AS match_type,
+                    '' AS sample_value,
+                    sum(attribute_count) AS total_count
+                FROM log_attributes
+                WHERE time_bucket >= {date_from_start_of_interval}
+                AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
+                AND attribute_type = {attributeType}
+                AND attribute_key ILIKE {search}
+                AND {where}
+                GROUP BY team_id, attribute_key
+
+                UNION ALL
+
+                SELECT
+                    attribute_key,
+                    'value' AS match_type,
+                    argMax(attribute_value, attribute_count) AS sample_value,
+                    sum(attribute_count) AS total_count
+                FROM log_attributes
+                WHERE time_bucket >= {date_from_start_of_interval}
+                AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
+                AND attribute_type = {attributeType}
+                AND attribute_value ILIKE {search}
+                AND attribute_key NOT ILIKE {search}
+                AND {where}
+                GROUP BY team_id, attribute_key
+            )
+            ORDER BY
+                match_type = 'key' DESC,
+                lower(attribute_key) = lower({exact}) DESC,
+                has(splitByNonAlpha(lower(attribute_key)), lower({exact})) DESC,
+                total_count DESC,
+                attribute_key ASC
+            LIMIT {limit}
+            OFFSET {offset}
             """,
             placeholders={
                 "search": ast.Constant(value=f"%{self.query.search}%"),
@@ -103,20 +177,53 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
             settings=self.settings,
         )
 
-        formatted_results = []
-        if isinstance(response.results, list) and len(response.results) > 0 and len(response.results[0]) > 0:
-            for result in response.results[0][0]:
-                entry = {
-                    "name": result,
-                    "propertyFilterType": "log_resource_attribute"
-                    if self.query.attributeType == "resource"
-                    else "log_attribute",
-                }
-                formatted_results.append(entry)
+        property_filter_type = "log_resource_attribute" if self.query.attributeType == "resource" else "log_attribute"
 
-            total_count = response.results[0][1] + self.query.offset
-            return LogAttributesQueryResponse(results=formatted_results, count=total_count)
-        return LogAttributesQueryResponse(results=[], count=0)
+        if self._should_search_values():
+            return self._format_value_search_response(response, property_filter_type)
+        return self._format_keys_only_response(response, property_filter_type)
+
+    def _format_keys_only_response(self, response, property_filter_type: str) -> LogAttributesQueryResponse:
+        if not (isinstance(response.results, list) and len(response.results) > 0 and len(response.results[0]) > 0):
+            return LogAttributesQueryResponse(results=[], count=0)
+
+        formatted_results: list[LogAttributeResult] = []
+        for result in response.results[0][0]:
+            formatted_results.append(
+                LogAttributeResult(
+                    name=result,
+                    propertyFilterType=property_filter_type,
+                    matchedOn=MatchedOn.KEY,
+                )
+            )
+
+        total_count = response.results[0][1] + self.query.offset
+        return LogAttributesQueryResponse(results=formatted_results, count=total_count)
+
+    def _format_value_search_response(self, response, property_filter_type: str) -> LogAttributesQueryResponse:
+        if not isinstance(response.results, list):
+            return LogAttributesQueryResponse(results=[], count=0)
+
+        formatted_results: list[LogAttributeResult] = []
+        for row in response.results:
+            attribute_key, match_type, sample_value, _total_count = row
+            matched_on_key = match_type == "key"
+            formatted_results.append(
+                LogAttributeResult(
+                    name=attribute_key,
+                    propertyFilterType=property_filter_type,
+                    matchedOn=MatchedOn.KEY if matched_on_key else MatchedOn.VALUE,
+                    matchedValue=None if matched_on_key else (sample_value or None),
+                )
+            )
+
+        # Total count for value-search isn't separately computed; use returned page size
+        # plus offset as a lower bound. The frontend uses this only to decide whether to
+        # show a "load more" affordance, so an exact count isn't required.
+        return LogAttributesQueryResponse(
+            results=formatted_results,
+            count=len(formatted_results) + self.query.offset,
+        )
 
     @cached_property
     def settings(self):

--- a/products/logs/backend/test/test_log_values_attributes.py
+++ b/products/logs/backend/test/test_log_values_attributes.py
@@ -159,6 +159,73 @@ class TestLogValuesAttributesTimezones(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(all_names, empty_names, "Empty value filter should return same values as no filter")
         self.assertEqual(set(all_names), {"info", "DEBUG", "PING", "more", "error"})
 
+    def test_log_attributes_search_values_off_by_default(self):
+        """Searching with `search_values` unset should match attribute keys only."""
+
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "attribute_type": "resource",
+            "search": "argo-rollouts-dashboard",
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/attributes", query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        # No attribute key contains "argo-rollouts-dashboard", so without value search the result is empty.
+        self.assertEqual(results, [], "search_values defaults to false — value-only matches must not surface")
+
+    def test_log_attributes_search_values_finds_match_on_value(self):
+        """When `search_values=true`, matches against attribute_value should surface with matchedOn='value'."""
+
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "attribute_type": "resource",
+            "search": "argo-rollouts-dashboard",
+            "search_values": "true",
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/attributes", query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        self.assertGreater(len(results), 0, "Expected value-based matches for argo-rollouts-dashboard")
+
+        for entry in results:
+            self.assertIn("matchedOn", entry)
+            self.assertIn(entry["matchedOn"], ("key", "value"))
+            if entry["matchedOn"] == "value":
+                self.assertTrue(entry.get("matchedValue"), "Value matches should expose the matched sample value")
+                self.assertIn("argo-rollouts-dashboard", (entry["matchedValue"] or "").lower())
+
+        # All keys here match purely on value (no attribute key contains "argo-rollouts-dashboard").
+        self.assertTrue(any(r["matchedOn"] == "value" for r in results))
+
+    def test_log_attributes_search_values_ranks_key_matches_first(self):
+        """Key matches must always rank above value matches when both exist."""
+
+        # Search "argo" — `service.name` value is "argo-rollouts" (value match), and several
+        # k8s.* keys contain it as substring of their values, but no key literally contains "argo".
+        # We assert that whenever a key match is present it appears before any value match.
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "attribute_type": "resource",
+            "search": "argo",
+            "search_values": "true",
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/attributes", query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        match_kinds = [r["matchedOn"] for r in results]
+
+        # Once we hit the first value match, we should never see a key match after it.
+        first_value_idx = next((i for i, m in enumerate(match_kinds) if m == "value"), None)
+        if first_value_idx is not None:
+            tail = match_kinds[first_value_idx:]
+            self.assertNotIn("key", tail, "key matches must appear before value matches")
+
     def test_log_attributes_search_trace_id_before_pid(self):
         """Test that searching attributes for 'id' returns trace_id before pid"""
 

--- a/products/logs/backend/test/test_log_values_attributes.py
+++ b/products/logs/backend/test/test_log_values_attributes.py
@@ -201,6 +201,29 @@ class TestLogValuesAttributesTimezones(ClickhouseTestMixin, APIBaseTest):
         # All keys here match purely on value (no attribute key contains "argo-rollouts-dashboard").
         self.assertTrue(any(r["matchedOn"] == "value" for r in results))
 
+    def test_log_attributes_search_values_skipped_for_short_search(self):
+        """Searches under 4 characters should never trigger value matching, even with `search_values=true`."""
+
+        # "arg" (3 chars) is a substring of values like "argo-rollouts-dashboard", but value
+        # search is gated to >= 4 chars to avoid scanning attribute_value on broad queries.
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "attribute_type": "resource",
+            "search": "arg",
+            "search_values": "true",
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/attributes", query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        for entry in results:
+            self.assertNotEqual(
+                entry.get("matchedOn"),
+                "value",
+                "value matches must not surface when search term is shorter than the minimum length",
+            )
+
     def test_log_attributes_search_values_ranks_key_matches_first(self):
         """Key matches must always rank above value matches when both exist."""
 

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -607,10 +607,31 @@ export interface _LogPropertyFilterApi {
     value?: unknown | null
 }
 
+/**
+ * * `key` - key
+ * `value` - value
+ */
+export type MatchedOnEnumApi = (typeof MatchedOnEnumApi)[keyof typeof MatchedOnEnumApi]
+
+export const MatchedOnEnumApi = {
+    Key: 'key',
+    Value: 'value',
+} as const
+
 export interface _LogAttributeEntryApi {
     name: string
     /** Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering. */
     propertyFilterType: string
+    /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
+
+* `key` - key
+* `value` - value */
+    matchedOn: MatchedOnEnumApi
+    /**
+     * Sample matching value — only set when matchedOn is "value".
+     * @nullable
+     */
+    matchedValue?: string | null
 }
 
 export interface _LogsAttributesResponseApi {
@@ -981,6 +1002,10 @@ export type LogsAttributesRetrieveParams = {
      * @minLength 1
      */
     search?: string
+    /**
+     * When true, the search query also matches attribute values (not just keys). Each result indicates whether it matched on key or value.
+     */
+    search_values?: boolean
     /**
      * Filter attributes to those appearing in logs from these services.
      */

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -245,6 +245,9 @@ tools:
     event-definitions-partial-update:
         operation: event_definitions_partial_update
         enabled: false
+    event-definitions-promoted-properties-retrieve:
+        operation: event_definitions_promoted_properties_retrieve
+        enabled: false
     event-definitions-python-retrieve:
         operation: event_definitions_python_retrieve
         enabled: false
@@ -791,7 +794,4 @@ tools:
         enabled: false
     users-verify-email-create:
         operation: users_verify_email_create
-        enabled: false
-    event-definitions-promoted-properties-retrieve:
-        operation: event_definitions_promoted_properties_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19298,7 +19298,26 @@ export namespace Schemas {
       LogAttributesQuery: 'LogAttributesQuery',
     } as const;
 
-    export type LogAttributesQueryResponseResultsItem = { [key: string]: unknown };
+    export type MatchedOn = typeof MatchedOn[keyof typeof MatchedOn];
+
+
+    export const MatchedOn = {
+      Key: 'key',
+      Value: 'value',
+    } as const;
+
+    export interface LogAttributeResult {
+      /** Whether this row matched the search by attribute key or by attribute value. */
+      matchedOn: MatchedOn;
+      /**
+       * Sample value that matched the search — only set when matchedOn is 'value'.
+       * @nullable
+       */
+      matchedValue?: string | null;
+      name: string;
+      /** Either 'log_attribute' or 'log_resource_attribute'. */
+      propertyFilterType: string;
+    }
 
     export interface LogAttributesQueryResponse {
       count: number;
@@ -19318,7 +19337,7 @@ export namespace Schemas {
       query_status?: QueryStatus | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: LogAttributesQueryResponseResultsItem[];
+      results: LogAttributeResult[];
       /**
        * Measured timings for different parts of the query generation process
        * @nullable
@@ -19340,6 +19359,11 @@ export namespace Schemas {
       response?: LogAttributesQueryResponse | null;
       /** @nullable */
       search?: string | null;
+      /**
+       * When true, the search query also matches attribute values (not just keys).
+       * @nullable
+       */
+      searchValues?: boolean | null;
       /** @nullable */
       serviceNames?: string[] | null;
       /** @nullable */
@@ -21545,6 +21569,18 @@ export namespace Schemas {
     export interface MarkToleratedInput {
       snapshot_id: string;
     }
+
+    /**
+     * * `key` - key
+    * `value` - value
+     */
+    export type MatchedOnEnum = typeof MatchedOnEnum[keyof typeof MatchedOnEnum];
+
+
+    export const MatchedOnEnum = {
+      Key: 'key',
+      Value: 'value',
+    } as const;
 
     /**
      * Per-column bucket function overrides, e.g. {"timestamp": "hour"}
@@ -34256,8 +34292,6 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
     }
 
-    export type QueryResponseAlternative76ResultsItem = { [key: string]: unknown };
-
     export interface QueryResponseAlternative76 {
       count: number;
       /**
@@ -34276,7 +34310,7 @@ export namespace Schemas {
       query_status?: QueryStatus | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: QueryResponseAlternative76ResultsItem[];
+      results: LogAttributeResult[];
       /**
        * Measured timings for different parts of the query generation process
        * @nullable
@@ -36733,6 +36767,16 @@ export namespace Schemas {
       name: string;
       /** Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering. */
       propertyFilterType: string;
+      /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
+
+    * `key` - key
+    * `value` - value */
+      matchedOn: MatchedOnEnum;
+      /**
+       * Sample matching value — only set when matchedOn is "value".
+       * @nullable
+       */
+      matchedValue?: string | null;
     }
 
     export interface _LogAttributeValue {
@@ -38678,6 +38722,10 @@ export namespace Schemas {
      * @minLength 1
      */
     search?: string;
+    /**
+     * When true, the search query also matches attribute values (not just keys). Each result indicates whether it matched on key or value.
+     */
+    search_values?: boolean;
     /**
      * Filter attributes to those appearing in logs from these services.
      */
@@ -43001,6 +43049,10 @@ export namespace Schemas {
      * @minLength 1
      */
     search?: string;
+    /**
+     * When true, the search query also matches attribute values (not just keys). Each result indicates whether it matched on key or value.
+     */
+    search_values?: boolean;
     /**
      * Filter attributes to those appearing in logs from these services.
      */

--- a/services/mcp/src/generated/logs/api.ts
+++ b/services/mcp/src/generated/logs/api.ts
@@ -195,6 +195,7 @@ export const logsAttributesRetrieveQueryLimitMax = 100
 
 export const logsAttributesRetrieveQueryOffsetMin = 0
 
+export const logsAttributesRetrieveQuerySearchValuesDefault = false
 export const logsAttributesRetrieveQueryServiceNamesDefault = []
 
 export const LogsAttributesRetrieveQueryParams = /* @__PURE__ */ zod.object({
@@ -279,6 +280,12 @@ export const LogsAttributesRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe('Pagination offset (default: 0)'),
     search: zod.string().min(1).optional().describe('Search filter for attribute names'),
+    search_values: zod
+        .boolean()
+        .default(logsAttributesRetrieveQuerySearchValuesDefault)
+        .describe(
+            'When true, the search query also matches attribute values (not just keys). Each result indicates whether it matched on key or value.'
+        ),
     serviceNames: zod
         .array(zod.string())
         .default(logsAttributesRetrieveQueryServiceNamesDefault)

--- a/services/mcp/src/tools/generated/logs.ts
+++ b/services/mcp/src/tools/generated/logs.ts
@@ -289,6 +289,7 @@ const logsAttributesList = (): ToolBase<typeof LogsAttributesListSchema, Schemas
                 limit: params.limit,
                 offset: params.offset,
                 search: params.search,
+                search_values: params.search_values,
                 serviceNames: params.serviceNames,
             },
         })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/logs-attributes-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/logs-attributes-list.json
@@ -98,6 +98,11 @@
             "minLength": 1,
             "type": "string"
         },
+        "search_values": {
+            "default": false,
+            "description": "When true, the search query also matches attribute values (not just keys). Each result indicates whether it matched on key or value.",
+            "type": "boolean"
+        },
         "serviceNames": {
             "default": [],
             "description": "Filter attributes to those appearing in logs from these services.",


### PR DESCRIPTION


## Problem
previously filtering was only on attribute names, then you had to separately search in values

now you can immediately search for a value (e.g. an email, id, token, whatever) and see the attributes which have that value (attribute names will take priority in the UI)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

makes the search bar more usable by searching keys AND values

<img width="1450" height="536" alt="image" src="https://github.com/user-attachments/assets/a8194281-9109-4925-846a-6883198f1f13" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
