### PR TITLE
feat(ci): track github rate-limit in posthog

### DIFF
--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -1,6 +1,6 @@
 // Master CI Alerts - Cron-based rolling window alert for sustained master failures
 //
-// Polls the GitHub API every 10 minutes. Emits three independent signals:
+// Polls the GitHub API every 10 minutes. Emits two independent signals:
 //
 // 1. Per-workflow streak: alerts when any watched workflow has
 //    WORKFLOW_FAILURE_STREAK_THRESHOLD (default 5) consecutive failures on master.
@@ -12,8 +12,8 @@
 //    flakes, etc.) where no single workflow hits the per-workflow threshold
 //    but master is still consistently red.
 //
-// 3. Rate limit: alerts independently if GitHub API quota drops critically
-//    low — CI monitoring may be blind otherwise.
+// GitHub API rate-limit observability is handled by the separate
+// monitor-github-rate-limit workflow, which emits to PostHog as time series.
 //
 // State structure (persisted via GitHub Actions cache as .alerts-devex):
 // {
@@ -24,9 +24,6 @@
 //   last_failing_list: string,
 //   last_failing_detail: string,  // preserved for resolve messages
 //   resolved: boolean,
-//   rate_limit_alerted: boolean,
-//   rate_limit_slack_ts: string | null,
-//   rate_limit_slack_channel: string | null,
 //   commit_failure_streak_alerted: boolean,
 //   commit_failure_streak_slack_ts: string | null,
 //   commit_failure_streak_slack_channel: string | null,
@@ -35,21 +32,6 @@
 // }
 
 const STATE_FILE = '.alerts-devex'
-
-async function checkRateLimit(github) {
-    const { data } = await github.rest.rateLimit.get()
-    const { remaining, limit, reset } = data.resources.core
-    const thresholdPercent = parseInt(process.env.RATE_LIMIT_THRESHOLD_PERCENT || '10', 10)
-    const critical = remaining < limit * (thresholdPercent / 100)
-    return { remaining, limit, reset, critical }
-}
-
-function determineRateLimitAction(state, critical) {
-    const wasAlerted = state?.rate_limit_alerted === true
-    if (critical && !wasAlerted) return 'create'
-    if (!critical && wasAlerted) return 'resolve'
-    return 'none'
-}
 
 async function fetchWorkflowRuns(github, owner, repo, workflowFile, perPage) {
     const { data } = await github.rest.actions.listWorkflowRuns({
@@ -281,9 +263,6 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
                 console.log('Found resolved incident, treating as no active state')
                 state = {
                     failing: {},
-                    rate_limit_alerted: raw.rate_limit_alerted ?? false,
-                    rate_limit_slack_ts: raw.rate_limit_slack_ts ?? null,
-                    rate_limit_slack_channel: raw.rate_limit_slack_channel ?? null,
                     commit_failure_streak_alerted: raw.commit_failure_streak_alerted ?? false,
                     commit_failure_streak_slack_ts: raw.commit_failure_streak_slack_ts ?? null,
                     commit_failure_streak_slack_channel: raw.commit_failure_streak_slack_channel ?? null,
@@ -297,17 +276,6 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         } catch (e) {
             console.log('Failed to parse state file, treating as fresh')
         }
-    }
-
-    // Check rate limits before polling workflows
-    let rateLimit = null
-    let rateLimitAction = 'none'
-    try {
-        rateLimit = await checkRateLimit(github)
-        console.log(`Rate limit: ${rateLimit.remaining}/${rateLimit.limit} remaining`)
-        rateLimitAction = determineRateLimitAction(state, rateLimit.critical)
-    } catch (err) {
-        console.log(`Failed to check rate limit: ${err.message}`)
     }
 
     // Fetch recent runs for each watched workflow
@@ -366,7 +334,6 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
 
     // Save when there's an action or evolving failure counts to track
     const shouldSave = action !== 'none' || Object.keys(failing).length > 0
-    const saveRateLimit = rateLimitAction !== 'none'
     const saveCommitFailureStreak = commitFailureStreakAction !== 'none' || commitFailureStreakCount > 0
 
     // Build new state
@@ -378,10 +345,6 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         last_failing_list: failingList,
         last_failing_detail: failingDetail || state?.last_failing_detail || '',
         resolved: action === 'resolve',
-        rate_limit_alerted:
-            rateLimitAction === 'create' || (state?.rate_limit_alerted === true && rateLimitAction !== 'resolve'),
-        rate_limit_slack_ts: state?.rate_limit_slack_ts || null,
-        rate_limit_slack_channel: state?.rate_limit_slack_channel || null,
         commit_failure_streak_alerted:
             commitFailureStreakAction === 'create' ||
             (state?.commit_failure_streak_alerted === true && commitFailureStreakAction !== 'resolve'),
@@ -391,13 +354,13 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         commit_failure_streak_last_sample: commitFailureStreakDetail || state?.commit_failure_streak_last_sample || '',
     }
 
-    if (shouldSave || saveRateLimit || saveCommitFailureStreak) {
+    if (shouldSave || saveCommitFailureStreak) {
         fs.writeFileSync(STATE_FILE, JSON.stringify(newState, null, 2))
     }
 
     // Set outputs
     core.setOutput('action', action)
-    core.setOutput('save_cache', shouldSave || saveRateLimit || saveCommitFailureStreak ? 'true' : 'false')
+    core.setOutput('save_cache', shouldSave || saveCommitFailureStreak ? 'true' : 'false')
     core.setOutput('delete_old_caches', action === 'create' ? 'true' : 'false')
     core.setOutput('failing_workflows', failingList)
     core.setOutput('failing_count', String(Object.keys(failing).length))
@@ -435,19 +398,6 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         core.setOutput('slack_channel', state?.slack_channel || '')
         core.setOutput('last_failing_list', state?.last_failing_list || '')
         core.setOutput('last_failing_detail', state?.last_failing_detail || '')
-    }
-
-    // Rate limit outputs
-    core.setOutput('rate_limit_action', rateLimitAction)
-    if (rateLimit) {
-        core.setOutput('rate_limit_remaining', String(rateLimit.remaining))
-        core.setOutput('rate_limit_limit', String(rateLimit.limit))
-        const resetMins = Math.max(0, Math.round((rateLimit.reset * 1000 - now.getTime()) / 60000))
-        core.setOutput('rate_limit_reset_mins', String(resetMins))
-    }
-    if (rateLimitAction === 'resolve') {
-        core.setOutput('rate_limit_slack_ts', state?.rate_limit_slack_ts || '')
-        core.setOutput('rate_limit_slack_channel', state?.rate_limit_slack_channel || '')
     }
 
     // Commit-failure-streak outputs

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -52,27 +52,12 @@ function commitsWithRuns(perCommitConclusions) {
     return { commits, runsByWorkflow }
 }
 
-function createGithubMock(workflowRuns, { rateLimitRemaining = 4500, commits = [] } = {}) {
+function createGithubMock(workflowRuns, { commits = [] } = {}) {
     return {
         rest: {
             actions: {
                 listWorkflowRuns: jest.fn(({ workflow_id }) =>
                     Promise.resolve({ data: { workflow_runs: workflowRuns[workflow_id] || [] } })
-                ),
-            },
-            rateLimit: {
-                get: jest.fn(() =>
-                    Promise.resolve({
-                        data: {
-                            resources: {
-                                core: {
-                                    remaining: rateLimitRemaining,
-                                    limit: 5000,
-                                    reset: Math.floor(T_BASE.getTime() / 1000) + 3600,
-                                },
-                            },
-                        },
-                    })
                 ),
             },
             repos: {
@@ -94,7 +79,6 @@ function run(github, { state = null, now = minutes(0) } = {}) {
     process.env.WATCHED_WORKFLOWS = 'ci-backend.yml,ci-frontend.yml'
     process.env.WORKFLOW_FAILURE_STREAK_THRESHOLD = '5'
     process.env.COMMIT_FAILURE_STREAK_THRESHOLD = '10'
-    process.env.RATE_LIMIT_THRESHOLD_PERCENT = '10'
     process.env.CRITICAL_WORKFLOWS = 'ci-backend.yml'
 
     return ciAlertsDevex({ github, context: { repo: { owner: 'PostHog', repo: 'posthog' } }, core }, { fs: mockFs, now }).then(() => ({
@@ -109,7 +93,6 @@ afterEach(() => {
     delete process.env.WATCHED_WORKFLOWS
     delete process.env.WORKFLOW_FAILURE_STREAK_THRESHOLD
     delete process.env.COMMIT_FAILURE_STREAK_THRESHOLD
-    delete process.env.RATE_LIMIT_THRESHOLD_PERCENT
     delete process.env.CRITICAL_WORKFLOWS
 })
 
@@ -184,45 +167,6 @@ describe('ci-alerts-devex', () => {
         const { outputs } = await run(github)
         expect(outputs.failing_detail).toMatch(/^\*Blocking:\*.*Backend CI/)
         expect(outputs.failing_detail).toMatch(/\*Non-blocking:\*.*Frontend CI/)
-    })
-
-    describe('rate limit', () => {
-        it('alerts when critical, resolves when healthy', async () => {
-            // Fire alert
-            let github = createGithubMock(allPassing(), { rateLimitRemaining: 50 })
-            let { outputs, writtenState } = await run(github)
-            expect(outputs.rate_limit_action).toBe('create')
-            expect(writtenState.rate_limit_alerted).toBe(true)
-
-            // Recover
-            github = createGithubMock(allPassing(), { rateLimitRemaining: 4500 })
-            ;({ outputs, writtenState } = await run(github, {
-                state: { failing: {}, rate_limit_alerted: true, rate_limit_slack_ts: '1', rate_limit_slack_channel: 'C' },
-            }))
-            expect(outputs.rate_limit_action).toBe('resolve')
-            expect(writtenState.rate_limit_alerted).toBe(false)
-        })
-
-        it('degrades gracefully when rate limit API fails', async () => {
-            const github = createGithubMock(allPassing())
-            github.rest.rateLimit.get = jest.fn(() => Promise.reject(new Error('API error')))
-            const { outputs } = await run(github)
-            expect(outputs.rate_limit_action).toBe('none')
-            expect(outputs.action).toBe('none')
-        })
-
-        it('fires workflow and rate-limit signals independently in the same tick', async () => {
-            const github = createGithubMock(
-                {
-                    'ci-backend.yml': runs('Backend CI', Array(5).fill('failure')),
-                    'ci-frontend.yml': runs('Frontend CI', ['success']),
-                },
-                { rateLimitRemaining: 50 }
-            )
-            const { outputs } = await run(github)
-            expect(outputs.action).toBe('create')
-            expect(outputs.rate_limit_action).toBe('create')
-        })
     })
 
     describe('red commit streak', () => {

--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -11,8 +11,8 @@
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 const EVENT_NAME = 'github_rate_limit_observed'
 
-async function captureEvent({ posthogToken, event, distinctId, properties, timestamp }) {
-    const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+async function captureEvent({ fetchImpl, posthogToken, event, distinctId, properties, timestamp }) {
+    const res = await fetchImpl(`${POSTHOG_HOST}/capture/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -29,10 +29,9 @@ async function captureEvent({ posthogToken, event, distinctId, properties, times
     }
 }
 
-function buildProperties({ resource, snapshot, observedAt, repo, runId }) {
+function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId }) {
     const used = typeof snapshot.used === 'number' ? snapshot.used : snapshot.limit - snapshot.remaining
     const utilization = snapshot.limit > 0 ? used / snapshot.limit : 0
-    const nowSeconds = Math.floor(Date.parse(observedAt) / 1000)
     return {
         repo,
         resource,
@@ -41,7 +40,7 @@ function buildProperties({ resource, snapshot, observedAt, repo, runId }) {
         limit: snapshot.limit,
         utilization,
         reset_at: new Date(snapshot.reset * 1000).toISOString(),
-        reset_in_seconds: Math.max(0, snapshot.reset - nowSeconds),
+        reset_in_seconds: Math.max(0, snapshot.reset - observedAtSeconds),
         source: 'github_token',
         observed_at: observedAt,
         workflow_run_id: runId || null,
@@ -49,10 +48,10 @@ function buildProperties({ resource, snapshot, observedAt, repo, runId }) {
 }
 
 module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch } = {}) => {
-    if (_fetch) {
-        global.fetch = _fetch
-    }
-    const observedAt = (_now ? _now() : new Date()).toISOString()
+    const fetchImpl = _fetch || fetch
+    const observedAtDate = _now ? _now() : new Date()
+    const observedAt = observedAtDate.toISOString()
+    const observedAtSeconds = Math.floor(observedAtDate.getTime() / 1000)
     const repo = `${context.repo.owner}/${context.repo.repo}`
     const runId = process.env.GITHUB_RUN_ID || null
 
@@ -71,10 +70,11 @@ module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch } 
     let failures = 0
     for (const [resource, snapshot] of Object.entries(resources)) {
         if (!snapshot || typeof snapshot.limit !== 'number' || typeof snapshot.remaining !== 'number') continue
-        const properties = buildProperties({ resource, snapshot, observedAt, repo, runId })
+        const properties = buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId })
         core.info(`${resource}: ${properties.remaining}/${properties.limit} remaining (resets ${properties.reset_at})`)
         try {
             await captureEvent({
+                fetchImpl,
                 posthogToken,
                 event: EVENT_NAME,
                 distinctId: repo,

--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -1,0 +1,97 @@
+// Polls GitHub's /rate_limit endpoint and emits one PostHog event per resource.
+//
+// The default github-script auth is the workflow's $GITHUB_TOKEN, so the snapshot
+// reflects this repository's per-repo bucket — the slice that GitHub's org-level
+// API Insights dashboard does not surface (search, graphql, code_search included
+// for parity even though they have separate buckets).
+//
+// /rate_limit calls themselves do not consume the budget they observe, so this
+// monitor is safe to run on a tight cron without distorting its own measurement.
+
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+const EVENT_NAME = 'github_rate_limit_observed'
+
+async function captureEvent({ posthogToken, event, distinctId, properties, timestamp }) {
+    const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            api_key: posthogToken,
+            event,
+            distinct_id: distinctId,
+            properties,
+            timestamp,
+        }),
+    })
+    if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        throw new Error(`capture ${res.status}: ${body.slice(0, 200)}`)
+    }
+}
+
+function buildProperties({ resource, snapshot, observedAt, repo, runId }) {
+    const used = typeof snapshot.used === 'number' ? snapshot.used : snapshot.limit - snapshot.remaining
+    const utilization = snapshot.limit > 0 ? used / snapshot.limit : 0
+    const nowSeconds = Math.floor(Date.parse(observedAt) / 1000)
+    return {
+        repo,
+        resource,
+        used,
+        remaining: snapshot.remaining,
+        limit: snapshot.limit,
+        utilization,
+        reset_at: new Date(snapshot.reset * 1000).toISOString(),
+        reset_in_seconds: Math.max(0, snapshot.reset - nowSeconds),
+        source: 'github_token',
+        observed_at: observedAt,
+        workflow_run_id: runId || null,
+    }
+}
+
+module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch } = {}) => {
+    if (_fetch) {
+        global.fetch = _fetch
+    }
+    const observedAt = (_now ? _now() : new Date()).toISOString()
+    const repo = `${context.repo.owner}/${context.repo.repo}`
+    const runId = process.env.GITHUB_RUN_ID || null
+
+    const posthogToken = process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN
+    if (!posthogToken) {
+        core.warning('POSTHOG_DEVEX_PROJECT_API_TOKEN not set; nothing to emit')
+        core.setOutput('emitted', '0')
+        core.setOutput('failures', '0')
+        return
+    }
+
+    const { data } = await github.rest.rateLimit.get()
+    const resources = data?.resources || {}
+
+    let emitted = 0
+    let failures = 0
+    for (const [resource, snapshot] of Object.entries(resources)) {
+        if (!snapshot || typeof snapshot.limit !== 'number' || typeof snapshot.remaining !== 'number') continue
+        const properties = buildProperties({ resource, snapshot, observedAt, repo, runId })
+        core.info(`${resource}: ${properties.remaining}/${properties.limit} remaining (resets ${properties.reset_at})`)
+        try {
+            await captureEvent({
+                posthogToken,
+                event: EVENT_NAME,
+                distinctId: repo,
+                properties,
+                timestamp: observedAt,
+            })
+            emitted++
+        } catch (err) {
+            failures++
+            core.warning(`Failed to emit ${resource}: ${err.message}`)
+        }
+    }
+
+    core.info(`Emitted ${emitted} event(s); ${failures} failure(s)`)
+    core.setOutput('emitted', String(emitted))
+    core.setOutput('failures', String(failures))
+}
+
+module.exports.buildProperties = buildProperties
+module.exports.captureEvent = captureEvent

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -3,36 +3,22 @@ const monitor = require('./monitor-github-rate-limit')
 const T_BASE = new Date('2026-04-27T18:00:00Z')
 const T_BASE_SECONDS = Math.floor(T_BASE.getTime() / 1000)
 
-function snapshot({ remaining, limit, used, resetSecondsFromBase = 1800 }) {
-    return {
-        remaining,
-        limit,
-        used: used ?? limit - remaining,
-        reset: T_BASE_SECONDS + resetSecondsFromBase,
-    }
-}
+const snapshot = ({ remaining, limit, resetSecondsFromBase = 1800 }) => ({
+    remaining,
+    limit,
+    used: limit - remaining,
+    reset: T_BASE_SECONDS + resetSecondsFromBase,
+})
 
-function createGithubMock(resources) {
-    return {
-        rest: {
-            rateLimit: {
-                get: jest.fn(() => Promise.resolve({ data: { resources } })),
-            },
-        },
-    }
-}
+const createGithubMock = (resources) => ({
+    rest: { rateLimit: { get: jest.fn(() => Promise.resolve({ data: { resources } })) } },
+})
 
-function createCore() {
-    return {
-        info: jest.fn(),
-        warning: jest.fn(),
-        setOutput: jest.fn(),
-    }
-}
-
-const context = { repo: { owner: 'PostHog', repo: 'posthog' } }
+const createCore = () => ({ info: jest.fn(), warning: jest.fn(), setOutput: jest.fn() })
 
 const fetchOk = () => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('ok') })
+
+const context = { repo: { owner: 'PostHog', repo: 'posthog' } }
 
 describe('monitor-github-rate-limit', () => {
     const ORIGINAL_ENV = process.env
@@ -40,143 +26,53 @@ describe('monitor-github-rate-limit', () => {
     beforeEach(() => {
         process.env = { ...ORIGINAL_ENV }
         delete process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN
-        delete process.env.GITHUB_RUN_ID
     })
 
     afterAll(() => {
         process.env = ORIGINAL_ENV
     })
 
-    test('emits one event per resource', async () => {
+    test('emits one event per resource with the expected payload shape', async () => {
         process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
-        const fetchMock = jest.fn(fetchOk)
-        const core = createCore()
-        const github = createGithubMock({
-            core: snapshot({ remaining: 12000, limit: 15000 }),
-            search: snapshot({ remaining: 30, limit: 30 }),
-            graphql: snapshot({ remaining: 5000, limit: 5000 }),
-        })
-
-        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
-
-        expect(fetchMock).toHaveBeenCalledTimes(3)
-        expect(core.setOutput).toHaveBeenCalledWith('emitted', '3')
-        expect(core.setOutput).toHaveBeenCalledWith('failures', '0')
-    })
-
-    test('skips emission when devex token is not configured', async () => {
-        const fetchMock = jest.fn(fetchOk)
-        const core = createCore()
-        const github = createGithubMock({ core: snapshot({ remaining: 1, limit: 15000 }) })
-
-        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
-
-        expect(fetchMock).not.toHaveBeenCalled()
-        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('POSTHOG_DEVEX_PROJECT_API_TOKEN'))
-        expect(core.setOutput).toHaveBeenCalledWith('emitted', '0')
-    })
-
-    test('skips malformed snapshots without crashing', async () => {
-        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
-        const fetchMock = jest.fn(fetchOk)
-        const core = createCore()
-        const github = createGithubMock({
-            core: snapshot({ remaining: 1000, limit: 15000 }),
-            broken: { limit: 'whoops' },
-            empty: null,
-            partial: { limit: 100 }, // missing remaining
-        })
-
-        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
-
-        expect(fetchMock).toHaveBeenCalledTimes(1)
-        expect(core.setOutput).toHaveBeenCalledWith('emitted', '1')
-        expect(core.setOutput).toHaveBeenCalledWith('failures', '0')
-    })
-
-    test('counts capture failures without aborting subsequent emissions', async () => {
-        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
-        let calls = 0
-        const fetchMock = jest.fn(() => {
-            calls++
-            if (calls === 1) {
-                return Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('boom') })
-            }
-            return fetchOk()
-        })
-        const core = createCore()
-        const github = createGithubMock({
-            core: snapshot({ remaining: 12000, limit: 15000 }),
-            graphql: snapshot({ remaining: 4000, limit: 5000 }),
-        })
-
-        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
-
-        expect(fetchMock).toHaveBeenCalledTimes(2)
-        expect(core.setOutput).toHaveBeenCalledWith('emitted', '1')
-        expect(core.setOutput).toHaveBeenCalledWith('failures', '1')
-        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('capture 500'))
-    })
-
-    test('payload includes utilization, reset metadata, and run id', async () => {
-        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
-        process.env.GITHUB_RUN_ID = '42'
         const captured = []
         const fetchMock = jest.fn((_url, opts) => {
             captured.push(JSON.parse(opts.body))
             return fetchOk()
         })
-        const core = createCore()
         const github = createGithubMock({
             core: snapshot({ remaining: 3000, limit: 15000, resetSecondsFromBase: 600 }),
+            graphql: snapshot({ remaining: 5000, limit: 5000 }),
         })
+        const core = createCore()
 
         await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
 
-        expect(captured).toHaveLength(1)
-        const payload = captured[0]
-        expect(payload).toMatchObject({
+        expect(captured).toHaveLength(2)
+        expect(captured[0]).toMatchObject({
             api_key: 'devex-key',
             event: 'github_rate_limit_observed',
             distinct_id: 'PostHog/posthog',
-            timestamp: T_BASE.toISOString(),
+            properties: {
+                resource: 'core',
+                used: 12000,
+                remaining: 3000,
+                limit: 15000,
+                source: 'github_token',
+                reset_in_seconds: 600,
+            },
         })
-        expect(payload.properties).toMatchObject({
-            repo: 'PostHog/posthog',
-            resource: 'core',
-            used: 12000,
-            remaining: 3000,
-            limit: 15000,
-            source: 'github_token',
-            workflow_run_id: '42',
-            reset_in_seconds: 600,
-        })
-        expect(payload.properties.utilization).toBeCloseTo(12000 / 15000)
-        expect(payload.properties.reset_at).toBe(new Date((T_BASE_SECONDS + 600) * 1000).toISOString())
-    })
-})
-
-describe('buildProperties', () => {
-    test('falls back to limit-remaining when used is missing', () => {
-        const props = monitor.buildProperties({
-            resource: 'core',
-            snapshot: { remaining: 4000, limit: 15000, reset: T_BASE_SECONDS + 60 },
-            observedAt: T_BASE.toISOString(),
-            repo: 'PostHog/posthog',
-            runId: null,
-        })
-        expect(props.used).toBe(11000)
-        expect(props.utilization).toBeCloseTo(11000 / 15000)
+        expect(captured[0].properties.utilization).toBeCloseTo(12000 / 15000)
+        expect(core.setOutput).toHaveBeenCalledWith('emitted', '2')
     })
 
-    test('handles already-reset bucket without negative reset_in_seconds', () => {
-        const props = monitor.buildProperties({
-            resource: 'core',
-            snapshot: { remaining: 15000, limit: 15000, used: 0, reset: T_BASE_SECONDS - 60 },
-            observedAt: T_BASE.toISOString(),
-            repo: 'PostHog/posthog',
-            runId: null,
-        })
-        expect(props.reset_in_seconds).toBe(0)
+    test('skips emission when devex token is not configured', async () => {
+        const fetchMock = jest.fn(fetchOk)
+        const github = createGithubMock({ core: snapshot({ remaining: 1, limit: 15000 }) })
+        const core = createCore()
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(fetchMock).not.toHaveBeenCalled()
+        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('POSTHOG_DEVEX_PROJECT_API_TOKEN'))
     })
 })

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -65,6 +65,27 @@ describe('monitor-github-rate-limit', () => {
         expect(core.setOutput).toHaveBeenCalledWith('emitted', '2')
     })
 
+    test('counts capture failures without aborting later emissions', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        let calls = 0
+        const fetchMock = jest.fn(() =>
+            ++calls === 1
+                ? Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('boom') })
+                : fetchOk()
+        )
+        const github = createGithubMock({
+            core: snapshot({ remaining: 3000, limit: 15000 }),
+            graphql: snapshot({ remaining: 4000, limit: 5000 }),
+        })
+        const core = createCore()
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(core.setOutput).toHaveBeenCalledWith('emitted', '1')
+        expect(core.setOutput).toHaveBeenCalledWith('failures', '1')
+        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('capture 500'))
+    })
+
     test('skips emission when devex token is not configured', async () => {
         const fetchMock = jest.fn(fetchOk)
         const github = createGithubMock({ core: snapshot({ remaining: 1, limit: 15000 }) })

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -1,0 +1,182 @@
+const monitor = require('./monitor-github-rate-limit')
+
+const T_BASE = new Date('2026-04-27T18:00:00Z')
+const T_BASE_SECONDS = Math.floor(T_BASE.getTime() / 1000)
+
+function snapshot({ remaining, limit, used, resetSecondsFromBase = 1800 }) {
+    return {
+        remaining,
+        limit,
+        used: used ?? limit - remaining,
+        reset: T_BASE_SECONDS + resetSecondsFromBase,
+    }
+}
+
+function createGithubMock(resources) {
+    return {
+        rest: {
+            rateLimit: {
+                get: jest.fn(() => Promise.resolve({ data: { resources } })),
+            },
+        },
+    }
+}
+
+function createCore() {
+    return {
+        info: jest.fn(),
+        warning: jest.fn(),
+        setOutput: jest.fn(),
+    }
+}
+
+const context = { repo: { owner: 'PostHog', repo: 'posthog' } }
+
+const fetchOk = () => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('ok') })
+
+describe('monitor-github-rate-limit', () => {
+    const ORIGINAL_ENV = process.env
+
+    beforeEach(() => {
+        process.env = { ...ORIGINAL_ENV }
+        delete process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN
+        delete process.env.GITHUB_RUN_ID
+    })
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV
+    })
+
+    test('emits one event per resource', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        const fetchMock = jest.fn(fetchOk)
+        const core = createCore()
+        const github = createGithubMock({
+            core: snapshot({ remaining: 12000, limit: 15000 }),
+            search: snapshot({ remaining: 30, limit: 30 }),
+            graphql: snapshot({ remaining: 5000, limit: 5000 }),
+        })
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(fetchMock).toHaveBeenCalledTimes(3)
+        expect(core.setOutput).toHaveBeenCalledWith('emitted', '3')
+        expect(core.setOutput).toHaveBeenCalledWith('failures', '0')
+    })
+
+    test('skips emission when devex token is not configured', async () => {
+        const fetchMock = jest.fn(fetchOk)
+        const core = createCore()
+        const github = createGithubMock({ core: snapshot({ remaining: 1, limit: 15000 }) })
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(fetchMock).not.toHaveBeenCalled()
+        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('POSTHOG_DEVEX_PROJECT_API_TOKEN'))
+        expect(core.setOutput).toHaveBeenCalledWith('emitted', '0')
+    })
+
+    test('skips malformed snapshots without crashing', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        const fetchMock = jest.fn(fetchOk)
+        const core = createCore()
+        const github = createGithubMock({
+            core: snapshot({ remaining: 1000, limit: 15000 }),
+            broken: { limit: 'whoops' },
+            empty: null,
+            partial: { limit: 100 }, // missing remaining
+        })
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(core.setOutput).toHaveBeenCalledWith('emitted', '1')
+        expect(core.setOutput).toHaveBeenCalledWith('failures', '0')
+    })
+
+    test('counts capture failures without aborting subsequent emissions', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        let calls = 0
+        const fetchMock = jest.fn(() => {
+            calls++
+            if (calls === 1) {
+                return Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('boom') })
+            }
+            return fetchOk()
+        })
+        const core = createCore()
+        const github = createGithubMock({
+            core: snapshot({ remaining: 12000, limit: 15000 }),
+            graphql: snapshot({ remaining: 4000, limit: 5000 }),
+        })
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(core.setOutput).toHaveBeenCalledWith('emitted', '1')
+        expect(core.setOutput).toHaveBeenCalledWith('failures', '1')
+        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('capture 500'))
+    })
+
+    test('payload includes utilization, reset metadata, and run id', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        process.env.GITHUB_RUN_ID = '42'
+        const captured = []
+        const fetchMock = jest.fn((_url, opts) => {
+            captured.push(JSON.parse(opts.body))
+            return fetchOk()
+        })
+        const core = createCore()
+        const github = createGithubMock({
+            core: snapshot({ remaining: 3000, limit: 15000, resetSecondsFromBase: 600 }),
+        })
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        expect(captured).toHaveLength(1)
+        const payload = captured[0]
+        expect(payload).toMatchObject({
+            api_key: 'devex-key',
+            event: 'github_rate_limit_observed',
+            distinct_id: 'PostHog/posthog',
+            timestamp: T_BASE.toISOString(),
+        })
+        expect(payload.properties).toMatchObject({
+            repo: 'PostHog/posthog',
+            resource: 'core',
+            used: 12000,
+            remaining: 3000,
+            limit: 15000,
+            source: 'github_token',
+            workflow_run_id: '42',
+            reset_in_seconds: 600,
+        })
+        expect(payload.properties.utilization).toBeCloseTo(12000 / 15000)
+        expect(payload.properties.reset_at).toBe(new Date((T_BASE_SECONDS + 600) * 1000).toISOString())
+    })
+})
+
+describe('buildProperties', () => {
+    test('falls back to limit-remaining when used is missing', () => {
+        const props = monitor.buildProperties({
+            resource: 'core',
+            snapshot: { remaining: 4000, limit: 15000, reset: T_BASE_SECONDS + 60 },
+            observedAt: T_BASE.toISOString(),
+            repo: 'PostHog/posthog',
+            runId: null,
+        })
+        expect(props.used).toBe(11000)
+        expect(props.utilization).toBeCloseTo(11000 / 15000)
+    })
+
+    test('handles already-reset bucket without negative reset_in_seconds', () => {
+        const props = monitor.buildProperties({
+            resource: 'core',
+            snapshot: { remaining: 15000, limit: 15000, used: 0, reset: T_BASE_SECONDS - 60 },
+            observedAt: T_BASE.toISOString(),
+            repo: 'PostHog/posthog',
+            runId: null,
+        })
+        expect(props.reset_in_seconds).toBe(0)
+    })
+})

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -19,7 +19,6 @@ env:
     SLACK_CHANNEL: 'C0AS64N6DJL' # #alerts-devex
     WORKFLOW_FAILURE_STREAK_THRESHOLD: '5'
     COMMIT_FAILURE_STREAK_THRESHOLD: '10'
-    RATE_LIMIT_THRESHOLD_PERCENT: '10'
     # Keep in sync with ci-master-status.yml watched workflows
     WATCHED_WORKFLOWS: 'ci-backend.yml,ci-nodejs.yml,ci-frontend.yml,ci-storybook.yml,ci-security.yaml,ci-dagster.yml,ci-e2e-playwright.yml,ci-rust.yml'
     CRITICAL_WORKFLOWS: 'ci-backend.yml,ci-frontend.yml,ci-e2e-playwright.yml'
@@ -227,57 +226,6 @@ jobs:
                           text:
                             type: "mrkdwn"
                             text: ":large_green_circle: *Master stable again* (streak ended after ${{ steps.check.outputs.commit_failure_streak_last_count }} consecutive red commits)"
-
-            # ============ RATE LIMIT: CREATE ============
-
-            - name: Post rate limit alert to Slack
-              if: steps.check.outputs.rate_limit_action == 'create'
-              id: slack_rate_limit
-              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-              with:
-                  method: chat.postMessage
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  errors: true
-                  payload: |
-                      channel: "${{ env.SLACK_CHANNEL }}"
-                      text: ":warning: GitHub API rate limit critically low (${{ steps.check.outputs.rate_limit_remaining }}/${{ steps.check.outputs.rate_limit_limit }} remaining, resets in ~${{ steps.check.outputs.rate_limit_reset_mins }} min)"
-                      blocks:
-                        - type: "section"
-                          text:
-                            type: "mrkdwn"
-                            text: ":warning: *GitHub API rate limit critically low*\n${{ steps.check.outputs.rate_limit_remaining }}/${{ steps.check.outputs.rate_limit_limit }} remaining — resets in ~${{ steps.check.outputs.rate_limit_reset_mins }} min\nCI monitoring may be blind — workflow status checks could fail silently."
-
-            - name: Save rate limit Slack info to state
-              if: steps.check.outputs.rate_limit_action == 'create'
-              env:
-                  SLACK_CHANNEL_ID: ${{ steps.slack_rate_limit.outputs.channel_id }}
-                  SLACK_TS: ${{ steps.slack_rate_limit.outputs.ts }}
-              run: |
-                  jq \
-                    --arg channel "$SLACK_CHANNEL_ID" \
-                    --arg ts "$SLACK_TS" \
-                    '. + {rate_limit_slack_channel: $channel, rate_limit_slack_ts: $ts}' \
-                    .alerts-devex > .alerts-devex.tmp
-                  mv .alerts-devex.tmp .alerts-devex
-
-            # ============ RATE LIMIT: RESOLVE ============
-
-            - name: Update rate limit alert to resolved
-              if: steps.check.outputs.rate_limit_action == 'resolve'
-              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-              with:
-                  method: chat.update
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  errors: true
-                  payload: |
-                      channel: "${{ steps.check.outputs.rate_limit_slack_channel }}"
-                      ts: "${{ steps.check.outputs.rate_limit_slack_ts }}"
-                      text: "GitHub API rate limit recovered :v:"
-                      blocks:
-                        - type: "section"
-                          text:
-                            type: "mrkdwn"
-                            text: "*GitHub API rate limit recovered* :v:"
 
             # ============ CACHE ============
 

--- a/.github/workflows/monitor-github-rate-limit.yml
+++ b/.github/workflows/monitor-github-rate-limit.yml
@@ -1,0 +1,36 @@
+name: Monitor GitHub Rate Limit
+
+# Polls /rate_limit and emits one PostHog event per resource, so the per-repo
+# GITHUB_TOKEN bucket is observable as a time series — that bucket is the slice
+# of GitHub API usage that the org-level API Insights dashboard does not cover.
+#
+# Alerting belongs downstream in PostHog (windowed thresholds, attribution by
+# repo) — not in the workflow itself. Keep this file focused on emission.
+
+on:
+    schedule:
+        - cron: '*/5 * * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    poll:
+        runs-on: ubuntu-latest
+        timeout-minutes: 3
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  sparse-checkout: |
+                      .github/scripts/monitor-github-rate-limit.js
+                  sparse-checkout-cone-mode: false
+
+            - name: Poll /rate_limit and emit to PostHog
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              with:
+                  script: |
+                      const script = require('./.github/scripts/monitor-github-rate-limit.js')
+                      await script({ github, context, core })


### PR DESCRIPTION
## Problem

GitHub's [API Insights dashboard](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-programmatic-access-to-your-organization/viewing-api-insights-in-your-organization) does not surface the bucket that actually fails on us in CI: **GitHub Actions `GITHUB_TOKEN`** traffic. Per GitHub's docs:

> "API activity for search, GitHub Actions (using the `GITHUB_TOKEN` secret), and secondary rate-limiting are not supported."

That's the slice that produces `API rate limit exceeded for installation` errors during heavy CI bursts (`dorny/paths-filter`, CodeQL, comment-resolution bots). On Enterprise Cloud the per-repo `GITHUB_TOKEN` cap is a flat 15,000/hr — shared across every concurrent Actions job in a repo — and we have no retrospective visibility into how close we get.

## Changes

A small, self-contained workflow that polls `GET /rate_limit` every 5 minutes and emits one PostHog event per resource (`core`, `search`, `graphql`, `code_search`, etc.) to the DevEx project.

- `.github/workflows/monitor-github-rate-limit.yml` — cron-only, sparse-checkout, single step.
- `.github/scripts/monitor-github-rate-limit.js` — calls `github.rest.rateLimit.get()` and POSTs to `https://us.i.posthog.com/capture/`. Default `$GITHUB_TOKEN` auth, so the snapshot reflects this repo's per-repo bucket. `/rate_limit` calls don't consume the budget they observe.
- `.github/scripts/monitor-github-rate-limit.test.js` — minimal coverage (payload shape + missing-token guard).

The same commit **extracts the rate-limit threshold logic out of the existing `ci-alerts-devex` workflow** (script + workflow steps + tests). That workflow is currently disabled. We don't want to tie the new monitor into that disabled workflow.

Event shape (`distinct_id = repo`, future-proof for expanding to other repos):

```json
{
  "event": "github_rate_limit_observed",
  "distinct_id": "PostHog/posthog",
  "properties": {
    "resource": "core",
    "used": 12000, "remaining": 3000, "limit": 15000,
    "utilization": 0.8,
    "reset_at": "...", "reset_in_seconds": 600,
    "source": "github_token"
  }
}