### PR TITLE
ci: add concurrency cancellation + lint guard

### DIFF
--- a/.github/scripts/check-ci-concurrency.py
+++ b/.github/scripts/check-ci-concurrency.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+# ruff: noqa: T201 allow print statements
+"""
+CI script to verify PR-triggered GitHub Actions workflows declare top-level concurrency.
+
+Without `concurrency:`, every push to a PR branch starts a fresh run while the
+in-flight one keeps burning minutes. The repo convention (used by 30+ workflows)
+is:
+
+    concurrency:
+        group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+        cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+Usage:
+    uv run .github/scripts/check-ci-concurrency.py
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / "workflows"
+
+# Workflows intentionally exempt from concurrency cancellation.
+# Each entry has a one-line reason so the next reader knows why.
+SKIP = {
+    # Telemetry / shadow measurement — cancelling stale runs may drop data.
+    "ci-test-selection-shadow.yml",
+    # Schedule-dominant; PR trigger filtered to a single script — cosmetic gain.
+    "ci-backend-update-test-timing.yml",
+    # Migration enforcement; arguably wants to complete on every PR state.
+    "ci-migrations-service-separation-check.yml",
+}
+
+PR_TRIGGERS = {"pull_request", "pull_request_target"}
+
+
+def is_pr_triggered(triggers: object) -> bool:
+    if isinstance(triggers, str):
+        return triggers in PR_TRIGGERS
+    if isinstance(triggers, list):
+        return any(t in PR_TRIGGERS for t in triggers)
+    if isinstance(triggers, dict):
+        return any(t in PR_TRIGGERS for t in triggers)
+    return False
+
+
+def check_concurrency() -> list[str]:
+    errors: list[str] = []
+    for workflow_file in sorted(WORKFLOWS_DIR.glob("ci-*.y*ml")):
+        if workflow_file.name in SKIP:
+            continue
+
+        with open(workflow_file) as f:
+            try:
+                data = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                errors.append(f"{workflow_file.name}: failed to parse YAML: {e}")
+                continue
+
+        if not isinstance(data, dict):
+            continue
+
+        # PyYAML parses the top-level `on:` key as boolean True.
+        triggers = data.get(True, data.get("on"))
+        if not is_pr_triggered(triggers):
+            continue
+
+        if "concurrency" not in data:
+            errors.append(f"{workflow_file.name}: missing top-level concurrency block")
+
+    return errors
+
+
+def main() -> None:
+    errors = check_concurrency()
+    if errors:
+        print(f"Found {len(errors)} PR-triggered workflow(s) missing concurrency:\n")
+        for error in errors:
+            print(f"  - {error}")
+        print("\nAdd this block after `on:`:\n")
+        print("concurrency:")
+        print("    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}")
+        print("    cancel-in-progress: ${{ github.event_name == 'pull_request' }}")
+        sys.exit(1)
+    else:
+        print("All PR-triggered ci-*.yml workflows have concurrency configured.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/check-ci-concurrency.py
+++ b/.github/scripts/check-ci-concurrency.py
@@ -83,10 +83,12 @@ def main() -> None:
         print(f"Found {len(errors)} PR-triggered workflow(s) missing concurrency:\n")
         for error in errors:
             print(f"  - {error}")
-        print("\nAdd this block after `on:`:\n")
+        print("\nFix by adding this block after `on:`:\n")
         print("concurrency:")
         print("    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}")
         print("    cancel-in-progress: ${{ github.event_name == 'pull_request' }}")
+        print("\nOr, if cancelling stale runs would lose data (telemetry, schedule-only PR triggers, etc.),")
+        print(f"add the filename to the SKIP set in {Path(__file__).name} with a one-line reason.")
         sys.exit(1)
     else:
         print("All PR-triggered ci-*.yml workflows have concurrency configured.")

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -7,6 +7,10 @@ on:
             - 'cli/**'
             - '.github/workflows/ci-cli.yml'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     tests:
         name: Run tests

--- a/.github/workflows/ci-dev-setup.yml
+++ b/.github/workflows/ci-dev-setup.yml
@@ -11,6 +11,10 @@ on:
             - 'pnpm-lock.yaml'
             - 'package.json'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 

--- a/.github/workflows/ci-hobby-installer.yml
+++ b/.github/workflows/ci-hobby-installer.yml
@@ -6,6 +6,10 @@ on:
             - '.github/workflows/ci-hobby-installer.yml'
             - 'bin/hobby-installer/**'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 

--- a/.github/workflows/ci-lint-workflows.yml
+++ b/.github/workflows/ci-lint-workflows.yml
@@ -7,6 +7,10 @@ on:
             - .github/scripts/**
             - services/**
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 
@@ -40,3 +44,13 @@ jobs:
               with:
                   version: '0.10.2'
             - run: uv run .github/scripts/check-dorny-paths-filter.py
+
+    check-concurrency:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@v6
+            - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+              with:
+                  version: '0.10.2'
+            - run: uv run .github/scripts/check-ci-concurrency.py

--- a/.github/workflows/ci-livestream-tui.yml
+++ b/.github/workflows/ci-livestream-tui.yml
@@ -6,6 +6,10 @@ on:
             - '.github/workflows/ci-livestream-tui.yml'
             - 'livestream/**'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -9,6 +9,10 @@ on:
             - '.github/workflows/ci-livestream.yml'
             - 'livestream/**'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 

--- a/.github/workflows/ci-openapi-codegen.yml
+++ b/.github/workflows/ci-openapi-codegen.yml
@@ -9,6 +9,10 @@ on:
             - '.github/workflows/ci-openapi-codegen.yml'
             - 'tools/openapi-codegen/**'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 

--- a/.github/workflows/ci-phrocs.yml
+++ b/.github/workflows/ci-phrocs.yml
@@ -9,6 +9,10 @@ on:
             - '.github/workflows/ci-phrocs.yml'
             - 'tools/phrocs/**'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
 

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -6,6 +6,10 @@ on:
     pull_request:
     merge_group:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
     pull-requests: read

--- a/.github/workflows/ci-survey-sdk-check.yml
+++ b/.github/workflows/ci-survey-sdk-check.yml
@@ -7,6 +7,10 @@ on:
             - 'docs/published/surveys/**'
             - 'frontend/bin/build-survey-sdk-docs.ts'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
     pull-requests: write


### PR DESCRIPTION
## Problem

13 PR-triggered `ci-*.yml` workflows lack the canonical top-level `concurrency:` block that 30+ siblings share. Every push to a PR branch starts a fresh run while the in-flight one keeps burning minutes. Continues the rollout from #54928...

## Changes

- Add the canonical concurrency block to 10 workflows: `ci-cli`, `ci-dev-setup`, `ci-hobby-installer`, `ci-lint-workflows`, `ci-livestream-tui`, `ci-livestream`, `ci-openapi-codegen`, `ci-phrocs`, `ci-proto`, `ci-survey-sdk-check`.
- Skip 3 with weak telemetry/scheduling intent (`ci-test-selection-shadow`, `ci-backend-update-test-timing`, `ci-migrations-service-separation-check`) — documented in a `SKIP` allowlist in the new lint.
- Add `.github/scripts/check-ci-concurrency.py` modeled on the existing `check-ci-timeouts.py`. Wired as a 4th job in `ci-lint-workflows.yml` so future drift is caught at PR time.

Out of scope: no changes to existing `cancel-in-progress` values, the 4 non-PR-triggered ci files, `cd-*.yml`, `pr-*.yml`, or `release.yml`.

## How did you test this code?

I'm an agent. Automated checks run:

- `uv run .github/scripts/check-ci-concurrency.py` — passes on the cleaned tree; verified it exits 1 with a useful message after stripping the block from one file, then passes again after restore.
- `uv run .github/scripts/check-ci-timeouts.py` — still passes (sanity).
- `grep -LE "^concurrency:" .github/workflows/ci-*.yml` returns exactly 7 files: 4 non-PR-triggered + 3 allowlisted.
- `ruff check` / `ruff format --check` clean on the new script.
- Pre-commit hooks (ruff, ty, yaml format) ran cleanly.

Not tested manually in the GitHub Actions UI — would need a follow-up push to a covered workflow's path filter to confirm cancellation behavior, but the canonical pattern is identical to 30+ existing workflows.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) under raul.n@posthog.com's direction. Key decisions:

- Scope tightened from 13 to 10 files after per-file intent analysis flagged 3 with weak telemetry/scheduling signals; those are documented in the lint's `SKIP` set rather than auto-fixed.
- Lint precedent (`check-ci-timeouts.py`) chosen over a new mechanism — same shape, same wiring, same `ci-lint-workflows.yml` job pattern.
- Concurrency block placed after `on:` (matches majority placement across canonical workflows like `ci-rust`, `ci-storybook`, `ci-frontend`).