### PR TITLE
fix(auth): skip known-device cookie for InternalAPIUser

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -2381,7 +2381,7 @@ class TestKnownLoginDeviceCookieMiddleware(APIBaseTest):
         request = RequestFactory().get("/api/internal/hog_flows/process_due_schedules")
         SessionMiddleware(lambda r: HttpResponse()).process_request(request)
         request.session["touched"] = True
-        request.user = InternalAPIUser()  # ty: ignore[invalid-assignment]
+        request.__dict__["user"] = InternalAPIUser()
 
         response = KnownLoginDeviceCookieMiddleware(lambda r: HttpResponse())(request)
 

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import mail
 from django.core.cache import cache
+from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
 from django.utils import timezone
 
@@ -29,12 +30,18 @@ from two_factor.utils import totp_digits
 
 from posthog.api.authentication import password_reset_token_generator, post_login, social_login_notification
 from posthog.api.oauth.test_dcr import generate_rsa_key
-from posthog.auth import OAuthAccessTokenAuthentication, ProjectSecretAPIKeyAuthentication, ProjectSecretAPIKeyUser
+from posthog.auth import (
+    InternalAPIUser,
+    OAuthAccessTokenAuthentication,
+    ProjectSecretAPIKeyAuthentication,
+    ProjectSecretAPIKeyUser,
+)
 from posthog.helpers.user_devices import (
     KNOWN_DEVICE_COOKIE,
     build_known_device_cookie_value,
     has_valid_known_device_cookie,
 )
+from posthog.middleware import KnownLoginDeviceCookieMiddleware
 from posthog.models import User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
@@ -2369,3 +2376,14 @@ class TestKnownLoginDeviceCookieMiddleware(APIBaseTest):
         response = self.client.get("/api/users/@me/")
         assert response.status_code == 200
         assert KNOWN_DEVICE_COOKIE.format(user_id=self.user.id) not in response.cookies
+
+    def test_does_not_set_known_device_cookie_for_internal_api_user(self):
+        request = RequestFactory().get("/api/internal/hog_flows/process_due_schedules")
+        SessionMiddleware(lambda r: HttpResponse()).process_request(request)
+        request.session["touched"] = True
+        request.user = InternalAPIUser()  # ty: ignore[invalid-assignment]
+
+        response = KnownLoginDeviceCookieMiddleware(lambda r: HttpResponse())(request)
+
+        assert response.status_code == 200
+        assert not any(name.startswith("ph_device_") for name in response.cookies)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -662,7 +662,7 @@ class KnownLoginDeviceCookieMiddleware:
 
     def __call__(self, request: HttpRequest):
         response = self.get_response(request)
-        if request.session.accessed and request.user.is_authenticated and not is_impersonated_session(request):
+        if isinstance(request.user, User) and request.session.accessed and not is_impersonated_session(request):
             set_known_device_cookie(response, request.user)
         return response
 


### PR DESCRIPTION
## Problem

`KnownLoginDeviceCookieMiddleware` (added in #55093) calls `set_known_device_cookie(response, request.user)` on every authenticated response, which formats the cookie name with [user.id](http://user.id). When a request is authenticated via `InternalAPIAuthentication`, `request.user` is an `InternalAPIUser` (with pk = -2) and no id attribute. So the middleware crashes with AttributeError: `InternalAPIUser object has no attribute id` and every internal-API endpoint returns 500.

Affected endpoints (anything authenticating with `X-Internal-Api-Secret`):

- POST /api/internal/hog_flows/process_due_schedules — workflow scheduler
- POST /api/projects/\<team>/internal/hog_flows/user_blast_radius_persons — workflow blast-radius preview
- Internal endpoints in products/signals/
- Session-replay deletion Temporal activity
- Batch-export workflows calling back into Django

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- Guard the middleware with `isinstance(request.user, User)` so it no-ops for synthetic principals.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

tests

## Publish to changelog?

no

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->