### PR TITLE
feat(experiments): Show multiple-variants row in exposures table

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -16,9 +16,10 @@ import {
     ExperimentExposureTimeSeries,
 } from '~/queries/schema/schema-general'
 
+import { EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { useChartColors } from '../MetricsView/shared/colors'
-import { filterLowMultipleVariant, getExposureConfigDisplayName } from '../utils'
+import { filterLowMultipleVariant, getExposureConfigDisplayName, resolveMultipleVariantHandling } from '../utils'
 import { VariantTag } from './components'
 import { exposureCriteriaModalLogic } from './exposureCriteriaModalLogic'
 
@@ -166,7 +167,13 @@ export function Exposures(): JSX.Element {
         }
     }
 
-    const filteredVariants = filterLowMultipleVariant(variants)
+    // Collapsed/header: hide `$multiple` below 0.5% for cleanliness
+    // Expanded/table: shows `$multiple` for clarity/investigating
+    const filteredVariantsForHeader = filterLowMultipleVariant(variants)
+
+    const resolvedHandling = resolveMultipleVariantHandling(exposureCriteria?.multiple_variant_handling)
+    const multipleTreatmentLabel =
+        resolvedHandling === 'first_seen' ? 'using first seen variant' : 'excluded from analysis'
 
     // Detect sample ratio mismatch (p < 0.001 is significant)
     const hasSRM = exposures?.sample_ratio_mismatch != null && exposures.sample_ratio_mismatch.p_value < 0.001
@@ -288,9 +295,9 @@ export function Exposures(): JSX.Element {
                                         : humanFriendlyNumber(totalExposures)}
                                 </span>
                                 {exposures?.timeseries?.length > 0 && <MicroChart exposures={exposures} />}
-                                {filteredVariants.length > 0 && (
+                                {filteredVariantsForHeader.length > 0 && (
                                     <div className="ml-2 flex items-center gap-4">
-                                        {filteredVariants.map(({ variant, percentage }) => (
+                                        {filteredVariantsForHeader.map(({ variant, percentage }) => (
                                             <div key={variant} className="flex items-center gap-2">
                                                 <div className="metric-cell">
                                                     <VariantTag variantKey={variant} />
@@ -375,10 +382,8 @@ export function Exposures(): JSX.Element {
                                     <h3 className="card-secondary">Total exposures</h3>
                                     <LemonTable
                                         dataSource={[
-                                            ...(exposures?.timeseries || []).filter(
-                                                (series: ExperimentExposureTimeSeries) =>
-                                                    filteredVariants.some((v) => v.variant === series.variant)
-                                            ),
+                                            //This includes EXPERIMENT_VARIANT_MULTIPLE
+                                            ...(exposures?.timeseries || []),
                                             { variant: '__total__', isTotal: true },
                                         ]}
                                         columns={[
@@ -389,7 +394,27 @@ export function Exposures(): JSX.Element {
                                                     if (series.isTotal) {
                                                         return <span className="font-semibold">Total</span>
                                                     }
-                                                    return <VariantTag variantKey={series.variant} />
+                                                    const isMultiple = series.variant === EXPERIMENT_VARIANT_MULTIPLE
+                                                    return (
+                                                        <div className="flex items-center gap-1.5">
+                                                            <VariantTag variantKey={series.variant} />
+                                                            {isMultiple && (
+                                                                <>
+                                                                    <span className="text-xs text-secondary">
+                                                                        ({multipleTreatmentLabel})
+                                                                    </span>
+                                                                    <LemonButton
+                                                                        icon={<IconPencil fontSize="12" />}
+                                                                        size="xsmall"
+                                                                        type="secondary"
+                                                                        onClick={() =>
+                                                                            openExposureCriteriaModal(exposureCriteria)
+                                                                        }
+                                                                    />
+                                                                </>
+                                                            )}
+                                                        </div>
+                                                    )
                                                 },
                                             },
                                             {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -55,6 +55,16 @@ export function filterLowMultipleVariant<T extends { variant: string; percentage
     )
 }
 
+/**
+ * Resolves the effective multi-variant handling, applying the backend default when unset.
+ * See posthog/hogql_queries/experiments/exposure_query_logic.py (default = `EXCLUDE`).
+ */
+export function resolveMultipleVariantHandling(
+    handling: 'exclude' | 'first_seen' | undefined
+): 'exclude' | 'first_seen' {
+    return handling ?? 'exclude'
+}
+
 export function isEventExposureConfig(config: ExperimentExposureConfig): config is ExperimentEventExposureConfig {
     return config.kind === NodeKind.ExperimentEventExposureConfig || 'event' in config
 }


### PR DESCRIPTION
## Problem

Users cannot see if they have multiple exposures if it's below 0.5% threshold. Even a small multiple-exposure percent however can have implications, for example in this bias inducing setup discussed here: [slack thread](https://posthog.slack.com/archives/C07PXH2GTGV/p1776856661475849?thread_ts=1776673806.646099&cid=C07PXH2GTGV)

This PR adds visibility of multiple exposures.

## Changes

- The table always shows the multiple-exposure row
- The row shows in brackets what the handling for multiple-exposures is (exclude / first seen)
- The rows shows a button to change it (opens the Edit exposure criteria modal) - without it I felt it was unclear that it can be changed / where to change it

<img width="747" height="501" alt="multi-exposure-table" src="https://github.com/user-attachments/assets/abc2acad-76ca-404b-acc7-1f0ca5118619" />


Note that this is only shown when the table is expanded, the collapsed state shows the warning icon only if it's above 0.5% threshold still:

<img width="742" height="97" alt="multi-exposure-header" src="https://github.com/user-attachments/assets/b2da326e-92d1-4c96-860b-02e25197cbe6" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

## Publish to changelog?

No