### PR TITLE
feat(web-analytics): include $http_log in bot analytics queries

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -12,6 +12,7 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { IconOpenInNew, IconTableChart } from 'lib/lemon-ui/icons'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -439,6 +440,20 @@ const MainContent = (): JSX.Element => {
 
     if (productTab === ProductTab.BOT_ANALYTICS && botDetailName) {
         return <BotDetail />
+    }
+
+    if (productTab === ProductTab.BOT_ANALYTICS) {
+        return (
+            <>
+                <LemonBanner type="info" dismissKey="bot-analytics-detection-info" className="mb-4">
+                    Bot detection is based on user agent pattern matching. Events with no user agent are excluded from
+                    these results. For better coverage, send server-side HTTP logs as <code>$http_log</code> events —
+                    most bots don't execute JavaScript, so client-side tracking alone misses the majority of crawler
+                    traffic.
+                </LemonBanner>
+                <Tiles />
+            </>
+        )
     }
 
     return <Tiles />

--- a/frontend/src/scenes/web-analytics/botDetailLogic.ts
+++ b/frontend/src/scenes/web-analytics/botDetailLogic.ts
@@ -82,21 +82,13 @@ export const botDetailLogic = kea<botDetailLogicType>([
                                 kind: NodeKind.TrendsQuery,
                                 dateRange,
                                 interval: interval ?? 'hour',
-                                series: [
-                                    {
-                                        event: null as unknown as string,
-                                        kind: NodeKind.EventsNode,
-                                        math: BaseMathType.TotalCount,
-                                        name: 'All events',
-                                        custom_name: 'Requests',
-                                        properties: [
-                                            {
-                                                type: PropertyFilterType.HogQL,
-                                                key: `event IN (${BOT_ANALYTICS_EVENTS.map((e) => `'${e}'`).join(', ')})`,
-                                            },
-                                        ],
-                                    },
-                                ],
+                                series: BOT_ANALYTICS_EVENTS.map((event) => ({
+                                    event,
+                                    kind: NodeKind.EventsNode,
+                                    math: BaseMathType.TotalCount,
+                                    name: event,
+                                    custom_name: 'Requests',
+                                })),
                                 trendsFilter: {
                                     display: ChartDisplayType.ActionsLineGraph,
                                 },

--- a/frontend/src/scenes/web-analytics/botDetailLogic.ts
+++ b/frontend/src/scenes/web-analytics/botDetailLogic.ts
@@ -4,7 +4,14 @@ import { NodeKind, WebAnalyticsPropertyFilters, WebStatsBreakdown } from '~/quer
 import { BaseMathType, ChartDisplayType, InsightLogicProps, PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { botDetailLogicType } from './botDetailLogicType'
-import { QueryTile, TileId, WEB_ANALYTICS_DEFAULT_QUERY_TAGS, WebAnalyticsTile, WebTileLayout } from './common'
+import {
+    BOT_ANALYTICS_EVENTS,
+    QueryTile,
+    TileId,
+    WEB_ANALYTICS_DEFAULT_QUERY_TAGS,
+    WebAnalyticsTile,
+    WebTileLayout,
+} from './common'
 import { webAnalyticsLogic } from './webAnalyticsLogic'
 
 export const botDetailLogic = kea<botDetailLogicType>([
@@ -77,11 +84,17 @@ export const botDetailLogic = kea<botDetailLogicType>([
                                 interval: interval ?? 'hour',
                                 series: [
                                     {
-                                        event: '$pageview',
+                                        event: null as unknown as string,
                                         kind: NodeKind.EventsNode,
                                         math: BaseMathType.TotalCount,
-                                        name: 'Pageview',
+                                        name: 'All events',
                                         custom_name: 'Requests',
+                                        properties: [
+                                            {
+                                                type: PropertyFilterType.HogQL,
+                                                key: `event IN (${BOT_ANALYTICS_EVENTS.map((e) => `'${e}'`).join(', ')})`,
+                                            },
+                                        ],
                                     },
                                 ],
                                 trendsFilter: {

--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -485,6 +485,9 @@ export const INITIAL_DATE_FROM = '-7d' as string | null
 export const INITIAL_DATE_TO = null as string | null
 export const INITIAL_INTERVAL = getDefaultInterval(INITIAL_DATE_FROM, INITIAL_DATE_TO)
 
+/** Events included in bot analytics queries — crawlers don't execute JS so $http_log captures most real bot traffic */
+export const BOT_ANALYTICS_EVENTS = ['$pageview', '$screen', '$http_log']
+
 export const WEB_ANALYTICS_DEFAULT_QUERY_TAGS: QueryLogTags = {
     productKey: ProductKey.WEB_ANALYTICS,
 }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -671,6 +671,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 operator: PropertyOperator.Exact,
                                 type: PropertyFilterType.Event,
                             },
+                            {
+                                // Exclude events with no user agent — these are missing data, not confirmed bots
+                                key: '$virt_traffic_category',
+                                value: ['no_user_agent'],
+                                operator: PropertyOperator.IsNot,
+                                type: PropertyFilterType.Event,
+                            },
                         ]
                     }
                 }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2379,7 +2379,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 FROM events
 WHERE \`$virt_is_bot\` = true
     AND \`$virt_bot_name\` != ''
-    AND event IN ('$pageview', '$screen', '$http_log')
+    AND event IN (${BOT_ANALYTICS_EVENTS.map((e) => `'${e}'`).join(', ')})
     AND {filters}
 GROUP BY "Crawler", "Category"
 ORDER BY "Requests" DESC

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -80,6 +80,7 @@ import {
 
 import {
     ActiveHoursTab,
+    BOT_ANALYTICS_EVENTS,
     BotTrafficFilter,
     ConversionGoalWarning,
     DeviceTab,
@@ -2295,13 +2296,20 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                     const botTiles: (WebAnalyticsTile | null)[] = [
                         (() => {
+                            const botEventFilter = `event IN (${BOT_ANALYTICS_EVENTS.map((e) => `'${e}'`).join(', ')})`
                             const botTrendsSeries = [
                                 {
-                                    event: '$pageview',
+                                    event: null as unknown as string,
                                     kind: NodeKind.EventsNode as const,
                                     math: BaseMathType.TotalCount,
-                                    name: 'Pageview',
+                                    name: 'All events',
                                     custom_name: 'Requests',
+                                    properties: [
+                                        {
+                                            type: PropertyFilterType.HogQL,
+                                            key: botEventFilter,
+                                        },
+                                    ],
                                 },
                             ]
                             const createBotTrendsTab = (
@@ -2373,7 +2381,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 FROM events
 WHERE \`$virt_is_bot\` = true
     AND \`$virt_bot_name\` != ''
-    AND event IN ('$pageview', '$screen')
+    AND event IN ('$pageview', '$screen', '$http_log')
     AND {filters}
 GROUP BY "Crawler", "Category"
 ORDER BY "Requests" DESC

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2303,22 +2303,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                     const botTiles: (WebAnalyticsTile | null)[] = [
                         (() => {
-                            const botEventFilter = `event IN (${BOT_ANALYTICS_EVENTS.map((e) => `'${e}'`).join(', ')})`
-                            const botTrendsSeries = [
-                                {
-                                    event: null as unknown as string,
-                                    kind: NodeKind.EventsNode as const,
-                                    math: BaseMathType.TotalCount,
-                                    name: 'All events',
-                                    custom_name: 'Requests',
-                                    properties: [
-                                        {
-                                            type: PropertyFilterType.HogQL,
-                                            key: botEventFilter,
-                                        },
-                                    ],
-                                },
-                            ]
+                            const botTrendsSeries = BOT_ANALYTICS_EVENTS.map((event) => ({
+                                event,
+                                kind: NodeKind.EventsNode as const,
+                                math: BaseMathType.TotalCount,
+                                name: event,
+                                custom_name: 'Requests',
+                            }))
                             const createBotTrendsTab = (
                                 id: string,
                                 title: string,


### PR DESCRIPTION
## Problem

Bot analytics only queried `$pageview` and `$screen` events. Since most crawlers don't execute JavaScript, client-side tracking misses the majority of real bot traffic.

## Changes

- Add `$http_log` to bot analytics queries via a shared `BOT_ANALYTICS_EVENTS` constant (trends, crawlers table, bot detail)
- Switch the bot trends query to use multiple series instead of a HogQL `event IN (...)` filter, so each event type renders as its own line
- Derive the crawlers table event list from the same constant
- Add a dismissible info banner on the bot analytics tab explaining detection limitations and the `$http_log` recommendation
- Frontend-side stop-gap to exclude events with no `$raw_user_agent` from the "Bot" toggle (a follow-up PR moves this exclusion into the HogQL `is_bot` definition)

## How did you test this code?

Agent-authored. Automated tests run:

- `pnpm --filter=@posthog/frontend typescript:check` — pass
- 257 web-analytics jest tests — pass

No manual UI testing.

## Publish to changelog?

no

## 🤖 Agent context

Originally this branch combined two changes: bundling `$http_log` into bot analytics (this PR), and extending the HogQL `is_bot` definition to exclude empty user agents. Split per author's request — the HogQL changes ship in a stacked PR on top of this one.
