### PR TITLE
ci(dagster): experiment — shard dagster tests 4 ways

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -153,7 +153,7 @@ jobs:
     dagster:
         name: Dagster tests (${{ matrix.runner }}, ${{ matrix.group }}/4)
         needs: [changes]
-        timeout-minutes: 15
+        timeout-minutes: 30 # SEED RUN: temp 30 to let imbalanced shards finish & emit .test_durations
         strategy:
             fail-fast: false
             matrix:
@@ -263,6 +263,7 @@ jobs:
                   pytest posthog/dags products/**/dags \
                       --splits 4 --group ${{ matrix.group }} \
                       --splitting-algorithm=duration_based_chunks \
+                      --store-durations --durations-min=1.0 \
                       --durations=20 \
                       --junitxml=junit-dagster-${{ matrix.group }}.xml
                   exit_code=$?
@@ -279,6 +280,13 @@ jobs:
               with:
                   name: junit-results-dagster-${{ matrix.group }}
                   path: junit-*.xml
+
+            - name: Upload .test_durations (seed run)
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always() && !startsWith(matrix.runner, 'blacksmith')
+              with:
+                  name: test-durations-shard-${{ matrix.group }}
+                  path: .test_durations
 
     # Job just to collate the status of the matrix jobs for requiring passing status
     dagster_tests:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -151,14 +151,15 @@ jobs:
                   echo "oldest_supported=[\"$oldest_supported\"]" >> $GITHUB_OUTPUT
 
     dagster:
-        name: Dagster tests (${{ matrix.runner }})
+        name: Dagster tests (${{ matrix.runner }}, ${{ matrix.group }}/4)
         needs: [changes]
-        timeout-minutes: 30
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:
                 clickhouse-server-image: ${{ fromJson(needs.changes.outputs.oldest_supported) }}
                 runner: ${{ vars.BLACKSMITH_SHADOW_ENABLED == 'true' && fromJson('["depot-ubuntu-latest","blacksmith-2vcpu-ubuntu-2404"]') || fromJson('["depot-ubuntu-latest"]') }}
+                group: [1, 2, 3, 4]
         if: needs.changes.outputs.dagster == 'true'
         runs-on: ${{ matrix.runner }}
         continue-on-error: ${{ startsWith(matrix.runner, 'blacksmith') }}
@@ -258,17 +259,25 @@ jobs:
 
             - name: Run Dagster tests
               run: |
-                  pytest posthog/dags --junitxml=junit-dagster.xml
-
-            - name: Run products Dagster tests
-              run: |
-                  pytest products/**/dags --junitxml=junit-products.xml
+                  set +e
+                  pytest posthog/dags products/**/dags \
+                      --splits 4 --group ${{ matrix.group }} \
+                      --splitting-algorithm=duration_based_chunks \
+                      --durations=20 \
+                      --junitxml=junit-dagster-${{ matrix.group }}.xml
+                  exit_code=$?
+                  set -e
+                  if [ $exit_code -eq 5 ]; then
+                      echo "No tests collected for this shard; expected when splitting tests"
+                      exit 0
+                  fi
+                  exit $exit_code
 
             - name: Upload test results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               if: always() && !startsWith(matrix.runner, 'blacksmith')
               with:
-                  name: junit-results-dagster
+                  name: junit-results-dagster-${{ matrix.group }}
                   path: junit-*.xml
 
     # Job just to collate the status of the matrix jobs for requiring passing status


### PR DESCRIPTION
## Problem

The Dagster CI job runs ~600 tests serially in a single job, taking ~29-30 minutes. It frequently brushes the 30-min runner timeout on slow runs (e.g. master 29:08, my [duckdb 1.5.2 PR](https://github.com/PostHog/posthog/pull/56610) at 30:15+). It's the slowest backend test job in the repo and the only one that's *not* already sharded.

## Changes

Shard the dagster test job into **4 parallel matrix entries** using `pytest-split` (already in dev deps), the same approach Django CI uses (38-way) and Temporal CI (multi-way).

- Add `group: [1, 2, 3, 4]` matrix dimension; rename to `Dagster tests (<runner>, <group>/4)`
- Drop per-shard `timeout-minutes` from 30 → 15 (each shard does ~1/4 of the test work)
- Combine `posthog/dags` + `products/**/dags` into one pytest invocation so the splitter can balance both directories' tests
- Use `--splits 4 --group N --splitting-algorithm=duration_based_chunks`
- Suffix artifact names with the shard group to avoid upload collisions
- Treat pytest exit code 5 (no tests collected) as success per Django pattern

## Expected result

| Metric | Before | After (expected) |
|---|---|---|
| Wall-clock per shard | 29-30 min | ~12 min (7m setup + ~5m tests) |
| Total runner-minutes | ~30 | ~50 (5x) |
| Risk of 30m timeout | ~50% on slow runs | none |

Trades ~4x more runner-minutes for ~3x wall-clock speedup. Depot runners are cheap; engineer wait time isn't.

## Risks / things to watch

- **Test isolation across shards**: each shard is a separate job with its own Postgres/ClickHouse — shouldn't cause cross-shard interference, but worth confirming nothing in `posthog/dags` relies on global Dagster instance state surviving across the suite.
- **First run won't be optimally balanced** — without a checked-in `.test_durations` file, splits are by file count. After this lands and runs on master a few times, Django's `--store-durations --durations-min=1.0` pattern can be added to capture timings for better balance (deferred to keep this PR small).
- **Total CI minutes go up ~4x**, but only when dagster code changes (the `dagster: 'true'` change-detector still gates the job).

## How did you test this code?

I'm an agent — I haven't manually run the workflow. The CI run on this PR will be the experiment. Looking for: (a) all 4 shards green, (b) per-shard wall-clock significantly under 15m, (c) total test count across shards = 631+ (matching the unsharded baseline).

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code at the user's request as a draft experiment to validate dagster test sharding before committing to the pattern. Pattern copied from `.github/workflows/ci-backend.yml`'s Django/Temporal jobs. Discussion happened in the same session as the duckdb 1.5.2 bump ([#56610](https://github.com/PostHog/posthog/pull/56610)) — that PR keeps hitting the 30m cap, which surfaced the underlying capacity issue.

Keep as draft until shard timings are validated.