### PR TITLE
feat(visual-review): keyboard nav, persisted comparison mode, autocapture data-attrs

### DIFF
--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
@@ -93,6 +93,16 @@ function EmptyImageState({ title }: { title: string }): JSX.Element {
 /** Images smaller than this threshold render at 2x with pixelated scaling */
 const SMALL_IMAGE_THRESHOLD = 600
 
+function effectiveMode(requested: ComparisonMode, supportsComparison: boolean, hasDiffImage: boolean): ComparisonMode {
+    if (!supportsComparison) {
+        return 'blend'
+    }
+    if (!hasDiffImage && requested === 'diff') {
+        return 'blend'
+    }
+    return requested
+}
+
 export function VisualImageDiffViewer({
     baselineUrl,
     currentUrl,
@@ -118,7 +128,8 @@ export function VisualImageDiffViewer({
     const pixelatedClass = isSmallImage ? '' : 'max-w-full'
 
     const [internalMode, setInternalMode] = useState<ComparisonMode>('sideBySide')
-    const mode = controlledMode ?? internalMode
+    const requestedMode = controlledMode ?? internalMode
+    const mode: ComparisonMode = effectiveMode(requestedMode, supportsComparison, hasDiffImage)
     const setMode = (newMode: ComparisonMode): void => {
         setInternalMode(newMode)
         onModeChange?.(newMode)
@@ -145,16 +156,6 @@ export function VisualImageDiffViewer({
         }
         return modes
     }, [hasDiffImage])
-
-    useEffect(() => {
-        if (!supportsComparison) {
-            setMode('blend')
-            return
-        }
-        if (!hasDiffImage && mode === 'diff') {
-            setMode('blend')
-        }
-    }, [supportsComparison, hasDiffImage, mode])
 
     useEffect(() => {
         if (!(flicker && mode === 'split' && result === 'changed' && hasBothImages)) {

--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
@@ -135,13 +135,13 @@ export function VisualImageDiffViewer({
     const diffLabel = formatDiffPercentage(diffPercentage)
 
     const comparisonModes = useMemo(() => {
-        const modes: { value: ComparisonMode; label: string }[] = [
-            { value: 'sideBySide', label: 'Side by side' },
-            { value: 'blend', label: 'Blend' },
-            { value: 'split', label: 'Split' },
+        const modes: { value: ComparisonMode; label: string; 'data-attr': string }[] = [
+            { value: 'sideBySide', label: 'Side by side', 'data-attr': 'image-diff-mode-side-by-side' },
+            { value: 'blend', label: 'Blend', 'data-attr': 'image-diff-mode-blend' },
+            { value: 'split', label: 'Split', 'data-attr': 'image-diff-mode-split' },
         ]
         if (hasDiffImage) {
-            modes.push({ value: 'diff', label: 'Diff' })
+            modes.push({ value: 'diff', label: 'Diff', 'data-attr': 'image-diff-mode-diff' })
         }
         return modes
     }, [hasDiffImage])

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -1,9 +1,10 @@
+import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconGithub } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput, LemonModal, LemonSkeleton, LemonTag, Link } from '@posthog/lemon-ui'
 
-import { VisualImageDiffViewer, type ComparisonMode, type VisualDiffResult } from 'lib/components/VisualImageDiffViewer'
+import { VisualImageDiffViewer, type VisualDiffResult } from 'lib/components/VisualImageDiffViewer'
 import { dayjs } from 'lib/dayjs'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
@@ -15,6 +16,7 @@ import type {
     SnapshotHistoryEntryApi,
     ToleratedHashEntryApi,
 } from '../generated/api.schemas'
+import { visualReviewPreferencesLogic } from '../scenes/visualReviewPreferencesLogic'
 import { SnapshotStatusIndicator } from './SnapshotStatusIndicator'
 
 function DiffMinimap({ url, onClick }: { url: string; onClick?: () => void }): JSX.Element {
@@ -26,6 +28,7 @@ function DiffMinimap({ url, onClick }: { url: string; onClick?: () => void }): J
                 type="button"
                 className="relative rounded border border-border overflow-hidden bg-bg-3000 w-full cursor-pointer hover:border-primary transition-colors"
                 onClick={onClick}
+                data-attr="visual-review-diff-minimap"
             >
                 {!loaded && <LemonSkeleton className="absolute inset-0" />}
                 <img
@@ -88,7 +91,12 @@ function QuarantineAction({
 
     return (
         <div>
-            <LemonButton type="secondary" size="small" onClick={() => setIsOpen(true)}>
+            <LemonButton
+                type="secondary"
+                size="small"
+                onClick={() => setIsOpen(true)}
+                data-attr="visual-review-quarantine-open"
+            >
                 Quarantine this identifier
             </LemonButton>
             <LemonModal
@@ -97,13 +105,18 @@ function QuarantineAction({
                 title="Quarantine snapshot"
                 footer={
                     <>
-                        <LemonButton type="secondary" onClick={() => setIsOpen(false)}>
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => setIsOpen(false)}
+                            data-attr="visual-review-quarantine-cancel"
+                        >
                             Cancel
                         </LemonButton>
                         <LemonButton
                             type="primary"
                             disabledReason={!reason.trim() ? 'Reason is required' : undefined}
                             onClick={handleSubmit}
+                            data-attr="visual-review-quarantine-confirm"
                         >
                             Quarantine
                         </LemonButton>
@@ -214,7 +227,8 @@ export function SnapshotDiffViewer({
     onRecompute,
     recomputeDisabledReason,
 }: SnapshotDiffViewerProps): JSX.Element {
-    const [comparisonMode, setComparisonMode] = useState<ComparisonMode>('sideBySide')
+    const { comparisonMode } = useValues(visualReviewPreferencesLogic)
+    const { setComparisonMode } = useActions(visualReviewPreferencesLogic)
     const baselineUrl = snapshot.baseline_artifact?.download_url
     const currentUrl = snapshot.current_artifact?.download_url
 
@@ -259,6 +273,7 @@ export function SnapshotDiffViewer({
                                 type="secondary"
                                 size="small"
                                 disabledReason="Leaving a snapshot unreviewed already blocks the PR. To fix it, update your code and rerun CI."
+                                data-attr="visual-review-snapshot-reject"
                             >
                                 Reject
                             </LemonButton>
@@ -279,11 +294,18 @@ export function SnapshotDiffViewer({
                                             secondaryButton: { children: 'Cancel' },
                                         })
                                     }}
+                                    data-attr="visual-review-snapshot-tolerate"
                                 >
                                     Tolerate
                                 </LemonButton>
                             )}
-                            <LemonButton type="primary" size="small" onClick={onApprove} loading={isApproving}>
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={onApprove}
+                                loading={isApproving}
+                                data-attr="visual-review-snapshot-accept"
+                            >
                                 Accept change
                             </LemonButton>
                         </>
@@ -438,6 +460,7 @@ export function SnapshotDiffViewer({
                                         size="xsmall"
                                         loading={isRecomputing}
                                         disabledReason={recomputeDisabledReason}
+                                        data-attr="visual-review-snapshot-recompute"
                                         onClick={() => {
                                             LemonDialog.open({
                                                 title: 'Re-trigger CI job?',
@@ -556,6 +579,7 @@ export function SnapshotDiffViewer({
                                 type="secondary"
                                 status="danger"
                                 size="small"
+                                data-attr="visual-review-unquarantine"
                                 onClick={() => {
                                     LemonDialog.open({
                                         title: 'Unquarantine this identifier?',

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -441,10 +441,9 @@ export function VisualReviewRunScene(): JSX.Element {
                                 icon={<IconChevronLeft />}
                                 onClick={goToPrevious}
                                 disabledReason={!hasPrevious ? 'No previous snapshot' : undefined}
-                                sideIcon={<KeyboardShortcut p />}
                                 data-attr="visual-review-snapshot-previous"
                             >
-                                Previous
+                                Previous <KeyboardShortcut p />
                             </LemonButton>
                             {currentIndex >= 0 && (
                                 <span className="text-xs text-muted">
@@ -453,13 +452,12 @@ export function VisualReviewRunScene(): JSX.Element {
                             )}
                             <LemonButton
                                 size="xsmall"
-                                icon={<KeyboardShortcut n />}
+                                sideIcon={<IconChevronRight />}
                                 onClick={goToNext}
                                 disabledReason={!hasNext ? 'No next snapshot' : undefined}
-                                sideIcon={<IconChevronRight />}
                                 data-attr="visual-review-snapshot-next"
                             >
-                                Next
+                                Next <KeyboardShortcut n />
                             </LemonButton>
                         </div>
                     )}

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
 import { PostHogCaptureOnViewed } from '@posthog/react'
 
 import { DetectiveHog } from 'lib/components/hedgehogs'
+import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -51,6 +52,7 @@ function SnapshotThumbnail({
         <button
             type="button"
             onClick={onClick}
+            data-attr="visual-review-snapshot-thumbnail"
             className="relative flex flex-col items-center gap-1 shrink-0 rounded overflow-hidden p-1.5 transition-colors"
             // eslint-disable-next-line react/forbid-dom-props
             style={{
@@ -208,6 +210,34 @@ export function VisualReviewRunScene(): JSX.Element {
         recomputeRun,
     } = useActions(visualReviewRunSceneLogic)
 
+    // Navigation — use changed snapshots when there are changes, otherwise all snapshots
+    const navSnapshots = sortedChangedSnapshots.length > 0 ? sortedChangedSnapshots : snapshots
+    const currentIndex = selectedSnapshot
+        ? navSnapshots.findIndex((s: SnapshotApi) => s.id === selectedSnapshot.id)
+        : -1
+    const hasPrevious = currentIndex > 0
+    const hasNext = currentIndex >= 0 && currentIndex < navSnapshots.length - 1
+
+    const goToPrevious = (): void => {
+        if (hasPrevious) {
+            setSelectedSnapshotId(navSnapshots[currentIndex - 1].id)
+        }
+    }
+
+    const goToNext = (): void => {
+        if (hasNext) {
+            setSelectedSnapshotId(navSnapshots[currentIndex + 1].id)
+        }
+    }
+
+    useKeyboardHotkeys(
+        {
+            p: { action: goToPrevious, disabled: !hasPrevious },
+            n: { action: goToNext, disabled: !hasNext },
+        },
+        [hasPrevious, hasNext, currentIndex]
+    )
+
     if (runLoading || !run) {
         return (
             <SceneContent>
@@ -284,26 +314,6 @@ export function VisualReviewRunScene(): JSX.Element {
 
     const hasMore = diffChanged + diffNew + diffRemoved > reviewPending + reviewApproved + reviewTolerated
 
-    // Navigation — use changed snapshots when there are changes, otherwise all snapshots
-    const navSnapshots = sortedChangedSnapshots.length > 0 ? sortedChangedSnapshots : snapshots
-    const currentIndex = selectedSnapshot
-        ? navSnapshots.findIndex((s: SnapshotApi) => s.id === selectedSnapshot.id)
-        : -1
-    const hasPrevious = currentIndex > 0
-    const hasNext = currentIndex >= 0 && currentIndex < navSnapshots.length - 1
-
-    const goToPrevious = (): void => {
-        if (hasPrevious) {
-            setSelectedSnapshotId(navSnapshots[currentIndex - 1].id)
-        }
-    }
-
-    const goToNext = (): void => {
-        if (hasNext) {
-            setSelectedSnapshotId(navSnapshots[currentIndex + 1].id)
-        }
-    }
-
     const handleApproveSnapshot = (): void => {
         if (selectedSnapshot) {
             approveSnapshot(selectedSnapshot)
@@ -319,7 +329,12 @@ export function VisualReviewRunScene(): JSX.Element {
                     !run.approved &&
                     !run.is_stale &&
                     (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0) ? (
-                        <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
+                        <LemonButton
+                            type="primary"
+                            onClick={approveChanges}
+                            loading={isApproving}
+                            data-attr="visual-review-commit-baseline"
+                        >
                             {reviewPending > 0 ? `Approve ${reviewPending} pending and commit` : 'Commit to baseline'}
                         </LemonButton>
                     ) : undefined
@@ -345,6 +360,7 @@ export function VisualReviewRunScene(): JSX.Element {
                         children: 'Re-trigger CI',
                         loading: isRecomputing,
                         onClick: recomputeRun,
+                        'data-attr': 'visual-review-recompute-run',
                     }}
                 >
                     All changes are resolved — re-trigger to update the commit status and pass the gate.
@@ -424,6 +440,8 @@ export function VisualReviewRunScene(): JSX.Element {
                                 icon={<IconChevronLeft />}
                                 onClick={goToPrevious}
                                 disabledReason={!hasPrevious ? 'No previous snapshot' : undefined}
+                                tooltip="Previous (P)"
+                                data-attr="visual-review-snapshot-previous"
                             >
                                 Previous
                             </LemonButton>
@@ -437,6 +455,8 @@ export function VisualReviewRunScene(): JSX.Element {
                                 sideIcon={<IconChevronRight />}
                                 onClick={goToNext}
                                 disabledReason={!hasNext ? 'No next snapshot' : undefined}
+                                tooltip="Next (N)"
+                                data-attr="visual-review-snapshot-next"
                             >
                                 Next
                             </LemonButton>

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -11,6 +11,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
 
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
@@ -440,7 +441,7 @@ export function VisualReviewRunScene(): JSX.Element {
                                 icon={<IconChevronLeft />}
                                 onClick={goToPrevious}
                                 disabledReason={!hasPrevious ? 'No previous snapshot' : undefined}
-                                tooltip="Previous (P)"
+                                sideIcon={<KeyboardShortcut p />}
                                 data-attr="visual-review-snapshot-previous"
                             >
                                 Previous
@@ -452,10 +453,10 @@ export function VisualReviewRunScene(): JSX.Element {
                             )}
                             <LemonButton
                                 size="xsmall"
-                                sideIcon={<IconChevronRight />}
+                                icon={<KeyboardShortcut n />}
                                 onClick={goToNext}
                                 disabledReason={!hasNext ? 'No next snapshot' : undefined}
-                                tooltip="Next (N)"
+                                sideIcon={<IconChevronRight />}
                                 data-attr="visual-review-snapshot-next"
                             >
                                 Next

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -235,7 +235,7 @@ export function VisualReviewRunScene(): JSX.Element {
             p: { action: goToPrevious, disabled: !hasPrevious },
             n: { action: goToNext, disabled: !hasNext },
         },
-        [hasPrevious, hasNext, currentIndex]
+        [currentIndex, navSnapshots.length]
     )
 
     if (runLoading || !run) {

--- a/products/visual_review/frontend/scenes/visualReviewPreferencesLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewPreferencesLogic.ts
@@ -1,0 +1,21 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import type { ComparisonMode } from 'lib/components/VisualImageDiffViewer/VisualImageDiffViewer'
+
+import type { visualReviewPreferencesLogicType } from './visualReviewPreferencesLogicType'
+
+export const visualReviewPreferencesLogic = kea<visualReviewPreferencesLogicType>([
+    path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewPreferencesLogic']),
+    actions({
+        setComparisonMode: (mode: ComparisonMode) => ({ mode }),
+    }),
+    reducers({
+        comparisonMode: [
+            'sideBySide' as ComparisonMode,
+            { persist: true, prefix: 'visual_review_' },
+            {
+                setComparisonMode: (_, { mode }) => mode,
+            },
+        ],
+    }),
+])


### PR DESCRIPTION
a few tiny changes based on what i'd like after some uses of the page :)

## Problem

Reviewing a long list of changed snapshots in the visual review run scene means reaching for the mouse for every navigation step. The comparison mode (Side by side / Blend / Split / Diff) resets every time you change snapshot because it lives in a `useState` that gets remounted, and again on reload. None of the buttons in the scene carry `data-attr` values, so we can't track usage via autocapture.

## Changes

- Added `p` / `n` keyboard hotkeys for previous / next snapshot, reusing the existing `goToPrevious` / `goToNext` handlers and the existing chevron buttons as the visual affordance. The `useKeyboardHotkeys` hook already suppresses input/textarea/contentEditable focus and modifier keys. Tooltips on the buttons make the hotkeys discoverable.
- New `visualReviewPreferencesLogic` (non-keyed) holds `comparisonMode` in a kea reducer with `{ persist: true, prefix: 'visual_review_' }`, mirroring the pattern used in llm_analytics. `SnapshotDiffViewer` now reads/writes through the logic instead of local state, so the chosen mode survives snapshot changes, page reloads, and switching between runs.
- Added `data-attr` values on every button in the scene: previous/next, commit-to-baseline, re-trigger CI, snapshot thumbnails, accept/tolerate/reject change, quarantine open/cancel/confirm, unquarantine, recompute, and the diff minimap. The shared `VisualImageDiffViewer` segmented mode picker gets per-option `data-attr`s too, scoped with a generic `image-diff-mode-` prefix since the component lives in `lib/`.

## How did you test this code?

I'm an agent. I did not run manual end-to-end testing in a browser.

Automated checks I ran:

- `pnpm --filter=@posthog/frontend format` (oxlint + oxfmt) — passes with the introduced changes; rules-of-hooks initially flagged the new hook call below an early return, fixed by hoisting the navigation derivation above the early returns.
- `pnpm --filter=@posthog/frontend typescript:check` (`tsc --noEmit`) — adds zero new errors versus master baseline. The 6 pre-existing errors (`@posthog/hogvm` / `@posthog/quill` module-not-found) are unrelated and present on master.
- `kea-typegen write` generated `visualReviewPreferencesLogicType.ts` cleanly.

Manual verification a human reviewer should do:

- open `/visual_review/runs/<id>#snapshot=<snap>` with multiple changed snapshots
- press `p` / `n` — selection moves; URL hash updates; thumbnail strip selection follows
- press `p` / `n` while focused inside the quarantine modal input — no navigation fires
- hover Previous/Next — tooltip shows the hotkey
- switch to "Blend", click between snapshots and reload the page — mode stays Blend; same on a different run

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Plan was reviewed and approved before any edits. Task ID: a83eeaa7-f226-4eeb-89b1-226110a0f3a8.

Key decisions:
- Used a separate non-keyed `visualReviewPreferencesLogic` rather than putting the mode reducer in `visualReviewRunSceneLogic`, because the latter is keyed by `runId` and kea-localstorage scopes its key by logic path including the kea key — that would scope the preference per-run, which is not what was asked for.
- Used a generic `image-diff-mode-` prefix on the data-attrs in the shared `VisualImageDiffViewer` component (rather than `visual-review-`) since it's a generic component in `lib/` that could in theory be reused.
- Hoisted the navigation derivation (`navSnapshots`, `currentIndex`, `hasPrevious`, `hasNext`, `goToPrevious`, `goToNext`) above the scene's early returns, so `useKeyboardHotkeys` is called unconditionally and rules-of-hooks is satisfied.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*