### PR TITLE
fix: Wrap redshift identifiers in sql.Identifier

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -294,14 +294,14 @@ class RedshiftClient(PostgreSQLClient):
         )
 
         if stage_fields_cast_to_super is not None:
-            select_stage_table_fields = sql.SQL(
-                ",".join(
-                    f"JSON_PARSE({field[0]}) AS {field[0]}" if field[0] in stage_fields_cast_to_super else field[0]
-                    for field in final_table_fields
-                )
+            select_stage_table_fields = sql.SQL(",").join(
+                sql.SQL("JSON_PARSE({field}) AS {field}").format(field=sql.Identifier(field[0]))
+                if field[0] in stage_fields_cast_to_super
+                else sql.Identifier(field[0])
+                for field in final_table_fields
             )
         else:
-            select_stage_table_fields = sql.SQL(",".join(field[0] for field in final_table_fields))
+            select_stage_table_fields = sql.SQL(",").join(sql.Identifier(field[0]) for field in final_table_fields)
 
         merge_query = sql.SQL(
             """\


### PR DESCRIPTION
## Problem

We don't wrap some field names in `sql.Identifier` in Redshift.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Wrap them, like we do others.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
