### PR TITLE
fix(surveys): allow hosted survey display language override

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"{% if embed_mode %} class="embed-mode"{% endif %}>
+<html lang="{{ display_language|default:'en' }}"{% if embed_mode %} class="embed-mode"{% endif %}>
 
 <head>
     <meta charset="UTF-8">
@@ -640,10 +640,12 @@
 
     {{ survey_data|json_script:"survey-data" }}
     {{ project_config|json_script:"project-config" }}
+    {{ display_language|json_script:"display-language" }}
     {% include "surveys/_appearance_helpers.html" %}
     <script nonce="{{ request.csp_nonce }}">
         const survey = JSON.parse(document.getElementById("survey-data").textContent);
         const projectConfig = JSON.parse(document.getElementById("project-config").textContent);
+        const displayLanguage = JSON.parse(document.getElementById("display-language").textContent);
 
         // Defaults tuned for the standalone hosted survey page. Customer-supplied
         // appearance values always win — we only fill in fields they didn't customize,
@@ -1008,7 +1010,11 @@
             }
         }
 
-        const URL_PARAMS_TO_IGNORE = ['distinct_id', '__posthog_debug__', '__posthog_debug', 'auto_submit'];
+        if (displayLanguage) {
+            config.override_display_language = displayLanguage;
+        }
+
+        const URL_PARAMS_TO_IGNORE = ['distinct_id', 'display_language', '__posthog_debug__', '__posthog_debug', 'auto_submit'];
         const surveyEventProperties = {};
 
         for (const [key, value] of searchParams.entries()) {

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Min
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
@@ -87,6 +87,8 @@ from ee.surveys.summaries.headline_summary import generate_survey_headline
 # Constants for better maintainability
 logger = structlog.get_logger(__name__)
 CACHE_TIMEOUT_SECONDS = 300
+DISPLAY_LANGUAGE_QUERY_PARAM = "display_language"
+DISPLAY_LANGUAGE_RE = re.compile(r"^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8}){0,3}$")
 
 ALLOWED_LINK_URL_SCHEMES = ["https", "mailto"]
 EMAIL_REGEX = r"^mailto:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
@@ -104,6 +106,19 @@ FIELDS_NOT_APPLICABLE_TO_EXTERNAL_SURVEYS = [
     "linked_flag_id",
     "targeting_flag_filters",
 ]
+
+
+def get_hosted_survey_display_language(request: HttpRequest) -> str | None:
+    display_language = request.GET.get(DISPLAY_LANGUAGE_QUERY_PARAM)
+    if not display_language:
+        return None
+
+    display_language = display_language.strip()
+    if not display_language or len(display_language) > 35 or not DISPLAY_LANGUAGE_RE.fullmatch(display_language):
+        return None
+
+    return display_language
+
 
 # Does not include actions or events, as those are objects and thus are evaluated differently
 CONDITION_FIELDS_NOT_APPLICABLE_TO_EXTERNAL_SURVEYS = [
@@ -2894,6 +2909,7 @@ def public_survey_page(request, survey_id: str):
         "survey_id": survey_id,
         "survey_data": survey_data,
         "project_config": project_config,
+        "display_language": get_hosted_survey_display_language(request),
         "debug": settings.DEBUG,
         "embed_mode": request.GET.get("embed") == "true",
     }

--- a/products/surveys/backend/api/test/test_external_surveys.py
+++ b/products/surveys/backend/api/test/test_external_surveys.py
@@ -2,12 +2,15 @@ import re
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
+from urllib.parse import parse_qsl
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.core.cache import cache
 from django.test import TestCase
+
+from parameterized import parameterized
 
 from products.surveys.backend.models import Survey
 
@@ -21,6 +24,12 @@ class TestExternalSurveys(APIBaseTest):
     def setUp(self):
         super().setUp()
         cache.clear()
+
+    def get_json_script_value(self, content: str, script_id: str) -> object:
+        script_match = re.search(rf'<script[^>]*id="{script_id}"[^>]*>(.*?)</script>', content, re.DOTALL)
+        assert script_match is not None
+
+        return json.loads(script_match.group(1))
 
     def create_external_survey(self, **kwargs):
         """Helper method to create external surveys for testing"""
@@ -285,6 +294,63 @@ class TestExternalSurveys(APIBaseTest):
         project_config = json.loads(config_match.group(1))
         assert "api_host" in project_config
         assert "token" in project_config
+
+    @parameterized.expand(
+        [
+            ("base_locale", "es", "es"),
+            ("locale_with_region", "en-US", "en-US"),
+            ("locale_with_script_and_region", "zh-Hant-TW", "zh-Hant-TW"),
+        ]
+    )
+    def test_valid_display_language_query_param_configures_sdk_override(
+        self, _name: str, locale: str, expected_display_language: str
+    ):
+        survey = self.create_external_survey()
+
+        response = self.client.get(f"/external_surveys/{survey.id}/?display_language={locale}&campaign=spring")
+        assert response.status_code == 200
+
+        content = response.content.decode()
+        assert f'<html lang="{expected_display_language}">' in content
+        assert self.get_json_script_value(content, "display-language") == expected_display_language
+        assert "config.override_display_language = displayLanguage" in content
+
+    @parameterized.expand(
+        [
+            ("javascript_url", "javascript:alert(1)"),
+            ("empty_value", ""),
+            ("overlong_value", "x" * 36),
+            ("numeric_base", "1234"),
+            ("underscore_separator", "pt_BR"),
+        ]
+    )
+    def test_invalid_display_language_query_param_is_ignored(self, _name: str, locale: str):
+        survey = self.create_external_survey()
+
+        response = self.client.get(f"/external_surveys/{survey.id}/?display_language={locale}")
+        assert response.status_code == 200
+
+        content = response.content.decode()
+        assert '<html lang="en">' in content
+        assert self.get_json_script_value(content, "display-language") is None
+
+    def test_display_language_query_param_is_not_added_to_survey_event_properties(self):
+        survey = self.create_external_survey()
+
+        response = self.client.get(f"/external_surveys/{survey.id}/?display_language=es&campaign=spring")
+        assert response.status_code == 200
+
+        content = response.content.decode()
+        ignored_params_match = re.search(r"const URL_PARAMS_TO_IGNORE = \[(.*?)\];", content)
+        assert ignored_params_match is not None
+        ignored_params = re.findall(r"'([^']+)'", ignored_params_match.group(1))
+
+        survey_event_properties = {}
+        for key, value in parse_qsl("display_language=es&campaign=spring"):
+            if key.lower() not in ignored_params and not re.match(r"^q\d+$", key.lower()):
+                survey_event_properties[key] = value
+
+        assert survey_event_properties == {"campaign": "spring"}
 
     # PERFORMANCE & CACHING TESTS
 


### PR DESCRIPTION
## Problem

Hosted surveys need a way to force a specific rendered language when testing survey translations from a hosted link. Browser/person language detection is useful for production rendering, but it makes QA cumbersome when verifying a specific locale.

## Changes

Add a validated `display_language` query parameter for hosted survey pages. When present and locale-shaped, the page passes it to posthog-js as `override_display_language` so the SDK renders that language, and renders the initial document language as `<html lang="...">` for matching browser/accessibility semantics. The query parameter is also excluded from arbitrary survey event metadata, leaving `$survey_language` as the canonical captured language signal.

Example: `/external_surveys/<survey_id>/?distinct_id=test-user&display_language=es`.

## How did you test this code?

As an agent, I ran:

- `ruff check products/surveys/backend/api/survey.py products/surveys/backend/api/test/test_external_surveys.py`
- `ruff format --check products/surveys/backend/api/test/test_external_surveys.py`
- `git diff --check`

I also attempted `./bin/hogli test products/surveys/backend/api/test/test_external_surveys.py`, but local test collection was blocked by environment setup before tests ran: the flox activation failed building `phrocs` due a local Go toolchain mismatch, and direct pytest startup failed on an unrelated `langgraph._internal` import mismatch.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed. This is a small hosted survey QA/testing query parameter.

## 🤖 Agent context

Authored with Codex. Key decisions: use `display_language` rather than `language` to avoid clashing with customer metadata query params; validate the value as a short locale-like tag before embedding it; use the validated value for both the document language and SDK override; exclude the control param from survey response metadata so SDK-captured `$survey_language` remains the canonical analytics field.
