### PR TITLE
fix(trends): allow single multi-syntax breakdown for data warehouse

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py
@@ -50,6 +50,16 @@ class TestValidateDataWarehouseBreakdown(BaseTest):
 
         ValidateDataWarehouseBreakdown().validate(self._context(query))
 
+    def test_allows_data_warehouse_single_breakdown_in_multi_syntax(self) -> None:
+        query = TrendsQuery(
+            series=self._data_warehouse_series(),
+            breakdownFilter=BreakdownFilter(
+                breakdowns=[Breakdown(property="plan", type=BreakdownType.DATA_WAREHOUSE)],
+            ),
+        )
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))
+
     @parameterized.expand(
         [
             (
@@ -63,6 +73,10 @@ class TestValidateDataWarehouseBreakdown(BaseTest):
             (
                 "person_breakdown",
                 BreakdownFilter(breakdown="$geoip_country_code", breakdown_type=BreakdownType.PERSON),
+            ),
+            (
+                "event_breakdown_multi_syntax",
+                BreakdownFilter(breakdowns=[Breakdown(property="$browser", type=BreakdownType.EVENT)]),
             ),
         ]
     )

--- a/posthog/hogql_queries/insights/trends/trend_validation_rules.py
+++ b/posthog/hogql_queries/insights/trends/trend_validation_rules.py
@@ -27,13 +27,24 @@ class ValidateDataWarehouseBreakdown:
         assert context.query.breakdownFilter is not None  # type checking
         breakdown_filter = context.query.breakdownFilter
 
-        if has_multi_breakdown(breakdown_filter):
+        if has_multi_breakdown(breakdown_filter) and breakdown_filter.breakdowns is not None and len(breakdown_filter.breakdowns) > 1:
             raise ValidationError(
                 f"Multi-breakdowns not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
                 code=self.code,
             )
 
         if has_single_breakdown(breakdown_filter) and breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE:
+            raise ValidationError(
+                f"Event based breakdowns are not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
+                code=self.code,
+            )
+
+        if (
+            has_multi_breakdown(breakdown_filter)
+            and breakdown_filter.breakdowns is not None
+            and len(breakdown_filter.breakdowns) == 1
+            and breakdown_filter.breakdowns[0].type != BreakdownType.DATA_WAREHOUSE
+        ):
             raise ValidationError(
                 f"Event based breakdowns are not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
                 code=self.code,


### PR DESCRIPTION
### Motivation
- Fix validation that incorrectly rejects a single-item `breakdowns` array on trends queries that include a data warehouse series so a single data-warehouse breakdown can be expressed using the multi-breakdown syntax.

### Description
- Updated `posthog/hogql_queries/insights/trends/trend_validation_rules.py` to treat `breakdowns` as a true multi-breakdown only when `len(breakdown_filter.breakdowns) > 1`, added an explicit single-item `breakdowns` check to enforce that its `type` must be `BreakdownType.DATA_WAREHOUSE`, and added unit tests in `posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py` covering the single-item `breakdowns` cases.

### Testing
- Attempted automated runs with `hogli test`, `flox activate -- bash -c "hogli test ..."`, and `python -m pytest posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py`, but they could not complete in this environment due to missing `hogli`/`flox` and a missing `django` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3b85431883328b5c5d07cfbae67c)