### PR TITLE
fix(tasks): terminalize workflow start failures

### DIFF
--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from django.conf import settings
 from django.db import transaction
+from django.utils import timezone as django_timezone
 
 import posthoganalytics
 from asgiref.sync import sync_to_async
@@ -51,11 +52,22 @@ def _terminalize_unstarted_task_run(run_id: str, error_message: str) -> bool:
                 )
                 return False
 
-            task_run.mark_failed(error_message)
+            task_run.status = TaskRun.Status.FAILED
+            task_run.error_message = error_message
+            task_run.completed_at = django_timezone.now()
+            task_run.save(update_fields=["status", "error_message", "completed_at"])
     except TaskRun.DoesNotExist:
         logger.warning("task_processing_start_failure_task_run_missing", extra={"run_id": run_id})
         return False
 
+    task_run.publish_stream_state_event()
+    task_run.capture_event(
+        "task_run_failed",
+        {
+            "error_message": error_message[:500],
+            "duration_seconds": task_run._duration_seconds(),
+        },
+    )
     return True
 
 

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -4,8 +4,10 @@ import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 from django.conf import settings
+from django.db import transaction
 
 import posthoganalytics
+from asgiref.sync import sync_to_async
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.models.team.team import Team
@@ -23,6 +25,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_PRE_START_STATUSES: tuple[str, ...] = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED)
+
+
 def _normalize_slack_context(slack_thread_context: Optional[Any]) -> Optional[dict[str, Any]]:
     """Convert slack_thread_context to dict if needed."""
     if slack_thread_context is None:
@@ -30,6 +35,32 @@ def _normalize_slack_context(slack_thread_context: Optional[Any]) -> Optional[di
     if hasattr(slack_thread_context, "to_dict"):
         return slack_thread_context.to_dict()
     return slack_thread_context
+
+
+def _terminalize_unstarted_task_run(run_id: str, error_message: str) -> bool:
+    try:
+        with transaction.atomic():
+            task_run = TaskRun.objects.select_for_update().get(id=run_id)
+            if task_run.status not in _PRE_START_STATUSES:
+                logger.info(
+                    "task_processing_start_failure_not_terminalized",
+                    extra={
+                        "run_id": run_id,
+                        "status": task_run.status,
+                    },
+                )
+                return False
+
+            task_run.mark_failed(error_message)
+    except TaskRun.DoesNotExist:
+        logger.warning("task_processing_start_failure_task_run_missing", extra={"run_id": run_id})
+        return False
+
+    return True
+
+
+async def _terminalize_unstarted_task_run_async(run_id: str, error_message: str) -> bool:
+    return await sync_to_async(_terminalize_unstarted_task_run)(run_id, error_message)
 
 
 async def execute_task_processing_workflow_async(
@@ -69,6 +100,7 @@ async def execute_task_processing_workflow_async(
         else:
             if not user_id:
                 logger.warning("task_processing_missing_user_id", extra={"task_id": task_id})
+                await _terminalize_unstarted_task_run_async(run_id, "Failed to start task workflow: missing user id")
                 return
 
             logger.info("task_processing_fetching_team_and_user", extra={"team_id": team_id, "user_id": user_id})
@@ -91,6 +123,10 @@ async def execute_task_processing_workflow_async(
 
         if not tasks_enabled:
             logger.warning("task_processing_blocked_feature_flag", extra={"task_id": task_id})
+            await _terminalize_unstarted_task_run_async(
+                run_id,
+                "Failed to start task workflow: tasks feature is disabled",
+            )
             return
 
         workflow_id = TaskRun.get_workflow_id(task_id, run_id)
@@ -125,10 +161,18 @@ async def execute_task_processing_workflow_async(
             "task_processing_permission_validation_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
         )
+        await _terminalize_unstarted_task_run_async(
+            run_id,
+            f"Failed to start task workflow: permission validation failed: {e}",
+        )
     except Exception as e:
         logger.exception(
             "task_processing_workflow_start_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
+        )
+        await _terminalize_unstarted_task_run_async(
+            run_id,
+            f"Failed to start task workflow: {e}",
         )
 
 
@@ -173,6 +217,7 @@ def execute_task_processing_workflow(
         else:
             if not user_id:
                 logger.warning("task_processing_missing_user_id", extra={"task_id": task_id})
+                _terminalize_unstarted_task_run(run_id, "Failed to start task workflow: missing user id")
                 return
 
             user = User.objects.get(id=user_id)
@@ -190,6 +235,10 @@ def execute_task_processing_workflow(
 
         if not tasks_enabled:
             logger.warning("task_processing_blocked_feature_flag", extra={"task_id": task_id})
+            _terminalize_unstarted_task_run(
+                run_id,
+                "Failed to start task workflow: tasks feature is disabled",
+            )
             return
 
         workflow_id = TaskRun.get_workflow_id(task_id, run_id)
@@ -232,10 +281,18 @@ def execute_task_processing_workflow(
             "task_processing_permission_validation_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
         )
+        _terminalize_unstarted_task_run(
+            run_id,
+            f"Failed to start task workflow: permission validation failed: {e}",
+        )
     except Exception as e:
         logger.exception(
             "task_processing_workflow_start_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
+        )
+        _terminalize_unstarted_task_run(
+            run_id,
+            f"Failed to start task workflow: {e}",
         )
 
 

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from django.test import TransactionTestCase, override_settings
 
 from asgiref.sync import async_to_sync
+from parameterized import parameterized
 
 from posthog.models import Organization, Team
 from posthog.models.user import User
@@ -41,89 +42,86 @@ class TestExecuteTaskProcessingWorkflow(TransactionTestCase):
         self.assertEqual(run.error_message, expected_error)
         self.assertIsNotNone(run.completed_at)
 
-    def test_marks_run_failed_when_user_id_is_missing(self) -> None:
+    def _execute_workflow(self, executor: str, run: TaskRun, user_id: int | None) -> None:
+        kwargs = {
+            "task_id": str(self.task.id),
+            "run_id": str(run.id),
+            "team_id": self.team.id,
+            "user_id": user_id,
+        }
+        if executor == "sync":
+            execute_task_processing_workflow(**kwargs)
+            return
+
+        async_to_sync(execute_task_processing_workflow_async)(**kwargs)
+
+    @parameterized.expand([("sync",), ("async",)])
+    def test_marks_run_failed_when_user_id_is_missing(self, executor: str) -> None:
         run = self._create_run()
 
-        execute_task_processing_workflow(
-            task_id=str(self.task.id),
-            run_id=str(run.id),
-            team_id=self.team.id,
-            user_id=None,
-        )
+        self._execute_workflow(executor, run, None)
 
         self._assert_run_failed(run, "Failed to start task workflow: missing user id")
 
-    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False)
-    def test_marks_run_failed_when_tasks_feature_is_disabled(self, mock_feature_enabled: Mock) -> None:
+    @parameterized.expand([("sync",), ("async",)])
+    def test_marks_run_failed_when_tasks_feature_is_disabled(self, executor: str) -> None:
         run = self._create_run()
 
-        execute_task_processing_workflow(
-            task_id=str(self.task.id),
-            run_id=str(run.id),
-            team_id=self.team.id,
-            user_id=self.user.id,
-        )
+        with patch(
+            "products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False
+        ) as mock_feature_enabled:
+            self._execute_workflow(executor, run, self.user.id)
 
         self._assert_run_failed(run, "Failed to start task workflow: tasks feature is disabled")
         mock_feature_enabled.assert_called_once()
 
-    @patch("products.tasks.backend.temporal.client.sync_connect")
-    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True)
-    def test_marks_run_failed_when_temporal_start_fails(
-        self,
-        mock_feature_enabled: Mock,
-        mock_sync_connect: Mock,
-    ) -> None:
+    @parameterized.expand([("sync",), ("async",)])
+    def test_marks_run_failed_when_temporal_start_fails(self, executor: str) -> None:
         run = self._create_run()
         client = Mock()
         client.start_workflow = AsyncMock(side_effect=RuntimeError("temporal unavailable"))
-        mock_sync_connect.return_value = client
 
-        execute_task_processing_workflow(
-            task_id=str(self.task.id),
-            run_id=str(run.id),
-            team_id=self.team.id,
-            user_id=self.user.id,
+        connect_target = (
+            "products.tasks.backend.temporal.client.sync_connect"
+            if executor == "sync"
+            else "products.tasks.backend.temporal.client.async_connect"
         )
+        connect_mock = Mock(return_value=client) if executor == "sync" else AsyncMock(return_value=client)
+
+        with (
+            patch(
+                "products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True
+            ) as mock_feature_enabled,
+            patch(connect_target, connect_mock),
+        ):
+            self._execute_workflow(executor, run, self.user.id)
 
         self._assert_run_failed(run, "Failed to start task workflow: temporal unavailable")
         mock_feature_enabled.assert_called_once()
 
-    @patch("products.tasks.backend.temporal.client.sync_connect")
-    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True)
-    def test_does_not_overwrite_run_that_already_started(
-        self,
-        mock_feature_enabled: Mock,
-        mock_sync_connect: Mock,
-    ) -> None:
+    @parameterized.expand([("sync",), ("async",)])
+    def test_does_not_overwrite_run_that_already_started(self, executor: str) -> None:
         run = self._create_run(status=TaskRun.Status.IN_PROGRESS)
         client = Mock()
         client.start_workflow = AsyncMock(side_effect=RuntimeError("temporal unavailable"))
-        mock_sync_connect.return_value = client
 
-        execute_task_processing_workflow(
-            task_id=str(self.task.id),
-            run_id=str(run.id),
-            team_id=self.team.id,
-            user_id=self.user.id,
+        connect_target = (
+            "products.tasks.backend.temporal.client.sync_connect"
+            if executor == "sync"
+            else "products.tasks.backend.temporal.client.async_connect"
         )
+        connect_mock = Mock(return_value=client) if executor == "sync" else AsyncMock(return_value=client)
+
+        with (
+            patch(
+                "products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True
+            ) as mock_feature_enabled,
+            patch(connect_target, connect_mock),
+        ):
+            self._execute_workflow(executor, run, self.user.id)
 
         run.refresh_from_db()
         self.assertEqual(run.status, TaskRun.Status.IN_PROGRESS)
         self.assertIsNone(run.error_message)
         self.assertIsNone(run.completed_at)
-        mock_feature_enabled.assert_called_once()
-
-    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False)
-    def test_async_marks_run_failed_when_tasks_feature_is_disabled(self, mock_feature_enabled: Mock) -> None:
-        run = self._create_run()
-
-        async_to_sync(execute_task_processing_workflow_async)(
-            task_id=str(self.task.id),
-            run_id=str(run.id),
-            team_id=self.team.id,
-            user_id=self.user.id,
-        )
-
-        self._assert_run_failed(run, "Failed to start task workflow: tasks feature is disabled")
         mock_feature_enabled.assert_called_once()

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -1,0 +1,129 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+from django.test import TransactionTestCase, override_settings
+
+from asgiref.sync import async_to_sync
+
+from posthog.models import Organization, Team
+from posthog.models.user import User
+
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.client import (
+    execute_task_processing_workflow,
+    execute_task_processing_workflow_async,
+)
+
+
+@override_settings(DEBUG=False)
+class TestExecuteTaskProcessingWorkflow(TransactionTestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create(email="test@example.com")
+        self.task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Test Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+
+    def _create_run(self, status: TaskRun.Status = TaskRun.Status.QUEUED) -> TaskRun:
+        return TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=status,
+        )
+
+    def _assert_run_failed(self, run: TaskRun, expected_error: str) -> None:
+        run.refresh_from_db()
+        self.assertEqual(run.status, TaskRun.Status.FAILED)
+        self.assertEqual(run.error_message, expected_error)
+        self.assertIsNotNone(run.completed_at)
+
+    def test_marks_run_failed_when_user_id_is_missing(self) -> None:
+        run = self._create_run()
+
+        execute_task_processing_workflow(
+            task_id=str(self.task.id),
+            run_id=str(run.id),
+            team_id=self.team.id,
+            user_id=None,
+        )
+
+        self._assert_run_failed(run, "Failed to start task workflow: missing user id")
+
+    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False)
+    def test_marks_run_failed_when_tasks_feature_is_disabled(self, mock_feature_enabled: Mock) -> None:
+        run = self._create_run()
+
+        execute_task_processing_workflow(
+            task_id=str(self.task.id),
+            run_id=str(run.id),
+            team_id=self.team.id,
+            user_id=self.user.id,
+        )
+
+        self._assert_run_failed(run, "Failed to start task workflow: tasks feature is disabled")
+        mock_feature_enabled.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.sync_connect")
+    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True)
+    def test_marks_run_failed_when_temporal_start_fails(
+        self,
+        mock_feature_enabled: Mock,
+        mock_sync_connect: Mock,
+    ) -> None:
+        run = self._create_run()
+        client = Mock()
+        client.start_workflow = AsyncMock(side_effect=RuntimeError("temporal unavailable"))
+        mock_sync_connect.return_value = client
+
+        execute_task_processing_workflow(
+            task_id=str(self.task.id),
+            run_id=str(run.id),
+            team_id=self.team.id,
+            user_id=self.user.id,
+        )
+
+        self._assert_run_failed(run, "Failed to start task workflow: temporal unavailable")
+        mock_feature_enabled.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.sync_connect")
+    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=True)
+    def test_does_not_overwrite_run_that_already_started(
+        self,
+        mock_feature_enabled: Mock,
+        mock_sync_connect: Mock,
+    ) -> None:
+        run = self._create_run(status=TaskRun.Status.IN_PROGRESS)
+        client = Mock()
+        client.start_workflow = AsyncMock(side_effect=RuntimeError("temporal unavailable"))
+        mock_sync_connect.return_value = client
+
+        execute_task_processing_workflow(
+            task_id=str(self.task.id),
+            run_id=str(run.id),
+            team_id=self.team.id,
+            user_id=self.user.id,
+        )
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, TaskRun.Status.IN_PROGRESS)
+        self.assertIsNone(run.error_message)
+        self.assertIsNone(run.completed_at)
+        mock_feature_enabled.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled", return_value=False)
+    def test_async_marks_run_failed_when_tasks_feature_is_disabled(self, mock_feature_enabled: Mock) -> None:
+        run = self._create_run()
+
+        async_to_sync(execute_task_processing_workflow_async)(
+            task_id=str(self.task.id),
+            run_id=str(run.id),
+            team_id=self.team.id,
+            user_id=self.user.id,
+        )
+
+        self._assert_run_failed(run, "Failed to start task workflow: tasks feature is disabled")
+        mock_feature_enabled.assert_called_once()


### PR DESCRIPTION
## Problem

cloud task runs are created before the temporal workflow is started. If workflow-start validation or temporal startup fails before the workflow begins, the `TaskRun` can remain queued indefinitely instead of reaching a terminal state.
we started tracking this so let's do an initial improvement there, later on before release we can do a cleanup.

## Changes

- added a guarded terminalization helper for workflow-start failures
