### PR TITLE
fix(event-definitions): include custom events without schema in generated sdk

### DIFF
--- a/posthog/api/event_definition_generators/base.py
+++ b/posthog/api/event_definition_generators/base.py
@@ -1,7 +1,7 @@
 import hashlib
 from abc import ABC, abstractmethod
 
-from django.db.models import Exists, OuterRef, Q, QuerySet
+from django.db.models import Q, QuerySet
 
 import orjson
 
@@ -90,19 +90,13 @@ class EventDefinitionGenerator(ABC):
         Fetch event definitions and build schema map. The key of `schema_map` references a EventDefinition.ID
         from the returned event_definitions set.
         """
-        # Include core PostHog events (from the taxonomy), verified events, and
-        # custom events with a schema. This prevents spam events and events with
-        # personal information from being included in generated code.
-        has_schema = Exists(EventSchema.objects.filter(event_definition=OuterRef("pk")))
-
+        # Include core PostHog events, verified events, and custom non-system events.
         event_definitions = (
             EventDefinition.objects.filter(team__project_id=project_id)
             .filter(
                 Q(name__in=CORE_EVENTS)  # Core PostHog events from the taxonomy
                 | Q(enterpriseeventdefinition__verified=True)  # Any verified event
-                | (
-                    ~Q(name__startswith="$") & has_schema  # Custom events with a schema
-                )
+                | ~Q(name__startswith="$")  # Custom events (with or without schema)
             )
             .order_by("name")
         )

--- a/posthog/api/test/test_event_definition_golang.py
+++ b/posthog/api/test/test_event_definition_golang.py
@@ -11,8 +11,6 @@ from rest_framework import status
 from posthog.api.event_definition_generators.golang import GolangGenerator
 from posthog.models import EventDefinition, EventSchema, SchemaPropertyGroup, SchemaPropertyGroupProperty
 
-from ee.models.event_definition import EnterpriseEventDefinition
-
 
 class TestGolangGenerator(APIBaseTest):
     """Test the GolangGenerator class directly"""
@@ -653,28 +651,13 @@ func main() {
                 f"Generated Go file:\n{go_content}",
             )
 
-    def test_excludes_unverified_events_without_schema(self):
-        EventDefinition.objects.create(team=self.team, project=self.project, name="spam_event")
-        EventDefinition.objects.create(team=self.team, project=self.project, name="John Smith clicked button")
+    def test_includes_custom_events_without_schema(self):
+        EventDefinition.objects.create(team=self.team, project=self.project, name="no_schema_event")
 
         response = self.client.get(f"/api/projects/{self.project.id}/event_definitions/golang")
         code = response.json()["content"]
 
-        self.assertNotIn("spam_event", code)
-        self.assertNotIn("John Smith", code)
-        # Events with schemas from setUp should still be present
-        self.assertIn("FileDownloadedCapture", code)
-        self.assertIn("UserSignedUpCapture", code)
-
-    def test_includes_verified_events_without_schema(self):
-        EnterpriseEventDefinition.objects.create(
-            team=self.team, project=self.project, name="verified_no_schema", verified=True
-        )
-
-        response = self.client.get(f"/api/projects/{self.project.id}/event_definitions/golang")
-        code = response.json()["content"]
-
-        self.assertIn("VerifiedNoSchemaCapture", code)
+        self.assertIn("NoSchemaEventCapture", code)
 
     def _test_telemetry_called(self, mock_report) -> None:
         # Verify telemetry was called

--- a/posthog/api/test/test_event_definition_python.py
+++ b/posthog/api/test/test_event_definition_python.py
@@ -411,6 +411,14 @@ class TestPythonGeneratorAPI(APIBaseTest):
         self.assertNotIn("capture_money", code)
         self.assertIn("capture_pageview", code)
 
+    def test_python_endpoint_includes_custom_events_without_schema(self):
+        EventDefinition.objects.create(team=self.team, project=self.project, name="no_schema_event")
+
+        response = self.client.get(f"/api/projects/{self.project.id}/event_definitions/python")
+
+        code = response.json()["content"]
+        self.assertIn("def capture_no_schema_event(", code)
+
     @patch("posthog.api.event_definition_generators.base.report_user_action")
     def test_python_endpoint_handles_no_events(self, mock_report):
         EventDefinition.objects.filter(team=self.team).delete()

--- a/posthog/api/test/test_event_definition_typescript.py
+++ b/posthog/api/test/test_event_definition_typescript.py
@@ -18,6 +18,7 @@ import pytest
 from posthog.test.base import APIBaseTest, BaseTest
 from unittest.mock import MagicMock, patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.event_definition_generators.typescript import TypeScriptGenerator
@@ -284,6 +285,37 @@ posthog.capture("a'a\\\\'b\\"c>?>%}}%%>c<[[?${{%}}cake'", {
             # This ensures any changes to the TypeScript generation are intentional and reviewed
             # Strip the dynamic timestamp so the snapshot is stable
             self.snapshot.assert_match(self._strip_dynamic_timestamp(ts_content))
+
+
+class TestTypeScriptGeneratorAPI(APIBaseTest):
+    def _setup_event_with_schema(self) -> None:
+        event = EventDefinition.objects.create(team=self.team, project=self.project, name="has_schema_event")
+        group = SchemaPropertyGroup.objects.create(team=self.team, project=self.project, name="G")
+        SchemaPropertyGroupProperty.objects.create(
+            property_group=group, name="some_field", property_type="String", is_required=True
+        )
+        EventSchema.objects.create(event_definition=event, property_group=group)
+
+    @parameterized.expand(
+        [
+            ("without_schema", False, ['"no_schema_event": Record<string, any>']),
+            ("with_schema", True, ['"has_schema_event"', '"some_field": string']),
+        ]
+    )
+    def test_typescript_endpoint_includes_custom_event(
+        self, _, with_schema: bool, expected_fragments: list[str]
+    ) -> None:
+        if with_schema:
+            self._setup_event_with_schema()
+        else:
+            EventDefinition.objects.create(team=self.team, project=self.project, name="no_schema_event")
+
+        response = self.client.get(f"/api/projects/{self.project.id}/event_definitions/typescript/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.json()["content"]
+
+        for fragment in expected_fragments:
+            self.assertIn(fragment, content)
 
 
 class TestTypeScriptGeneratorOptionalInTypes(BaseTest):


### PR DESCRIPTION
## Problem

Custom events without property groups were silently dropped from generated SDK output (TypeScript, Go, Python) after generator v1.1.0. In v1.0.0 these events were correctly included as `Record<string, any>` (TS) / untyped captures (Go, Python). This broke the `EventName` union type for any event without a schema, forcing workarounds like `posthog.capture(name as EventName)`.

Closes #55416

## Changes

- Removed the `has_schema` subquery filter from `EventDefinitionGenerator.get_definitions()` in `posthog/api/event_definition_generators/base.py`
- All custom non-system events (those not starting with `$`) are now included regardless of whether they have a property group attached
- Events without a schema continue to generate as `Record<string, any>` (TS), untyped captures (Go/Python)
- Updated tests across TypeScript, Go, and Python generators to reflect the new behavior

## How did you test this code?

- `hogli test posthog/api/test/test_event_definition_typescript.py` — all tests pass
- Updated `test_event_definition_golang.py` and added `test_event_definition_python.py` coverage for the no-schema case

## Publish to changelog?

No

## 🤖 Agent context

Co-authored with an AI coding assistant.
The human author reviewed the diff and confirmed the fix matches the behavior described in #55416 before pushing.