### PR TITLE
feat(replay): periodic Gemini-file cleanup sweeper

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -131,6 +131,10 @@ from posthog.temporal.session_replay.replay_count_metrics import (
     WORKFLOWS as REPLAY_COUNT_METRICS_WORKFLOWS,
 )
 from posthog.temporal.session_replay.session_summary import SESSION_SUMMARY_ACTIVITIES, SESSION_SUMMARY_WORKFLOWS
+from posthog.temporal.session_replay.session_summary.cleanup_sweep import (
+    CLEANUP_SWEEP_ACTIVITIES,
+    CLEANUP_SWEEP_WORKFLOWS,
+)
 from posthog.temporal.session_replay.summarization_sweep import (
     SUMMARIZATION_SWEEP_ACTIVITIES,
     SUMMARIZATION_SWEEP_WORKFLOWS,
@@ -273,7 +277,8 @@ _task_queue_specs = [
     ),
     (
         settings.SESSION_REPLAY_TASK_QUEUE,
-        COUNT_PLAYLIST_ITEMS_WORKFLOWS
+        CLEANUP_SWEEP_WORKFLOWS
+        + COUNT_PLAYLIST_ITEMS_WORKFLOWS
         + DELETE_RECORDING_WORKFLOWS
         + ENFORCE_MAX_REPLAY_RETENTION_WORKFLOWS
         + EXPORT_RECORDING_WORKFLOWS
@@ -282,7 +287,8 @@ _task_queue_specs = [
         + REPLAY_COUNT_METRICS_WORKFLOWS
         + SESSION_SUMMARY_WORKFLOWS
         + SUMMARIZATION_SWEEP_WORKFLOWS,
-        COUNT_PLAYLIST_ITEMS_ACTIVITIES
+        CLEANUP_SWEEP_ACTIVITIES
+        + COUNT_PLAYLIST_ITEMS_ACTIVITIES
         + DELETE_RECORDING_ACTIVITIES
         + ENFORCE_MAX_REPLAY_RETENTION_ACTIVITIES
         + EXPORT_RECORDING_ACTIVITIES

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -61,6 +61,7 @@ from posthog.temporal.salesforce_enrichment.workflow import SalesforceEnrichment
 from posthog.temporal.session_replay.delete_recordings.types import PurgeDeletedMetadataInput
 from posthog.temporal.session_replay.enforce_max_replay_retention.types import EnforceMaxReplayRetentionInput
 from posthog.temporal.session_replay.replay_count_metrics.types import ReplayCountMetricsInput
+from posthog.temporal.session_replay.session_summary.cleanup_sweep import create_cleanup_sweep_schedule
 from posthog.temporal.session_replay.summarization_sweep.reconciler import (
     create_summarization_sweep_reconciler_schedule,
 )
@@ -553,6 +554,11 @@ schedules = [
     create_wa_weekly_digest_schedule,
     create_logs_alert_check_schedule,
 ]
+
+if settings.CLOUD_DEPLOYMENT:
+    # Sweeper compares the deployment prefix on each Gemini file's display_name against its own
+    # CLOUD_DEPLOYMENT, so it can't run unscoped (would risk reaping sibling deployments' files).
+    schedules.append(create_cleanup_sweep_schedule)
 
 if settings.EE_AVAILABLE:
     schedules.append(create_schedule_all_subscriptions_schedule)

--- a/posthog/temporal/session_replay/session_summary/activities/a2_upload_video_to_gemini.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a2_upload_video_to_gemini.py
@@ -45,6 +45,10 @@ async def upload_video_to_gemini_activity(
     inputs: VideoSummarySingleSessionInputs, asset_id: int
 ) -> UploadVideoToGeminiOutput:
     """Upload full video to Gemini for analysis and return file reference with duration, plus team name"""
+    # display_name is read by the cleanup sweeper. The deployment prefix scopes ownership so that
+    # one cluster's sweeper can't delete another cluster's in-use files when they share a Gemini key.
+    deployment = settings.CLOUD_DEPLOYMENT or "local"
+    display_name = f"{deployment}:{temporalio.activity.info().workflow_id}"
     try:
         # Fetch team name once here to avoid fetching it 100+ times in parallel segment analysis
         team_name = (await Team.objects.only("name").aget(id=inputs.team_id)).name
@@ -80,7 +84,8 @@ async def upload_video_to_gemini_activity(
             raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
             # Wrap sync Google API call in thread pool to avoid blocking the event loop
             uploaded_file = await sync_to_async(raw_client.files.upload, thread_sensitive=False)(
-                file=tmp_file.name, config=types.UploadFileConfig(mime_type=asset.export_format)
+                file=tmp_file.name,
+                config=types.UploadFileConfig(mime_type=asset.export_format, display_name=display_name),
             )
             # Wait for file to be ready
             wait_start_time = time.time()

--- a/posthog/temporal/session_replay/session_summary/cleanup_sweep/__init__.py
+++ b/posthog/temporal/session_replay/session_summary/cleanup_sweep/__init__.py
@@ -1,0 +1,12 @@
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.activities import sweep_gemini_files_activity
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.schedule import create_cleanup_sweep_schedule
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.workflow import GeminiFileCleanupSweepWorkflow
+
+CLEANUP_SWEEP_WORKFLOWS = [GeminiFileCleanupSweepWorkflow]
+CLEANUP_SWEEP_ACTIVITIES = [sweep_gemini_files_activity]
+
+__all__ = [
+    "CLEANUP_SWEEP_ACTIVITIES",
+    "CLEANUP_SWEEP_WORKFLOWS",
+    "create_cleanup_sweep_schedule",
+]

--- a/posthog/temporal/session_replay/session_summary/cleanup_sweep/activities.py
+++ b/posthog/temporal/session_replay/session_summary/cleanup_sweep/activities.py
@@ -1,0 +1,177 @@
+import asyncio
+from dataclasses import replace
+from datetime import UTC, datetime
+
+from django.conf import settings
+
+import structlog
+from asgiref.sync import sync_to_async
+from google.genai import (
+    Client as RawGenAIClient,
+    types,
+)
+from temporalio import activity
+from temporalio.client import Client, WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.temporal.common.client import async_connect
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.constants import (
+    AGE_THRESHOLD,
+    DELETE_CONCURRENCY,
+    DESCRIBE_CONCURRENCY,
+    LIST_PAGE_SIZE,
+    MAX_FILES_PER_SWEEP,
+    display_name_prefix_for,
+)
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.models import CleanupSweepInputs, CleanupSweepResult
+
+logger = structlog.get_logger(__name__)
+
+_TERMINAL_STATUSES = frozenset(
+    {
+        WorkflowExecutionStatus.COMPLETED,
+        WorkflowExecutionStatus.FAILED,
+        WorkflowExecutionStatus.CANCELED,
+        WorkflowExecutionStatus.TERMINATED,
+        WorkflowExecutionStatus.TIMED_OUT,
+    }
+)
+
+
+def _list_candidates(
+    raw_client: RawGenAIClient, cutoff: datetime, deployment: str
+) -> tuple[int, int, int, int, list[tuple[str, str]], bool]:
+    """Returns ``(listed, age_skipped, prefix_skipped, no_name_skipped, candidates, hit_cap)``.
+
+    Sync because ``Pager`` is sync; call via ``sync_to_async``.
+    """
+    full_prefix = display_name_prefix_for(deployment)
+    deployment_prefix = f"{deployment}:"
+    listed = 0
+    age_skipped = 0
+    prefix_skipped = 0
+    no_name_skipped = 0
+    candidates: list[tuple[str, str]] = []
+    hit_cap = False
+
+    pager = raw_client.files.list(config=types.ListFilesConfig(page_size=LIST_PAGE_SIZE))
+    for f in pager:
+        listed += 1
+        if f.create_time is None or f.create_time > cutoff:
+            age_skipped += 1
+            continue
+        if not f.display_name or not f.display_name.startswith(full_prefix):
+            prefix_skipped += 1
+            continue
+        if not f.name:
+            # Owned by us per display_name, but unusable — surface separately for ops.
+            no_name_skipped += 1
+            continue
+        workflow_id = f.display_name[len(deployment_prefix) :]
+        candidates.append((f.name, workflow_id))
+        if len(candidates) >= MAX_FILES_PER_SWEEP:
+            hit_cap = True
+            break
+    return listed, age_skipped, prefix_skipped, no_name_skipped, candidates, hit_cap
+
+
+async def _classify_workflow(temporal: Client, workflow_id: str) -> str:
+    """Returns ``"delete"``, ``"running"``, or ``"error"``."""
+    try:
+        desc = await temporal.get_workflow_handle(workflow_id).describe()
+    except RPCError as e:
+        if e.status == RPCStatusCode.NOT_FOUND:
+            return "delete"
+        return "error"
+    except Exception:
+        return "error"
+
+    if desc.status in _TERMINAL_STATUSES:
+        return "delete"
+    return "running"
+
+
+@activity.defn
+async def sweep_gemini_files_activity(inputs: CleanupSweepInputs) -> CleanupSweepResult:
+    """Reclaims orphaned Gemini files. Failures are counted, never raised."""
+    if not settings.CLOUD_DEPLOYMENT:
+        raise RuntimeError("cleanup sweep requires CLOUD_DEPLOYMENT to be set")
+    raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
+    temporal = await async_connect()
+    cutoff = datetime.now(UTC) - AGE_THRESHOLD
+
+    listed, age_skipped, prefix_skipped, no_name_skipped, candidates, hit_cap = await sync_to_async(
+        _list_candidates, thread_sensitive=False
+    )(raw_client, cutoff, settings.CLOUD_DEPLOYMENT)
+    activity.heartbeat({"phase": "listed", "listed": listed, "candidates": len(candidates)})
+
+    describe_sem = asyncio.Semaphore(DESCRIBE_CONCURRENCY)
+
+    async def _classify_with_sem(file_name: str, workflow_id: str) -> tuple[str, str]:
+        async with describe_sem:
+            outcome = await _classify_workflow(temporal, workflow_id)
+            return file_name, outcome
+
+    classifications = await asyncio.gather(
+        *(_classify_with_sem(fn, wid) for fn, wid in candidates),
+    )
+    activity.heartbeat({"phase": "classified", "classified": len(classifications)})
+
+    to_delete = [fn for fn, outcome in classifications if outcome == "delete"]
+    skipped_running = sum(1 for _, outcome in classifications if outcome == "running")
+    skipped_error = sum(1 for _, outcome in classifications if outcome == "error")
+
+    base_result = CleanupSweepResult(
+        listed=listed,
+        skipped_too_young=age_skipped,
+        skipped_unrecognized_prefix=prefix_skipped,
+        skipped_no_name=no_name_skipped,
+        skipped_running=skipped_running,
+        skipped_temporal_error=skipped_error,
+        hit_max_files_cap=hit_cap,
+        dry_run=inputs.dry_run,
+    )
+
+    if inputs.dry_run:
+        logger.info(
+            "cleanup_sweep.dry_run.would_delete",
+            count=len(to_delete),
+            listed=listed,
+            signals_type="cleanup-sweep",
+        )
+        return replace(base_result, deleted=len(to_delete))
+
+    delete_sem = asyncio.Semaphore(DELETE_CONCURRENCY)
+
+    async def _delete(file_name: str) -> bool:
+        async with delete_sem:
+            try:
+                await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=file_name)
+                return True
+            except Exception:
+                logger.exception(
+                    "cleanup_sweep.delete_failed",
+                    gemini_file_name=file_name,
+                    signals_type="cleanup-sweep",
+                )
+                return False
+
+    delete_results = await asyncio.gather(*(_delete(fn) for fn in to_delete))
+    deleted = sum(1 for r in delete_results if r)
+    delete_failed = sum(1 for r in delete_results if not r)
+
+    result = replace(base_result, deleted=deleted, delete_failed=delete_failed)
+    logger.info(
+        "cleanup_sweep.cycle_complete",
+        listed=result.listed,
+        deleted=result.deleted,
+        skipped_running=result.skipped_running,
+        skipped_too_young=result.skipped_too_young,
+        skipped_unrecognized_prefix=result.skipped_unrecognized_prefix,
+        skipped_no_name=result.skipped_no_name,
+        skipped_temporal_error=result.skipped_temporal_error,
+        delete_failed=result.delete_failed,
+        hit_max_files_cap=result.hit_max_files_cap,
+        signals_type="cleanup-sweep",
+    )
+    return result

--- a/posthog/temporal/session_replay/session_summary/cleanup_sweep/constants.py
+++ b/posthog/temporal/session_replay/session_summary/cleanup_sweep/constants.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+
+SCHEDULE_ID = "session-summary-cleanup-sweep-schedule"
+WORKFLOW_ID = "session-summary-cleanup-sweep"
+WORKFLOW_NAME = "session-summary-cleanup-sweep"
+SCHEDULE_TYPE = "session-summary-cleanup-sweep"
+
+SCHEDULE_INTERVAL = timedelta(minutes=30)
+
+# Must exceed worst-case `summarize-session` runtime (~45 min including retries).
+AGE_THRESHOLD = timedelta(hours=4)
+
+LIST_PAGE_SIZE = 100
+DESCRIBE_CONCURRENCY = 20
+DELETE_CONCURRENCY = 10
+MAX_FILES_PER_SWEEP = 5000
+
+WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=20)
+SWEEP_ACTIVITY_TIMEOUT = timedelta(minutes=15)
+SWEEP_ACTIVITY_HEARTBEAT_TIMEOUT = timedelta(minutes=2)
+
+DISPLAY_NAME_WORKFLOW_PREFIX = "session-summary:single:"
+
+
+def display_name_prefix_for(deployment: str) -> str:
+    """Per-deployment prefix on Gemini ``display_name``. Keeps one deployment's sweeper from reaping another's files."""
+    return f"{deployment}:{DISPLAY_NAME_WORKFLOW_PREFIX}"

--- a/posthog/temporal/session_replay/session_summary/cleanup_sweep/models.py
+++ b/posthog/temporal/session_replay/session_summary/cleanup_sweep/models.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CleanupSweepInputs:
+    dry_run: bool = False
+
+
+@dataclass
+class CleanupSweepResult:
+    listed: int = 0
+    deleted: int = 0
+    skipped_running: int = 0
+    skipped_too_young: int = 0
+    skipped_unrecognized_prefix: int = 0
+    skipped_no_name: int = 0
+    skipped_temporal_error: int = 0
+    delete_failed: int = 0
+    hit_max_files_cap: bool = False
+    dry_run: bool = False

--- a/posthog/temporal/session_replay/session_summary/cleanup_sweep/schedule.py
+++ b/posthog/temporal/session_replay/session_summary/cleanup_sweep/schedule.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+
+from temporalio import common
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+from temporalio.common import SearchAttributePair, TypedSearchAttributes
+
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_TYPE_KEY
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.constants import (
+    SCHEDULE_ID,
+    SCHEDULE_INTERVAL,
+    SCHEDULE_TYPE,
+    WORKFLOW_EXECUTION_TIMEOUT,
+    WORKFLOW_ID,
+    WORKFLOW_NAME,
+)
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.models import CleanupSweepInputs
+
+
+async def create_cleanup_sweep_schedule(client: Client) -> None:
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_NAME,
+            CleanupSweepInputs(),
+            id=WORKFLOW_ID,
+            task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
+            execution_timeout=WORKFLOW_EXECUTION_TIMEOUT,
+            retry_policy=common.RetryPolicy(maximum_attempts=1),
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=SCHEDULE_INTERVAL)]),
+        policy=SchedulePolicy(
+            overlap=ScheduleOverlapPolicy.SKIP,
+            catchup_window=SCHEDULE_INTERVAL,
+        ),
+    )
+    search_attributes = TypedSearchAttributes(
+        search_attributes=[SearchAttributePair(key=POSTHOG_SCHEDULE_TYPE_KEY, value=SCHEDULE_TYPE)]
+    )
+    if await a_schedule_exists(client, SCHEDULE_ID):
+        await a_update_schedule(client, SCHEDULE_ID, schedule, search_attributes=search_attributes)
+    else:
+        await a_create_schedule(
+            client,
+            SCHEDULE_ID,
+            schedule,
+            trigger_immediately=True,
+            search_attributes=search_attributes,
+        )

--- a/posthog/temporal/session_replay/session_summary/cleanup_sweep/workflow.py
+++ b/posthog/temporal/session_replay/session_summary/cleanup_sweep/workflow.py
@@ -1,0 +1,47 @@
+import json
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.constants import (
+    SWEEP_ACTIVITY_HEARTBEAT_TIMEOUT,
+    SWEEP_ACTIVITY_TIMEOUT,
+    WORKFLOW_NAME,
+)
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.models import CleanupSweepInputs
+
+with workflow.unsafe.imports_passed_through():
+    from posthog.temporal.session_replay.session_summary.cleanup_sweep.activities import sweep_gemini_files_activity
+
+
+@workflow.defn(name=WORKFLOW_NAME)
+class GeminiFileCleanupSweepWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> CleanupSweepInputs:
+        if not inputs:
+            return CleanupSweepInputs()
+        return CleanupSweepInputs(**json.loads(inputs[0]))
+
+    @workflow.run
+    async def run(self, inputs: CleanupSweepInputs) -> dict[str, Any]:
+        result = await workflow.execute_activity(
+            sweep_gemini_files_activity,
+            inputs,
+            start_to_close_timeout=SWEEP_ACTIVITY_TIMEOUT,
+            heartbeat_timeout=SWEEP_ACTIVITY_HEARTBEAT_TIMEOUT,
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+        return {
+            "listed": result.listed,
+            "deleted": result.deleted,
+            "skipped_running": result.skipped_running,
+            "skipped_too_young": result.skipped_too_young,
+            "skipped_unrecognized_prefix": result.skipped_unrecognized_prefix,
+            "skipped_no_name": result.skipped_no_name,
+            "skipped_temporal_error": result.skipped_temporal_error,
+            "delete_failed": result.delete_failed,
+            "hit_max_files_cap": result.hit_max_files_cap,
+            "dry_run": result.dry_run,
+        }

--- a/posthog/temporal/tests/session_replay/session_summary/cleanup_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/session_summary/cleanup_sweep/test_activities.py
@@ -1,0 +1,367 @@
+import datetime as dt
+from dataclasses import dataclass
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from google.genai import types
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.activities import sweep_gemini_files_activity
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.constants import AGE_THRESHOLD, MAX_FILES_PER_SWEEP
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.models import CleanupSweepInputs, CleanupSweepResult
+
+_NOW = dt.datetime(2026, 4, 24, 12, 0, 0, tzinfo=dt.UTC)
+_DEPLOYMENT = "TEST"
+
+
+@pytest.fixture(autouse=True)
+def _set_deployment(settings):
+    settings.CLOUD_DEPLOYMENT = _DEPLOYMENT
+
+
+def _file(
+    *,
+    name: str,
+    display_name: str | None,
+    age: dt.timedelta,
+) -> types.File:
+    return types.File(name=name, display_name=display_name, create_time=_NOW - age)
+
+
+@dataclass
+class _Outcome:
+    status: WorkflowExecutionStatus | None = None
+    raise_not_found: bool = False
+    raise_rpc_error: bool = False
+
+
+class _StubHandle:
+    def __init__(self, outcome: _Outcome) -> None:
+        self._outcome = outcome
+
+    async def describe(self):
+        if self._outcome.raise_not_found:
+            raise RPCError("not found", RPCStatusCode.NOT_FOUND, b"")
+        if self._outcome.raise_rpc_error:
+            raise RPCError("boom", RPCStatusCode.INTERNAL, b"")
+
+        class _Desc:
+            status = self._outcome.status
+
+        return _Desc()
+
+
+class _StubTemporal:
+    def __init__(self, outcomes: dict[str, _Outcome]) -> None:
+        self._outcomes = outcomes
+
+    def get_workflow_handle(self, workflow_id: str) -> _StubHandle:
+        return _StubHandle(self._outcomes.get(workflow_id, _Outcome(status=WorkflowExecutionStatus.RUNNING)))
+
+
+class _StubFiles:
+    def __init__(self, files: list[types.File]) -> None:
+        self._files = files
+        self.deleted: list[str] = []
+        self.delete_raises_for: set[str] = set()
+
+    def list(self, *, config=None):
+        return iter(self._files)
+
+    def delete(self, *, name: str) -> None:
+        if name in self.delete_raises_for:
+            raise RuntimeError(f"simulated delete failure for {name}")
+        self.deleted.append(name)
+
+
+class _StubRawClient:
+    def __init__(self, files: list[types.File]) -> None:
+        self.files = _StubFiles(files)
+
+
+@pytest.fixture
+def fixed_now():
+    class _FixedDatetime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _NOW if tz is None else _NOW.astimezone(tz)
+
+    with patch(
+        "posthog.temporal.session_replay.session_summary.cleanup_sweep.activities.datetime",
+        _FixedDatetime,
+    ):
+        yield
+
+
+def _patch_clients(raw_client: _StubRawClient, temporal: _StubTemporal):
+    return (
+        patch(
+            "posthog.temporal.session_replay.session_summary.cleanup_sweep.activities.RawGenAIClient",
+            return_value=raw_client,
+        ),
+        patch(
+            "posthog.temporal.session_replay.session_summary.cleanup_sweep.activities.async_connect",
+            new=AsyncMock(return_value=temporal),
+        ),
+    )
+
+
+def _wid(team_id: int, session_id: str) -> str:
+    """Temporal workflow id (matches `SummarizeSingleSessionWorkflow.workflow_id_for`)."""
+    return f"session-summary:single:{team_id}:{session_id}"
+
+
+def _dn(team_id: int, session_id: str) -> str:
+    """Display-name a real upload would write: deployment-prefixed workflow id."""
+    return f"{_DEPLOYMENT}:{_wid(team_id, session_id)}"
+
+
+@pytest.mark.asyncio
+async def test_empty_pager_returns_zeros(activity_environment, fixed_now):
+    raw, tmp = _StubRawClient([]), _StubTemporal({})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result == CleanupSweepResult()
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_skips_files_younger_than_threshold(activity_environment, fixed_now):
+    f = _file(name="files/young", display_name=_dn(1, "s1"), age=AGE_THRESHOLD - dt.timedelta(minutes=1))
+    raw, tmp = _StubRawClient([f]), _StubTemporal({_wid(1, "s1"): _Outcome(status=WorkflowExecutionStatus.COMPLETED)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_too_young == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_skips_files_without_recognized_prefix(activity_environment, fixed_now):
+    files = [
+        _file(name="files/foreign", display_name="some-other-tool:upload", age=AGE_THRESHOLD * 2),
+        _file(name="files/no-display", display_name=None, age=AGE_THRESHOLD * 2),
+    ]
+    raw, tmp = _StubRawClient(files), _StubTemporal({})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_unrecognized_prefix == 2
+    assert result.deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_files_with_valid_prefix_but_no_name_are_counted_separately(activity_environment, fixed_now):
+    # Owned by us per display_name, but unusable — surface as a distinct bucket
+    # so a Gemini API anomaly can be diagnosed instead of looking like an unrelated upload.
+    f = types.File(name=None, display_name=_dn(1, "s1"), create_time=_NOW - AGE_THRESHOLD * 2)
+    raw, tmp = _StubRawClient([f]), _StubTemporal({})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_no_name == 1
+    assert result.skipped_unrecognized_prefix == 0
+    assert result.deleted == 0
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        WorkflowExecutionStatus.COMPLETED,
+        WorkflowExecutionStatus.FAILED,
+        WorkflowExecutionStatus.CANCELED,
+        WorkflowExecutionStatus.TERMINATED,
+        WorkflowExecutionStatus.TIMED_OUT,
+    ],
+)
+@pytest.mark.asyncio
+async def test_deletes_files_for_terminal_workflows(activity_environment, fixed_now, status):
+    f = _file(name="files/old", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2)
+    raw, tmp = _StubRawClient([f]), _StubTemporal({_wid(1, "s1"): _Outcome(status=status)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert raw.files.deleted == ["files/old"]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [WorkflowExecutionStatus.RUNNING, WorkflowExecutionStatus.CONTINUED_AS_NEW],
+)
+@pytest.mark.asyncio
+async def test_skips_files_for_active_workflows(activity_environment, fixed_now, status):
+    f = _file(name="files/in-use", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2)
+    raw, tmp = _StubRawClient([f]), _StubTemporal({_wid(1, "s1"): _Outcome(status=status)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_running == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_files_from_other_deployments_are_skipped(activity_environment, fixed_now):
+    # Sibling deployment's file: prefix matches our `session-summary:single:` workflow
+    # convention but with a different deployment tag → must not be touched.
+    other = _file(
+        name="files/eu",
+        display_name=f"OTHER:{_wid(1, 's1')}",
+        age=AGE_THRESHOLD * 2,
+    )
+    raw, tmp = _StubRawClient([other]), _StubTemporal({})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_unrecognized_prefix == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_status_none_is_treated_as_running(activity_environment, fixed_now):
+    # `WorkflowExecutionDescription.status` can come back unset; we mustn't delete on that.
+    f = _file(name="files/maybe-running", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2)
+    raw, tmp = _StubRawClient([f]), _StubTemporal({_wid(1, "s1"): _Outcome(status=None)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_running == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_deletes_when_workflow_not_found(activity_environment, fixed_now):
+    f = _file(name="files/orphan", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2)
+    raw, tmp = _StubRawClient([f]), _StubTemporal({_wid(1, "s1"): _Outcome(raise_not_found=True)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert raw.files.deleted == ["files/orphan"]
+
+
+@pytest.mark.asyncio
+async def test_skips_on_temporal_rpc_error(activity_environment, fixed_now):
+    f = _file(name="files/unknown", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2)
+    raw, tmp = _StubRawClient([f]), _StubTemporal({_wid(1, "s1"): _Outcome(raise_rpc_error=True)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_temporal_error == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_counts_without_deleting(activity_environment, fixed_now):
+    files = [
+        _file(name="files/one", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2),
+        _file(name="files/two", display_name=_dn(1, "s2"), age=AGE_THRESHOLD * 2),
+    ]
+    raw = _StubRawClient(files)
+    tmp = _StubTemporal(
+        {
+            _wid(1, "s1"): _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+            _wid(1, "s2"): _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+        }
+    )
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs(dry_run=True))
+    assert result.deleted == 2
+    assert result.dry_run is True
+    assert raw.files.deleted == []  # no real deletes
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_counted_does_not_raise(activity_environment, fixed_now):
+    files = [
+        _file(name="files/ok", display_name=_dn(1, "s1"), age=AGE_THRESHOLD * 2),
+        _file(name="files/bad", display_name=_dn(1, "s2"), age=AGE_THRESHOLD * 2),
+    ]
+    raw = _StubRawClient(files)
+    raw.files.delete_raises_for = {"files/bad"}
+    tmp = _StubTemporal(
+        {
+            _wid(1, "s1"): _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+            _wid(1, "s2"): _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+        }
+    )
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert result.delete_failed == 1
+    assert raw.files.deleted == ["files/ok"]
+
+
+@pytest.mark.asyncio
+async def test_hits_max_files_cap_on_candidate_count(activity_environment, fixed_now):
+    files = [
+        _file(name=f"files/n{i}", display_name=_dn(1, f"s{i}"), age=AGE_THRESHOLD * 2)
+        for i in range(MAX_FILES_PER_SWEEP + 1)
+    ]
+    raw = _StubRawClient(files)
+    tmp = _StubTemporal({_wid(1, f"s{i}"): _Outcome(raise_not_found=True) for i in range(MAX_FILES_PER_SWEEP + 1)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.hit_max_files_cap is True
+    assert result.deleted == MAX_FILES_PER_SWEEP
+
+
+@pytest.mark.asyncio
+async def test_unrelated_files_do_not_consume_cap(activity_environment, fixed_now):
+    # Cap counts candidates only — a backlog of foreign / young files in front of one
+    # eligible orphan must not prevent the orphan from being collected and deleted.
+    young_or_foreign = [
+        _file(name=f"files/y{i}", display_name=_dn(1, f"y{i}"), age=dt.timedelta(seconds=1))
+        for i in range(MAX_FILES_PER_SWEEP)
+    ]
+    orphan = _file(name="files/orphan", display_name=_dn(1, "real"), age=AGE_THRESHOLD * 2)
+    raw = _StubRawClient([*young_or_foreign, orphan])
+    tmp = _StubTemporal({_wid(1, "real"): _Outcome(raise_not_found=True)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.hit_max_files_cap is False
+    assert result.deleted == 1
+    assert raw.files.deleted == ["files/orphan"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_cycle_aggregates_correctly(activity_environment, fixed_now):
+    files = [
+        _file(name="files/young", display_name=_dn(1, "s1"), age=dt.timedelta(minutes=10)),
+        _file(name="files/foreign", display_name="other-tool:upload", age=AGE_THRESHOLD * 2),
+        _file(name="files/done", display_name=_dn(1, "s2"), age=AGE_THRESHOLD * 2),
+        _file(name="files/running", display_name=_dn(1, "s3"), age=AGE_THRESHOLD * 2),
+        _file(name="files/orphan", display_name=_dn(1, "s4"), age=AGE_THRESHOLD * 2),
+        _file(name="files/error", display_name=_dn(1, "s5"), age=AGE_THRESHOLD * 2),
+    ]
+    raw = _StubRawClient(files)
+    tmp = _StubTemporal(
+        {
+            _wid(1, "s2"): _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+            _wid(1, "s3"): _Outcome(status=WorkflowExecutionStatus.RUNNING),
+            _wid(1, "s4"): _Outcome(raise_not_found=True),
+            _wid(1, "s5"): _Outcome(raise_rpc_error=True),
+        }
+    )
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.listed == 6
+    assert result.skipped_too_young == 1
+    assert result.skipped_unrecognized_prefix == 1
+    assert result.skipped_running == 1
+    assert result.skipped_temporal_error == 1
+    assert result.deleted == 2
+    assert sorted(raw.files.deleted) == ["files/done", "files/orphan"]

--- a/posthog/temporal/tests/session_replay/session_summary/cleanup_sweep/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/session_summary/cleanup_sweep/test_workflow.py
@@ -1,0 +1,59 @@
+import uuid
+
+import pytest
+
+import temporalio.worker
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.constants import WORKFLOW_NAME
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.models import CleanupSweepInputs, CleanupSweepResult
+from posthog.temporal.session_replay.session_summary.cleanup_sweep.workflow import GeminiFileCleanupSweepWorkflow
+
+
+@pytest.mark.asyncio
+async def test_workflow_returns_activity_result_as_dict():
+    @activity.defn(name="sweep_gemini_files_activity")
+    async def sweep_mocked(inputs: CleanupSweepInputs) -> CleanupSweepResult:
+        return CleanupSweepResult(
+            listed=42,
+            deleted=10,
+            skipped_running=5,
+            skipped_too_young=20,
+            skipped_unrecognized_prefix=2,
+            skipped_no_name=1,
+            skipped_temporal_error=1,
+            delete_failed=1,
+            hit_max_files_cap=False,
+            dry_run=False,
+        )
+
+    task_queue = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[GeminiFileCleanupSweepWorkflow],
+            activities=[sweep_mocked],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                WORKFLOW_NAME,
+                CleanupSweepInputs(),
+                id=str(uuid.uuid4()),
+                task_queue=task_queue,
+            )
+
+    assert result == {
+        "listed": 42,
+        "deleted": 10,
+        "skipped_running": 5,
+        "skipped_too_young": 20,
+        "skipped_unrecognized_prefix": 2,
+        "skipped_no_name": 1,
+        "skipped_temporal_error": 1,
+        "delete_failed": 1,
+        "hit_max_files_cap": False,
+        "dry_run": False,
+    }


### PR DESCRIPTION
## Problem

Gemini's Files API stores uploaded files for 48h. Per-request cleanup in the
session-summary workflow is best-effort, so any path that bypasses it leaves
files behind until TTL — eventually pushing against the 20 GB project quota.

## Changes

A 30-min Temporal Schedule lists Gemini files older than 4h, asks Temporal
whether the owning workflow is terminal/missing, and deletes only those.
Uploads carry the workflow id in `display_name`, deployment-prefixed so a
shared Gemini API key across clusters never causes one sweeper to reap
another deployment's in-use files. The schedule is only registered when
`CLOUD_DEPLOYMENT` is set, so local dev never runs it.

Per-request cleanup stays best-effort.

## How did you test this code?

Agent-authored, no manual testing of the workflow itself. Automated:

- 20 activity unit tests covering all status branches (including
  `status=None`), age/prefix filters, sibling-deployment isolation,
  dry-run, delete-failure, and the post-filter candidate cap
- 1 workflow happy-path test via `WorkflowEnvironment`
- `ruff` clean; schedule gated on `CLOUD_DEPLOYMENT` (verified locally:
  `cleanup_sweep` not registered when unset)
- Empirically verified `display_name` round-trips `:` intact via a real
  upload + delete against the Gemini API

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) in Claude Code from a multi-turn design
discussion. Key decision: filter by workflow status, not age alone, so the
4h threshold is safe even when a summary runs long.
