### PR TITLE
fix: Add the EU region to alert check SLOs now that we migrated to Temporal

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -28,7 +28,7 @@ locals {
     alert_check = {
       name    = "Alert checks"
       slo     = 99.95 # error budget = 0.05%
-      regions = ["US"] # EU not captured yet: ph_scoped_capture hardcodes US client
+      regions = ["US", "EU"]
     }
   }
 


### PR DESCRIPTION
## Problem

Now that we've migrated the alert checks to Temporal (https://app.graphite.com/github/pr/PostHog/posthog/53836) we start to emit alert_check SLO events from the EU cluster as well. This as Celery metrics are limited / isolated only to the US region (thus EU ends up in the US) whilst Temporal does not have this limitation.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Wire up the EU region for the alert_check SLO

## How did you test this code?

Terragrunt speculative CI plan is looking good: https://github.com/PostHog/posthog/runs/73364848200?pr=56671

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->