### PR TITLE
fix(data-warehouse): skip partitioning when existing delta table is unpartitioned

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -22,6 +22,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     setup_partitioning,
     table_from_py_list,
 )
+from posthog.temporal.data_imports.pipelines.test_mocks import mock_delta_table
 
 
 def test_table_from_py_list_uuid():
@@ -715,148 +716,81 @@ def _mock_resource(**overrides: Any) -> MagicMock:
     return resource
 
 
-def _mock_delta_table(*, schema_fields: list[pa.Field], partition_columns: list[str]) -> MagicMock:
-    """Build a mock DeltaTable whose schema and metadata().partition_columns are controllable."""
-    arrow_schema = pa.schema(schema_fields)
-    table = MagicMock()
-    table.schema = MagicMock(return_value=MagicMock(to_arrow=MagicMock(return_value=arrow_schema)))
-    table.metadata = MagicMock(return_value=MagicMock(partition_columns=list(partition_columns)))
-    return table
+# Regression coverage for the `DeltaError: Specified table partitioning does not match` bug.
+#
+# When an existing delta table contains `_ph_partition_key` in its *schema columns*
+# but not in its *partition columns* (e.g. left over from a write committed with
+# `partition_by=None`), subsequent writes with `partition_by=PARTITION_KEY` raise:
+#
+#     DeltaError: Generic error: Specified table partitioning does not match
+#     table partitioning: expected: [], got: ["_ph_partition_key"]
+#
+# The fix checks `delta_table.metadata().partition_columns` rather than the
+# table's schema columns when deciding whether to add the partition key.
+_COL_ID = pa.field("id", pa.int64())
+_COL_PARTITION = pa.field(PARTITION_KEY, pa.string())
 
 
-class TestSetupPartitioningExistingUnpartitionedTable:
-    """Regression tests for the `DeltaError: Specified table partitioning does not match` bug.
+@pytest.mark.parametrize(
+    "case,schema_fields,partition_columns,expect_key",
+    [
+        # Column in schema but NOT in partition_columns → skip (the exact bug scenario).
+        ("column_in_schema_not_partitioned", [_COL_ID, _COL_PARTITION], [], False),
+        # `metadata().partition_columns` returning None → skip defensively.
+        ("partition_columns_is_none", [_COL_ID, _COL_PARTITION], None, False),
+        # Truly partitioned by `_ph_partition_key` → happy path, partitioning applies.
+        ("table_partitioned_by_key", [_COL_ID, _COL_PARTITION], [PARTITION_KEY], True),
+        # Legacy unpartitioned table without the column at all → skip.
+        ("column_missing_entirely", [_COL_ID], [], False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_setup_partitioning_respects_existing_delta_partition_columns(
+    case: str,
+    schema_fields: list[pa.Field],
+    partition_columns: list[str] | None,
+    expect_key: bool,
+):
+    logger: FilteringBoundLogger = structlog.get_logger()
+    pa_table = pa.table({"id": [1, 2, 3]})
+    delta_table = mock_delta_table(schema_fields=schema_fields, partition_columns=partition_columns)
 
-    When an existing delta table contains `_ph_partition_key` in its *schema columns*
-    but not in its *partition columns* (e.g. left over from a write committed with
-    `partition_by=None`), subsequent writes with `partition_by=PARTITION_KEY` raise:
+    # For the happy-path case we need the schema mock to look "already aligned" so that
+    # `set_partitioning_enabled` isn't invoked (which would require DB integration).
+    schema_kwargs: dict[str, Any] = {"partitioning_keys": ["id"]}
+    if expect_key:
+        schema_kwargs.update(partition_mode="md5", partition_format=None)
+    resource_kwargs: dict[str, Any] = {"partition_keys": ["id"]}
+    if expect_key:
+        resource_kwargs["partition_count"] = 10
 
-        DeltaError: Generic error: Specified table partitioning does not match
-        table partitioning: expected: [], got: ["_ph_partition_key"]
+    result = await setup_partitioning(
+        pa_table=pa_table,
+        existing_delta_table=delta_table,
+        schema=_mock_schema(**schema_kwargs),
+        resource=_mock_resource(**resource_kwargs),
+        logger=logger,
+    )
 
-    The fix checks `delta_table.metadata().partition_columns` rather than the
-    table's schema columns when deciding whether to add the partition key.
-    """
-
-    @pytest.mark.asyncio
-    async def test_skips_partitioning_when_column_in_schema_but_not_in_partition_columns(self):
-        """Existing delta table has `_ph_partition_key` in schema but is NOT partitioned by it."""
-        logger: FilteringBoundLogger = structlog.get_logger()
-        pa_table = pa.table({"id": [1, 2, 3]})
-
-        delta_table = _mock_delta_table(
-            schema_fields=[
-                pa.field("id", pa.int64()),
-                pa.field(PARTITION_KEY, pa.string()),  # column exists in schema
-            ],
-            partition_columns=[],  # but table is NOT actually partitioned
-        )
-
-        result = await setup_partitioning(
-            pa_table=pa_table,
-            existing_delta_table=delta_table,
-            schema=_mock_schema(partitioning_keys=["id"]),
-            resource=_mock_resource(partition_keys=["id"]),
-            logger=logger,
-        )
-
-        assert PARTITION_KEY not in result.column_names
-        assert result.equals(pa_table)
-
-    @pytest.mark.asyncio
-    async def test_skips_partitioning_when_table_has_no_partition_columns_attr(self):
-        """Defensive: `metadata().partition_columns` could be None on some delta-rs versions."""
-        logger: FilteringBoundLogger = structlog.get_logger()
-        pa_table = pa.table({"id": [1, 2, 3]})
-
-        delta_table = MagicMock()
-        delta_table.schema = MagicMock(
-            return_value=MagicMock(
-                to_arrow=MagicMock(
-                    return_value=pa.schema([pa.field("id", pa.int64()), pa.field(PARTITION_KEY, pa.string())])
-                )
-            )
-        )
-        delta_table.metadata = MagicMock(return_value=MagicMock(partition_columns=None))
-
-        result = await setup_partitioning(
-            pa_table=pa_table,
-            existing_delta_table=delta_table,
-            schema=_mock_schema(partitioning_keys=["id"]),
-            resource=_mock_resource(partition_keys=["id"]),
-            logger=logger,
-        )
-
-        assert PARTITION_KEY not in result.column_names
-
-    @pytest.mark.asyncio
-    async def test_applies_partitioning_when_partition_columns_matches(self):
-        """Happy path: table is truly partitioned by `_ph_partition_key` → partitioning continues."""
-        logger: FilteringBoundLogger = structlog.get_logger()
-        pa_table = pa.table({"id": [1, 2, 3]})
-
-        delta_table = _mock_delta_table(
-            schema_fields=[
-                pa.field("id", pa.int64()),
-                pa.field(PARTITION_KEY, pa.string()),
-            ],
-            partition_columns=[PARTITION_KEY],
-        )
-
-        schema = _mock_schema(partitioning_keys=["id"])
-        # database_sync_to_async_pool is only invoked if the schema's partitioning
-        # config changed. Reset the flag so set_partitioning_enabled isn't called.
-        schema.partitioning_enabled = True
-        schema.partition_mode = "md5"
-        schema.partition_format = None
-        schema.partitioning_keys = ["id"]
-
-        result = await setup_partitioning(
-            pa_table=pa_table,
-            existing_delta_table=delta_table,
-            schema=schema,
-            resource=_mock_resource(partition_keys=["id"], partition_count=10),
-            logger=logger,
-        )
-
-        assert PARTITION_KEY in result.column_names
-
-    @pytest.mark.asyncio
-    async def test_skips_partitioning_when_column_missing_entirely(self):
-        """Legacy unpartitioned table with no `_ph_partition_key` at all → still skip."""
-        logger: FilteringBoundLogger = structlog.get_logger()
-        pa_table = pa.table({"id": [1, 2, 3]})
-
-        delta_table = _mock_delta_table(
-            schema_fields=[pa.field("id", pa.int64())],
-            partition_columns=[],
-        )
-
-        result = await setup_partitioning(
-            pa_table=pa_table,
-            existing_delta_table=delta_table,
-            schema=_mock_schema(partitioning_keys=["id"]),
-            resource=_mock_resource(partition_keys=["id"]),
-            logger=logger,
-        )
-
-        assert PARTITION_KEY not in result.column_names
-        assert result.equals(pa_table)
+    if expect_key:
+        assert PARTITION_KEY in result.column_names, case
+    else:
+        assert PARTITION_KEY not in result.column_names, case
+        assert result.equals(pa_table), case
 
 
-class TestSetupPartitioningNoDeltaTable:
-    @pytest.mark.asyncio
-    async def test_first_sync_with_no_partition_keys_returns_unchanged(self):
-        logger: FilteringBoundLogger = structlog.get_logger()
-        pa_table = pa.table({"id": [1, 2, 3]})
+@pytest.mark.asyncio
+async def test_setup_partitioning_no_delta_table_no_partition_keys_returns_unchanged():
+    logger: FilteringBoundLogger = structlog.get_logger()
+    pa_table = pa.table({"id": [1, 2, 3]})
 
-        result = await setup_partitioning(
-            pa_table=pa_table,
-            existing_delta_table=None,
-            schema=_mock_schema(),
-            resource=_mock_resource(),
-            logger=logger,
-        )
+    result = await setup_partitioning(
+        pa_table=pa_table,
+        existing_delta_table=None,
+        schema=_mock_schema(),
+        resource=_mock_resource(),
+        logger=logger,
+    )
 
-        assert result.equals(pa_table)
-        assert PARTITION_KEY not in result.column_names
+    assert result.equals(pa_table)
+    assert PARTITION_KEY not in result.column_names

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import Any, cast
 
 import pytest
+from unittest.mock import MagicMock
 
 import pyarrow as pa
 import deltalake
@@ -12,11 +13,13 @@ import structlog
 from dateutil import parser
 from structlog.types import FilteringBoundLogger
 
+from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
 from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     _evolve_pyarrow_schema,
     _get_max_decimal_type,
     append_partition_key_to_table,
     normalize_table_column_names,
+    setup_partitioning,
     table_from_py_list,
 )
 
@@ -687,3 +690,173 @@ def test_append_partition_key_to_table_does_not_type_error(name: str, data: list
         )
     except TypeError:
         pytest.fail(f"raised TypeError for case {name} with data: {data}")
+
+
+def _mock_schema(**overrides: Any) -> MagicMock:
+    schema = MagicMock()
+    schema.partition_count = overrides.get("partition_count")
+    schema.partition_size = overrides.get("partition_size")
+    schema.partitioning_keys = overrides.get("partitioning_keys")
+    schema.partition_format = overrides.get("partition_format")
+    schema.partition_mode = overrides.get("partition_mode")
+    schema.partitioning_enabled = overrides.get("partitioning_enabled", True)
+    schema.set_partitioning_enabled = MagicMock()
+    return schema
+
+
+def _mock_resource(**overrides: Any) -> MagicMock:
+    resource = MagicMock()
+    resource.partition_count = overrides.get("partition_count")
+    resource.partition_size = overrides.get("partition_size")
+    resource.partition_keys = overrides.get("partition_keys")
+    resource.primary_keys = overrides.get("primary_keys")
+    resource.partition_format = overrides.get("partition_format")
+    resource.partition_mode = overrides.get("partition_mode")
+    return resource
+
+
+def _mock_delta_table(*, schema_fields: list[pa.Field], partition_columns: list[str]) -> MagicMock:
+    """Build a mock DeltaTable whose schema and metadata().partition_columns are controllable."""
+    arrow_schema = pa.schema(schema_fields)
+    table = MagicMock()
+    table.schema = MagicMock(return_value=MagicMock(to_arrow=MagicMock(return_value=arrow_schema)))
+    table.metadata = MagicMock(return_value=MagicMock(partition_columns=list(partition_columns)))
+    return table
+
+
+class TestSetupPartitioningExistingUnpartitionedTable:
+    """Regression tests for the `DeltaError: Specified table partitioning does not match` bug.
+
+    When an existing delta table contains `_ph_partition_key` in its *schema columns*
+    but not in its *partition columns* (e.g. left over from a write committed with
+    `partition_by=None`), subsequent writes with `partition_by=PARTITION_KEY` raise:
+
+        DeltaError: Generic error: Specified table partitioning does not match
+        table partitioning: expected: [], got: ["_ph_partition_key"]
+
+    The fix checks `delta_table.metadata().partition_columns` rather than the
+    table's schema columns when deciding whether to add the partition key.
+    """
+
+    @pytest.mark.asyncio
+    async def test_skips_partitioning_when_column_in_schema_but_not_in_partition_columns(self):
+        """Existing delta table has `_ph_partition_key` in schema but is NOT partitioned by it."""
+        logger: FilteringBoundLogger = structlog.get_logger()
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = _mock_delta_table(
+            schema_fields=[
+                pa.field("id", pa.int64()),
+                pa.field(PARTITION_KEY, pa.string()),  # column exists in schema
+            ],
+            partition_columns=[],  # but table is NOT actually partitioned
+        )
+
+        result = await setup_partitioning(
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=_mock_schema(partitioning_keys=["id"]),
+            resource=_mock_resource(partition_keys=["id"]),
+            logger=logger,
+        )
+
+        assert PARTITION_KEY not in result.column_names
+        assert result.equals(pa_table)
+
+    @pytest.mark.asyncio
+    async def test_skips_partitioning_when_table_has_no_partition_columns_attr(self):
+        """Defensive: `metadata().partition_columns` could be None on some delta-rs versions."""
+        logger: FilteringBoundLogger = structlog.get_logger()
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = MagicMock()
+        delta_table.schema = MagicMock(
+            return_value=MagicMock(
+                to_arrow=MagicMock(
+                    return_value=pa.schema([pa.field("id", pa.int64()), pa.field(PARTITION_KEY, pa.string())])
+                )
+            )
+        )
+        delta_table.metadata = MagicMock(return_value=MagicMock(partition_columns=None))
+
+        result = await setup_partitioning(
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=_mock_schema(partitioning_keys=["id"]),
+            resource=_mock_resource(partition_keys=["id"]),
+            logger=logger,
+        )
+
+        assert PARTITION_KEY not in result.column_names
+
+    @pytest.mark.asyncio
+    async def test_applies_partitioning_when_partition_columns_matches(self):
+        """Happy path: table is truly partitioned by `_ph_partition_key` → partitioning continues."""
+        logger: FilteringBoundLogger = structlog.get_logger()
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = _mock_delta_table(
+            schema_fields=[
+                pa.field("id", pa.int64()),
+                pa.field(PARTITION_KEY, pa.string()),
+            ],
+            partition_columns=[PARTITION_KEY],
+        )
+
+        schema = _mock_schema(partitioning_keys=["id"])
+        # database_sync_to_async_pool is only invoked if the schema's partitioning
+        # config changed. Reset the flag so set_partitioning_enabled isn't called.
+        schema.partitioning_enabled = True
+        schema.partition_mode = "md5"
+        schema.partition_format = None
+        schema.partitioning_keys = ["id"]
+
+        result = await setup_partitioning(
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=schema,
+            resource=_mock_resource(partition_keys=["id"], partition_count=10),
+            logger=logger,
+        )
+
+        assert PARTITION_KEY in result.column_names
+
+    @pytest.mark.asyncio
+    async def test_skips_partitioning_when_column_missing_entirely(self):
+        """Legacy unpartitioned table with no `_ph_partition_key` at all → still skip."""
+        logger: FilteringBoundLogger = structlog.get_logger()
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = _mock_delta_table(
+            schema_fields=[pa.field("id", pa.int64())],
+            partition_columns=[],
+        )
+
+        result = await setup_partitioning(
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=_mock_schema(partitioning_keys=["id"]),
+            resource=_mock_resource(partition_keys=["id"]),
+            logger=logger,
+        )
+
+        assert PARTITION_KEY not in result.column_names
+        assert result.equals(pa_table)
+
+
+class TestSetupPartitioningNoDeltaTable:
+    @pytest.mark.asyncio
+    async def test_first_sync_with_no_partition_keys_returns_unchanged(self):
+        logger: FilteringBoundLogger = structlog.get_logger()
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        result = await setup_partitioning(
+            pa_table=pa_table,
+            existing_delta_table=None,
+            schema=_mock_schema(),
+            resource=_mock_resource(),
+            logger=logger,
+        )
+
+        assert result.equals(pa_table)
+        assert PARTITION_KEY not in result.column_names

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -341,8 +341,14 @@ async def setup_partitioning(
         return pa_table
 
     if existing_delta_table:
-        delta_schema = existing_delta_table.schema().to_arrow()
-        if PARTITION_KEY not in delta_schema.names:
+        # Check the table's *partition columns* — not its schema columns. A delta
+        # table can contain `_ph_partition_key` in its schema without being
+        # partitioned by it (e.g. leftover from a prior write that included the
+        # column but was committed with `partition_by=None`). Writing with
+        # `partition_by=PARTITION_KEY` in that case raises
+        # `DeltaError: Specified table partitioning does not match table partitioning`.
+        partition_columns = getattr(existing_delta_table.metadata(), "partition_columns", None) or []
+        if PARTITION_KEY not in partition_columns:
             logger.debug("Delta table already exists without partitioning, skipping partitioning")
             return pa_table
 

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -64,8 +64,14 @@ def _apply_partitioning(
         return pa_table
 
     if existing_delta_table:
-        delta_schema = existing_delta_table.schema().to_arrow()
-        if PARTITION_KEY not in delta_schema.names:
+        # Check the table's *partition columns* — not its schema columns. A delta
+        # table can contain `_ph_partition_key` in its schema without being
+        # partitioned by it (e.g. leftover from a prior write that included the
+        # column but was committed with `partition_by=None`). Writing with
+        # `partition_by=PARTITION_KEY` in that case raises
+        # `DeltaError: Specified table partitioning does not match table partitioning`.
+        partition_columns = getattr(existing_delta_table.metadata(), "partition_columns", None) or []
+        if PARTITION_KEY not in partition_columns:
             logger.debug("Delta table already exists without partitioning, skipping partitioning")
             return pa_table
 

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -1,6 +1,12 @@
+from typing import Any
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
 from parameterized import parameterized
 
-from posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor import _get_write_type
+from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
+from posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor import _apply_partitioning, _get_write_type
 
 
 class TestGetWriteType:
@@ -14,3 +20,124 @@ class TestGetWriteType:
     )
     def test_mapping(self, sync_type, expected):
         assert _get_write_type(sync_type) == expected
+
+
+def _export_signal(**overrides: Any) -> MagicMock:
+    signal = MagicMock()
+    signal.partition_keys = overrides.get("partition_keys")
+    signal.partition_count = overrides.get("partition_count")
+    signal.partition_size = overrides.get("partition_size")
+    signal.partition_mode = overrides.get("partition_mode")
+    signal.partition_format = overrides.get("partition_format")
+    return signal
+
+
+def _schema(**overrides: Any) -> MagicMock:
+    schema = MagicMock()
+    schema.partitioning_enabled = overrides.get("partitioning_enabled", True)
+    schema.partition_mode = overrides.get("partition_mode")
+    schema.partition_format = overrides.get("partition_format")
+    schema.partitioning_keys = overrides.get("partitioning_keys")
+    schema.set_partitioning_enabled = MagicMock()
+    return schema
+
+
+def _delta_table(*, schema_fields: list[pa.Field], partition_columns: list[str]) -> MagicMock:
+    arrow_schema = pa.schema(schema_fields)
+    table = MagicMock()
+    table.schema = MagicMock(return_value=MagicMock(to_arrow=MagicMock(return_value=arrow_schema)))
+    table.metadata = MagicMock(return_value=MagicMock(partition_columns=list(partition_columns)))
+    return table
+
+
+class TestApplyPartitioningExistingUnpartitionedTable:
+    """Regression tests for the `DeltaError: Specified table partitioning does not match` bug.
+
+    When a delta table contains `_ph_partition_key` in its schema but NOT in its
+    partition columns (e.g. left over from a prior write committed with
+    `partition_by=None`), the v3 loader must skip partitioning subsequent writes
+    to avoid delta-rs rejecting the `partition_by=PARTITION_KEY` argument.
+    """
+
+    def test_skips_partitioning_when_column_in_schema_but_not_in_partition_columns(self):
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = _delta_table(
+            schema_fields=[
+                pa.field("id", pa.int64()),
+                pa.field(PARTITION_KEY, pa.string()),  # column exists in schema
+            ],
+            partition_columns=[],  # but table is NOT actually partitioned
+        )
+
+        result = _apply_partitioning(
+            export_signal=_export_signal(partition_keys=["id"]),
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=_schema(),
+        )
+
+        assert PARTITION_KEY not in result.column_names
+        assert result.equals(pa_table)
+
+    def test_skips_partitioning_when_partition_columns_is_none(self):
+        """Defensive: `metadata().partition_columns` could be None on some delta-rs versions."""
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = MagicMock()
+        delta_table.schema = MagicMock(
+            return_value=MagicMock(
+                to_arrow=MagicMock(
+                    return_value=pa.schema([pa.field("id", pa.int64()), pa.field(PARTITION_KEY, pa.string())])
+                )
+            )
+        )
+        delta_table.metadata = MagicMock(return_value=MagicMock(partition_columns=None))
+
+        result = _apply_partitioning(
+            export_signal=_export_signal(partition_keys=["id"]),
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=_schema(),
+        )
+
+        assert PARTITION_KEY not in result.column_names
+
+    def test_applies_partitioning_when_table_is_partitioned_by_key(self):
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        delta_table = _delta_table(
+            schema_fields=[
+                pa.field("id", pa.int64()),
+                pa.field(PARTITION_KEY, pa.string()),
+            ],
+            partition_columns=[PARTITION_KEY],
+        )
+
+        schema = _schema(
+            partitioning_enabled=True,
+            partition_mode="md5",
+            partitioning_keys=["id"],
+        )
+
+        result = _apply_partitioning(
+            export_signal=_export_signal(partition_keys=["id"], partition_count=10),
+            pa_table=pa_table,
+            existing_delta_table=delta_table,
+            schema=schema,
+        )
+
+        assert PARTITION_KEY in result.column_names
+
+    def test_skips_partitioning_when_no_partition_keys(self):
+        pa_table = pa.table({"id": [1, 2, 3]})
+
+        result = _apply_partitioning(
+            export_signal=_export_signal(partition_keys=None),
+            pa_table=pa_table,
+            existing_delta_table=None,
+            schema=_schema(),
+        )
+
+        assert PARTITION_KEY not in result.column_names
+        assert result.equals(pa_table)

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
 from posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor import _apply_partitioning, _get_write_type
+from posthog.temporal.data_imports.pipelines.test_mocks import mock_delta_table
 
 
 class TestGetWriteType:
@@ -42,16 +43,12 @@ def _schema(**overrides: Any) -> MagicMock:
     return schema
 
 
-def _delta_table(*, schema_fields: list[pa.Field], partition_columns: list[str]) -> MagicMock:
-    arrow_schema = pa.schema(schema_fields)
-    table = MagicMock()
-    table.schema = MagicMock(return_value=MagicMock(to_arrow=MagicMock(return_value=arrow_schema)))
-    table.metadata = MagicMock(return_value=MagicMock(partition_columns=list(partition_columns)))
-    return table
+_COL_ID = pa.field("id", pa.int64())
+_COL_PARTITION = pa.field(PARTITION_KEY, pa.string())
 
 
-class TestApplyPartitioningExistingUnpartitionedTable:
-    """Regression tests for the `DeltaError: Specified table partitioning does not match` bug.
+class TestApplyPartitioning:
+    """Regression coverage for the `DeltaError: Specified table partitioning does not match` bug.
 
     When a delta table contains `_ph_partition_key` in its schema but NOT in its
     partition columns (e.g. left over from a prior write committed with
@@ -59,75 +56,48 @@ class TestApplyPartitioningExistingUnpartitionedTable:
     to avoid delta-rs rejecting the `partition_by=PARTITION_KEY` argument.
     """
 
-    def test_skips_partitioning_when_column_in_schema_but_not_in_partition_columns(self):
+    @parameterized.expand(
+        [
+            # Column in schema but NOT in partition_columns → skip (the exact bug scenario).
+            ("column_in_schema_not_partitioned", [_COL_ID, _COL_PARTITION], [], False),
+            # `metadata().partition_columns` returning None → skip defensively.
+            ("partition_columns_is_none", [_COL_ID, _COL_PARTITION], None, False),
+            # Truly partitioned by `_ph_partition_key` → happy path, partitioning applies.
+            ("table_partitioned_by_key", [_COL_ID, _COL_PARTITION], [PARTITION_KEY], True),
+        ]
+    )
+    def test_respects_existing_delta_partition_columns(
+        self,
+        _case: str,
+        schema_fields: list[pa.Field],
+        partition_columns: list[str] | None,
+        expect_key: bool,
+    ):
         pa_table = pa.table({"id": [1, 2, 3]})
+        delta_table = mock_delta_table(schema_fields=schema_fields, partition_columns=partition_columns)
 
-        delta_table = _delta_table(
-            schema_fields=[
-                pa.field("id", pa.int64()),
-                pa.field(PARTITION_KEY, pa.string()),  # column exists in schema
-            ],
-            partition_columns=[],  # but table is NOT actually partitioned
-        )
-
-        result = _apply_partitioning(
-            export_signal=_export_signal(partition_keys=["id"]),
-            pa_table=pa_table,
-            existing_delta_table=delta_table,
-            schema=_schema(),
-        )
-
-        assert PARTITION_KEY not in result.column_names
-        assert result.equals(pa_table)
-
-    def test_skips_partitioning_when_partition_columns_is_none(self):
-        """Defensive: `metadata().partition_columns` could be None on some delta-rs versions."""
-        pa_table = pa.table({"id": [1, 2, 3]})
-
-        delta_table = MagicMock()
-        delta_table.schema = MagicMock(
-            return_value=MagicMock(
-                to_arrow=MagicMock(
-                    return_value=pa.schema([pa.field("id", pa.int64()), pa.field(PARTITION_KEY, pa.string())])
-                )
+        schema_kwargs: dict[str, Any] = {}
+        export_kwargs: dict[str, Any] = {"partition_keys": ["id"]}
+        if expect_key:
+            schema_kwargs.update(
+                partitioning_enabled=True,
+                partition_mode="md5",
+                partitioning_keys=["id"],
             )
-        )
-        delta_table.metadata = MagicMock(return_value=MagicMock(partition_columns=None))
+            export_kwargs["partition_count"] = 10
 
         result = _apply_partitioning(
-            export_signal=_export_signal(partition_keys=["id"]),
+            export_signal=_export_signal(**export_kwargs),
             pa_table=pa_table,
             existing_delta_table=delta_table,
-            schema=_schema(),
+            schema=_schema(**schema_kwargs),
         )
 
-        assert PARTITION_KEY not in result.column_names
-
-    def test_applies_partitioning_when_table_is_partitioned_by_key(self):
-        pa_table = pa.table({"id": [1, 2, 3]})
-
-        delta_table = _delta_table(
-            schema_fields=[
-                pa.field("id", pa.int64()),
-                pa.field(PARTITION_KEY, pa.string()),
-            ],
-            partition_columns=[PARTITION_KEY],
-        )
-
-        schema = _schema(
-            partitioning_enabled=True,
-            partition_mode="md5",
-            partitioning_keys=["id"],
-        )
-
-        result = _apply_partitioning(
-            export_signal=_export_signal(partition_keys=["id"], partition_count=10),
-            pa_table=pa_table,
-            existing_delta_table=delta_table,
-            schema=schema,
-        )
-
-        assert PARTITION_KEY in result.column_names
+        if expect_key:
+            assert PARTITION_KEY in result.column_names
+        else:
+            assert PARTITION_KEY not in result.column_names
+            assert result.equals(pa_table)
 
     def test_skips_partitioning_when_no_partition_keys(self):
         pa_table = pa.table({"id": [1, 2, 3]})

--- a/posthog/temporal/data_imports/pipelines/test_mocks.py
+++ b/posthog/temporal/data_imports/pipelines/test_mocks.py
@@ -1,0 +1,24 @@
+"""Shared mock helpers for data-imports pipeline tests (v1 + v3)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+
+
+def mock_delta_table(*, schema_fields: list[pa.Field], partition_columns: Optional[list[str]]) -> MagicMock:
+    """Build a mock DeltaTable with controllable schema and metadata().partition_columns.
+
+    Pass `partition_columns=None` to simulate delta-rs returning a missing attribute
+    (defensive branch in callers).
+    """
+    arrow_schema = pa.schema(schema_fields)
+    table = MagicMock()
+    table.schema = MagicMock(return_value=MagicMock(to_arrow=MagicMock(return_value=arrow_schema)))
+    table.metadata = MagicMock(
+        return_value=MagicMock(partition_columns=list(partition_columns) if partition_columns is not None else None)
+    )
+    return table


### PR DESCRIPTION
## Problem

Error tracking reports **43,161 occurrences across 43,161 distinct runs** (last 30 days) of:

```
DeltaError: Generic error: Specified table partitioning does not match table partitioning:
  expected: [], got: ["_ph_partition_key"]
```

surfaced from the Stripe source and other data-import sources running through
the shared `DeltaTableHelper`. The error fires on every sync retry attempt, so
affected schemas are completely stuck.

### Root cause

`setup_partitioning` (v1, `pipeline/utils.py`) and `_apply_partitioning` (v3,
`pipeline_v3/load/processor.py`) decide whether to add the `_ph_partition_key`
column to the next write by checking whether the column is in the existing
delta table's **schema columns**:

```python
delta_schema = existing_delta_table.schema().to_arrow()
if PARTITION_KEY not in delta_schema.names:
    # skip partitioning
```

That check is incorrect. A delta table can contain `_ph_partition_key` in its
schema without being **partitioned** by it — for example, after the
`SchemaMismatchError` fallback in `DeltaTableHelper.write_to_deltalake` writes
with `partition_by=None, schema_mode="overwrite"`, which commits the column as
a regular column and drops the partition declaration.

Once that happens, every subsequent sync:

1. sees the column in the schema → adds `_ph_partition_key` to incoming data,
2. calls `write_deltalake(..., partition_by=PARTITION_KEY)` on the now-unpartitioned table,
3. delta-rs rejects: `expected: [], got: ["_ph_partition_key"]`.

## Changes

- `setup_partitioning` and `_apply_partitioning` now check
  `existing_delta_table.metadata().partition_columns` instead of the schema
  column list when deciding whether to skip partitioning. This matches the
  existing `_fetch_delta_partition_columns` helper in the ducklake workflows.
- Handles `partition_columns=None` defensively for delta-rs versions that may
  return `None` from `metadata().partition_columns`.

With this fix, tables in the broken state simply keep syncing **without
partitioning** (the column stays as a vestigial data column) instead of
hard-erroring on every retry. Properly-partitioned tables are unaffected.

### Non-retryable vs. bug

Considered and rejected as user error. This is our code passing `partition_by`
that doesn't match the existing table state — not a credential or upstream
issue — so it belongs in the fix path, not the Stripe `get_non_retryable_errors`
list.

### Scoped, minimal

- No changes to retry policy.
- No changes to the `SchemaMismatchError` fallback (which is the upstream cause
  of the state mismatch) — deliberately out of scope. The `setup_partitioning`
  fix makes the system resilient to that state regardless of how it was reached.

## How did you test this code?

I'm an agent. I did not run the service end-to-end. Automated tests I ran locally:

- `pytest posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py` — 76 passed
- `pytest posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py` — 12 passed
- `ruff check` + `ruff format --check` on the four touched files — all clean

New regression tests (both v1 and v3):

1. Column in schema but NOT in `partition_columns` → partitioning skipped (the exact scenario in error tracking).
2. `partition_columns=None` → partitioning skipped (defensive).
3. Column in `partition_columns` → partitioning still applied (happy path preserved).
4. No existing table / no partition keys → baseline behavior preserved.

## Publish to changelog?

no

## 🤖 Agent context

Agent: PostHog Code (Task `655c6f0d-5d34-4cfe-80b3-f63100c504cb`).

Key decisions:
- Treated as a fixable bug, not a non-retryable user error — the mismatch is
  our code's fault and suppressing it would hide real data-loss scenarios.
- Left the `SchemaMismatchError` fallback alone. It's the likely upstream
  cause of the mismatched state, but changing write semantics is riskier than
  fixing the read-side check. The new check makes both paths safe.
- Mocked `DeltaTable` / `metadata()` in tests rather than writing real delta
  tables, matching the style already used in `test_delta_table_helper.py`.

Requires human review — do not self-merge.

Generated-By: PostHog Code
