### PR TITLE
fix(batch-exports): filter directory entries in debugger S3 file listing

### DIFF
--- a/posthog/batch_exports/debug/debugger.py
+++ b/posthog/batch_exports/debug/debugger.py
@@ -352,7 +352,7 @@ class BatchExportsDebugger:
         )
 
         # get the most recent attempt
-        file_infos = self.s3fs.get_file_info(file_selector)
+        file_infos = [fi for fi in self.s3fs.get_file_info(file_selector) if fi.type == fs.FileType.File]
         matches = [re.search(r"attempt_(\d+)", file_info.path) for file_info in file_infos]
         attempt_numbers = [int(match.group(1)) for match in matches if match is not None]
         if attempt_numbers:


### PR DESCRIPTION
## Problem

The batch exports debugger's `load_run_s3_data` / `iter_run_record_batches_from_s3` fails with `FileNotFoundError` when pyarrow's `S3FileSystem.get_file_info` returns directory marker entries alongside actual files. The code attempts to open these directory entries as Arrow IPC files, which fails.

## Changes

Filter `get_file_info` results to only include `FileType.File` entries before processing, so directory markers (e.g. the `attempt_1` prefix key) are excluded.

## How did you test this code?

Verified in a production Django shell that `load_run_s3_data` now succeeds where it previously raised `FileNotFoundError` on directory entries.

## Publish to changelog?

No

## 🤖 Agent context

Agent-assisted fix based on a debugging session with the batch exports debugger tool.