### PR TITLE
fix(ci): shadow test selection breaks on large PRs

### DIFF
--- a/.github/workflows/ci-test-selection-shadow.yml
+++ b/.github/workflows/ci-test-selection-shadow.yml
@@ -34,6 +34,17 @@ jobs:
                   set -euo pipefail
                   mkdir -p /tmp/shadow-selection
 
+                  # Write metadata first so the artifact still has run context if
+                  # selection itself blows up (set -e would otherwise skip it).
+                  jq -n \
+                      --arg pr "$PR_NUMBER" \
+                      --arg sha "$PR_SHA" \
+                      --arg branch "$PR_BRANCH" \
+                      --arg base "$BASE_REF" \
+                      --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                      '{pr: $pr, sha: $sha, branch: $branch, base: $base, timestamp: $timestamp}' \
+                      > /tmp/shadow-selection/metadata.json
+
                   # Fetch the *current* tip of the base branch, not pull_request.base.sha:
                   # base.sha is captured at webhook time and goes stale if the branch later
                   # merges a newer master, which makes `base.sha...HEAD` balloon to include
@@ -45,15 +56,6 @@ jobs:
                       --summary-path "$GITHUB_STEP_SUMMARY" \
                       --pretty \
                       > /tmp/shadow-selection/selection.json
-
-                  jq -n \
-                      --arg pr "$PR_NUMBER" \
-                      --arg sha "$PR_SHA" \
-                      --arg branch "$PR_BRANCH" \
-                      --arg base "$BASE_REF" \
-                      --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                      '{pr: $pr, sha: $sha, branch: $branch, base: $base, timestamp: $timestamp}' \
-                      > /tmp/shadow-selection/metadata.json
 
             - name: Upload shadow selection artifact
               if: always()

--- a/.github/workflows/ci-test-selection-shadow.yml
+++ b/.github/workflows/ci-test-selection-shadow.yml
@@ -24,94 +24,36 @@ jobs:
               with:
                   version: '0.10.2'
 
-            - name: Compute Snob and AST selections (shadow mode)
-              id: selection
+            - name: Run shadow selection
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_SHA: ${{ github.event.pull_request.head.sha }}
+                  PR_BRANCH: ${{ github.event.pull_request.head.ref }}
               run: |
-                  # Fetch the *current* tip of the base branch, not pull_request.base.sha
+                  set -euo pipefail
+                  mkdir -p /tmp/shadow-selection
+
+                  # Fetch the *current* tip of the base branch, not pull_request.base.sha:
                   # base.sha is captured at webhook time and goes stale if the branch later
                   # merges a newer master, which makes `base.sha...HEAD` balloon to include
                   # every merged-in master change.
                   git fetch --no-tags origin "$BASE_REF"
-                  echo "### Changed files" >&2
-                  git diff --name-only "origin/$BASE_REF"...HEAD >&2
 
-                  RESULT=$(uv run tools/snob_backend_test_selection_shadow.py --base-ref "origin/$BASE_REF" 2>/dev/stderr | tail -1)
-                  echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+                  uv run tools/snob_backend_test_selection_shadow.py \
+                      --base-ref "origin/$BASE_REF" \
+                      --summary-path "$GITHUB_STEP_SUMMARY" \
+                      --pretty \
+                      > /tmp/shadow-selection/selection.json
 
-            - name: Write job summary
-              env:
-                  RESULT: ${{ steps.selection.outputs.result }}
-              run: |
-                  CHANGED_COUNT=$(echo "$RESULT" | jq -r '.changed_file_count')
-                  SNOB_STATUS=$(echo "$RESULT" | jq -r '.snob.status')
-                  SNOB_COUNT=$(echo "$RESULT" | jq -r '.snob.count')
-                  AST_COUNT=$(echo "$RESULT" | jq -r '.ast.tests | length')
-                  COMBINED_COUNT=$(echo "$RESULT" | jq -r '.combined.count')
-                  SNOB_SECONDS=$(echo "$RESULT" | jq -r '.durations.snob_seconds')
-                  AST_SECONDS=$(echo "$RESULT" | jq -r '.durations.ast_seconds')
-                  COMBINED_SECONDS=$(echo "$RESULT" | jq -r '.combined.duration_seconds')
-                  TOTAL_SECONDS=$(echo "$RESULT" | jq -r '.durations.total_seconds')
-                  AST_GROUPS=$(echo "$RESULT" | jq -r '.ast.groups | to_entries | map("| `\(.key)` | \(.value | length) |") | join("\n")')
-                  FULL_REASONS=$(echo "$RESULT" | jq -r '.ast.full_run_reasons[]? | "- " + .')
-
-                  cat >> "$GITHUB_STEP_SUMMARY" << EOF
-                  ## Shadow test selection
-
-                  This is shadow-only. It compares Snob's import-graph selection with PostHog-specific AST groups for API-client and other non-import-shaped tests.
-
-                  | Metric | Count | Est. duration |
-                  |---|---:|---:|
-                  | Changed files | $CHANGED_COUNT | - |
-                  | Snob-selected tests | $SNOB_COUNT | ${SNOB_SECONDS}s |
-                  | AST-selected tests | $AST_COUNT | ${AST_SECONDS}s |
-                  | Combined unique tests | $COMBINED_COUNT | ${COMBINED_SECONDS}s |
-                  | Full duration data | - | ${TOTAL_SECONDS}s |
-
-                  | AST group | Test files |
-                  |---|---:|
-                  ${AST_GROUPS:-| none | 0 |}
-                  EOF
-
-                  if [ "$SNOB_STATUS" != "ok" ]; then
-                    SNOB_ERROR=$(echo "$RESULT" | jq -r '.snob.error // "unknown"')
-                    cat >> "$GITHUB_STEP_SUMMARY" << EOF
-
-                  **Snob error:** $SNOB_ERROR
-                  EOF
-                  fi
-
-                  if [ -n "$FULL_REASONS" ]; then
-                    cat >> "$GITHUB_STEP_SUMMARY" << EOF
-
-                  ### Full-run signals
-
-                  $FULL_REASONS
-                  EOF
-                  fi
-
-                  echo "SHADOW_METRICS: $(echo "$RESULT" | jq -c '{mode: .mode, changed: .changed_file_count, snob_status: .snob.status, snob: .snob.count, ast: (.ast.tests | length), combined: .combined.count, snob_dur: .durations.snob_seconds, ast_dur: .durations.ast_seconds, combined_dur: .combined.duration_seconds, total_dur: .durations.total_seconds}')"
-
-            - name: Save selection result for bulk analysis
-              if: always()
-              env:
-                  SELECTION_RESULT: ${{ steps.selection.outputs.result }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
-                  PR_SHA: ${{ github.event.pull_request.head.sha }}
-                  PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-                  PR_BASE: ${{ github.event.pull_request.base.ref }}
-              run: |
-                  mkdir -p /tmp/shadow-selection
-                  echo "$SELECTION_RESULT" | jq '.' > /tmp/shadow-selection/selection.json
                   jq -n \
-                    --arg pr "$PR_NUMBER" \
-                    --arg sha "$PR_SHA" \
-                    --arg branch "$PR_BRANCH" \
-                    --arg base "$PR_BASE" \
-                    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                    '{pr: $pr, sha: $sha, branch: $branch, base: $base, timestamp: $timestamp}' \
-                    > /tmp/shadow-selection/metadata.json
+                      --arg pr "$PR_NUMBER" \
+                      --arg sha "$PR_SHA" \
+                      --arg branch "$PR_BRANCH" \
+                      --arg base "$BASE_REF" \
+                      --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                      '{pr: $pr, sha: $sha, branch: $branch, base: $base, timestamp: $timestamp}' \
+                      > /tmp/shadow-selection/metadata.json
 
             - name: Upload shadow selection artifact
               if: always()

--- a/tools/snob_backend_test_selection_shadow.py
+++ b/tools/snob_backend_test_selection_shadow.py
@@ -614,10 +614,53 @@ def build_result(base_ref: str) -> dict[str, object]:
     }
 
 
+def format_summary(result: dict[str, object]) -> str:
+    snob = result["snob"]
+    ast_data = result["ast"]
+    combined = result["combined"]
+    durations = result["durations"]
+
+    lines = [
+        "## Shadow test selection",
+        "",
+        "Shadow-only. Compares Snob's import-graph selection with PostHog-specific AST groups for API-client and other non-import-shaped tests.",
+        "",
+        "| Metric | Count | Est. duration |",
+        "|---|---:|---:|",
+        f"| Changed files | {result['changed_file_count']} | - |",
+        f"| Snob-selected tests | {snob['count']} | {durations['snob_seconds']}s |",
+        f"| AST-selected tests | {len(ast_data['tests'])} | {durations['ast_seconds']}s |",
+        f"| Combined unique tests | {combined['count']} | {combined['duration_seconds']}s |",
+        f"| Full duration data | - | {durations['total_seconds']}s |",
+        "",
+        "| AST group | Test files |",
+        "|---|---:|",
+    ]
+    groups = ast_data.get("groups") or {}
+    if groups:
+        lines.extend(f"| `{name}` | {len(tests)} |" for name, tests in groups.items())
+    else:
+        lines.append("| none | 0 |")
+
+    if snob.get("status") != "ok":
+        lines += ["", f"**Snob error:** {snob.get('error', 'unknown')}"]
+
+    full_run_reasons = ast_data.get("full_run_reasons") or []
+    if full_run_reasons:
+        lines += ["", "### Full-run signals", ""]
+        lines.extend(f"- {reason}" for reason in full_run_reasons)
+
+    return "\n".join(lines) + "\n"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-ref", required=True, help="Base ref for git diff, for example origin/master")
     parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument(
+        "--summary-path",
+        help="Append a Markdown summary to this file (e.g. $GITHUB_STEP_SUMMARY)",
+    )
     args = parser.parse_args()
 
     try:
@@ -628,6 +671,9 @@ def main() -> None:
 
     indent = 2 if args.pretty else None
     sys.stdout.write(json.dumps(result, indent=indent, sort_keys=True) + "\n")
+
+    if args.summary_path:
+        Path(args.summary_path).expanduser().open("a").write(format_summary(result))
 
 
 if __name__ == "__main__":

--- a/tools/snob_backend_test_selection_shadow.py
+++ b/tools/snob_backend_test_selection_shadow.py
@@ -673,7 +673,8 @@ def main() -> None:
     sys.stdout.write(json.dumps(result, indent=indent, sort_keys=True) + "\n")
 
     if args.summary_path:
-        Path(args.summary_path).expanduser().open("a").write(format_summary(result))
+        with Path(args.summary_path).expanduser().open("a") as fh:
+            fh.write(format_summary(result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The shadow test selection workflow started failing on master with `Argument list too long` errors when bash tried to start any post-compute step. Root cause: the workflow piped the full Snob+AST result JSON through `steps.selection.outputs.result`, which Actions re-injects as an env var on every later step. On PRs touching many files the blob blew past `ARG_MAX` and the runner couldn't even spawn `/usr/bin/bash`.

## Changes

- Workflow no longer round-trips the JSON through step outputs. The script writes `selection.json` to disk once and that's it.
- Markdown step summary moves into the script itself (`format_summary` + new `--summary-path` flag) instead of being reconstructed from a dozen `jq` extractions in shell.
- Workflow collapsed from three bash steps to one (plus the artifact upload).

## How did you test this code?

Agent-authored. No CI run yet — verified `format_summary` locally against two payload shapes (normal + empty-groups + snob-error). Real validation will come from the shadow workflow run on this PR.

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude Code. Fix follows up the breakage observed on master after PR #56127.