### PR TITLE
chore(frontend): lazy-load SessionGroupSummaryDetailsModal

### DIFF
--- a/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
@@ -1,5 +1,9 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react'
+
+const SessionGroupSummaryDetailsModal = lazy(() =>
+    import('./SessionGroupSummaryDetailsModal').then((m) => ({ default: m.SessionGroupSummaryDetailsModal }))
+)
 
 import { IconCheck, IconSearch, IconShare, IconSort } from '@posthog/icons'
 import {
@@ -25,7 +29,6 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { SessionGroupSummaryDetailsMetadata } from './SessionGroupSummaryDetailsMetadata'
-import { SessionGroupSummaryDetailsModal } from './SessionGroupSummaryDetailsModal'
 import { SessionGroupSummarySceneLogicProps, sessionGroupSummarySceneLogic } from './sessionGroupSummarySceneLogic'
 import {
     EnrichedSessionGroupSummaryPattern,
@@ -516,11 +519,15 @@ export function SessionGroupSummary(): JSX.Element {
                 </div>
             </div>
 
-            <SessionGroupSummaryDetailsModal
-                isOpen={selectedEvent !== null}
-                onClose={handleCloseModal}
-                event={selectedEvent}
-            />
+            {selectedEvent !== null && (
+                <Suspense fallback={null}>
+                    <SessionGroupSummaryDetailsModal
+                        isOpen={selectedEvent !== null}
+                        onClose={handleCloseModal}
+                        event={selectedEvent}
+                    />
+                </Suspense>
+            )}
         </SceneContent>
     )
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
