### PR TITLE
fix(data-warehouse): retry google sheets 429 quota errors on all api calls

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -1,6 +1,7 @@
 import time
 import random
-from typing import Any, Optional
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 
 from django.conf import settings
 
@@ -34,23 +35,20 @@ max_attempts = 10
 jitter_in_seconds = 10
 sleep_per_attempt_in_seconds = 30
 
+T = TypeVar("T")
 
-@cached(cache)
-def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet:
-    """Attempt to get a worksheet with linear backoff. Google Sheets has a 300
-    request quota per minute. We add a +- 10s jitter to the sleep per attempt so
-    that multiple jobs blocked by quota limits dont all retry at the same time"""
 
-    def execute():
-        client = google_sheets_client()
-        spreadsheet = client.open_by_url(spreadsheet_url)
-        return spreadsheet.get_worksheet_by_id(worksheet_id)
+def _retry_on_quota_exceeded(operation: Callable[[], T]) -> T:
+    """Run a gspread API call with linear backoff on 429 quota-exceeded errors.
 
+    Google Sheets enforces per-minute read/write quotas at the Google Cloud project
+    level, shared across all customer syncs. We add a +- 10s jitter to the sleep per
+    attempt so that multiple jobs blocked by quota limits don't all retry at the
+    same time."""
     attempts = 1
-
     while True:
         try:
-            return execute()
+            return operation()
         except gspread.exceptions.APIError as e:
             if e.code != 429 or attempts >= max_attempts:
                 raise
@@ -62,12 +60,25 @@ def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet
             attempts = attempts + 1
 
 
+@cached(cache)
+def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet:
+    def execute() -> gspread.Worksheet:
+        client = google_sheets_client()
+        spreadsheet = client.open_by_url(spreadsheet_url)
+        return spreadsheet.get_worksheet_by_id(worksheet_id)
+
+    return _retry_on_quota_exceeded(execute)
+
+
 def get_schemas(config: GoogleSheetsSourceConfig) -> list[tuple[str, int]]:
     """Returns a tuple of worksheets in the form of (title, id)"""
 
-    client = google_sheets_client()
-    spreadsheet = client.open_by_url(config.spreadsheet_url)
-    worksheets = spreadsheet.worksheets()
+    def execute() -> list[gspread.Worksheet]:
+        client = google_sheets_client()
+        spreadsheet = client.open_by_url(config.spreadsheet_url)
+        return spreadsheet.worksheets()
+
+    worksheets = _retry_on_quota_exceeded(execute)
 
     return [(NamingConvention.normalize_identifier(worksheet.title), worksheet.id) for worksheet in worksheets]
 
@@ -82,7 +93,7 @@ def get_schema_incremental_fields(config: GoogleSheetsSourceConfig, worksheet_na
 
     worksheet = _get_worksheet(config.spreadsheet_url, worksheet_id)
 
-    rows = worksheet.get_all_values("1:2")  # Get the first two rows
+    rows = _retry_on_quota_exceeded(lambda: worksheet.get_all_values("1:2"))  # Get the first two rows
 
     if len(rows) > 1 and "id" in rows[0]:
         index_of_id = rows[0].index("id")
@@ -115,7 +126,7 @@ def google_sheets_source(
 
     worksheet = _get_worksheet(config.spreadsheet_url, worksheet_id)
 
-    headers = worksheet.get_all_values("1:1")  # Get the first row
+    headers = _retry_on_quota_exceeded(lambda: worksheet.get_all_values("1:1"))  # Get the first row
     primary_keys = None
     if len(headers) > 0 and "id" in headers[0]:
         primary_keys = ["id"]
@@ -123,7 +134,7 @@ def google_sheets_source(
     def get_rows():
         worksheet = _get_worksheet(config.spreadsheet_url, worksheet_id)
 
-        values = worksheet.get_all_records()
+        values = _retry_on_quota_exceeded(worksheet.get_all_records)
 
         if should_use_incremental_field and db_incremental_field_last_value is not None:
             values = [value for value in values if value.get("id", 0) > db_incremental_field_last_value]

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -200,6 +200,7 @@ def test_google_sheets_source_retries_get_all_records_on_quota_exceeded():
 
         with pytest.raises(gspread.exceptions.APIError):
             # items is a generator factory; consume it to trigger the API call
-            list(response.items())
+            for _ in response.items():
+                pass
 
         assert mock_worksheet.get_all_records.call_count == 10

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -3,7 +3,35 @@ from unittest import mock
 
 import gspread
 
-from posthog.temporal.data_imports.sources.google_sheets.google_sheets import _get_worksheet
+from posthog.temporal.data_imports.sources.google_sheets.google_sheets import (
+    _get_worksheet,
+    cache,
+    get_schema_incremental_fields,
+    get_schemas,
+)
+
+
+def _quota_exceeded_api_error() -> gspread.exceptions.APIError:
+    mock_response = mock.MagicMock()
+    mock_response.json.return_value = {
+        "error": {
+            "code": 429,
+            "message": (
+                "Quota exceeded for quota metric 'Read requests' and limit "
+                "'Read requests per minute' of service 'sheets.googleapis.com' "
+                "for consumer 'project_number:951095883823'."
+            ),
+            "status": "RESOURCE_EXHAUSTED",
+        }
+    }
+    return gspread.exceptions.APIError(mock_response)
+
+
+@pytest.fixture(autouse=True)
+def clear_worksheet_cache():
+    cache.clear()
+    yield
+    cache.clear()
 
 
 def test_get_worksheet_backoff():
@@ -16,16 +44,7 @@ def test_get_worksheet_backoff():
         mock_spreadsheet = mock.MagicMock()
         mock_get_worksheet_by_id = mock.MagicMock()
 
-        mock_response = mock.MagicMock()
-        mock_response.json.return_value = {
-            "error": {
-                "code": 429,
-                "message": "Rate limit exceeded",
-                "status": "RESOURCE_EXHAUSTED",
-            }
-        }
-
-        mock_get_worksheet_by_id.side_effect = gspread.exceptions.APIError(mock_response)
+        mock_get_worksheet_by_id.side_effect = _quota_exceeded_api_error()
 
         instance = mock_google_sheets_client.return_value
         instance.open_by_url.return_value = mock_spreadsheet
@@ -56,3 +75,62 @@ def test_get_worksheet_caching():
 
         # It should now have 2 calls, we've changed one of the arguments, but the second/third calls should be cached
         assert mock_google_sheets_client.call_count == 2
+
+
+def test_get_schemas_retries_on_quota_exceeded():
+    """Regression: get_schemas previously did not retry on 429, causing sync_new_schemas
+    to fail the whole import when the shared Google Cloud project hit its per-minute read quota."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_spreadsheet = mock.MagicMock()
+        mock_worksheets = mock.MagicMock()
+        mock_worksheets.side_effect = _quota_exceeded_api_error()
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.return_value = mock_spreadsheet
+        mock_spreadsheet.worksheets = mock_worksheets
+
+        config = mock.MagicMock()
+        config.spreadsheet_url = "https://docs.google.com/spreadsheets/d/abc/edit"
+
+        with pytest.raises(gspread.exceptions.APIError):
+            get_schemas(config)
+
+        assert mock_worksheets.call_count == 10
+
+
+def test_get_schema_incremental_fields_retries_on_quota_exceeded():
+    """Regression: get_schema_incremental_fields called worksheet.get_all_values without
+    the 429 retry wrapper, so a quota-exceeded response at that step would fail
+    sync_new_schemas even though the existing _get_worksheet retry logic covered
+    the preceding call."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_worksheet = mock.MagicMock()
+        mock_worksheet.id = 1
+        mock_worksheet.title = "Sheet1"
+
+        mock_spreadsheet = mock.MagicMock()
+        mock_spreadsheet.worksheets.return_value = [mock_worksheet]
+        mock_spreadsheet.get_worksheet_by_id.return_value = mock_worksheet
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.return_value = mock_spreadsheet
+
+        mock_worksheet.get_all_values.side_effect = _quota_exceeded_api_error()
+
+        config = mock.MagicMock()
+        config.spreadsheet_url = "https://docs.google.com/spreadsheets/d/abc/edit"
+
+        with pytest.raises(gspread.exceptions.APIError):
+            get_schema_incremental_fields(config, "sheet1")
+
+        assert mock_worksheet.get_all_values.call_count == 10

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -8,6 +8,7 @@ from posthog.temporal.data_imports.sources.google_sheets.google_sheets import (
     cache,
     get_schema_incremental_fields,
     get_schemas,
+    google_sheets_source,
 )
 
 
@@ -134,3 +135,71 @@ def test_get_schema_incremental_fields_retries_on_quota_exceeded():
             get_schema_incremental_fields(config, "sheet1")
 
         assert mock_worksheet.get_all_values.call_count == 10
+
+
+def test_google_sheets_source_retries_get_all_values_on_quota_exceeded():
+    """Regression: google_sheets_source calls worksheet.get_all_values("1:1") to
+    inspect the header row for primary-key detection. This must retry on 429 so a
+    transient per-minute quota hit doesn't fail the whole pipeline setup."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_worksheet = mock.MagicMock()
+        mock_worksheet.id = 1
+        mock_worksheet.title = "Sheet1"
+
+        mock_spreadsheet = mock.MagicMock()
+        mock_spreadsheet.worksheets.return_value = [mock_worksheet]
+        mock_spreadsheet.get_worksheet_by_id.return_value = mock_worksheet
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.return_value = mock_spreadsheet
+
+        mock_worksheet.get_all_values.side_effect = _quota_exceeded_api_error()
+
+        config = mock.MagicMock()
+        config.spreadsheet_url = "https://docs.google.com/spreadsheets/d/abc/edit"
+
+        with pytest.raises(gspread.exceptions.APIError):
+            google_sheets_source(config, "sheet1", db_incremental_field_last_value=None)
+
+        assert mock_worksheet.get_all_values.call_count == 10
+
+
+def test_google_sheets_source_retries_get_all_records_on_quota_exceeded():
+    """Regression: the per-row generator inside google_sheets_source calls
+    worksheet.get_all_records() to fetch the worksheet contents. This must retry
+    on 429 so a transient per-minute quota hit during data fetching doesn't
+    fail the activity."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_worksheet = mock.MagicMock()
+        mock_worksheet.id = 1
+        mock_worksheet.title = "Sheet1"
+        mock_worksheet.get_all_values.return_value = [["name", "email"]]
+        mock_worksheet.get_all_records.side_effect = _quota_exceeded_api_error()
+
+        mock_spreadsheet = mock.MagicMock()
+        mock_spreadsheet.worksheets.return_value = [mock_worksheet]
+        mock_spreadsheet.get_worksheet_by_id.return_value = mock_worksheet
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.return_value = mock_spreadsheet
+
+        config = mock.MagicMock()
+        config.spreadsheet_url = "https://docs.google.com/spreadsheets/d/abc/edit"
+
+        response = google_sheets_source(config, "sheet1", db_incremental_field_last_value=None)
+
+        with pytest.raises(gspread.exceptions.APIError):
+            # items is a generator factory; consume it to trigger the API call
+            list(response.items())
+
+        assert mock_worksheet.get_all_records.call_count == 10


### PR DESCRIPTION
## Problem

Google Sheets imports were failing with `APIError: [429]: Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute'`. PostHog error tracking (issue `019c48b6-2f4c-70d3-8ea9-ec84817db39c`, 117 occurrences across multiple workspaces) shows the failure raised from `worksheet.get_all_values("1:2")` inside `get_schema_incremental_fields`.

The module already had a 10-attempt linear-backoff retry for 429s, but it only wrapped `_get_worksheet`. The sibling `spreadsheet.worksheets()`, `worksheet.get_all_values()`, and `worksheet.get_all_records()` calls all hit the same shared per-minute quota on the shared GCP project but weren't retried, so transient quota saturation crashed `sync_new_schemas_activity` after Temporal's 3 attempts.

## Changes

- Extracted `_retry_on_quota_exceeded(operation)` helper from the inlined retry loop in `_get_worksheet`.
- Applied it to every gspread API callsite in `google_sheets.py`: `_get_worksheet`, `spreadsheet.worksheets()`, `worksheet.get_all_values("1:1")`, `worksheet.get_all_values("1:2")`, and `worksheet.get_all_records()`.
- Same 10-attempt jittered linear backoff for all callsites; behaviour is unchanged on the existing path.

## How did you test this code?

Agent-authored. Automated tests only — no manual reproduction:

- Existing 429 retry test for `_get_worksheet` (via `get_schemas` / `get_schema_incremental_fields`) still passes.
- Added `test_google_sheets_source_retries_get_all_values_on_quota_exceeded` covering the `worksheet.get_all_values("1:1")` call inside `google_sheets_source`.
- Added `test_google_sheets_source_retries_get_all_records_on_quota_exceeded` covering the per-row `worksheet.get_all_records()` call.
- All 6 tests in `test_google_sheets.py` pass; `ruff check` and `mypy` clean.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude) triaging error tracking issue `019c48b6-2f4c-70d3-8ea9-ec84817db39c`.
- Decision: fixable bug, not user error — adding to `NonRetryableErrors` would have prevented self-recovery from a transient shared-quota saturation. Scoped change to the specific module.
- Replaces #56277 (closed) — same diff, opened from my fork instead of an org branch.