### PR TITLE
feat(logs): Attribute scrubbing

### DIFF
--- a/nodejs/src/logs-ingestion/log-pii-scrub.test.ts
+++ b/nodejs/src/logs-ingestion/log-pii-scrub.test.ts
@@ -132,7 +132,7 @@ describe('log-pii-scrub', () => {
             expect(r.body).toBe(`plain ${PII_REDACTED} log`)
         })
 
-        it('does not mutate attributes, resource_attributes, or metadata string fields', () => {
+        it('scrubs pattern-shaped PII in log attributes; does not mutate resource_attributes or metadata string fields', () => {
             const r = baseRecord()
             r.body = 'ok'
             r.attributes = { safe: 'ok', auth_token: 'secret@x.com' }
@@ -143,12 +143,21 @@ describe('log-pii-scrub', () => {
             r.instrumentation_scope = 'scope@lib.example'
             scrubLogRecord(r)
             expect(r.body).toBe('ok')
-            expect(r.attributes).toEqual({ safe: 'ok', auth_token: 'secret@x.com' })
+            expect(r.attributes).toEqual({ safe: 'ok', auth_token: PII_REDACTED })
             expect(r.resource_attributes).toEqual({ host: 'srv', note: 'x@example.com' })
             expect(r.service_name).toBe('svc@corp.example')
             expect(r.severity_text).toBe('warn ops@example.com')
             expect(r.event_name).toBe('evt user@host.invalid')
             expect(r.instrumentation_scope).toBe('scope@lib.example')
+        })
+
+        it('scrubs log attributes when body is null (no early return)', () => {
+            const r = baseRecord()
+            r.body = null
+            r.attributes = { x: 'a@b.co' }
+            const stats = scrubLogRecord(r)
+            expect(r.attributes).toEqual({ x: PII_REDACTED })
+            expect(stats.piiReplacements).toBe(1)
         })
 
         it('scrubs pattern-shaped PII in JSON array body string; does not redact by JSON key alone', () => {

--- a/nodejs/src/logs-ingestion/log-pii-scrub.ts
+++ b/nodejs/src/logs-ingestion/log-pii-scrub.ts
@@ -84,5 +84,5 @@ export function scrubLogRecord(record: LogRecord): PiiScrubStats {
         }
     }
 
-    return { piiReplacements }
+    return piiReplacements === 0 ? EMPTY_PII : { piiReplacements }
 }

--- a/nodejs/src/logs-ingestion/log-pii-scrub.ts
+++ b/nodejs/src/logs-ingestion/log-pii-scrub.ts
@@ -1,7 +1,7 @@
 /**
- * Lossy ingestion scrub: replace matches with PII_REDACTED ({{REDACTED}}). Only `record.body` is scrubbed — one
- * RE2 pass over the raw UTF-8 string (no JSON parse). Rules: Bearer-shaped tokens, Stripe `sk_*` keys, email
- * addresses. OTLP `attributes` / `resource_attributes` and other string fields are not modified here.
+ * Lossy ingestion scrub: replace matches with PII_REDACTED ({{REDACTED}}). Scrubs `record.body` and each value in
+ * `record.attributes` (no JSON parse). Rules: Bearer-shaped tokens, Stripe `sk_*` keys, email addresses.
+ * `resource_attributes` and other string fields (e.g. `service_name`, `severity_text`) are not modified here.
  *
  * **Not guaranteed:** secrets only discoverable by JSON object keys inside `body` (no tree walk), values only in
  * JSON number/boolean leaves. PAN-like digit runs are not redacted.
@@ -63,12 +63,26 @@ export function scrubPlainString(input: string): string {
     return scrubPlainStringWithStats(input).output
 }
 
-/** Mutate record in place: `body` only. Returns PII replacement count for that record. */
+/**
+ * Mutate record in place: `body` and each `attributes` value.
+ * `piiReplacements` is the sum of all successful redactions (body + every attribute value), not split by field.
+ */
 export function scrubLogRecord(record: LogRecord): PiiScrubStats {
-    if (record.body == null) {
-        return EMPTY_PII
+    let piiReplacements = 0
+
+    if (record.body != null) {
+        const { output, piiReplacements: n } = scrubPlainStringWithStats(record.body)
+        record.body = output
+        piiReplacements += n
     }
-    const { output, piiReplacements } = scrubPlainStringWithStats(record.body)
-    record.body = output
+
+    if (record.attributes != null) {
+        for (const [key, val] of Object.entries(record.attributes)) {
+            const { output, piiReplacements: n } = scrubPlainStringWithStats(val)
+            record.attributes[key] = output
+            piiReplacements += n
+        }
+    }
+
     return { piiReplacements }
 }

--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -517,6 +517,37 @@ describe('log-record-avro', () => {
             expect(body.message).toContain('{{REDACTED}}')
         })
 
+        it('scrubs log attributes when json parse is off and pii scrub is on', async () => {
+            const records: LogRecord[] = [
+                {
+                    uuid: 'test-uuid',
+                    trace_id: null,
+                    span_id: null,
+                    trace_flags: null,
+                    timestamp: null,
+                    observed_timestamp: null,
+                    body: 'plain',
+                    severity_text: null,
+                    severity_number: null,
+                    service_name: null,
+                    resource_attributes: null,
+                    instrumentation_scope: null,
+                    event_name: null,
+                    attributes: { note: 'only-attr@example.com' },
+                },
+            ]
+
+            const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
+            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
+                json_parse_logs: false,
+                pii_scrub_logs: true,
+            })
+            expect(pii.piiReplacements).toBe(1)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            expect(decoded[0]?.body).toBe('plain')
+            expect(decoded[0]?.attributes).toEqual({ note: PII_REDACTED })
+        })
+
         it('scrubs body then enriches when both JSON parse and PII scrub are on', async () => {
             const records: LogRecord[] = [
                 {
@@ -542,12 +573,12 @@ describe('log-record-avro', () => {
                 json_parse_logs: true,
                 pii_scrub_logs: true,
             })
-            expect(pii.piiReplacements).toBe(1)
+            expect(pii.piiReplacements).toBe(2)
             const [_, __, decoded] = await decodeLogRecords(outputBuffer)
             expect(decoded[0]?.attributes).toEqual({
                 level: encodeAttributeCell('info'),
                 message: encodeAttributeCell(PII_REDACTED),
-                note: 'c@d.co',
+                note: PII_REDACTED,
             })
         })
 


### PR DESCRIPTION
## Problem

log **`attributes`** (the string map on each log record) are independent of the log **body**. PII scrubbing only ran on `body`, so the same pattern-based redaction (email, Bearer token shape, Stripe `sk_*` keys) could be applied to the body but **not** to values already present on `record.attributes`—including cases where those attributes “win” on merge with body-derived JSON keys. This could leave PII in stored log attributes when `pii_scrub_logs` is on.

## Changes

- **`scrubLogRecord`** ([`nodejs/src/logs-ingestion/log-pii-scrub.ts`](nodejs/src/logs-ingestion/log-pii-scrub.ts)): run the same `scrubPlainStringWithStats` (RE2) pass on **each value** in `record.attributes` (in place), in addition to `body`. **No** scrub of `resource_attributes` or other top-level string fields in this change.
- **Null body:** if `body` is null but `attributes` is set, attribute values are still scrubbed (removed early return that skipped the whole record).
- **`piiReplacements`:** single total per record = redactions in `body` + all attribute value strings.
- **Tests:** updated/added in [`log-pii-scrub.test.ts`](nodejs/src/logs-ingestion/log-pii-scrub.test.ts) and [`log-record-avro.test.ts`](nodejs/src/logs-ingestion/log-record-avro.test.ts) (including `json_parse` off + PII in attributes only, and wire `note` + body both contributing to the count).

**Expected impact:** Slightly more CPU on the PII path (one regex pass per attribute value string; same complexity class as an extra “mini body” per key). Slightly higher `pii_replacements` / usage stats when the same patterns appear in both body and attributes. Stored log attributes should no longer contain those pattern classes when PII scrub is enabled.

## How did you test this code?

- **Automated:** Jest unit/integration coverage in `log-pii-scrub.test.ts` and `log-record-avro.test.ts` (assertions for scrubbed attribute values, combined `pii` counts, and `json_parse` off + attributes-only case). Typecheck: `pnpm exec tsc --noEmit` from `nodejs` in an environment where it succeeds.
- I’m an **agent** and did not run a full E2E OTLP/curl or production-like ingest in your environment. For manual smoke: send logs with PII in **log** `attributes` (not only in `body`) with `pii_scrub_logs` on and confirm values show `{{REDACTED}}` where the regex matches.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

**No** (internal ingestion behavior fix; not user-facing product change unless you want to call out stricter PII on attributes in release notes—optional).

## Docs update

**No** required; optional note in logs/PII docs that scrub applies to **log** `body` and **log** `attribute` **values** when the team setting is on.

## LLM context

- **Scope:** Regex PII scrub extended from `LogRecord.body` to each `LogRecord.attributes` value; `resource_attributes` unchanged.
- **Call site:** Unchanged order in `processLogMessageBuffer`: decode → PII scrub → (optional) parse / JSON enrich → encode.
- **Review focus:** Hot-path cost (extra `replace` per attribute value), correctness of `piiReplacements` aggregation for metrics, and that OTLP/capture string encoding in attribute values still matches substrings the regex was written for.