### PR TITLE
chore(cloud-agent): update agent hardening version

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -68,12 +68,18 @@ RUN set -eux; \
     rm /tmp/gh.deb
 
 # Install agentsh for runtime egress policy enforcement
-ARG AGENTSH_TAG=v0.16.7
+ARG AGENTSH_TAG=v0.18.3
 RUN set -eux; \
     version="${AGENTSH_TAG#v}"; \
     arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) agentsh_sha256="4ac486eea1e10600c29078a7a992d2067774edfb66be1318a2acf1fcf8b6d774" ;; \
+      arm64) agentsh_sha256="d1393a27943d207442ea077b1d36d9561a8af5613e7b67d9f7d4fafd00626c6b" ;; \
+      *) echo "Unsupported architecture for agentsh: $arch" >&2; exit 1 ;; \
+    esac; \
     curl -fsSL -o /tmp/agentsh.deb \
       "https://github.com/canyonroad/agentsh/releases/download/${AGENTSH_TAG}/agentsh_${version}_linux_${arch}.deb" && \
+    echo "${agentsh_sha256}  /tmp/agentsh.deb" | sha256sum -c - && \
     dpkg -i /tmp/agentsh.deb && \
     rm /tmp/agentsh.deb && \
     agentsh --version && \

--- a/products/tasks/backend/services/agentsh.py
+++ b/products/tasks/backend/services/agentsh.py
@@ -1,3 +1,4 @@
+import shlex
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -159,6 +160,11 @@ def generate_policy_yaml(allowed_domains: list[str] | None = None) -> str:
                 "decision": "allow",
             },
             {
+                "name": "deny-cloud-metadata",
+                "cidrs": ["169.254.169.254/32", "fd00:ec2::254/128"],
+                "decision": "deny",
+            },
+            {
                 "name": "allow-domains",
                 "domains": merged_domains,
                 "ports": allowed_ports,
@@ -246,13 +252,13 @@ def build_audit_query_command(since_ns: int = 0, limit: int = 50) -> str:
         where_parts.append(f"ts_unix_ns > {since_ns}")
     where_parts.append("(type LIKE 'net%' OR (effective_decision IS NOT NULL AND domain IS NOT NULL))")
     where_clause = " AND ".join(where_parts)
-    return (
-        f"sqlite3 -json {AGENTSH_AUDIT_DB} "
-        f'"SELECT ts_unix_ns, type, domain, remote, effective_decision, policy_rule '
+    query = (
+        "SELECT ts_unix_ns, type, domain, remote, effective_decision, policy_rule "
         f"FROM events "
         f"WHERE {where_clause} "
-        f"ORDER BY ts_unix_ns DESC LIMIT {limit};" + ' 2>/dev/null || echo "[]"'
+        f"ORDER BY ts_unix_ns DESC LIMIT {limit};"
     )
+    return f"sqlite3 -json {shlex.quote(AGENTSH_AUDIT_DB)} {shlex.quote(query)} 2>/dev/null || echo '[]'"
 
 
 def build_exec_prefix() -> str:

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -637,7 +637,7 @@ class DockerSandbox(SandboxBase):
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
 
-        if allowed_domains:
+        if allowed_domains is not None:
             return (
                 f"cd /scripts && env -0 > {ENV_FILE} && "
                 f"{build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(inner)} &"
@@ -688,11 +688,8 @@ class DockerSandbox(SandboxBase):
             org, repo = repository.lower().split("/")
             repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
-        # TODO: Re-enable agentsh egress enforcement in the Docker sandbox once
-        # agentsh works reliably inside local Docker containers.
-        # For now we skip setup and ignore allowed_domains so that callers
-        # (signals, tasks, etc.) don't need to hotfix around Docker failures.
-        allowed_domains = None
+        if allowed_domains is not None:
+            self._setup_agentsh(WORKING_DIR, allowed_domains)
 
         mcp_servers_arg = ""
         if mcp_configs:
@@ -760,14 +757,14 @@ class DockerSandbox(SandboxBase):
         )
 
     def _setup_agentsh(self, workspace_path: str, allowed_domains: list[str] | None = None) -> None:
-        if allowed_domains:
+        if allowed_domains is not None:
             logger.info(
                 "Configuring agentsh in Docker sandbox %s for %d allowed domain(s)", self.id, len(allowed_domains)
             )
         else:
             logger.info("Configuring agentsh in Docker sandbox %s (allow-all mode)", self.id)
 
-        config_yaml = generate_config_yaml()
+        config_yaml = generate_config_yaml(enable_ptrace=False)
         policy_yaml = generate_policy_yaml(allowed_domains)
 
         self.execute("pkill -f 'agentsh server' || true", timeout_seconds=5)

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -550,7 +550,7 @@ class ModalSandbox(SandboxBase):
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
 
-        if allowed_domains:
+        if allowed_domains is not None:
             return (
                 f"cd /scripts && env -0 > {ENV_FILE} && "
                 f"{build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(inner)} &"
@@ -595,7 +595,7 @@ class ModalSandbox(SandboxBase):
             org, repo = repository.lower().split("/")
             repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
-        if allowed_domains:
+        if allowed_domains is not None:
             self._setup_agentsh(WORKING_DIR, allowed_domains)
 
         mcp_servers_arg = ""
@@ -631,7 +631,7 @@ class ModalSandbox(SandboxBase):
         logger.info(f"Agent-server started in sandbox {self.id}")
 
     def _setup_agentsh(self, workspace_path: str, allowed_domains: list[str] | None = None) -> None:
-        if allowed_domains:
+        if allowed_domains is not None:
             logger.info("Configuring agentsh in sandbox %s for %d allowed domain(s)", self.id, len(allowed_domains))
         else:
             logger.info("Configuring agentsh in sandbox %s (allow-all mode)", self.id)

--- a/products/tasks/backend/services/test_docker_sandbox.py
+++ b/products/tasks/backend/services/test_docker_sandbox.py
@@ -337,8 +337,7 @@ class TestDockerSandboxUnit:
         assert "nohup" in command
         assert "./node_modules/.bin/agent-server" in command
 
-    def test_start_agent_server_ignores_allowed_domains_in_docker(self):
-        """allowed_domains is intentionally ignored in Docker sandbox until agentsh works reliably."""
+    def test_start_agent_server_wraps_with_agentsh_when_domains_provided(self):
         sandbox = DockerSandbox.__new__(DockerSandbox)
         sandbox._container_id = "abc123"
         sandbox.id = "abc123"
@@ -360,11 +359,67 @@ class TestDockerSandboxUnit:
                         allowed_domains=["example.com"],
                     )
 
-        mock_setup_agentsh.assert_not_called()
+        mock_setup_agentsh.assert_called_once_with("/tmp/workspace", ["example.com"])
         command = mock_execute.call_args_list[0][0][0]
         assert "--createPr true" in command
+        assert "--allowedDomains example.com" in command
+        assert "agentsh exec" in command
+
+    def test_start_agent_server_wraps_with_agentsh_when_domains_empty(self):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._host_port = 12345
+
+        with patch.object(sandbox, "is_running", return_value=True):
+            with patch.object(sandbox, "execute") as mock_execute:
+                mock_execute.side_effect = [
+                    ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                    ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+                ]
+                with patch.object(sandbox, "_setup_agentsh") as mock_setup_agentsh:
+                    sandbox.start_agent_server(
+                        "posthog/posthog",
+                        "task-123",
+                        "run-456",
+                        "background",
+                        allowed_domains=[],
+                    )
+
+        mock_setup_agentsh.assert_called_once_with("/tmp/workspace", [])
+        command = mock_execute.call_args_list[0][0][0]
         assert "--allowedDomains" not in command
-        assert "agentsh exec" not in command
+        assert "agentsh exec" in command
+
+    def test_setup_agentsh_disables_ptrace_in_docker(self):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+
+        with (
+            patch(
+                "products.tasks.backend.services.docker_sandbox.generate_config_yaml", return_value="config"
+            ) as mock_config,
+            patch("products.tasks.backend.services.docker_sandbox.generate_policy_yaml", return_value="policy"),
+            patch("products.tasks.backend.services.docker_sandbox.generate_env_wrapper", return_value="wrapper"),
+            patch("products.tasks.backend.services.docker_sandbox.build_setup_script", return_value="setup"),
+            patch.object(sandbox, "write_file") as mock_write_file,
+            patch.object(sandbox, "execute") as mock_execute,
+        ):
+            mock_execute.side_effect = [
+                ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                ExecutionResult(stdout="session-123", stderr="", exit_code=0, error=None),
+            ]
+
+            sandbox._setup_agentsh("/tmp/workspace", ["example.com"])
+
+        mock_config.assert_called_once_with(enable_ptrace=False)
+        mock_write_file.assert_any_call("/etc/agentsh/config.yaml", b"config")
 
     @pytest.mark.parametrize(
         ("create_pr", "expected_flag"),

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -238,6 +238,29 @@ class TestModalSandboxAgentServer:
         assert "/tmp/agentsh-env-wrapper.sh" in command
         assert "./node_modules/.bin/agent-server" in command
 
+    def test_start_agent_server_wraps_with_agentsh_when_domains_empty(self, mock_sandbox: Any):
+        mock_sandbox.execute = MagicMock(
+            side_effect=[
+                ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+            ]
+        )
+
+        with patch.object(mock_sandbox, "_setup_agentsh") as mock_setup_agentsh:
+            mock_sandbox.start_agent_server(
+                repository="posthog/posthog",
+                task_id="task-123",
+                run_id="run-456",
+                mode="background",
+                allowed_domains=[],
+            )
+
+        mock_setup_agentsh.assert_called_once_with("/tmp/workspace", [])
+        command = mock_sandbox.execute.call_args_list[0][0][0]
+        assert "--allowedDomains" not in command
+        assert "agentsh exec --client-timeout 2h --timeout 2h" in command
+        assert "env -0 > /tmp/agent-env" in command
+
     @pytest.mark.parametrize(
         ("create_pr", "expected_flag"),
         [

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -158,10 +158,12 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
             )
         else:
             sandbox_environment_name = sandbox_environment.name
-            effective_domains = sandbox_environment.get_effective_domains()
-            allowed_domains = effective_domains or None
+            if sandbox_environment.network_access_level == SandboxEnvironment.NetworkAccessLevel.FULL:
+                allowed_domains = None
+            else:
+                allowed_domains = sandbox_environment.get_effective_domains()
 
-            if allowed_domains:
+            if allowed_domains is not None:
                 emit_agent_log(
                     run_id,
                     "debug",

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -72,7 +72,7 @@ def _run_connectivity_diagnostics(ctx: TaskProcessingContext, sandbox: SandboxBa
             " https://gateway.us.posthog.com/health 2>&1 || echo 'CURL_GATEWAY: failed'"
         )
 
-        if ctx.allowed_domains:
+        if ctx.allowed_domains is not None:
             cmd = (
                 f"cd /scripts && env -0 > {ENV_FILE} && "
                 f"{build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(checks)}"
@@ -167,7 +167,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 "No MCP configs were resolved for this run. PostHog MCP tools will be unavailable in the agent session.",
             )
 
-        if ctx.allowed_domains:
+        if ctx.allowed_domains is not None:
             environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id or "selected environment"
             emit_agent_log(
                 ctx.run_id,
@@ -205,10 +205,10 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 mark_mcp_token_issued(ctx.run_id)
 
             # emit agentsh logs
-            if ctx.allowed_domains:
+            if ctx.allowed_domains is not None:
                 _emit_agentsh_log_tail(ctx, sandbox)
         except Exception as e:
-            if ctx.allowed_domains:
+            if ctx.allowed_domains is not None:
                 _emit_agentsh_log_tail(ctx, sandbox)
             _emit_agent_server_log_tail(ctx, sandbox)
             raise SandboxExecutionError(
@@ -222,7 +222,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 cause=e,
             )
 
-        if ctx.allowed_domains:
+        if ctx.allowed_domains is not None:
             emit_agent_log(ctx.run_id, "debug", "agentsh policy initialized successfully")
             _emit_agentsh_log_tail(ctx, sandbox)
         _emit_agent_server_log_tail(ctx, sandbox)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -109,6 +109,40 @@ class TestGetTaskProcessingContextActivity:
         assert result.allowed_domains == ["example.com"]
 
     @pytest.mark.django_db
+    def test_get_task_processing_context_preserves_empty_restricted_domains(self, activity_environment, test_task):
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=test_task.team,
+            created_by=test_task.created_by,
+            name="Restricted empty env",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.CUSTOM,
+            allowed_domains=[],
+        )
+        task_run = test_task.create_run(extra_state={"sandbox_environment_id": str(sandbox_environment.id)})
+
+        input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
+        result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
+
+        assert result.sandbox_environment_id == str(sandbox_environment.id)
+        assert result.allowed_domains == []
+
+    @pytest.mark.django_db
+    def test_get_task_processing_context_keeps_full_access_unrestricted(self, activity_environment, test_task):
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=test_task.team,
+            created_by=test_task.created_by,
+            name="Full access env",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+            allowed_domains=[],
+        )
+        task_run = test_task.create_run(extra_state={"sandbox_environment_id": str(sandbox_environment.id)})
+
+        input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
+        result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
+
+        assert result.sandbox_environment_id == str(sandbox_environment.id)
+        assert result.allowed_domains is None
+
+    @pytest.mark.django_db
     def test_get_task_processing_context_rejects_other_users_private_sandbox_environment(
         self, activity_environment, test_task
     ):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -358,6 +358,9 @@ def get_sandbox_github_token(
 
 
 def format_allowed_domains_for_log(domains: list[str], limit: int = 5) -> str:
+    if not domains:
+        return "no custom domains"
+
     preview = ", ".join(domains[:limit])
     remaining = len(domains) - limit
     if remaining > 0:

--- a/products/tasks/backend/tests/test_agentsh.py
+++ b/products/tasks/backend/tests/test_agentsh.py
@@ -1,3 +1,4 @@
+import shlex
 from typing import Any
 
 from unittest.mock import Mock
@@ -93,15 +94,29 @@ class TestGeneratePolicyYaml(TestCase):
     def test_allowed_domains_before_deny_rules(self, domains):
         policy = yaml.safe_load(generate_policy_yaml(domains))
         rules = policy["network_rules"]
-        first_deny_idx = next(i for i, rule in enumerate(rules) if rule["decision"] == "deny")
+        default_deny_idx = next(i for i, rule in enumerate(rules) if rule["name"] == "default-deny-network")
         for i, rule in enumerate(rules):
             if rule.get("decision") == "allow" and rule.get("domains"):
-                self.assertLess(i, first_deny_idx)
+                self.assertLess(i, default_deny_idx)
 
     def test_localhost_always_allowed(self):
         policy = yaml.safe_load(generate_policy_yaml([]))
         localhost_rule = next(rule for rule in policy["network_rules"] if rule["name"] == "allow-localhost")
         self.assertIn("127.0.0.0/8", localhost_rule["cidrs"])
+
+    def test_restricted_policy_denies_cloud_metadata(self):
+        policy = yaml.safe_load(generate_policy_yaml(["example.com"]))
+        metadata_rule = next(rule for rule in policy["network_rules"] if rule["name"] == "deny-cloud-metadata")
+        self.assertEqual(metadata_rule["decision"], "deny")
+        self.assertIn("169.254.169.254/32", metadata_rule["cidrs"])
+        self.assertIn("fd00:ec2::254/128", metadata_rule["cidrs"])
+
+    def test_cloud_metadata_deny_precedes_allowed_domains(self):
+        policy = yaml.safe_load(generate_policy_yaml(["example.com"]))
+        rules = policy["network_rules"]
+        metadata_idx = next(i for i, rule in enumerate(rules) if rule["name"] == "deny-cloud-metadata")
+        allow_domains_idx = next(i for i, rule in enumerate(rules) if rule["name"] == "allow-domains")
+        self.assertLess(metadata_idx, allow_domains_idx)
 
     def test_file_rules_allow_all(self):
         policy = yaml.safe_load(generate_policy_yaml([]))
@@ -130,6 +145,11 @@ class TestGeneratePolicyYaml(TestCase):
         policy = yaml.safe_load(generate_policy_yaml(None))
         deny_rules = [r for r in policy["network_rules"] if r["decision"] == "deny"]
         self.assertEqual(len(deny_rules), 0)
+
+    def test_allow_all_policy_has_no_metadata_deny_rule(self):
+        policy = yaml.safe_load(generate_policy_yaml(None))
+        rule_names = [r["name"] for r in policy["network_rules"]]
+        self.assertNotIn("deny-cloud-metadata", rule_names)
 
 
 class TestEnvWrapper(TestCase):
@@ -160,6 +180,12 @@ class TestBuildAuditQueryCommand(TestCase):
     def test_respects_limit(self):
         cmd = build_audit_query_command(limit=10)
         self.assertIn("LIMIT 10", cmd)
+
+    def test_command_is_shell_parseable(self):
+        cmd = build_audit_query_command(limit=10)
+        parts = shlex.split(cmd)
+        self.assertEqual(parts[0], "sqlite3")
+        self.assertTrue(any(part.startswith("SELECT ts_unix_ns") for part in parts))
 
 
 class TestBuildExecPrefix(TestCase):

--- a/products/tasks/backend/tests/test_agentsh_docker.py
+++ b/products/tasks/backend/tests/test_agentsh_docker.py
@@ -126,6 +126,20 @@ class TestAgentshDockerEnforcement:
             sandbox.destroy()
 
     @pytest.mark.django_db
+    def test_blocks_cloud_metadata_endpoint(self, sandbox_image):
+        sandbox = self._create_sandbox(sandbox_image)
+        try:
+            result = self._setup_agentsh_and_exec(
+                sandbox,
+                "curl -s --connect-timeout 2 --max-time 5 http://169.254.169.254/latest/meta-data/",
+                allowed_domains=["github.com"],
+            )
+            assert "blocked by policy" in result.stdout
+            assert "deny-cloud-metadata" in result.stderr
+        finally:
+            sandbox.destroy()
+
+    @pytest.mark.django_db
     def test_allows_custom_domain(self, sandbox_image):
         sandbox = self._create_sandbox(sandbox_image)
         try:

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -245,6 +245,9 @@ tools:
     event-definitions-partial-update:
         operation: event_definitions_partial_update
         enabled: false
+    event-definitions-promoted-properties-retrieve:
+        operation: event_definitions_promoted_properties_retrieve
+        enabled: false
     event-definitions-python-retrieve:
         operation: event_definitions_python_retrieve
         enabled: false
@@ -791,7 +794,4 @@ tools:
         enabled: false
     users-verify-email-create:
         operation: users_verify_email_create
-        enabled: false
-    event-definitions-promoted-properties-retrieve:
-        operation: event_definitions_promoted_properties_retrieve
         enabled: false


### PR DESCRIPTION
## Problem

Cloud agent sandboxes need the current `agentsh` hardening runtime and matching coverage for restricted egress behavior across our sandbox providers.

## Changes

- updated the sandbox image `agentsh` package from `0.16.7` to `0.18.3` with SHA256 checksum
- added an explicit metadata-service deny rule for restricted `agentsh` policies