### PR TITLE
fix(logs): fix rate limiter logic using min timestamp instead of max

### DIFF
--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -595,6 +595,29 @@ describe('LogsRateLimiterService', () => {
                 expect(result.dropped).toHaveLength(0)
             })
 
+            it('should refill from newest timestamp when batch spans an old timestamp (catch-up scenario)', async () => {
+                // First batch drains the bucket at t0.
+                const t0 = new Date('2024-01-01T00:00:00Z').toISOString()
+                const messages1 = [createMessageWithHeaders(1, 10000, [{ created_at: t0 }])] // 10KB = full bucket
+                const result1 = await rateLimiter.filterMessages(messages1)
+                expect(result1.allowed).toHaveLength(1)
+
+                // Second batch (catch-up) spans 10 seconds — oldest message is at t0 (matches previous
+                // batch), newest at t10. Refill rate is 1KB/s, so 10 seconds of producer time => 10KB.
+                // If we used the oldest timestamp the Lua would compute timeDiff=0 and not refill,
+                // dropping the messages.
+                const t10 = new Date('2024-01-01T00:00:10Z').toISOString()
+                const messages2 = [
+                    createMessageWithHeaders(1, 5120, [{ created_at: t0 }]), // 5KB at t0
+                    createMessageWithHeaders(1, 3072, [{ created_at: t10 }]), // 3KB at t10
+                ]
+
+                const result2 = await rateLimiter.filterMessages(messages2)
+
+                expect(result2.allowed).toHaveLength(2)
+                expect(result2.dropped).toHaveLength(0)
+            })
+
             it('should allow more throughput when batch spans time (backfill scenario)', async () => {
                 // Simulate backfill: first batch drains the bucket
                 const t0 = new Date('2024-01-01T00:00:00Z').toISOString()
@@ -604,8 +627,8 @@ describe('LogsRateLimiterService', () => {
 
                 // Second batch arrives 10 seconds later.
                 // Bucket is empty, refill rate is 1KB/s, so 10 seconds of refill = 10KB.
-                // filterMessages uses the oldest timestamp per team, so all messages
-                // need to be at t10 for the refill to kick in.
+                // filterMessages uses the newest timestamp per team for refill, so the batch
+                // gets credit for the full producer-time span it covers.
                 const t10 = new Date('2024-01-01T00:00:10Z').toISOString()
                 const messages2 = [
                     createMessageWithHeaders(1, 5120, [{ created_at: t10 }]), // 5KB at t0+10s
@@ -614,7 +637,7 @@ describe('LogsRateLimiterService', () => {
 
                 const result2 = await rateLimiter.filterMessages(messages2)
 
-                // Oldest timestamp t10 gives 10KB refill from t0, enough for 5+3=8KB
+                // Newest timestamp t10 gives 10KB refill from t0, enough for 5+3=8KB
                 expect(result2.allowed).toHaveLength(2)
                 expect(result2.dropped).toHaveLength(0)
             })

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
@@ -188,13 +188,19 @@ export class LogsRateLimiterService {
         // Group messages by team to calculate total cost per team (only for teams with rate limiting enabled)
         const teamCosts = new Map<number, number>()
         const teamOldestTimestamps = new Map<number, number>()
+        const teamNewestTimestamps = new Map<number, number>()
 
         for (const message of messages) {
             const messageTimestamp = this.getTimestampFromMessage(message)
 
-            const existing = teamOldestTimestamps.get(message.teamId)
-            if (existing === undefined || messageTimestamp < existing) {
+            const existingOldest = teamOldestTimestamps.get(message.teamId)
+            if (existingOldest === undefined || messageTimestamp < existingOldest) {
                 teamOldestTimestamps.set(message.teamId, messageTimestamp)
+            }
+
+            const existingNewest = teamNewestTimestamps.get(message.teamId)
+            if (existingNewest === undefined || messageTimestamp > existingNewest) {
+                teamNewestTimestamps.set(message.teamId, messageTimestamp)
             }
 
             if (!this.isRateLimitingEnabledForTeam(message.teamId)) {
@@ -212,12 +218,14 @@ export class LogsRateLimiterService {
             logsMessageLagHistogram.observe(nowSeconds - timestamp)
         }
 
-        // Check rate limits for all teams
+        // Use the newest timestamp per team for the token bucket: this gives the bucket credit
+        // for the full producer-time span the batch covers, so a catch-up batch refills against
+        // its own time range instead of seeing timeDiff=0 from the previous batch's last call.
         const rateLimitResults = await this.rateLimitMany(
             Array.from(teamCosts.entries()).map(([teamId, cost]) => [
                 teamId.toString(),
                 cost,
-                teamOldestTimestamps.get(teamId) ?? msToSeconds(Date.now()),
+                teamNewestTimestamps.get(teamId) ?? msToSeconds(Date.now()),
             ])
         )
 


### PR DESCRIPTION
## Problem

when we were catching up lag we noticed spikes in rate limiting message drops (just for our teams luckily)

We had previously tried to fix this by using the latest timestamp in a batch to run the rate limiter logic on - however the implementation had a logic error and used the minimum timestamp instead 🤦 

## Changes

make rate limit checks use the latest timestamp in a batch instead of earliest
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally, tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
