### PR TITLE
feat(logs): allow bot detection on logs via attributes user-agent

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22788,7 +22788,7 @@
         },
         "LogsSparklineBreakdownBy": {
             "description": "Field to break down sparkline data by",
-            "enum": ["severity", "service"],
+            "enum": ["severity", "service", "traffic_type"],
             "type": "string"
         },
         "MADDetectorConfig": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2879,7 +2879,7 @@ export interface LogMessage {
 }
 
 /** Field to break down sparkline data by */
-export type LogsSparklineBreakdownBy = 'severity' | 'service'
+export type LogsSparklineBreakdownBy = 'severity' | 'service' | 'traffic_type'
 
 /** @title LogsOrderBy */
 export type LogsOrderBy = 'latest' | 'earliest'

--- a/posthog/hogql/database/schema/test/test_log_traffic_type.py
+++ b/posthog/hogql/database/schema/test/test_log_traffic_type.py
@@ -1,0 +1,107 @@
+import pytest
+
+from posthog.hogql import ast
+from posthog.hogql.database.models import ExpressionField
+from posthog.hogql.database.schema.traffic_type import (
+    create_log_bot_name_field,
+    create_log_bot_operator_field,
+    create_log_is_bot_field,
+    create_log_traffic_category_field,
+    create_log_traffic_type_field,
+    log_user_agent_expr,
+)
+
+LOG_FACTORY_FUNCTIONS = [
+    create_log_is_bot_field,
+    create_log_traffic_type_field,
+    create_log_traffic_category_field,
+    create_log_bot_name_field,
+    create_log_bot_operator_field,
+]
+LOG_FIELD_NAMES = [
+    "$virt_is_bot",
+    "$virt_traffic_type",
+    "$virt_traffic_category",
+    "$virt_bot_name",
+    "$virt_bot_operator",
+]
+
+
+class TestLogUserAgentExpr:
+    def test_returns_coalesce(self):
+        expr = log_user_agent_expr()
+        assert isinstance(expr, ast.Call)
+        assert expr.name == "coalesce"
+        assert len(expr.args) == 4
+
+    def test_checks_otel_http_user_agent_first(self):
+        expr = log_user_agent_expr()
+        first_null_if = expr.args[0]
+        assert isinstance(first_null_if, ast.Call)
+        assert first_null_if.name == "nullIf"
+        assert first_null_if.args[0] == ast.Field(chain=["attributes", "http.user_agent"])
+
+    def test_checks_user_agent_original_second(self):
+        expr = log_user_agent_expr()
+        second_null_if = expr.args[1]
+        assert isinstance(second_null_if, ast.Call)
+        assert second_null_if.name == "nullIf"
+        assert second_null_if.args[0] == ast.Field(chain=["attributes", "user_agent.original"])
+
+    def test_checks_posthog_raw_user_agent_third(self):
+        expr = log_user_agent_expr()
+        third_null_if = expr.args[2]
+        assert isinstance(third_null_if, ast.Call)
+        assert third_null_if.name == "nullIf"
+        assert third_null_if.args[0] == ast.Field(chain=["attributes", "$raw_user_agent"])
+
+    def test_falls_back_to_posthog_user_agent(self):
+        expr = log_user_agent_expr()
+        assert expr.args[3] == ast.Field(chain=["attributes", "$user_agent"])
+
+
+class TestLogExpressionFieldFactories:
+    @pytest.mark.parametrize(
+        "factory_fn,field_name",
+        list(zip(LOG_FACTORY_FUNCTIONS, LOG_FIELD_NAMES)),
+    )
+    def test_returns_expression_field_with_correct_name(self, factory_fn, field_name):
+        field = factory_fn(name=field_name)
+        assert isinstance(field, ExpressionField)
+        assert field.name == field_name
+
+    @pytest.mark.parametrize("factory_fn", LOG_FACTORY_FUNCTIONS)
+    def test_isolate_scope_is_true(self, factory_fn):
+        field = factory_fn(name="test")
+        assert field.isolate_scope is True
+
+    @pytest.mark.parametrize("factory_fn", LOG_FACTORY_FUNCTIONS)
+    def test_expr_uses_log_attributes(self, factory_fn):
+        field = factory_fn(name="test")
+        expr_str = str(field.expr)
+        assert "attributes" in expr_str
+
+
+class TestLogIsBotField:
+    def test_returns_compare_operation(self):
+        field = create_log_is_bot_field(name="$virt_is_bot")
+        assert isinstance(field.expr, ast.CompareOperation)
+        assert field.expr.op == ast.CompareOperationOp.NotEq
+
+    def test_uses_multiMatchAnyIndex(self):
+        field = create_log_is_bot_field(name="$virt_is_bot")
+        assert isinstance(field.expr.left, ast.Call)
+        assert field.expr.left.name == "multiMatchAnyIndex"
+
+
+class TestLogTrafficTypeField:
+    def test_returns_if_expression(self):
+        field = create_log_traffic_type_field(name="$virt_traffic_type")
+        assert isinstance(field.expr, ast.Call)
+        assert field.expr.name == "if"
+
+    def test_default_value_is_regular(self):
+        field = create_log_traffic_type_field(name="$virt_traffic_type")
+        default = field.expr.args[1]
+        assert isinstance(default, ast.Constant)
+        assert default.value == "Regular"

--- a/posthog/hogql/database/schema/test/test_log_traffic_type.py
+++ b/posthog/hogql/database/schema/test/test_log_traffic_type.py
@@ -40,7 +40,7 @@ class TestLogUserAgentExpr:
         first_null_if = expr.args[0]
         assert isinstance(first_null_if, ast.Call)
         assert first_null_if.name == "nullIf"
-        assert first_null_if.args[0] == ast.Field(chain=["attributes", "http.user_agent"])
+        assert first_null_if.args[0] == ast.Field(chain=["attributes_map_str", "http.user_agent__str"])
 
     def test_checks_user_agent_original_second(self):
         expr = log_user_agent_expr()
@@ -48,7 +48,7 @@ class TestLogUserAgentExpr:
         second_null_if = expr.args[1]
         assert isinstance(second_null_if, ast.Call)
         assert second_null_if.name == "nullIf"
-        assert second_null_if.args[0] == ast.Field(chain=["attributes", "user_agent.original"])
+        assert second_null_if.args[0] == ast.Field(chain=["attributes_map_str", "user_agent.original__str"])
 
     def test_checks_posthog_raw_user_agent_third(self):
         expr = log_user_agent_expr()
@@ -56,12 +56,12 @@ class TestLogUserAgentExpr:
         third_null_if = expr.args[2]
         assert isinstance(third_null_if, ast.Call)
         assert third_null_if.name == "nullIf"
-        assert third_null_if.args[0] == ast.Field(chain=["attributes", "$raw_user_agent"])
+        assert third_null_if.args[0] == ast.Field(chain=["attributes_map_str", "$raw_user_agent__str"])
 
     def test_falls_back_to_posthog_user_agent(self):
         expr = log_user_agent_expr()
         assert isinstance(expr, ast.Call)
-        assert expr.args[3] == ast.Field(chain=["attributes", "$user_agent"])
+        assert expr.args[3] == ast.Field(chain=["attributes_map_str", "$user_agent__str"])
 
 
 class TestLogExpressionFieldFactories:

--- a/posthog/hogql/database/schema/test/test_log_traffic_type.py
+++ b/posthog/hogql/database/schema/test/test_log_traffic_type.py
@@ -36,6 +36,7 @@ class TestLogUserAgentExpr:
 
     def test_checks_otel_http_user_agent_first(self):
         expr = log_user_agent_expr()
+        assert isinstance(expr, ast.Call)
         first_null_if = expr.args[0]
         assert isinstance(first_null_if, ast.Call)
         assert first_null_if.name == "nullIf"
@@ -43,6 +44,7 @@ class TestLogUserAgentExpr:
 
     def test_checks_user_agent_original_second(self):
         expr = log_user_agent_expr()
+        assert isinstance(expr, ast.Call)
         second_null_if = expr.args[1]
         assert isinstance(second_null_if, ast.Call)
         assert second_null_if.name == "nullIf"
@@ -50,6 +52,7 @@ class TestLogUserAgentExpr:
 
     def test_checks_posthog_raw_user_agent_third(self):
         expr = log_user_agent_expr()
+        assert isinstance(expr, ast.Call)
         third_null_if = expr.args[2]
         assert isinstance(third_null_if, ast.Call)
         assert third_null_if.name == "nullIf"
@@ -57,6 +60,7 @@ class TestLogUserAgentExpr:
 
     def test_falls_back_to_posthog_user_agent(self):
         expr = log_user_agent_expr()
+        assert isinstance(expr, ast.Call)
         assert expr.args[3] == ast.Field(chain=["attributes", "$user_agent"])
 
 
@@ -90,6 +94,7 @@ class TestLogIsBotField:
 
     def test_uses_multiMatchAnyIndex(self):
         field = create_log_is_bot_field(name="$virt_is_bot")
+        assert isinstance(field.expr, ast.CompareOperation)
         assert isinstance(field.expr.left, ast.Call)
         assert field.expr.left.name == "multiMatchAnyIndex"
 
@@ -102,6 +107,7 @@ class TestLogTrafficTypeField:
 
     def test_default_value_is_regular(self):
         field = create_log_traffic_type_field(name="$virt_traffic_type")
+        assert isinstance(field.expr, ast.Call)
         default = field.expr.args[1]
         assert isinstance(default, ast.Constant)
         assert default.value == "Regular"

--- a/posthog/hogql/database/schema/traffic_type.py
+++ b/posthog/hogql/database/schema/traffic_type.py
@@ -74,16 +74,29 @@ def create_bot_operator_field(name: str, properties_path: Optional[list[str]] = 
 
 
 def log_user_agent_expr() -> ast.Expr:
-    """Resolve user agent from log attributes, checking OTEL and PostHog conventions."""
+    """Resolve user agent from log attributes, checking OTEL and PostHog conventions.
+
+    Goes through `attributes_map_str` (raw stored Map column with `__str`-suffixed keys)
+    rather than the `attributes` alias. The alias strips the `__str` suffix and is exposed
+    as a JSON-typed HogQL field for the legacy query-runner path; for our purposes we want
+    direct Map subscript access against the underlying column.
+    """
     return ast.Call(
         name="coalesce",
         args=[
-            ast.Call(name="nullIf", args=[ast.Field(chain=["attributes", "http.user_agent"]), ast.Constant(value="")]),
             ast.Call(
-                name="nullIf", args=[ast.Field(chain=["attributes", "user_agent.original"]), ast.Constant(value="")]
+                name="nullIf",
+                args=[ast.Field(chain=["attributes_map_str", "http.user_agent__str"]), ast.Constant(value="")],
             ),
-            ast.Call(name="nullIf", args=[ast.Field(chain=["attributes", "$raw_user_agent"]), ast.Constant(value="")]),
-            ast.Field(chain=["attributes", "$user_agent"]),
+            ast.Call(
+                name="nullIf",
+                args=[ast.Field(chain=["attributes_map_str", "user_agent.original__str"]), ast.Constant(value="")],
+            ),
+            ast.Call(
+                name="nullIf",
+                args=[ast.Field(chain=["attributes_map_str", "$raw_user_agent__str"]), ast.Constant(value="")],
+            ),
+            ast.Field(chain=["attributes_map_str", "$user_agent__str"]),
         ],
     )
 

--- a/posthog/hogql/database/schema/traffic_type.py
+++ b/posthog/hogql/database/schema/traffic_type.py
@@ -71,3 +71,58 @@ def create_bot_operator_field(name: str, properties_path: Optional[list[str]] = 
         expr=get_bot_operator(node=_dummy_call(name), args=[user_agent_expr(properties_path)]),
         isolate_scope=True,
     )
+
+
+def log_user_agent_expr() -> ast.Expr:
+    """Resolve user agent from log attributes, checking OTEL and PostHog conventions."""
+    return ast.Call(
+        name="coalesce",
+        args=[
+            ast.Call(name="nullIf", args=[ast.Field(chain=["attributes", "http.user_agent"]), ast.Constant(value="")]),
+            ast.Call(
+                name="nullIf", args=[ast.Field(chain=["attributes", "user_agent.original"]), ast.Constant(value="")]
+            ),
+            ast.Call(name="nullIf", args=[ast.Field(chain=["attributes", "$raw_user_agent"]), ast.Constant(value="")]),
+            ast.Field(chain=["attributes", "$user_agent"]),
+        ],
+    )
+
+
+def create_log_is_bot_field(name: str) -> ExpressionField:
+    return ExpressionField(
+        name=name,
+        expr=is_bot(node=_dummy_call(name), args=[log_user_agent_expr()]),
+        isolate_scope=True,
+    )
+
+
+def create_log_traffic_type_field(name: str) -> ExpressionField:
+    return ExpressionField(
+        name=name,
+        expr=get_traffic_type(node=_dummy_call(name), args=[log_user_agent_expr()]),
+        isolate_scope=True,
+    )
+
+
+def create_log_traffic_category_field(name: str) -> ExpressionField:
+    return ExpressionField(
+        name=name,
+        expr=get_traffic_category(node=_dummy_call(name), args=[log_user_agent_expr()]),
+        isolate_scope=True,
+    )
+
+
+def create_log_bot_name_field(name: str) -> ExpressionField:
+    return ExpressionField(
+        name=name,
+        expr=get_bot_name(node=_dummy_call(name), args=[log_user_agent_expr()]),
+        isolate_scope=True,
+    )
+
+
+def create_log_bot_operator_field(name: str) -> ExpressionField:
+    return ExpressionField(
+        name=name,
+        expr=get_bot_operator(node=_dummy_call(name), args=[log_user_agent_expr()]),
+        isolate_scope=True,
+    )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2827,6 +2827,7 @@ class LogsOrderBy(StrEnum):
 class LogsSparklineBreakdownBy(StrEnum):
     SEVERITY = "severity"
     SERVICE = "service"
+    TRAFFIC_TYPE = "traffic_type"
 
 
 class MarkdownBlock(BaseModel):

--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -8,13 +8,23 @@ from posthog.clickhouse.client.connection import Workload
 
 from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunner
 
-# Maps API breakdown type to ClickHouse field name
+# Maps API breakdown type to a ClickHouse field name or HogQL expression
 BREAKDOWN_DB_FIELD: dict[LogsSparklineBreakdownBy, str] = {
     LogsSparklineBreakdownBy.SEVERITY: "severity_text",
     LogsSparklineBreakdownBy.SERVICE: "service_name",
 }
 
 DEFAULT_BREAKDOWN = LogsSparklineBreakdownBy.SEVERITY
+
+
+def _breakdown_expr(breakdown_by: LogsSparklineBreakdownBy) -> ast.Expr:
+    if breakdown_by == LogsSparklineBreakdownBy.TRAFFIC_TYPE:
+        from posthog.hogql.database.schema.traffic_type import log_user_agent_expr
+        from posthog.hogql.functions.traffic_type import get_traffic_type
+
+        return get_traffic_type(node=ast.Call(name="__placeholder", args=[]), args=[log_user_agent_expr()])
+
+    return ast.Field(chain=[BREAKDOWN_DB_FIELD[breakdown_by]])
 
 
 class SparklineQueryRunner(LogsQueryRunner):
@@ -30,7 +40,9 @@ class SparklineQueryRunner(LogsQueryRunner):
             settings=self.settings,
         )
 
-        result_key = (self.query.sparklineBreakdownBy or DEFAULT_BREAKDOWN).value  # 'severity' or 'service'
+        result_key = (
+            self.query.sparklineBreakdownBy or DEFAULT_BREAKDOWN
+        ).value  # 'severity', 'service', or 'traffic_type'
 
         results = []
         for result in response.results:
@@ -46,6 +58,9 @@ class SparklineQueryRunner(LogsQueryRunner):
         return LogsQueryResponse(results=results)
 
     def to_query(self) -> ast.SelectQuery:
+        breakdown_by = self.query.sparklineBreakdownBy or DEFAULT_BREAKDOWN
+        breakdown = _breakdown_expr(breakdown_by)
+
         query = parse_select(
             """
                 SELECT
@@ -90,9 +105,7 @@ class SparklineQueryRunner(LogsQueryRunner):
                 if self.query_date_range.interval_name != "second"
                 else ast.Field(chain=["timestamp"]),
                 "where": self.where(),
-                "breakdown_field": ast.Field(
-                    chain=[BREAKDOWN_DB_FIELD[self.query.sparklineBreakdownBy or DEFAULT_BREAKDOWN]]
-                ),
+                "breakdown_field": breakdown,
             },
         )
         if not isinstance(query, ast.SelectQuery):

--- a/products/logs/backend/test/test_sparkline_traffic_type.py
+++ b/products/logs/backend/test/test_sparkline_traffic_type.py
@@ -23,6 +23,7 @@ class TestBreakdownExpr:
 
     def test_traffic_type_uses_multiMatchAnyIndex(self):
         expr = _breakdown_expr(LogsSparklineBreakdownBy.TRAFFIC_TYPE)
+        assert isinstance(expr, ast.Call)
         comparison = expr.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         assert isinstance(comparison.left, ast.Call)
@@ -30,6 +31,7 @@ class TestBreakdownExpr:
 
     def test_traffic_type_default_is_regular(self):
         expr = _breakdown_expr(LogsSparklineBreakdownBy.TRAFFIC_TYPE)
+        assert isinstance(expr, ast.Call)
         default = expr.args[1]
         assert isinstance(default, ast.Constant)
         assert default.value == "Regular"

--- a/products/logs/backend/test/test_sparkline_traffic_type.py
+++ b/products/logs/backend/test/test_sparkline_traffic_type.py
@@ -1,0 +1,39 @@
+from posthog.schema import LogsSparklineBreakdownBy
+
+from posthog.hogql import ast
+
+from products.logs.backend.sparkline_query_runner import BREAKDOWN_DB_FIELD, _breakdown_expr
+
+
+class TestBreakdownExpr:
+    def test_severity_returns_field(self):
+        expr = _breakdown_expr(LogsSparklineBreakdownBy.SEVERITY)
+        assert isinstance(expr, ast.Field)
+        assert expr.chain == ["severity_text"]
+
+    def test_service_returns_field(self):
+        expr = _breakdown_expr(LogsSparklineBreakdownBy.SERVICE)
+        assert isinstance(expr, ast.Field)
+        assert expr.chain == ["service_name"]
+
+    def test_traffic_type_returns_if_expression(self):
+        expr = _breakdown_expr(LogsSparklineBreakdownBy.TRAFFIC_TYPE)
+        assert isinstance(expr, ast.Call)
+        assert expr.name == "if"
+
+    def test_traffic_type_uses_multiMatchAnyIndex(self):
+        expr = _breakdown_expr(LogsSparklineBreakdownBy.TRAFFIC_TYPE)
+        comparison = expr.args[0]
+        assert isinstance(comparison, ast.CompareOperation)
+        assert isinstance(comparison.left, ast.Call)
+        assert comparison.left.name == "multiMatchAnyIndex"
+
+    def test_traffic_type_default_is_regular(self):
+        expr = _breakdown_expr(LogsSparklineBreakdownBy.TRAFFIC_TYPE)
+        default = expr.args[1]
+        assert isinstance(default, ast.Constant)
+        assert default.value == "Regular"
+
+    def test_all_simple_breakdowns_in_field_map(self):
+        for breakdown in [LogsSparklineBreakdownBy.SEVERITY, LogsSparklineBreakdownBy.SERVICE]:
+            assert breakdown in BREAKDOWN_DB_FIELD

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19241,6 +19241,7 @@ export namespace Schemas {
     export const LogsSparklineBreakdownBy = {
       Severity: 'severity',
       Service: 'service',
+      TrafficType: 'traffic_type',
     } as const;
 
     export interface LogsQuery {


### PR DESCRIPTION
## Problem

We already detect bots on event traffic via `is_bot`, `get_traffic_type`, `get_bot_name`, etc. (in `posthog/hogql/functions/traffic_type.py`). These take a user-agent expression and return classification. Logs ingested via OTEL or direct CDN feeds carry the user agent inside `attributes` under a few different keys (`http.user_agent` for OTEL, `user_agent.original` for newer OTEL semconv, `$raw_user_agent` / `$user_agent` for PostHog conventions). There was no way to point the existing bot functions at log data.

Stacked on top of #56615 (HogQL Map field type) — without that, `attributes['http.user_agent']` blows up at query time.

## Changes

- `posthog/hogql/database/schema/traffic_type.py`:
  - New `log_user_agent_expr()` helper. Coalesces across OTEL (`http.user_agent`, `user_agent.original`) and PostHog (`$raw_user_agent`, `$user_agent`) keys, treating empty strings as missing.
  - 5 new factory functions (`create_log_is_bot_field`, `create_log_traffic_type_field`, `create_log_traffic_category_field`, `create_log_bot_name_field`, `create_log_bot_operator_field`) that wire `log_user_agent_expr()` into the existing bot HogQL functions.
- `products/logs/backend/sparkline_query_runner.py`:
  - Breakdown selector now accepts an `ast.Expr` instead of just a column name.
  - New `TRAFFIC_TYPE` breakdown that calls `get_traffic_type(log_user_agent_expr())` directly. Lets users group log volume by traffic type without writing custom HogQL.
- `posthog/schema.py`: adds `TRAFFIC_TYPE` to `LogsSparklineBreakdownBy`.

This PR does **not** register `$virt_*` virtual fields on the logs table — that's intentionally a follow-up so reviewers can land "process logs with bot functions" and "expose them as virtual properties" separately.

## How did you test this code?

I'm an agent. Tests I actually ran:

- New `posthog/hogql/database/schema/test/test_log_traffic_type.py` (24 tests) — covers `log_user_agent_expr()` shape and the 5 factory functions.
- New `products/logs/backend/test/test_sparkline_traffic_type.py` (6 tests) — covers the new sparkline breakdown.
- Combined with the Map-field PR base: end-to-end query against real ClickHouse returning `is_bot=1, bot_name=GPTBot, traffic_type='AI Agent'` for an ingested OTEL log.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Claude Opus 4.7). Middle of a 3-PR stack — depends on #56615; the follow-up PR adds `$virt_*` virtual fields on the logs table so users can write `SELECT $virt_is_bot FROM logs` directly.