### PR TITLE
feat(logs): add uncapped alert team IDs for bypassing max alerts limit

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -1,3 +1,4 @@
+import os
 import datetime as dt
 from datetime import UTC, datetime
 from typing import Final, TypedDict, cast
@@ -48,6 +49,14 @@ from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfig
 
 ALLOWED_WINDOW_MINUTES = {5, 10, 15, 30, 60}
 MAX_ALERTS_PER_TEAM = 20
+# Comma-separated team IDs that bypass MAX_ALERTS_PER_TEAM. Configured via
+# argocd for internal dogfood projects whose observability needs exceed the
+# customer-facing cap; the cap's correctness assumptions (bounded N+1 in list,
+# semaphore-sized fan-out in the Temporal activity) still hold for any team
+# not in this set.
+UNCAPPED_ALERT_TEAM_IDS: frozenset[int] = frozenset(
+    int(t) for x in os.environ.get("LOGS_ALERTS_UNCAPPED_TEAM_IDS", "").split(",") if (t := x.strip()).isdigit()
+)
 MAX_SIMULATE_LOOKBACK_DAYS = 30
 MAX_SIMULATE_BUCKETS = 15_000
 STATE_TIMELINE_LOOKBACK_HOURS = 24
@@ -455,9 +464,10 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             # Django optimises count() to SELECT COUNT(*). Locking the team
             # row instead serialises concurrent creates for this team.
             Team.objects.select_for_update().get(id=validated_data["team_id"])
-            count = LogsAlertConfiguration.objects.filter(team_id=validated_data["team_id"]).count()
-            if count >= MAX_ALERTS_PER_TEAM:
-                raise ValidationError(f"Maximum number of alerts ({MAX_ALERTS_PER_TEAM}) reached for this team.")
+            if validated_data["team_id"] not in UNCAPPED_ALERT_TEAM_IDS:
+                count = LogsAlertConfiguration.objects.filter(team_id=validated_data["team_id"]).count()
+                if count >= MAX_ALERTS_PER_TEAM:
+                    raise ValidationError(f"Maximum number of alerts ({MAX_ALERTS_PER_TEAM}) reached for this team.")
             return super().create(validated_data)
 
 

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -317,7 +317,13 @@ class TestLogsAlertAPI(APIBaseTest):
 
     # --- Per-team limit ---
 
-    def test_per_team_limit(self):
+    @parameterized.expand(
+        [
+            ("capped", False, status.HTTP_400_BAD_REQUEST, MAX_ALERTS_PER_TEAM),
+            ("uncapped", True, status.HTTP_201_CREATED, MAX_ALERTS_PER_TEAM + 1),
+        ]
+    )
+    def test_per_team_limit(self, _name, uncapped, expected_status, expected_count):
         for i in range(MAX_ALERTS_PER_TEAM):
             LogsAlertConfiguration.objects.create(
                 team=self.team,
@@ -327,13 +333,15 @@ class TestLogsAlertAPI(APIBaseTest):
                 filters={"severityLevels": ["error"]},
             )
 
-        response = self.client.post(
-            self.base_url,
-            self._valid_payload(name="One too many"),
-            format="json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Maximum" in str(response.json())
+        patched_ids = frozenset({self.team.id}) if uncapped else frozenset()
+        with patch("products.logs.backend.alerts_api.UNCAPPED_ALERT_TEAM_IDS", patched_ids):
+            response = self.client.post(
+                self.base_url,
+                self._valid_payload(name="Boundary"),
+                format="json",
+            )
+        assert response.status_code == expected_status
+        assert LogsAlertConfiguration.objects.filter(team=self.team).count() == expected_count
 
     # --- Read-only fields ---
 


### PR DESCRIPTION
## Problem

Internal dogfood projects have observability needs that exceed the customer-facing cap of 20 alerts per team (`MAX_ALERTS_PER_TEAM`). There was no mechanism to allow specific teams to exceed this limit without raising the cap globally for all customers.

## Changes

Introduces `UNCAPPED_ALERT_TEAM_IDS`, a `frozenset` of team IDs populated from the `LOGS_ALERTS_UNCAPPED_TEAM_IDS` environment variable (comma-separated), configured via ArgoCD. Teams in this set bypass the `MAX_ALERTS_PER_TEAM` check during alert creation. The cap and its correctness assumptions (bounded N+1 in list, semaphore-sized fan-out in the Temporal activity) remain fully intact for all other teams.

## How did you test this code?

A new test `test_per_team_limit_bypassed_for_uncapped_team` verifies that a team included in `UNCAPPED_ALERT_TEAM_IDS` can successfully create alerts beyond `MAX_ALERTS_PER_TEAM`, while the existing `test_per_team_limit` confirms the cap still applies to all other teams.

## Publish to changelog?

No