### PR TITLE
feat(admin): keep admin panel usable while impersonating

### DIFF
--- a/posthog/helpers/impersonation.py
+++ b/posthog/helpers/impersonation.py
@@ -1,9 +1,13 @@
 from datetime import timedelta
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import (
+    get_user as auth_get_user,
+    get_user_model,
+)
 from django.core.signing import TimestampSigner
 
 from loginas import settings as la_settings
+from loginas.utils import is_impersonated_session
 
 
 def get_original_user_from_session(request):
@@ -18,3 +22,21 @@ def get_original_user_from_session(request):
         return User.objects.get(pk=original_user_pk)
     except Exception:
         return None
+
+
+def get_impersonated_user(request):
+    """Return the user being impersonated, looked up from the session.
+
+    Reads from the session (not `request.user`) so callers get the right user even
+    after `AdminImpersonationMiddleware` has swapped `request.user` to the original
+    staff user on `/admin/` paths.
+    """
+    if not is_impersonated_session(request):
+        return None
+    user = auth_get_user(request)
+    return user if user.is_authenticated else None
+
+
+def impersonation_context(request):
+    """Template context processor exposing the impersonated user for admin templates."""
+    return {"impersonated_user": get_impersonated_user(request)}

--- a/posthog/helpers/impersonation.py
+++ b/posthog/helpers/impersonation.py
@@ -1,9 +1,6 @@
 from datetime import timedelta
 
-from django.contrib.auth import (
-    get_user as auth_get_user,
-    get_user_model,
-)
+from django.contrib.auth import BACKEND_SESSION_KEY, SESSION_KEY, get_user_model, load_backend
 from django.core.signing import TimestampSigner
 
 from loginas import settings as la_settings
@@ -25,18 +22,33 @@ def get_original_user_from_session(request):
 
 
 def get_impersonated_user(request):
-    """Return the user being impersonated, looked up from the session.
+    """Return the user being impersonated, looked up directly from the session.
 
-    Reads from the session (not `request.user`) so callers get the right user even
-    after `AdminImpersonationMiddleware` has swapped `request.user` to the original
-    staff user on `/admin/` paths.
+    Reads `SESSION_KEY`/`BACKEND_SESSION_KEY` from the session (not `request.user`
+    nor `request._cached_user`) so callers get the impersonated customer even after
+    `AdminImpersonationMiddleware` has swapped both attributes to the original staff
+    user on `/admin/` paths.
     """
     if not is_impersonated_session(request):
         return None
-    user = auth_get_user(request)
-    return user if user.is_authenticated else None
+    try:
+        user_id = request.session[SESSION_KEY]
+        backend_path = request.session[BACKEND_SESSION_KEY]
+    except KeyError:
+        return None
+    try:
+        backend = load_backend(backend_path)
+        return backend.get_user(user_id)
+    except Exception:
+        return None
 
 
 def impersonation_context(request):
-    """Template context processor exposing the impersonated user for admin templates."""
+    """Template context processor exposing the impersonated user for admin templates.
+
+    Only active for `/admin/` paths to avoid the per-render DB lookup
+    `auth_get_user` performs on every other view.
+    """
+    if not getattr(request, "path", "").startswith("/admin/"):
+        return {}
     return {"impersonated_user": get_impersonated_user(request)}

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -36,6 +36,7 @@ from posthog.cloud_utils import is_cloud, is_dev_mode
 from posthog.constants import AUTH_BACKEND_KEYS
 from posthog.event_usage import get_event_source, get_mcp_properties
 from posthog.geoip import get_geoip_properties
+from posthog.helpers.impersonation import get_original_user_from_session
 from posthog.helpers.user_devices import set_known_device_cookie
 from posthog.models import Action, Cohort, FeatureFlag, Insight, Team, User
 from posthog.models.activity_logging.utils import (
@@ -688,6 +689,47 @@ def get_impersonated_session_expires_at(request: HttpRequest) -> Optional[dateti
     return min(idle_expiry_time, total_expiry_time)
 
 
+class AdminImpersonationMiddleware:
+    """
+    During impersonation, allow the original (staff) user to keep using the admin panel.
+
+    Without this, an impersonated session swaps `request.user` to the customer being
+    impersonated — who is not staff — locking the admin out of the admin panel and
+    every staff-only command. This middleware swaps `request.user` back to the
+    original staff user for `/admin/` routes so admin views, model permissions, and
+    `staff_member_required` decorators all see the real operator. The impersonation
+    session itself is left intact (the loginas session flag stays set), so the
+    impersonated user is still surfaced everywhere else and `is_impersonated_session`
+    keeps returning True. The impersonated user is exposed on
+    `request.impersonated_user` so templates can show a status banner.
+    """
+
+    # Endpoints that need to see the impersonated user as `request.user`.
+    EXEMPT_PATHS: tuple[str, ...] = (
+        # impersonated_session_logout reads request.user.pk to redirect back to the
+        # impersonated user's admin change page after restoring the original login.
+        "/admin/logout/",
+    )
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        if self._should_swap_user(request):
+            original_user = get_original_user_from_session(request)
+            if original_user and original_user.is_active and original_user.is_staff:
+                request.impersonated_user = request.user
+                request.user = original_user
+        return self.get_response(request)
+
+    def _should_swap_user(self, request: HttpRequest) -> bool:
+        if not request.path.startswith("/admin/"):
+            return False
+        if request.path.startswith(self.EXEMPT_PATHS):
+            return False
+        return is_impersonated_session(request)
+
+
 class AutoLogoutImpersonateMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -1042,6 +1084,11 @@ class ImpersonationReadOnlyMiddleware:
 
     def __call__(self, request: HttpRequest):
         if not is_read_only_impersonation(request):
+            return self.get_response(request)
+
+        # Admin paths run as the original staff user (see AdminImpersonationMiddleware),
+        # so impersonation read-only restrictions don't apply there.
+        if request.path.startswith("/admin/"):
             return self.get_response(request)
 
         if request.method in IMPERSONATION_SAFE_METHODS:

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -698,10 +698,9 @@ class AdminImpersonationMiddleware:
     every staff-only command. This middleware swaps `request.user` back to the
     original staff user for `/admin/` routes so admin views, model permissions, and
     `staff_member_required` decorators all see the real operator. The impersonation
-    session itself is left intact (the loginas session flag stays set), so the
-    impersonated user is still surfaced everywhere else and `is_impersonated_session`
-    keeps returning True. The impersonated user is exposed on
-    `request.impersonated_user` so templates can show a status banner.
+    session itself is left intact (the loginas session flag stays set), so
+    `is_impersonated_session` keeps returning True and `get_impersonated_user` still
+    returns the customer (looked up from the session).
     """
 
     # Endpoints that need to see the impersonated user as `request.user`.
@@ -718,7 +717,6 @@ class AdminImpersonationMiddleware:
         if self._should_swap_user(request):
             original_user = get_original_user_from_session(request)
             if original_user and original_user.is_active and original_user.is_staff:
-                request.impersonated_user = request.user
                 request.user = original_user
         return self.get_response(request)
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -718,12 +718,14 @@ class AdminImpersonationMiddleware:
             original_user = get_original_user_from_session(request)
             if original_user and original_user.is_active and original_user.is_staff:
                 request.user = original_user
+                # Keep the lazy auth-middleware cache in sync with the swapped user.
+                request._cached_user = original_user  # type: ignore[attr-defined]
         return self.get_response(request)
 
     def _should_swap_user(self, request: HttpRequest) -> bool:
         if not request.path.startswith("/admin/"):
             return False
-        if request.path.startswith(self.EXEMPT_PATHS):
+        if request.path in self.EXEMPT_PATHS:
             return False
         return is_impersonated_session(request)
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -128,6 +128,9 @@ MIDDLEWARE = [
     "posthog.middleware.CsrfOrKeyViewMiddleware",
     "posthog.middleware.QueryTimeCountingMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # Must run immediately after AuthenticationMiddleware so downstream middleware
+    # (activity logging, structlog binding, etc.) sees the swapped staff user on /admin/* paths.
+    "posthog.middleware.AdminImpersonationMiddleware",
     "posthog.api.query_coalescer.QueryCoalescingMiddleware",
     "posthog.middleware.SocialAuthExceptionMiddleware",
     "posthog.middleware.SessionAgeMiddleware",
@@ -136,7 +139,6 @@ MIDDLEWARE = [
     "posthog.middleware.user_logging_context_middleware",
     "django_otp.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "posthog.middleware.AdminImpersonationMiddleware",
     "posthog.middleware.AutoLogoutImpersonateMiddleware",
     "posthog.middleware.ImpersonationReadOnlyMiddleware",
     "posthog.middleware.ImpersonationBlockedPathsMiddleware",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -191,6 +191,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "loginas.context_processors.impersonated_session_status",
+                "posthog.helpers.impersonation.impersonation_context",
             ]
         },
     }

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -136,6 +136,7 @@ MIDDLEWARE = [
     "posthog.middleware.user_logging_context_middleware",
     "django_otp.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "posthog.middleware.AdminImpersonationMiddleware",
     "posthog.middleware.AutoLogoutImpersonateMiddleware",
     "posthog.middleware.ImpersonationReadOnlyMiddleware",
     "posthog.middleware.ImpersonationBlockedPathsMiddleware",

--- a/posthog/templates/admin/backfill_precalculated_person_properties.html
+++ b/posthog/templates/admin/backfill_precalculated_person_properties.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style>
     .form-row {
         margin-bottom: 15px;

--- a/posthog/templates/admin/base_site.html
+++ b/posthog/templates/admin/base_site.html
@@ -2,3 +2,39 @@
 {% block extrahead %}
     <link rel="shortcut icon" href="/static/icons/favicon.ico?v=2023-07-07">
 {% endblock %}
+{% block extrastyle %}
+    {{ block.super }}
+    {% if is_impersonated_session %}
+    <style>
+        .impersonation-banner {
+            background: #fff3cd;
+            border-bottom: 2px solid #f0c000;
+            color: #5a4500;
+            padding: 10px 16px;
+            font-size: 13px;
+            text-align: center;
+            line-height: 1.4;
+        }
+        .impersonation-banner strong { color: #5a4500; }
+        .impersonation-banner a.impersonation-stop {
+            color: #5a4500 !important;
+            text-decoration: underline !important;
+            font-weight: 700;
+            margin-left: 6px;
+        }
+        .impersonation-banner a.impersonation-stop:hover {
+            color: #000 !important;
+        }
+    </style>
+    {% endif %}
+{% endblock %}
+{% block header %}
+    {% if is_impersonated_session and request.impersonated_user %}
+    <div class="impersonation-banner">
+        Acting as <strong>{{ user.email }}</strong> in admin while impersonating
+        <strong>{{ request.impersonated_user.email }}</strong>.
+        <a class="impersonation-stop" href="/admin/logout/">Stop impersonating</a>
+    </div>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}

--- a/posthog/templates/admin/base_site.html
+++ b/posthog/templates/admin/base_site.html
@@ -29,10 +29,10 @@
     {% endif %}
 {% endblock %}
 {% block header %}
-    {% if is_impersonated_session and request.impersonated_user %}
+    {% if is_impersonated_session and impersonated_user %}
     <div class="impersonation-banner">
         Acting as <strong>{{ user.email }}</strong> in admin while impersonating
-        <strong>{{ request.impersonated_user.email }}</strong>.
+        <strong>{{ impersonated_user.email }}</strong>.
         <a class="impersonation-stop" href="/admin/logout/">Stop impersonating</a>
     </div>
     {% endif %}

--- a/posthog/templates/admin/email_mfa_bypass.html
+++ b/posthog/templates/admin/email_mfa_bypass.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style nonce="{{ request.csp_nonce }}">
     .form-row { margin-bottom: 15px; margin-top: 15px; }
     .help { font-size: 11px; color: #666; }

--- a/posthog/templates/admin/health_checks/list.html
+++ b/posthog/templates/admin/health_checks/list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style>
     .checks-table {
         width: 100%;

--- a/posthog/templates/admin/health_checks/trigger.html
+++ b/posthog/templates/admin/health_checks/trigger.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style>
     .config-card {
         border: 1px solid #e5e7eb;

--- a/posthog/templates/admin/radar_bypass.html
+++ b/posthog/templates/admin/radar_bypass.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style nonce="{{ request.csp_nonce }}">
     .form-row { margin-bottom: 15px; margin-top: 15px; }
     .help { font-size: 11px; color: #666; }

--- a/posthog/templates/admin/realtime_cohort_calculation.html
+++ b/posthog/templates/admin/realtime_cohort_calculation.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style>
     .form-row {
         margin-bottom: 15px;

--- a/posthog/templates/admin/resave_cohorts.html
+++ b/posthog/templates/admin/resave_cohorts.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static %}
 
 {% block extrastyle %}
-{{ super }}
+{{ block.super }}
 <style>
     .form-row { margin-bottom: 15px; }
     .help { font-size: 11px; color: #666; }

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -966,24 +966,30 @@ class TestAdminImpersonationMiddleware(APIBaseTest):
             data={"read_only": "true", "reason": "Test read-only impersonation"},
         )
 
-    def test_admin_writes_allowed_during_read_only_impersonation(self):
+    @patch("posthog.views.get_client")
+    def test_admin_writes_allowed_during_read_only_impersonation(self, mock_get_client: MagicMock):
         """Admin POST/PATCH/DELETE actions must not be blocked by the read-only
         impersonation middleware — admin runs as the original staff user."""
+        mock_redis = MagicMock()
+        mock_redis.ttl.return_value = -1
+        mock_get_client.return_value = mock_redis
+
         self.login_as_other_user_read_only()
 
-        # Hit an admin endpoint that performs a write. /admin/redis/edit-ttl is a
-        # POST endpoint that the impersonation read-only middleware would otherwise reject.
+        # POST to /admin/redis/edit-ttl — a function-based admin view registered directly
+        # in the URLconf (not lazy-loaded), so it's reachable in tests. A successful POST
+        # redirects (302) to the redis values list.
         response = self.client.post(
             "/admin/redis/edit-ttl",
             data={"key": "test:key", "ttl_seconds": "60"},
         )
 
-        # The middleware must not return its 403 read-only response.
-        assert not (
-            response.status_code == 403
-            and response.headers.get("Content-Type", "").startswith("application/json")
-            and response.json().get("code") == "impersonation_read_only"
-        )
+        # Endpoint must be reached (would-be 404 means the test isn't proving anything).
+        assert response.status_code != 404, "admin URL not registered in test environment"
+        # Middleware must not return its read-only 403.
+        assert response.status_code != 403, f"unexpected 403: {response.content!r}"
+        # Sanity check the write actually happened.
+        mock_redis.expire.assert_called_once_with("test:key", 60)
 
     def test_api_writes_still_blocked_during_read_only_impersonation(self):
         """Non-admin write requests must still be blocked under read-only impersonation."""

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -886,6 +886,135 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
 @override_settings(ADMIN_PORTAL_ENABLED=True)
 @override_settings(ADMIN_AUTH_GOOGLE_OAUTH2_KEY=None)
 @override_settings(ADMIN_AUTH_GOOGLE_OAUTH2_SECRET=None)
+# Bypass ManifestStaticFilesStorage so admin templates render in tests without a manifest.
+@override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})
+class TestAdminImpersonationMiddleware(APIBaseTest):
+    """Tests AdminImpersonationMiddleware: admin panel must remain accessible to the
+    original staff user during impersonation, even though `request.user` would
+    normally be the (non-staff) impersonated customer."""
+
+    other_user: User
+
+    def setUp(self):
+        super().setUp()
+        self.other_user = User.objects.create_and_join(
+            self.organization, email="other-user@posthog.com", password="123456"
+        )
+        self.user.is_staff = True
+        self.user.save()
+
+        # Use Django's standard Client because the loginas admin view expects
+        # form-encoded POST data (APIClient defaults to JSON).
+        self.client = cast(Any, DjangoClient())
+        self.client.force_login(self.user)
+
+    def login_as_other_user(self):
+        # Don't `follow=True` — the post-loginas redirect lands on `/` which renders
+        # the frontend's index.html (not present in tests).
+        return self.client.post(
+            reverse("loginas-user-login", kwargs={"user_id": self.other_user.id}),
+            data={"read_only": "false", "reason": "Test impersonation"},
+        )
+
+    def test_admin_index_accessible_during_impersonation(self):
+        """The admin index must respond 200, not redirect to /admin/login/, during impersonation."""
+        self.login_as_other_user()
+
+        # API confirms we're impersonating
+        assert self.client.get("/api/users/@me").json()["email"] == "other-user@posthog.com"
+
+        response = self.client.get("/admin/")
+        assert response.status_code == 200
+        # Banner should be rendered with the impersonated user
+        assert b"other-user@posthog.com" in response.content
+
+    def test_admin_index_redirects_when_no_impersonation_and_not_staff(self):
+        """Sanity check: a non-staff user without impersonation still cannot access /admin/."""
+        self.user.is_staff = False
+        self.user.save()
+
+        response = self.client.get("/admin/")
+        # Django redirects to /admin/login/ for unauthorized requests
+        assert response.status_code == 302
+        assert "/admin/login" in response.headers.get("Location", "")
+
+    def test_non_admin_paths_still_use_impersonated_user(self):
+        """Outside of /admin/, the impersonated user must remain in effect."""
+        self.login_as_other_user()
+
+        response = self.client.get("/api/users/@me/")
+        assert response.status_code == 200
+        assert response.json()["email"] == "other-user@posthog.com"
+
+    def test_admin_logout_still_sees_impersonated_user(self):
+        """/admin/logout/ must keep the impersonated user as request.user so it can
+        redirect back to that user's admin change page."""
+        self.login_as_other_user()
+
+        response = self.client.get("/admin/logout/")
+        assert response.status_code == 302
+        assert response.headers["Location"] == f"/admin/posthog/user/{self.other_user.id}/change/"
+
+    def test_admin_unaffected_when_not_impersonating(self):
+        """Regular staff users without an impersonation session still access admin normally."""
+        response = self.client.get("/admin/")
+        assert response.status_code == 200
+
+    def login_as_other_user_read_only(self):
+        return self.client.post(
+            reverse("loginas-user-login", kwargs={"user_id": self.other_user.id}),
+            data={"read_only": "true", "reason": "Test read-only impersonation"},
+        )
+
+    def test_admin_writes_allowed_during_read_only_impersonation(self):
+        """Admin POST/PATCH/DELETE actions must not be blocked by the read-only
+        impersonation middleware — admin runs as the original staff user."""
+        self.login_as_other_user_read_only()
+
+        # Hit an admin endpoint that performs a write. /admin/redis/edit-ttl is a
+        # POST endpoint that the impersonation read-only middleware would otherwise reject.
+        response = self.client.post(
+            "/admin/redis/edit-ttl",
+            data={"key": "test:key", "ttl_seconds": "60"},
+        )
+
+        # The middleware must not return its 403 read-only response.
+        assert not (
+            response.status_code == 403
+            and response.headers.get("Content-Type", "").startswith("application/json")
+            and response.json().get("code") == "impersonation_read_only"
+        )
+
+    def test_api_writes_still_blocked_during_read_only_impersonation(self):
+        """Non-admin write requests must still be blocked under read-only impersonation."""
+        from products.dashboards.backend.models.dashboard import Dashboard
+
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        self.login_as_other_user_read_only()
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/dashboards/{dashboard.id}/")
+        assert response.status_code == 403
+        assert response.json()["code"] == "impersonation_read_only"
+
+    def test_admin_blocked_when_original_user_loses_staff(self):
+        """If the original (impersonator) user is no longer staff, admin access is denied."""
+        self.login_as_other_user()
+
+        # Demote the original user mid-session.
+        self.user.is_staff = False
+        self.user.save()
+
+        response = self.client.get("/admin/")
+        # No swap happens (original isn't staff anymore) → impersonated non-staff user blocked
+        assert response.status_code == 302
+        assert "/admin/login" in response.headers.get("Location", "")
+
+
+@override_settings(IMPERSONATION_TIMEOUT_SECONDS=100)
+@override_settings(IMPERSONATION_IDLE_TIMEOUT_SECONDS=20)
+@override_settings(ADMIN_PORTAL_ENABLED=True)
+@override_settings(ADMIN_AUTH_GOOGLE_OAUTH2_KEY=None)
+@override_settings(ADMIN_AUTH_GOOGLE_OAUTH2_SECRET=None)
 class TestImpersonationBlockedPathsMiddleware(APIBaseTest):
     other_user: User
 


### PR DESCRIPTION
## Problem

While impersonating a user, the admin panel becomes inaccessible — `request.user` is the (non-staff) impersonated customer, so `staff_member_required` and the read-only impersonation middleware lock the operator out. Today the only workaround is to stop impersonating, run the admin command, and re-impersonate.

## Changes

- New `AdminImpersonationMiddleware`: on `/admin/*` paths during an impersonated session, swap `request.user` back to the original staff user. The loginas session flag stays intact so impersonation continues elsewhere. `/admin/logout/` is exempted (it needs the impersonated user to redirect correctly).
- `ImpersonationReadOnlyMiddleware` now skips `/admin/*` — admin actions run as the staff user, so read-only restrictions don't apply.
- Admin `base_site.html` shows a banner: "Acting as `<staff>` in admin while impersonating `<customer>`" with a "Stop impersonating" link.

## How did you test this code?

I'm an agent; only ran automated tests. Added 8 cases in `TestAdminImpersonationMiddleware` covering admin index access, the banner, non-admin paths still using the impersonated user, the `/admin/logout/` exemption, demoted-staff edge case, and admin writes during read-only impersonation. All existing impersonation/admin tests still pass.

- Manually
	- Tested accessing admin as staff user (impersonated and non impersonated).
	- Admin not accessible for non staff user

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Key decisions: swap `request.user` via middleware (rather than overriding `AdminSite`/per-`ModelAdmin` permissions) — PostHog's `User.is_superuser == is_staff`, so a single user swap unlocks every Django admin permission check at once.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*