### PR TITLE
feat(phai): capture inner tool calls dispatched via MCP exec

### DIFF
--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -7,6 +7,7 @@ export enum AnalyticsEvent {
     MCP_INIT = 'mcp init',
     MCP_PROJECT_SWITCHED = 'mcp project switched',
     MCP_ORGANIZATION_SWITCHED = 'mcp organization switched',
+    MCP_TOOL_CALLED = 'mcp_tool_called', // matching mcpcat
 }
 
 export type MCPAnalyticsContext = {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -39,7 +39,7 @@ import EXECUTE_SQL_PROMPT from '@/templates/execute-sql-prompt.md'
 import INSTRUCTIONS_TEMPLATE_V1 from '@/templates/instructions-v1.md'
 import INSTRUCTIONS_TEMPLATE_V2 from '@/templates/instructions-v2.md'
 import SINGLE_EXEC_INSTRUCTIONS from '@/templates/single-exec-instructions.md'
-import { createExecTool } from '@/tools/exec'
+import { createExecTool, type ExecInnerCallTracker } from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import { type CloudRegion, type Context, type State, type Tool } from '@/tools/types'
 
@@ -645,12 +645,26 @@ export class MCP extends McpAgent<Env> {
                 supportsInstructions ? undefined : queryToolInfos
             )
 
+            const trackInnerCall: ExecInnerCallTracker = (toolName, properties) => {
+                this.ctx.waitUntil(
+                    (async () => {
+                        const freshContext = await this.getAnalyticsContextSafe(await this.getContext())
+                        await this.trackEvent(
+                            AnalyticsEvent.MCP_TOOL_CALLED,
+                            { tool_name: toolName, ...properties },
+                            freshContext ? { context: freshContext } : undefined
+                        )
+                    })()
+                )
+            }
+
             const execTool = createExecTool(
                 allTools,
                 context,
                 CLI_PROXY_TOOL,
                 commandReference,
-                this.requestProperties.mcpConsumer
+                this.requestProperties.mcpConsumer,
+                trackInnerCall
             )
             const typedExecTool = execTool as Tool<z.ZodObject>
             this.registerTool(typedExecTool, async (params) => typedExecTool.handler(context, params))

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -179,6 +179,7 @@ export function createExecTool(
                         }
                     }
 
+                    const useJson = forceJson || tool._meta?.[POSTHOG_META_KEY]?.outputFormat === 'json'
                     const startedAt = Date.now()
                     let result: unknown
                     try {
@@ -187,7 +188,7 @@ export function createExecTool(
                         trackInnerCall?.(tool.name, {
                             duration_ms: Date.now() - startedAt,
                             success: false,
-                            output_format: forceJson ? 'json' : 'text',
+                            output_format: useJson ? 'json' : 'text',
                             error_message: err instanceof Error ? err.message : String(err),
                         })
                         throw err
@@ -225,7 +226,6 @@ export function createExecTool(
                         )
                     }
 
-                    const useJson = forceJson || tool._meta?.[POSTHOG_META_KEY]?.outputFormat === 'json'
                     trackInnerCall?.(tool.name, {
                         duration_ms: durationMs,
                         success: true,

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -9,6 +9,15 @@ import { POSTHOG_META_KEY, type Context, type Tool, type ZodObjectAny } from './
 
 type ExecSchema = ReturnType<typeof makeExecSchema>
 
+export interface ExecInnerCallProperties {
+    duration_ms: number
+    success: boolean
+    output_format: 'json' | 'text' | 'structured'
+    error_message?: string
+}
+
+export type ExecInnerCallTracker = (toolName: string, properties: ExecInnerCallProperties) => void
+
 function makeExecSchema(commandReference: string): z.ZodObject<{ command: z.ZodString }> {
     return z.object({
         command: z.string().describe(commandReference),
@@ -38,7 +47,8 @@ export function createExecTool(
     context: Context,
     toolDescription: string,
     commandReference: string,
-    mcpConsumer: string | undefined
+    mcpConsumer: string | undefined,
+    trackInnerCall?: ExecInnerCallTracker
 ): Tool<ExecSchema> {
     const ExecSchema = makeExecSchema(commandReference)
 
@@ -169,7 +179,20 @@ export function createExecTool(
                         }
                     }
 
-                    const result = await tool.handler(context, input)
+                    const startedAt = Date.now()
+                    let result: unknown
+                    try {
+                        result = await tool.handler(context, input)
+                    } catch (err) {
+                        trackInnerCall?.(tool.name, {
+                            duration_ms: Date.now() - startedAt,
+                            success: false,
+                            output_format: forceJson ? 'json' : 'text',
+                            error_message: err instanceof Error ? err.message : String(err),
+                        })
+                        throw err
+                    }
+                    const durationMs = Date.now() - startedAt
 
                     // If the inner tool has a UI app attached AND the caller self-identifies as
                     // PostHog Code (the UI-apps host), emit a full `CallToolResult` payload
@@ -181,6 +204,11 @@ export function createExecTool(
                     if (tool._meta?.ui?.resourceUri && isPostHogCodeConsumer(mcpConsumer)) {
                         const isStringResult = typeof result === 'string'
                         const distinctId = isStringResult ? undefined : await context.getDistinctId()
+                        trackInnerCall?.(tool.name, {
+                            duration_ms: durationMs,
+                            success: true,
+                            output_format: 'structured',
+                        })
                         return markExecPayload(
                             buildToolResultPayload({
                                 handlerResult: result,
@@ -198,6 +226,11 @@ export function createExecTool(
                     }
 
                     const useJson = forceJson || tool._meta?.[POSTHOG_META_KEY]?.outputFormat === 'json'
+                    trackInnerCall?.(tool.name, {
+                        duration_ms: durationMs,
+                        success: true,
+                        output_format: useJson ? 'json' : 'text',
+                    })
                     return useJson ? JSON.stringify(result) : formatResponse(result)
                 }
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -10,7 +10,7 @@ import { SessionManager } from '@/lib/SessionManager'
 import CLI_PROXY_COMMAND from '@/templates/cli-proxy-command.md'
 import CLI_PROXY_TOOL from '@/templates/cli-proxy-tool.md'
 import { getToolsFromContext } from '@/tools'
-import { createExecTool } from '@/tools/exec'
+import { createExecTool, type ExecInnerCallProperties } from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import { POSTHOG_META_KEY, type Context, type Tool, type ZodObjectAny } from '@/tools/types'
 
@@ -150,6 +150,52 @@ describe('exec tool', () => {
             const result = await exec.handler(mockContext, { command: 'call mock-tool {}' })
             // Plain text fallback — no CallToolResult shape leaks out
             expect(typeof result).toBe('string')
+        })
+
+        it('invokes the inner-call tracker on successful inner tool dispatch', async () => {
+            const calls: { toolName: string; properties: ExecInnerCallProperties }[] = []
+            const tracker = (toolName: string, properties: ExecInnerCallProperties): void => {
+                calls.push({ toolName, properties })
+            }
+            const exec = createExecTool(
+                [makeMockTool()],
+                mockContext,
+                'test description',
+                'test command reference',
+                undefined,
+                tracker
+            )
+            await exec.handler(mockContext, { command: 'call --json mock-tool {}' })
+            expect(calls).toHaveLength(1)
+            expect(calls[0]!.toolName).toBe('mock-tool')
+            expect(calls[0]!.properties.success).toBe(true)
+            expect(calls[0]!.properties.output_format).toBe('json')
+            expect(typeof calls[0]!.properties.duration_ms).toBe('number')
+        })
+
+        it('invokes the inner-call tracker with success=false when the inner tool throws', async () => {
+            const calls: { toolName: string; properties: ExecInnerCallProperties }[] = []
+            const tracker = (toolName: string, properties: ExecInnerCallProperties): void => {
+                calls.push({ toolName, properties })
+            }
+            const failing = makeMockTool({
+                handler: async () => {
+                    throw new Error('boom')
+                },
+            })
+            const exec = createExecTool(
+                [failing],
+                mockContext,
+                'test description',
+                'test command reference',
+                undefined,
+                tracker
+            )
+            await expect(exec.handler(mockContext, { command: 'call mock-tool {}' })).rejects.toThrow('boom')
+            expect(calls).toHaveLength(1)
+            expect(calls[0]!.properties.success).toBe(false)
+            expect(calls[0]!.properties.error_message).toBe('boom')
+            expect(calls[0]!.properties.output_format).toBe('text')
         })
     })
 


### PR DESCRIPTION
## Problem

In single-exec mode, the MCP server registers a single `exec` tool that dispatches to all the underlying PostHog MCP tools via `exec call <tool> <json>`. mcpcat's tracing only sees the outer `exec` invocation at the MCP protocol layer — the inner tool dispatch is just an in-process function call and never produces its own analytics event.

## Changes

- Added `MCP_TOOL_CALLED = 'mcp_tool_called'` to `AnalyticsEvent` (name aligned with mcpcat's tool-call convention).
- `createExecTool` accepts an optional `trackInnerCall` tracker. The `call` branch times the inner handler, fires the tracker on success (with `output_format: 'json' | 'text' | 'structured'`) and on failure (with `error_message`), then re-throws so existing error semantics are preserved.
- `mcp.ts` wires the tracker as a fire-and-forget closure via `ctx.waitUntil`. Org/project context is resolved fresh per call so post-`switch-project`/`switch-organization` events get the correct `$groups`. All standard MCP context properties (client name/version, transport, session id, etc.) are attached automatically by the existing `trackEvent` path.

Event properties: `tool_name`, `duration_ms`, `success`, `output_format`, optional `error_message`.

## How did you test this code?

I'm an agent. Automated tests only:

- Added two unit tests in `services/mcp/tests/unit/exec.test.ts` covering tracker invocation on success and on inner-tool error (both passing).
- `pnpm typecheck` clean.
- `pnpm exec vitest run tests/unit/exec.test.ts` — 18/18 passing.

No manual end-to-end verification against a live MCP client.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7, 1M context) at the user's direction. The user pointed out that the inner tool dispatched by `exec call` was not separately captured in analytics and asked for it to be emitted as a separate event. Reviewed the existing `trackEvent` path in `mcp.ts` and the mcpcat hookup in `lib/mcpcat.ts` to confirm where the gap was, then plumbed an optional tracker through `createExecTool` so the analytics concern stays at the MCP-agent layer rather than leaking into the exec tool's logic. Requires human review.