### PR TITLE
fix(cli): add --language flag to schema pull command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5,7 +5,10 @@ use crate::{
     download::SymbolSetsSubcommand,
     dsym::DsymSubcommand,
     error::CapturedError,
-    experimental::{endpoints::EndpointCommand, query::command::QueryCommand, tasks::TaskCommand},
+    experimental::{
+        endpoints::EndpointCommand, query::command::QueryCommand, schema::Language,
+        tasks::TaskCommand,
+    },
     invocation_context::{context, init_context, INVOCATION_CONTEXT},
     proguard::ProguardSubcommand,
     sourcemaps::{hermes::HermesSubcommand, plain::SourcemapCommand},
@@ -134,6 +137,9 @@ pub enum SchemaCommand {
         /// Output path for generated definitions (stored in posthog.json for future runs)
         #[arg(short, long)]
         output: Option<String>,
+        /// Language to generate definitions for
+        #[arg(short, long)]
+        language: Option<Language>,
     },
     /// Show current schema sync status
     Status,
@@ -259,8 +265,8 @@ impl Cli {
                     }
                 },
                 ExpCommand::Schema { cmd } => match cmd {
-                    SchemaCommand::Pull { output } => {
-                        crate::experimental::schema::pull(self.host, output)?;
+                    SchemaCommand::Pull { output, language } => {
+                        crate::experimental::schema::pull(self.host, output, language)?;
                     }
                     SchemaCommand::Status => {
                         crate::experimental::schema::status()?;
@@ -274,5 +280,96 @@ impl Cli {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_pull_accepts_all_languages() {
+        for (flag, expected) in [
+            ("typescript", Language::TypeScript),
+            ("golang", Language::Golang),
+            ("python", Language::Python),
+        ] {
+            let cli =
+                Cli::try_parse_from(["posthog-cli", "exp", "schema", "pull", "--language", flag])
+                    .unwrap_or_else(|_| panic!("--language {flag} should parse"));
+
+            match cli.command {
+                Commands::Exp {
+                    cmd: ExpCommand::Schema {
+                        cmd: SchemaCommand::Pull { language: Some(language), .. },
+                    },
+                } => assert_eq!(language, expected, "--language {flag}"),
+                _ => panic!("expected schema pull command for --language {flag}"),
+            }
+        }
+    }
+
+    #[test]
+    fn schema_pull_accepts_short_flag_for_all_languages() {
+        for (flag, expected) in [
+            ("typescript", Language::TypeScript),
+            ("golang", Language::Golang),
+            ("python", Language::Python),
+        ] {
+            let cli =
+                Cli::try_parse_from(["posthog-cli", "exp", "schema", "pull", "-l", flag])
+                    .unwrap_or_else(|_| panic!("-l {flag} should parse"));
+
+            match cli.command {
+                Commands::Exp {
+                    cmd: ExpCommand::Schema {
+                        cmd: SchemaCommand::Pull { language: Some(language), .. },
+                    },
+                } => assert_eq!(language, expected, "-l {flag}"),
+                _ => panic!("expected schema pull command for -l {flag}"),
+            }
+        }
+    }
+
+    #[test]
+    fn schema_pull_language_and_output_together() {
+        let cli = Cli::try_parse_from([
+            "posthog-cli",
+            "exp",
+            "schema",
+            "pull",
+            "--language",
+            "typescript",
+            "--output",
+            "src/posthog-typed.ts",
+        ])
+        .expect("--language and --output together should parse");
+
+        match cli.command {
+            Commands::Exp {
+                cmd: ExpCommand::Schema {
+                    cmd: SchemaCommand::Pull { output, language: Some(language) },
+                },
+            } => {
+                assert_eq!(language, Language::TypeScript);
+                assert_eq!(output, Some("src/posthog-typed.ts".to_string()));
+            }
+            _ => panic!("expected schema pull command"),
+        }
+    }
+
+    #[test]
+    fn schema_pull_without_language_flag_defaults_to_none() {
+        let cli = Cli::try_parse_from(["posthog-cli", "exp", "schema", "pull"])
+            .expect("schema pull without language should parse");
+
+        match cli.command {
+            Commands::Exp {
+                cmd: ExpCommand::Schema {
+                    cmd: SchemaCommand::Pull { language, .. },
+                },
+            } => assert_eq!(language, None),
+            _ => panic!("expected schema pull command"),
+        }
     }
 }

--- a/cli/src/experimental/schema.rs
+++ b/cli/src/experimental/schema.rs
@@ -9,11 +9,14 @@ use tracing::info;
 use crate::api::client::PHClient;
 use crate::invocation_context::context;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
-enum Language {
+pub enum Language {
+    #[value(name = "typescript")]
     TypeScript,
+    #[value(name = "golang")]
     Golang,
+    #[value(name = "python")]
     Python,
 }
 
@@ -190,9 +193,16 @@ struct DefinitionsResponse {
     schema_hash: String,
 }
 
-pub fn pull(_host: Option<String>, output_override: Option<String>) -> Result<()> {
+pub fn pull(
+    _host: Option<String>,
+    output_override: Option<String>,
+    language_override: Option<Language>,
+) -> Result<()> {
     // Select language
-    let language = select_language()?;
+    let language = match language_override {
+        Some(language) => language,
+        None => select_language()?,
+    };
 
     info!(
         "Fetching {} definitions from PostHog...",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

`posthog-cli exp schema pull` always prompts interactively for the language, making it impossible to use in CI/CD pipelines or scripts without a TTY. There was no way to pass the language non-interactively.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Added `--language` / `-l` flag to `posthog-cli exp schema pull` accepting `typescript`, `golang`, or `python`
- When the flag is provided the interactive prompt is skipped entirely
- When omitted the existing interactive `inquire` prompt is preserved (no breaking change)
- Added 3 unit tests in `cli/src/commands.rs`: all languages accepted via `--language`, short `-l` flag, and default `None` when flag is omitted

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
Automated tests were run via `cargo test` (Rust unit tests in `commands.rs`). Also manually verified against a live local PostHog instance:

    posthog-cli --host http://localhost:8010 exp schema pull \
      --language typescript --output posthog-typed.ts

No prompt appeared and the file was generated correctly.

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
No
## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->

Co-authored with GitHub Copilot in VS Code.
Changes reviewed and tested by the human author before opening this PR.