### PR TITLE
feat(clerk): treat 401/403 from api.clerk.com as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -27,6 +27,12 @@ class ClerkSource(SimpleSource[ClerkSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLERK
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.clerk.com": "Your Clerk secret key is invalid or expired. Please generate a new key and reconnect.",
+            "403 Client Error: Forbidden for url: https://api.clerk.com": "Your Clerk secret key does not have permission to access this endpoint. This usually means your Clerk plan does not include the feature (for example, Organizations) or the key is missing the required permissions.",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.clerk.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.clerk.source import ClerkSource
+from posthog.temporal.data_imports.sources.generated_configs import ClerkSourceConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestClerkSource:
+    def setup_method(self):
+        self.source = ClerkSource()
+        self.team_id = 123
+        self.config = ClerkSourceConfig(secret_key="sk_live_test")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.CLERK
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Clerk"
+        assert config.label == "Clerk"
+        assert config.iconPath == "/static/services/clerk.png"
+        assert len(config.fields) == 1
+
+        secret_key_field = config.fields[0]
+        assert isinstance(secret_key_field, SourceFieldInputConfig)
+        assert secret_key_field.name == "secret_key"
+        assert secret_key_field.type == SourceFieldInputConfigType.PASSWORD
+        assert secret_key_field.required is True
+
+    def test_non_retryable_errors(self):
+        errors = self.source.get_non_retryable_errors()
+
+        assert "401 Client Error: Unauthorized for url: https://api.clerk.com" in errors
+        assert "403 Client Error: Forbidden for url: https://api.clerk.com" in errors
+
+        real_error = "403 Client Error: Forbidden for url: https://api.clerk.com/v1/organizations?limit=100"
+        assert any(key in real_error for key in errors)
+
+    def test_get_schemas(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        schema_names = {schema.name for schema in schemas}
+        assert schema_names == set(ENDPOINTS)
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["users"])
+
+        assert len(schemas) == 1
+        assert schemas[0].name == "users"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["nonexistent"])
+
+        assert schemas == []
+
+    @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
+    def test_validate_credentials_success(self, mock_validate):
+        mock_validate.return_value = (True, None)
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is True
+        assert error_message is None
+        mock_validate.assert_called_once_with(self.config.secret_key)
+
+    @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
+    def test_validate_credentials_failure(self, mock_validate):
+        mock_validate.return_value = (False, "Invalid Clerk credentials")
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is False
+        assert error_message == "Invalid Clerk credentials"

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 
 from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
@@ -60,21 +61,19 @@ class TestClerkSource:
 
         assert schemas == []
 
+    @pytest.mark.parametrize(
+        ("return_value", "expected_valid", "expected_message"),
+        [
+            ((True, None), True, None),
+            ((False, "Invalid Clerk credentials"), False, "Invalid Clerk credentials"),
+        ],
+    )
     @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
-    def test_validate_credentials_success(self, mock_validate):
-        mock_validate.return_value = (True, None)
+    def test_validate_credentials(self, mock_validate, return_value, expected_valid, expected_message):
+        mock_validate.return_value = return_value
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
-        assert is_valid is True
-        assert error_message is None
+        assert is_valid is expected_valid
+        assert error_message == expected_message
         mock_validate.assert_called_once_with(self.config.secret_key)
-
-    @mock.patch("posthog.temporal.data_imports.sources.clerk.source.validate_clerk_credentials")
-    def test_validate_credentials_failure(self, mock_validate):
-        mock_validate.return_value = (False, "Invalid Clerk credentials")
-
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
-
-        assert is_valid is False
-        assert error_message == "Invalid Clerk credentials"


### PR DESCRIPTION
## Problem

The data warehouse Clerk source retries `403 Client Error: Forbidden for url: https://api.clerk.com/v1/organizations?limit=100` indefinitely, even though the failure is caused by the customer's Clerk configuration and cannot recover on retry. Typical root causes:

- The customer's Clerk plan doesn't include the Organizations feature.
- The `sk_live_...` secret key doesn't have permission to read the failing endpoint.

A single error tracking issue ([`019c8025-88cb-7d71-a3f6-ac55c180f040`](https://us.posthog.com/project/2/error_tracking/019c8025-88cb-7d71-a3f6-ac55c180f040)) alone accounted for ~5,085 occurrences, and there are at least 8 similar issues across different teams repeating the same pattern against `https://api.clerk.com/v1/organizations`.

## Changes

- Override `get_non_retryable_errors` on `ClerkSource` to match `401 Client Error: Unauthorized for url: https://api.clerk.com` and `403 Client Error: Forbidden for url: https://api.clerk.com`, mirroring the pattern already used by `AttioSource` and `StripeSource`. Matching is a substring check on `str(e)` in `import_data_activity_sync`, so the `https://api.clerk.com` prefix keeps false positives from unrelated sources at zero while remaining stable against endpoint/query-string variance.
- Add `tests/test_clerk_source.py` with a unit test that asserts both substrings are registered and that the exact error message seen in production matches one of them.

## How did you test this code?

- `pytest posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py` → 8 passed.
- `ruff check` / `ruff format --check` clean on `posthog/temporal/data_imports/sources/clerk/`.

## Publish to changelog?

no

## 🤖 Agent context

- Re-opened from my personal fork after the original PR (#56268) was opened from a bot account.
- Authored by PostHog Code (Claude Opus 4.7).
- Decision: treat this as a user/upstream error, not a bug in our code — the request is well-formed and Clerk is correctly returning 403 because the account/key can't access the endpoint. Retrying only amplifies noise in error tracking without ever succeeding.
- Scope guardrails followed: no change to global retry policy; matcher scoped to `https://api.clerk.com` to avoid swallowing 403s from any other source; no refactoring of unrelated code.