### PR TITLE
fix(agentic-provisioning): scope provisioned PAT to authorized team

### DIFF
--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -129,6 +129,18 @@ class TestProvisioningResources(ProvisioningTestBase):
         assert pat is not None
         assert pat.label.startswith("Stripe Projects")
 
+    def test_create_resource_pat_is_scoped_to_authorized_team(self):
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        pat = PersonalAPIKey.objects.filter(user=self.user).order_by("-created_at").first()
+        assert pat is not None
+        assert pat.scoped_teams == [self.team.id]
+        assert pat.scoped_organizations == [str(self.team.organization_id)]
+
     def test_create_resource_does_not_delete_existing_pats(self):
         token = self._get_bearer_token()
         self._post_signed_with_bearer(

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -95,6 +95,21 @@ class TestProvisioningRotateCredentials(ProvisioningTestBase):
         personal_api_key = res.json()["complete"]["access_configuration"]["personal_api_key"]
         assert personal_api_key.startswith("phx_")
 
+    def test_rotate_pat_is_scoped_to_authorized_team(self):
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
+            token=token,
+        )
+        pat = (
+            PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects")
+            .order_by("-created_at")
+            .first()
+        )
+        assert pat is not None
+        assert pat.scoped_teams == [self.team.id]
+        assert pat.scoped_organizations == [str(self.team.organization_id)]
+
     def test_rotate_preserves_existing_pats(self):
         token = self._get_bearer_token()
         self._post_signed_with_bearer(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1176,6 +1176,8 @@ def _create_provisioned_pat(user: User, team: Team) -> str | None:
             secure_value=hash_key_value(api_key_value),
             mask_value=mask_key_value(api_key_value),
             scopes=[],
+            scoped_teams=[team.id],
+            scoped_organizations=[str(team.organization_id)],
         )
 
         return api_key_value


### PR DESCRIPTION
## Problem

The Personal API Key created during agentic provisioning (issued alongside the Stripe-Projects-style provisioning response in `access_configuration`) was unscoped. It had access to every team the authenticated user is a member of, instead of being restricted to the team the OAuth flow authorized.

The OAuth access/refresh tokens issued in the same provisioning flow are already scoped to the authorized team — the bundled PAT was the odd one out. Reported via [detail.dev](https://app.detail.dev/oss/PostHog/posthog/bug_88ecda9b-39f6-4e44-901b-01ae9dad46fc).

This is also the closing half of the suggestion the Hex bot left on [#54272](https://github.com/PostHog/posthog/pull/54272#discussion_r3102590439): that PR added `scoped_teams` to the OAuth tokens but the bundled PAT was missed. This PR completes it and adds `scoped_organizations` to match.

## Changes

In `_create_provisioned_pat`, set `scoped_teams=[team.id]` and `scoped_organizations=[str(team.organization_id)]` on the new `PersonalAPIKey`, mirroring the OAuth tokens issued in the same flow (see `views.py:982,991,1057,1066`). Adds tests asserting the new keys are scoped on both create and rotate paths.

Risks (covered in the worktree review):
- Scoped PATs cannot reach org-level / non-team-nested endpoints (`posthog/permissions.py:551-552`). The OAuth tokens issued in this flow already enforce the same restriction, so this is not a new constraint for the consumer.
- Existing PATs in the wild keep `scoped_teams=None`. They get re-scoped naturally on the next credential rotation; no backfill — the fleet is small and a backfill is riskier than letting rotation drain it.

## How did you test this code?

I'm an agent. I ran the affected suites locally (`pytest ee/api/agentic_provisioning/test/test_resources.py ee/api/agentic_provisioning/test/test_rotate_credentials.py`) — 39 passing, including the two new assertions. No manual testing performed.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by Claude Opus 4.7 with Matt in the loop. Investigation seeded by a [detail.dev finding](https://app.detail.dev/oss/PostHog/posthog/bug_88ecda9b-39f6-4e44-901b-01ae9dad46fc).
- Considered scoping levels:
  - `scoped_teams` only — fixes the reported bug.
  - `scoped_teams` + `scoped_organizations` — chosen, mirrors the OAuth tokens issued by the same flow and matches the closing suggestion on [#54272](https://github.com/PostHog/posthog/pull/54272#discussion_r3102590439).
- Tests intentionally split across the two test files (resource create + rotate). They test distinct endpoints in distinct test classes, so a shared parameterized helper isn't a clean fit.