### PR TITLE
chore(ducklake): show organization in DuckLake and duckgres admin

### DIFF
--- a/posthog/admin/admins/duckgres_server_admin.py
+++ b/posthog/admin/admins/duckgres_server_admin.py
@@ -5,6 +5,7 @@ class DuckgresServerAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "team_id",
+        "organization_id",
         "host",
         "port",
         "flight_port",
@@ -12,15 +13,15 @@ class DuckgresServerAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     )
-    search_fields = ("=team__id", "host")
+    search_fields = ("=team__id", "=organization__id", "host")
     readonly_fields = ("id", "created_at", "updated_at")
-    raw_id_fields = ("team",)
+    raw_id_fields = ("team", "organization")
 
     fieldsets = (
         (
             None,
             {
-                "fields": ("id", "team"),
+                "fields": ("id", "team", "organization"),
             },
         ),
         (

--- a/posthog/admin/admins/ducklake_catalog_admin.py
+++ b/posthog/admin/admins/ducklake_catalog_admin.py
@@ -5,6 +5,7 @@ class DuckLakeCatalogAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "team_id",
+        "organization_id",
         "db_host",
         "db_database",
         "bucket",
@@ -14,15 +15,15 @@ class DuckLakeCatalogAdmin(admin.ModelAdmin):
         "updated_at",
     )
     list_filter = ("bucket_region",)
-    search_fields = ("=team__id", "db_host", "bucket", "cross_account_role_arn")
+    search_fields = ("=team__id", "=organization__id", "db_host", "bucket", "cross_account_role_arn")
     readonly_fields = ("id", "created_at", "updated_at")
-    raw_id_fields = ("team",)
+    raw_id_fields = ("team", "organization")
 
     fieldsets = (
         (
             None,
             {
-                "fields": ("id", "team"),
+                "fields": ("id", "team", "organization"),
             },
         ),
         (


### PR DESCRIPTION
## Problem

DuckLakeCatalog and DuckgresServer rows now carry an `organization` FK (added in #53481, backfilled in #53482), but the Django admin only surfaces the `team` FK. When triaging a misconfigured warehouse it's hard to locate the right row by org, or to see at a glance which org a row belongs to.

## Changes

For both `DuckLakeCatalogAdmin` and `DuckgresServerAdmin`:
- Add `organization_id` to `list_display` so the org shows up in the change-list table next to `team_id`
- Add `=organization__id` to `search_fields` so admins can find a row by org id
- Add `organization` to the change-page fieldset so it can be inspected/edited
- Add `organization` to `raw_id_fields` so the FK widget uses an id input instead of a `<select>` (the default would load every org row per page render — see AGENTS.md FK widget rule)

## How did you test this code?

I'm an agent — I did not manually verify in a running admin. Pre-commit ran `ruff` and `ty` (type check) cleanly. No tests in this area; logic is purely declarative admin config.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code at the user's request as a small, mergeable cleanup separate from PR #53487 (the ducklake-org-fk caller refactor). No model or migration changes — admin config only.