### PR TITLE
feat(phai): add v1->v2 tool deprecation redirects in MCP exec dispatcher

### DIFF
--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -33,9 +33,38 @@ function parseCommand(input: string): { verb: string; rest: string } {
     return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
 }
 
+// Tools removed from v2 (single-exec) MCP. When the model attempts to call one,
+// surface a targeted redirect to the v2 replacement instead of dumping the full
+// tool catalog. Sourced from tools marked `new_mcp: false` in
+// schema/tool-definitions.json. Keep the redirect text editorial — schemas
+// don't carry "use X instead" guidance.
+const DEPRECATED_TOOL_REDIRECTS: Record<string, (allTools: Tool<ZodObjectAny>[]) => string> = {
+    'entity-search': () =>
+        'Tool "entity-search" was removed in MCP v2. Use "execute-sql" to search PostHog data via HogQL. Consult the `query-examples` skill for system-table patterns (system.insights, system.dashboards, system.cohorts, ...).',
+    'event-definitions-list': () =>
+        'Tool "event-definitions-list" was removed in MCP v2. Use "read-data-schema" with input { "query": { "kind": "events" } } to list event definitions.',
+    'properties-list': () =>
+        'Tool "properties-list" was removed in MCP v2. Use "read-data-schema": { "query": { "kind": "event_properties", "event_name": "..." } } for event properties, or { "kind": "entity_properties", "entity": "person" | "session" | "group/<n>" } for entity properties.',
+    'property-definitions': () =>
+        'Tool "property-definitions" was removed in MCP v2. Use "read-data-schema" with the appropriate kind: "event_properties", "entity_properties", or "action_properties" — see its info schema for required fields.',
+    'query-generate-hogql-from-question': () =>
+        'Tool "query-generate-hogql-from-question" was removed in MCP v2. Write the HogQL yourself and run it via "execute-sql". Consult the `query-examples` skill for HogQL patterns.',
+    'query-run': (allTools) => {
+        const queryTools = allTools
+            .filter((t) => t.name.startsWith('query-'))
+            .map((t) => `- ${t.name}: ${t.description.split('\n')[0]}`)
+            .join('\n')
+        return `Tool "query-run" was removed in MCP v2. Pick the typed query tool that matches your intent, or use "execute-sql" for arbitrary HogQL. Available query-* tools:\n${queryTools}`
+    },
+}
+
 function findTool(tools: Tool<ZodObjectAny>[], name: string): Tool<ZodObjectAny> {
     const tool = tools.find((t) => t.name === name)
     if (!tool) {
+        const redirect = DEPRECATED_TOOL_REDIRECTS[name]
+        if (redirect) {
+            throw new Error(redirect(tools))
+        }
         const available = tools.map((t) => t.name).join(', ')
         throw new Error(`Unknown tool: "${name}". Available tools: ${available}`)
     }

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -199,6 +199,28 @@ describe('exec tool', () => {
         })
     })
 
+    describe('deprecated tool redirects', () => {
+        it.each([
+            ['entity-search', 'execute-sql'],
+            ['event-definitions-list', 'read-data-schema'],
+            ['properties-list', 'read-data-schema'],
+            ['property-definitions', 'read-data-schema'],
+            ['query-generate-hogql-from-question', 'execute-sql'],
+            ['query-run', 'execute-sql'],
+        ])('throws redirect when calling deprecated %s', async (deprecated, replacement) => {
+            const exec = createExec()
+            await expect(exec.handler(mockContext, { command: `call ${deprecated} {}` })).rejects.toThrow(
+                new RegExp(`removed in MCP v2[\\s\\S]*${replacement}`)
+            )
+        })
+
+        it('lists available query-* tools when query-run is called', async () => {
+            const queryTrends = makeMockTool({ name: 'query-trends', description: 'Run a trends query' })
+            const exec = createExec([queryTrends])
+            await expect(exec.handler(mockContext, { command: 'call query-run {}' })).rejects.toThrow(/query-trends/)
+        })
+    })
+
     describe('schema snapshot', () => {
         function createSnapshotContext(): Context {
             return {


### PR DESCRIPTION
## Problem

PostHog MCP v2 (single-exec) drops 6 tools that were available in v1 by marking them `new_mcp: false` in `services/mcp/schema/tool-definitions.json`. When the model calls one via `exec call <tool>`, `findTool` throws a generic `Unknown tool: "X". Available tools: ...` error that dumps the entire 270-tool catalog. The model gets no signal that the tool was *intentionally removed* nor what to use instead, so it tends to retry the same call or pick an arbitrary nearby tool.

## Changes

Added a `DEPRECATED_TOOL_REDIRECTS` map in `services/mcp/src/tools/exec.ts` and a redirect branch in `findTool` that fires before the generic error. Each removed tool now produces a one-line redirect:

| Removed v1 tool | Redirect |
|---|---|
| `entity-search` | `execute-sql` + `query-examples` skill |
| `event-definitions-list` | `read-data-schema` (`kind: "events"`) |
| `properties-list` | `read-data-schema` (`event_properties` / `entity_properties` / `action_properties`) |
| `property-definitions` | `read-data-schema` (same kinds as above) |
| `query-generate-hogql-from-question` | `execute-sql` + `query-examples` skill |
| `query-run` | dynamic list of live `query-*` tools, plus `execute-sql` fallback |

The `query-run` redirect enumerates the live `query-*` tools from `allTools` so the message stays current as new typed query tools are added.

**Scope:** this layer only exists for the single-exec dispatcher (v2). The legacy tools-based MCP (v1) registers each tool as its own handler — removed tools simply aren't on the wire, so there's no central chokepoint to add a 404 to. If we ever want symmetric behavior in the tools-based mode, it would have to be done at the MCP server level (e.g., registering stub handlers) and is out of scope here.

## How did you test this code?

- Added `deprecated tool redirects` describe block in `services/mcp/tests/unit/exec.test.ts` — parameterized check across all 6 deprecations + a dynamic-list test asserting that `query-run`'s message includes a `query-*` tool name from the live tool set.
- `pnpm test tests/unit/exec.test.ts` — 25 tests pass (18 original + 7 new).
- `pnpm exec tsc --noEmit` — clean.

## Publish to changelog?

no

## 🤖 Agent context

Implemented by Claude Opus 4.7. Exploration confirmed the dispatcher chokepoint at `services/mcp/src/tools/exec.ts:36-43` (`findTool`), which is reached from `info`/`schema`/`call` cases — throwing a more helpful error there propagates through the existing inner-call tracker and MCP error pipeline without signature changes. Considered but rejected: deriving the redirect map from `new_mcp: false` in the schema (the editorial "use X instead" text doesn't live in any schema) and returning a structured `CallToolResult` (would force every `findTool` caller to special-case the redirect path).