### PR TITLE
fix(ws): add HTTP retry for rate-limited data import sources

### DIFF
--- a/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 import requests
 from requests import Request, Response
 from requests.auth import AuthBase
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt
 
 from .exceptions import IgnoreResponseException
 from .jsonpath_utils import TJsonPath, find_values
@@ -17,7 +17,19 @@ logger = logging.getLogger(__name__)
 
 
 class RESTClientRetryableError(Exception):
-    pass
+    def __init__(self, message: str, retry_after: Optional[float] = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+def _retry_wait_seconds(state: RetryCallState) -> float:
+    fallback = min(2 ** (state.attempt_number - 1), 60)
+    if state.outcome is None or not state.outcome.failed:
+        return float(fallback)
+    exc = state.outcome.exception()
+    if isinstance(exc, RESTClientRetryableError) and exc.retry_after is not None:
+        return exc.retry_after
+    return float(fallback)
 
 
 Hooks = dict[str, list[Any]]
@@ -103,7 +115,7 @@ class RESTClient:
     @retry(
         retry=retry_if_exception_type(RESTClientRetryableError),
         stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
+        wait=_retry_wait_seconds,
         reraise=True,
     )
     def _send_request(self, request: Request, hooks: Hooks) -> Response:
@@ -111,7 +123,17 @@ class RESTClient:
         response = self.session.send(prepared)
 
         if response.status_code == 429 or response.status_code >= 500:
-            raise RESTClientRetryableError(f"HTTP {response.status_code} for {response.url}")
+            retry_after: Optional[float] = None
+            retry_after_header = response.headers.get("Retry-After")
+            if retry_after_header:
+                try:
+                    retry_after = float(retry_after_header)
+                except ValueError:
+                    pass
+            raise RESTClientRetryableError(
+                f"HTTP {response.status_code} for {response.url}",
+                retry_after=retry_after,
+            )
 
         response_hooks = hooks.get("response", [])
         if response_hooks:

--- a/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -7,12 +7,18 @@ from urllib.parse import urljoin
 import requests
 from requests import Request, Response
 from requests.auth import AuthBase
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from .exceptions import IgnoreResponseException
 from .jsonpath_utils import TJsonPath, find_values
 from .paginators import BasePaginator
 
 logger = logging.getLogger(__name__)
+
+
+class RESTClientRetryableError(Exception):
+    pass
+
 
 Hooks = dict[str, list[Any]]
 
@@ -94,9 +100,18 @@ class RESTClient:
             if paginator is None or not paginator.has_next_page:
                 break
 
+    @retry(
+        retry=retry_if_exception_type(RESTClientRetryableError),
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=1, max=30),
+        reraise=True,
+    )
     def _send_request(self, request: Request, hooks: Hooks) -> Response:
         prepared = self.session.prepare_request(request)
         response = self.session.send(prepared)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise RESTClientRetryableError(f"HTTP {response.status_code} for {response.url}")
 
         response_hooks = hooks.get("response", [])
         if response_hooks:

--- a/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -28,7 +28,7 @@ def _retry_wait_seconds(state: RetryCallState) -> float:
         return float(fallback)
     exc = state.outcome.exception()
     if isinstance(exc, RESTClientRetryableError) and exc.retry_after is not None:
-        return exc.retry_after
+        return min(exc.retry_after, 300.0)
     return float(fallback)
 
 
@@ -127,9 +127,19 @@ class RESTClient:
             retry_after_header = response.headers.get("Retry-After")
             if retry_after_header:
                 try:
-                    retry_after = float(retry_after_header)
+                    retry_after = min(float(retry_after_header), 300.0)
                 except ValueError:
-                    pass
+                    import datetime
+                    from email.utils import parsedate_to_datetime
+
+                    try:
+                        dt = parsedate_to_datetime(retry_after_header)
+                        retry_after = min(
+                            max(0.0, (dt - datetime.datetime.now(datetime.UTC)).total_seconds()),
+                            300.0,
+                        )
+                    except Exception:
+                        pass
             raise RESTClientRetryableError(
                 f"HTTP {response.status_code} for {response.url}",
                 retry_after=retry_after,

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -1,13 +1,14 @@
 import json
 from typing import Any
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from requests import Response
 
 from posthog.temporal.data_imports.sources.common.rest_source.exceptions import IgnoreResponseException
 from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator, SinglePagePaginator
-from posthog.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
+from posthog.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient, RESTClientRetryableError
 
 
 def _make_response(json_body: Any, status_code: int = 200) -> Response:
@@ -215,3 +216,53 @@ class TestRESTClient:
 
         prepared_request = mock_session.prepare_request.call_args.args[0]
         assert prepared_request.params == {"limit": 100, "name": "alice"}
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
+    def test_send_request_retries_on_429(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        rate_limited = _make_response({"error": "rate limited"}, status_code=429)
+        rate_limited.url = "https://api.example.com/items"
+        ok = _make_response({"results": [{"id": 1}]})
+
+        mock_session.send.side_effect = [rate_limited, ok]
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator()))
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
+    def test_send_request_retries_on_500(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        server_error = _make_response({"error": "internal"}, status_code=500)
+        server_error.url = "https://api.example.com/items"
+        ok = _make_response([{"id": 1}])
+
+        mock_session.send.side_effect = [server_error, ok]
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(client.paginate(path="/items", paginator=SinglePagePaginator()))
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
+    def test_send_request_raises_after_max_retries(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        error = _make_response({"error": "rate limited"}, status_code=429)
+        error.url = "https://api.example.com/items"
+        mock_session.send.return_value = error
+
+        client = RESTClient(base_url="https://api.example.com")
+        with pytest.raises(RESTClientRetryableError):
+            list(client.paginate(path="/items", paginator=SinglePagePaginator()))

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -266,3 +266,22 @@ class TestRESTClient:
         client = RESTClient(base_url="https://api.example.com")
         with pytest.raises(RESTClientRetryableError):
             list(client.paginate(path="/items", paginator=SinglePagePaginator()))
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
+    def test_send_request_respects_retry_after_header(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        rate_limited = _make_response({"error": "rate limited"}, status_code=429)
+        rate_limited.url = "https://api.example.com/items"
+        rate_limited.headers["Retry-After"] = "90"
+        ok = _make_response({"results": [{"id": 1}]})
+
+        mock_session.send.side_effect = [rate_limited, ok]
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator()))
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2

--- a/posthog/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/zendesk.py
@@ -270,6 +270,9 @@ class ZendeskIncrementalEndpointPaginator(BasePaginator):
 
     def update_request(self, request: Request) -> None:
         request.url = self._next_page
+        # next_page is a full URL that already contains all query params —
+        # clear params to avoid duplicates when prepare_request merges them.
+        request.params = {}
 
 
 def zendesk_source(


### PR DESCRIPTION
## Problem

Data warehouse Zendesk imports fail permanently on HTTP 429 (Too Many Requests) errors because the shared REST client has no per-request retry logic. When Zendesk rate-limits after ~2 pages of ticket_events, the activity crashes, Temporal restarts the whole import from scratch (since incrementality is disabled for this endpoint), and it hits the same rate limit at roughly the same point

## Changes

  Shared REST client retry (rest_client.py):
  - Added RESTClientRetryableError exception class
  - Decorated _send_request with tenacity: 5 attempts, exponential backoff with jitter (1–30s)
  - Intercepts 429 and 5xx responses before hooks/raise_for_status, so all ~13 sources using the shared REST client benefit (Zendesk, Attio, Chargebee, Reddit Ads, Typeform, Mailchimp, Snapchat Ads, Vitally,
  Salesforce, Clerk, Sentry, etc.)
  - Non-retryable 4xx errors (400, 401, 403, 404) still fail immediately

  Zendesk duplicate params fix (zendesk.py):
  - ZendeskIncrementalEndpointPaginator.update_request() now clears request.params after setting the URL, since next_page from Zendesk's response already contains all needed query parameters


## How did you test this code?

- local run for zendesk
- local run for klaviyo
- tests pass


## Publish to changelog?

NO
