### PR TITLE
feat(integrations): support Stripe sandbox OAuth flow

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5588,7 +5588,7 @@ const api = {
         async list(): Promise<PaginatedResponse<IntegrationType>> {
             return await new ApiRequest().integrations().get()
         },
-        authorizeUrl(params: { kind: string; next?: string }): string {
+        authorizeUrl(params: { kind: string; next?: string; is_sandbox?: boolean }): string {
             return new ApiRequest().integrations().withAction('authorize').withQueryString(params).assembleFullUrl(true)
         },
         async slackChannels(

--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -84,11 +84,16 @@ export function IntegrationChoice({
         closeNewIntegrationModal()
     }
 
+    // Stripe sandboxes have a separate client_id from live installs. The Stripe app
+    // forwards is_sandbox=true on the URL it sends users to, so we forward it through
+    // to the authorize endpoint when it's present.
+    const isSandbox = new URLSearchParams(window.location.search).get('is_sandbox') === 'true'
+
     const setupDef = getIntegrationSetup(kind)
     const setupMenuItem = setupDef
         ? setupDef.menuItem({ kind, openModal: openNewIntegrationModal, uploadKey })
         : {
-              to: api.integrations.authorizeUrl({ kind, next: redirectUrl }),
+              to: api.integrations.authorizeUrl({ kind, next: redirectUrl, is_sandbox: isSandbox || undefined }),
               disableClientSideRouting: true,
               onClick: beforeRedirect,
               label: integrationsOfKind?.length

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -487,11 +487,12 @@ class IntegrationViewSet(
     def authorize(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         kind = request.GET.get("kind")
         next = request.GET.get("next", "")
+        is_sandbox = request.GET.get("is_sandbox", "").lower() in ("true", "1", "yes")
         token = os.urandom(33).hex()
 
         if kind in OauthIntegration.supported_kinds:
             try:
-                auth_url = OauthIntegration.authorize_url(kind, next=next, token=token)
+                auth_url = OauthIntegration.authorize_url(kind, next=next, token=token, is_sandbox=is_sandbox)
                 response = redirect(auth_url)
                 # nosemgrep: python.django.security.audit.secure-cookies.django-secure-set-cookie (OAuth state, short-lived, needed for cross-site redirect)
                 response.set_cookie("ph_oauth_state", token, max_age=60 * 5)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -296,7 +296,7 @@ class OauthIntegration:
 
     @classmethod
     @cache_for(timedelta(minutes=5))
-    def oauth_config_for_kind(cls, kind: str) -> OauthConfig:
+    def oauth_config_for_kind(cls, kind: str, is_sandbox: bool = False) -> OauthConfig:
         if kind == "slack":
             from_settings = get_instance_settings(
                 [
@@ -582,13 +582,22 @@ class OauthIntegration:
             if not settings.STRIPE_APP_CLIENT_ID or not settings.STRIPE_APP_SECRET_KEY:
                 raise NotImplementedError("Stripe app not configured")
 
+            # Stripe issues separate client_ids for live vs sandbox installs of the
+            # same app. Same authorize endpoint and same client_secret for both.
+            if is_sandbox:
+                if not settings.STRIPE_APP_SANDBOX_CLIENT_ID:
+                    raise NotImplementedError("Stripe sandbox client_id not configured")
+                client_id = settings.STRIPE_APP_SANDBOX_CLIENT_ID
+            else:
+                client_id = settings.STRIPE_APP_CLIENT_ID
+
             authorize_url = (
                 settings.STRIPE_APP_OVERRIDE_AUTHORIZE_URL or "https://marketplace.stripe.com/oauth/v2/authorize"
             )
             return OauthConfig(
                 authorize_url=authorize_url,
                 token_url="https://api.stripe.com/v1/oauth/token",
-                client_id=settings.STRIPE_APP_CLIENT_ID,
+                client_id=client_id,
                 client_secret=settings.STRIPE_APP_SECRET_KEY,
                 scope="",
                 id_path="stripe_user_id",
@@ -609,8 +618,8 @@ class OauthIntegration:
         return f"{settings.SITE_URL.replace('http://', 'https://')}/integrations/{path_kind}/callback"
 
     @classmethod
-    def authorize_url(cls, kind: str, token: str, next="") -> str:
-        oauth_config = cls.oauth_config_for_kind(kind)
+    def authorize_url(cls, kind: str, token: str, next: str = "", is_sandbox: bool = False) -> str:
+        oauth_config = cls.oauth_config_for_kind(kind, is_sandbox=is_sandbox)
 
         state_payload: dict[str, str] = {"next": next, "token": token}
         if kind == "slack-posthog-code":

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -581,6 +581,37 @@ class TestOauthIntegrationModel(BaseTest):
         assert call.kwargs["auth"].username == "sk_test_secret"
         assert call.kwargs["auth"].password == ""
 
+    def test_stripe_authorize_url_uses_live_client_id_by_default(self):
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
+            STRIPE_APP_SECRET_KEY="sk_test_secret",
+            STRIPE_APP_OVERRIDE_AUTHORIZE_URL="",
+        ):
+            url = OauthIntegration.authorize_url("stripe", token="state_token", next="/projects/test")
+            assert "client_id=ca_live_clientid" in url
+            assert "client_id=ca_sandbox_clientid" not in url
+
+    def test_stripe_authorize_url_uses_sandbox_client_id_when_is_sandbox(self):
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
+            STRIPE_APP_SECRET_KEY="sk_test_secret",
+            STRIPE_APP_OVERRIDE_AUTHORIZE_URL="",
+        ):
+            url = OauthIntegration.authorize_url("stripe", token="state_token", next="/projects/test", is_sandbox=True)
+            assert "client_id=ca_sandbox_clientid" in url
+            assert "client_id=ca_live_clientid" not in url
+
+    def test_stripe_authorize_url_raises_when_sandbox_requested_but_not_configured(self):
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="",
+            STRIPE_APP_SECRET_KEY="sk_test_secret",
+        ):
+            with pytest.raises(NotImplementedError, match="sandbox"):
+                OauthIntegration.authorize_url("stripe", token="state_token", is_sandbox=True)
+
     @patch("posthog.models.integration.reload_integrations_on_workers")
     @patch("posthog.models.integration.requests.post")
     def test_stripe_refresh_access_token_uses_apps_endpoint_and_basic_auth(self, mock_post, mock_reload):

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -71,11 +71,13 @@ ATLASSIAN_APP_CLIENT_SECRET = get_from_env("ATLASSIAN_APP_CLIENT_SECRET", "")
 # with our internal OAuth system to allow the Stripe app to make API calls to users' PostHog instances.
 # We also support their agentic provisioning protocol which requires us to check even more stuff
 # - STRIPE_APP_CLIENT_ID: The app's public client ID, used in the OAuth authorize redirect URL
+# - STRIPE_APP_SANDBOX_CLIENT_ID: Separate client ID Stripe issues for sandbox installs of the same app
 # - STRIPE_APP_OVERRIDE_AUTHORIZE_URL: Optional override for testing (e.g., with a channel link URL)
 # - STRIPE_APP_SECRET_KEY: API secret key used for HTTP Basic auth during token exchange/refresh
 # - STRIPE_POSTHOG_OAUTH_CLIENT_ID: Client ID of the PostHog OAuthApplication for Stripe to authenticate with PostHog APIs
 # - STRIPE_SIGNING_SECRET: Used to verify the authenticity of incoming webhook/agentic provisioning requests from Stripe
 STRIPE_APP_CLIENT_ID = get_from_env("STRIPE_APP_CLIENT_ID", "")
+STRIPE_APP_SANDBOX_CLIENT_ID = get_from_env("STRIPE_APP_SANDBOX_CLIENT_ID", "")
 STRIPE_APP_OVERRIDE_AUTHORIZE_URL = get_from_env("STRIPE_APP_OVERRIDE_AUTHORIZE_URL", "")
 STRIPE_APP_SECRET_KEY = get_from_env("STRIPE_APP_SECRET_KEY", "")
 STRIPE_POSTHOG_OAUTH_CLIENT_ID = get_from_env("STRIPE_POSTHOG_OAUTH_CLIENT_ID", "")

--- a/services/stripe-app/src/constants.ts
+++ b/services/stripe-app/src/constants.ts
@@ -27,6 +27,18 @@ export function getConstants(environment: ExtensionContextValue['environment']):
     return (environment?.constants as unknown as AppConstants | undefined) ?? FALLBACK_CONSTANTS
 }
 
+// Stripe issues separate client_ids for sandbox vs live installs of the same app,
+// so PostHog needs to know which one to use when starting OAuth. The Stripe app
+// passes is_sandbox=true through to PostHog when the user is connecting from a
+// sandbox account; PostHog forwards it to /integrations/authorize.
+export function appendSandboxParam(url: string, isSandbox: boolean): string {
+    if (!isSandbox) {
+        return url
+    }
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}is_sandbox=true`
+}
+
 export { BrandIcon }
 
 export interface Timeframe {

--- a/services/stripe-app/src/views/FullPage.tsx
+++ b/services/stripe-app/src/views/FullPage.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from 'react'
 import Stripe from 'stripe'
 
 import { DevTokenEntry } from '../components/PostHogConnect'
-import { BRAND_COLOR, BrandIcon, getConstants } from '../constants'
+import { appendSandboxParam, BRAND_COLOR, BrandIcon, getConstants } from '../constants'
 import EventsTab from '../fullPage/EventsTab'
 import ExperimentsTab from '../fullPage/ExperimentsTab'
 import FeatureFlagsTab from '../fullPage/FeatureFlagsTab'
@@ -25,7 +25,7 @@ const DISCONNECTED_DESCRIPTION =
     'PostHog gives you product analytics, session replays, experiments, and feature flags for your Stripe customers. ' +
     'To get started, connect this Stripe account from your PostHog dashboard.'
 
-const FullPage = ({ environment }: ExtensionContextValue): JSX.Element => {
+const FullPage = ({ environment, userContext }: ExtensionContextValue): JSX.Element => {
     const [state, setState] = useState<ConnectionState>({ status: 'loading' })
 
     // The runtime passes a fresh `environment` prop on every render, so anything derived
@@ -33,6 +33,7 @@ const FullPage = ({ environment }: ExtensionContextValue): JSX.Element => {
     // and we end up in a render → fetch → setState loop.
     const [constants] = useState(() => getConstants(environment))
     const [mode] = useState<'live' | 'test'>(() => environment?.mode ?? 'live')
+    const [isSandbox] = useState<boolean>(() => userContext?.account?.isSandbox ?? false)
 
     const loadConnection = useCallback(async (): Promise<void> => {
         try {
@@ -82,7 +83,7 @@ const FullPage = ({ environment }: ExtensionContextValue): JSX.Element => {
                     descriptionActionLabel="Learn more"
                     primaryAction={{
                         label: 'Connect in PostHog',
-                        href: constants.POSTHOG_NEW_SOURCE_URL,
+                        href: appendSandboxParam(constants.POSTHOG_NEW_SOURCE_URL, isSandbox),
                         target: '_blank',
                     }}
                     secondaryAction={{

--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,7 +2,7 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "1.2.9",
+    "version": "1.2.10",
     "icon": "./assets/logomark.png",
     "provisioning": {
         "base_url": "https://us.posthog.com/api/agentic/",


### PR DESCRIPTION
## Problem

Stripe Apps issue separate `client_id`s for live vs sandbox installs of the same app (same authorize endpoint and same `client_secret`, just different `client_id`s). PostHog always initiated the OAuth flow with the live `client_id`, so users connecting to PostHog from a Stripe sandbox account hit a dead end - the OAuth never completed.

Surfaced when testing v1.2.9 from a Stripe sandbox account: the marketplace install link from the Stripe app always points at the live-mode flow, with no way to trigger a sandbox-mode connection.

## Changes

End-to-end propagation of `is_sandbox=true` from the Stripe app through to the OAuth authorize endpoint:

1. **Stripe app** (`services/stripe-app`) - reads `userContext.account.isSandbox` and appends `is_sandbox=true` to the URL it sends users to (`POSTHOG_NEW_SOURCE_URL`)
2. **Frontend** - `IntegrationChoice` reads `is_sandbox` from URL params and forwards to `api.integrations.authorizeUrl`
3. **`/integrations/authorize` endpoint** - accepts `is_sandbox` query param and passes through to `OauthIntegration.authorize_url`
4. **`OauthIntegration.oauth_config_for_kind`** - when `is_sandbox=True` and `kind="stripe"`, uses `STRIPE_APP_SANDBOX_CLIENT_ID` instead of `STRIPE_APP_CLIENT_ID`. Raises if sandbox is requested but the env var is unset.

Adds new env var `STRIPE_APP_SANDBOX_CLIENT_ID`. Must be populated in secrets manager before sandbox installs will work - the value is the sandbox `client_id` from the Stripe app dashboard's External test / Test OAuth section.

## How did you test this code?

Authored by Claude (Opus 4.7).

- Ruff lint + frontend lint pass.
- Three new unit tests in `posthog/models/test/test_integration_model.py` cover: live client_id used by default, sandbox client_id used when `is_sandbox=True`, raises if sandbox requested without configured client_id.
- Local pytest run blocked on Postgres connection in this dev env - tests will run in CI.
- No live Stripe install testing yet; manual sandbox install verification needs the env var populated in prod.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by Claude (Opus 4.7, 1M context).
- Stripe authorize flow uses HTTP Basic with the secret as username for token exchange/refresh, so client_id only matters at OAuth initiation - no callback or refresh changes needed.
- The frontend reads `is_sandbox` from `window.location.search` at the moment the user clicks "Connect" on the DW source page. Works because the user lands on that page from the Stripe app with the param in the URL. If they navigate away and come back without the param, they'd fall back to the live client_id - acceptable since most flows go straight from Stripe app to connect.