### PR TITLE
feat(visual-review): add open-pr button next to branch title

### DIFF
--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -225,8 +225,7 @@ export function VisualReviewRunScene(): JSX.Element {
         )
     }
 
-    const prUrl =
-        run.pr_number && repoFullName ? `https://github.com/${repoFullName}/pull/${run.pr_number}` : null
+    const prUrl = run.pr_number && repoFullName ? `https://github.com/${repoFullName}/pull/${run.pr_number}` : null
     const openPrButton = prUrl ? (
         <LemonButton
             type="secondary"
@@ -306,6 +305,9 @@ export function VisualReviewRunScene(): JSX.Element {
 
     const hasMore = diffChanged + diffNew + diffRemoved > reviewPending + reviewApproved + reviewTolerated
 
+    const showApproveButton =
+        !run.approved && !run.is_stale && (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0)
+
     // Navigation — use changed snapshots when there are changes, otherwise all snapshots
     const navSnapshots = sortedChangedSnapshots.length > 0 ? sortedChangedSnapshots : snapshots
     const currentIndex = selectedSnapshot
@@ -338,18 +340,18 @@ export function VisualReviewRunScene(): JSX.Element {
                 name={run.branch}
                 resourceType={{ type: 'visual_review' }}
                 actions={
-                    <div className="flex gap-2">
-                        {openPrButton}
-                        {!run.approved &&
-                        !run.is_stale &&
-                        (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0) ? (
-                            <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
-                                {reviewPending > 0
-                                    ? `Approve ${reviewPending} pending and commit`
-                                    : 'Commit to baseline'}
-                            </LemonButton>
-                        ) : null}
-                    </div>
+                    openPrButton || showApproveButton ? (
+                        <div className="flex gap-2">
+                            {openPrButton}
+                            {showApproveButton && (
+                                <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
+                                    {reviewPending > 0
+                                        ? `Approve ${reviewPending} pending and commit`
+                                        : 'Commit to baseline'}
+                                </LemonButton>
+                            )}
+                        </div>
+                    ) : undefined
                 }
             />
 

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React, { useState } from 'react'
 
-import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { IconChevronLeft, IconChevronRight, IconExternal } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
 import { PostHogCaptureOnViewed } from '@posthog/react'
 
@@ -225,10 +225,28 @@ export function VisualReviewRunScene(): JSX.Element {
         )
     }
 
+    const prUrl =
+        run.pr_number && repoFullName ? `https://github.com/${repoFullName}/pull/${run.pr_number}` : null
+    const openPrButton = prUrl ? (
+        <LemonButton
+            type="secondary"
+            icon={<IconExternal />}
+            to={prUrl}
+            targetBlank
+            tooltip={`Open PR #${run.pr_number} on GitHub`}
+        >
+            PR #{run.pr_number}
+        </LemonButton>
+    ) : null
+
     if (isRunInProgress) {
         return (
             <SceneContent>
-                <SceneTitleSection name={run.branch} resourceType={{ type: 'visual_review' }} />
+                <SceneTitleSection
+                    name={run.branch}
+                    resourceType={{ type: 'visual_review' }}
+                    actions={openPrButton ?? undefined}
+                />
                 <RunInProgressEmptyState
                     isProcessing={isRunProcessing}
                     createdAt={run.created_at}
@@ -241,7 +259,11 @@ export function VisualReviewRunScene(): JSX.Element {
     if (run.status === 'failed') {
         return (
             <SceneContent>
-                <SceneTitleSection name={run.branch} resourceType={{ type: 'visual_review' }} />
+                <SceneTitleSection
+                    name={run.branch}
+                    resourceType={{ type: 'visual_review' }}
+                    actions={openPrButton ?? undefined}
+                />
                 <LemonBanner type="error">
                     This run failed to process.{run.error_message ? ` ${run.error_message}` : ''} Check the CI logs for
                     details, or rerun the job to try again.
@@ -316,13 +338,18 @@ export function VisualReviewRunScene(): JSX.Element {
                 name={run.branch}
                 resourceType={{ type: 'visual_review' }}
                 actions={
-                    !run.approved &&
-                    !run.is_stale &&
-                    (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0) ? (
-                        <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
-                            {reviewPending > 0 ? `Approve ${reviewPending} pending and commit` : 'Commit to baseline'}
-                        </LemonButton>
-                    ) : undefined
+                    <div className="flex gap-2">
+                        {openPrButton}
+                        {!run.approved &&
+                        !run.is_stale &&
+                        (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0) ? (
+                            <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
+                                {reviewPending > 0
+                                    ? `Approve ${reviewPending} pending and commit`
+                                    : 'Commit to baseline'}
+                            </LemonButton>
+                        ) : null}
+                    </div>
                 }
             />
 

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -1,17 +1,19 @@
 import { useActions, useValues } from 'kea'
 import React, { useState } from 'react'
 
-import { IconChevronLeft, IconChevronRight, IconExternal } from '@posthog/icons'
+import { IconChevronLeft, IconChevronRight, IconExternal, IconGithub } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
 import { PostHogCaptureOnViewed } from '@posthog/react'
 
 import { DetectiveHog } from 'lib/components/hedgehogs'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ScenePanel, ScenePanelInfoSection, ScenePanelLabel } from '~/layout/scenes/SceneLayout'
 
 import { SnapshotDiffViewer } from '../components/SnapshotDiffViewer'
 import { SnapshotStatusIndicator } from '../components/SnapshotStatusIndicator'
@@ -226,26 +228,26 @@ export function VisualReviewRunScene(): JSX.Element {
     }
 
     const prUrl = run.pr_number && repoFullName ? `https://github.com/${repoFullName}/pull/${run.pr_number}` : null
-    const openPrButton = prUrl ? (
-        <LemonButton
-            type="secondary"
-            icon={<IconExternal />}
-            to={prUrl}
-            targetBlank
-            tooltip={`Open PR #${run.pr_number} on GitHub`}
-        >
-            PR #{run.pr_number}
-        </LemonButton>
+    const prPanel = prUrl ? (
+        <ScenePanel>
+            <ScenePanelInfoSection>
+                <ScenePanelLabel title="Pull request">
+                    <Link to={prUrl} target="_blank">
+                        <ButtonPrimitive fullWidth>
+                            <IconGithub />#{run.pr_number}
+                            <IconExternal className="ml-auto" />
+                        </ButtonPrimitive>
+                    </Link>
+                </ScenePanelLabel>
+            </ScenePanelInfoSection>
+        </ScenePanel>
     ) : null
 
     if (isRunInProgress) {
         return (
             <SceneContent>
-                <SceneTitleSection
-                    name={run.branch}
-                    resourceType={{ type: 'visual_review' }}
-                    actions={openPrButton ?? undefined}
-                />
+                {prPanel}
+                <SceneTitleSection name={run.branch} resourceType={{ type: 'visual_review' }} />
                 <RunInProgressEmptyState
                     isProcessing={isRunProcessing}
                     createdAt={run.created_at}
@@ -258,11 +260,8 @@ export function VisualReviewRunScene(): JSX.Element {
     if (run.status === 'failed') {
         return (
             <SceneContent>
-                <SceneTitleSection
-                    name={run.branch}
-                    resourceType={{ type: 'visual_review' }}
-                    actions={openPrButton ?? undefined}
-                />
+                {prPanel}
+                <SceneTitleSection name={run.branch} resourceType={{ type: 'visual_review' }} />
                 <LemonBanner type="error">
                     This run failed to process.{run.error_message ? ` ${run.error_message}` : ''} Check the CI logs for
                     details, or rerun the job to try again.
@@ -305,9 +304,6 @@ export function VisualReviewRunScene(): JSX.Element {
 
     const hasMore = diffChanged + diffNew + diffRemoved > reviewPending + reviewApproved + reviewTolerated
 
-    const showApproveButton =
-        !run.approved && !run.is_stale && (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0)
-
     // Navigation — use changed snapshots when there are changes, otherwise all snapshots
     const navSnapshots = sortedChangedSnapshots.length > 0 ? sortedChangedSnapshots : snapshots
     const currentIndex = selectedSnapshot
@@ -336,21 +332,17 @@ export function VisualReviewRunScene(): JSX.Element {
 
     return (
         <SceneContent>
+            {prPanel}
             <SceneTitleSection
                 name={run.branch}
                 resourceType={{ type: 'visual_review' }}
                 actions={
-                    openPrButton || showApproveButton ? (
-                        <div className="flex gap-2">
-                            {openPrButton}
-                            {showApproveButton && (
-                                <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
-                                    {reviewPending > 0
-                                        ? `Approve ${reviewPending} pending and commit`
-                                        : 'Commit to baseline'}
-                                </LemonButton>
-                            )}
-                        </div>
+                    !run.approved &&
+                    !run.is_stale &&
+                    (reviewPending > 0 || reviewApproved > 0 || reviewTolerated > 0) ? (
+                        <LemonButton type="primary" onClick={approveChanges} loading={isApproving}>
+                            {reviewPending > 0 ? `Approve ${reviewPending} pending and commit` : 'Commit to baseline'}
+                        </LemonButton>
                     ) : undefined
                 }
             />


### PR DESCRIPTION
## Problem

When reviewing a Visual review run, there's no quick way to jump from the run page to the underlying PR on GitHub. The PR number is shown on the runs list (`BranchCell`) but disappears once you're inside a single run.

## Changes

Added a secondary `LemonButton` with `IconExternal` next to the branch title in `VisualReviewRunScene`, opening `https://github.com/<repo>/pull/<pr_number>` in a new tab. Wired into the `actions` slot of all three `SceneTitleSection` states — in-progress, failed, and the main review view — so it's always reachable. Renders only when both `repoFullName` and `run.pr_number` are available.

## How did you test this code?

I am an agent (PostHog Code). No manual browser testing performed. Verified the change by reading sibling code (`VisualReviewRunsScene.tsx` for the existing PR-link pattern, `VisualReviewSettingsScene.tsx` for `LemonButton` `to`/`targetBlank` usage). No automated tests ran in this workspace — `pnpm typescript:check` and `pnpm format` could not run due to missing `node_modules` / `oxlint` binary.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code agent.
- Task: surface a one-click "Open PR" affordance from the run review screen.
- Key decisions:
  - Reused the existing GitHub URL convention (`https://github.com/<repo>/pull/<n>`) already used in `VisualReviewRunsScene` and `SnapshotDiffViewer`.
  - Placed the button in the `SceneTitleSection` `actions` slot rather than modifying `SceneTitleSection` to support inline content next to the name — keeps the change local.
  - Kept text label `PR #N` plus `IconExternal` for discoverability rather than icon-only.