### PR TITLE
fix(logs-ingestion): limit to 50 concurrent messages processing at a time

### DIFF
--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -16,6 +16,7 @@ const SPAN_LOGS_PARSE_BODIES = 'logsIngestionConsumer.handleEachBatch.parseLogBo
 const SPAN_LOGS_ENRICH_JSON = 'logsIngestionConsumer.handleEachBatch.enrichJsonAttributes'
 const SPAN_LOGS_PII_SCRUB = 'logsIngestionConsumer.handleEachBatch.piiScrubLogRecords'
 const SPAN_LOGS_ENCODE = 'logsIngestionConsumer.handleEachBatch.encodeLogRecords'
+const SPAN_LOGS_PROCESS_BUFFER = 'logsIngestionConsumer.handleEachBatch.processLogMessageBuffer'
 
 const logRecordProcessInstrumentOpts = { measureTime: false, sendException: false } as const
 
@@ -270,7 +271,10 @@ const scrubBatch = instrumented({
  * When both `json_parse_logs` and `pii_scrub_logs` are on, scrub runs **before** parse/enrich so flattened JSON
  * attributes are derived from the redacted body string. `parseLogBodiesForIngestion` runs only when JSON parse is on.
  */
-export async function processLogMessageBuffer(
+export const processLogMessageBuffer = instrumented({
+    key: SPAN_LOGS_PROCESS_BUFFER,
+    ...logRecordProcessInstrumentOpts,
+})(async function processLogMessageBufferImpl(
     buffer: Buffer,
     settings: LogsSettings
 ): Promise<{ value: Buffer; pii: PiiScrubStats }> {
@@ -318,4 +322,4 @@ export async function processLogMessageBuffer(
             durationSeconds
         )
     }
-}
+}) as (buffer: Buffer, settings: LogsSettings) => Promise<{ value: Buffer; pii: PiiScrubStats }>

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1442,10 +1442,6 @@ describe('LogsIngestionConsumer', () => {
     describe('thread relief', () => {
         jest.setTimeout(30000)
 
-        let interval: NodeJS.Timeout
-        let lastCheck = 0
-        let longestDelay = 0
-
         beforeEach(async () => {
             // Parent beforeEach mocks Date.now/toISOString — restore for real-time tracking.
             jest.spyOn(Date, 'now').mockRestore()
@@ -1460,17 +1456,6 @@ describe('LogsIngestionConsumer', () => {
                 'updateTeamLogsForThreadRelief'
             )
             hub.teamManager['lazyLoader'].markForRefresh(String(team.id))
-
-            lastCheck = Date.now()
-            longestDelay = 0
-            interval = setInterval(() => {
-                longestDelay = Math.max(longestDelay, Date.now() - lastCheck)
-                lastCheck = Date.now()
-            }, 0)
-        })
-
-        afterEach(() => {
-            clearInterval(interval)
         })
 
         it('should process large batches without blocking the main thread', async () => {
@@ -1482,24 +1467,31 @@ describe('LogsIngestionConsumer', () => {
                 message: 'A long log message ' + 'x'.repeat(500),
             })
 
-            // 1000+ messages is where unbounded fan-out starves the loop in production.
-            // Locally the bench shows max event-loop lag ~800ms unbounded vs ~5ms with cap=50.
-            const numberToTest = 1000
+            const numberToTest = 2000
             const messages = await createKafkaMessages(
                 Array.from({ length: numberToTest }, () => ({ message: body })),
                 { token: team.api_token }
             )
 
-            await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
+            // Track event-loop lag only during the consumer's processing.
+            let lastCheck = Date.now()
+            let longestDelay = 0
+            const interval = setInterval(() => {
+                longestDelay = Math.max(longestDelay, Date.now() - lastCheck)
+                lastCheck = Date.now()
+            }, 0)
 
-            // All messages should have been produced.
+            try {
+                await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
+            } finally {
+                clearInterval(interval)
+            }
+
             const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
             expect(logsMessages).toHaveLength(numberToTest)
 
-            // Without the pLimit cap on per-message processing, longestDelay measured >500ms
-            // for batches of this size on the bench. With the cap (currently 50) it stays
-            // well under 200ms even on a loaded machine. Threshold below leaves CI headroom.
-            expect(longestDelay).toBeLessThan(500)
+            console.log(`[thread-relief] longestDelay = ${longestDelay}ms`)
+            expect(longestDelay).toBeLessThan(120)
         })
     })
 })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1438,4 +1438,68 @@ describe('LogsIngestionConsumer', () => {
             expect(droppedMetrics).toHaveLength(0)
         })
     })
+
+    describe('thread relief', () => {
+        jest.setTimeout(30000)
+
+        let interval: NodeJS.Timeout
+        let lastCheck = 0
+        let longestDelay = 0
+
+        beforeEach(async () => {
+            // Parent beforeEach mocks Date.now/toISOString — restore for real-time tracking.
+            jest.spyOn(Date, 'now').mockRestore()
+            jest.spyOn(Date.prototype, 'toISOString').mockRestore()
+
+            // Enable PII scrub + JSON parse so processLogMessageBuffer does real CPU work
+            // (without these settings it short-circuits and never decodes the buffer).
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `UPDATE posthog_team SET logs_settings = $1 WHERE id = $2`,
+                [JSON.stringify({ pii_scrub_logs: true, json_parse_logs: true }), team.id],
+                'updateTeamLogsForThreadRelief'
+            )
+            hub.teamManager['lazyLoader'].markForRefresh(String(team.id))
+
+            lastCheck = Date.now()
+            longestDelay = 0
+            interval = setInterval(() => {
+                longestDelay = Math.max(longestDelay, Date.now() - lastCheck)
+                lastCheck = Date.now()
+            }, 0)
+        })
+
+        afterEach(() => {
+            clearInterval(interval)
+        })
+
+        it('should process large batches without blocking the main thread', async () => {
+            // Body large enough that JSON parse + PII scrub do meaningful sync work per message.
+            const body = JSON.stringify({
+                user_id: 'usr_abc123',
+                email: 'jane.doe@example.com',
+                nested: { a: 1, b: 'two', c: [1, 2, 3, 4, 5] },
+                message: 'A long log message ' + 'x'.repeat(500),
+            })
+
+            // 1000+ messages is where unbounded fan-out starves the loop in production.
+            // Locally the bench shows max event-loop lag ~800ms unbounded vs ~5ms with cap=50.
+            const numberToTest = 1000
+            const messages = await createKafkaMessages(
+                Array.from({ length: numberToTest }, () => ({ message: body })),
+                { token: team.api_token }
+            )
+
+            await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
+
+            // All messages should have been produced.
+            const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
+            expect(logsMessages).toHaveLength(numberToTest)
+
+            // Without the pLimit cap on per-message processing, longestDelay measured >500ms
+            // for batches of this size on the bench. With the cap (currently 50) it stays
+            // well under 200ms even on a loaded machine. Threshold below leaves CI headroom.
+            expect(longestDelay).toBeLessThan(500)
+        })
+    })
 })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -1,4 +1,5 @@
 import { Message } from 'node-rdkafka'
+import pLimit from 'p-limit'
 import { Counter } from 'prom-client'
 
 import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
@@ -56,6 +57,9 @@ export type UsageStatsByTeam = Map<number, UsageStats>
 
 /** Ingestion default when `logs_settings.retention_days` is unset; must be in `TeamSerializer.VALID_RETENTION_DAYS`. */
 export const DEFAULT_LOGS_RETENTION_DAYS = 14
+
+/** Cap concurrent per-message processing within a single kafka batch. */
+const MAX_CONCURRENT_MESSAGE_PROCESSES = 50
 
 export const logMessageDroppedCounter = new Counter({
     name: 'logs_ingestion_message_dropped_count',
@@ -301,46 +305,49 @@ export class LogsIngestionConsumer {
         messages: LogsIngestionMessage[],
         usageStats: UsageStatsByTeam
     ): Promise<void> {
+        const limit = pLimit(MAX_CONCURRENT_MESSAGE_PROCESSES)
         const results = await Promise.allSettled(
-            messages.map(async (message) => {
-                try {
-                    // Fetch team to get logs_settings
-                    const team = await this.deps.teamManager.getTeam(message.teamId)
-                    const logsSettings = team?.logs_settings || {}
+            messages.map((message) =>
+                limit(async () => {
+                    try {
+                        // Fetch team to get logs_settings
+                        const team = await this.deps.teamManager.getTeam(message.teamId)
+                        const logsSettings = team?.logs_settings || {}
 
-                    // Extract settings with defaults
-                    const jsonParse = logsSettings.json_parse_logs ?? false
-                    const retentionDays = logsSettings.retention_days ?? DEFAULT_LOGS_RETENTION_DAYS
+                        // Extract settings with defaults
+                        const jsonParse = logsSettings.json_parse_logs ?? false
+                        const retentionDays = logsSettings.retention_days ?? DEFAULT_LOGS_RETENTION_DAYS
 
-                    // ignore empty messages
-                    if (message.message.value === null) {
-                        return Promise.resolve()
-                    }
-                    const { value: processedValue, pii } = await processLogMessageBuffer(
-                        message.message.value,
-                        logsSettings
-                    )
-                    this.addPiiStatsIntoUsage(usageStats, message.teamId, pii)
+                        // ignore empty messages
+                        if (message.message.value === null) {
+                            return
+                        }
+                        const { value: processedValue, pii } = await processLogMessageBuffer(
+                            message.message.value,
+                            logsSettings
+                        )
+                        this.addPiiStatsIntoUsage(usageStats, message.teamId, pii)
 
-                    // Await so a rejection here lands in the catch and routes to the DLQ.
-                    await this.deps.outputs.queueMessages(LOGS_OUTPUT, [
-                        {
-                            value: processedValue,
-                            key: null,
-                            headers: {
-                                ...parseKafkaHeaders(message.message.headers),
-                                token: message.token,
-                                team_id: message.teamId.toString(),
-                                'json-parse': jsonParse.toString(),
-                                'retention-days': retentionDays.toString(),
+                        // Await so a rejection here lands in the catch and routes to the DLQ.
+                        await this.deps.outputs.queueMessages(LOGS_OUTPUT, [
+                            {
+                                value: processedValue,
+                                key: null,
+                                headers: {
+                                    ...parseKafkaHeaders(message.message.headers),
+                                    token: message.token,
+                                    team_id: message.teamId.toString(),
+                                    'json-parse': jsonParse.toString(),
+                                    'retention-days': retentionDays.toString(),
+                                },
                             },
-                        },
-                    ])
-                } catch (error) {
-                    await this.produceToDlq(message, error)
-                    throw error
-                }
-            })
+                        ])
+                    } catch (error) {
+                        await this.produceToDlq(message, error)
+                        throw error
+                    }
+                })
+            )
         )
 
         const failures = results.filter((r) => r.status === 'rejected')


### PR DESCRIPTION
## Problem

when we have large batches doing lots of work we get kafka produce timeouts, presumably because the kafka produce call gets cpu starved and never given the chance to finish

we should expect instead of get slow batches but produces themselves shouldn't time out (the produce step is very little work, just waiting for kafka to confirm)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

limit the number of concurrent message processes to 50
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
n/a, very tricky thing to test - we can't really cause CPU starvation in tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
