### PR TITLE
feat(logs): bounded concurrency for alert eval loop

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -1,6 +1,7 @@
 """Temporal activities for logs alerting."""
 
 import time
+import asyncio
 import dataclasses
 from datetime import UTC, datetime, timedelta
 
@@ -35,6 +36,7 @@ from products.logs.backend.alert_state_machine import (
 from products.logs.backend.alert_utils import advance_next_check_at
 from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
+from products.logs.backend.temporal.constants import MAX_CONCURRENT_ALERT_EVALS
 from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
@@ -93,12 +95,50 @@ class CheckAlertsOutput:
 
 @temporalio.activity.defn
 async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
-    """Find all due alerts and evaluate them sequentially."""
-    return await database_sync_to_async_pool(_check_alerts_sync)()
+    """Find all due alerts and evaluate them with bounded concurrency."""
+    now, all_alerts, checkpoint = await database_sync_to_async_pool(_load_alerts_and_checkpoint)()
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_ALERT_EVALS)
+    eval_async = database_sync_to_async_pool(_evaluate_single_alert)
+
+    async def _bounded_eval(alert: LogsAlertConfiguration) -> dict[str, int]:
+        async with semaphore:
+            local_stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+            try:
+                await eval_async(alert, now, local_stats, checkpoint=checkpoint)
+            except Exception:
+                logger.exception(
+                    "Unexpected error evaluating alert",
+                    alert_id=str(alert.id),
+                    alert_name=alert.name,
+                    team_id=alert.team_id,
+                )
+                local_stats["errored"] += 1
+            return local_stats
+
+    tasks: list[asyncio.Task[dict[str, int]]] = []
+    async with asyncio.TaskGroup() as tg:
+        for alert in all_alerts:
+            tasks.append(tg.create_task(_bounded_eval(alert)))
+
+    aggregated = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+    for task in tasks:
+        for k, v in task.result().items():
+            aggregated[k] += v
+
+    if aggregated["checked"] > 0:
+        logger.info("Alert check cycle complete", **aggregated)
+
+    return CheckAlertsOutput(
+        alerts_checked=aggregated["checked"],
+        alerts_fired=aggregated["fired"],
+        alerts_resolved=aggregated["resolved"],
+        alerts_errored=aggregated["errored"],
+    )
 
 
-def _check_alerts_sync() -> CheckAlertsOutput:
-    """Synchronous alert checking — runs in a thread."""
+def _load_alerts_and_checkpoint() -> tuple[datetime, list[LogsAlertConfiguration], datetime | None]:
+    """Sync setup: pin `now`, load due alerts, fetch ingestion checkpoint, emit cycle metrics."""
     now = datetime.now(UTC)
 
     all_alerts = list(
@@ -131,10 +171,15 @@ def _check_alerts_sync() -> CheckAlertsOutput:
     except Exception:
         logger.exception("Failed to record checkpoint metric")
 
-    stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+    return now, all_alerts, checkpoint
 
-    # Sequential for now. TODO, stagger
-    # or cap concurrency to avoid bursting all ClickHouse queries at :00 each minute.
+
+def _check_alerts_sync() -> CheckAlertsOutput:
+    """Synchronous variant kept for unit tests. Production runs through
+    `check_alerts_activity` (async + bounded concurrency)."""
+    now, all_alerts, checkpoint = _load_alerts_and_checkpoint()
+
+    stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
     for alert in all_alerts:
         try:
             _evaluate_single_alert(alert, now, stats, checkpoint=checkpoint)
@@ -148,10 +193,7 @@ def _check_alerts_sync() -> CheckAlertsOutput:
             stats["errored"] += 1
 
     if stats["checked"] > 0:
-        logger.info(
-            "Alert check cycle complete",
-            **stats,
-        )
+        logger.info("Alert check cycle complete", **stats)
 
     return CheckAlertsOutput(
         alerts_checked=stats["checked"],

--- a/products/logs/backend/temporal/constants.py
+++ b/products/logs/backend/temporal/constants.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timedelta
 
 from temporalio.common import RetryPolicy
@@ -17,3 +18,9 @@ ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_interval=timedelta(seconds=30),
     backoff_coefficient=2.0,
 )
+
+# Bounded concurrency for the per-alert evaluation loop. Each eval blocks on a
+# ~1.3-3.7s ClickHouse query post-stateless-eval; sequential execution overruns
+# the 60s cron interval past ~40 alerts at canonical-grid-aligned cadence.
+# Override via env when scaling the alert population without redeploying.
+MAX_CONCURRENT_ALERT_EVALS = int(os.environ.get("LOGS_ALERTING_MAX_CONCURRENT_EVALS", "5"))

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -1,5 +1,8 @@
 import json
+import time
+import asyncio
 import datetime as dt
+import threading
 from datetime import UTC, datetime, timedelta
 
 import unittest
@@ -21,10 +24,12 @@ from products.logs.backend.alert_check_query import BucketedCount
 from products.logs.backend.alert_state_machine import AlertState, NotificationAction
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.activities import (
+    CheckAlertsInput,
     CheckAlertsOutput,
     _check_alerts_sync,
     _derive_breaches,
     _evaluate_single_alert,
+    check_alerts_activity,
 )
 
 
@@ -231,6 +236,109 @@ class TestCheckAlertsSync(APIBaseTest):
         assert result.alerts_checked == 1
         mock_record_lag.assert_not_called()
         mock_unavailable.assert_called_once()
+
+
+class TestCheckAlertsActivityConcurrency(unittest.TestCase):
+    """Async path: bounded concurrency via asyncio.TaskGroup + Semaphore.
+
+    These tests exercise the orchestration layer in isolation by patching the
+    DB-touching helpers (`_load_alerts_and_checkpoint`, `_evaluate_single_alert`).
+    The single-alert eval logic is covered by `TestEvaluateSingleAlert` and
+    `TestEvaluateSingleAlertEndToEnd`; the per-cycle DB read by `TestCheckAlertsSync`.
+    """
+
+    @staticmethod
+    def _mock_alerts(n: int) -> list[MagicMock]:
+        return [MagicMock(id=f"alert-{i}", name=f"alert-{i}", team_id=1) for i in range(n)]
+
+    @parameterized.expand([("fired",), ("resolved",), ("errored",)])
+    def test_evaluates_all_alerts_and_aggregates_stats(self, outcome):
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        alerts = self._mock_alerts(4)
+
+        def fake_eval(alert, now, stats, *, checkpoint=None):
+            stats["checked"] += 1
+            stats[outcome] += 1
+
+        with (
+            patch(
+                "products.logs.backend.temporal.activities._load_alerts_and_checkpoint",
+                return_value=(now, alerts, None),
+            ),
+            patch(
+                "products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=fake_eval
+            ) as mock_eval,
+        ):
+            result = asyncio.run(check_alerts_activity(CheckAlertsInput()))
+
+        assert mock_eval.call_count == 4
+        assert result.alerts_checked == 4
+        assert getattr(result, f"alerts_{outcome}") == 4
+        for other in ("fired", "resolved", "errored"):
+            if other != outcome:
+                assert getattr(result, f"alerts_{other}") == 0
+
+    def test_bounded_concurrency_does_not_exceed_semaphore_limit(self):
+        """Force overlap; peak concurrent in-flight must equal the semaphore limit."""
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        alerts = self._mock_alerts(10)
+
+        peak = 0
+        active = 0
+        lock = threading.Lock()
+
+        def fake_eval(alert, now, stats, *, checkpoint=None):
+            nonlocal peak, active
+            with lock:
+                active += 1
+                peak = max(peak, active)
+            time.sleep(0.05)
+            with lock:
+                active -= 1
+            stats["checked"] += 1
+
+        with (
+            patch(
+                "products.logs.backend.temporal.activities._load_alerts_and_checkpoint",
+                return_value=(now, alerts, None),
+            ),
+            patch("products.logs.backend.temporal.activities.MAX_CONCURRENT_ALERT_EVALS", 3),
+            patch("products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=fake_eval),
+        ):
+            result = asyncio.run(check_alerts_activity(CheckAlertsInput()))
+
+        assert peak <= 3, f"expected peak concurrency ≤ 3 (semaphore limit), got {peak}"
+        assert peak > 1, f"expected concurrency to be utilised (peak={peak}), check thread pool availability"
+        assert result.alerts_checked == 10
+
+    def test_unexpected_error_isolates_to_single_alert(self):
+        """One alert raising must not block the others; the activity counts it as errored."""
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        alerts = self._mock_alerts(3)
+
+        call_count = 0
+        lock = threading.Lock()
+
+        def fake_eval(alert, now, stats, *, checkpoint=None):
+            nonlocal call_count
+            with lock:
+                call_count += 1
+                this_call = call_count
+            if this_call == 2:
+                raise RuntimeError("kaboom")
+            stats["checked"] += 1
+
+        with (
+            patch(
+                "products.logs.backend.temporal.activities._load_alerts_and_checkpoint",
+                return_value=(now, alerts, None),
+            ),
+            patch("products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=fake_eval),
+        ):
+            result = asyncio.run(check_alerts_activity(CheckAlertsInput()))
+
+        assert result.alerts_checked == 2
+        assert result.alerts_errored == 1
 
 
 class TestEvaluateSingleAlert(APIBaseTest):


### PR DESCRIPTION
## Problem

Sequential alert evaluation in the logs alerting Temporal activity was overrunning the 60-second cron interval when the alert population grew beyond ~40 alerts. Each per-alert evaluation blocks on a ClickHouse query taking roughly 1.3–3.7 seconds, making purely sequential execution a bottleneck that worsens linearly with alert count.

## Changes

Alert evaluation in `check_alerts_activity` now runs with bounded concurrency using `asyncio.TaskGroup` and a `asyncio.Semaphore`. The setup logic (loading due alerts, fetching the ingestion checkpoint, emitting cycle metrics) has been extracted into `_load_alerts_and_checkpoint` so it runs once before the concurrent evaluation loop begins.

The concurrency limit defaults to `5` and is configurable via the `LOGS_ALERTING_MAX_CONCURRENT_EVALS` environment variable, allowing the limit to be tuned without a redeploy as the alert population scales.

The original `_check_alerts_sync` function is retained for unit tests, now delegating to `_load_alerts_and_checkpoint` to avoid duplicating setup logic.

## How did you test this code?

Three new unit tests cover the async orchestration path in `TestCheckAlertsActivityConcurrency`:

- **`test_evaluates_all_alerts_and_aggregates_stats`** — verifies all alerts are evaluated and stats are correctly aggregated across tasks.
- **`test_bounded_concurrency_does_not_exceed_semaphore_limit`** — uses a threading lock and a sleep to force overlap, asserting peak in-flight concurrency equals the semaphore limit (3 in the test).
- **`test_unexpected_error_isolates_to_single_alert`** — verifies that one alert raising an exception is counted as `errored` without preventing the remaining alerts from completing.

## Publish to changelog?

No