### PR TITLE
chore: exclude hogql schema files from required hogql team review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,8 @@ posthog/clickhouse/migrations/** @PostHog/clickhouse
 
 # HogQL team owns HogQL changes
 posthog/hogql/** @PostHog/hogql
+# ...except per-table schema definitions, which product teams add and maintain for their own features
+posthog/hogql/database/schema/**
 
 # Being open source brings us unwanted problems because Github Actions are untrusted and inherently unsafe
 # so we have to be extra careful with changes here. Let's have the security team own these checks.


### PR DESCRIPTION
## Problem

The HogQL CODEOWNERS rule (`posthog/hogql/** @PostHog/hogql`) currently forces a HogQL team review on every PR that touches `posthog/hogql/database/schema/`. In practice that directory holds per-table virtual table definitions that product teams (web-analytics, insights, error-tracking, tasks, llma, etc.) add and maintain for their own features — not core HogQL behavior. The blanket rule was creating unnecessary cross-team review hops on routine product work.

This is consistent with the file's own preamble, which calls for keeping CODEOWNERS narrow.

## Changes

- Add a no-owner override for `posthog/hogql/database/schema/**` so the HogQL team is no longer a required reviewer on changes there. Core HogQL files (parser, resolver, `database.py`, `models.py`, etc.) still require HogQL team review.

## How did you test this code?

I'm an agent and have not tested this manually beyond reviewing the diff. CODEOWNERS behavior is a static GitHub feature; the change should take effect once merged. A subsequent PR touching only `posthog/hogql/database/schema/` would confirm the HogQL team is not auto-required.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code agent at the user's request. The user asked whether HogQL team should review schema-table additions and approved narrowing the rule. The CODEOWNERS file itself is owned by `@PostHog/team-security`, who will be required reviewers on this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*