### PR TITLE
fix(data-warehouse): mark customer.io signing_secret field as secret

### DIFF
--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -91,6 +91,7 @@ Once created, copy the **Signing key** from the webhook details page and add it 
                         type=SourceFieldInputConfigType.PASSWORD,
                         required=True,
                         placeholder="Customer.io reporting webhook signing key",
+                        secret=True,
                     ),
                 ],
             ),


### PR DESCRIPTION
## Problem

Master CI has been red on `Python code quality > Check static typing` (mypy 1.19.1) since #55592 ("feat(data-warehouse): add customer.io webhook source") merged, with:

```
posthog/temporal/data_imports/sources/customer_io/source.py:88: error: Missing named argument "secret" for "SourceFieldInputConfig"  [call-arg]
```

`SourceFieldInputConfig.secret` is a required `bool` field — every input field in a source config must explicitly classify whether it contains sensitive data so the value can be stripped from API responses. The customer.io `signing_secret` field omitted this kwarg.

cc @Gilbert09

## Changes

Add `secret=True` to the `signing_secret` `SourceFieldInputConfig` in the customer.io source. The field is the customer.io reporting-webhook signing key (PASSWORD-typed credential), so it must be redacted from API responses, matching the pattern used by every other credential-bearing source (attio, klaviyo, etc.).

One-line fix; no behavior change beyond making the (already secret) field correctly typed as such.

## How did you test this code?

I am an agent (Claude Code) and did not perform manual testing. Automated checks I ran:

- Pre-commit hooks (ruff, formatter, `uv run ty check`) all passed locally.
- Did not run full mypy locally (per AGENTS.md guidance — too slow). CI mypy will validate.
- Inspected `class SourceFieldInputConfig` in `posthog/schema.py` (line 8219) to confirm `secret: bool` is required, and cross-checked `secret=True` usage in 20+ peer sources for PASSWORD-type fields.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by a sub-agent (Claude Code) on behalf of @andehen (Anders Asheim Hennum) to unblock master CI. Master mypy has been red ~3 hours; no follow-up from the original PR author yet, so this lands the minimal fix. Human review still required — please do not self-merge.

Key decisions:
- Picked `secret=True` (not `False`) because the field is the webhook signing key — used to verify HMAC signatures on inbound webhooks, exactly the kind of credential the `secret` flag exists to redact.
- Kept the change to a single line; did not refactor or alter the schema definition.