### PR TITLE
fix(ci): Update CODEOWNERS to remove dependency file assignments

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -145,10 +145,6 @@ posthog/temporal/weekly-digest @PostHog/team-growth
 .github/dependabot.yml @PostHog/team-devex
 Dockerfile @PostHog/team-devex
 docker-compose\*.yml @PostHog/team-devex
-pyproject.toml @PostHog/team-devex
-uv.lock @PostHog/team-devex
-package.json @PostHog/team-devex
-package-lock.json @PostHog/team-devex
 .prettierrc @PostHog/team-devex
 mypy.ini @PostHog/team-devex
 posthog/management/migration_analysis/ @PostHog/team-devex
@@ -160,7 +156,7 @@ CODEOWNERS @PostHog/team-devex
 CLAUDE.md @PostHog/team-devex
 AGENTS.md @PostHog/team-devex
 .claude/ @PostHog/team-devex
-.agents/ @PostHog/team-devex
+.agents/* @PostHog/team-devex
 .claude/agents/ingestion/ @PostHog/team-ingestion
 .agents/skills/ingestion-*/ @PostHog/team-ingestion
 .claude/skills/ingestion-*/ @PostHog/team-ingestion


### PR DESCRIPTION
## Problem

The CODEOWNERS file currently assigns ownership of dependency management files (`pyproject.toml`, `uv.lock`, `package.json`, `package-lock.json`) to team-devex. These files are better managed through automated dependency update processes rather than requiring team review on every change.

Additionally, the `.agents/` pattern should be more specific to avoid unintended matches.

## Changes

- Removed team-devex ownership assignments for:
  - `pyproject.toml`
  - `uv.lock`
  - `package.json`
  - `package-lock.json`
- Updated `.agents/` pattern to `.agents/*` for more precise matching

## How did you test this code?

No testing needed. This is a configuration change to CODEOWNERS file patterns. The syntax changes are straightforward pattern updates that will be validated by GitHub's CODEOWNERS parser.

## Publish to changelog?

No

https://claude.ai/code/session_01JzRpzbNKEPYcCj54xTcJiC