### PR TITLE
fix(tasks): bound CI follow-up skip path to CI_FOLLOW_UP_DELAY

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -208,6 +208,7 @@ def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
             fingerprint="closed-fp",
         )
     if behavior == "unchanged":
+        _pr_context_overrides["_call_count"] = _pr_context_overrides.get("_call_count", 0) + 1
         return GetPrContextOutput(
             pr_url="https://github.com/org/repo/pull/1",
             pr_state="open",
@@ -475,9 +476,10 @@ class TestFollowupGuards:
         # The first CI check runs (fingerprint moves from None → "stable-fp"),
         # sending a single follow-up. Subsequent checks must see the stored
         # fingerprint match and skip — so only one follow-up should ever be
-        # dispatched. We drive the workflow to inactivity timeout to exercise
-        # multiple CI cycles; if skipping were broken, _ci_followup_calls
-        # would grow past 1.
+        # dispatched, and get_pr_context must be called at most once per
+        # CI_FOLLOW_UP_DELAY tick. If the skip path forgot to advance
+        # _last_active_time, _wait_for_ci_follow_up would return immediately
+        # on every loop iteration and burn the GitHub API rate limit.
         _pr_context_overrides["behavior"] = "unchanged"
 
         async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -491,12 +493,25 @@ class TestFollowupGuards:
                     retry_policy=RetryPolicy(maximum_attempts=1),
                     execution_timeout=timedelta(hours=2),
                 )
-                # Sleep past the second CI deadline (30m) so a skip must fire.
-                await env.sleep(CI_FOLLOW_UP_DELAY.total_seconds() * 2)
+                # Sleep well past the third CI deadline (45m+) so the skip
+                # path is exercised twice. With the bug, _wait_for_ci_follow_up
+                # returns instantly after each skip and the activity gets
+                # called as fast as the round-trip allows; with the fix, each
+                # skip resets _last_active_time and the next call is gated to
+                # +CI_FOLLOW_UP_DELAY.
+                await env.sleep(CI_FOLLOW_UP_DELAY.total_seconds() * 3 + 60)
                 await handle.signal(ProcessTaskWorkflow.complete_task, args=["completed", None])
                 await handle.result()
 
         assert len(_ci_followup_calls) == 1
+        # One call per CI tick: fire at T=15m, skip at T=30m, skip at T=45m.
+        # If _last_active_time isn't advanced on skip, _wait_for_ci_follow_up
+        # returns immediately and the activity gets hammered.
+        pr_context_calls = _pr_context_overrides.get("_call_count", 0)
+        assert pr_context_calls <= 4, (
+            f"expected ≤4 get_pr_context calls across 45m+, got {pr_context_calls} — "
+            "skip path is tight-looping and burning the GitHub rate limit"
+        )
 
     @pytest.mark.timeout(60)
     async def test_ci_follow_up_fires_on_changed_fingerprint_and_persists(self):

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -379,6 +379,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                         elif follow_up_result == "no_pr":
                             # No PR will ever appear — stop the CI loop entirely.
                             self._ci_repetitions = MAX_CI_REPETITIONS
+                        elif follow_up_result == "skip":
+                            # Bound the next get_pr_context call to +CI_FOLLOW_UP_DELAY.
+                            # Without this, _wait_for_ci_follow_up returns immediately
+                            # whenever last_active_time is older than the delay, and the
+                            # workflow tight-loops calling GET /repos/.../pulls/{n}.
+                            self._last_active_time = workflow.now()
                     case TaskEvent.SIGNAL_RECEIVED:
                         if self._pending_followup is not None:
                             workflow.logger.info(


### PR DESCRIPTION
**Problem**

The `process-task` workflow's CI follow-up loop tight-looped on `get_pr_context` whenever the PR fingerprint was unchanged, hammering `GET /repos/.../pulls/{n}` as fast as the activity could round-trip. Across the fleet that showed up as ~3 rps sustained (peaks of 9 rps) on the `posthog_integration` (kind=`github`) installation token bucket, exhausting the GitHub App rate limit and cascading 403s onto otherwise healthy callers.

**Root cause**

`_should_run_ci_follow_up` was extended in #55662 to return `"skip"` when the PR hasn't changed. The skip branch wasn't wired into the workflow's bookkeeping — it didn't advance `_last_active_time` and didn't bump `_ci_repetitions`. On the next loop iteration, `_wait_for_ci_follow_up` computed `remaining = CI_FOLLOW_UP_DELAY - elapsed` as ≤0, returned `CI_FOLLOW_UP` immediately (no `workflow.sleep`), and the workflow re-entered `_should_run_ci_follow_up` → fired the activity → got `"skip"` again → looped.

`_dispatch_ci_follow_up` already does the right thing on the fire path (sets `_last_active_time = workflow.now()`); the skip path was just missing that line.

**Fix**

One branch added to the `CI_FOLLOW_UP` event handler in `workflow.py`: on `"skip"`, advance `_last_active_time` to now. Caps per-workflow rate at one fetch per `CI_FOLLOW_UP_DELAY` (15m).

**Out of scope**

The bigger optimization — feed PR webhook payloads back into the workflow via a Temporal signal so `get_pr_context` can be skipped entirely in steady state — is a separate PR. This one is just the bleeding-stop.

**How tested**

Extended `test_skips_ci_follow_up_when_fingerprint_unchanged` in `test_followup.py` to count `get_pr_context` invocations across 45m+ of virtual time. Without the fix the workflow tight-loops and the Temporal RPC times out; with the fix the activity fires three times (one fire at T=15m, skips at T=30m and T=45m). I'm an agent — only the automated test was run, no manual prod verification.

**Publish to changelog?**

no

## 🤖 Agent context

Diagnosed by walking the GitHub API rate-limit metric (`github_integration_api_requests_total`, added in #56459) on the cloud-background-agents-runs Grafana dashboard. Top traffic was `temporal-worker-tasks-agent` namespace → `GET /repos/.../pulls/{n}` at 2.9 rps → traced to `get_pr_context` activity → traced to the missing skip-path bookkeeping in the workflow event loop.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>