### PR TITLE
fix: harden KnownLoginDeviceCookieMiddleware against session reset

### DIFF
--- a/posthog/helpers/tests/test_user_devices.py
+++ b/posthog/helpers/tests/test_user_devices.py
@@ -89,34 +89,63 @@ class TestKnownLoginDeviceCookieMiddleware(BaseTest):
         middleware = KnownLoginDeviceCookieMiddleware(lambda r: response)
         return middleware(request)
 
+    def _cookie_name(self) -> str:
+        return KNOWN_DEVICE_COOKIE.format(user_id=self.user.id)
+
     def test_sets_cookie_for_authenticated_user(self):
         request = self._make_request(user=self.user)
-        request.session.accessed = True
         response = self._run_middleware(request)
-        cookie_name = KNOWN_DEVICE_COOKIE.format(user_id=self.user.id)
-        self.assertIn(cookie_name, response.cookies)
+        self.assertIn(self._cookie_name(), response.cookies)
 
-    def test_no_crash_when_user_is_none(self):
+    def test_does_not_set_cookie_when_session_has_no_auth_user_id(self):
+        # API-key style requests: request.user is set by DRF auth, but no session login happened.
+        request = RequestFactory().get("/")
+        request.session = SessionStore()
+        request.user = self.user
+        response = self._run_middleware(request)
+        self.assertNotIn(self._cookie_name(), response.cookies)
+
+    def test_does_not_set_cookie_when_user_is_none(self):
         request = self._make_request()
         request.user = None
-        request.session.accessed = True
         response = self._run_middleware(request)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.cookies), 0)
 
-    def test_no_crash_when_user_has_no_id(self):
-        fake_user = MagicMock(spec=[])
-        fake_user.is_authenticated = True
-        request = self._make_request()
-        request.user = fake_user
-        request.session.accessed = True
-        response = self._run_middleware(request)
-        self.assertEqual(response.status_code, 200)
-
-    def test_no_crash_when_user_attr_missing(self):
+    def test_does_not_set_cookie_when_user_attr_missing(self):
         request = RequestFactory().get("/")
         request.session = SessionStore()
         if hasattr(request, "user"):
             del request.user
-        request.session.accessed = True
         response = self._run_middleware(request)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.cookies), 0)
+
+    def test_does_not_set_cookie_for_anonymous_user(self):
+        from django.contrib.auth.models import AnonymousUser
+
+        request = RequestFactory().get("/")
+        request.session = SessionStore()
+        request.user = AnonymousUser()
+        response = self._run_middleware(request)
+        self.assertEqual(len(response.cookies), 0)
+
+    def test_does_not_set_cookie_for_non_user_types(self):
+        # Things like ProjectSecretAPIKeyUser / InternalAPIUser set request.user directly to a
+        # non-User type. The gate must reject these without crashing on missing attributes.
+        fake_user = MagicMock(spec=[])
+        fake_user.is_authenticated = True
+        request = self._make_request()
+        request.user = fake_user
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.cookies), 0)
+
+    def test_does_not_set_cookie_when_session_attr_missing(self):
+        request = RequestFactory().get("/")
+        if hasattr(request, "session"):
+            del request.session
+        request.user = self.user
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.cookies), 0)

--- a/posthog/helpers/tests/test_user_devices.py
+++ b/posthog/helpers/tests/test_user_devices.py
@@ -1,7 +1,10 @@
 import uuid
 
 from posthog.test.base import BaseTest
+from unittest.mock import MagicMock
 
+from django.contrib.sessions.backends.db import SessionStore
+from django.http import HttpResponse
 from django.test import RequestFactory
 
 from parameterized import parameterized
@@ -11,6 +14,7 @@ from posthog.helpers.user_devices import (
     build_known_device_cookie_value,
     has_valid_known_device_cookie,
 )
+from posthog.middleware import KnownLoginDeviceCookieMiddleware
 from posthog.models import User
 
 
@@ -69,3 +73,50 @@ class TestHasValidKnownDeviceCookie(BaseTest):
         user = self._make_user()
         request = self._request_with_cookies({KNOWN_DEVICE_COOKIE.format(user_id=user.id): value})
         self.assertFalse(has_valid_known_device_cookie(request, user))
+
+
+class TestKnownLoginDeviceCookieMiddleware(BaseTest):
+    def _make_request(self, user=None):
+        request = RequestFactory().get("/")
+        request.session = SessionStore()
+        if user is not None:
+            request.user = user
+            request.session["_auth_user_id"] = str(user.id)
+        return request
+
+    def _run_middleware(self, request):
+        response = HttpResponse()
+        middleware = KnownLoginDeviceCookieMiddleware(lambda r: response)
+        return middleware(request)
+
+    def test_sets_cookie_for_authenticated_user(self):
+        request = self._make_request(user=self.user)
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        cookie_name = KNOWN_DEVICE_COOKIE.format(user_id=self.user.id)
+        self.assertIn(cookie_name, response.cookies)
+
+    def test_no_crash_when_user_is_none(self):
+        request = self._make_request()
+        request.user = None
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_crash_when_user_has_no_id(self):
+        fake_user = MagicMock(spec=[])
+        fake_user.is_authenticated = True
+        request = self._make_request()
+        request.user = fake_user
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_crash_when_user_attr_missing(self):
+        request = RequestFactory().get("/")
+        request.session = SessionStore()
+        if hasattr(request, "user"):
+            del request.user
+        request.session.accessed = True
+        response = self._run_middleware(request)
+        self.assertEqual(response.status_code, 200)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -12,7 +12,6 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.auth import logout
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
 from django.core.exceptions import MiddlewareNotUsed
 from django.db import connection
@@ -537,14 +536,25 @@ class CustomPrometheusMetrics(Metrics):
         return super().register_metric(metric_cls, name, documentation, labelnames=labelnames, **kwargs)
 
 
-class PostHogTokenCookieMiddleware(SessionMiddleware):
+class PostHogTokenCookieMiddleware:
     """
-    Adds two secure cookies to enable auto-filling the current project token on the docs.
+    Adds secure cookies that let the website auto-fill the current project token / login method on docs.
+
+    Note: this used to subclass SessionMiddleware, which had the side effect of running a second
+    SessionMiddleware.process_request mid-chain — replacing request.session with a fresh SessionStore.
+    That caused subtle bugs when downstream code relied on session state populated earlier (notably,
+    Django's separate _cached_user / _acached_user caches across sync vs ASGI auth). The session is
+    already saved by the SessionMiddleware higher in the stack; we only need to set response cookies.
     """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return self.process_response(request, response)
 
     def process_response(self, request, response):
-        response = super().process_response(request, response)
-
         if settings.TEST:
             pass
         elif is_dev_mode():
@@ -655,7 +665,16 @@ class SessionAgeMiddleware:
 
 
 class KnownLoginDeviceCookieMiddleware:
-    """(Re)issues the known-device cookie on every session-authenticated response"""
+    """(Re)issues the known-device cookie on every session-authenticated response.
+
+    Gate is a positive check on the session for an auth user id, plus an isinstance(User) guard
+    on request.user. We deliberately do not use request.session.accessed: it's a leaky proxy that
+    flips True/False depending on whether earlier middleware happened to read the session, and
+    Django keeps separate auth caches for sync (request._cached_user) vs ASGI (request._acached_user)
+    so the proxy is asymmetric across transports. Endpoints authenticated via API key (e.g.
+    ProjectSecretAPIKeyUser, InternalAPIUser) set request.user directly and never have an auth user
+    in the session — this gate excludes them cleanly.
+    """
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -663,11 +682,11 @@ class KnownLoginDeviceCookieMiddleware:
     def __call__(self, request: HttpRequest):
         response = self.get_response(request)
         user = getattr(request, "user", None)
+        session = getattr(request, "session", None)
         if (
-            user
-            and getattr(user, "id", None)
-            and request.session.accessed
-            and user.is_authenticated
+            isinstance(user, User)
+            and session is not None
+            and session.get("_auth_user_id")
             and not is_impersonated_session(request)
         ):
             set_known_device_cookie(response, user)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -662,8 +662,15 @@ class KnownLoginDeviceCookieMiddleware:
 
     def __call__(self, request: HttpRequest):
         response = self.get_response(request)
-        if request.session.accessed and request.user.is_authenticated and not is_impersonated_session(request):
-            set_known_device_cookie(response, request.user)
+        user = getattr(request, "user", None)
+        if (
+            user
+            and getattr(user, "id", None)
+            and request.session.accessed
+            and user.is_authenticated
+            and not is_impersonated_session(request)
+        ):
+            set_known_device_cookie(response, user)
         return response
 
 


### PR DESCRIPTION
## Problem

Two related fixes addressing the same root cause that surfaced during the Django 5.2 + ASGI rollout, where the just-shipped known-device cookie middleware crashed on requests authenticated with non-User types (e.g. project-secret API keys).

The chain of causality:

1. \`PostHogTokenCookieMiddleware\` subclassed \`SessionMiddleware\`, which ran a second \`SessionMiddleware.process_request\` mid-chain. That replaced \`request.session\` with a fresh \`SessionStore\` (\`accessed=False\`), throwing away the access flag set by earlier middleware on the original store.
2. Django keeps two separate auth caches — \`request._cached_user\` (sync) and \`request._acached_user\` (ASGI). Earlier middleware (\`SessionAgeMiddleware\`) warms \`_cached_user\` against the original session, hiding session reads from later sync code. Under WSGI, this means \`session.accessed\` stays False after the session swap and the known-device cookie middleware does nothing.
3. Under ASGI, \`posthoganalytics.PosthogContextMiddleware.__acall__\` awaits \`request.auser()\`, which goes through the *empty* \`_acached_user\` cache. That re-reads the (now fresh) session, flipping \`accessed=True\`, opening the known-device cookie gate, and trying to fingerprint a \`ProjectSecretAPIKeyUser\` that has no \`id\`. Boom.

The previously-shipped \`getattr(user, "id", None)\` defensive guard masks the symptom but leaves the leaky proxy in place.

## Changes

- **\`PostHogTokenCookieMiddleware\` no longer subclasses \`SessionMiddleware\`.** It only writes response cookies; the session is already saved by the outer \`SessionMiddleware\`. This removes the mid-chain session swap entirely.
- **\`KnownLoginDeviceCookieMiddleware\` no longer gates on \`request.session.accessed\`.** Replaced with a positive check: \`isinstance(request.user, User)\` and an \`_auth_user_id\` in the session. This excludes API-key style requests (\`ProjectSecretAPIKeyUser\`, \`InternalAPIUser\`) cleanly, so the \`getattr(user, "id", None)\` guard is dropped as redundant.

## How did you test this code?

Agent-authored. Ran \`pytest posthog/helpers/tests/test_user_devices.py\` (17 tests, all pass). Did not run the broader middleware integration test (\`test_middleware.py::TestPostHogTokenCookieMiddleware\`) — it requires a database and the local environment was not set up for it; CI will cover.

Tests added/updated:
- \`test_sets_cookie_for_authenticated_user\` — happy path still works without \`session.accessed\`
- \`test_does_not_set_cookie_when_session_has_no_auth_user_id\` — API-key style request, user set but no session login → no cookie
- \`test_does_not_set_cookie_for_anonymous_user\`
- \`test_does_not_set_cookie_for_non_user_types\` — \`ProjectSecretAPIKeyUser\`-style mock
- \`test_does_not_set_cookie_when_session_attr_missing\`
- \`test_does_not_set_cookie_when_user_is_none\` / \`_user_attr_missing\`

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude (Opus 4.7). Triggered by post-mortem analysis of the Django 5.2 rollout regression. Mechanism explained above; companion PR planned in posthog-python to make the async middleware reuse \`_cached_user\` when populated.