### PR TITLE
chore(experiments): default cuped lookback to 7 days

### DIFF
--- a/posthog/hogql_queries/experiments/cuped_config.py
+++ b/posthog/hogql_queries/experiments/cuped_config.py
@@ -5,7 +5,7 @@ from posthog.schema import ActionsNode, EventsNode, ExperimentMeanMetric
 
 from posthog.hogql_queries.experiments.base_query_utils import is_session_property_metric
 
-DEFAULT_CUPED_LOOKBACK_DAYS = 14
+DEFAULT_CUPED_LOOKBACK_DAYS = 7
 MIN_CUPED_LOOKBACK_DAYS = 1
 MAX_CUPED_LOOKBACK_DAYS = 365
 


### PR DESCRIPTION
## Problem

The default CUPED lookback window for experiment metrics was 14 days, longer than necessary for the variance-reduction signal in most cases. A shorter window keeps pre-experiment data more representative of current user behavior and reduces query cost.

## Changes

- `posthog/hogql_queries/experiments/cuped_config.py`: change `DEFAULT_CUPED_LOOKBACK_DAYS` from `14` to `7`.

This only affects experiments that have CUPED enabled but do not specify their own `lookback_days` in `stats_config.cuped`. Experiments with an explicit `lookback_days` are unchanged. Min/max bounds (1 / 365) are unchanged.

## How did you test this code?

I'm an agent. No automated tests were run for this one-line constant change. Existing tests in `posthog/hogql_queries/experiments/test/experiment_query_runner/test_cuped_mean_metric.py` already pass an explicit `lookback_days` so they aren't affected by the default.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code on behalf of @andehen.
- Single-line constant change. Verified there are no other hardcoded copies of the 14-day default in the codebase (frontend has no CUPED references; the value is read from this constant in `cuped_config.py` and flows through `experiment_query_builder.py`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*