### PR TITLE
feat(data-deletion): refactor Person bulk_delete and make code usable…

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,8 +1,7 @@
 import uuid
-import asyncio
 import builtins
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
 from django.conf import settings
@@ -31,7 +30,6 @@ from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
-from temporalio import common
 
 from posthog.schema import ProductKey
 
@@ -58,16 +56,16 @@ from posthog.models.filters.lifecycle_filter import LifecycleFilter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.properties_timeline_filter import PropertiesTimelineFilter
 from posthog.models.filters.retention_filter import RetentionFilter
+from posthog.models.person.bulk_delete import (
+    delete_persons_profile,
+    queue_person_event_deletion,
+    queue_person_recording_deletion,
+    resolve_persons_for_deletion,
+)
 from posthog.models.person.deletion import reset_deleted_person_distinct_ids
 from posthog.models.person.missing_person import MissingPerson
 from posthog.models.person.person import PersonDistinctId
-from posthog.models.person.util import (
-    delete_person,
-    delete_persons_from_postgres,
-    get_person_by_pk_or_uuid,
-    get_persons_by_distinct_ids,
-    get_persons_by_uuids,
-)
+from posthog.models.person.util import get_person_by_pk_or_uuid, get_persons_by_distinct_ids, get_persons_by_uuids
 from posthog.queries.actor_base_query import ActorBaseQuery, get_serialized_people
 from posthog.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
 from posthog.queries.funnels.funnel_strict_persons import ClickhouseFunnelStrictActors
@@ -81,8 +79,6 @@ from posthog.rate_limit import ClickHouseBurstRateThrottle, PersonalApiKeyRateTh
 from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
 from posthog.tasks.split_person import split_person
-from posthog.temporal.common.client import sync_connect
-from posthog.temporal.session_replay.delete_recordings.types import DeletionConfig, RecordingsWithPersonInput
 from posthog.utils import format_query_params_absolute_url, is_anonymous_id, refresh_requested_by_client
 
 logger = structlog.get_logger(__name__)
@@ -617,62 +613,32 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         delete_recordings: bool = False,
         keep_person: bool = False,
     ) -> dict[str, Any]:
-        """
-        This method is meant to be the canonical way to delete anything via the Persons API.
-        """
-
-        if distinct_ids:
-            if len(distinct_ids) > 1000:
-                raise ValidationError("You can only pass 1000 distinct_ids in one call")
-            # Optimize query by avoiding expensive JOIN - first get person_ids, then fetch persons
-            person_ids = PersonDistinctId.objects.filter(
-                team_id=self.team_id, distinct_id__in=distinct_ids
-            ).values_list("person_id", flat=True)
-            persons_queryset = self.get_queryset().filter(id__in=person_ids, team_id=self.team_id).defer("properties")
-        elif ids:
-            if len(ids) > 1000:
-                raise ValidationError("You can only pass 1000 ids in one call")
-            persons_queryset = self.get_queryset().filter(uuid__in=ids, team_id=self.team_id).defer("properties")
-        else:
+        if distinct_ids and len(distinct_ids) > 1000:
+            raise ValidationError("You can only pass 1000 distinct_ids in one call")
+        if ids and len(ids) > 1000:
+            raise ValidationError("You can only pass 1000 ids in one call")
+        if not distinct_ids and not ids:
             raise ValidationError("You need to specify either distinct_ids or ids")
 
-        # Materialize queryset once before any deletions to avoid re-evaluating
-        # after records are deleted (which would return empty results)
-        persons = list(persons_queryset)
+        persons = resolve_persons_for_deletion(self.team_id, ids, distinct_ids)
 
         persons_deleted = 0
         errors: builtins.list[dict[str, str]] = []
-        deleted_persons: builtins.list[Person] = []
         if not keep_person:
-            # Send ClickHouse deletion events and log activity per person
-            for person in persons:
-                try:
-                    delete_person(person=person)
-                    persons_deleted += 1
-                    deleted_persons.append(person)
-                except Exception:
-                    logger.exception("Failed to delete person", person_uuid=str(person.uuid))
-                    errors.append({"person_uuid": str(person.uuid)})
-                    continue
-                log_activity(
-                    organization_id=self.organization.id,
-                    team_id=self.team_id,
-                    user=cast(User, request.user),
-                    was_impersonated=is_impersonated_session(request),
-                    item_id=person.pk,
-                    scope="Person",
-                    activity="deleted",
-                    detail=Detail(name=str(person.uuid)),
-                )
-            # Postgres deletes happen after CH deletes. If the Postgres batch fails,
-            # persons may remain in Postgres that are already marked deleted in ClickHouse.
-            delete_persons_from_postgres(self.team_id, deleted_persons)
+            result = delete_persons_profile(
+                self.team_id,
+                persons,
+                actor=cast(User, request.user),
+                request=request,
+                organization_id=self.organization.id,
+            )
+            persons_deleted = result.deleted_count
+            errors = [{"person_uuid": str(u)} for u in result.errors]
 
         if delete_events:
-            self._queue_event_deletion(persons)
-
+            queue_person_event_deletion(self.team_id, persons, actor=cast(User, request.user))
         if delete_recordings:
-            self._queue_delete_recordings(persons)
+            queue_person_recording_deletion(self.team_id, persons, actor=cast(User, request.user))
 
         return {
             "persons_found": len(persons),
@@ -1220,7 +1186,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         """
         try:
             person = self.get_object()
-            self._queue_delete_recordings([person])
+            queue_person_recording_deletion(self.team_id, [person], actor=cast(User, request.user))
             return response.Response(status=202)
         except Person.DoesNotExist:
             raise NotFound(detail="Person not found.")
@@ -1237,7 +1203,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         """
         try:
             person = self.get_object()
-            self._queue_event_deletion([person])
+            queue_person_event_deletion(self.team_id, [person], actor=cast(User, request.user))
             return response.Response(status=202)
         except Person.DoesNotExist:
             raise NotFound(detail="Person not found.")
@@ -1300,52 +1266,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             results[str(person.uuid)] = MinimalPersonSerializer(person, context={"get_team": lambda: self.team}).data
 
         return response.Response({"results": results})
-
-    def _queue_event_deletion(self, persons: builtins.list[Person]) -> None:
-        """Helper to queue deletion of all events for a person."""
-        AsyncDeletion.objects.bulk_create(
-            [
-                AsyncDeletion(
-                    deletion_type=DeletionType.Person,
-                    team_id=self.team_id,
-                    key=str(person.uuid),
-                    created_by=cast(User, self.request.user),
-                )
-                for person in persons
-            ],
-            ignore_conflicts=True,
-        )
-
-    def _queue_delete_recordings(self, persons: builtins.list[Person]) -> None:
-        if not persons:
-            return
-
-        temporal = sync_connect()
-
-        async def start_all_workflows():
-            tasks = []
-            for person in persons:
-                workflow_input = RecordingsWithPersonInput(
-                    distinct_ids=person.distinct_ids,
-                    team_id=self.team_id,
-                    config=DeletionConfig(deleted_by=cast(User, self.request.user).email, reason="person deletion"),
-                )
-                workflow_id = f"delete-recordings-{self.team_id}-person-{person.uuid}-{uuid.uuid4()}"
-                tasks.append(
-                    temporal.start_workflow(
-                        "delete-recordings-with-person",
-                        workflow_input,
-                        id=workflow_id,
-                        task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
-                        retry_policy=common.RetryPolicy(
-                            maximum_attempts=2,
-                            initial_interval=timedelta(minutes=1),
-                        ),
-                    )
-                )
-            await asyncio.gather(*tasks)
-
-        asyncio.run(start_all_workflows())
 
     @extend_schema(
         parameters=[

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -613,6 +613,8 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         delete_recordings: bool = False,
         keep_person: bool = False,
     ) -> dict[str, Any]:
+        if distinct_ids and ids:
+            raise ValidationError("You must provide either distinct_ids or ids, not both")
         if distinct_ids and len(distinct_ids) > 1000:
             raise ValidationError("You can only pass 1000 distinct_ids in one call")
         if ids and len(ids) > 1000:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -421,7 +421,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertIsNone(async_deletion.delete_verified_at)
 
     @freeze_time("2021-08-25T22:09:14.252Z")
-    @mock.patch("posthog.api.person.PersonViewSet._queue_delete_recordings")
+    @mock.patch("posthog.api.person.queue_person_recording_deletion")
     def test_delete_person_and_recordings(self, _mock_queue_delete):
         person = _create_person(
             team=self.team,
@@ -437,7 +437,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(Person.objects.filter(team=self.team).count(), 0)
 
     @freeze_time("2021-08-25T22:09:14.252Z")
-    @mock.patch("posthog.api.person.PersonViewSet._queue_delete_recordings")
+    @mock.patch("posthog.api.person.queue_person_recording_deletion")
     def test_delete_person_and_recordings_and_events(self, _mock_queue_delete):
         person = _create_person(
             team=self.team,
@@ -588,7 +588,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(async_deletion.deletion_type, DeletionType.Person)
         self.assertEqual(async_deletion.key, str(person.uuid))
 
-    @mock.patch("posthog.api.person.PersonViewSet._queue_delete_recordings")
+    @mock.patch("posthog.api.person.queue_person_recording_deletion")
     def test_bulk_delete_with_recordings(self, _mock_queue_delete):
         """Test that bulk_delete queues recording deletion"""
         person = _create_person(
@@ -747,7 +747,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(data["count"], 1)
         self.assertEqual(data["results"][0]["person_uuid"], str(person1.uuid))
 
-    @mock.patch("posthog.api.person.delete_person")
+    @mock.patch("posthog.models.person.bulk_delete.delete_person")
     def test_bulk_delete_partial_failure(self, mock_delete_person):
         """Test that bulk_delete continues when a single person fails to delete and reports errors"""
         person1 = _create_person(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -638,6 +638,14 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("distinct_ids or ids", str(response.content))
 
+    def test_bulk_delete_validation_rejects_both_ids_and_distinct_ids(self):
+        response = self.client.post(
+            f"/api/person/bulk_delete/",
+            {"ids": [str(uuid4())], "distinct_ids": ["did_1"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("not both", str(response.content))
+
     def test_bulk_delete_no_matching_persons(self):
         response = self.client.post(
             f"/api/person/bulk_delete/",

--- a/posthog/api/test/test_person_personhog.py
+++ b/posthog/api/test/test_person_personhog.py
@@ -316,7 +316,7 @@ class TestBulkDeletePersons(PersonhogTestMixin, APIBaseTest):
         # Other team's person should be untouched
         assert Person.objects.filter(team_id=other_team.pk, uuid=other_person.uuid).count() == 1
 
-    @mock.patch("posthog.api.person.delete_person")
+    @mock.patch("posthog.models.person.bulk_delete.delete_person")
     def test_bulk_delete_partial_failure_only_deletes_successful_from_postgres(self, mock_delete_person):
         p1 = self._seed_person(team=self.team, distinct_ids=["did-1"])
         p2 = self._seed_person(team=self.team, distinct_ids=["did-2"])

--- a/posthog/models/person/bulk_delete.py
+++ b/posthog/models/person/bulk_delete.py
@@ -1,0 +1,166 @@
+import uuid as uuid_lib
+import asyncio
+import builtins
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import cast
+
+from django.conf import settings
+from django.db.models import Prefetch
+
+import structlog
+from loginas.utils import is_impersonated_session
+from temporalio import common
+
+from posthog.models.activity_logging.activity_log import Detail, log_activity
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.person import Person, PersonDistinctId
+from posthog.models.person.util import delete_person, delete_persons_from_postgres
+from posthog.models.user import User
+from posthog.temporal.common.client import sync_connect
+from posthog.temporal.session_replay.delete_recordings.types import DeletionConfig, RecordingsWithPersonInput
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class PersonProfileDeletionResult:
+    deleted_count: int
+    errors: list[uuid_lib.UUID] = field(default_factory=list)
+
+
+def resolve_persons_for_deletion(
+    team_id: int,
+    uuids: builtins.list[str] | None,
+    distinct_ids: builtins.list[str] | None,
+) -> builtins.list[Person]:
+    """Materialize Persons matching either uuids or distinct_ids (or both)."""
+    person_ids: set[int] = set()
+    if uuids:
+        person_ids.update(Person.objects.filter(team_id=team_id, uuid__in=uuids).values_list("id", flat=True))
+    if distinct_ids:
+        person_ids.update(
+            PersonDistinctId.objects.filter(team_id=team_id, distinct_id__in=distinct_ids).values_list(
+                "person_id", flat=True
+            )
+        )
+    if not person_ids:
+        return []
+    return list(
+        Person.objects.filter(id__in=person_ids, team_id=team_id)
+        .defer("properties")
+        .prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
+    )
+
+
+def delete_persons_profile(
+    team_id: int,
+    persons: builtins.list[Person],
+    *,
+    actor: User | None,
+    request=None,
+    organization_id=None,
+) -> PersonProfileDeletionResult:
+    """Run ClickHouse Kafka tombstones, then a single Postgres batch delete.
+
+    Activity logging is performed only when both ``request`` and ``organization_id``
+    are provided (i.e. from a DRF endpoint). Dagster ops should leave them as None.
+    """
+    deleted: builtins.list[Person] = []
+    errors: builtins.list[uuid_lib.UUID] = []
+    for person in persons:
+        try:
+            delete_person(person=person)
+            deleted.append(person)
+        except Exception:
+            logger.exception("Failed to delete person", person_uuid=str(person.uuid))
+            errors.append(person.uuid)
+            continue
+        if request is not None and organization_id is not None and actor is not None:
+            log_activity(
+                organization_id=organization_id,
+                team_id=team_id,
+                user=cast(User, actor),
+                was_impersonated=is_impersonated_session(request),
+                item_id=person.pk,
+                scope="Person",
+                activity="deleted",
+                detail=Detail(name=str(person.uuid)),
+            )
+
+    if deleted:
+        delete_persons_from_postgres(team_id, deleted)
+    return PersonProfileDeletionResult(deleted_count=len(deleted), errors=errors)
+
+
+def queue_person_event_deletion(
+    team_id: int,
+    persons: builtins.list[Person],
+    *,
+    actor: User | None,
+) -> None:
+    if not persons:
+        return
+    AsyncDeletion.objects.bulk_create(
+        [
+            AsyncDeletion(
+                deletion_type=DeletionType.Person,
+                team_id=team_id,
+                key=str(person.uuid),
+                created_by=actor,
+            )
+            for person in persons
+        ],
+        ignore_conflicts=True,
+    )
+
+
+def queue_person_recording_deletion(
+    team_id: int,
+    persons: builtins.list[Person],
+    *,
+    actor: User | None,
+    reason: str = "person deletion",
+) -> None:
+    if not persons:
+        return
+    _start_recording_workflows(team_id, persons, actor, reason)
+
+
+def _start_recording_workflows(
+    team_id: int,
+    persons: builtins.list[Person],
+    actor: User | None,
+    reason: str,
+) -> None:
+    """Kick off one ``delete-recordings-with-person`` workflow per person.
+
+    The Temporal connection is established here (rather than in the caller) so
+    that tests patching this seam don't need to mock ``sync_connect`` separately.
+    """
+    temporal = sync_connect()
+
+    async def start_all_workflows():
+        tasks = []
+        for person in persons:
+            workflow_input = RecordingsWithPersonInput(
+                distinct_ids=person.distinct_ids,
+                team_id=team_id,
+                config=DeletionConfig(deleted_by=getattr(actor, "email", None), reason=reason),
+            )
+            workflow_id = f"delete-recordings-{team_id}-person-{person.uuid}-{uuid_lib.uuid4()}"
+            tasks.append(
+                temporal.start_workflow(
+                    "delete-recordings-with-person",
+                    workflow_input,
+                    id=workflow_id,
+                    task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
+                    retry_policy=common.RetryPolicy(
+                        maximum_attempts=2,
+                        initial_interval=timedelta(minutes=1),
+                    ),
+                )
+            )
+        await asyncio.gather(*tasks)
+
+    asyncio.run(start_all_workflows())

--- a/posthog/models/person/test/test_bulk_delete_helpers.py
+++ b/posthog/models/person/test/test_bulk_delete_helpers.py
@@ -1,0 +1,95 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.person import Person
+from posthog.models.person.bulk_delete import (
+    delete_persons_profile,
+    queue_person_event_deletion,
+    queue_person_recording_deletion,
+    resolve_persons_for_deletion,
+)
+
+
+class ResolvePersonsTests(BaseTest):
+    def test_resolves_by_uuid(self):
+        p = Person.objects.create(team=self.team, distinct_ids=["a"], properties={})
+        result = resolve_persons_for_deletion(self.team.pk, uuids=[str(p.uuid)], distinct_ids=None)
+        assert [r.uuid for r in result] == [p.uuid]
+
+    def test_resolves_by_distinct_id(self):
+        p = Person.objects.create(team=self.team, distinct_ids=["did-x"], properties={})
+        result = resolve_persons_for_deletion(self.team.pk, uuids=None, distinct_ids=["did-x"])
+        assert [r.uuid for r in result] == [p.uuid]
+
+    def test_resolves_by_mixed_inputs(self):
+        p1 = Person.objects.create(team=self.team, distinct_ids=["d1"], properties={})
+        p2 = Person.objects.create(team=self.team, distinct_ids=["d2"], properties={})
+        result = resolve_persons_for_deletion(self.team.pk, uuids=[str(p1.uuid)], distinct_ids=["d2"])
+        assert {r.uuid for r in result} == {p1.uuid, p2.uuid}
+
+    def test_returns_empty_when_neither(self):
+        assert resolve_persons_for_deletion(self.team.pk, uuids=None, distinct_ids=None) == []
+
+
+class QueueEventDeletionTests(BaseTest):
+    def test_creates_one_async_deletion_per_person(self):
+        p = Person.objects.create(team=self.team, distinct_ids=["a"], properties={})
+        queue_person_event_deletion(self.team.pk, [p], actor=self.user)
+        assert (
+            AsyncDeletion.objects.filter(
+                team_id=self.team.pk, deletion_type=DeletionType.Person, key=str(p.uuid)
+            ).count()
+            == 1
+        )
+
+    def test_ignores_duplicate_queueing(self):
+        p = Person.objects.create(team=self.team, distinct_ids=["a"], properties={})
+        queue_person_event_deletion(self.team.pk, [p], actor=self.user)
+        queue_person_event_deletion(self.team.pk, [p], actor=self.user)
+        assert AsyncDeletion.objects.filter(team_id=self.team.pk).count() == 1
+
+
+class DeletePersonsProfileTests(BaseTest):
+    def test_deletes_persons_via_helpers(self):
+        p = Person.objects.create(team=self.team, distinct_ids=["a"], properties={})
+        with (
+            patch("posthog.models.person.bulk_delete.delete_person") as ch_delete,
+            patch("posthog.models.person.bulk_delete.delete_persons_from_postgres") as pg_delete,
+        ):
+            result = delete_persons_profile(self.team.pk, [p], actor=self.user)
+        assert result.deleted_count == 1
+        assert result.errors == []
+        ch_delete.assert_called_once_with(person=p)
+        pg_delete.assert_called_once_with(self.team.pk, [p])
+
+    def test_collects_errors_and_skips_failed_persons_in_pg_batch(self):
+        p1 = Person.objects.create(team=self.team, distinct_ids=["a"], properties={})
+        p2 = Person.objects.create(team=self.team, distinct_ids=["b"], properties={})
+        with (
+            patch(
+                "posthog.models.person.bulk_delete.delete_person",
+                side_effect=[None, RuntimeError("boom")],
+            ),
+            patch("posthog.models.person.bulk_delete.delete_persons_from_postgres") as pg_delete,
+        ):
+            result = delete_persons_profile(self.team.pk, [p1, p2], actor=self.user)
+        assert result.deleted_count == 1
+        assert [str(e) for e in result.errors] == [str(p2.uuid)]
+        pg_delete.assert_called_once_with(self.team.pk, [p1])
+
+
+class QueueRecordingDeletionTests(BaseTest):
+    def test_skips_when_no_persons(self):
+        with patch("posthog.models.person.bulk_delete.sync_connect") as conn:
+            queue_person_recording_deletion(self.team.pk, [], actor=self.user)
+            conn.assert_not_called()
+
+    def test_starts_workflow_per_person(self):
+        p1 = Person.objects.create(team=self.team, distinct_ids=["a"], properties={})
+        p2 = Person.objects.create(team=self.team, distinct_ids=["b"], properties={})
+        with patch("posthog.models.person.bulk_delete._start_recording_workflows") as start:
+            queue_person_recording_deletion(self.team.pk, [p1, p2], actor=self.user)
+            start.assert_called_once()
+            (_, persons, _, _) = start.call_args.args
+            assert {p.uuid for p in persons} == {p1.uuid, p2.uuid}


### PR DESCRIPTION
… in other places

## Problem

We need to make data deletion work 100%.

## Changes

Separate logic into helpers so it can be safely used in Dagster. This change should no-op semantic wise.

## How did you test this code?

Tests.
