### PR TITLE
fix(postgres): treat 'server closed the connection unexpectedly' as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -135,6 +135,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
             "No primary key defined for table": None,
             "failed: timeout expired": None,
             "SSL connection has been closed unexpectedly": None,
+            "server closed the connection unexpectedly": None,
             "Address not in tenant allow_list": None,
             "FATAL: no such database": None,
             "does not exist": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -115,6 +115,8 @@ class TestPostgresSourceNonRetryableErrors:
             'FATAL:  password authentication failed for user "myuser"',
             'FATAL: no such database "nonexistent_db"',
             "Name or service not known",
+            'OperationalError: connection failed: connection to server at "127.0.0.1", port 44703 failed: server closed the connection unexpectedly\n\tThis probably means the server terminated abnormally\n\tbefore or while processing the request.',
+            "consuming input failed: server closed the connection unexpectedly",
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

A `psycopg.OperationalError` with message `server closed the connection unexpectedly. This probably means the server terminated abnormally before or while processing the request.` is one of the highest-volume errors on the Postgres data-import source — ~29k occurrences in the last 30 days from the import pipeline alone (see issue `019cdc57-1d72-7e50-94bf-f017d3e9c41b`, plus related issues surfacing the same message from `postgres.py` and `source.py`).

The stack trace for the top occurrence ends at `postgres.py::get_rows` → `get_connection()` → `psycopg.connect(...)`, i.e. the remote Postgres server (or an intermediate firewall / proxy / SSH tunnel) dropped the TCP connection during connection setup. Root causes are always external to PostHog:

- customer's DB restarting or being upgraded
- customer's DB crashing (OOM, segfault, etc.)
- firewall / proxy / load balancer terminating the connection
- SSL/TLS misconfiguration causing the server to reset mid-handshake

There is nothing sensible we can do from our side to recover. Today this error falls through as retryable, so Temporal keeps replaying the activity and we burn runner time on a condition that only the customer can fix.

## Changes

- Add the substring `"server closed the connection unexpectedly"` to `PostgresSource.get_non_retryable_errors()`. This is a stable, low-false-positive marker that appears in both `psycopg.connect(...)` failures and mid-query `consuming input failed: ...` failures when the peer closes the socket.
- The existing non-retryable list already contains the SSL-specific variant (`"SSL connection has been closed unexpectedly"`) and related connection failures (`Connection refused`, `No route to host`, `Name or service not known`), so this matches the established pattern for this source.
- `handle_non_retryable_error` still gates non-retryable errors through a 3-attempt Redis counter before giving up, so short transient DB restarts are still covered — we just stop retrying forever on genuinely broken setups.
- Extend the parameterized `test_permanent_connection_errors_are_non_retryable` with two representative messages from the error-tracking events (the full `connection failed: ... server closed the connection unexpectedly ...` message and the mid-query `consuming input failed: server closed the connection unexpectedly` variant).

Scope is intentionally narrow: no retry-policy changes elsewhere in the pipeline, no changes to other sources.

## How did you test this code?

I'm an agent. I only ran automated tests:

- `pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors -v` — 13 passed, including the 2 new parameterized cases. The existing `test_transient_connection_errors_are_retryable` cases continue to pass, confirming the new substring doesn't accidentally widen into genuinely transient errors (`MaxClientsInSessionMode`, `remaining connection slots are reserved`, `too many connections`).

## Publish to changelog?

no

## 🤖 Agent context

- Reopened from Gilbert09's fork; supersedes #56275.
- Authored by PostHog Code (agent triage of a top-volume data-import error tracking issue).
- Decision rationale: user/upstream error (stack terminates in customer's DB dropping the socket during `psycopg.connect` or mid-fetch). Matches the shape of existing non-retryable entries such as `"SSL connection has been closed unexpectedly"` and `"Connection refused"`.
- Guardrail honoured: substring is specific enough to not swallow the transient `too many connections` / `MaxClientsInSessionMode` class of errors, which are kept retryable and verified by the existing parameterized test.
- No retry policy or global pipeline behaviour changed — only the Postgres source's allowlist of known-non-retryable substrings.
