### PR TITLE
fix(visual-review): handle GitHub rate limits and improve pending run UX

### DIFF
--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -31,6 +31,7 @@ RunNotFoundError = logic.RunNotFoundError
 ArtifactNotFoundError = logic.ArtifactNotFoundError
 GitHubIntegrationNotFoundError = logic.GitHubIntegrationNotFoundError
 GitHubCommitError = logic.GitHubCommitError
+GitHubRateLimitError = logic.GitHubRateLimitError
 PRSHAMismatchError = logic.PRSHAMismatchError
 StaleRunError = logic.StaleRunError
 BaselineFilePathNotConfiguredError = logic.BaselineFilePathNotConfiguredError

--- a/products/visual_review/backend/github.py
+++ b/products/visual_review/backend/github.py
@@ -7,6 +7,8 @@ so individual call sites don't need to handle any of this.
 
 from __future__ import annotations
 
+import time
+
 import requests
 import structlog
 
@@ -32,7 +34,7 @@ def github_request(
 ) -> requests.Response:
     """Make a GitHub API request with standard headers, rate limit logging, and rate limit detection.
 
-    Raises GitHubRateLimitError on 403 when the rate limit is exhausted.
+    Raises GitHubRateLimitError on 403/429 when the rate limit is exhausted.
     """
     headers = {
         "Accept": "application/vnd.github+json",
@@ -49,6 +51,15 @@ def github_request(
     return response
 
 
+def _safe_int(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
 def _log_rate_limit_headers(response: requests.Response, method: str, url: str) -> None:
     remaining = response.headers.get("x-ratelimit-remaining")
     if remaining is None:
@@ -59,7 +70,7 @@ def _log_rate_limit_headers(response: requests.Response, method: str, url: str) 
     reset = response.headers.get("x-ratelimit-reset")
     resource = response.headers.get("x-ratelimit-resource")
 
-    remaining_int = int(remaining) if remaining else None
+    remaining_int = _safe_int(remaining)
 
     if remaining_int is not None and remaining_int < 100:
         logger.warning(
@@ -83,28 +94,35 @@ def _log_rate_limit_headers(response: requests.Response, method: str, url: str) 
 
 
 def _check_rate_limit_response(response: requests.Response, method: str, url: str) -> None:
-    if response.status_code != 403:
+    # GitHub returns 429 for secondary rate limits (concurrent request limits)
+    # and 403 with "rate limit" in the body for primary rate limits.
+    if response.status_code == 429:
+        is_rate_limited = True
+    elif response.status_code == 403:
+        body = ""
+        try:
+            body = response.text
+        except Exception:
+            pass
+        is_rate_limited = "rate limit" in body.lower()
+    else:
         return
 
-    body = ""
-    try:
-        body = response.text
-    except Exception:
-        pass
-
-    if "rate limit" not in body.lower():
+    if not is_rate_limited:
         return
 
-    reset = response.headers.get("x-ratelimit-reset")
-    retry_after = response.headers.get("retry-after")
+    reset_at = _safe_int(response.headers.get("x-ratelimit-reset"))
+    retry_after_seconds = _safe_int(response.headers.get("retry-after"))
 
-    reset_at = int(reset) if reset else None
-    retry_after_seconds = int(retry_after) if retry_after else None
+    # Derive retry_after from reset_at when GitHub only sends the reset timestamp
+    if retry_after_seconds is None and reset_at is not None:
+        retry_after_seconds = max(1, reset_at - int(time.time()))
 
     logger.error(
         "visual_review.github_rate_limit_exceeded",
         method=method,
         url=_sanitize_url(url),
+        status_code=response.status_code,
         reset_at=reset_at,
         retry_after=retry_after_seconds,
         remaining=response.headers.get("x-ratelimit-remaining"),

--- a/products/visual_review/backend/github.py
+++ b/products/visual_review/backend/github.py
@@ -1,0 +1,124 @@
+"""
+GitHub API client wrapper for visual_review.
+
+Centralizes auth headers, rate limit logging, and rate limit error detection
+so individual call sites don't need to handle any of this.
+"""
+
+from __future__ import annotations
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+GITHUB_API_VERSION = "2022-11-28"
+
+
+class GitHubRateLimitError(Exception):
+    """GitHub API rate limit exhausted for this installation."""
+
+    def __init__(self, message: str, reset_at: int | None = None, retry_after: int | None = None):
+        super().__init__(message)
+        self.reset_at = reset_at
+        self.retry_after = retry_after
+
+
+def github_request(
+    method: str,
+    url: str,
+    access_token: str,
+    **kwargs,
+) -> requests.Response:
+    """Make a GitHub API request with standard headers, rate limit logging, and rate limit detection.
+
+    Raises GitHubRateLimitError on 403 when the rate limit is exhausted.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {access_token}",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        **(kwargs.pop("headers", {})),
+    }
+
+    response = requests.request(method, url, headers=headers, **kwargs)
+
+    _log_rate_limit_headers(response, method, url)
+    _check_rate_limit_response(response, method, url)
+
+    return response
+
+
+def _log_rate_limit_headers(response: requests.Response, method: str, url: str) -> None:
+    remaining = response.headers.get("x-ratelimit-remaining")
+    if remaining is None:
+        return
+
+    limit = response.headers.get("x-ratelimit-limit")
+    used = response.headers.get("x-ratelimit-used")
+    reset = response.headers.get("x-ratelimit-reset")
+    resource = response.headers.get("x-ratelimit-resource")
+
+    remaining_int = int(remaining) if remaining else None
+
+    if remaining_int is not None and remaining_int < 100:
+        logger.warning(
+            "visual_review.github_rate_limit_low",
+            remaining=remaining,
+            limit=limit,
+            used=used,
+            reset=reset,
+            resource=resource,
+            method=method,
+            url=_sanitize_url(url),
+        )
+    else:
+        logger.debug(
+            "visual_review.github_rate_limit",
+            remaining=remaining,
+            limit=limit,
+            used=used,
+            resource=resource,
+        )
+
+
+def _check_rate_limit_response(response: requests.Response, method: str, url: str) -> None:
+    if response.status_code != 403:
+        return
+
+    body = ""
+    try:
+        body = response.text
+    except Exception:
+        pass
+
+    if "rate limit" not in body.lower():
+        return
+
+    reset = response.headers.get("x-ratelimit-reset")
+    retry_after = response.headers.get("retry-after")
+
+    reset_at = int(reset) if reset else None
+    retry_after_seconds = int(retry_after) if retry_after else None
+
+    logger.error(
+        "visual_review.github_rate_limit_exceeded",
+        method=method,
+        url=_sanitize_url(url),
+        reset_at=reset_at,
+        retry_after=retry_after_seconds,
+        remaining=response.headers.get("x-ratelimit-remaining"),
+        limit=response.headers.get("x-ratelimit-limit"),
+        resource=response.headers.get("x-ratelimit-resource"),
+    )
+
+    raise GitHubRateLimitError(
+        f"GitHub API rate limit exceeded (resets at {reset_at})",
+        reset_at=reset_at,
+        retry_after=retry_after_seconds,
+    )
+
+
+def _sanitize_url(url: str) -> str:
+    """Strip query params from URL for logging (may contain tokens in rare cases)."""
+    return url.split("?")[0]

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -769,7 +769,12 @@ def complete_run(run_id: UUID) -> Run:
     # Fetch baseline merged with merge-base to heal rebase-induced drift.
     # Branch baseline tracks approvals; merge-base fills entries lost when
     # git rebase replays a full-file bot commit destructively.
-    baseline, healed_count = _resolve_baselines_with_merge_base(repo, run.run_type, run.branch)
+    try:
+        baseline, healed_count = _resolve_baselines_with_merge_base(repo, run.run_type, run.branch)
+    except GitHubRateLimitError:
+        # Roll back to PENDING so the caller can retry after the limit resets
+        Run.objects.filter(id=run_id).update(status=RunStatus.PENDING)
+        raise
     if healed_count:
         run.metadata["baseline_healed_from_merge_base"] = healed_count
         run.save(using=WRITER_DB, update_fields=["metadata"])

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 from .classifier import SnapshotClassifier
 from .db import WRITER_DB
 from .facade.enums import ReviewDecision, ReviewState, RunPurpose, RunStatus, SnapshotResult, ToleratedReason
+from .github import GitHubRateLimitError  # noqa: F401 — re-exported for facade
 from .models import Artifact, QuarantinedIdentifier, Repo, Run, RunSnapshot, ToleratedHash
 from .signing import sign_snapshot_hash, verify_signed_hash
 from .storage import ArtifactStorage
@@ -344,15 +345,14 @@ def _get_merge_base_sha(github: GitHubIntegration, repo_full_name: str, base: st
 
     import requests
 
+    from .github import github_request
+
     access_token = github.integration.sensitive_config["access_token"]
     try:
-        response = requests.get(
+        response = github_request(
+            "GET",
             f"https://api.github.com/repos/{repo_full_name}/compare/{quote(base, safe='')}...{quote(head, safe='')}",
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {access_token}",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
+            access_token=access_token,
             timeout=10,
         )
     except requests.RequestException:
@@ -384,15 +384,14 @@ def _get_default_branch(github: GitHubIntegration, repo_full_name: str) -> str:
     """Get the repo's default branch name via the GitHub API. Falls back to 'master'."""
     import requests
 
+    from .github import github_request
+
     access_token = github.integration.sensitive_config["access_token"]
     try:
-        response = requests.get(
+        response = github_request(
+            "GET",
             f"https://api.github.com/repos/{repo_full_name}",
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {access_token}",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
+            access_token=access_token,
             timeout=10,
         )
     except requests.RequestException:
@@ -1050,16 +1049,13 @@ def _resolve_repo_by_id(github, repo_external_id: int) -> str | None:
     latest full_name even if the repo was renamed or transferred.
     Returns None if the repo is inaccessible.
     """
-    import requests
+    from .github import github_request
 
     access_token = github.integration.sensitive_config["access_token"]
-    response = requests.get(
+    response = github_request(
+        "GET",
         f"https://api.github.com/repositories/{repo_external_id}",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {access_token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
+        access_token=access_token,
         timeout=10,
     )
     if response.status_code == 200:
@@ -1082,7 +1078,7 @@ def _github_api_request(
     """
     from urllib.parse import quote
 
-    import requests
+    from .github import github_request
 
     # Prevent path traversal — each segment must be safe
     safe_path = "/".join(quote(segment, safe="") for segment in path.split("/"))
@@ -1092,15 +1088,9 @@ def _github_api_request(
         github.refresh_access_token()
 
     access_token = github.integration.sensitive_config["access_token"]
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {access_token}",
-        "X-GitHub-Api-Version": "2022-11-28",
-        **(kwargs.pop("headers", {})),
-    }
 
     url = f"https://api.github.com/repos/{repo.repo_full_name}/{safe_path}"
-    response = requests.request(method, url, headers=headers, **kwargs)
+    response = github_request(method, url, access_token=access_token, **kwargs)
 
     if response.status_code == 404 and repo.repo_external_id:
         new_full_name = _resolve_repo_by_id(github, repo.repo_external_id)
@@ -1115,7 +1105,7 @@ def _github_api_request(
             repo.save(update_fields=["repo_full_name"])
 
             url = f"https://api.github.com/repos/{new_full_name}/{safe_path}"
-            response = requests.request(method, url, headers=headers, **kwargs)
+            response = github_request(method, url, access_token=access_token, **kwargs)
 
     return response
 
@@ -1126,17 +1116,15 @@ def _get_pr_info(github, repo_full_name: str, pr_number: int) -> dict:
 
     Returns dict with head_ref (branch) and head_sha.
     """
-    import requests
+    from .github import github_request
 
     access_token = github.integration.sensitive_config["access_token"]
 
-    response = requests.get(
+    response = github_request(
+        "GET",
         f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {access_token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
+        access_token=access_token,
+        timeout=10,
     )
 
     if response.status_code != 200:
@@ -1162,18 +1150,16 @@ def _fetch_baseline_file(
     import base64
 
     import yaml
-    import requests
+
+    from .github import github_request
 
     access_token = github.integration.sensitive_config["access_token"]
 
-    response = requests.get(
+    response = github_request(
+        "GET",
         f"https://api.github.com/repos/{repo_full_name}/contents/{file_path}",
+        access_token=access_token,
         params={"ref": branch},
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {access_token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
         timeout=10,
     )
 
@@ -1262,7 +1248,7 @@ def _post_commit_status(
 
     from django.conf import settings
 
-    import requests
+    from .github import github_request
 
     try:
         github = get_github_integration_for_repo(repo)
@@ -1276,18 +1262,15 @@ def _post_commit_status(
     target_url = f"{settings.SITE_URL}/project/{repo.team_id}/visual_review/runs/{run.id}"
 
     try:
-        response = requests.post(
+        response = github_request(
+            "POST",
             f"https://api.github.com/repos/{repo.repo_full_name}/statuses/{run.commit_sha}",
+            access_token=access_token,
             json={
                 "state": state,
                 "description": description[:140],
                 "context": f"PostHog Visual Review / {run.run_type}",
                 "target_url": target_url,
-            },
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {access_token}",
-                "X-GitHub-Api-Version": "2022-11-28",
             },
             timeout=10,
         )

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -340,6 +340,14 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             run = api.complete_run(UUID(pk), team_id=self.team_id)
         except api.RunNotFoundError:
             return Response({"detail": "Run not found"}, status=status.HTTP_404_NOT_FOUND)
+        except api.GitHubRateLimitError as e:
+            response = Response(
+                {"detail": "GitHub API rate limit exceeded. Please retry later.", "code": "rate_limited"},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+            if e.retry_after:
+                response["Retry-After"] = str(e.retry_after)
+            return response
         return Response(RunSerializer(instance=run).data)
 
     @validated_request(
@@ -386,6 +394,14 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             )
         except api.PRSHAMismatchError as e:
             return Response({"detail": str(e), "code": "sha_mismatch"}, status=status.HTTP_409_CONFLICT)
+        except api.GitHubRateLimitError as e:
+            response = Response(
+                {"detail": "GitHub API rate limit exceeded. Please retry later.", "code": "rate_limited"},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+            if e.retry_after:
+                response["Retry-After"] = str(e.retry_after)
+            return response
         except api.GitHubCommitError:
             return Response({"detail": "GitHub commit failed"}, status=status.HTTP_502_BAD_GATEWAY)
 

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -13,6 +13,8 @@ from uuid import UUID
 import structlog
 from celery import shared_task
 
+from ..github import GitHubRateLimitError
+
 logger = structlog.get_logger(__name__)
 
 
@@ -21,6 +23,10 @@ logger = structlog.get_logger(__name__)
     ignore_result=True,
     acks_late=True,
     reject_on_worker_lost=True,
+    autoretry_for=(GitHubRateLimitError,),
+    max_retries=3,
+    retry_backoff=60,
+    retry_backoff_max=600,
 )
 def process_run_diffs(run_id: str) -> None:
     """
@@ -38,6 +44,9 @@ def process_run_diffs(run_id: str) -> None:
         process_diffs(run_uuid)
         logic.finish_processing(run_uuid)
         logger.info("visual_review.diff_processing_completed", run_id=run_id)
+    except GitHubRateLimitError:
+        logger.warning("visual_review.diff_processing_rate_limited", run_id=run_id)
+        raise
     except Exception as e:
         logger.exception("visual_review.diff_processing_failed", run_id=run_id, error=str(e))
         logic.finish_processing(run_uuid, error_message=str(e))

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -20,15 +20,13 @@ logger = structlog.get_logger(__name__)
 
 @shared_task(
     name="products.visual_review.backend.tasks.process_run_diffs",
+    bind=True,
     ignore_result=True,
     acks_late=True,
     reject_on_worker_lost=True,
-    autoretry_for=(GitHubRateLimitError,),
     max_retries=3,
-    retry_backoff=60,
-    retry_backoff_max=600,
 )
-def process_run_diffs(run_id: str) -> None:
+def process_run_diffs(self, run_id: str) -> None:
     """
     Process diffs for all snapshots in a run.
 
@@ -44,9 +42,18 @@ def process_run_diffs(run_id: str) -> None:
         process_diffs(run_uuid)
         logic.finish_processing(run_uuid)
         logger.info("visual_review.diff_processing_completed", run_id=run_id)
-    except GitHubRateLimitError:
-        logger.warning("visual_review.diff_processing_rate_limited", run_id=run_id)
-        raise
+    except GitHubRateLimitError as e:
+        logger.warning(
+            "visual_review.diff_processing_rate_limited",
+            run_id=run_id,
+            retry=self.request.retries,
+            max_retries=self.max_retries,
+        )
+        try:
+            countdown = e.retry_after or 60
+            self.retry(countdown=min(countdown, 600), exc=e)
+        except self.MaxRetriesExceededError:
+            logic.finish_processing(run_uuid, error_message="GitHub API rate limit exceeded after retries")
     except Exception as e:
         logger.exception("visual_review.diff_processing_failed", run_id=run_id, error=str(e))
         logic.finish_processing(run_uuid, error_message=str(e))

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -127,19 +127,46 @@ function SnapshotThumbnail({
     )
 }
 
-function RunInProgressEmptyState({ isProcessing }: { isProcessing: boolean }): JSX.Element {
-    const title = isProcessing ? 'Processing diffs' : 'Waiting for snapshots'
+const PENDING_STALE_THRESHOLD_MS = 15 * 60 * 1000
+
+function RunInProgressEmptyState({
+    isProcessing,
+    createdAt,
+    ciJobUrl,
+}: {
+    isProcessing: boolean
+    createdAt: string
+    ciJobUrl?: string
+}): JSX.Element {
+    const ageMs = Date.now() - new Date(createdAt).getTime()
+    const isStale = !isProcessing && ageMs > PENDING_STALE_THRESHOLD_MS
+
+    const title = isProcessing ? 'Processing diffs' : isStale ? 'Still waiting for snapshots' : 'Waiting for snapshots'
     const copy = isProcessing
         ? 'Snapshots are being compared against the baseline. This usually takes under a minute.'
-        : 'This run is waiting for the CI job to upload snapshot artifacts. It will appear here once the upload completes.'
+        : isStale
+          ? 'This run has been waiting for over 15 minutes. The CI job may have failed before uploading snapshots.'
+          : 'This run is waiting for the CI job to upload snapshot artifacts. It will appear here once the upload completes.'
 
     return (
         <PostHogCaptureOnViewed
             name="visual-review-run-in-progress-shown"
-            properties={{ is_processing: isProcessing }}
+            properties={{ is_processing: isProcessing, is_stale: isStale }}
             className="flex flex-col items-center justify-center text-center gap-3 py-12 px-6"
             data-attr="visual-review-run-in-progress"
         >
+            {isStale ? (
+                <LemonBanner type="warning" className="max-w-lg mb-4">
+                    The CI job hasn't reported back.{' '}
+                    {ciJobUrl ? (
+                        <Link to={ciJobUrl} target="_blank" className="font-semibold">
+                            Check CI logs
+                        </Link>
+                    ) : (
+                        'Check your CI logs to see if the job failed.'
+                    )}
+                </LemonBanner>
+            ) : null}
             <DetectiveHog className="w-32 h-32" />
             <h2 className="m-0">{title}</h2>
             <p className="max-w-md text-tertiary m-0">
@@ -202,7 +229,11 @@ export function VisualReviewRunScene(): JSX.Element {
         return (
             <SceneContent>
                 <SceneTitleSection name={run.branch} resourceType={{ type: 'visual_review' }} />
-                <RunInProgressEmptyState isProcessing={isRunProcessing} />
+                <RunInProgressEmptyState
+                    isProcessing={isRunProcessing}
+                    createdAt={run.created_at}
+                    ciJobUrl={run.metadata?.ci_job_url}
+                />
             </SceneContent>
         )
     }

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -232,7 +232,7 @@ export function VisualReviewRunScene(): JSX.Element {
                 <RunInProgressEmptyState
                     isProcessing={isRunProcessing}
                     createdAt={run.created_at}
-                    ciJobUrl={run.metadata?.ci_job_url}
+                    ciJobUrl={run.metadata?.ci_job_url as string | undefined}
                 />
             </SceneContent>
         )


### PR DESCRIPTION
## Problem

VR was throwing a generic `GitHubCommitError` (surfaced as HTTP 502) when hitting GitHub's per-installation rate limit, giving no signal about what happened or when to retry. Separately, when CI fails before uploading snapshots, runs stay `pending` forever showing "Waiting for snapshots" with no indication anything is wrong.

## Changes

**Rate limit handling** — new `github.py` with a `github_request()` wrapper that all GitHub API calls now go through:
- Logs `x-ratelimit-remaining`, `-limit`, `-used`, `-reset`, `-resource` on every response, warns when remaining < 100
- Raises `GitHubRateLimitError` on 403 rate limit responses (with `reset_at` and `retry_after` from headers)
- Views return HTTP 429 with `Retry-After` instead of 502
- Celery task retries automatically (3 attempts, 60s backoff, 600s max) without marking the run as failed

**Pending run UX** — when a run has been `pending` for over 15 minutes, shows a warning banner ("The CI job hasn't reported back") with a link to CI logs when `metadata.ci_job_url` is available. Title changes from "Waiting for snapshots" to "Still waiting for snapshots".

## How did you test this code?

Agent-authored. Ran existing test suites: 7/7 GitHub integration tests pass, 87/87 logic tests pass. Linted with ruff (clean) and formatted with oxfmt.

## 🤖 Agent context

Co-authored with Claude Code. Rate limit error observed in production: `GitHubCommitError: Failed to fetch baseline file: 403` for installation ID 99844466 during `complete_run` → `_fetch_baseline_file`. The wrapper approach avoids touching every call site's logic — just swaps `requests.get/post` for `github_request`.