### PR TITLE
fix: guard set_known_device_cookie against non-User request.user

### DIFF
--- a/posthog/helpers/tests/test_user_devices.py
+++ b/posthog/helpers/tests/test_user_devices.py
@@ -1,7 +1,10 @@
 import uuid
 
 from posthog.test.base import BaseTest
+from unittest.mock import MagicMock
 
+from django.contrib.sessions.backends.db import SessionStore
+from django.http import HttpResponse
 from django.test import RequestFactory
 
 from parameterized import parameterized
@@ -11,6 +14,7 @@ from posthog.helpers.user_devices import (
     build_known_device_cookie_value,
     has_valid_known_device_cookie,
 )
+from posthog.middleware import KnownLoginDeviceCookieMiddleware
 from posthog.models import User
 
 
@@ -69,3 +73,50 @@ class TestHasValidKnownDeviceCookie(BaseTest):
         user = self._make_user()
         request = self._request_with_cookies({KNOWN_DEVICE_COOKIE.format(user_id=user.id): value})
         self.assertFalse(has_valid_known_device_cookie(request, user))
+
+
+class TestKnownLoginDeviceCookieMiddleware(BaseTest):
+    def _make_request(self, user=None):
+        request = RequestFactory().get("/")
+        request.session = SessionStore()
+        if user is not None:
+            request.user = user
+            request.session["_auth_user_id"] = str(user.id)
+        return request
+
+    def _run_middleware(self, request):
+        response = HttpResponse()
+        middleware = KnownLoginDeviceCookieMiddleware(lambda r: response)
+        return middleware(request)
+
+    def test_sets_cookie_for_authenticated_user(self):
+        request = self._make_request(user=self.user)
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        cookie_name = KNOWN_DEVICE_COOKIE.format(user_id=self.user.id)
+        self.assertIn(cookie_name, response.cookies)
+
+    def test_no_crash_when_user_is_none(self):
+        request = self._make_request()
+        request.user = None
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_crash_when_user_has_no_id(self):
+        fake_user = MagicMock(spec=[])
+        fake_user.is_authenticated = True
+        request = self._make_request()
+        request.user = fake_user
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_crash_when_user_attr_missing(self):
+        request = RequestFactory().get("/")
+        request.session = SessionStore()
+        if hasattr(request, "user"):
+            del request.user
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -662,8 +662,15 @@ class KnownLoginDeviceCookieMiddleware:
 
     def __call__(self, request: HttpRequest):
         response = self.get_response(request)
-        if request.session.accessed and request.user.is_authenticated and not is_impersonated_session(request):
-            set_known_device_cookie(response, request.user)
+        user = getattr(request, "user", None)
+        if (
+            user
+            and getattr(user, "id", None)
+            and request.session.accessed
+            and user.is_authenticated
+            and not is_impersonated_session(request)
+        ):
+            set_known_device_cookie(response, user)
         return response
 
 


### PR DESCRIPTION
## Problem

`KnownLoginDeviceCookieMiddleware` (added in #55093) crashes with 500s on endpoints where `request.user` is not a standard `User` instance:
- `NoneType` on unauthenticated widget endpoints (`/api/conversations/v1/widget/tickets`)
- `ProjectSecretAPIKeyUser` on API-key-authenticated endpoints (remote_config, etc.)
- `InternalAPIUser` on internal service-to-service calls

These are actively 500ing in prod-us right now.

## Changes

Guard the middleware: check `request.user` exists and has an `id` attribute before accessing `is_authenticated` or calling `set_known_device_cookie`.

## How did you test this code?

Added 4 middleware tests covering: authenticated user (happy path), None user, user without id, and missing user attribute entirely.

## 🤖 Agent context

Discovered via Grafana Loki while monitoring the Django 5.2 rollout. Not Django 5 related — the middleware was added 5 days ago and never encountered these user types.

## Publish to changelog?

No