### PR TITLE
fix(background-agents): check repo and branch for analytics

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -236,6 +236,35 @@ class TestGitHubPRWebhook(TestCase):
         response = self.client.get("/webhooks/github/pr/")
         self.assertEqual(response.status_code, 405)
 
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_webhook_does_not_attribute_foreign_repo_pr_to_unrelated_run(self, mock_capture, mock_get_secret):
+        # Regression: a PR opened on a repo that has no matching TaskRun must
+        # not fall through to a branch-only lookup that attributes the event
+        # to an unrelated team's run with a colliding branch name.
+        mock_get_secret.return_value = self.webhook_secret
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="main",
+        )
+
+        payload = {
+            "action": "opened",
+            "repository": {"full_name": "ArkeroAI/arkero2"},
+            "pull_request": {
+                "html_url": "https://github.com/ArkeroAI/arkero2/pull/533",
+                "merged": False,
+                "head": {"ref": "main"},
+            },
+        }
+
+        response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+        mock_capture.assert_not_called()
+
 
 class TestFindTaskRun(TestCase):
     def setUp(self):
@@ -268,7 +297,7 @@ class TestFindTaskRun(TestCase):
             status=TaskRun.Status.IN_PROGRESS,
             branch="feature/my-branch",
         )
-        result = find_task_run(branch="feature/my-branch")
+        result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
 
     def test_pr_url_takes_priority_over_branch(self):
@@ -288,6 +317,7 @@ class TestFindTaskRun(TestCase):
         result = find_task_run(
             pr_url="https://github.com/posthog/posthog/pull/123",
             branch="feature/my-branch",
+            repository="posthog/posthog",
         )
         self.assertEqual(result, pr_run)
 
@@ -301,6 +331,7 @@ class TestFindTaskRun(TestCase):
         result = find_task_run(
             pr_url="https://github.com/posthog/posthog/pull/999",
             branch="feature/my-branch",
+            repository="posthog/posthog",
         )
         self.assertEqual(result, branch_run)
 
@@ -311,3 +342,46 @@ class TestFindTaskRun(TestCase):
     def test_returns_none_with_no_args(self):
         result = find_task_run()
         self.assertIsNone(result)
+
+    def test_branch_fallback_requires_repository(self):
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="main",
+        )
+        # Without a repository the branch fallback must not match — bare branch
+        # names like "main" collide across every team in the database.
+        self.assertIsNone(find_task_run(branch="main"))
+
+    def test_branch_fallback_does_not_match_other_repositories(self):
+        # The task's repository is "posthog/posthog"; a webhook from a foreign
+        # repo with the same branch name must not be attributed to this run.
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="main",
+        )
+        result = find_task_run(branch="main", repository="ArkeroAI/arkero2")
+        self.assertIsNone(result)
+
+    def test_branch_fallback_matches_repository_case_insensitively(self):
+        task_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="feature/my-branch",
+        )
+        result = find_task_run(branch="feature/my-branch", repository="PostHog/PostHog")
+        self.assertEqual(result, task_run)
+
+    def test_branch_fallback_rejects_empty_repository(self):
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="main",
+        )
+        for value in ("", "   ", "\t"):
+            self.assertIsNone(find_task_run(branch="main", repository=value))

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -17,14 +17,26 @@ logger = structlog.get_logger(__name__)
 TASK_RUN_SELECT_RELATED = ("task", "task__created_by", "team")
 
 
-def find_task_run(pr_url: str | None = None, branch: str | None = None) -> TaskRun | None:
+def find_task_run(
+    pr_url: str | None = None,
+    branch: str | None = None,
+    repository: str | None = None,
+) -> TaskRun | None:
     if pr_url:
         task_run = TaskRun.objects.filter(output__pr_url=pr_url).select_related(*TASK_RUN_SELECT_RELATED).first()
         if task_run:
             return task_run
 
-    if branch:
-        task_run = TaskRun.objects.filter(branch=branch).select_related(*TASK_RUN_SELECT_RELATED).first()
+    # Branch-only lookups must be scoped to the repository the webhook came from.
+    # Without this, a PR opened on an unrelated repo with a colliding branch name
+    # (e.g. "main") gets attributed to whichever TaskRun shares that branch.
+    repository = repository.strip() if repository else None
+    if branch and repository:
+        task_run = (
+            TaskRun.objects.filter(branch=branch, task__repository__iexact=repository)
+            .select_related(*TASK_RUN_SELECT_RELATED)
+            .first()
+        )
         if task_run:
             return task_run
 
@@ -129,7 +141,8 @@ def github_pr_webhook(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=200)
 
     branch = pull_request.get("head", {}).get("ref")
-    task_run = find_task_run(pr_url=pr_url, branch=branch)
+    repository_full_name = (payload.get("repository") or {}).get("full_name")
+    task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name)
 
     if not task_run:
         logger.debug(
@@ -139,9 +152,6 @@ def github_pr_webhook(request: HttpRequest) -> HttpResponse:
             message="No TaskRun found with this PR URL",
         )
         return HttpResponse(status=200)
-
-    # Emit messgae to the task run
-    task_run.emit_console_event("info", f"PR {event_action}: {pr_url}")
 
     logger.info(
         "github_pr_webhook_processed",


### PR DESCRIPTION
This was naively falling back to a branch check for analytics, this makes the fallback include repo.