### PR TITLE
chore(cloud-agent): remove legacy relay timeout patch

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -381,9 +381,7 @@ class TestRelaySandboxEventsErrorHandling:
 
 
 class TestRelaySandboxEventsWorkflowOptions:
-    async def test_relay_sandbox_events_uses_extended_timeout_for_new_workflows(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_relay_sandbox_events_uses_extended_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         workflow = ProcessTaskWorkflow()
         workflow._context = TaskProcessingContext(
             task_id="task-id",
@@ -399,7 +397,6 @@ class TestRelaySandboxEventsWorkflowOptions:
             _branch="feature-branch",
         )
         execute_activity_mock = AsyncMock()
-        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", lambda _patch_id: True)
         monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", execute_activity_mock)
 
         await workflow._relay_sandbox_events(

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -75,7 +75,6 @@ class TaskEvent(StrEnum):
 
 INACTIVITY_TIMEOUT = timedelta(minutes=5)
 CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
-RELAY_SANDBOX_EVENTS_LEGACY_START_TO_CLOSE_TIMEOUT = timedelta(minutes=65)
 RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT = timedelta(hours=24)
 PENDING_MESSAGE_FORWARD_TIMEOUT_SECONDS = 180
 MAX_CI_REPETITIONS = 3
@@ -116,7 +115,6 @@ After fixing, commit and push so CI can re-run.
 #   2. Second cleanup PR (after another full drain): delete this helper and
 #      `_PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT`.
 _PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT = "tasks-ci-follow-up-pr-context"
-_PATCH_ID_LONG_RELAY_TIMEOUT = "tasks-long-relay-timeout"
 
 
 def _deprecate_ci_follow_up_pr_context_patch() -> None:
@@ -735,11 +733,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
     ) -> None:
         """Start the SSE relay activity as a concurrent task (best-effort)."""
         try:
-            start_to_close_timeout = (
-                RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT
-                if workflow.patched(_PATCH_ID_LONG_RELAY_TIMEOUT)
-                else RELAY_SANDBOX_EVENTS_LEGACY_START_TO_CLOSE_TIMEOUT
-            )
             relay_input = RelaySandboxEventsInput(
                 run_id=self.context.run_id,
                 task_id=self.context.task_id,
@@ -752,7 +745,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 relay_sandbox_events,
                 relay_input,
-                start_to_close_timeout=start_to_close_timeout,
+                start_to_close_timeout=RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT,
                 heartbeat_timeout=timedelta(minutes=2),
                 retry_policy=RetryPolicy(maximum_attempts=1),
                 cancellation_type=workflow.ActivityCancellationType.TRY_CANCEL,


### PR DESCRIPTION
## Problem

relay timeout rollout no longer needs the replay-only 65-minute branch now that old workflow histories have drained, let's cleanup