### PR TITLE
feat(replay): log session id on rasterize-recording workflow failure

### DIFF
--- a/posthog/temporal/session_replay/rasterize_recording/workflow.py
+++ b/posthog/temporal/session_replay/rasterize_recording/workflow.py
@@ -47,8 +47,10 @@ class RasterizeRecordingWorkflow(PostHogWorkflow):
             # recordings that fail-then-succeed.
             info = wf.info()
             retry_policy = info.retry_policy
+
             max_attempts = retry_policy.maximum_attempts if retry_policy else 1
-            is_terminal = max_attempts > 0 and info.attempt >= max_attempts
+            is_terminal = max_attempts is not None and max_attempts > 0 and info.attempt >= max_attempts
+
             if is_terminal:
                 session_recording_id = info.typed_search_attributes.get(POSTHOG_SESSION_RECORDING_ID_KEY)
                 wf.logger.warning(

--- a/posthog/temporal/session_replay/rasterize_recording/workflow.py
+++ b/posthog/temporal/session_replay/rasterize_recording/workflow.py
@@ -6,6 +6,7 @@ import temporalio.workflow as wf
 from temporalio import common
 
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY
 
 with wf.unsafe.imports_passed_through():
     from django.conf import settings
@@ -39,6 +40,28 @@ class RasterizeRecordingWorkflow(PostHogWorkflow):
 
     @wf.run
     async def run(self, inputs: RasterizeRecordingInputs) -> RasterizationActivityOutput:
+        try:
+            return await self._run(inputs)
+        except Exception:
+            # Only log on the terminal attempt — retries would double-count
+            # recordings that fail-then-succeed.
+            info = wf.info()
+            retry_policy = info.retry_policy
+            max_attempts = retry_policy.maximum_attempts if retry_policy else 1
+            is_terminal = max_attempts > 0 and info.attempt >= max_attempts
+            if is_terminal:
+                session_recording_id = info.typed_search_attributes.get(POSTHOG_SESSION_RECORDING_ID_KEY)
+                wf.logger.warning(
+                    "rasterize_recording.workflow_failed",
+                    extra={
+                        "session_recording_id": session_recording_id,
+                        "exported_asset_id": inputs.exported_asset_id,
+                        "phase": self._phase,
+                    },
+                )
+            raise
+
+    async def _run(self, inputs: RasterizeRecordingInputs) -> RasterizationActivityOutput:
         retry_policy = common.RetryPolicy(maximum_attempts=3)
 
         # Step 1: Read ExportedAsset, validate, build activity input

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -12,6 +12,7 @@ import * as zod from 'zod'
 export const featureFlagsCopyFlagsCreateBodyTargetProjectIdsMax = 50
 
 export const featureFlagsCopyFlagsCreateBodyCopyScheduleDefault = false
+export const featureFlagsCopyFlagsCreateBodyDisableCopiedFlagDefault = false
 
 export const FeatureFlagsCopyFlagsCreateBody = /* @__PURE__ */ zod.object({
     feature_flag_key: zod.string().describe('Key of the feature flag to copy'),
@@ -24,6 +25,12 @@ export const FeatureFlagsCopyFlagsCreateBody = /* @__PURE__ */ zod.object({
         .boolean()
         .default(featureFlagsCopyFlagsCreateBodyCopyScheduleDefault)
         .describe('Whether to also copy scheduled changes for this flag'),
+    disable_copied_flag: zod
+        .boolean()
+        .default(featureFlagsCopyFlagsCreateBodyDisableCopiedFlagDefault)
+        .describe(
+            "Whether to force the copied flag to be disabled in target projects, ignoring the source flag's enabled status"
+        ),
 })
 
 /**


### PR DESCRIPTION
## Problem

The SDK's `temporal_workflow_failed{workflow_type="rasterize-recording"}` metric counts failed workflows but is not labeled with a session recording id, so dashboards cannot dedupe failures by recording.

## Changes

Wrap `RasterizeRecordingWorkflow.run()` in a try/except. On terminal failure, emit a structured warning with the `PostHogSessionRecordingId` search attribute set on dispatch, then re-raise. Failure semantics are unchanged.

A Loki panel can then count distinct recording ids over a time range.

## How did you test this code?

I am Claude Code. Verified `ast.parse` and `ruff check` / `ruff format`. No automated workflow test was added.

## Publish to changelog?

No.

## 🤖 Agent context

Authored by Claude Code at the user's request as a follow-up to #56359.