### PR TITLE
fix(data-warehouse): mark customer.io signing key as secret

### DIFF
--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -91,6 +91,7 @@ Once created, copy the **Signing key** from the webhook details page and add it 
                         type=SourceFieldInputConfigType.PASSWORD,
                         required=True,
                         placeholder="Customer.io reporting webhook signing key",
+                        secret=True,
                     ),
                 ],
             ),


### PR DESCRIPTION
## Problem

The recently-introduced required `secret: bool` on `SourceFieldInputConfig` (`posthog/schema.py`) was missed for the **customer_io** webhook `signing_secret` field. As a result every call to `GET /api/environments/<id>/external_data_sources/wizard/` that loads the customer_io source raises:

```
pydantic.ValidationError: 1 validation error for SourceFieldInputConfig
secret
  Field required [type=missing, input_value={'name': 'signing_secret', ...}, input_type=dict]
```

Error-tracking issue [`019dd3b1-77c2-7e20-b054-1aaa299e36db`](https://us.posthog.com/project/2/error_tracking/019dd3b1-77c2-7e20-b054-1aaa299e36db) — first seen 2026-04-28T10:45 UTC, ~273 occurrences across 113 users in the few hours since deploy. It's the only new error-tracking issue introduced by the `secret`-field rollout (verified: every other source under `posthog/temporal/data_imports/sources/**/source.py` already declares `secret`).

## Changes

`posthog/temporal/data_imports/sources/customer_io/source.py` — add `secret=True` to the `signing_secret` `SourceFieldInputConfig`. The field holds the Customer.io webhook signing key (used for HMAC verification of inbound webhook payloads), which is sensitive credential material, so `True` is the correct classification.

## How did you test this code?

I'm an agent — no manual testing was performed. The local environment lacks `flox`/`hogli`, so I relied on:

- Static verification: parenthesis-balanced grep across all `posthog/temporal/data_imports/sources/**/source.py` confirms `customer_io` was the only source missing `secret=`.
- CI will run the existing unit tests under `posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py` and the customer_io tests.

After merge, watch the linked error-tracking issue — occurrence rate should drop to zero.

## Publish to changelog?

No.

## Docs update

Not applicable.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). The user noticed they had recently introduced a required `secret` boolean on source config fields and asked whether it had caused error-tracking issues. Investigation found a single new ValidationError attributable to the change, isolated to `customer_io/source.py`. Fix is a one-line addition; classification (`True`) chosen because the field is a webhook signing key. Requires human review before merge — do not auto-merge.