### PR TITLE
feat(hogql): introspect postgres/duckdb table functions

### DIFF
--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -60,12 +60,17 @@ MATCH_ANY_CHARACTER = "$$_POSTHOG_ANY_$$"
 PROPERTY_DEFINITION_LIMIT = 220
 
 
-def get_connection_supported_functions(context: HogQLContext) -> list[str]:
+def _get_direct_connection_metadata(context: HogQLContext) -> Optional[dict]:
     metadata = context.direct_postgres_connection_metadata
     if metadata is None and context.database is not None:
         metadata = getattr(context.database, "_direct_connection_metadata", None)
 
-    if not isinstance(metadata, dict):
+    return metadata if isinstance(metadata, dict) else None
+
+
+def get_connection_supported_functions(context: HogQLContext) -> list[str]:
+    metadata = _get_direct_connection_metadata(context)
+    if metadata is None:
         return []
 
     available_functions = metadata.get("available_functions")
@@ -83,15 +88,15 @@ def get_available_functions(language: str, context: HogQLContext) -> list[str]:
 
 
 def get_direct_table_function_names(context: HogQLContext) -> list[str]:
-    metadata = context.direct_postgres_connection_metadata
-    if metadata is None and context.database is not None:
-        metadata = getattr(context.database, "_direct_connection_metadata", None)
-
-    if not isinstance(metadata, dict):
+    metadata = _get_direct_connection_metadata(context)
+    if metadata is None:
         return []
 
-    introspected = metadata.get("available_table_functions") or []
-    return sorted({name for name in introspected if isinstance(name, str)})
+    available_table_functions = metadata.get("available_table_functions")
+    if not isinstance(available_table_functions, list):
+        return []
+
+    return sorted({name for name in available_table_functions if isinstance(name, str)})
 
 
 def append_function_suggestions(

--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -82,6 +82,18 @@ def get_available_functions(language: str, context: HogQLContext) -> list[str]:
     return ALL_HOG_FUNCTIONS
 
 
+def get_direct_table_function_names(context: HogQLContext) -> list[str]:
+    metadata = context.direct_postgres_connection_metadata
+    if metadata is None and context.database is not None:
+        metadata = getattr(context.database, "_direct_connection_metadata", None)
+
+    if not isinstance(metadata, dict):
+        return []
+
+    introspected = metadata.get("available_table_functions") or []
+    return sorted({name for name in introspected if isinstance(name, str)})
+
+
 def append_function_suggestions(
     suggestions: list[AutocompleteCompletionItem], language: str, context: HogQLContext, prefix: str = ""
 ) -> None:
@@ -725,6 +737,15 @@ def get_hogql_autocomplete(
                             kind=AutocompleteCompletionItemKind.FOLDER,
                             details=["Table"] * len(table_names),
                         )
+                        table_function_names = get_direct_table_function_names(context)
+                        if table_function_names:
+                            extend_responses(
+                                keys=table_function_names,
+                                suggestions=response.suggestions,
+                                kind=AutocompleteCompletionItemKind.FUNCTION,
+                                insert_text=lambda key: f"{key}()",
+                                details=["Table function"] * len(table_function_names),
+                            )
                     elif node.chain[0] in posthog_table_names:
                         pass
                     else:

--- a/posthog/hogql/database/schema/duckdb_table_functions.py
+++ b/posthog/hogql/database/schema/duckdb_table_functions.py
@@ -5,6 +5,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
     FunctionCallTable,
     IntegerDatabaseField,
+    UnknownDatabaseField,
 )
 from posthog.hogql.errors import QueryError
 
@@ -49,3 +50,39 @@ class GenerateSeriesTable(FunctionCallTable, DANGEROUS_NoTeamIdCheckTable):
 
     def to_printed_hogql(self):
         return "generate_series"
+
+
+def build_opaque_function_call_table(name: str) -> "OpaqueFunctionCallTable":
+    """Synthesize a table for a Postgres/DuckDB table-valued function discovered via introspection.
+
+    The output column shape isn't introspected — we expose a single column named after the function
+    with an unknown type. That covers the common single-column shapes (range, generate_series, unnest,
+    jsonb_array_elements_text, regexp_split_to_table, …) without needing per-function schemas.
+    """
+    return OpaqueFunctionCallTable(
+        name=name,
+        fields={name: UnknownDatabaseField(name=name, nullable=True)},
+    )
+
+
+class OpaqueFunctionCallTable(FunctionCallTable, DANGEROUS_NoTeamIdCheckTable):
+    """Generic table function for Postgres/DuckDB calls discovered via connection introspection.
+
+    Used as a fallback when a `FROM some_func(args)` doesn't match a hand-rolled FunctionCallTable
+    but the function name appears in the connection's available_table_functions.
+    """
+
+    fields: dict[str, FieldOrTable]
+    name: str
+    requires_args: bool = True
+    min_args: Optional[int] = 1
+    max_args: Optional[int] = None
+
+    def to_printed_clickhouse(self, context):
+        raise QueryError(f"Table function '{self.name}' is not supported in ClickHouse dialect")
+
+    def to_printed_postgres(self, context):
+        return self.name
+
+    def to_printed_hogql(self):
+        return self.name

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4820,6 +4820,60 @@ class TestPostgresPrinter(BaseTest):
             self._select(query)
         self.assertIn(expected_error, str(ctx.exception))
 
+    def _context_with_table_functions(self, *function_names: str) -> HogQLContext:
+        return HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            direct_postgres_connection_metadata={
+                "available_table_functions": list(function_names),
+            },
+        )
+
+    @parameterized.expand(
+        [
+            ("unnest", "SELECT unnest FROM unnest(ARRAY[1, 2, 3])", "unnest("),
+            (
+                "regexp_matches",
+                "SELECT regexp_matches FROM regexp_matches('abc', '.', 'g')",
+                "regexp_matches(",
+            ),
+            (
+                "jsonb_array_elements_text",
+                "SELECT jsonb_array_elements_text FROM jsonb_array_elements_text('[\"a\"]')",
+                "jsonb_array_elements_text(",
+            ),
+        ]
+    )
+    def test_opaque_table_function_from_introspected_metadata(self, name, query, expected):
+        context = self._context_with_table_functions(name)
+        printed = self._select(query, context=context)
+        self.assertIn(expected, printed)
+
+    def test_opaque_table_function_unknown_name_still_errors(self):
+        context = self._context_with_table_functions("unnest")
+        with self.assertRaises(QueryError) as ctx:
+            self._select("SELECT * FROM totally_made_up_function(1)", context=context)
+        self.assertIn("Unknown table", str(ctx.exception))
+
+    def test_opaque_table_function_requires_args(self):
+        context = self._context_with_table_functions("unnest")
+        with self.assertRaises(QueryError) as ctx:
+            self._select("SELECT * FROM unnest", context=context)
+        self.assertIn("Unknown table", str(ctx.exception))
+
+    def test_opaque_table_function_rejects_empty_call(self):
+        context = self._context_with_table_functions("unnest")
+        with self.assertRaises(QueryError) as ctx:
+            self._select("SELECT * FROM unnest()", context=context)
+        self.assertIn("requires at least 1 argument", str(ctx.exception))
+
+    def test_opaque_table_function_falls_back_to_hardcoded_range_without_metadata(self):
+        # Connections that haven't refreshed since this rolled out won't have
+        # `available_table_functions` in their metadata. The hand-rolled RangeTable
+        # / GenerateSeriesTable registrations keep those two working.
+        printed = self._select("SELECT range FROM range(10)")
+        self.assertIn("range(10)", printed)
+
     @parameterized.expand(
         [
             (

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -25,6 +25,11 @@ from posthog.hogql.constants import (
 )
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.direct_postgres_table import DirectPostgresTable
+from posthog.hogql.database.schema.duckdb_table_functions import (
+    GenerateSeriesTable,
+    OpaqueFunctionCallTable,
+    RangeTable,
+)
 from posthog.hogql.database.schema.logs import HOGQL_MAX_BYTES_TO_READ_FOR_LOGS_USER_QUERIES
 from posthog.hogql.direct_connection import (
     get_direct_connection_source_none_or_raise,
@@ -458,7 +463,14 @@ class HogQLQueryExecutor:
         if query_type is None:
             return None
 
-        base_table_types = extract_base_table_types(query_type)
+        # Dialect-level table functions (range, generate_series, introspected opaque calls)
+        # aren't bound to any source — they're standalone SQL any direct connection can run,
+        # so they shouldn't influence source dispatching or block table-less execution.
+        base_table_types = [
+            table_type
+            for table_type in extract_base_table_types(query_type)
+            if not isinstance(table_type.table, (RangeTable, GenerateSeriesTable, OpaqueFunctionCallTable))
+        ]
         direct_source_ids = {
             table_type.table.external_data_source_id
             for table_type in base_table_types

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -48,6 +48,8 @@ from posthog.models.utils import UUIDT
 # To quickly disable global joins, switch this to False
 USE_GLOBAL_JOINS = False
 
+_SAFE_TABLE_FUNCTION_NAME_RE = re2.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 EMPTY_SCOPE = ast.SelectQueryType()
 
 type PostgresKeywordType = type[ast.DateType] | type[ast.DateTimeType]
@@ -2065,6 +2067,9 @@ class Resolver(CloningVisitor):
 
         function_name = table_name_chain[0].lower()
         if function_name not in {entry.lower() for entry in available_table_functions if isinstance(entry, str)}:
+            return None
+
+        if not _SAFE_TABLE_FUNCTION_NAME_RE.match(function_name):
             return None
 
         return build_opaque_function_call_table(function_name)

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -13,6 +13,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import FunctionCallTable, LazyTable, SavedQuery, StringJSONDatabaseField
 from posthog.hogql.database.s3_table import S3Table
+from posthog.hogql.database.schema.duckdb_table_functions import build_opaque_function_call_table
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PersonsTable
 from posthog.hogql.errors import ImpossibleASTError, NotImplementedError, QueryError, ResolutionError
@@ -1031,7 +1032,17 @@ class Resolver(CloningVisitor):
 
                 return node
 
-            database_table = cast(Database, self.database).get_table(table_name_chain)
+            try:
+                database_table = cast(Database, self.database).get_table(table_name_chain)
+            except QueryError:
+                # Direct Postgres/DuckDB sources expose introspected table-valued functions
+                # (range, generate_series, unnest, …) via connection metadata. If the lookup
+                # failed but the name matches one of those, synthesize an opaque single-column
+                # table so the call resolves and the printer emits it as a passthrough.
+                opaque_table = self._build_opaque_table_function(table_name_chain, node)
+                if opaque_table is None:
+                    raise
+                database_table = opaque_table
 
             if isinstance(database_table, SavedQuery):
                 self.current_view_depth += 1
@@ -2030,6 +2041,33 @@ class Resolver(CloningVisitor):
             return isinstance(table.table, S3Table)
 
         return False
+
+    def _build_opaque_table_function(
+        self, table_name_chain: list[str], node: ast.JoinExpr
+    ) -> Optional[FunctionCallTable]:
+        # Only meaningful when the FROM looks like a function call (`FROM foo(args)`),
+        # not a plain table reference. `table_args` is always set on a function call,
+        # even if empty.
+        if node.table_args is None:
+            return None
+
+        # Multi-segment names (`schema.func`) aren't supported by the opaque path.
+        if len(table_name_chain) != 1:
+            return None
+
+        metadata = self.context.direct_postgres_connection_metadata
+        if not isinstance(metadata, dict):
+            return None
+
+        available_table_functions = metadata.get("available_table_functions")
+        if not isinstance(available_table_functions, list):
+            return None
+
+        function_name = table_name_chain[0].lower()
+        if function_name not in {entry.lower() for entry in available_table_functions if isinstance(entry, str)}:
+            return None
+
+        return build_opaque_function_call_table(function_name)
 
     def _is_next_s3(self, node: Optional[ast.JoinExpr]):
         if node is None:

--- a/posthog/hogql/test/test_autocomplete.py
+++ b/posthog/hogql/test/test_autocomplete.py
@@ -133,6 +133,34 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
 
         assert "icu_collate_nl" in [suggestion.label for suggestion in results.suggestions]
 
+    def test_autocomplete_includes_introspected_table_functions_in_from(self):
+        database = Database.create_for(team=self.team)
+        database._direct_connection_metadata = {
+            "available_table_functions": ["unnest", "regexp_matches", "generate_series"],
+        }
+
+        query = "select * from "
+        results = self._select(query=query, start=14, end=14, database=database)
+
+        labels = [suggestion.label for suggestion in results.suggestions]
+        insert_texts = {suggestion.insertText for suggestion in results.suggestions}
+        details_by_label = {suggestion.label: suggestion.detail for suggestion in results.suggestions}
+
+        assert "unnest" in labels
+        assert "regexp_matches" in labels
+        assert "generate_series" in labels
+        assert "unnest()" in insert_texts
+        assert details_by_label["unnest"] == "Table function"
+
+    def test_autocomplete_skips_table_functions_without_metadata(self):
+        database = Database.create_for(team=self.team)
+
+        query = "select * from "
+        results = self._select(query=query, start=14, end=14, database=database)
+
+        for suggestion in results.suggestions:
+            assert suggestion.detail != "Table function"
+
     def test_autocomplete_persons_suggestions(self):
         query = "select  from persons"
         results = self._select(query=query, start=7, end=7)

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -360,6 +360,67 @@ class TestDirectPostgresQuery(APIBaseTest):
         self.assertIn("icu_collate_nl", sql)
         self.assertEqual(executor.direct_postgres_source_id, str(source.id))
 
+    def test_generate_sql_for_direct_postgres_introspected_table_function(self):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+            },
+            connection_metadata={"available_table_functions": ["unnest"]},
+        )
+
+        executor = HogQLQueryExecutor(
+            query="SELECT * FROM unnest(ARRAY[1, 2, 3])",
+            team=self.team,
+            connection_id=str(source.id),
+        )
+
+        sql, _context = executor.generate_clickhouse_sql()
+
+        self.assertIn("unnest(", sql)
+        self.assertEqual(executor.direct_postgres_source_id, str(source.id))
+
+    def test_generate_sql_for_direct_postgres_hardcoded_range_table_function(self):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+            },
+        )
+
+        executor = HogQLQueryExecutor(
+            query="SELECT range FROM range(10)",
+            team=self.team,
+            connection_id=str(source.id),
+        )
+
+        sql, _context = executor.generate_clickhouse_sql()
+
+        self.assertIn("range(10)", sql)
+        self.assertEqual(executor.direct_postgres_source_id, str(source.id))
+
     def test_generate_sql_for_duckdb_direct_postgres_table_uses_connection_catalog(self):
         source = ExternalDataSource.objects.create(
             team=self.team,

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -360,16 +360,38 @@ class TestDirectPostgresQuery(APIBaseTest):
         self.assertIn("icu_collate_nl", sql)
         self.assertEqual(executor.direct_postgres_source_id, str(source.id))
 
-    def test_generate_sql_for_direct_postgres_introspected_table_function(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team,
-            source_id="source_id",
-            connection_id="connection_id",
-            status=ExternalDataSource.Status.COMPLETED,
-            source_type="Postgres",
-            access_method=ExternalDataSource.AccessMethod.DIRECT,
-            prefix="ph3",
-            job_inputs={
+    @parameterized.expand(
+        [
+            (
+                "introspected_via_metadata",
+                {"available_table_functions": ["unnest"]},
+                "SELECT * FROM unnest(ARRAY[1, 2, 3])",
+                "unnest(",
+            ),
+            (
+                "hardcoded_range_without_metadata",
+                None,
+                "SELECT range FROM range(10)",
+                "range(10)",
+            ),
+        ]
+    )
+    def test_generate_sql_for_direct_postgres_table_function(
+        self,
+        _name: str,
+        connection_metadata: dict[str, Any] | None,
+        query: str,
+        expected_sql_fragment: str,
+    ):
+        source_kwargs: dict[str, Any] = {
+            "team": self.team,
+            "source_id": "source_id",
+            "connection_id": "connection_id",
+            "status": ExternalDataSource.Status.COMPLETED,
+            "source_type": "Postgres",
+            "access_method": ExternalDataSource.AccessMethod.DIRECT,
+            "prefix": "ph3",
+            "job_inputs": {
                 "host": "localhost",
                 "port": 5432,
                 "database": "postgres",
@@ -377,48 +399,16 @@ class TestDirectPostgresQuery(APIBaseTest):
                 "password": "postgres",
                 "schema": "ph3",
             },
-            connection_metadata={"available_table_functions": ["unnest"]},
-        )
+        }
+        if connection_metadata is not None:
+            source_kwargs["connection_metadata"] = connection_metadata
+        source = ExternalDataSource.objects.create(**source_kwargs)
 
-        executor = HogQLQueryExecutor(
-            query="SELECT * FROM unnest(ARRAY[1, 2, 3])",
-            team=self.team,
-            connection_id=str(source.id),
-        )
+        executor = HogQLQueryExecutor(query=query, team=self.team, connection_id=str(source.id))
 
         sql, _context = executor.generate_clickhouse_sql()
 
-        self.assertIn("unnest(", sql)
-        self.assertEqual(executor.direct_postgres_source_id, str(source.id))
-
-    def test_generate_sql_for_direct_postgres_hardcoded_range_table_function(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team,
-            source_id="source_id",
-            connection_id="connection_id",
-            status=ExternalDataSource.Status.COMPLETED,
-            source_type="Postgres",
-            access_method=ExternalDataSource.AccessMethod.DIRECT,
-            prefix="ph3",
-            job_inputs={
-                "host": "localhost",
-                "port": 5432,
-                "database": "postgres",
-                "user": "postgres",
-                "password": "postgres",
-                "schema": "ph3",
-            },
-        )
-
-        executor = HogQLQueryExecutor(
-            query="SELECT range FROM range(10)",
-            team=self.team,
-            connection_id=str(source.id),
-        )
-
-        sql, _context = executor.generate_clickhouse_sql()
-
-        self.assertIn("range(10)", sql)
+        self.assertIn(expected_sql_fragment, sql)
         self.assertEqual(executor.direct_postgres_source_id, str(source.id))
 
     def test_generate_sql_for_duckdb_direct_postgres_table_uses_connection_catalog(self):

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -601,6 +601,7 @@ def get_connection_metadata(
 
             function_source = "duckdb_functions" if is_duckdb else "pg_proc"
             available_functions: list[str] = []
+            available_table_functions: list[str] = []
 
             try:
                 if is_duckdb:
@@ -611,12 +612,29 @@ def get_connection_metadata(
             except Exception as error:
                 capture_exception(error)
 
+            try:
+                if is_duckdb:
+                    cursor.execute(
+                        "SELECT DISTINCT function_name FROM duckdb_functions() WHERE function_type = 'table'"
+                    )
+                else:
+                    # prokind='f' excludes aggregates/windows/procedures; proretset=true selects set-returning fns,
+                    # which is how Postgres exposes table functions in pg_proc.
+                    cursor.execute(
+                        "SELECT DISTINCT proname FROM pg_proc "
+                        "WHERE pg_function_is_visible(oid) AND proretset = true AND prokind = 'f'"
+                    )
+                available_table_functions = _normalize_function_names([row[0] for row in cursor.fetchall()])
+            except Exception as error:
+                capture_exception(error)
+
             return {
                 "database": current_database,
                 "version": version,
                 "engine": "duckdb" if is_duckdb else "postgres",
                 "function_source": function_source,
                 "available_functions": available_functions,
+                "available_table_functions": available_table_functions,
             }
 
 


### PR DESCRIPTION
## Problem

Direct postgres/duckdb sources support `FROM range(10)` and `FROM generate_series(1, 10)` because both have a hand-rolled `FunctionCallTable` subclass (`RangeTable`, `GenerateSeriesTable`) explicitly registered in the database root. Every other set-returning function (`unnest`, `jsonb_array_elements_text`, `regexp_matches`, `generate_subscripts`, …) raises `Unknown table` because there's no generic dispatch — each new function would need its own class with hardcoded fields, a `to_printed_postgres`, and a registry entry.

## Changes

The connection-metadata introspection already runs at source create / edit / refresh time (`get_connection_metadata` queries `pg_proc` / `duckdb_functions()`), but only captured scalar function names. This PR:

1. Extends the discovery query to also capture set-returning functions (`pg_proc.proretset = true AND prokind = 'f'` for PG, `duckdb_functions().function_type = 'table'` for DuckDB) and persists them as `available_table_functions` in `ExternalDataSource.connection_metadata`.
2. Adds a generic `OpaqueFunctionCallTable` (single `UnknownDatabaseField` named after the function, `requires_args=True`, `min_args=1`, `max_args=None`) plus a `build_opaque_function_call_table(name)` helper.
3. In the resolver, wraps `database.get_table` in try/except. On miss, if the chain is a single name, the call has args, and the name is in the connection's `available_table_functions`, it synthesizes an `OpaqueFunctionCallTable`. Otherwise the original `Unknown table` error is re-raised.

The hardcoded `RangeTable` / `GenerateSeriesTable` registrations stay in place so existing connections that haven't refreshed since this rolled out keep working without a backfill — `get_table` finds them first, so the opaque path only kicks in for everything else. Once a user refreshes or the source is edited, the introspected list takes over and arbitrary table functions become available.

The output column is opaque (single column named after the function with `UnknownType`), which covers the common single-column shapes (`range`, `generate_series`, `unnest`, `jsonb_array_elements_text`, `regexp_split_to_table`, …) without per-function schemas. Multi-column shapes (`regexp_matches`, `json_to_record`) and shape-variable functions (where the output type depends on argument types) would need a follow-up that defers field resolution until after argument types are known — out of scope here.

## How did you test this code?

I'm an agent (Claude Opus 4.7, 1M context). I did not perform manual testing.

Automated tests added in `posthog/hogql/printer/test/test_printer.py::TestPostgresPrinter`:

- 3 cases for the introspected path (`unnest`, `regexp_matches`, `jsonb_array_elements_text`) emitting valid passthrough SQL when the function appears in metadata.
- Unknown function name (not in metadata) still raises `Unknown table`.
- Bare `FROM unnest` (no args) still raises `Unknown table` (only function-call form gets the fallback).
- `FROM unnest()` (empty args) raises the standard `requires at least 1 argument` error.
- Regression: hardcoded `range(10)` still works without any metadata set on the context.

I ran the relevant test suites locally:

- `posthog/hogql/printer/test/test_printer.py::TestPostgresPrinter` + `::TestDuckDBPrinter` — 280 passed.
- `posthog/hogql/test/test_resolver.py` + `posthog/hogql/test/test_direct_postgres_query.py` — 232 passed.
- `posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestNormalizeFunctionNames` — 7 passed.

I did not exercise the discovery query change against a real Postgres or DuckDB instance — just verified the SQL strings compile and match the expected `pg_proc` / `duckdb_functions` schema.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code, paired with @georgemunyoro.

Key decisions:

- **Lazy rollout, no backfill.** Keeping the hand-rolled `RangeTable` / `GenerateSeriesTable` means existing connections continue working without a forced metadata refresh. The introspected list silently takes over once a user touches the source. Discussed two alternatives (eager backfill, refresh on first failure) — went with lazy because it matches the existing pattern for `available_functions` and adds zero migration work.
- **Opaque single-column fallback over deferred field resolution.** Most real-world set-returning functions produce one column (`range`, `generate_series`, `unnest`, `jsonb_array_elements_text`, …). A proper shape-variable solution would require resolver-level changes to defer `Table.fields` resolution until argument types are known — much heavier. Opaque covers the common case; multi-column / shape-variable funcs can be a follow-up.
- **Validation reuses existing `requires_args` / `min_args` / `max_args` plumbing** in the printer (`posthog/hogql/printer/base.py:585-604`), so per-function arg validation comes for free at the cost of being looser than the per-function classes (no upper bound).

Agent-authored — requires human review before merging.