### PR TITLE
feat(experiments): add CUPED toggle to experiment settings tab

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -294,6 +294,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_SPIKE_ALERTING: 'error-tracking-spike-alerting', // owner: #team-error-tracking
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
+    EXPERIMENT_CUPED: 'experiment-cuped', // owner: @andehen #team-experiments
     EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
     EXPERIMENT_FUNNEL_DWH_SUPPORT: 'experiment-funnel-dwh-support', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
@@ -548,7 +549,10 @@ export enum CohortTypeEnum {
  * Mock Node.js `process`, which is required by VFile that is used by ReactMarkdown.
  * See https://github.com/remarkjs/react-markdown/issues/339.
  */
-export const MOCK_NODE_PROCESS = { cwd: () => '', env: {} } as unknown as NodeJS.Process
+export const MOCK_NODE_PROCESS = {
+    cwd: () => '',
+    env: {},
+} as unknown as NodeJS.Process
 
 export const SSO_PROVIDER_NAMES: Record<SSOProvider, string> = {
     'google-oauth2': 'Google',

--- a/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
@@ -56,9 +56,8 @@ export function CupedModal(): JSX.Element {
         >
             <div className="flex flex-col gap-4">
                 <p className="text-secondary m-0">
-                    CUPED (Controlled-experiment Using Pre-Experiment Data) reduces variance by adjusting metrics with
-                    pre-experiment data, which can shorten the time required to detect a significant effect. Currently
-                    supported for mean and funnel metrics.
+                    CUPED (Controlled-experiment Using Pre-Experiment Data) uses pre-experiment data to detect
+                    significant effects faster. Currently supported for mean and funnel metrics.
                 </p>
                 <LemonSwitch
                     label="Enable CUPED"

--- a/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
@@ -1,0 +1,99 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonInput, LemonLabel, LemonModal, LemonSwitch } from '@posthog/lemon-ui'
+
+import { experimentLogic } from '../experimentLogic'
+import { modalsLogic } from '../modalsLogic'
+
+const DEFAULT_LOOKBACK_DAYS = 14
+const MIN_LOOKBACK_DAYS = 1
+const MAX_LOOKBACK_DAYS = 365
+
+export function CupedModal(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { updateExperiment, setExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic)
+    const { closeCupedModal } = useActions(modalsLogic)
+    const { isCupedModalOpen } = useValues(modalsLogic)
+
+    const enabled = experiment.stats_config?.cuped?.enabled ?? false
+    const lookbackDays = experiment.stats_config?.cuped?.lookback_days ?? DEFAULT_LOOKBACK_DAYS
+
+    const onClose = (): void => {
+        restoreUnmodifiedExperiment()
+        closeCupedModal()
+    }
+
+    const updateCupedConfig = (next: { enabled?: boolean; lookback_days?: number }): void => {
+        setExperiment({
+            stats_config: {
+                ...experiment.stats_config,
+                cuped: {
+                    ...experiment.stats_config?.cuped,
+                    ...next,
+                },
+            },
+        })
+    }
+
+    return (
+        <LemonModal
+            maxWidth={600}
+            isOpen={isCupedModalOpen}
+            onClose={onClose}
+            title="CUPED variance reduction"
+            footer={
+                <div className="flex items-center gap-2 justify-end">
+                    <LemonButton type="secondary" onClick={onClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={() => {
+                            updateExperiment({ stats_config: experiment.stats_config })
+                            closeCupedModal()
+                        }}
+                    >
+                        Save
+                    </LemonButton>
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-4">
+                <p className="text-secondary m-0">
+                    CUPED (Controlled-experiment Using Pre-Experiment Data) reduces variance by adjusting metrics with
+                    pre-experiment data, which can shorten the time required to detect a significant effect. Currently
+                    supported for mean metrics.
+                </p>
+                <LemonSwitch
+                    label="Enable CUPED"
+                    checked={enabled}
+                    onChange={(checked) => updateCupedConfig({ enabled: checked })}
+                    bordered
+                    fullWidth
+                />
+                {enabled && (
+                    <div className="flex flex-col gap-1">
+                        <LemonLabel>Lookback window (days)</LemonLabel>
+                        <LemonInput
+                            type="number"
+                            min={MIN_LOOKBACK_DAYS}
+                            max={MAX_LOOKBACK_DAYS}
+                            value={lookbackDays}
+                            onChange={(value) => {
+                                if (value === undefined || value === null) {
+                                    return
+                                }
+                                updateCupedConfig({ lookback_days: Number(value) })
+                            }}
+                            className="w-32"
+                        />
+                        <p className="text-xs text-secondary m-0">
+                            Number of days before the experiment start to use as the pre-experiment window. Must be
+                            between {MIN_LOOKBACK_DAYS} and {MAX_LOOKBACK_DAYS} days.
+                        </p>
+                    </div>
+                )}
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
@@ -58,7 +58,7 @@ export function CupedModal(): JSX.Element {
                 <p className="text-secondary m-0">
                     CUPED (Controlled-experiment Using Pre-Experiment Data) reduces variance by adjusting metrics with
                     pre-experiment data, which can shorten the time required to detect a significant effect. Currently
-                    supported for mean metrics.
+                    supported for mean and funnel metrics.
                 </p>
                 <LemonSwitch
                     label="Enable CUPED"

--- a/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
@@ -92,14 +92,10 @@ export function CupedModal(): JSX.Element {
                             max={MAX_LOOKBACK_DAYS}
                             value={lookbackDays}
                             onChange={(value) => {
-                                if (value === undefined || value === null) {
+                                if (typeof value !== 'number' || !Number.isFinite(value) || value < MIN_LOOKBACK_DAYS) {
                                     return
                                 }
-                                const parsed = Number(value)
-                                if (!Number.isFinite(parsed)) {
-                                    return
-                                }
-                                updateCupedConfig({ lookback_days: parsed })
+                                updateCupedConfig({ lookback_days: value })
                             }}
                             className="w-32"
                         />

--- a/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
@@ -5,9 +5,12 @@ import { LemonButton, LemonInput, LemonLabel, LemonModal, LemonSwitch } from '@p
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 
-const DEFAULT_LOOKBACK_DAYS = 14
-const MIN_LOOKBACK_DAYS = 1
-const MAX_LOOKBACK_DAYS = 365
+export const DEFAULT_LOOKBACK_DAYS = 14
+export const MIN_LOOKBACK_DAYS = 1
+export const MAX_LOOKBACK_DAYS = 365
+
+const clampLookbackDays = (value: number): number =>
+    Math.min(Math.max(Math.round(value), MIN_LOOKBACK_DAYS), MAX_LOOKBACK_DAYS)
 
 export function CupedModal(): JSX.Element {
     const { experiment } = useValues(experimentLogic)
@@ -35,6 +38,21 @@ export function CupedModal(): JSX.Element {
         })
     }
 
+    const onSave = (): void => {
+        const cupedConfig = experiment.stats_config?.cuped
+        const clampedLookback = clampLookbackDays(cupedConfig?.lookback_days ?? DEFAULT_LOOKBACK_DAYS)
+        updateExperiment({
+            stats_config: {
+                ...experiment.stats_config,
+                cuped: {
+                    ...cupedConfig,
+                    lookback_days: clampedLookback,
+                },
+            },
+        })
+        closeCupedModal()
+    }
+
     return (
         <LemonModal
             maxWidth={600}
@@ -46,13 +64,7 @@ export function CupedModal(): JSX.Element {
                     <LemonButton type="secondary" onClick={onClose}>
                         Cancel
                     </LemonButton>
-                    <LemonButton
-                        type="primary"
-                        onClick={() => {
-                            updateExperiment({ stats_config: experiment.stats_config })
-                            closeCupedModal()
-                        }}
-                    >
+                    <LemonButton type="primary" onClick={onSave}>
                         Save
                     </LemonButton>
                 </div>
@@ -83,7 +95,11 @@ export function CupedModal(): JSX.Element {
                                 if (value === undefined || value === null) {
                                     return
                                 }
-                                updateCupedConfig({ lookback_days: Number(value) })
+                                const parsed = Number(value)
+                                if (!Number.isFinite(parsed)) {
+                                    return
+                                }
+                                updateCupedConfig({ lookback_days: parsed })
                             }}
                             className="w-32"
                         />

--- a/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/CupedModal.tsx
@@ -2,15 +2,9 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonInput, LemonLabel, LemonModal, LemonSwitch } from '@posthog/lemon-ui'
 
+import { DEFAULT_LOOKBACK_DAYS, MAX_LOOKBACK_DAYS, MIN_LOOKBACK_DAYS } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
-
-export const DEFAULT_LOOKBACK_DAYS = 14
-export const MIN_LOOKBACK_DAYS = 1
-export const MAX_LOOKBACK_DAYS = 365
-
-const clampLookbackDays = (value: number): number =>
-    Math.min(Math.max(Math.round(value), MIN_LOOKBACK_DAYS), MAX_LOOKBACK_DAYS)
 
 export function CupedModal(): JSX.Element {
     const { experiment } = useValues(experimentLogic)
@@ -39,17 +33,7 @@ export function CupedModal(): JSX.Element {
     }
 
     const onSave = (): void => {
-        const cupedConfig = experiment.stats_config?.cuped
-        const clampedLookback = clampLookbackDays(cupedConfig?.lookback_days ?? DEFAULT_LOOKBACK_DAYS)
-        updateExperiment({
-            stats_config: {
-                ...experiment.stats_config,
-                cuped: {
-                    ...cupedConfig,
-                    lookback_days: clampedLookback,
-                },
-            },
-        })
+        updateExperiment({ stats_config: experiment.stats_config })
         closeCupedModal()
     }
 
@@ -92,10 +76,14 @@ export function CupedModal(): JSX.Element {
                             max={MAX_LOOKBACK_DAYS}
                             value={lookbackDays}
                             onChange={(value) => {
-                                if (typeof value !== 'number' || !Number.isFinite(value) || value < MIN_LOOKBACK_DAYS) {
+                                if (typeof value !== 'number' || !Number.isFinite(value)) {
                                     return
                                 }
-                                updateCupedConfig({ lookback_days: value })
+                                const rounded = Math.round(value)
+                                if (rounded < MIN_LOOKBACK_DAYS || rounded > MAX_LOOKBACK_DAYS) {
+                                    return
+                                }
+                                updateCupedConfig({ lookback_days: rounded })
                             }}
                             className="w-32"
                         />

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -60,7 +60,8 @@ export function SettingsTab(): JSX.Element {
                         <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
                     </div>
                     <p className="text-muted text-xs mt-1">
-                        Reduce variance using pre-experiment data as a covariate. Currently supported for mean metrics.
+                        Reduce variance using pre-experiment data as a covariate. Currently supported for mean and
+                        funnel metrics.
                     </p>
                     <CupedModal />
                 </div>

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconPencil } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -32,7 +32,6 @@ export function SettingsTab(): JSX.Element {
 
     const cupedEnabled = experiment.stats_config?.cuped?.enabled ?? false
     const cupedLookbackDays = experiment.stats_config?.cuped?.lookback_days ?? DEFAULT_LOOKBACK_DAYS
-    const cupedDisplay = cupedEnabled ? `Enabled / ${cupedLookbackDays}-day lookback` : 'Disabled'
 
     const returnTo = urls.experiment(experiment.id)
 
@@ -56,7 +55,10 @@ export function SettingsTab(): JSX.Element {
                 <div>
                     <h2 className="font-semibold text-lg">CUPED</h2>
                     <div className="flex items-center gap-2">
-                        <span>{cupedDisplay}</span>
+                        <LemonTag type={cupedEnabled ? 'success' : 'default'}>
+                            {cupedEnabled ? 'Enabled' : 'Disabled'}
+                        </LemonTag>
+                        {cupedEnabled && <span>{cupedLookbackDays}-day lookback</span>}
                         <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
                     </div>
                     <p className="text-muted text-xs mt-1">

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -12,12 +12,13 @@ import { ExperimentStatsMethod, PropertyFilterType, PropertyOperator } from '~/t
 
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
+import { CupedModal } from './CupedModal'
 import { StatsMethodModal } from './StatsMethodModal'
 
 export function SettingsTab(): JSX.Element {
     const { experiment, statsMethod } = useValues(experimentLogic)
     const { updateExperiment } = useActions(experimentLogic)
-    const { openStatsEngineModal } = useActions(modalsLogic)
+    const { openStatsEngineModal, openCupedModal } = useActions(modalsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const isBayesian = statsMethod === ExperimentStatsMethod.Bayesian
@@ -25,6 +26,10 @@ export function SettingsTab(): JSX.Element {
     const confidenceDisplay = isBayesian
         ? `${((experiment.stats_config?.bayesian?.ci_level ?? 0.95) * 100).toFixed(0)}%`
         : `${((1 - (experiment.stats_config?.frequentist?.alpha ?? 0.05)) * 100).toFixed(0)}%`
+
+    const cupedEnabled = experiment.stats_config?.cuped?.enabled ?? false
+    const cupedLookbackDays = experiment.stats_config?.cuped?.lookback_days ?? 14
+    const cupedDisplay = cupedEnabled ? `Enabled / ${cupedLookbackDays} day lookback` : 'Disabled'
 
     const returnTo = urls.experiment(experiment.id)
 
@@ -43,6 +48,17 @@ export function SettingsTab(): JSX.Element {
                     <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openStatsEngineModal} />
                 </div>
                 <StatsMethodModal />
+            </div>
+            <div>
+                <h2 className="font-semibold text-lg">CUPED</h2>
+                <div className="flex items-center gap-2">
+                    <span>{cupedDisplay}</span>
+                    <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
+                </div>
+                <p className="text-muted text-xs mt-1">
+                    Reduce variance using pre-experiment data as a covariate. Currently supported for mean metrics.
+                </p>
+                <CupedModal />
             </div>
             <div>
                 <h2 className="font-semibold text-lg">Conversion windows</h2>

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -12,7 +12,7 @@ import { ExperimentStatsMethod, PropertyFilterType, PropertyOperator } from '~/t
 
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
-import { CupedModal } from './CupedModal'
+import { CupedModal, DEFAULT_LOOKBACK_DAYS } from './CupedModal'
 import { StatsMethodModal } from './StatsMethodModal'
 
 export function SettingsTab(): JSX.Element {
@@ -28,7 +28,7 @@ export function SettingsTab(): JSX.Element {
         : `${((1 - (experiment.stats_config?.frequentist?.alpha ?? 0.05)) * 100).toFixed(0)}%`
 
     const cupedEnabled = experiment.stats_config?.cuped?.enabled ?? false
-    const cupedLookbackDays = experiment.stats_config?.cuped?.lookback_days ?? 14
+    const cupedLookbackDays = experiment.stats_config?.cuped?.lookback_days ?? DEFAULT_LOOKBACK_DAYS
     const cupedDisplay = cupedEnabled ? `Enabled / ${cupedLookbackDays} day lookback` : 'Disabled'
 
     const returnTo = urls.experiment(experiment.id)

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -4,6 +4,7 @@ import { IconPencil } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, Link } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { urls } from 'scenes/urls'
@@ -21,6 +22,7 @@ export function SettingsTab(): JSX.Element {
     const { updateExperiment } = useActions(experimentLogic)
     const { openStatsEngineModal, openCupedModal } = useActions(modalsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const showCupedOption = useFeatureFlag('EXPERIMENT_CUPED')
 
     const isBayesian = statsMethod === ExperimentStatsMethod.Bayesian
 
@@ -50,17 +52,19 @@ export function SettingsTab(): JSX.Element {
                 </div>
                 <StatsMethodModal />
             </div>
-            <div>
-                <h2 className="font-semibold text-lg">CUPED</h2>
-                <div className="flex items-center gap-2">
-                    <span>{cupedDisplay}</span>
-                    <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
+            {showCupedOption && (
+                <div>
+                    <h2 className="font-semibold text-lg">CUPED</h2>
+                    <div className="flex items-center gap-2">
+                        <span>{cupedDisplay}</span>
+                        <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
+                    </div>
+                    <p className="text-muted text-xs mt-1">
+                        Reduce variance using pre-experiment data as a covariate. Currently supported for mean metrics.
+                    </p>
+                    <CupedModal />
                 </div>
-                <p className="text-muted text-xs mt-1">
-                    Reduce variance using pre-experiment data as a covariate. Currently supported for mean metrics.
-                </p>
-                <CupedModal />
-            </div>
+            )}
             <div>
                 <h2 className="font-semibold text-lg">Conversion windows</h2>
                 <div className="flex items-center gap-2">

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -10,9 +10,10 @@ import { urls } from 'scenes/urls'
 
 import { ExperimentStatsMethod, PropertyFilterType, PropertyOperator } from '~/types'
 
+import { DEFAULT_LOOKBACK_DAYS } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
-import { CupedModal, DEFAULT_LOOKBACK_DAYS } from './CupedModal'
+import { CupedModal } from './CupedModal'
 import { StatsMethodModal } from './StatsMethodModal'
 
 export function SettingsTab(): JSX.Element {
@@ -29,7 +30,7 @@ export function SettingsTab(): JSX.Element {
 
     const cupedEnabled = experiment.stats_config?.cuped?.enabled ?? false
     const cupedLookbackDays = experiment.stats_config?.cuped?.lookback_days ?? DEFAULT_LOOKBACK_DAYS
-    const cupedDisplay = cupedEnabled ? `Enabled / ${cupedLookbackDays} day lookback` : 'Disabled'
+    const cupedDisplay = cupedEnabled ? `Enabled / ${cupedLookbackDays}-day lookback` : 'Disabled'
 
     const returnTo = urls.experiment(experiment.id)
 

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -62,7 +62,7 @@ export function SettingsTab(): JSX.Element {
                         <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
                     </div>
                     <p className="text-muted text-xs mt-1">
-                        Reduce variance using pre-experiment data as a covariate. Currently supported for mean and
+                        Use pre-experiment data to detect significant effects faster. Currently supported for mean and
                         funnel metrics.
                     </p>
                     <CupedModal />

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -42,7 +42,7 @@ export const EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS = 10
 // CUPED lookback window (days)
 export const DEFAULT_LOOKBACK_DAYS = 14
 export const MIN_LOOKBACK_DAYS = 1
-export const MAX_LOOKBACK_DAYS = 365
+export const MAX_LOOKBACK_DAYS = 30
 
 // Autorefresh constants
 export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -39,6 +39,11 @@ export const CONFIDENCE_LEVEL_OPTIONS = [
 export const EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS = 50
 export const EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS = 10
 
+// CUPED lookback window (days)
+export const DEFAULT_LOOKBACK_DAYS = 14
+export const MIN_LOOKBACK_DAYS = 1
+export const MAX_LOOKBACK_DAYS = 365
+
 // Autorefresh constants
 export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5
 export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min

--- a/frontend/src/scenes/experiments/modalsLogic.ts
+++ b/frontend/src/scenes/experiments/modalsLogic.ts
@@ -34,6 +34,8 @@ export const modalsLogic = kea<modalsLogicType>([
         closeDescriptionModal: true,
         openStatsEngineModal: true,
         closeStatsEngineModal: true,
+        openCupedModal: true,
+        closeCupedModal: true,
         openPrimaryMetricModal: (uuid: string) => ({ uuid }),
         closePrimaryMetricModal: true,
         openSecondaryMetricModal: (uuid: string) => ({ uuid }),
@@ -196,6 +198,13 @@ export const modalsLogic = kea<modalsLogicType>([
             {
                 openStatsEngineModal: () => true,
                 closeStatsEngineModal: () => false,
+            },
+        ],
+        isCupedModalOpen: [
+            false,
+            {
+                openCupedModal: () => true,
+                closeCupedModal: () => false,
             },
         ],
         isRunningTimeConfigModalOpen: [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4592,6 +4592,10 @@ export interface Experiment {
         frequentist?: {
             alpha?: number
         }
+        cuped?: {
+            enabled?: boolean
+            lookback_days?: number
+        }
     }
     scheduling_config?: {
         timeseries?: boolean


### PR DESCRIPTION
## Problem

CUPED (variance reduction using pre-experiment data) was added to the experiment query backend recently, but it can only be enabled by manually editing the `stats_config` JSON on an experiment. There's no way for users to turn it on or configure the lookback window from the UI.

## Changes

Behind a feature flag

<img width="920" height="388" alt="Screenshot 2026-05-04 at 14 21 05 copy" src="https://github.com/user-attachments/assets/06f91ec5-7375-4cc8-98ad-86455ecf9f18" />

<img width="619" height="421" alt="Screenshot 2026-05-04 at 14 21 11" src="https://github.com/user-attachments/assets/a2b6e774-3706-49b9-b492-c530bd70f6e1" />

- New **CUPED** section in the experiment Settings tab showing the current state (`Disabled`, or `Enabled / N day lookback`) with a pencil edit button.
- New `CupedModal` to toggle CUPED on/off and configure the lookback window (1–365 days, default 14). Uses the same `setExperiment` + `restoreUnmodifiedExperiment` cancel/save pattern as `StatsMethodModal`.
- Extends `Experiment.stats_config` type with `cuped: { enabled?, lookback_days? }` to match the schema parsed by `posthog/hogql_queries/experiments/cuped_config.py`.

## How did you test this code?

Tested manually

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Backend support for `stats_config.cuped.{enabled,lookback_days}` already exists on master; this PR only adds the UI to set the same values that were previously editable only by hand-editing the JSON.

Key decisions:
- Followed the existing `StatsMethodModal` pattern (display + pencil button → modal with Save/Cancel) rather than inline checkbox + number input, so we don't fire a save on every keystroke for `lookback_days`.
- No feature flag gate — backend already accepts these values.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*