### PR TITLE
feat(logs): expose bot detection as $virt_* virtual fields on logs

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1540,6 +1540,11 @@ def _use_virtual_fields(database: Database, modifiers: HogQLQueryModifiers, timi
             create_bot_name_field,
             create_bot_operator_field,
             create_is_bot_field,
+            create_log_bot_name_field,
+            create_log_bot_operator_field,
+            create_log_is_bot_field,
+            create_log_traffic_category_field,
+            create_log_traffic_type_field,
             create_traffic_category_field,
             create_traffic_type_field,
         )
@@ -1552,6 +1557,16 @@ def _use_virtual_fields(database: Database, modifiers: HogQLQueryModifiers, timi
             ("$virt_bot_operator", create_bot_operator_field),
         ]:
             events_table.fields[field_name] = factory_fn(name=field_name)
+
+        logs_table = database.get_table("logs")
+        for field_name, factory_fn in [
+            ("$virt_is_bot", create_log_is_bot_field),
+            ("$virt_traffic_type", create_log_traffic_type_field),
+            ("$virt_traffic_category", create_log_traffic_category_field),
+            ("$virt_bot_name", create_log_bot_name_field),
+            ("$virt_bot_operator", create_log_bot_operator_field),
+        ]:
+            logs_table.fields[field_name] = factory_fn(name=field_name)
 
     revenue_fields = ["revenue", "mrr"]
     with timings.measure("revenue_analytics_virtual_fields"):

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1559,14 +1559,14 @@ def _use_virtual_fields(database: Database, modifiers: HogQLQueryModifiers, timi
             events_table.fields[field_name] = factory_fn(name=field_name)
 
         logs_table = database.get_table("logs")
-        for field_name, factory_fn in [
+        for log_field_name, log_factory_fn in [
             ("$virt_is_bot", create_log_is_bot_field),
             ("$virt_traffic_type", create_log_traffic_type_field),
             ("$virt_traffic_category", create_log_traffic_category_field),
             ("$virt_bot_name", create_log_bot_name_field),
             ("$virt_bot_operator", create_log_bot_operator_field),
         ]:
-            logs_table.fields[field_name] = factory_fn(name=field_name)
+            logs_table.fields[log_field_name] = log_factory_fn(name=log_field_name)
 
     revenue_fields = ["revenue", "mrr"]
     with timings.measure("revenue_analytics_virtual_fields"):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -2497,6 +2497,56 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "$virt_is_bot": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_is_bot`",
+                  "id": null,
+                  "name": "$virt_is_bot",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
+              },
+              "$virt_traffic_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_traffic_type`",
+                  "id": null,
+                  "name": "$virt_traffic_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "$virt_traffic_category": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_traffic_category`",
+                  "id": null,
+                  "name": "$virt_traffic_category",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "$virt_bot_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_bot_name`",
+                  "id": null,
+                  "name": "$virt_bot_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "$virt_bot_operator": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_bot_operator`",
+                  "id": null,
+                  "name": "$virt_bot_operator",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
               }
           },
           "id": "logs",
@@ -9055,6 +9105,56 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "$virt_is_bot": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_is_bot`",
+                  "id": null,
+                  "name": "$virt_is_bot",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
+              },
+              "$virt_traffic_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_traffic_type`",
+                  "id": null,
+                  "name": "$virt_traffic_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "$virt_traffic_category": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_traffic_category`",
+                  "id": null,
+                  "name": "$virt_traffic_category",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "$virt_bot_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_bot_name`",
+                  "id": null,
+                  "name": "$virt_bot_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "$virt_bot_operator": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_bot_operator`",
+                  "id": null,
+                  "name": "$virt_bot_operator",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
               }
           },
           "id": "logs",


### PR DESCRIPTION
## Problem

Stacked on top of #56616. With the bot factories in place, users can write HogQL like `is_bot(coalesce(attributes['http.user_agent'], …))` against logs — but it's verbose and doesn't match the events table, where `$virt_is_bot`, `$virt_traffic_type`, etc. are first-class virtual fields. We want the same ergonomics for logs.

## Changes

Single 15-line change in `_use_virtual_fields` (`posthog/hogql/database/database.py`):

- Imports the 5 `create_log_*_field` factories added in #56616.
- Registers `$virt_is_bot`, `$virt_traffic_type`, `$virt_traffic_category`, `$virt_bot_name`, `$virt_bot_operator` on the logs HogQL table, mirroring the events-table registration.

After this, `SELECT $virt_is_bot, $virt_bot_name FROM logs` Just Works.

## How did you test this code?

I'm an agent. Tests I actually ran:

- The factory unit tests from #56616 already cover the construction of these fields. With this PR applied, an end-to-end HogQL query against real ClickHouse returns the correct virtual-column values for an ingested OTEL log: `(test-cdn-bot-analytics, 1, 'GPTBot', 'AI Agent', 'ai_crawler', 'OpenAI')`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Claude Opus 4.7). Top of a 3-PR stack: #56615 (HogQL Map field type) → #56616 (bot detection on logs) → this. Kept deliberately small so the "expose as virtual fields" decision can be reviewed independently from the "make bot detection callable on logs" foundation.