### PR TITLE
fix(phai): explain when /init skips the site crawl due to no events

### DIFF
--- a/ee/hogai/chat_agent/memory/nodes.py
+++ b/ee/hogai/chat_agent/memory/nodes.py
@@ -51,6 +51,7 @@ from ee.models.assistant import CoreMemory
 from .parsers import check_memory_collection_completed, compressed_memory_parser
 from .prompts import (
     ENQUIRY_INITIAL_MESSAGE,
+    ENQUIRY_NO_EVENTS_INITIAL_MESSAGE,
     INITIALIZE_CORE_MEMORY_SYSTEM_PROMPT,
     INITIALIZE_CORE_MEMORY_WITH_BUNDLE_IDS_USER_PROMPT,
     INITIALIZE_CORE_MEMORY_WITH_DOMAINS_USER_PROMPT,
@@ -159,12 +160,13 @@ class MemoryOnboardingNode(MemoryInitializerContextMixin, MemoryOnboardingShould
 
         retrieved_prop = await self._aretrieve_context(config=config)
 
-        # No host or app bundle ID found
+        # No host or app bundle ID found - tell the user we couldn't crawl their site
+        # so the silent fallback to question-based onboarding doesn't read as a failure.
         if not retrieved_prop:
             return PartialAssistantState(
                 messages=[
                     AssistantMessage(
-                        content=ENQUIRY_INITIAL_MESSAGE,
+                        content=ENQUIRY_NO_EVENTS_INITIAL_MESSAGE,
                         id=str(uuid4()),
                     )
                 ]

--- a/ee/hogai/chat_agent/memory/prompts.py
+++ b/ee/hogai/chat_agent/memory/prompts.py
@@ -53,10 +53,10 @@ ENQUIRY_INITIAL_MESSAGE = "Let me now ask you a few questions to help me underst
 
 ENQUIRY_NO_EVENTS_INITIAL_MESSAGE = (
     "I'd usually start by reading your site to learn about your product, "
-    "but I haven't seen any pageview or screen events for this project yet, "
+    "but I don't have any pageview or screen events I can use to identify your site yet, "
     "so I'll ask you a few questions instead. "
-    "Once you've captured at least one event from a real domain, "
-    "re-run /init and I'll pick up your site automatically."
+    "Once you've captured at least one event from your live site or app, "
+    "re-run /init and I'll pick it up automatically."
 )
 
 SCRAPING_VERIFICATION_MESSAGE = "Does this look like a comprehensive description of your project?"

--- a/ee/hogai/chat_agent/memory/prompts.py
+++ b/ee/hogai/chat_agent/memory/prompts.py
@@ -51,6 +51,14 @@ SCRAPING_INITIAL_MESSAGE = (
 
 ENQUIRY_INITIAL_MESSAGE = "Let me now ask you a few questions to help me understand your project better…"
 
+ENQUIRY_NO_EVENTS_INITIAL_MESSAGE = (
+    "I'd usually start by reading your site to learn about your product, "
+    "but I haven't seen any pageview or screen events for this project yet, "
+    "so I'll ask you a few questions instead. "
+    "Once you've captured at least one event from a real domain, "
+    "re-run /init and I'll pick up your site automatically."
+)
+
 SCRAPING_VERIFICATION_MESSAGE = "Does this look like a comprehensive description of your project?"
 
 SCRAPING_CONFIRMATION_MESSAGE = "Yes, save this"

--- a/ee/hogai/chat_agent/memory/test/test_nodes.py
+++ b/ee/hogai/chat_agent/memory/test/test_nodes.py
@@ -131,7 +131,7 @@ class TestMemoryOnboardingNode(ClickhouseTestMixin, NonAtomicBaseTest):
         node = MemoryOnboardingNode(team=self.team, user=self.user)
         self.assertEqual(await node.should_run_onboarding_at_start(AssistantState(messages=[])), "continue")
 
-    async def test_onboarding_initial_message_is_sent_if_no_events(self):
+    async def test_onboarding_message_explains_missing_events_when_no_pageviews(self):
         await sync_to_async(flush_persons_and_events)()
         node = MemoryOnboardingNode(team=self.team, user=self.user)
         # Mock _aretrieve_context to return None (no events found) to avoid ClickHouse state leakage between tests
@@ -142,7 +142,10 @@ class TestMemoryOnboardingNode(ClickhouseTestMixin, NonAtomicBaseTest):
         new_state = cast(PartialAssistantState, new_state)
         self.assertEqual(len(new_state.messages), 1)
         self.assertTrue(isinstance(new_state.messages[0], AssistantMessage))
-        self.assertEqual(cast(AssistantMessage, new_state.messages[0]).content, prompts.ENQUIRY_INITIAL_MESSAGE)
+        self.assertEqual(
+            cast(AssistantMessage, new_state.messages[0]).content,
+            prompts.ENQUIRY_NO_EVENTS_INITIAL_MESSAGE,
+        )
 
     async def test_node_uses_project_description(self):
         self.team.project.product_description = "This is a product analytics platform"

--- a/ee/hogai/eval/ci/eval_memory_onboarding.py
+++ b/ee/hogai/eval/ci/eval_memory_onboarding.py
@@ -15,6 +15,7 @@ from posthog.sync import database_sync_to_async
 from ee.hogai.chat_agent import AssistantGraph
 from ee.hogai.chat_agent.memory.prompts import (
     ENQUIRY_INITIAL_MESSAGE,
+    ENQUIRY_NO_EVENTS_INITIAL_MESSAGE,
     SCRAPING_SUCCESS_KEY_PHRASE,
     SCRAPING_TERMINATION_MESSAGE,
 )
@@ -30,7 +31,7 @@ class MemoryLLMClassifier(LLMClassifier):
     def _run_eval_sync(self, output, expected, **kwargs):
         if not output:
             return Score(name=self._name(), score=None)
-        if expected in [ENQUIRY_INITIAL_MESSAGE, SCRAPING_TERMINATION_MESSAGE]:
+        if expected in [ENQUIRY_INITIAL_MESSAGE, ENQUIRY_NO_EVENTS_INITIAL_MESSAGE, SCRAPING_TERMINATION_MESSAGE]:
             # For the special cases, we MUST see the expected messages verbatim
             return Score(
                 name=self._name(),
@@ -41,7 +42,7 @@ class MemoryLLMClassifier(LLMClassifier):
     async def _run_eval_async(self, output, expected, **kwargs):
         if not output:
             return Score(name=self._name(), score=None)
-        if expected in [ENQUIRY_INITIAL_MESSAGE, SCRAPING_TERMINATION_MESSAGE]:
+        if expected in [ENQUIRY_INITIAL_MESSAGE, ENQUIRY_NO_EVENTS_INITIAL_MESSAGE, SCRAPING_TERMINATION_MESSAGE]:
             # For the special cases, we MUST see the expected messages verbatim
             return Score(
                 name=self._name(),
@@ -392,7 +393,7 @@ Clash of Clans is a long-running, free-to-play mobile strategy game by Supercell
             # Case: No domain/bundle ID available (e.g. only localhost was present in the data)
             EvalCase(
                 input=("Zapier", None),  # No EventTaxonomyItem, but let's say the org name is well-known (Zapier)
-                expected=ENQUIRY_INITIAL_MESSAGE,  # Should fall back to enquiry flow INSTEAD OF scraping
+                expected=ENQUIRY_NO_EVENTS_INITIAL_MESSAGE,  # Should fall back to enquiry flow INSTEAD OF scraping
             ),
             # Case: Non-existing product
             EvalCase(


### PR DESCRIPTION
## Problem

When a user runs `/init` in PostHog AI with no `$pageview` or `$screen` events (or only `localhost` ones, which `_aretrieve_context` filters out), `MemoryOnboardingNode` silently falls back to the same "Let me ask you a few questions…" message it uses when a product description is already set. The user has no signal that a site crawl was attempted, why it was skipped, or how to unblock it. A customer hit this on a fresh project and assumed the feature was broken (trace `546e719b-bcb7-4717-9e5d-4675076a98f0`).

## Changes

- Add `ENQUIRY_NO_EVENTS_INITIAL_MESSAGE` in `ee/hogai/chat_agent/memory/prompts.py`. Explains the skip and points the user at re-running `/init` once they've captured an event from a live site or app. Wording covers both the "no events" and "only localhost events" branches of `_aretrieve_context`.
- `MemoryOnboardingNode.arun` uses the new message in the "no host or bundle ID" branch only. The `product_description` branch keeps `ENQUIRY_INITIAL_MESSAGE`.
- Test renamed and asserts the new constant.
- `eval_memory_onboarding.py`: the no-domain case expects the new constant, and the verbatim-match allowlist in `MemoryLLMClassifier` includes it.

## How did you test this code?

I'm an agent (PostHog Code). Lint and pre-commit (`ruff`, `uv run ty check`) pass. Ran `hogli test ee/hogai/chat_agent/memory/test/test_nodes.py::TestMemoryOnboardingNode` locally: all 6 tests pass. The `eval_memory_onboarding` CI job will exercise the eval changes.

## Publish to changelog?

no

## Docs update

No docs change.

## 🤖 Agent context

Co-authored by PostHog Code (Claude Opus 4.7).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
