### PR TITLE
fix(experiments): populate primary_metrics_ordered_uuids on demo experiments

### DIFF
--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -1322,6 +1322,7 @@ class HedgeboxMatrix(Matrix):
         # --- Additional experiments for coverage of various states ---
 
         # Pricing page redesign (inconclusive) — uses high-volume pageview→signup funnel
+        pricing_metric_uuids = [str(uuid.uuid4()) for _ in range(2)]
         Experiment.objects.create(
             team=team,
             name="Pricing page redesign",
@@ -1332,7 +1333,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "funnel",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": pricing_metric_uuids[0],
                     "name": "Pricing page to signup",
                     "series": [
                         {"kind": "EventsNode", "event": "$pageview"},
@@ -1345,13 +1346,14 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "mean",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": pricing_metric_uuids[1],
                     "name": "Pageviews per user",
                     "source": {"kind": "EventsNode", "event": "$pageview"},
                     "goal": "increase",
                 },
             ],
             metrics_secondary=[],
+            primary_metrics_ordered_uuids=pricing_metric_uuids,
             parameters={
                 "feature_flag_variants": [
                     {"key": "control", "rollout_percentage": 50},
@@ -1368,6 +1370,7 @@ class HedgeboxMatrix(Matrix):
         )
 
         # File sharing incentive (lost) — uses upload→download funnel and upload mean
+        sharing_metric_uuids = [str(uuid.uuid4()) for _ in range(2)]
         Experiment.objects.create(
             team=team,
             name="File sharing incentive",
@@ -1378,7 +1381,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "mean",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": sharing_metric_uuids[0],
                     "name": "Uploads per user",
                     "source": {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
                     "goal": "increase",
@@ -1386,7 +1389,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "funnel",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": sharing_metric_uuids[1],
                     "name": "Upload to download",
                     "series": [
                         {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
@@ -1398,6 +1401,7 @@ class HedgeboxMatrix(Matrix):
                 },
             ],
             metrics_secondary=[],
+            primary_metrics_ordered_uuids=sharing_metric_uuids,
             parameters={
                 "feature_flag_variants": [
                     {"key": "control", "rollout_percentage": 50},
@@ -1414,6 +1418,7 @@ class HedgeboxMatrix(Matrix):
         )
 
         # Upgrade prompt experiment (running, recently started) — uses high-volume events
+        upgrade_metric_uuids = [str(uuid.uuid4()) for _ in range(2)]
         Experiment.objects.create(
             team=team,
             name="Upgrade prompt experiment",
@@ -1424,7 +1429,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "funnel",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": upgrade_metric_uuids[0],
                     "name": "Login to upload",
                     "series": [
                         {"kind": "EventsNode", "event": EVENT_LOGGED_IN},
@@ -1437,13 +1442,14 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "mean",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": upgrade_metric_uuids[1],
                     "name": "Downloads per user",
                     "source": {"kind": "EventsNode", "event": EVENT_DOWNLOADED_FILE},
                     "goal": "increase",
                 },
             ],
             metrics_secondary=[],
+            primary_metrics_ordered_uuids=upgrade_metric_uuids,
             parameters={
                 "feature_flag_variants": [
                     {"key": "control", "rollout_percentage": 34},
@@ -1459,6 +1465,7 @@ class HedgeboxMatrix(Matrix):
         )
 
         # Retention nudge (draft - not yet started)
+        retention_metric_uuids = [str(uuid.uuid4()) for _ in range(2)]
         Experiment.objects.create(
             team=team,
             name="Retention nudge",
@@ -1469,7 +1476,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "retention",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": retention_metric_uuids[0],
                     "name": "7-day login retention",
                     "goal": "increase",
                     "start_event": {"kind": "EventsNode", "event": EVENT_LOGGED_IN},
@@ -1482,13 +1489,14 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "mean",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": retention_metric_uuids[1],
                     "name": "Downloads per user",
                     "source": {"kind": "EventsNode", "event": EVENT_DOWNLOADED_FILE},
                     "goal": "increase",
                 },
             ],
             metrics_secondary=[],
+            primary_metrics_ordered_uuids=retention_metric_uuids,
             parameters={
                 "feature_flag_variants": [
                     {"key": "control", "rollout_percentage": 50},
@@ -1503,6 +1511,7 @@ class HedgeboxMatrix(Matrix):
         )
 
         # Team collaboration boost (stopped early) — uses high-volume events
+        team_collab_metric_uuids = [str(uuid.uuid4()) for _ in range(2)]
         Experiment.objects.create(
             team=team,
             name="Team collaboration boost",
@@ -1513,7 +1522,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "mean",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": team_collab_metric_uuids[0],
                     "name": "Files uploaded per user",
                     "source": {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
                     "goal": "increase",
@@ -1521,7 +1530,7 @@ class HedgeboxMatrix(Matrix):
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "funnel",
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": team_collab_metric_uuids[1],
                     "name": "Signup to upload",
                     "series": [
                         {"kind": "EventsNode", "event": EVENT_SIGNED_UP},
@@ -1533,6 +1542,7 @@ class HedgeboxMatrix(Matrix):
                 },
             ],
             metrics_secondary=[],
+            primary_metrics_ordered_uuids=team_collab_metric_uuids,
             parameters={
                 "feature_flag_variants": [
                     {"key": "control", "rollout_percentage": 50},

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -245,6 +245,9 @@ tools:
     event-definitions-partial-update:
         operation: event_definitions_partial_update
         enabled: false
+    event-definitions-promoted-properties-retrieve:
+        operation: event_definitions_promoted_properties_retrieve
+        enabled: false
     event-definitions-python-retrieve:
         operation: event_definitions_python_retrieve
         enabled: false
@@ -791,7 +794,4 @@ tools:
         enabled: false
     users-verify-email-create:
         operation: users_verify_email_create
-        enabled: false
-    event-definitions-promoted-properties-retrieve:
-        operation: event_definitions_promoted_properties_retrieve
         enabled: false


### PR DESCRIPTION
## Problem

Demo experiments were missing `primary_metrics_ordered_uuids`, causing any API update (even unrelated fields like `archived`) to fail with a validation error.

## Changes

Capture metric UUIDs into variables and pass them as `primary_metrics_ordered_uuids` for the 5 affected demo experiments.

## How did you test this code?

Ran mypy on the changed file. Verified the fix by archiving/unarchiving demo experiments via MCP tools.

## 🤖 Agent context

Agent-authored with human review. Discovered the issue while archiving/unarchiving demo experiments via MCP — the `experiment-update` tool failed because `_validate_metric_ordering_on_update` requires `primary_metrics_ordered_uuids` when metrics exist.