### PR TITLE
feat(taxonomic-filter): capture missing taxonomy entries

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -26,6 +26,7 @@ import {
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
 
@@ -36,6 +37,21 @@ import { teamLogic } from '../../../scenes/teamLogic'
 import { captureTimeToSeeData } from '../../internalMetrics'
 import { getItemGroup } from './InfiniteList'
 import type { infiniteListLogicType } from './infiniteListLogicType'
+
+const TAXONOMY_TRACKED_GROUP_TYPES = new Set<TaxonomicFilterGroupType>([
+    TaxonomicFilterGroupType.Events,
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.NumericalEventProperties,
+    TaxonomicFilterGroupType.PersonProperties,
+    TaxonomicFilterGroupType.SessionProperties,
+])
+
+function shouldTrackMissingTaxonomy(listGroupType: TaxonomicFilterGroupType): boolean {
+    return (
+        TAXONOMY_TRACKED_GROUP_TYPES.has(listGroupType) ||
+        listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix)
+    )
+}
 
 function pinnedItemMatchesSearch(
     item: TaxonomicDefinitionTypes,
@@ -213,6 +229,8 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         actions: [
             taxonomicFilterLogic(props),
             ['setSearchQuery', 'setActiveTab', 'selectItem', 'infiniteListResultsReceived'],
+            eventUsageLogic,
+            ['reportMissingTaxonomyEntries'],
         ],
     })),
     actions({
@@ -947,6 +965,28 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         },
         infiniteListResultsReceived: () => {
             actions.reconcilePinnedRowState()
+            const listGroupType = props.listGroupType
+            if (!shouldTrackMissingTaxonomy(listGroupType)) {
+                return
+            }
+            const group = values.group
+            const missing: { name: string; groupType: TaxonomicFilterGroupType }[] = []
+            for (const item of values.results) {
+                if (!item || isSkeletonItem(item) || isQuickFilterItem(item)) {
+                    continue
+                }
+                const name = group?.getName?.(item) ?? ('name' in item ? (item as { name?: string }).name : undefined)
+                if (!name || !name.startsWith('$')) {
+                    continue
+                }
+                if (getCoreFilterDefinition(name, listGroupType) !== null) {
+                    continue
+                }
+                missing.push({ name, groupType: listGroupType })
+            }
+            if (missing.length > 0) {
+                actions.reportMissingTaxonomyEntries(missing)
+            }
         },
         applyInitialPinnedRow: ({ rowIndex }) => {
             actions.setIndex(rowIndex)

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -30,7 +30,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
 
-import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+import { getCoreFilterDefinition, isCoreFilter } from '~/taxonomy/helpers'
+import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
 import { CohortType, EventDefinition, GroupTypeIndex, PropertyType } from '~/types'
 
 import { teamLogic } from '../../../scenes/teamLogic'
@@ -38,17 +39,9 @@ import { captureTimeToSeeData } from '../../internalMetrics'
 import { getItemGroup } from './InfiniteList'
 import type { infiniteListLogicType } from './infiniteListLogicType'
 
-const TAXONOMY_TRACKED_GROUP_TYPES = new Set<TaxonomicFilterGroupType>([
-    TaxonomicFilterGroupType.Events,
-    TaxonomicFilterGroupType.EventProperties,
-    TaxonomicFilterGroupType.NumericalEventProperties,
-    TaxonomicFilterGroupType.PersonProperties,
-    TaxonomicFilterGroupType.SessionProperties,
-])
-
-function shouldTrackMissingTaxonomy(listGroupType: TaxonomicFilterGroupType): boolean {
+function isTaxonomyTrackedListType(listGroupType: TaxonomicFilterGroupType): boolean {
     return (
-        TAXONOMY_TRACKED_GROUP_TYPES.has(listGroupType) ||
+        listGroupType in CORE_FILTER_DEFINITIONS_BY_GROUP ||
         listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix)
     )
 }
@@ -966,20 +959,20 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         infiniteListResultsReceived: () => {
             actions.reconcilePinnedRowState()
             const listGroupType = props.listGroupType
-            if (!shouldTrackMissingTaxonomy(listGroupType)) {
+            if (!isTaxonomyTrackedListType(listGroupType)) {
                 return
             }
             const group = values.group
             const missing: { name: string; groupType: TaxonomicFilterGroupType }[] = []
             for (const item of values.results) {
-                if (!item || isSkeletonItem(item) || isQuickFilterItem(item)) {
+                if (isSkeletonItem(item) || isQuickFilterItem(item)) {
                     continue
                 }
-                const name = group?.getName?.(item) ?? ('name' in item ? (item as { name?: string }).name : undefined)
+                const name = group?.getName?.(item) ?? ('name' in item ? item.name : undefined)
                 if (!name || !name.startsWith('$')) {
                     continue
                 }
-                if (getCoreFilterDefinition(name, listGroupType) !== null) {
+                if (getCoreFilterDefinition(name, listGroupType) !== null || isCoreFilter(name)) {
                     continue
                 }
                 missing.push({ name, groupType: listGroupType })

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -956,7 +956,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         loadRemoteItemsSuccess: ({ remoteItems }) => {
             actions.infiniteListResultsReceived(props.listGroupType, remoteItems)
         },
-        infiniteListResultsReceived: () => {
+        infiniteListResultsReceived: ({ results }) => {
             actions.reconcilePinnedRowState()
             const listGroupType = props.listGroupType
             if (!isTaxonomyTrackedListType(listGroupType)) {
@@ -964,7 +964,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             }
             const group = values.group
             const missing: { name: string; groupType: TaxonomicFilterGroupType }[] = []
-            for (const item of values.results) {
+            for (const item of results.results) {
                 if (isSkeletonItem(item) || isQuickFilterItem(item)) {
                     continue
                 }

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -322,6 +322,8 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
     return objectClean(payload)
 }
 
+const reportedMissingTaxonomyEntries = new Set<string>()
+
 export const eventUsageLogic = kea<eventUsageLogicType>([
     path(['lib', 'utils', 'eventUsageLogic']),
     connect(() => ({
@@ -765,6 +767,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             eventName,
         }),
         reportTaxonomicFilterAddFilterClicked: (eventName?: string) => ({ eventName }),
+        reportMissingTaxonomyEntries: (entries: { name: string; groupType: TaxonomicFilterGroupType }[]) => ({
+            entries,
+        }),
         // Definition Popover
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType, mediaPreviewCount?: number) => ({
             type,
@@ -1764,6 +1769,20 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportTaxonomicFilterAddFilterClicked: ({ eventName }) => {
             posthog.capture('taxonomic filter add filter clicked', { eventName })
+        },
+        reportMissingTaxonomyEntries: ({ entries }) => {
+            for (const { name, groupType } of entries) {
+                const key = `${groupType}::${name}`
+                if (reportedMissingTaxonomyEntries.has(key)) {
+                    continue
+                }
+                reportedMissingTaxonomyEntries.add(key)
+                posthog.capture('taxonomy entry missing', {
+                    name,
+                    group_type: groupType,
+                    source: 'taxonomic_filter',
+                })
+            }
         },
         reportDataManagementDefinitionHovered: ({ type, mediaPreviewCount }) => {
             posthog.capture('definition hovered', { type, media_preview_count: mediaPreviewCount ?? 0 })


### PR DESCRIPTION
## Problem

PostHog ships a static taxonomy (`CORE_FILTER_DEFINITIONS_BY_GROUP` in `posthog/taxonomy/taxonomy.py`, mirrored to the frontend as a JSON blob) that gives every `$`-prefixed core event/property a `label`, `description`, and `examples`. The TaxonomicFilter renders those rows via `getCoreFilterDefinition(name, listGroupType)`.

When SDKs or product code introduce a new `$`-prefixed event/property and nobody updates the static taxonomy, the row shows up in the filter with no label, no description, and no PostHog logo. We have no signal that this is happening other than someone noticing in the UI.

## Changes

- Adds a new `taxonomy entry missing` PostHog event captured from the frontend with properties `{ name, group_type, source: 'taxonomic_filter' }`.
- Detection runs inside `infiniteListLogic.ts` on the existing `infiniteListResultsReceived` listener, so it fires once per list load (both remote and local data paths).
- Restricted to taxonomy-relevant group types: `Events`, `EventProperties`, `NumericalEventProperties`, `PersonProperties`, `SessionProperties`, and any `groups_*` group property type. Skeletons and quick-filter shortcut items are skipped.
- Per-session dedup via a module-level `Set<string>` keyed by `${groupType}::${name}` in `eventUsageLogic.ts` — every `(group_type, name)` pair fires at most once per page load.

Once merged we can build an insight on `taxonomy entry missing` (count of unique `name`) and add an alert.

## How did you test this code?

I'm an agent (PostHog Code). No manual UI testing was performed. Automated checks I ran locally:

- `pnpm --filter=@posthog/frontend typegen:write` — regenerated kea types.
- `tsc --noEmit` for the two modified files — clean (no errors in `infiniteListLogic.ts` or `eventUsageLogic.ts`).

The repo's Jest environment had a pre-existing `@posthog/hogvm` resolution failure on my machine that prevents `infiniteListLogic.test.ts` from running locally — unrelated to these changes. CI will exercise the test suite.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by the PostHog Code agent on behalf of @pauldambra.
- Plan file: \`posthog-has-a-taxonomy-glowing-backus.md\` (local).
- Key decisions:
  - Hook into the existing \`infiniteListResultsReceived\` listener (already fires after both remote and local data loads) rather than emitting per-render from \`PropertyKeyInfo\` — avoids spamming events on virtualized scroll.
  - Per-session dedup via a module-level \`Set\` rather than persistence — fine for "is this gap on someone's screen" telemetry; we don't need cross-session dedup.
  - Allow-list of group types rather than checking every \`$\`-prefixed name everywhere, so cohort/data-warehouse/action lists don't generate false positives.
- Requires human review before merging.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*