### PR TITLE
fix(settings): require opt-in for db writes in pod shells

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sys
 import time
 from contextlib import suppress
 from functools import lru_cache
@@ -68,6 +69,35 @@ def postgres_config(host: str) -> dict:
     }
 
 
+def _is_manage_py_shell_command(argv: list[str]) -> bool:
+    if len(argv) < 2:
+        return False
+
+    management_commands = {"shell", "shell_plus", "dbshell"}
+    return any(command in management_commands for command in argv[1:])
+
+
+def _should_enforce_read_only_for_exec(env: dict[str, str], argv: list[str]) -> bool:
+    if not env.get("KUBERNETES_SERVICE_HOST"):
+        return False
+
+    allow_writes = str_to_bool(env.get("ALLOW_POD_SHELL_DB_WRITE", "false"))
+    if allow_writes:
+        return False
+
+    return _is_manage_py_shell_command(argv)
+
+
+def _add_default_transaction_read_only_option(database_config: dict) -> None:
+    options = database_config.setdefault("OPTIONS", {})
+    current_options = options.get("options", "")
+    read_only_option = "-c default_transaction_read_only=on"
+
+    if read_only_option not in current_options:
+        options["options"] = f"{current_options} {read_only_option}".strip()
+
+
+
 if TEST or DEBUG:
     PG_HOST: str = os.getenv("PGHOST", "db")
     PG_USER: str = os.getenv("PGUSER", "posthog")
@@ -117,6 +147,10 @@ else:
     raise ImproperlyConfigured(
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
+
+
+if _should_enforce_read_only_for_exec(os.environ, sys.argv):
+    _add_default_transaction_read_only_option(DATABASES["default"])
 
 DATABASE_ROUTERS: list[str] = []
 

--- a/posthog/settings/test/test_data_stores.py
+++ b/posthog/settings/test/test_data_stores.py
@@ -1,0 +1,46 @@
+from parameterized import parameterized
+
+from posthog.settings.data_stores import (
+    _add_default_transaction_read_only_option,
+    _is_manage_py_shell_command,
+    _should_enforce_read_only_for_exec,
+)
+
+
+@parameterized.expand(
+    [
+        ("django_shell", ["manage.py", "shell"], True),
+        ("django_shell_plus", ["manage.py", "shell_plus"], True),
+        ("django_dbshell", ["manage.py", "dbshell"], True),
+        ("django_runserver", ["manage.py", "runserver"], False),
+        ("not_enough_args", ["manage.py"], False),
+    ]
+)
+def test_is_manage_py_shell_command(_: str, argv: list[str], expected: bool) -> None:
+    assert _is_manage_py_shell_command(argv) is expected
+
+
+@parameterized.expand(
+    [
+        ("k8s_shell_without_override", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, ["manage.py", "shell"], True),
+        (
+            "k8s_shell_with_override",
+            {"KUBERNETES_SERVICE_HOST": "10.0.0.1", "ALLOW_POD_SHELL_DB_WRITE": "true"},
+            ["manage.py", "shell"],
+            False,
+        ),
+        ("k8s_runserver", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, ["manage.py", "runserver"], False),
+        ("not_k8s_shell", {}, ["manage.py", "shell"], False),
+    ]
+)
+def test_should_enforce_read_only_for_exec(_: str, env: dict[str, str], argv: list[str], expected: bool) -> None:
+    assert _should_enforce_read_only_for_exec(env, argv) is expected
+
+
+def test_add_default_transaction_read_only_option() -> None:
+    database_config: dict = {"OPTIONS": {"options": "-c statement_timeout=5000"}}
+
+    _add_default_transaction_read_only_option(database_config)
+    _add_default_transaction_read_only_option(database_config)
+
+    assert database_config["OPTIONS"]["options"] == "-c statement_timeout=5000 -c default_transaction_read_only=on"


### PR DESCRIPTION
### Motivation

- Prevent accidental writes when an operator `exec`s into a pod and opens a Django management shell by making such sessions default to read-only unless explicitly allowed.

### Description

- added helper functions `_is_manage_py_shell_command`, `_should_enforce_read_only_for_exec`, and `_add_default_transaction_read_only_option` in `posthog/settings/data_stores.py` to detect manage.py shell-like commands and mutate DB options.
- when running in Kubernetes (presence of `KUBERNETES_SERVICE_HOST`) and the process argv indicates `shell`, `shell_plus`, or `dbshell`, the code injects `-c default_transaction_read_only=on` into `DATABASES['default']['OPTIONS']['options']` unless `ALLOW_POD_SHELL_DB_WRITE=true` is set.
- added a `sys` import and a runtime check using `sys.argv` to decide whether to apply the safeguard for the current process.
- added unit tests in `posthog/settings/test/test_data_stores.py` to cover command detection, the Kubernetes + env-var override behavior, and idempotent options injection.

### Testing

- `python -m compileall posthog/settings/data_stores.py posthog/settings/test/test_data_stores.py` succeeded and the modified files compiled.
- `pytest -q posthog/settings/test/test_data_stores.py` could not be executed in this environment due to missing Django runtime dependencies (failed to import `django`).
- `hogli test posthog/settings/test/test_data_stores.py` could not be run in this environment because `hogli` was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa91109cc832e8a3c77b85eae9dbf)