### PR TITLE
fix(data-warehouse): guard empty results in vitally paginator

### DIFF
--- a/posthog/temporal/data_imports/sources/vitally/vitally.py
+++ b/posthog/temporal/data_imports/sources/vitally/vitally.py
@@ -284,7 +284,12 @@ class VitallyPaginator(BasePaginator):
             return
 
         if self._should_use_incremental_field and self._incremental_start_value is not None:
-            updated_at_str = res["results"][0]["updatedAt"]
+            results = res.get("results")
+            if not results:
+                self._has_next_page = False
+                return
+
+            updated_at_str = results[0]["updatedAt"]
             updated_at = parser.parse(updated_at_str).timestamp()
             if isinstance(self._incremental_start_value, str):
                 start_value = parser.parse(self._incremental_start_value).timestamp()


### PR DESCRIPTION
## Problem

Incremental Vitally data warehouse syncs hit `IndexError: list index out of range` at `posthog/temporal/data_imports/sources/vitally/vitally.py:287` whenever the upstream API returns a paginated response with an empty `results` list (e.g. `{"results": [], "next": ...}`). The existing `if not res:` guard only catches a falsy top-level body, not an empty results array, so the access on `res["results"][0]["updatedAt"]` crashes the `import_data_activity_sync` Temporal activity for the affected sync.

## Changes

In `VitallyPaginator.update_state`, before reading `res["results"][0]["updatedAt"]` in the incremental branch, check that `res.get("results")` is a non-empty list. If results is empty or missing, set `self._has_next_page = False` and return — mirroring the existing `if not res:` short-circuit — so a stray empty page cleanly ends pagination instead of crashing the activity.

## How did you test this code?

I am an agent. I did not run automated tests for this change — there are currently no tests for `VitallyPaginator`, and adding a fixture-driven paginator test was out of scope for this targeted fix. The change is a narrow guard that mirrors the existing `if not res:` short-circuit a few lines above and only takes effect when the API returns an empty `results` list.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code agent in response to an error tracking signal report flagging a first-seen `IndexError` from this paginator. Root cause identified as the unguarded `res["results"][0]` access introduced when the source was first added and preserved across subsequent refactors. Fix mirrors the existing falsy-body guard pattern in the same method to keep the change minimal.