### PR TITLE
fix: preserve boolean false value in flag evaluation conditions

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -672,8 +672,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     },
                 }
             },
-            submit: async (featureFlag) => {
-                await actions.submitFeatureFlagWithValidation(featureFlag)
+            submit: async () => {
+                // Validation/save uses reducer state in submitFeatureFlagWithValidation; kea-forms can omit nested updates from setFeatureFlagFilters.
+                await actions.submitFeatureFlagWithValidation({} as Partial<FeatureFlagType>)
             },
         },
     })),
@@ -2107,7 +2108,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 actions.loadFeatureFlag()
             }
         },
-        submitFeatureFlagWithValidation: async ({ featureFlag }, breakpoint, action, previousState) => {
+        submitFeatureFlagWithValidation: async (_payload, breakpoint, action, previousState) => {
+            const featureFlag = values.featureFlag
             const originalFlag = values.originalFeatureFlag
             const keyChanged = originalFlag && featureFlag.id && originalFlag.key !== featureFlag.key
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When creating a feature flag condition that depends on another flag's evaluation, selecting `false` as the evaluation value causes it to revert to `true` after saving and reloading the feature flag. This makes it impossible to create conditions that check if a flag evaluates to false.

## Changes

**Fixed in `featureFlagLogic.ts`:**

The bug was that the `submit` action was using the kea-forms snapshot, which can omit filters that were updated only via `setFeatureFlagFilters` (e.g., V2 release conditions). 

The fix makes the save function read from `values.featureFlag` (the current reducer state) instead of the stale kea-forms snapshot, ensuring the PATCH request matches what's shown in the editor.

```typescript
// Before:
submit: async (featureFlag) => {
    await actions.submitFeatureFlagWithValidation(featureFlag)
}

// After:  
submit: async () => {
    // Use reducer state, not forms snapshot
    await actions.submitFeatureFlagWithValidation({} as Partial<FeatureFlagType>)
}

submitFeatureFlagWithValidation: async (_payload, breakpoint, action, previousState) => {
    const featureFlag = values.featureFlag  // ← Read current state
    // ...
}
```

## How did you test this code?

### Manual testing steps:

1. Created and edited a feature flag
2. Add a condition based on another flag evaluation  
3. Select a flag from the dropdown
4. Select `false` from the evaluation dropdown
5. Save the feature flag
6. Reload the page or navigate away and back
7. Verify that the condition still shows `false` (not `true`)

**Expected behavior:** The `false` value persists correctly after save/reload.

## Publish to changelog?

no

## Docs update

No docs changes needed - this is a bug fix for existing functionality.

## 🤖 Agent context

**Fix authored by**: @darkopia (Ben Lea)  

