### PR TITLE
feat(clerk): treat 401/403 auth failures as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -27,6 +27,12 @@ class ClerkSource(SimpleSource[ClerkSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLERK
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.clerk.com": "Your Clerk secret key is invalid, revoked, or expired. Please generate a new secret key in your Clerk dashboard and reconnect.",
+            "403 Client Error: Forbidden for url: https://api.clerk.com": "Your Clerk secret key does not have permission to access this resource. Please check the key's permissions in your Clerk dashboard and try again.",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 
 from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
@@ -32,14 +33,19 @@ class TestClerkSource:
         assert secret_key_field.type == SourceFieldInputConfigType.PASSWORD
         assert secret_key_field.required is True
 
-    def test_non_retryable_errors(self):
-        errors = self.source.get_non_retryable_errors()
+    @pytest.mark.parametrize(
+        "expected_key",
+        [
+            "401 Client Error: Unauthorized for url: https://api.clerk.com",
+            "403 Client Error: Forbidden for url: https://api.clerk.com",
+        ],
+    )
+    def test_non_retryable_errors_contains_key(self, expected_key):
+        assert expected_key in self.source.get_non_retryable_errors()
 
-        assert "401 Client Error: Unauthorized for url: https://api.clerk.com" in errors
-        assert "403 Client Error: Forbidden for url: https://api.clerk.com" in errors
-
+    def test_non_retryable_errors_matches_real_production_message(self):
         real_message = "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/invitations?limit=100"
-        assert any(key in real_message for key in errors)
+        assert any(key in real_message for key in self.source.get_non_retryable_errors())
 
     def test_get_schemas(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
@@ -60,21 +66,19 @@ class TestClerkSource:
 
         assert schemas == []
 
+    @pytest.mark.parametrize(
+        "validate_return,expected_valid,expected_error",
+        [
+            ((True, None), True, None),
+            ((False, "Invalid Clerk credentials"), False, "Invalid Clerk credentials"),
+        ],
+    )
     @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
-    def test_validate_credentials_success(self, mock_validate):
-        mock_validate.return_value = (True, None)
+    def test_validate_credentials(self, mock_validate, validate_return, expected_valid, expected_error):
+        mock_validate.return_value = validate_return
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
-        assert is_valid is True
-        assert error_message is None
+        assert is_valid is expected_valid
+        assert error_message == expected_error
         mock_validate.assert_called_once_with(self.config.secret_key)
-
-    @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
-    def test_validate_credentials_failure(self, mock_validate):
-        mock_validate.return_value = (False, "Invalid Clerk credentials")
-
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
-
-        assert is_valid is False
-        assert error_message == "Invalid Clerk credentials"

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.clerk.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.clerk.source import ClerkSource
+from posthog.temporal.data_imports.sources.generated_configs import ClerkSourceConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestClerkSource:
+    def setup_method(self):
+        self.source = ClerkSource()
+        self.team_id = 123
+        self.config = ClerkSourceConfig(secret_key="sk_live_test")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.CLERK
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Clerk"
+        assert config.label == "Clerk"
+        assert config.iconPath == "/static/services/clerk.png"
+        assert len(config.fields) == 1
+
+        secret_key_field = config.fields[0]
+        assert isinstance(secret_key_field, SourceFieldInputConfig)
+        assert secret_key_field.name == "secret_key"
+        assert secret_key_field.type == SourceFieldInputConfigType.PASSWORD
+        assert secret_key_field.required is True
+
+    def test_non_retryable_errors(self):
+        errors = self.source.get_non_retryable_errors()
+
+        assert "401 Client Error: Unauthorized for url: https://api.clerk.com" in errors
+        assert "403 Client Error: Forbidden for url: https://api.clerk.com" in errors
+
+        real_message = "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/invitations?limit=100"
+        assert any(key in real_message for key in errors)
+
+    def test_get_schemas(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        schema_names = {schema.name for schema in schemas}
+        assert schema_names == set(ENDPOINTS)
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["invitations"])
+
+        assert len(schemas) == 1
+        assert schemas[0].name == "invitations"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["nonexistent"])
+
+        assert schemas == []
+
+    @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
+    def test_validate_credentials_success(self, mock_validate):
+        mock_validate.return_value = (True, None)
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is True
+        assert error_message is None
+        mock_validate.assert_called_once_with(self.config.secret_key)
+
+    @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
+    def test_validate_credentials_failure(self, mock_validate):
+        mock_validate.return_value = (False, "Invalid Clerk credentials")
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is False
+        assert error_message == "Invalid Clerk credentials"

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -43,8 +43,14 @@ class TestClerkSource:
     def test_non_retryable_errors_contains_key(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
 
-    def test_non_retryable_errors_matches_real_production_message(self):
-        real_message = "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/invitations?limit=100"
+    @pytest.mark.parametrize(
+        "real_message",
+        [
+            "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/invitations?limit=100",
+            "403 Client Error: Forbidden for url: https://api.clerk.com/v1/organizations",
+        ],
+    )
+    def test_non_retryable_errors_matches_real_production_message(self, real_message):
         assert any(key in real_message for key in self.source.get_non_retryable_errors())
 
     def test_get_schemas(self):


### PR DESCRIPTION
## Problem

The Clerk data-import source does not override `get_non_retryable_errors`, so auth failures from the Clerk API go through the normal retry path. Error tracking shows hundreds of occurrences of

```
HTTPError: 401 Client Error: Unauthorized for url: https://api.clerk.com/v1/invitations?limit=100
```

and matching 403 Forbidden variants against `api.clerk.com/v1/organizations`, all grouped under a single active issue (`019cdc3d-7c2a-73a1-bcfb-f6751414cf03`). These happen when the customer's Clerk secret key is invalid, revoked, expired, or lacks permission for an endpoint — nothing our pipeline can fix by retrying.

## Changes

- Override `get_non_retryable_errors` on `ClerkSource`, mirroring the Stripe/Attio pattern. Match by URL-prefixed substring (`https://api.clerk.com`) so the rule is stable (no volatile path/query/id fragments) and scoped to Clerk's API host to avoid accidental matches from other sources sharing helper code.
  - 401 Client Error → "Your Clerk secret key is invalid, revoked, or expired."
  - 403 Client Error → "Your Clerk secret key does not have permission to access this resource."
- Add `test_clerk_source.py` covering `get_non_retryable_errors`, schemas, and credential validation, including a substring assertion against the real production error message so the matcher cannot silently drift.

## How did you test this code?

I'm an agent; I did not run tests manually — no Python env was available in this sandbox. I added unit tests in `posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py` which CI will execute, and I verified the changes pass `ruff check` and `ruff format --check`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (task `b008bd3d-173b-4b94-84c7-daf74346765e`). Triaged the error-tracking issue, confirmed it's a credentials/permissions failure on the customer side (Clerk returns 401/403 for both missing/revoked keys and insufficient-scope keys), then applied the non-retryable pattern used by Stripe and Attio.

Decision rationale for scope:
- Match on URL prefix (`https://api.clerk.com`) rather than just `401 Client Error` to avoid accidentally short-circuiting 401s from unrelated callers that might appear in shared rest-source helpers.
- Included 403 because the same error-tracking issue contains 403 Forbidden events against `/v1/organizations` — same root cause (user credential/scope issue), same recovery path.
- Did not widen further (e.g. 4xx blanket) — 400s from Clerk may reflect real bugs in our request construction and should keep retrying/surfacing.
