### PR TITLE
fix(dashboards): stop auto-refresh polling on permanent 4xx

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -21,7 +21,7 @@ import { ResponsiveLayouts } from 'react-grid-layout'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
-import api, { ApiError, ApiMethodOptions, getJSONOrNull } from 'lib/api'
+import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { DataColorTheme } from 'lib/colors'
 import { quickFiltersSectionLogic } from 'lib/components/QuickFilters'
 import { OrganizationMembershipLevel } from 'lib/constants'
@@ -98,6 +98,7 @@ import {
     encodeURLVariables,
     getDashboardWidgetType,
     getInsightWithRetry,
+    isPermanentClientError,
     layoutsByTile,
     parseURLFilters,
     parseURLVariables,
@@ -2097,6 +2098,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         if (refreshedInsight) {
                             dashboardsModel.actions.updateDashboardInsight(refreshedInsight, undefined, dashboardId)
                             actions.setRefreshStatus(insight.short_id)
+                            actions.clearTileNonAutoRefreshable(insight.short_id)
                             tilesRefreshedCount++
                             if (refreshedInsight.is_cached) {
                                 tilesRefreshedCachedCount++
@@ -2121,12 +2123,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             tilesAbortedCount++
                         } else {
                             // Stop background polling for this tile if the failure is a permanent client error
-                            // (e.g. 401/403/404). Manual refreshes still go through and clear the skip on success.
-                            if (
-                                e instanceof ApiError &&
-                                e.status !== undefined &&
-                                [401, 403, 404].includes(e.status)
-                            ) {
+                            // (e.g. 4xx other than 408/429). Manual refreshes still go through and clear the skip on success.
+                            if (isPermanentClientError(e)) {
                                 actions.markTileNonAutoRefreshable(insight.short_id)
                             }
                             actions.setRefreshError(insight.short_id, e)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -21,7 +21,7 @@ import { ResponsiveLayouts } from 'react-grid-layout'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
-import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
+import api, { ApiError, ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { DataColorTheme } from 'lib/colors'
 import { quickFiltersSectionLogic } from 'lib/components/QuickFilters'
 import { OrganizationMembershipLevel } from 'lib/constants'
@@ -220,6 +220,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         refreshDashboardItems: (payload: {
             action: RefreshDashboardItemsAction | DashboardLoadAction
             forceRefresh?: boolean
+            isAutoRefresh?: boolean
         }) => payload,
         /** Update a single refresh status. */
         setRefreshStatus: (shortId: InsightShortId, loading = false, queued = false) => ({ shortId, loading, queued }),
@@ -230,6 +231,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             queued,
         }),
         setRefreshError: (shortId: InsightShortId, error?: Error) => ({ shortId, error }),
+        /** Mark a tile as ineligible for background auto-refresh (e.g. permanent 4xx). Manual refresh still works. */
+        markTileNonAutoRefreshable: (shortId: InsightShortId) => ({ shortId }),
+        clearTileNonAutoRefreshable: (shortId: InsightShortId) => ({ shortId }),
         abortQuery: (payload: { queryId: string; queryStartTime: number }) => payload,
         abortAnyRunningQuery: true,
         cancelDashboardRefresh: true,
@@ -914,6 +918,19 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 refreshDashboardItems: () => ({}),
                 abortQuery: () => ({}),
                 cancelDashboardRefresh: () => ({}),
+            },
+        ],
+        autoRefreshSkipShortIds: [
+            {} as Record<string, true>,
+            {
+                markTileNonAutoRefreshable: (state, { shortId }) => ({ ...state, [shortId]: true }),
+                clearTileNonAutoRefreshable: (state, { shortId }) => {
+                    if (!state[shortId]) {
+                        return state
+                    }
+                    const { [shortId]: _removed, ...rest } = state
+                    return rest
+                },
             },
         ],
         columns: [
@@ -1982,6 +1999,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 if (refreshedInsight) {
                     dashboardsModel.actions.updateDashboardInsight(refreshedInsight, undefined, dashboardId)
                     actions.setRefreshStatus(insight.short_id)
+                    actions.clearTileNonAutoRefreshable(insight.short_id)
                 } else {
                     actions.setRefreshError(insight.short_id)
                 }
@@ -1989,7 +2007,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.setRefreshError(insight.short_id, e)
             }
         },
-        refreshDashboardItems: async ({ action, forceRefresh }, breakpoint) => {
+        refreshDashboardItems: async ({ action, forceRefresh, isAutoRefresh }, breakpoint) => {
             const dashboardRefreshStartTime = performance.now()
             const isInitialLoad =
                 action === DashboardLoadAction.InitialLoad || action === DashboardLoadAction.InitialLoadWithVariables
@@ -1999,6 +2017,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const allInsightTiles = values.insightTiles || []
             const totalTileCount = allInsightTiles.length
 
+            const autoRefreshSkipShortIds = values.autoRefreshSkipShortIds
             const sortedTilesToRefresh = allInsightTiles
                 // sort tiles so we poll them in the exact order they are computed on the backend
                 .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
@@ -2013,6 +2032,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         !t.insight.cache_target_age ||
                         dayjs(t.insight.cache_target_age).isBefore(dayjs())
                 )
+                // skip tiles that previously returned a permanent client error (e.g. 403) when auto-refreshing
+                .filter((t) => !isAutoRefresh || !autoRefreshSkipShortIds[t.insight.short_id])
 
             const tilesStaleCount = sortedTilesToRefresh.length
             let tilesRefreshedCount = 0
@@ -2099,6 +2120,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             actions.abortQuery({ queryId, queryStartTime })
                             tilesAbortedCount++
                         } else {
+                            // Stop background polling for this tile if the failure is a permanent client error
+                            // (e.g. 401/403/404). Manual refreshes still go through and clear the skip on success.
+                            if (
+                                e instanceof ApiError &&
+                                e.status !== undefined &&
+                                [401, 403, 404].includes(e.status)
+                            ) {
+                                actions.markTileNonAutoRefreshable(insight.short_id)
+                            }
                             actions.setRefreshError(insight.short_id, e)
                             tilesErroredCount++
                         }
@@ -2265,6 +2295,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     actions.refreshDashboardItems({
                         action: RefreshDashboardItemsAction.Refresh,
                         forceRefresh: true,
+                        isAutoRefresh: true,
                     })
                 }
                 cache.disposables.add(() => {
@@ -2272,6 +2303,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         actions.refreshDashboardItems({
                             action: RefreshDashboardItemsAction.Refresh,
                             forceRefresh: true,
+                            isAutoRefresh: true,
                         })
                     }, values.autoRefresh.interval * 1000)
                     return () => clearInterval(intervalId)

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -2,7 +2,7 @@ import { ResponsiveLayouts } from 'react-grid-layout'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
+import api, { ApiError, ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { currentSessionId } from 'lib/internalMetrics'
 import { objectClean, shouldCancelQuery, toParams } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
@@ -293,6 +293,13 @@ export async function getInsightWithRetry(
         } catch (e: any) {
             if (shouldCancelQuery(e)) {
                 throw e // Re-throw cancellation errors
+            }
+
+            // Don't retry on 4xx errors except 408 (timeout) and 429 (rate limit) — they won't change on retry
+            if (e instanceof ApiError && e.status !== undefined && e.status >= 400 && e.status < 500) {
+                if (e.status !== 408 && e.status !== 429) {
+                    throw e
+                }
             }
 
             attempt++

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -176,6 +176,22 @@ export const layoutsByTile = (layouts: ResponsiveLayouts): Record<string, Record
 }
 
 /**
+ * True for 4xx errors that won't change on retry. 408 (timeout) and 429 (rate limit) are excluded
+ * because they're transient. Used both to short-circuit the retry loop and to mark a dashboard
+ * tile as ineligible for background auto-refresh.
+ */
+export function isPermanentClientError(e: unknown): boolean {
+    return (
+        e instanceof ApiError &&
+        e.status !== undefined &&
+        e.status >= 400 &&
+        e.status < 500 &&
+        e.status !== 408 &&
+        e.status !== 429
+    )
+}
+
+/**
  * Fetches an insight with a retry and polling mechanism.
  * It first attempts to fetch the insight synchronously. If rate-limited, it retries with exponential backoff.
  * After multiple failed attempts, it switches to asynchronous polling to fetch the result.
@@ -295,11 +311,9 @@ export async function getInsightWithRetry(
                 throw e // Re-throw cancellation errors
             }
 
-            // Don't retry on 4xx errors except 408 (timeout) and 429 (rate limit) — they won't change on retry
-            if (e instanceof ApiError && e.status !== undefined && e.status >= 400 && e.status < 500) {
-                if (e.status !== 408 && e.status !== 429) {
-                    throw e
-                }
+            // Don't retry on permanent 4xx errors — they won't change on retry
+            if (isPermanentClientError(e)) {
+                throw e
             }
 
             attempt++


### PR DESCRIPTION
## Problem

Dashboards with auto-refresh enabled keep polling each tile's insight on every interval forever, even when the request fails with a permanent client error like 401, 403, or 404. A long-lived browser session — e.g. a wall-mounted dashboard whose user lost access to one of the underlying insights — can produce an unbounded stream of `client_request_failure` events.

We saw this in practice: a single browser session was generating tens of thousands of 403s per day against a handful of insights it could no longer access, because nothing in the dashboard refresh path notices the response is permanently broken.

The amplification has two layers:
1. The auto-refresh interval re-fires the same failing requests every tick.
2. Inside each tick, `getInsightWithRetry` retries the same failing request up to 5 times with exponential backoff before giving up — even on 4xx, which won't change on retry.

## Changes

- **`dashboardLogic.tsx`** — track tiles that returned 401/403/404 in an `autoRefreshSkipShortIds` reducer, and skip them on subsequent auto-refresh ticks via a new `isAutoRefresh` flag passed from `resetInterval`. Manual single-tile refresh still attempts the fetch and clears the flag on success, so a permission fix is picked up without a full page reload. Initial load and preview/filter refreshes are unaffected (they aren't the source of the loop).
- **`dashboardUtils.ts`** — `getInsightWithRetry` now throws immediately on 4xx (except 408 and 429), instead of retrying 5x. 4xx responses won't change on retry; the retry was pure waste and a 5x amplifier on the failure rate.

Combined effect for a stuck wall display: per failing tile, the request count drops from `~5 retries × every interval forever` to `~1 request once`, then 0.

## How did you test this code?

I'm an agent (PostHog Code).

- No new automated tests added in this PR. Existing `dashboardUtils.test.ts` only covers URL parsing helpers; adding coverage for `getInsightWithRetry` retry semantics or the kea reducer behavior would warrant a separate, dedicated change.
- I did not perform manual browser testing in this environment (no dev server / `node_modules` available).
- TypeScript was not run locally for the same reason — relying on CI to verify the type changes (new action signatures, `ApiError` import, the optional `isAutoRefresh` payload field).

Suggested manual verification before merge:
1. Open a dashboard, revoke access to one of its insights for the current user, enable auto-refresh.
2. Confirm the affected tile shows an error once, and that subsequent auto-refresh ticks skip it (no further `client_request_failure` events with status 403 in the network tab).
3. Click "Refresh" on that single tile after access is restored — it should re-fetch and resume participating in auto-refresh.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (agent), session focused on diagnosing a 403 spike traced to a single dashboard polling insights it had lost access to. Key decisions:

- Skipping is **per-tile**, not whole-dashboard, so one inaccessible insight doesn't disable refresh for the rest of the dashboard.
- `isAutoRefresh` flag is the discriminator (rather than `forceRefresh`), because the existing manual-refresh button also passes `forceRefresh: true`. We only want to skip in the *background* polling path.
- The skip clears on a successful manual single-tile refresh, so users can re-enable polling without a page reload after a permission fix.
- Not all 4xx are skip-worthy — 408 (request timeout) and 429 (rate limit) are still retried inside `getInsightWithRetry`, since those *are* transient.

Human review required before merge.