### PR TITLE
wip(node): Added auto-deriving client ID config

### DIFF
--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -1,5 +1,6 @@
 import type { BaseServerConfig } from '../servers/base-server'
 import { isDevEnv, isProdEnv, isTestEnv } from '../utils/env-utils'
+import { deriveKafkaClientRack } from './pod-identity'
 
 export const DEFAULT_HTTP_SERVER_PORT = 6738
 
@@ -118,6 +119,7 @@ export type CommonConfig = BaseServerConfig & {
     // Kafka
     KAFKA_HOSTS: string
     KAFKA_CLIENT_RACK: string | undefined
+    KAFKA_AUTO_DERIVE_CLIENT_ID: boolean
     KAFKA_CLIENT_CERT_B64: string | undefined
     KAFKA_CLIENT_CERT_KEY_B64: string | undefined
     KAFKA_TRUSTED_CERT_B64: string | undefined
@@ -274,7 +276,13 @@ export function getDefaultCommonConfig(): CommonConfig {
 
         // Kafka
         KAFKA_HOSTS: 'kafka:9092',
-        KAFKA_CLIENT_RACK: undefined,
+        // Default to deriving rack from K8S_NODE_NAME so we no longer depend on the chart's
+        // bash preamble running envsubst correctly. Explicit KAFKA_CLIENT_RACK env var still wins.
+        KAFKA_CLIENT_RACK: deriveKafkaClientRack(process.env.K8S_NODE_NAME),
+        // When true, producer/consumer client IDs are assembled in code from per-target
+        // env vars (KAFKA_<TARGET>_CLIENT_ID_PREFIX, KAFKA_<TARGET>_CLIENT_ID_EXTRA) plus
+        // the rack and pod name. Off by default so this stays opt-in during rollout.
+        KAFKA_AUTO_DERIVE_CLIENT_ID: false,
         KAFKA_CLIENT_CERT_B64: undefined,
         KAFKA_CLIENT_CERT_KEY_B64: undefined,
         KAFKA_TRUSTED_CERT_B64: undefined,

--- a/nodejs/src/common/pod-identity.test.ts
+++ b/nodejs/src/common/pod-identity.test.ts
@@ -1,0 +1,136 @@
+import { assembleKafkaClientId, deriveKafkaClientRack, getPodName, isAutoDeriveClientIdEnabled } from './pod-identity'
+
+describe('pod-identity', () => {
+    let consoleWarnSpy: jest.SpyInstance
+    const originalEnv = { ...process.env }
+
+    beforeEach(() => {
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        consoleWarnSpy.mockRestore()
+        process.env = { ...originalEnv }
+    })
+
+    describe('deriveKafkaClientRack', () => {
+        it.each([
+            ['ip-10-20-99-1', 'use1-az6'],
+            ['ip-10-21-99-1', 'use1-az1'],
+            ['ip-10-22-99-1', 'use1-az2'],
+            ['ip-10-30-99-1', 'use1-az2'],
+            ['ip-10-31-99-1', 'use1-az4'],
+            ['ip-10-32-99-1', 'use1-az6'],
+            ['ip-10-40-99-1', 'euc1-az2'],
+            ['ip-10-41-99-1', 'euc1-az3'],
+            ['ip-10-42-99-1', 'euc1-az1'],
+            ['ip-10-22-99-1.ec2.internal', 'use1-az2'],
+        ])('derives rack from %s as %s', (nodeName, expected) => {
+            expect(deriveKafkaClientRack(nodeName)).toEqual(expected)
+            expect(consoleWarnSpy).not.toHaveBeenCalled()
+        })
+
+        it('returns undefined and warns when nodeName is undefined', () => {
+            expect(deriveKafkaClientRack(undefined)).toBeUndefined()
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+            expect(consoleWarnSpy.mock.calls[0][0]).toContain('K8S_NODE_NAME is not set')
+        })
+
+        it('returns undefined and warns when nodeName is empty string', () => {
+            expect(deriveKafkaClientRack('')).toBeUndefined()
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+        })
+
+        it.each(['no-octets-here', 'ip', 'ip-10', 'singleword'])(
+            'returns undefined and warns for malformed nodeName %s',
+            (nodeName) => {
+                expect(deriveKafkaClientRack(nodeName)).toBeUndefined()
+                expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+            }
+        )
+
+        it('returns undefined and warns for unknown octet', () => {
+            expect(deriveKafkaClientRack('ip-10-99-99-1')).toBeUndefined()
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+            expect(consoleWarnSpy.mock.calls[0][0]).toContain('unknown second octet "99"')
+        })
+    })
+
+    describe('getPodName', () => {
+        it('prefers POD_NAME', () => {
+            process.env.POD_NAME = 'my-pod-1'
+            process.env.HOSTNAME = 'host-fallback'
+            expect(getPodName()).toEqual('my-pod-1')
+        })
+
+        it('falls back to HOSTNAME when POD_NAME is unset', () => {
+            delete process.env.POD_NAME
+            process.env.HOSTNAME = 'host-fallback'
+            expect(getPodName()).toEqual('host-fallback')
+        })
+
+        it('falls back to os.hostname when both env vars are unset', () => {
+            delete process.env.POD_NAME
+            delete process.env.HOSTNAME
+            expect(getPodName()).toBeTruthy()
+        })
+    })
+
+    describe('assembleKafkaClientId', () => {
+        const podName = 'my-pod-1'
+
+        it('renders just the pod name when no per-target env vars are set', () => {
+            expect(assembleKafkaClientId('CONSUMER', { rack: 'use1-az2', podName })).toEqual('my-pod-1')
+        })
+
+        it('emits prefix_az=rack when prefix env is set and rack is available', () => {
+            process.env.KAFKA_CONSUMER_CLIENT_ID_PREFIX = 'ws'
+            expect(assembleKafkaClientId('CONSUMER', { rack: 'use1-az2', podName })).toEqual('ws_az=use1-az2,my-pod-1')
+        })
+
+        it('omits the rack segment when rack is undefined even if prefix is set', () => {
+            process.env.KAFKA_CONSUMER_CLIENT_ID_PREFIX = 'ws'
+            expect(assembleKafkaClientId('CONSUMER', { rack: undefined, podName })).toEqual('my-pod-1')
+        })
+
+        it('inserts extra between rack and pod name', () => {
+            process.env.KAFKA_MONITORING_PRODUCER_CLIENT_ID_PREFIX = 'ws'
+            process.env.KAFKA_MONITORING_PRODUCER_CLIENT_ID_EXTRA = 'ws_proxy_target=proxy-produce'
+            expect(assembleKafkaClientId('MONITORING_PRODUCER', { rack: 'use1-az2', podName })).toEqual(
+                'ws_az=use1-az2,ws_proxy_target=proxy-produce,my-pod-1'
+            )
+        })
+
+        it('keeps extra when only extra is configured (no prefix)', () => {
+            process.env.KAFKA_CDP_PRODUCER_CLIENT_ID_EXTRA = 'warpstream_proxy_target=proxy-consume'
+            expect(assembleKafkaClientId('CDP_PRODUCER', { rack: 'use1-az2', podName })).toEqual(
+                'warpstream_proxy_target=proxy-consume,my-pod-1'
+            )
+        })
+
+        it('reads env vars per-target, not globally', () => {
+            process.env.KAFKA_MSK_PRODUCER_CLIENT_ID_PREFIX = 'msk'
+            process.env.KAFKA_CONSUMER_CLIENT_ID_PREFIX = 'ws'
+            expect(assembleKafkaClientId('MSK_PRODUCER', { rack: 'use1-az2', podName })).toEqual(
+                'msk_az=use1-az2,my-pod-1'
+            )
+            expect(assembleKafkaClientId('CONSUMER', { rack: 'use1-az2', podName })).toEqual('ws_az=use1-az2,my-pod-1')
+        })
+    })
+
+    describe('isAutoDeriveClientIdEnabled', () => {
+        it('returns true only when env var is exactly "true"', () => {
+            delete process.env.KAFKA_AUTO_DERIVE_CLIENT_ID
+            expect(isAutoDeriveClientIdEnabled()).toBe(false)
+
+            process.env.KAFKA_AUTO_DERIVE_CLIENT_ID = 'true'
+            expect(isAutoDeriveClientIdEnabled()).toBe(true)
+
+            process.env.KAFKA_AUTO_DERIVE_CLIENT_ID = 'false'
+            expect(isAutoDeriveClientIdEnabled()).toBe(false)
+
+            process.env.KAFKA_AUTO_DERIVE_CLIENT_ID = '1'
+            expect(isAutoDeriveClientIdEnabled()).toBe(false)
+        })
+    })
+})

--- a/nodejs/src/common/pod-identity.ts
+++ b/nodejs/src/common/pod-identity.ts
@@ -1,0 +1,90 @@
+import { hostname } from 'os'
+
+// Mapped from the second octet of an `ip-A-B-C-D[.suffix]` Kubernetes node name.
+// Mirrored in charts/library/templates/_kafka.tpl, charts/millpond/templates/statefulset.yaml,
+// and the bash preambles in shared/{cdp,ingestion,logs}/common.yaml — all copies must move
+// together until the chart-side derivation is removed.
+export const OCTET_TO_AZ: Readonly<Record<string, string>> = Object.freeze({
+    '20': 'use1-az6', // dev
+    '21': 'use1-az1',
+    '22': 'use1-az2',
+    '30': 'use1-az2', // prod-us
+    '31': 'use1-az4',
+    '32': 'use1-az6',
+    '40': 'euc1-az2', // prod-eu
+    '41': 'euc1-az3',
+    '42': 'euc1-az1',
+})
+
+export function deriveKafkaClientRack(nodeName: string | undefined): string | undefined {
+    if (!nodeName) {
+        console.warn(
+            '[pod-identity] KAFKA_CLIENT_RACK could not be derived: K8S_NODE_NAME is not set. Cross-AZ Kafka traffic will not be optimised.'
+        )
+        return undefined
+    }
+
+    // Expected formats: `ip-10-22-99-1`, `ip-10-22-99-1.ec2.internal`. We want the second octet (e.g. `22`).
+    const parts = nodeName.split('-')
+    const octet = parts[2]
+    if (!octet) {
+        console.warn(
+            `[pod-identity] KAFKA_CLIENT_RACK could not be derived: K8S_NODE_NAME=${nodeName} did not match the expected ip-A-B-C-D shape.`
+        )
+        return undefined
+    }
+
+    const az = OCTET_TO_AZ[octet]
+    if (!az) {
+        console.warn(
+            `[pod-identity] KAFKA_CLIENT_RACK could not be derived: unknown second octet "${octet}" in K8S_NODE_NAME=${nodeName}. Update OCTET_TO_AZ in nodejs/src/common/pod-identity.ts.`
+        )
+        return undefined
+    }
+
+    return az
+}
+
+export function getPodName(): string {
+    return process.env.POD_NAME || process.env.HOSTNAME || hostname()
+}
+
+/**
+ * Assemble a Kafka client ID for the given target by reading per-target env
+ * vars set by the chart, then substituting in the rack and pod name.
+ *
+ * Env vars read (all optional):
+ * - `KAFKA_<TARGET>_CLIENT_ID_PREFIX` — emits `<prefix>_az=<rack>` when both
+ *   the prefix env and the rack are present.
+ * - `KAFKA_<TARGET>_CLIENT_ID_EXTRA` — comma-separated literal segment(s)
+ *   inserted between rack and pod name (e.g. `ws_proxy_target=proxy-produce`).
+ *
+ * The pod name is always appended as the last segment. Empty segments are
+ * skipped so `_az=,podname` cannot appear when the rack is missing.
+ *
+ * Callers are expected to gate this on `KAFKA_AUTO_DERIVE_CLIENT_ID` and to
+ * still let an explicit `KAFKA_<TARGET>_CLIENT_ID` env var win — see
+ * `consumer.ts` and `producer.ts` for the wiring pattern.
+ */
+export function assembleKafkaClientId(
+    target: string,
+    { rack, podName }: { rack: string | undefined; podName: string }
+): string {
+    const prefix = process.env[`KAFKA_${target}_CLIENT_ID_PREFIX`]
+    const extra = process.env[`KAFKA_${target}_CLIENT_ID_EXTRA`]
+    const segments: string[] = []
+
+    if (prefix && rack) {
+        segments.push(`${prefix}_az=${rack}`)
+    }
+    if (extra) {
+        segments.push(extra)
+    }
+    segments.push(podName)
+
+    return segments.join(',')
+}
+
+export function isAutoDeriveClientIdEnabled(): boolean {
+    return process.env.KAFKA_AUTO_DERIVE_CLIENT_ID === 'true'
+}

--- a/nodejs/src/ingestion/outputs/kafka-producer-registry-builder.ts
+++ b/nodejs/src/ingestion/outputs/kafka-producer-registry-builder.ts
@@ -1,5 +1,6 @@
 import { ProducerGlobalConfig } from 'node-rdkafka'
 
+import { assembleKafkaClientId, getPodName, isAutoDeriveClientIdEnabled } from '../../common/pod-identity'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { logger } from '../../utils/logger'
 import { AllowedConfigKey, parseProducerConfig } from './kafka-producer-config'
@@ -75,6 +76,12 @@ export class KafkaProducerRegistryBuilder<P extends string = never, CK extends s
                 }
 
                 const resolvedConfig = parseProducerConfig(values)
+                if (isAutoDeriveClientIdEnabled() && !resolvedConfig['client.id']) {
+                    resolvedConfig['client.id'] = assembleKafkaClientId(name, {
+                        rack: this.kafkaClientRack,
+                        podName: getPodName(),
+                    })
+                }
                 logger.info('📝', `Creating producer "${name}"`, { config: redactConfig(resolvedConfig) })
                 producers[name] = await KafkaProducerWrapper.createWithConfig(
                     this.kafkaClientRack,

--- a/nodejs/src/kafka/consumer.ts
+++ b/nodejs/src/kafka/consumer.ts
@@ -28,6 +28,7 @@ import { isTestEnv } from '~/utils/env-utils'
 import { parseJSON } from '~/utils/json-parse'
 import { normalizeSessionId } from '~/utils/utils'
 
+import { assembleKafkaClientId, isAutoDeriveClientIdEnabled } from '../common/pod-identity'
 import { instrumentFn } from '../common/tracing/tracing-utils'
 import { defaultConfig } from '../config/config'
 import { logger } from '../utils/logger'
@@ -209,7 +210,12 @@ export class KafkaConsumer {
             : true
 
         this.consumerConfig = {
-            'client.id': hostname(),
+            'client.id': isAutoDeriveClientIdEnabled()
+                ? assembleKafkaClientId('CONSUMER', {
+                      rack: defaultConfig.KAFKA_CLIENT_RACK,
+                      podName: this.podName,
+                  })
+                : hostname(),
             'security.protocol': 'plaintext',
             'metadata.broker.list': 'kafka:9092', // Overridden with KAFKA_CONSUMER_METADATA_BROKER_LIST
             log_level: 4, // WARN as the default

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -12,6 +12,7 @@ import {
 import { hostname } from 'os'
 import { Counter, Histogram, Summary } from 'prom-client'
 
+import { assembleKafkaClientId, getPodName, isAutoDeriveClientIdEnabled } from '../common/pod-identity'
 import { instrumentFn } from '../common/tracing/tracing-utils'
 import { DependencyUnavailableError, MessageSizeTooLarge } from '../utils/db/error'
 import { logger } from '../utils/logger'
@@ -66,7 +67,14 @@ export class KafkaProducerWrapper {
     static async create(kafkaClientRack: string | undefined, mode: KafkaConfigTarget = 'PRODUCER') {
         // NOTE: In addition to some defaults we allow overriding any setting via env vars.
         // This makes it much easier to react to issues without needing code changes
-        return KafkaProducerWrapper.createWithConfig(kafkaClientRack, getKafkaConfigFromEnv(mode))
+        const envConfig = getKafkaConfigFromEnv(mode)
+        if (isAutoDeriveClientIdEnabled() && !envConfig['client.id']) {
+            envConfig['client.id'] = assembleKafkaClientId(mode, {
+                rack: kafkaClientRack,
+                podName: getPodName(),
+            })
+        }
+        return KafkaProducerWrapper.createWithConfig(kafkaClientRack, envConfig)
     }
 
     /** Create a producer with a pre-built rdkafka config (merged over defaults). */


### PR DESCRIPTION
## Problem

We have a lot of boilerplate for setting up the right client id for every producer / consumer. Thought we could finally centralise this and move it to code so we never forget it (as forgetting it can be costly)

## Changes

- [ ] Very very AI coded first attempt to flesh out the idea before continuing
- [ ] Idea would be that we could enable this partially and try it out per producer/consumer until we are satisfied and then make it the default and clean up the startup code

## How did you test this code?

- [x] Some tests
- [ ] Want to deploy to dev and see it with my own eyes

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No