### PR TITLE
fix(security): add principle of least privilege in security guidelines

### DIFF
--- a/.agents/security.md
+++ b/.agents/security.md
@@ -2,30 +2,18 @@
 
 ## Principle of Least Privilege
 
-Default to the smallest permission, narrowest field set, and shortest scope that still works. If a change needs more access than what's there, stop and reconsider before widening it.
+Default to the smallest permission, narrowest field set, and shortest scope that still works. If a change needs more access than what's already in place, stop and reconsider the design before widening it.
 
-- Serializers expose only the fields the caller needs. Mark fields the user has no business setting as `read_only` (`team`, `created_by`, `organization`).
-- Reuse existing permission and access-control classes — don't loosen them to fit a new caller.
-- When a feature or role goes away, remove its permissions in the same change. Don't leave dormant grants behind.
-
-**Vulnerable pattern** — caller can overwrite ownership fields:
-
-```python
-class WidgetSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Widget
-        fields = ["id", "name", "team", "created_by"]  # team and created_by are writable
-```
-
-**Safe pattern**:
-
-```python
-class WidgetSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Widget
-        fields = ["id", "name", "team", "created_by"]
-        read_only_fields = ["team", "created_by"]  # set server-side from request context
-```
+- **Default deny.** Start from no access and add what's required, rather than opening things up and trimming back.
+- **Scope every queryset.** Filter by `team_id` (and `organization_id` where appropriate) so a request can only ever touch its own data.
+- **Reuse existing permission and access-control classes** — don't write a looser variant to fit a new caller. If the existing class doesn't fit, that's a design conversation, not a quick relax.
+- **Separate read and write checks.** "Can see" and "can modify" are different questions; don't let one imply the other.
+- **Lock down ownership fields.** Mark `team`, `created_by`, `organization`, and similar fields as `read_only` on serializers. Set them server-side from request context, never from client input.
+- **Expose the minimum on serializers.** Don't include tokens, secrets, internal IDs, or fields a caller doesn't need just because they exist on the model.
+- **Gate admin and internal paths explicitly.** Use `is_staff`, organization roles, or feature flags — never rely on URL obscurity or "no one will hit this".
+- **Background work runs with caller scope.** Celery tasks and Temporal activities should preserve the requesting user/team, not silently escalate to superuser.
+- **Tokens and credentials: narrowest scope, shortest lifetime.** Don't widen an existing token's scope to fit a new use case — mint a new one. Never log secrets, never commit them.
+- **Remove access in the same change as the feature.** When a role, endpoint, or capability goes away, delete its permissions and grants then and there. Dormant grants accumulate and become tomorrow's incident.
 
 ## SQL Security
 

--- a/.agents/security.md
+++ b/.agents/security.md
@@ -1,5 +1,21 @@
 # Security guidelines for agents
 
+## Principle of Least Privilege
+
+Always grant the minimum access, scope, and permissions required for code to do its job. When in doubt, default to deny.
+
+- **Scope queries to the team:** Always filter querysets by `team_id` so a request can only ever read its own team's data.
+- **Pick the narrowest permission:** Prefer per-action DRF permissions and scoped access controls over broad `IsAuthenticated`. Reuse existing permission classes rather than weakening checks.
+- **Limit field exposure:** Serializers should expose the smallest set of fields needed. Never add `password`, tokens, secrets, or internal IDs to a response unless explicitly required.
+- **Restrict mutation surface:** Make read-only fields read-only; do not accept user input for fields the user has no business setting (e.g. `team`, `created_by`, `organization`).
+- **Credentials and tokens:** Use the narrowest scope and shortest lifetime that works. Never log secrets, never commit them, and never widen an existing token's scope to fit a new use case — mint a new one.
+- **Database roles and migrations:** Use the role with the least privilege required (read-only where possible). Don't grant blanket `ALL PRIVILEGES`.
+- **External services / IAM:** Request only the specific actions and resources you need (e.g. one S3 prefix, one Kafka topic) — avoid wildcards.
+- **Feature flags and admin paths:** Gate sensitive functionality behind explicit checks (`is_staff`, organization-level role, feature flag) rather than relying on obscurity.
+- **Removing access is part of the change:** When a feature is removed or a user/role no longer needs access, delete the permission in the same change — don't leave dormant grants behind.
+
+If a change appears to require broader privileges than what's already in place, treat that as a signal to stop and reconsider the design before widening the scope.
+
 ## SQL Security
 
 - **Never** use f-strings with user-controlled values in SQL queries - this creates SQL injection vulnerabilities

--- a/.agents/security.md
+++ b/.agents/security.md
@@ -2,19 +2,30 @@
 
 ## Principle of Least Privilege
 
-Always grant the minimum access, scope, and permissions required for code to do its job. When in doubt, default to deny.
+Default to the smallest permission, narrowest field set, and shortest scope that still works. If a change needs more access than what's there, stop and reconsider before widening it.
 
-- **Scope queries to the team:** Always filter querysets by `team_id` so a request can only ever read its own team's data.
-- **Pick the narrowest permission:** Prefer per-action DRF permissions and scoped access controls over broad `IsAuthenticated`. Reuse existing permission classes rather than weakening checks.
-- **Limit field exposure:** Serializers should expose the smallest set of fields needed. Never add `password`, tokens, secrets, or internal IDs to a response unless explicitly required.
-- **Restrict mutation surface:** Make read-only fields read-only; do not accept user input for fields the user has no business setting (e.g. `team`, `created_by`, `organization`).
-- **Credentials and tokens:** Use the narrowest scope and shortest lifetime that works. Never log secrets, never commit them, and never widen an existing token's scope to fit a new use case — mint a new one.
-- **Database roles and migrations:** Use the role with the least privilege required (read-only where possible). Don't grant blanket `ALL PRIVILEGES`.
-- **External services / IAM:** Request only the specific actions and resources you need (e.g. one S3 prefix, one Kafka topic) — avoid wildcards.
-- **Feature flags and admin paths:** Gate sensitive functionality behind explicit checks (`is_staff`, organization-level role, feature flag) rather than relying on obscurity.
-- **Removing access is part of the change:** When a feature is removed or a user/role no longer needs access, delete the permission in the same change — don't leave dormant grants behind.
+- Serializers expose only the fields the caller needs. Mark fields the user has no business setting as `read_only` (`team`, `created_by`, `organization`).
+- Reuse existing permission and access-control classes — don't loosen them to fit a new caller.
+- When a feature or role goes away, remove its permissions in the same change. Don't leave dormant grants behind.
 
-If a change appears to require broader privileges than what's already in place, treat that as a signal to stop and reconsider the design before widening the scope.
+**Vulnerable pattern** — caller can overwrite ownership fields:
+
+```python
+class WidgetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Widget
+        fields = ["id", "name", "team", "created_by"]  # team and created_by are writable
+```
+
+**Safe pattern**:
+
+```python
+class WidgetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Widget
+        fields = ["id", "name", "team", "created_by"]
+        read_only_fields = ["team", "created_by"]  # set server-side from request context
+```
 
 ## SQL Security
 


### PR DESCRIPTION
## Problem

The security guidelines document lacked explicit guidance on the principle of least privilege, which is a foundational security concept. This gap could lead to inconsistent permission models and overly permissive access controls across the codebase.

## Changes

Added a comprehensive "Principle of Least Privilege" section to `.agents/security.md` that covers:

- Default deny approach and permission scoping
- Queryset filtering by `team_id` and `organization_id`
- Reusing existing permission classes rather than creating looser variants
- Separation of read and write permission checks
- Read-only ownership fields on serializers
- Minimal serializer exposure (no tokens, secrets, or unnecessary fields)
- Explicit gating of admin and internal paths
- Proper scope preservation in background tasks
- Token and credential management best practices
- Timely removal of access when features are deprecated

This guidance complements the existing SQL Security section and establishes clear expectations for secure API and permission design.

## How did you test this code?

N/A — This is a documentation update with no code logic changes.

## Publish to changelog?

No — This is an internal security guidelines update.

## Docs update

No docs update needed — this is an internal agent guidelines document.

https://claude.ai/code/session_01PS2pg2hzyoAUNu6AAo2nLK