### PR TITLE
feat(tasks): add workflow start handoff metrics

### DIFF
--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -1,0 +1,85 @@
+from typing import TYPE_CHECKING, Literal
+
+from prometheus_client import Counter
+
+if TYPE_CHECKING:
+    from products.tasks.backend.models import TaskRun
+
+
+TaskWorkflowStartOutcome = Literal["attempted", "blocked", "failed", "started"]
+_ALLOWED_MODES = {"background", "interactive"}
+_ALLOWED_RUN_SOURCES = {"manual", "signal_report"}
+_ALLOWED_RUNTIME_ADAPTERS = {"claude", "codex"}
+
+
+TASK_RUN_CREATED_TOTAL = Counter(
+    "posthog_tasks_task_run_created_total",
+    "TaskRun rows created by the Tasks product",
+    labelnames=["origin_product", "run_environment", "mode", "run_source", "runtime_adapter"],
+)
+
+TASK_RUN_WORKFLOW_START_TOTAL = Counter(
+    "posthog_tasks_task_run_workflow_start_total",
+    "TaskRun workflow start lifecycle events",
+    labelnames=[
+        "origin_product",
+        "run_environment",
+        "mode",
+        "run_source",
+        "runtime_adapter",
+        "outcome",
+        "reason",
+    ],
+)
+
+
+def _metric_label(value: object | None) -> str:
+    if value is None:
+        return "unknown"
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
+def _bounded_metric_label(value: object | None, allowed_values: set[str]) -> str:
+    label = _metric_label(value)
+    if label == "unknown" or label in allowed_values:
+        return label
+    return "other"
+
+
+def _task_run_labels(task_run: "TaskRun | None") -> dict[str, str]:
+    if task_run is None:
+        return {
+            "origin_product": "unknown",
+            "run_environment": "unknown",
+            "mode": "unknown",
+            "run_source": "unknown",
+            "runtime_adapter": "unknown",
+        }
+
+    state = task_run.state if isinstance(task_run.state, dict) else {}
+    return {
+        "origin_product": _metric_label(getattr(task_run.task, "origin_product", None)),
+        "run_environment": _metric_label(task_run.environment),
+        "mode": _bounded_metric_label(state.get("mode"), _ALLOWED_MODES),
+        "run_source": _bounded_metric_label(state.get("run_source"), _ALLOWED_RUN_SOURCES),
+        "runtime_adapter": _bounded_metric_label(state.get("runtime_adapter"), _ALLOWED_RUNTIME_ADAPTERS),
+    }
+
+
+def observe_task_run_created(task_run: "TaskRun") -> None:
+    TASK_RUN_CREATED_TOTAL.labels(**_task_run_labels(task_run)).inc()
+
+
+def observe_task_run_workflow_start(
+    task_run: "TaskRun | None",
+    *,
+    outcome: TaskWorkflowStartOutcome,
+    reason: str,
+) -> None:
+    TASK_RUN_WORKFLOW_START_TOTAL.labels(
+        **_task_run_labels(task_run),
+        outcome=outcome,
+        reason=reason,
+    ).inc()

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -35,6 +35,7 @@ from posthog.storage import object_storage
 from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.constants import DEFAULT_TRUSTED_DOMAINS
+from products.tasks.backend.metrics import observe_task_run_created
 from products.tasks.backend.stream.redis_stream import publish_task_run_stream_event
 
 logger = structlog.get_logger(__name__)
@@ -223,6 +224,7 @@ class Task(DeletedMetaFields, models.Model):
             branch=branch,
         )
         task_run.publish_stream_state_event()
+        observe_task_run_created(task_run)
         self.capture_event(
             "task_run_created",
             {

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -16,6 +16,7 @@ from posthog.models.user import User
 from posthog.temporal.common.client import async_connect, sync_connect
 from posthog.temporal.oauth import PosthogMcpScopes
 
+from products.tasks.backend.metrics import observe_task_run_workflow_start
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.process_task.workflow import ProcessTaskInput
 from products.tasks.backend.temporal.slack_relay.activities import RelaySlackMessageInput
@@ -75,6 +76,20 @@ async def _terminalize_unstarted_task_run_async(run_id: str, error_message: str)
     return await sync_to_async(_terminalize_unstarted_task_run)(run_id, error_message)
 
 
+def _get_task_run_for_metrics(run_id: str) -> TaskRun | None:
+    try:
+        return TaskRun.objects.select_related("task").get(id=run_id)
+    except Exception:
+        return None
+
+
+async def _aget_task_run_for_metrics(run_id: str) -> TaskRun | None:
+    try:
+        return await TaskRun.objects.select_related("task").aget(id=run_id)
+    except Exception:
+        return None
+
+
 async def execute_task_processing_workflow_async(
     task_id: str,
     run_id: str,
@@ -96,6 +111,8 @@ async def execute_task_processing_workflow_async(
         "execute_task_processing_workflow_async_called",
         extra={"task_id": task_id, "run_id": run_id},
     )
+    task_run_for_metrics = await _aget_task_run_for_metrics(run_id)
+    observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
     try:
         team = await Team.objects.select_related("organization").aget(id=team_id)
 
@@ -112,6 +129,7 @@ async def execute_task_processing_workflow_async(
         else:
             if not user_id:
                 logger.warning("task_processing_missing_user_id", extra={"task_id": task_id})
+                observe_task_run_workflow_start(task_run_for_metrics, outcome="blocked", reason="missing_user")
                 await _terminalize_unstarted_task_run_async(run_id, "Failed to start task workflow: missing user id")
                 return
 
@@ -135,6 +153,7 @@ async def execute_task_processing_workflow_async(
 
         if not tasks_enabled:
             logger.warning("task_processing_blocked_feature_flag", extra={"task_id": task_id})
+            observe_task_run_workflow_start(task_run_for_metrics, outcome="blocked", reason="feature_flag")
             await _terminalize_unstarted_task_run_async(
                 run_id,
                 "Failed to start task workflow: tasks feature is disabled",
@@ -167,8 +186,10 @@ async def execute_task_processing_workflow_async(
         )
 
         logger.info("task_processing_workflow_started", extra={"task_id": task_id, "run_id": run_id})
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="started", reason="accepted")
 
     except (Team.DoesNotExist, User.DoesNotExist) as e:
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="failed", reason="permission_validation")
         logger.exception(
             "task_processing_permission_validation_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
@@ -178,6 +199,7 @@ async def execute_task_processing_workflow_async(
             f"Failed to start task workflow: permission validation failed: {e}",
         )
     except Exception as e:
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="failed", reason="temporal_start")
         logger.exception(
             "task_processing_workflow_start_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
@@ -205,6 +227,8 @@ def execute_task_processing_workflow(
     Args:
         skip_user_check: If True, skip user-based feature flag check. Use for automated/system tasks.
     """
+    task_run_for_metrics = _get_task_run_for_metrics(run_id)
+    observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
     try:
         logger.info(
             "execute_task_processing_workflow_called",
@@ -229,6 +253,7 @@ def execute_task_processing_workflow(
         else:
             if not user_id:
                 logger.warning("task_processing_missing_user_id", extra={"task_id": task_id})
+                observe_task_run_workflow_start(task_run_for_metrics, outcome="blocked", reason="missing_user")
                 _terminalize_unstarted_task_run(run_id, "Failed to start task workflow: missing user id")
                 return
 
@@ -247,6 +272,7 @@ def execute_task_processing_workflow(
 
         if not tasks_enabled:
             logger.warning("task_processing_blocked_feature_flag", extra={"task_id": task_id})
+            observe_task_run_workflow_start(task_run_for_metrics, outcome="blocked", reason="feature_flag")
             _terminalize_unstarted_task_run(
                 run_id,
                 "Failed to start task workflow: tasks feature is disabled",
@@ -287,8 +313,10 @@ def execute_task_processing_workflow(
         )
 
         logger.info("task_processing_workflow_started", extra={"task_id": task_id, "run_id": run_id})
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="started", reason="accepted")
 
     except (Team.DoesNotExist, User.DoesNotExist) as e:
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="failed", reason="permission_validation")
         logger.exception(
             "task_processing_permission_validation_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},
@@ -298,6 +326,7 @@ def execute_task_processing_workflow(
             f"Failed to start task workflow: permission validation failed: {e}",
         )
     except Exception as e:
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="failed", reason="temporal_start")
         logger.exception(
             "task_processing_workflow_start_failed",
             extra={"task_id": task_id, "run_id": run_id, "error": str(e)},

--- a/products/tasks/backend/tests/test_task_run_metrics.py
+++ b/products/tasks/backend/tests/test_task_run_metrics.py
@@ -1,0 +1,161 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from parameterized import parameterized
+from prometheus_client import REGISTRY
+
+from posthog.models import Organization, Team, User
+
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.client import execute_task_processing_workflow
+
+
+def _sample_value(name: str, labels: dict[str, str]) -> float:
+    return REGISTRY.get_sample_value(name, labels) or 0.0
+
+
+class TestTaskRunMetrics(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_user(email="test@example.com", first_name="Test", password="password")
+        self.task = Task.objects.create(
+            team=self.team,
+            title="Test Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.user,
+        )
+
+    def test_create_run_increments_created_counter_with_run_metadata(self) -> None:
+        labels = {
+            "origin_product": "user_created",
+            "run_environment": "cloud",
+            "mode": "background",
+            "run_source": "manual",
+            "runtime_adapter": "codex",
+        }
+        before = _sample_value("posthog_tasks_task_run_created_total", labels)
+
+        self.task.create_run(
+            environment=TaskRun.Environment.CLOUD,
+            extra_state={"run_source": "manual", "runtime_adapter": "codex"},
+        )
+
+        assert _sample_value("posthog_tasks_task_run_created_total", labels) == before + 1
+
+    def test_create_run_bounds_unexpected_state_labels(self) -> None:
+        labels = {
+            "origin_product": "user_created",
+            "run_environment": "cloud",
+            "mode": "other",
+            "run_source": "other",
+            "runtime_adapter": "other",
+        }
+        before = _sample_value("posthog_tasks_task_run_created_total", labels)
+
+        self.task.create_run(
+            environment=TaskRun.Environment.CLOUD,
+            mode="custom-mode",
+            extra_state={"run_source": "custom-source", "runtime_adapter": "custom-adapter"},
+        )
+
+        assert _sample_value("posthog_tasks_task_run_created_total", labels) == before + 1
+
+    @parameterized.expand(
+        [
+            ("started", True, "user", True, None, [("attempted", "requested"), ("started", "accepted")], True),
+            (
+                "missing_user",
+                False,
+                "none",
+                True,
+                None,
+                [("attempted", "requested"), ("blocked", "missing_user")],
+                False,
+            ),
+            (
+                "feature_flag",
+                False,
+                "user",
+                False,
+                None,
+                [("attempted", "requested"), ("blocked", "feature_flag")],
+                False,
+            ),
+            (
+                "permission_validation",
+                False,
+                "missing",
+                True,
+                None,
+                [("attempted", "requested"), ("failed", "permission_validation")],
+                False,
+            ),
+            (
+                "temporal_start",
+                True,
+                "user",
+                True,
+                RuntimeError("boom"),
+                [("attempted", "requested"), ("failed", "temporal_start")],
+                True,
+            ),
+        ]
+    )
+    def test_workflow_start_increments_outcome_counters(
+        self,
+        _name: str,
+        debug: bool,
+        user_kind: str,
+        feature_enabled: bool,
+        sync_connect_side_effect: Exception | None,
+        expected_outcomes: list[tuple[str, str]],
+        expect_sync_connect_called: bool,
+    ) -> None:
+        task_run = self.task.create_run(environment=TaskRun.Environment.CLOUD)
+        base_labels = {
+            "origin_product": "user_created",
+            "run_environment": "cloud",
+            "mode": "background",
+            "run_source": "unknown",
+            "runtime_adapter": "unknown",
+        }
+        labels_by_outcome = [
+            {**base_labels, "outcome": outcome, "reason": reason} for outcome, reason in expected_outcomes
+        ]
+        before_by_outcome = [
+            _sample_value("posthog_tasks_task_run_workflow_start_total", labels) for labels in labels_by_outcome
+        ]
+        user_id = {
+            "user": self.user.id,
+            "none": None,
+            "missing": self.user.id + 1,
+        }[user_kind]
+
+        temporal_client = MagicMock()
+        temporal_client.start_workflow = AsyncMock()
+
+        with (
+            override_settings(DEBUG=debug),
+            patch("products.tasks.backend.temporal.client.posthoganalytics.feature_enabled") as mock_feature_enabled,
+            patch("products.tasks.backend.temporal.client.sync_connect") as mock_sync_connect,
+        ):
+            mock_feature_enabled.return_value = feature_enabled
+            if sync_connect_side_effect is not None:
+                mock_sync_connect.side_effect = sync_connect_side_effect
+            else:
+                mock_sync_connect.return_value = temporal_client
+
+            execute_task_processing_workflow(
+                task_id=str(self.task.id),
+                run_id=str(task_run.id),
+                team_id=self.team.id,
+                user_id=user_id,
+            )
+
+        for labels, before in zip(labels_by_outcome, before_by_outcome, strict=True):
+            assert _sample_value("posthog_tasks_task_run_workflow_start_total", labels) == before + 1
+
+        assert mock_sync_connect.called is expect_sync_connect_called


### PR DESCRIPTION
## Problem

cloud `TaskRun` rows can be created before a process-task workflow is accepted by Temporal. Our grafana dashboard can show queued rows, but the backend did not expose where the create/start handoff stopped.

## Changes

- added a TaskRun creation counter with bounded run metadata labels
- add a workflow start lifecycle counter for attempted, started, blocked, and failed outcomes with reasons