### PR TITLE
fix(test): bound k8s-awareness kube calls with per-call timeout

### DIFF
--- a/rust/common/k8s-awareness/src/discovery.rs
+++ b/rust/common/k8s-awareness/src/discovery.rs
@@ -7,7 +7,9 @@ use kube::Client;
 
 use crate::types::{ControllerKind, ControllerRef, PodInfo};
 
-/// Per-call timeout applied to each kube API request made during discovery.
+/// Per-call timeout applied to each kube API request issued by k8s-awareness
+/// (discovery `get`s, the watcher's manual ReplicaSet `list`, and the
+/// `kube::runtime::watcher` list/watch loops via `WatcherConfig::timeout`).
 ///
 /// kube-rs / reqwest's default request timeout is ~290s, which is longer than
 /// most callers' overall budget (e.g. the kafka-assigner k3s integration test's

--- a/rust/common/k8s-awareness/src/discovery.rs
+++ b/rust/common/k8s-awareness/src/discovery.rs
@@ -14,7 +14,7 @@ use crate::types::{ControllerKind, ControllerRef, PodInfo};
 /// 180s). When the API server enters a zombie state (TCP alive, no response),
 /// a single hung call can blow past those budgets. Bounding each call here
 /// turns a zombie into a quick error so the caller can retry or degrade.
-const KUBE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const KUBE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {

--- a/rust/common/k8s-awareness/src/discovery.rs
+++ b/rust/common/k8s-awareness/src/discovery.rs
@@ -48,9 +48,7 @@ pub async fn discover_controller(
     let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
     let pod = tokio::time::timeout(KUBE_CALL_TIMEOUT, pods.get(pod_name))
         .await
-        .map_err(|_| {
-            DiscoveryError::Timeout(KUBE_CALL_TIMEOUT, format!("pod.get({pod_name})"))
-        })?
+        .map_err(|_| DiscoveryError::Timeout(KUBE_CALL_TIMEOUT, format!("pod.get({pod_name})")))?
         .map_err(|e| {
             if is_not_found(&e) {
                 DiscoveryError::PodNotFound(pod_name.to_string())

--- a/rust/common/k8s-awareness/src/discovery.rs
+++ b/rust/common/k8s-awareness/src/discovery.rs
@@ -1,9 +1,20 @@
+use std::time::Duration;
+
 use k8s_openapi::api::apps::v1::ReplicaSet;
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::Api;
 use kube::Client;
 
 use crate::types::{ControllerKind, ControllerRef, PodInfo};
+
+/// Per-call timeout applied to each kube API request made during discovery.
+///
+/// kube-rs / reqwest's default request timeout is ~290s, which is longer than
+/// most callers' overall budget (e.g. the kafka-assigner k3s integration test's
+/// 180s). When the API server enters a zombie state (TCP alive, no response),
+/// a single hung call can blow past those budgets. Bounding each call here
+/// turns a zombie into a quick error so the caller can retry or degrade.
+const KUBE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {
@@ -17,6 +28,8 @@ pub enum DiscoveryError {
     ReplicaSetNoDeploymentOwner(String),
     #[error("pod {0} missing generation label")]
     MissingGenerationLabel(String),
+    #[error("kubernetes API call timed out after {0:?}: {1}")]
+    Timeout(Duration, String),
     #[error("kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
 }
@@ -33,13 +46,18 @@ pub async fn discover_controller(
     pod_name: &str,
 ) -> Result<PodInfo, DiscoveryError> {
     let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
-    let pod = pods.get(pod_name).await.map_err(|e| {
-        if is_not_found(&e) {
-            DiscoveryError::PodNotFound(pod_name.to_string())
-        } else {
-            DiscoveryError::Kube(e)
-        }
-    })?;
+    let pod = tokio::time::timeout(KUBE_CALL_TIMEOUT, pods.get(pod_name))
+        .await
+        .map_err(|_| {
+            DiscoveryError::Timeout(KUBE_CALL_TIMEOUT, format!("pod.get({pod_name})"))
+        })?
+        .map_err(|e| {
+            if is_not_found(&e) {
+                DiscoveryError::PodNotFound(pod_name.to_string())
+            } else {
+                DiscoveryError::Kube(e)
+            }
+        })?;
 
     let owner_refs = pod.metadata.owner_references.as_deref().unwrap_or_default();
 
@@ -68,7 +86,14 @@ pub async fn discover_controller(
     // ReplicaSet → Deployment
     if let Some(rs_owner) = owner_refs.iter().find(|r| r.kind == "ReplicaSet") {
         let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
-        let rs = rs_api.get(&rs_owner.name).await?;
+        let rs = tokio::time::timeout(KUBE_CALL_TIMEOUT, rs_api.get(&rs_owner.name))
+            .await
+            .map_err(|_| {
+                DiscoveryError::Timeout(
+                    KUBE_CALL_TIMEOUT,
+                    format!("replicaset.get({})", rs_owner.name),
+                )
+            })??;
 
         let rs_owners = rs.metadata.owner_references.as_deref().unwrap_or_default();
 

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet, StatefulSet};
@@ -13,6 +14,12 @@ use tracing::{debug, info, warn};
 use crate::detection;
 use crate::discovery::{self, DiscoveryError};
 use crate::types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
+
+/// Per-call timeout for ReplicaSet list inside the deployment-event handler.
+/// Mirrors `discovery::KUBE_CALL_TIMEOUT` — a hung kube call here would
+/// otherwise block the watcher event loop on a single event for ~290s
+/// (kube-rs / reqwest default).
+const REPLICASET_LIST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, thiserror::Error)]
 pub enum K8sAwarenessError {
@@ -238,8 +245,22 @@ async fn handle_deployment_event(
     // If this fails, skip the entire intent update to avoid mixing fresh
     // deployment fields (like rollout_in_progress) with stale generation data,
     // which would create an inconsistent ClusterIntent.
-    let owned_rses =
-        list_owned_replicasets(client, namespace, &controller.name, &label_selector).await;
+    let owned_rses = match tokio::time::timeout(
+        REPLICASET_LIST_TIMEOUT,
+        list_owned_replicasets(client, namespace, &controller.name, &label_selector),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            warn!(
+                controller = %controller,
+                timeout = ?REPLICASET_LIST_TIMEOUT,
+                "ReplicaSet list timed out, skipping intent update"
+            );
+            return;
+        }
+    };
     let rses = match owned_rses {
         Ok(rses) => rses,
         Err(e) => {

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -150,7 +150,9 @@ async fn run_deployment_watcher(
     cancel: CancellationToken,
 ) {
     let api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
-    let config = WatcherConfig::default().fields(&format!("metadata.name={}", controller.name));
+    let config = WatcherConfig::default()
+        .fields(&format!("metadata.name={}", controller.name))
+        .timeout(KUBE_CALL_TIMEOUT.as_secs() as u32);
 
     let stream = watcher::watcher(api, config);
     tokio::pin!(stream);
@@ -393,7 +395,9 @@ async fn run_statefulset_watcher(
     cancel: CancellationToken,
 ) {
     let api: Api<StatefulSet> = Api::namespaced(client.clone(), namespace);
-    let config = WatcherConfig::default().fields(&format!("metadata.name={}", controller.name));
+    let config = WatcherConfig::default()
+        .fields(&format!("metadata.name={}", controller.name))
+        .timeout(KUBE_CALL_TIMEOUT.as_secs() as u32);
 
     let stream = watcher::watcher(api, config);
     tokio::pin!(stream);

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet, StatefulSet};
@@ -12,14 +11,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::detection;
-use crate::discovery::{self, DiscoveryError};
+use crate::discovery::{self, DiscoveryError, KUBE_CALL_TIMEOUT};
 use crate::types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
-
-/// Per-call timeout for ReplicaSet list inside the deployment-event handler.
-/// Mirrors `discovery::KUBE_CALL_TIMEOUT` — a hung kube call here would
-/// otherwise block the watcher event loop on a single event for ~290s
-/// (kube-rs / reqwest default).
-const REPLICASET_LIST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, thiserror::Error)]
 pub enum K8sAwarenessError {
@@ -246,7 +239,7 @@ async fn handle_deployment_event(
     // deployment fields (like rollout_in_progress) with stale generation data,
     // which would create an inconsistent ClusterIntent.
     let owned_rses = match tokio::time::timeout(
-        REPLICASET_LIST_TIMEOUT,
+        KUBE_CALL_TIMEOUT,
         list_owned_replicasets(client, namespace, &controller.name, &label_selector),
     )
     .await
@@ -255,7 +248,7 @@ async fn handle_deployment_event(
         Err(_) => {
             warn!(
                 controller = %controller,
-                timeout = ?REPLICASET_LIST_TIMEOUT,
+                timeout = ?KUBE_CALL_TIMEOUT,
                 "ReplicaSet list timed out, skipping intent update"
             );
             return;


### PR DESCRIPTION
## Problem

The `kafka-assigner` k3s integration test `deployment_rollout_reassigns_partitions` flakes intermittently with the same panic across both master and PR branches:

```
panicked at kafka-assigner/tests/common/mod.rs:62:5:
condition not met within 180s
   3: ...{{closure}}::{{closure}} at ./tests/k3s_integration.rs:554:6
```

That panic site is the **first** `wait_for_condition` in the test (initial partition assignment) — strictly upstream of `wait_for_k3s_api_ready` (line 568) that PRs #55688 / #55696 protect. So when the flake hits *before* the rollout, those fixes don't apply.

Sample of failures with the same panic location (line shifts reflect file edits, not behavior):

| Run | Date | Branch | Line |
|---|---|---|---|
| 24987713996 | 2026-04-27 | feat/integration-for-postgresql-batch-exports | 554 |
| 24915946253 | 2026-04-24 | master | 554 |
| 24909230992 | 2026-04-24 | master | 554 |
| 24803249925 | 2026-04-22 | master | 554 |
| 24461233519 | 2026-04-15 | master | 532 |

The kafka-assigner failure rate on master dropped from ~6/100 (Apr 15–22) to ~1/100 (Apr 22–27) after #55696 landed, but the pre-rollout flake remains.

## Root cause hypothesis

The single-node k3s testcontainer can enter a zombie state (TCP alive, no responses). When that happens, kube API calls in the `k8s-awareness` library hit reqwest's default ~290 s request timeout — far past the test's 180 s `wait_for_condition` budget. Three call sites are vulnerable:

- `discovery::discover_controller` → `pods.get(...)` (`rust/common/k8s-awareness/src/discovery.rs`)
- `discovery::discover_controller` → `rs_api.get(...)` (same file)
- `watcher::handle_deployment_event` → `list_owned_replicasets` → `rs_api.list(...)` (`rust/common/k8s-awareness/src/watcher.rs`)

Evidence in failing logs: a tight burst of `~2.3k–3.2k` `kube_client::client::builder: failed with error client error (Connect)` lines clustered into 600–800 ms immediately before each panic — consistent with a hung kube call being torn down by runtime drop on test panic, not steady-state retries (successful runs have **0** Connect errors).

## Changes

Wraps each affected kube call with `tokio::time::timeout(30s)` and surfaces a typed timeout error:

- `discovery.rs`: new `DiscoveryError::Timeout(Duration, String)` variant; `pods.get` and `rs_api.get` are bounded.
- `watcher.rs`: `list_owned_replicasets` call in the deployment-event handler is bounded; on timeout we log a `warn!` and skip the intent update (same shape as the existing kube-error handling path).

30 s is generous for a healthy API (real calls return in milliseconds) and well inside the 180 s test budget, so a zombie now degrades to a quick error that the watcher reconnect / next register attempt can recover from.

This mirrors the per-call timeout pattern from #55696, applied to the pre-rollout call sites that PR did not cover.

## How did you test this code?

I'm an agent. Automated only:

- `cargo build -p k8s-awareness -p kafka-assigner` — clean.
- `cargo test -p k8s-awareness --lib` — 11/11 pass.
- `cargo test -p k8s-awareness --test mock_discovery` — 7/7 pass (covers the discovery happy + error paths the patch touches).
- `cargo test -p kafka-assigner --lib` — 42/42 pass.
- `cargo clippy -p k8s-awareness --all-targets` — no new warnings.

I did **not** reproduce the flake locally — that requires the k3s testcontainer entering its zombie state, which doesn't happen reliably on demand. CI on this branch is the actual signal; if it stays green over several master runs we'll know the bound is doing its job.

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

Authored by Claude Code at Raúl Negrón's direction. Investigation, evidence-gathering, and patch in a single session. Reviewer should sanity-check that 30 s is a reasonable upper bound for production kube calls (the assigner runs persistently in prod — these calls are short-lived `get`/`list`, so 30 s is well above any legitimate latency).