### PR TITLE
fix(data-warehouse): surface schema labels in source pickers

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5808,6 +5808,7 @@ export interface IncrementalField {
 
 export interface ExternalDataSourceSyncSchema {
     table: string
+    label?: string | null
     rows?: number | null
     should_sync: boolean
     sync_time_of_day: string | null

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1479,6 +1479,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         data = [
             {
                 "table": schema.name,
+                "label": schema.label,
                 "should_sync": False,
                 "incremental_fields": schema.incremental_fields,
                 "incremental_available": schema.supports_incremental,

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -2371,6 +2371,7 @@ class TestExternalDataSource(APIBaseTest):
             assert response.json() == [
                 {
                     "table": "table_1",
+                    "label": None,
                     "should_sync": False,
                     "should_sync_default": True,
                     "description": None,
@@ -2428,6 +2429,7 @@ class TestExternalDataSource(APIBaseTest):
             assert response.json() == [
                 {
                     "table": "table_1",
+                    "label": None,
                     "should_sync": False,
                     "should_sync_default": True,
                     "description": None,

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -485,7 +485,7 @@ function WebhookSetupStep(): JSX.Element {
 
     const webhookTables = databaseSchema
         .filter((s) => s.supports_webhooks && s.sync_type === 'webhook' && s.should_sync)
-        .map((s) => ({ name: s.table }))
+        .map((s) => ({ name: s.table, label: s.label }))
 
     return (
         <WebhookSetupForm

--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -229,7 +229,7 @@ export default function SchemaForm(): JSX.Element {
                                                     className="font-mono cursor-pointer"
                                                     onClick={() => onClickCheckbox(schema, !schema.should_sync)}
                                                 >
-                                                    {schema.table}
+                                                    {schema.label || schema.table}
                                                 </span>
                                                 {schema.description && (
                                                     <Tooltip title={schema.description}>

--- a/products/data_warehouse/frontend/shared/components/forms/WebhookSetupForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/WebhookSetupForm.tsx
@@ -16,7 +16,7 @@ import { sourceFieldToElement } from './SourceForm'
 interface WebhookSetupFormProps {
     sourceName: string
     sourceConfig?: SourceConfig | null
-    webhookTables?: { name: string }[]
+    webhookTables?: { name: string; label?: string | null }[]
     webhookResult?: { success: boolean; webhook_url: string; error?: string } | null
     webhookCreating: boolean
     onCreateWebhook: () => void
@@ -47,7 +47,7 @@ export function WebhookSetupForm({
                 <p className="font-semibold text-sm mb-1">Tables using webhook sync:</p>
                 <ul className="list-disc list-inside text-sm">
                     {webhookTables.map((t) => (
-                        <li key={t.name}>{t.name}</li>
+                        <li key={t.name}>{t.label || t.name}</li>
                     ))}
                 </ul>
             </div>


### PR DESCRIPTION
## Problem

Schema labels (the human-readable name) weren't being shown in the source table picker or the webhook setup table list — both surfaces fell back to the raw schema name (e.g. Slack channel IDs like `C01ABC123`), which is unreadable.

## Changes

- Surface `label` on `ExternalDataSchema` so it flows through to the frontend.
- Render `label` (with fallback to `name`) in the table picker and the webhook setup table list.

Stacked on top of #50928.

## How did you test this code?

I'm an agent. No automated tests added — the changes are minimal label-rendering tweaks and the existing component tests cover the rendering path. Verified the diff manually against the original commits.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) as part of splitting the original Slack webhook PR (#50928) into a Graphite stack.