### PR TITLE
feat: Added new event loop yielder

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -70,8 +70,6 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
     protected outputs: CdpOutputs
     protected abstract name: string
 
-    protected heartbeat = () => {}
-
     constructor(
         protected config: TConfig,
         protected deps: CdpConsumerBaseDeps
@@ -107,15 +105,6 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
             onShutdown: async () => await this.stop(),
             healthcheck: () => this.isHealthy(),
         }
-    }
-
-    protected async runWithHeartbeat<T>(func: () => Promise<T> | T): Promise<T> {
-        // Helper function to ensure that looping over lots of hog functions doesn't block up the thread, killing the consumer
-        const res = await func()
-        this.heartbeat()
-        await new Promise((resolve) => process.nextTick(resolve))
-
-        return res
     }
 
     public async start(): Promise<void> {

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.test.ts
@@ -8,6 +8,7 @@ import { UUIDT } from '~/utils/utils'
 
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
+import { configureEventLoopYield, getEventLoopYieldThresholdMs } from '../../utils/event-loop-yield'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../_tests/examples'
 import {
     createExampleInvocation,
@@ -409,17 +410,22 @@ describe('CdpCyclotronWorker', () => {
         describe('thread relief', () => {
             jest.setTimeout(10000)
             let interval: NodeJS.Timeout
+            const blockTime = 200
+            let originalThresholdMs: number
+
             beforeEach(() => {
                 jest.spyOn(Date, 'now').mockRestore()
                 jest.useRealTimers()
+                originalThresholdMs = getEventLoopYieldThresholdMs()
+                configureEventLoopYield(blockTime)
             })
 
             afterEach(() => {
                 clearInterval(interval)
+                configureEventLoopYield(originalThresholdMs)
             })
 
             it('should process batches in a way that does not block the main thread', async () => {
-                const blockTime = 200
                 let lastCheck = Date.now()
                 let longestDelay = 0
 

--- a/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
@@ -29,37 +29,35 @@ export class CdpDatawarehouseEventsConsumer extends CdpEventsConsumer {
 
     @instrumented('cdpConsumer.handleEachBatch.parseKafkaMessages')
     public override async _parseKafkaBatch(messages: Message[]): Promise<HogFunctionInvocationGlobals[]> {
-        return await this.runWithHeartbeat(async () => {
-            const events: HogFunctionInvocationGlobals[] = []
+        const events: HogFunctionInvocationGlobals[] = []
 
-            await Promise.all(
-                messages.map(async (message) => {
-                    try {
-                        const kafkaEvent = parseJSON(message.value!.toString()) as unknown
-                        const event = CdpDataWarehouseEventSchema.parse(kafkaEvent)
+        await Promise.all(
+            messages.map(async (message) => {
+                try {
+                    const kafkaEvent = parseJSON(message.value!.toString()) as unknown
+                    const event = CdpDataWarehouseEventSchema.parse(kafkaEvent)
 
-                        const [teamHogFunctions, teamHogFlows, team] = await Promise.all([
-                            this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, this.hogTypes),
-                            this.hogFlowManager.getHogFlowsForTeam(event.team_id),
-                            this.deps.teamManager.getTeam(event.team_id),
-                        ])
+                    const [teamHogFunctions, teamHogFlows, team] = await Promise.all([
+                        this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, this.hogTypes),
+                        this.hogFlowManager.getHogFlowsForTeam(event.team_id),
+                        this.deps.teamManager.getTeam(event.team_id),
+                    ])
 
-                        if ((!teamHogFunctions.length && !teamHogFlows.length) || !team) {
-                            return
-                        }
-
-                        events.push(
-                            convertDataWarehouseEventToHogFunctionInvocationGlobals(event, team, this.config.SITE_URL)
-                        )
-                    } catch (e) {
-                        logger.error('Error parsing message', e)
-                        counterParseError.labels({ error: e.message }).inc()
+                    if ((!teamHogFunctions.length && !teamHogFlows.length) || !team) {
+                        return
                     }
-                })
-            )
 
-            return events
-        })
+                    events.push(
+                        convertDataWarehouseEventToHogFunctionInvocationGlobals(event, team, this.config.SITE_URL)
+                    )
+                } catch (e) {
+                    logger.error('Error parsing message', e)
+                    counterParseError.labels({ error: e.message }).inc()
+                }
+            })
+        )
+
+        return events
     }
 }
 

--- a/nodejs/src/cdp/consumers/cdp-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-events.consumer.ts
@@ -116,7 +116,6 @@ export class CdpEventsConsumer<
 
                     this.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_function')
                     this.hogFunctionMonitoringService.queueLogs(logs, 'hog_function')
-                    this.heartbeat()
 
                     return invocations
                 })
@@ -273,7 +272,6 @@ export class CdpEventsConsumer<
 
                     this.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_flow')
                     this.hogFunctionMonitoringService.queueLogs(logs, 'hog_flow')
-                    this.heartbeat()
 
                     return invocations
                 })

--- a/nodejs/src/cdp/consumers/cdp-internal-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-internal-event.consumer.ts
@@ -24,35 +24,31 @@ export class CdpInternalEventsConsumer extends CdpEventsConsumer {
     // This consumer always parses from kafka
     @instrumented('cdpConsumer.handleEachBatch.parseKafkaMessages')
     public override async _parseKafkaBatch(messages: Message[]): Promise<HogFunctionInvocationGlobals[]> {
-        return await this.runWithHeartbeat(async () => {
-            const events: HogFunctionInvocationGlobals[] = []
-            await Promise.all(
-                messages.map(async (message) => {
-                    try {
-                        const kafkaEvent = parseJSON(message.value!.toString()) as unknown
-                        // This is the input stream from elsewhere so we want to do some proper validation
-                        const event = CdpInternalEventSchema.parse(kafkaEvent)
+        const events: HogFunctionInvocationGlobals[] = []
+        await Promise.all(
+            messages.map(async (message) => {
+                try {
+                    const kafkaEvent = parseJSON(message.value!.toString()) as unknown
+                    // This is the input stream from elsewhere so we want to do some proper validation
+                    const event = CdpInternalEventSchema.parse(kafkaEvent)
 
-                        const [teamHogFunctions, team] = await Promise.all([
-                            this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, ['internal_destination']),
-                            this.deps.teamManager.getTeam(event.team_id),
-                        ])
+                    const [teamHogFunctions, team] = await Promise.all([
+                        this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, ['internal_destination']),
+                        this.deps.teamManager.getTeam(event.team_id),
+                    ])
 
-                        if (!teamHogFunctions.length || !team) {
-                            return
-                        }
-
-                        events.push(
-                            convertInternalEventToHogFunctionInvocationGlobals(event, team, this.config.SITE_URL)
-                        )
-                    } catch (e) {
-                        logger.error('Error parsing message', e)
-                        counterParseError.labels({ error: e.message }).inc()
+                    if (!teamHogFunctions.length || !team) {
+                        return
                     }
-                })
-            )
 
-            return events
-        })
+                    events.push(convertInternalEventToHogFunctionInvocationGlobals(event, team, this.config.SITE_URL))
+                } catch (e) {
+                    logger.error('Error parsing message', e)
+                    counterParseError.labels({ error: e.message }).inc()
+                }
+            })
+        )
+
+        return events
     }
 }

--- a/nodejs/src/cdp/consumers/cdp-person-updates-consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-person-updates-consumer.ts
@@ -29,34 +29,32 @@ export class CdpPersonUpdatesConsumer extends CdpEventsConsumer {
     // This consumer always parses from kafka
     @instrumented('cdpConsumer.handleEachBatch.parseKafkaMessages')
     public override async _parseKafkaBatch(messages: Message[]): Promise<HogFunctionInvocationGlobals[]> {
-        return await this.runWithHeartbeat(async () => {
-            const globals: HogFunctionInvocationGlobals[] = []
-            await Promise.all(
-                messages.map(async (message) => {
-                    try {
-                        const data = parseJSON(message.value!.toString()) as ClickHousePerson
+        const globals: HogFunctionInvocationGlobals[] = []
+        await Promise.all(
+            messages.map(async (message) => {
+                try {
+                    const data = parseJSON(message.value!.toString()) as ClickHousePerson
 
-                        const [teamHogFunctions, team] = await Promise.all([
-                            this.hogFunctionManager.getHogFunctionsForTeam(data.team_id, ['destination']),
-                            this.deps.teamManager.getTeam(data.team_id),
-                        ])
+                    const [teamHogFunctions, team] = await Promise.all([
+                        this.hogFunctionManager.getHogFunctionsForTeam(data.team_id, ['destination']),
+                        this.deps.teamManager.getTeam(data.team_id),
+                    ])
 
-                        const filteredHogFunctions = teamHogFunctions.filter(this.filterHogFunction)
+                    const filteredHogFunctions = teamHogFunctions.filter(this.filterHogFunction)
 
-                        if (!filteredHogFunctions.length || !team) {
-                            return
-                        }
-
-                        globals.push(convertClickhousePersonToInvocationGlobals(data, team, this.config.SITE_URL))
-                    } catch (e) {
-                        logger.error('Error parsing message', e)
-                        counterParseError.labels({ error: e.message }).inc()
+                    if (!filteredHogFunctions.length || !team) {
+                        return
                     }
-                })
-            )
 
-            return globals
-        })
+                    globals.push(convertClickhousePersonToInvocationGlobals(data, team, this.config.SITE_URL))
+                } catch (e) {
+                    logger.error('Error parsing message', e)
+                    counterParseError.labels({ error: e.message }).inc()
+                }
+            })
+        )
+
+        return globals
     }
 }
 

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -10,7 +10,7 @@ import {
 import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
 import { KafkaConsumer } from '../../kafka/consumer'
 import { HealthCheckResult, RawClickHouseEvent } from '../../types'
-import { yieldEventLoopIfNeeded } from '../../utils/event-loop-yield'
+import { yieldEach } from '../../utils/event-loop-yield'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { PRECALCULATED_PERSON_PROPERTIES_OUTPUT, PREFILTERED_EVENTS_OUTPUT } from '../outputs/outputs'
@@ -221,7 +221,7 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
                 }
 
                 // Process each event for this team
-                for (const clickHouseEvent of teamEvents) {
+                await yieldEach('cdp-precalculated-filters', teamEvents, async (clickHouseEvent) => {
                     // Convert to filter globals for filter evaluation
                     const filterGlobals = convertClickhouseRawEventToFilterGlobals(clickHouseEvent)
 
@@ -279,9 +279,7 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
                             personPropertyEvents.push(personPropertyEvent)
                         }
                     }
-
-                    await yieldEventLoopIfNeeded('cdp-precalculated-filters')
-                }
+                })
             } catch (e) {
                 logger.error('Error processing team events', { teamId, error: e })
             }

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -10,6 +10,7 @@ import {
 import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
 import { KafkaConsumer } from '../../kafka/consumer'
 import { HealthCheckResult, RawClickHouseEvent } from '../../types'
+import { yieldEventLoopIfNeeded } from '../../utils/event-loop-yield'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { PRECALCULATED_PERSON_PROPERTIES_OUTPUT, PREFILTERED_EVENTS_OUTPUT } from '../outputs/outputs'
@@ -171,124 +172,121 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         precalculatedEvents: ProducedEvent[]
         precalculatedPersonProperties: ProducedPersonPropertiesEvent[]
     }> {
-        return await this.runWithHeartbeat(async () => {
-            const behavioralEvents: ProducedEvent[] = []
-            const personPropertyEvents: ProducedPersonPropertiesEvent[] = []
+        const behavioralEvents: ProducedEvent[] = []
+        const personPropertyEvents: ProducedPersonPropertiesEvent[] = []
 
-            // Step 1: Parse all messages and group by team_id
-            const eventsByTeam = new Map<number, RawClickHouseEvent[]>()
+        // Step 1: Parse all messages and group by team_id
+        const eventsByTeam = new Map<number, RawClickHouseEvent[]>()
 
-            // Parse and group events by team
-            for (const message of messages) {
-                try {
-                    const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
+        // Parse and group events by team
+        for (const message of messages) {
+            try {
+                const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
 
-                    if (!clickHouseEvent.person_id) {
-                        logger.error('Event missing person_id', {
-                            teamId: clickHouseEvent.team_id,
-                            event: clickHouseEvent.event,
-                            uuid: clickHouseEvent.uuid,
-                        })
-                        continue // Skip events without person_id
-                    }
-
-                    if (!eventsByTeam.has(clickHouseEvent.team_id)) {
-                        eventsByTeam.set(clickHouseEvent.team_id, [])
-                    }
-                    eventsByTeam.get(clickHouseEvent.team_id)!.push(clickHouseEvent)
-                } catch (e) {
-                    logger.error('Error parsing message', e)
+                if (!clickHouseEvent.person_id) {
+                    logger.error('Event missing person_id', {
+                        teamId: clickHouseEvent.team_id,
+                        event: clickHouseEvent.event,
+                        uuid: clickHouseEvent.uuid,
+                    })
+                    continue // Skip events without person_id
                 }
+
+                if (!eventsByTeam.has(clickHouseEvent.team_id)) {
+                    eventsByTeam.set(clickHouseEvent.team_id, [])
+                }
+                eventsByTeam.get(clickHouseEvent.team_id)!.push(clickHouseEvent)
+            } catch (e) {
+                logger.error('Error parsing message', e)
             }
+        }
 
-            // Step 2: Fetch all realtime supported filters for all teams in one query
-            const teamIds = Array.from(eventsByTeam.keys())
-            const filtersByTeam = await this.realtimeSupportedFilterManager.getRealtimeSupportedFiltersForTeams(teamIds)
+        // Step 2: Fetch all realtime supported filters for all teams in one query
+        const teamIds = Array.from(eventsByTeam.keys())
+        const filtersByTeam = await this.realtimeSupportedFilterManager.getRealtimeSupportedFiltersForTeams(teamIds)
 
-            // Step 3: Process each team's events with their realtime supported filters
-            for (const [teamId, teamEvents] of Array.from(eventsByTeam.entries())) {
-                try {
-                    const filters = filtersByTeam[String(teamId)]
-                    if (!filters) {
-                        continue
-                    }
+        // Step 3: Process each team's events with their realtime supported filters
+        for (const [teamId, teamEvents] of Array.from(eventsByTeam.entries())) {
+            try {
+                const filters = filtersByTeam[String(teamId)]
+                if (!filters) {
+                    continue
+                }
 
-                    const { behavioral: behavioralFilters, person_property: personPropertyFilters } = filters
+                const { behavioral: behavioralFilters, person_property: personPropertyFilters } = filters
 
-                    if (behavioralFilters.length === 0 && personPropertyFilters.length === 0) {
-                        // Skip teams with no filters
-                        continue
-                    }
+                if (behavioralFilters.length === 0 && personPropertyFilters.length === 0) {
+                    // Skip teams with no filters
+                    continue
+                }
 
-                    // Process each event for this team
-                    for (const clickHouseEvent of teamEvents) {
-                        // Convert to filter globals for filter evaluation
-                        const filterGlobals = convertClickhouseRawEventToFilterGlobals(clickHouseEvent)
+                // Process each event for this team
+                for (const clickHouseEvent of teamEvents) {
+                    // Convert to filter globals for filter evaluation
+                    const filterGlobals = convertClickhouseRawEventToFilterGlobals(clickHouseEvent)
 
-                        // Evaluate behavioral filters
-                        for (const filter of behavioralFilters) {
-                            const matches = await this.evaluateEventAgainstRealtimeSupportedFilter(
-                                filterGlobals,
-                                filter
-                            )
+                    // Evaluate behavioral filters
+                    for (const filter of behavioralFilters) {
+                        const matches = await this.evaluateEventAgainstRealtimeSupportedFilter(filterGlobals, filter)
 
-                            // Only publish if event matches the filter (don't publish non-matches)
-                            if (matches) {
-                                const preCalculatedEvent: ProducedEvent = {
-                                    payload: {
-                                        uuid: filterGlobals.uuid,
-                                        team_id: clickHouseEvent.team_id,
-                                        person_id: clickHouseEvent.person_id!,
-                                        distinct_id: filterGlobals.distinct_id,
-                                        condition: filter.conditionHash,
-                                        source: `cohort_filter_${filter.conditionHash}`,
-                                    },
-                                }
-
-                                behavioralEvents.push(preCalculatedEvent)
-                            }
-                        }
-
-                        // Evaluate person property filters using person_properties from the event
-                        if (personPropertyFilters.length > 0 && clickHouseEvent.person_properties) {
-                            const personProperties = parseJSON(clickHouseEvent.person_properties)
-
-                            const personGlobals: PersonPropertyFilterGlobals = {
-                                person: {
-                                    id: clickHouseEvent.person_id,
-                                    properties: personProperties,
-                                },
-                                project: {
-                                    id: clickHouseEvent.team_id,
+                        // Only publish if event matches the filter (don't publish non-matches)
+                        if (matches) {
+                            const preCalculatedEvent: ProducedEvent = {
+                                payload: {
+                                    uuid: filterGlobals.uuid,
+                                    team_id: clickHouseEvent.team_id,
+                                    person_id: clickHouseEvent.person_id!,
+                                    distinct_id: filterGlobals.distinct_id,
+                                    condition: filter.conditionHash,
+                                    source: `cohort_filter_${filter.conditionHash}`,
                                 },
                             }
 
-                            for (const filter of personPropertyFilters) {
-                                const matches = await this.evaluatePersonPropertiesAgainstFilter(personGlobals, filter)
-
-                                // CRITICAL: Always emit - both matches AND non-matches
-                                // Person properties are mutable state, need to track changes
-                                const personPropertyEvent: ProducedPersonPropertiesEvent = {
-                                    payload: {
-                                        distinct_id: clickHouseEvent.distinct_id,
-                                        person_id: clickHouseEvent.person_id!,
-                                        team_id: clickHouseEvent.team_id,
-                                        condition: filter.conditionHash,
-                                        matches: matches,
-                                        source: `cohort_filter_${filter.conditionHash}`,
-                                    },
-                                }
-
-                                personPropertyEvents.push(personPropertyEvent)
-                            }
+                            behavioralEvents.push(preCalculatedEvent)
                         }
                     }
-                } catch (e) {
-                    logger.error('Error processing team events', { teamId, error: e })
+
+                    // Evaluate person property filters using person_properties from the event
+                    if (personPropertyFilters.length > 0 && clickHouseEvent.person_properties) {
+                        const personProperties = parseJSON(clickHouseEvent.person_properties)
+
+                        const personGlobals: PersonPropertyFilterGlobals = {
+                            person: {
+                                id: clickHouseEvent.person_id,
+                                properties: personProperties,
+                            },
+                            project: {
+                                id: clickHouseEvent.team_id,
+                            },
+                        }
+
+                        for (const filter of personPropertyFilters) {
+                            const matches = await this.evaluatePersonPropertiesAgainstFilter(personGlobals, filter)
+
+                            // CRITICAL: Always emit - both matches AND non-matches
+                            // Person properties are mutable state, need to track changes
+                            const personPropertyEvent: ProducedPersonPropertiesEvent = {
+                                payload: {
+                                    distinct_id: clickHouseEvent.distinct_id,
+                                    person_id: clickHouseEvent.person_id!,
+                                    team_id: clickHouseEvent.team_id,
+                                    condition: filter.conditionHash,
+                                    matches: matches,
+                                    source: `cohort_filter_${filter.conditionHash}`,
+                                },
+                            }
+
+                            personPropertyEvents.push(personPropertyEvent)
+                        }
+                    }
+
+                    await yieldEventLoopIfNeeded('cdp-precalculated-filters')
                 }
+            } catch (e) {
+                logger.error('Error processing team events', { teamId, error: e })
             }
-            return { precalculatedEvents: behavioralEvents, precalculatedPersonProperties: personPropertyEvents }
-        })
+        }
+        return { precalculatedEvents: behavioralEvents, precalculatedPersonProperties: personPropertyEvents }
     }
 
     public override async start(): Promise<void> {

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -71,9 +71,10 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         }
 
         try {
-            const messages = events.map((event) => ({
-                value: Buffer.from(JSON.stringify(event.payload)),
-            }))
+            const messages: { value: Buffer }[] = []
+            await yieldEach('cdp-precalculated-filters-publish', events, (event) => {
+                messages.push({ value: Buffer.from(JSON.stringify(event.payload)) })
+            })
 
             await this.outputs.queueMessages(PREFILTERED_EVENTS_OUTPUT, messages)
         } catch (error) {
@@ -92,9 +93,10 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         }
 
         try {
-            const messages = events.map((event) => ({
-                value: Buffer.from(JSON.stringify(event.payload)),
-            }))
+            const messages: { value: Buffer }[] = []
+            await yieldEach('cdp-precalculated-filters-publish', events, (event) => {
+                messages.push({ value: Buffer.from(JSON.stringify(event.payload)) })
+            })
 
             await this.outputs.queueMessages(PRECALCULATED_PERSON_PROPERTIES_OUTPUT, messages)
         } catch (error) {
@@ -178,8 +180,7 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         // Step 1: Parse all messages and group by team_id
         const eventsByTeam = new Map<number, RawClickHouseEvent[]>()
 
-        // Parse and group events by team
-        for (const message of messages) {
+        await yieldEach('cdp-precalculated-filters-parse', messages, (message) => {
             try {
                 const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
 
@@ -189,7 +190,7 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
                         event: clickHouseEvent.event,
                         uuid: clickHouseEvent.uuid,
                     })
-                    continue // Skip events without person_id
+                    return // Skip events without person_id
                 }
 
                 if (!eventsByTeam.has(clickHouseEvent.team_id)) {
@@ -199,7 +200,7 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
             } catch (e) {
                 logger.error('Error parsing message', e)
             }
-        }
+        })
 
         // Step 2: Fetch all realtime supported filters for all teams in one query
         const teamIds = Array.from(eventsByTeam.keys())

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -679,7 +679,6 @@ describe('Hog Executor', () => {
                 },
                 error: undefined,
                 durationMs: 1,
-                waitedForThreadRelief: false,
             })
 
             const res = await executor.execute(createExampleInvocation(fn))
@@ -824,7 +823,6 @@ describe('Hog Executor', () => {
                 },
                 error: undefined,
                 durationMs: 1,
-                waitedForThreadRelief: false,
             })
         }
 

--- a/nodejs/src/cdp/utils/hog-exec.test.ts
+++ b/nodejs/src/cdp/utils/hog-exec.test.ts
@@ -1,3 +1,4 @@
+import { configureEventLoopYield, getEventLoopYieldThresholdMs } from '../../utils/event-loop-yield'
 import { compileHog } from '../templates/compiler'
 import { execHog } from './hog-exec'
 
@@ -9,10 +10,14 @@ describe('hog-exec', () => {
         let lastCheck = Date.now()
         let longestDelay = 0
         const blockTime = 100
+        let originalThresholdMs: number
 
         beforeEach(() => {
             jest.spyOn(Date, 'now').mockRestore()
             jest.useRealTimers()
+
+            originalThresholdMs = getEventLoopYieldThresholdMs()
+            configureEventLoopYield(blockTime)
 
             interval = setInterval(() => {
                 // Sets up an interval loop so we can see how long the longest delay between ticks is
@@ -23,6 +28,7 @@ describe('hog-exec', () => {
 
         afterEach(() => {
             clearInterval(interval)
+            configureEventLoopYield(originalThresholdMs)
         })
 
         it('should process batches in a way that does not block the main thread', async () => {

--- a/nodejs/src/cdp/utils/hog-exec.test.ts
+++ b/nodejs/src/cdp/utils/hog-exec.test.ts
@@ -58,85 +58,15 @@ describe('hog-exec', () => {
             )
 
             const timings = results.map((r) => r.durationMs)
-            const reliefs = results.map((r) => r.waitedForThreadRelief)
             const total = timings.reduce((x, y) => x + y, 0)
-            // Every one of these should have triggered a thread relief
-            expect(reliefs.every((r) => r)).toBe(true)
 
             // Timings is semi random so we can't test for exact values
             expect(total).toBeGreaterThan(100 * numberToTest)
             expect(total).toBeLessThan(200 * numberToTest) // the hog exec limiter isn't exact
             await new Promise((resolve) => setTimeout(resolve, 1))
-            expect(longestDelay).toBeLessThan(blockTime * 2) // Rough upper bound of the hog exec limiter (2x the block time)
-        })
-
-        it('should only trigger thread relief if necessary', async () => {
-            const blockTime = 100
-
-            const evilFunctionCode = await compileHog(`
-                fn fibonacci(number) {
-                    print('I AM FIBONACCI. ')
-                    if (number < 2) {
-                        return number;
-                    } else {
-                        return fibonacci(number - 1) + fibonacci(number - 2);
-                    }
-                }
-                print(f'fib {fibonacci(64)}');
-            `)
-
-            const simpleCode = await compileHog(`
-                print('I AM SIMPLE.')
-            `)
-
-            const toTest = [
-                evilFunctionCode,
-                simpleCode,
-                simpleCode,
-                simpleCode,
-                simpleCode,
-                simpleCode,
-                evilFunctionCode,
-                simpleCode,
-                simpleCode,
-                simpleCode,
-                evilFunctionCode,
-            ]
-
-            const results = await Promise.all(
-                toTest.map((code) =>
-                    execHog(code, {
-                        timeout: blockTime,
-                        functions: {
-                            print: () => {},
-                        },
-                    })
-                )
-            )
-
-            const timings = results.map((r) => r.durationMs)
-            const reliefs = results.map((r) => r.waitedForThreadRelief)
-            const total = timings.reduce((x, y) => x + y, 0)
-            // Every one of these should have triggered a thread relief
-            expect(reliefs).toEqual([
-                true, // evil function
-                false,
-                false,
-                false,
-                false,
-                false,
-                true, // evil function
-                false,
-                false,
-                false,
-                true, // evil function
-            ])
-
-            // Timings is semi random so we can't test for exact values
-            expect(total).toBeGreaterThan(100 * 3) // The 3 slow ones
-            expect(total).toBeLessThan(200 * 3) // Double the 3 slow ones
-            await new Promise((resolve) => setTimeout(resolve, 1))
-            expect(longestDelay).toBeLessThan(blockTime * 2) // Rough upper bound of the hog exec limiter (2x the block time)
+            // Rough upper bound: with the semaphore serializing calls, the
+            // event loop should never be starved for more than ~2× one block.
+            expect(longestDelay).toBeLessThan(blockTime * 2)
         })
     })
 })

--- a/nodejs/src/cdp/utils/hog-exec.test.ts
+++ b/nodejs/src/cdp/utils/hog-exec.test.ts
@@ -65,8 +65,9 @@ describe('hog-exec', () => {
             expect(total).toBeLessThan(200 * numberToTest) // the hog exec limiter isn't exact
             await new Promise((resolve) => setTimeout(resolve, 1))
             // Rough upper bound: with the semaphore serializing calls, the
-            // event loop should never be starved for more than ~2× one block.
-            expect(longestDelay).toBeLessThan(blockTime * 2)
+            // event loop should not be starved for more than ~2.5× one block.
+            // (If yielding were broken, this would be ~10× the block.)
+            expect(longestDelay).toBeLessThan(blockTime * 2.5)
         })
     })
 })

--- a/nodejs/src/cdp/utils/hog-exec.ts
+++ b/nodejs/src/cdp/utils/hog-exec.ts
@@ -17,18 +17,10 @@ export async function execHog(
     execResult?: ExecResult
     error?: any
     durationMs: number
-    waitedForThreadRelief: boolean
 }> {
     return await semaphore.run(async () => {
         return await instrumentFn(`hog-exec`, async () => {
-            const waitedForInitialRelief = await yieldEventLoopIfNeeded('hog-exec')
-            const result = execHogImmediate(bytecode, options)
-            const waitedForFinalRelief = await yieldEventLoopIfNeeded('hog-exec')
-
-            return {
-                ...result,
-                waitedForThreadRelief: waitedForInitialRelief || waitedForFinalRelief,
-            }
+            return await yieldEventLoopIfNeeded('hog-exec', () => execHogImmediate(bytecode, options))
         })
     })
 }

--- a/nodejs/src/cdp/utils/hog-exec.ts
+++ b/nodejs/src/cdp/utils/hog-exec.ts
@@ -1,53 +1,15 @@
 import crypto from 'crypto'
-import { Counter } from 'prom-client'
 
 import { DEFAULT_TIMEOUT_MS, ExecOptions, ExecResult, exec } from '@posthog/hogvm'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
+import { yieldEventLoopIfNeeded } from '../../utils/event-loop-yield'
 import { createTrackedRE2 } from '../../utils/tracked-re2'
 import { Semaphore } from './sempahore'
 
-export const MAX_THREAD_WAIT_TIME_MS = 200
-
-const hogExecThreadReliefCounter = new Counter({
-    name: 'cdp_hog_function_execution_thread_relief',
-    help: 'Whether the hog function execution was blocked by the thread relief',
-    // We have a timeout so we don't need to worry about much more than that
-    labelNames: ['waited'],
-})
-
 const semaphore = new Semaphore(1)
 
-let threadRelief: {
-    startedAt: number
-    promise: Promise<void>
-} | null = null
-
-const waitForThreadRelief = async (timeout: number = DEFAULT_TIMEOUT_MS): Promise<boolean> => {
-    if (!threadRelief) {
-        threadRelief = {
-            startedAt: performance.now(),
-            promise: new Promise((resolve) => {
-                setTimeout(() => {
-                    threadRelief = null
-                    resolve()
-                }, 0)
-            }),
-        }
-    }
-
-    if (performance.now() - threadRelief.startedAt < timeout) {
-        return false
-    }
-
-    await threadRelief.promise
-
-    return true
-}
-
-// NOTE: Hog execution can be expensive and in really bad cases can block the event loop for a long time.
-// To work around this we have a check when we run it to make sure that
 export async function execHog(
     bytecode: any,
     options?: ExecOptions
@@ -59,16 +21,13 @@ export async function execHog(
 }> {
     return await semaphore.run(async () => {
         return await instrumentFn(`hog-exec`, async () => {
-            const waitedForInitialRelief = await waitForThreadRelief(options?.timeout)
+            const waitedForInitialRelief = await yieldEventLoopIfNeeded('hog-exec')
             const result = execHogImmediate(bytecode, options)
-            const waitedForFinalRelief = await waitForThreadRelief(options?.timeout)
-
-            const waitedForThreadRelief = waitedForInitialRelief || waitedForFinalRelief
-            hogExecThreadReliefCounter.inc({ waited: waitedForThreadRelief ? 'true' : 'false' })
+            const waitedForFinalRelief = await yieldEventLoopIfNeeded('hog-exec')
 
             return {
                 ...result,
-                waitedForThreadRelief,
+                waitedForThreadRelief: waitedForInitialRelief || waitedForFinalRelief,
             }
         })
     })

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -162,6 +162,9 @@ export type CommonConfig = BaseServerConfig & {
 
     // Shared between ingestion and CDP (used by hog transformer in both)
     CDP_HOG_WATCHER_SAMPLE_RATE: number
+
+    // Event loop yield helper (yieldEventLoopIfNeeded)
+    EVENT_LOOP_YIELD_THRESHOLD_MS: number
 }
 
 export type ExternalRequestConfig = Pick<
@@ -325,6 +328,9 @@ export function getDefaultCommonConfig(): CommonConfig {
 
         // Shared between ingestion and CDP
         CDP_HOG_WATCHER_SAMPLE_RATE: 0,
+
+        // Event loop yield helper
+        EVENT_LOOP_YIELD_THRESHOLD_MS: 200,
 
         // Pod termination
         POD_TERMINATION_ENABLED: false,

--- a/nodejs/src/servers/base-server.ts
+++ b/nodejs/src/servers/base-server.ts
@@ -10,6 +10,7 @@ import { onShutdown } from '../lifecycle'
 import { PluginServerService, RedisPool } from '../types'
 import { PostgresRouter } from '../utils/db/postgres'
 import { isTestEnv } from '../utils/env-utils'
+import { configureEventLoopYield } from '../utils/event-loop-yield'
 import { logger } from '../utils/logger'
 import { NodeInstrumentation } from '../utils/node-instrumentation'
 import { captureException, shutdown as posthogShutdown } from '../utils/posthog'
@@ -26,6 +27,7 @@ export type BaseServerConfig = {
     CONTINUOUS_PROFILING_ENABLED: boolean
     PYROSCOPE_SERVER_ADDRESS: string
     PYROSCOPE_APPLICATION_NAME: string
+    EVENT_LOOP_YIELD_THRESHOLD_MS: number
 }
 
 export interface CleanupResources {
@@ -68,6 +70,7 @@ export class ServerLifecycle {
     constructor(private config: BaseServerConfig) {
         this.expressApp = setupExpressApp({ internalApiSecret: this.config.INTERNAL_API_SECRET })
         this.nodeInstrumentation = new NodeInstrumentation(this.config.INSTRUMENT_THREAD_PERFORMANCE)
+        configureEventLoopYield(this.config.EVENT_LOOP_YIELD_THRESHOLD_MS)
         this.setupContinuousProfiling()
     }
 

--- a/nodejs/src/utils/event-loop-yield.test.ts
+++ b/nodejs/src/utils/event-loop-yield.test.ts
@@ -110,8 +110,9 @@ describe('event-loop-yield', () => {
                     await yieldEventLoopIfNeeded('test', () => busyWaitMs(blockMs))
                 }
                 // 10 * 30 = 300ms total blocking. With yielding, longestDelay
-                // should be close to one block + scheduling jitter.
-                expect(longestDelay).toBeLessThan(blockMs * 3)
+                // should be close to one block + scheduling jitter. (If yielding
+                // were broken, this would be ~300ms.)
+                expect(longestDelay).toBeLessThan(blockMs * 4)
             } finally {
                 clearInterval(interval)
             }
@@ -260,8 +261,9 @@ describe('event-loop-yield', () => {
                 await yieldEach('test', items, () => busyWaitMs(blockMs))
 
                 // 10 * 30 = 300ms total blocking. With yielding, longestDelay
-                // should be close to one block + a little jitter.
-                expect(longestDelay).toBeLessThan(blockMs * 3)
+                // should be close to one block + a little jitter. (If yielding
+                // were broken, this would be ~300ms.)
+                expect(longestDelay).toBeLessThan(blockMs * 4)
             } finally {
                 clearInterval(interval)
             }

--- a/nodejs/src/utils/event-loop-yield.test.ts
+++ b/nodejs/src/utils/event-loop-yield.test.ts
@@ -1,4 +1,9 @@
-import { configureEventLoopYield, getEventLoopYieldThresholdMs, yieldEventLoopIfNeeded } from './event-loop-yield'
+import {
+    configureEventLoopYield,
+    getEventLoopYieldThresholdMs,
+    yieldEach,
+    yieldEventLoopIfNeeded,
+} from './event-loop-yield'
 
 function busyWaitMs(ms: number): void {
     const start = performance.now()
@@ -186,6 +191,88 @@ describe('event-loop-yield', () => {
             // Fast caller does no sync work — at least one call must have
             // returned false.
             expect(fast.some((r) => r === false)).toBe(true)
+        })
+    })
+
+    describe('yieldEach', () => {
+        it('calls fn for every item in order with the right index', async () => {
+            const items = ['a', 'b', 'c', 'd']
+            const seen: Array<[string, number]> = []
+            await yieldEach('test', items, (item, i) => {
+                seen.push([item, i])
+            })
+            expect(seen).toEqual([
+                ['a', 0],
+                ['b', 1],
+                ['c', 2],
+                ['d', 3],
+            ])
+        })
+
+        it('awaits async fn before moving on', async () => {
+            const order: string[] = []
+            await yieldEach('test', [1, 2, 3], async (item) => {
+                order.push(`start-${item}`)
+                await new Promise((resolve) => setTimeout(resolve, 0))
+                order.push(`end-${item}`)
+            })
+            expect(order).toEqual(['start-1', 'end-1', 'start-2', 'end-2', 'start-3', 'end-3'])
+        })
+
+        it('actually yields the event loop during a CPU-bound batch', async () => {
+            // Without yielding, longestDelay would equal the full batch wall time.
+            configureEventLoopYield(20)
+
+            let longestDelay = 0
+            let lastTick = performance.now()
+            const interval = setInterval(() => {
+                const now = performance.now()
+                longestDelay = Math.max(longestDelay, now - lastTick)
+                lastTick = now
+            }, 0)
+
+            try {
+                const blockMs = 30
+                const items = Array.from({ length: 10 }, (_, i) => i)
+                await yieldEach('test', items, () => busyWaitMs(blockMs))
+
+                // 10 * 30 = 300ms total blocking. With yielding, longestDelay
+                // should be close to one block + a little jitter.
+                expect(longestDelay).toBeLessThan(blockMs * 3)
+            } finally {
+                clearInterval(interval)
+            }
+        })
+
+        it('works on ArrayLike values, not just real arrays', async () => {
+            const arrayLike: ArrayLike<string> = { 0: 'x', 1: 'y', 2: 'z', length: 3 }
+            const seen: string[] = []
+            await yieldEach('test', arrayLike, (item) => {
+                seen.push(item)
+            })
+            expect(seen).toEqual(['x', 'y', 'z'])
+        })
+
+        it('passes the threshold override through to yieldEventLoopIfNeeded', async () => {
+            // Default threshold high; per-call override low. Without the override,
+            // longestDelay would be huge because we'd never yield.
+            configureEventLoopYield(10_000)
+
+            let longestDelay = 0
+            let lastTick = performance.now()
+            const interval = setInterval(() => {
+                const now = performance.now()
+                longestDelay = Math.max(longestDelay, now - lastTick)
+                lastTick = now
+            }, 0)
+
+            try {
+                const items = Array.from({ length: 10 }, (_, i) => i)
+                await yieldEach('test', items, () => busyWaitMs(30), { thresholdMs: 20 })
+                expect(longestDelay).toBeLessThan(120)
+            } finally {
+                clearInterval(interval)
+            }
         })
     })
 })

--- a/nodejs/src/utils/event-loop-yield.test.ts
+++ b/nodejs/src/utils/event-loop-yield.test.ts
@@ -1,0 +1,191 @@
+import { configureEventLoopYield, getEventLoopYieldThresholdMs, yieldEventLoopIfNeeded } from './event-loop-yield'
+
+function busyWaitMs(ms: number): void {
+    const start = performance.now()
+    while (performance.now() - start < ms) {
+        // spin — the whole point is to block the event loop
+    }
+}
+
+describe('event-loop-yield', () => {
+    let originalThreshold: number
+
+    beforeEach(() => {
+        jest.useRealTimers()
+        originalThreshold = getEventLoopYieldThresholdMs()
+    })
+
+    afterEach(async () => {
+        configureEventLoopYield(originalThreshold)
+        // Drain the singleton state — any in-flight setTimeout(0) needs to fire so
+        // the next test starts with a fresh state.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    describe('configuration', () => {
+        it('uses the configured default threshold', () => {
+            configureEventLoopYield(123)
+            expect(getEventLoopYieldThresholdMs()).toBe(123)
+        })
+    })
+
+    describe('single caller', () => {
+        it('returns false when nothing has accumulated yet', async () => {
+            configureEventLoopYield(100)
+            const result = await yieldEventLoopIfNeeded('test')
+            expect(result).toBe(false)
+        })
+
+        it('returns true once accumulated sync work crosses the threshold', async () => {
+            configureEventLoopYield(20)
+            await yieldEventLoopIfNeeded('test') // primes the shared state
+            busyWaitMs(40)
+            const result = await yieldEventLoopIfNeeded('test')
+            expect(result).toBe(true)
+        })
+
+        it('honors a per-call thresholdMs override below the default', async () => {
+            configureEventLoopYield(10_000)
+            await yieldEventLoopIfNeeded('test')
+            busyWaitMs(40)
+            const result = await yieldEventLoopIfNeeded('test', { thresholdMs: 20 })
+            expect(result).toBe(true)
+        })
+
+        it('honors a per-call thresholdMs override above the default', async () => {
+            configureEventLoopYield(5)
+            await yieldEventLoopIfNeeded('test')
+            busyWaitMs(20)
+            const result = await yieldEventLoopIfNeeded('test', { thresholdMs: 10_000 })
+            expect(result).toBe(false)
+        })
+
+        it('resets accumulated time after a yield so the next call starts fresh', async () => {
+            configureEventLoopYield(20)
+            await yieldEventLoopIfNeeded('test')
+            busyWaitMs(40)
+            const yielded = await yieldEventLoopIfNeeded('test')
+            expect(yielded).toBe(true)
+            // Right after yielding, a fresh call should be under the threshold again.
+            const next = await yieldEventLoopIfNeeded('test')
+            expect(next).toBe(false)
+        })
+    })
+
+    describe('parallel callers', () => {
+        it('shares accumulated time across callers', async () => {
+            configureEventLoopYield(20)
+            // Two callers prime the shared state at roughly the same moment.
+            const [first, second] = await Promise.all([
+                yieldEventLoopIfNeeded('caller-a'),
+                yieldEventLoopIfNeeded('caller-b'),
+            ])
+            // Both saw essentially zero blocked time, both return false.
+            expect([first, second]).toEqual([false, false])
+
+            // Block past the threshold synchronously — neither caller has yielded yet.
+            busyWaitMs(40)
+
+            // Now both cross the threshold against the same shared state.
+            const [third, fourth] = await Promise.all([
+                yieldEventLoopIfNeeded('caller-a'),
+                yieldEventLoopIfNeeded('caller-b'),
+            ])
+            expect([third, fourth]).toEqual([true, true])
+        })
+
+        it('resolves all queued waiters together when the macrotask fires', async () => {
+            configureEventLoopYield(10)
+            await yieldEventLoopIfNeeded('warmup')
+            busyWaitMs(30)
+
+            // Five parallel callers all cross the threshold against the same
+            // state.promise. When setTimeout(0) fires, they should all resolve.
+            const results = await Promise.all([
+                yieldEventLoopIfNeeded('a'),
+                yieldEventLoopIfNeeded('b'),
+                yieldEventLoopIfNeeded('c'),
+                yieldEventLoopIfNeeded('d'),
+                yieldEventLoopIfNeeded('e'),
+            ])
+            expect(results).toEqual([true, true, true, true, true])
+        })
+
+        it('keeps a setInterval making progress while two parallel workers are busy', async () => {
+            // Simulate two parallel producers doing batches of sync work in a tight
+            // async loop, and make sure a setInterval observer keeps getting ticks
+            // instead of being starved for the full duration of the work.
+            configureEventLoopYield(30)
+
+            const blockMs = 40
+            const iterations = 5
+            const workers = 2
+            const totalBlockingWork = blockMs * iterations * workers // = 400ms
+
+            let longestDelay = 0
+            let intervalTickCount = 0
+            let lastTick = performance.now()
+            const interval = setInterval(() => {
+                const now = performance.now()
+                longestDelay = Math.max(longestDelay, now - lastTick)
+                lastTick = now
+                intervalTickCount += 1
+            }, 0)
+
+            try {
+                const worker = async (id: string) => {
+                    for (let i = 0; i < iterations; i++) {
+                        busyWaitMs(blockMs)
+                        await yieldEventLoopIfNeeded(id)
+                    }
+                }
+                await Promise.all([worker('worker-a'), worker('worker-b')])
+            } finally {
+                clearInterval(interval)
+            }
+
+            // If yielding were broken, the interval would be starved for the
+            // entire 400ms of blocking work. With yielding, longestDelay should
+            // be bounded by a small multiple of (blockMs + threshold).
+            expect(longestDelay).toBeLessThan(totalBlockingWork / 2)
+            // And we should have actually observed multiple interval ticks
+            // during the work (otherwise we don't really know yielding happened).
+            expect(intervalTickCount).toBeGreaterThan(2)
+        })
+
+        it('does not unconditionally yield — fast callers below the threshold still return false', async () => {
+            // A caller that does no sync work should normally return false. Even
+            // when it shares state with a slow caller that does yield, fast
+            // callers should at least sometimes get a false back (proving the
+            // helper isn't degenerating into "always yield").
+            configureEventLoopYield(20)
+
+            const slowCaller = async (): Promise<boolean[]> => {
+                const results: boolean[] = []
+                for (let i = 0; i < 3; i++) {
+                    busyWaitMs(40)
+                    results.push(await yieldEventLoopIfNeeded('slow'))
+                }
+                return results
+            }
+
+            const fastCaller = async (): Promise<boolean[]> => {
+                const results: boolean[] = []
+                for (let i = 0; i < 6; i++) {
+                    // No sync work — just keeps polling.
+                    results.push(await yieldEventLoopIfNeeded('fast'))
+                }
+                return results
+            }
+
+            const [slow, fast] = await Promise.all([slowCaller(), fastCaller()])
+
+            // Slow caller does 40ms sync blocks against a 20ms threshold, so at
+            // least one of its calls must have yielded.
+            expect(slow.some((r) => r)).toBe(true)
+            // Fast caller does no sync work — at least one call must have
+            // returned false.
+            expect(fast.some((r) => r === false)).toBe(true)
+        })
+    })
+})

--- a/nodejs/src/utils/event-loop-yield.test.ts
+++ b/nodejs/src/utils/event-loop-yield.test.ts
@@ -1,3 +1,5 @@
+import { Counter, register } from 'prom-client'
+
 import {
     configureEventLoopYield,
     getEventLoopYieldThresholdMs,
@@ -12,6 +14,16 @@ function busyWaitMs(ms: number): void {
     }
 }
 
+async function getYieldCount(caller: string, waited: 'true' | 'false'): Promise<number> {
+    const metric = register.getSingleMetric('event_loop_yield_total') as Counter | undefined
+    if (!metric) {
+        return 0
+    }
+    const data = await metric.get()
+    const sample = data.values.find((v) => v.labels.caller === caller && v.labels.waited === waited)
+    return sample?.value ?? 0
+}
+
 describe('event-loop-yield', () => {
     let originalThreshold: number
 
@@ -22,8 +34,8 @@ describe('event-loop-yield', () => {
 
     afterEach(async () => {
         configureEventLoopYield(originalThreshold)
-        // Drain the singleton state — any in-flight setTimeout(0) needs to fire so
-        // the next test starts with a fresh state.
+        // Drain the singleton state — any in-flight setTimeout(0) needs to fire
+        // so the next test starts with a fresh state.
         await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
@@ -34,92 +46,82 @@ describe('event-loop-yield', () => {
         })
     })
 
-    describe('single caller', () => {
-        it('returns false when nothing has accumulated yet', async () => {
-            configureEventLoopYield(100)
-            const result = await yieldEventLoopIfNeeded('test')
-            expect(result).toBe(false)
+    describe('yieldEventLoopIfNeeded', () => {
+        it('returns the wrapped function result', async () => {
+            const result = await yieldEventLoopIfNeeded('test', () => 42)
+            expect(result).toBe(42)
         })
 
-        it('returns true once accumulated sync work crosses the threshold', async () => {
+        it('awaits an async wrapped function', async () => {
+            const result = await yieldEventLoopIfNeeded('test', async () => {
+                await new Promise((resolve) => setTimeout(resolve, 0))
+                return 'ok'
+            })
+            expect(result).toBe('ok')
+        })
+
+        it('still yields if the wrapped function throws', async () => {
             configureEventLoopYield(20)
-            await yieldEventLoopIfNeeded('test') // primes the shared state
-            busyWaitMs(40)
-            const result = await yieldEventLoopIfNeeded('test')
-            expect(result).toBe(true)
+            // Prime accumulated state so the next call's after-yield trips the threshold.
+            await yieldEventLoopIfNeeded('test', () => busyWaitMs(40))
+            const before = await getYieldCount('test', 'true')
+            await expect(
+                yieldEventLoopIfNeeded('test', () => {
+                    busyWaitMs(40)
+                    throw new Error('boom')
+                })
+            ).rejects.toThrow('boom')
+            const after = await getYieldCount('test', 'true')
+            // The wrapper should have yielded at least once even though fn threw.
+            expect(after).toBeGreaterThan(before)
         })
 
-        it('honors a per-call thresholdMs override below the default', async () => {
+        it('does not actually yield when accumulated work is below the threshold', async () => {
             configureEventLoopYield(10_000)
-            await yieldEventLoopIfNeeded('test')
-            busyWaitMs(40)
-            const result = await yieldEventLoopIfNeeded('test', { thresholdMs: 20 })
-            expect(result).toBe(true)
+            const before = await getYieldCount('test', 'true')
+            await yieldEventLoopIfNeeded('test', () => busyWaitMs(20))
+            const after = await getYieldCount('test', 'true')
+            expect(after - before).toBe(0)
         })
 
-        it('honors a per-call thresholdMs override above the default', async () => {
-            configureEventLoopYield(5)
-            await yieldEventLoopIfNeeded('test')
-            busyWaitMs(20)
-            const result = await yieldEventLoopIfNeeded('test', { thresholdMs: 10_000 })
-            expect(result).toBe(false)
-        })
-
-        it('resets accumulated time after a yield so the next call starts fresh', async () => {
+        it('actually yields when accumulated work crosses the threshold', async () => {
             configureEventLoopYield(20)
-            await yieldEventLoopIfNeeded('test')
-            busyWaitMs(40)
-            const yielded = await yieldEventLoopIfNeeded('test')
-            expect(yielded).toBe(true)
-            // Right after yielding, a fresh call should be under the threshold again.
-            const next = await yieldEventLoopIfNeeded('test')
-            expect(next).toBe(false)
+            const before = await getYieldCount('test', 'true')
+            await yieldEventLoopIfNeeded('test', () => busyWaitMs(40))
+            const after = await getYieldCount('test', 'true')
+            // Either the before- or after-yield should have crossed the threshold.
+            expect(after - before).toBeGreaterThan(0)
+        })
+
+        it('does not block the loop across many CPU-bound calls', async () => {
+            configureEventLoopYield(20)
+
+            let longestDelay = 0
+            let lastTick = performance.now()
+            const interval = setInterval(() => {
+                const now = performance.now()
+                longestDelay = Math.max(longestDelay, now - lastTick)
+                lastTick = now
+            }, 0)
+
+            try {
+                const blockMs = 30
+                for (let i = 0; i < 10; i++) {
+                    await yieldEventLoopIfNeeded('test', () => busyWaitMs(blockMs))
+                }
+                // 10 * 30 = 300ms total blocking. With yielding, longestDelay
+                // should be close to one block + scheduling jitter.
+                expect(longestDelay).toBeLessThan(blockMs * 3)
+            } finally {
+                clearInterval(interval)
+            }
         })
     })
 
     describe('parallel callers', () => {
-        it('shares accumulated time across callers', async () => {
-            configureEventLoopYield(20)
-            // Two callers prime the shared state at roughly the same moment.
-            const [first, second] = await Promise.all([
-                yieldEventLoopIfNeeded('caller-a'),
-                yieldEventLoopIfNeeded('caller-b'),
-            ])
-            // Both saw essentially zero blocked time, both return false.
-            expect([first, second]).toEqual([false, false])
-
-            // Block past the threshold synchronously — neither caller has yielded yet.
-            busyWaitMs(40)
-
-            // Now both cross the threshold against the same shared state.
-            const [third, fourth] = await Promise.all([
-                yieldEventLoopIfNeeded('caller-a'),
-                yieldEventLoopIfNeeded('caller-b'),
-            ])
-            expect([third, fourth]).toEqual([true, true])
-        })
-
-        it('resolves all queued waiters together when the macrotask fires', async () => {
-            configureEventLoopYield(10)
-            await yieldEventLoopIfNeeded('warmup')
-            busyWaitMs(30)
-
-            // Five parallel callers all cross the threshold against the same
-            // state.promise. When setTimeout(0) fires, they should all resolve.
-            const results = await Promise.all([
-                yieldEventLoopIfNeeded('a'),
-                yieldEventLoopIfNeeded('b'),
-                yieldEventLoopIfNeeded('c'),
-                yieldEventLoopIfNeeded('d'),
-                yieldEventLoopIfNeeded('e'),
-            ])
-            expect(results).toEqual([true, true, true, true, true])
-        })
-
         it('keeps a setInterval making progress while two parallel workers are busy', async () => {
-            // Simulate two parallel producers doing batches of sync work in a tight
-            // async loop, and make sure a setInterval observer keeps getting ticks
-            // instead of being starved for the full duration of the work.
+            // Two parallel producers in tight async loops. Without yielding, the
+            // setInterval observer would be starved for the full duration.
             configureEventLoopYield(30)
 
             const blockMs = 40
@@ -140,8 +142,7 @@ describe('event-loop-yield', () => {
             try {
                 const worker = async (id: string) => {
                     for (let i = 0; i < iterations; i++) {
-                        busyWaitMs(blockMs)
-                        await yieldEventLoopIfNeeded(id)
+                        await yieldEventLoopIfNeeded(id, () => busyWaitMs(blockMs))
                     }
                 }
                 await Promise.all([worker('worker-a'), worker('worker-b')])
@@ -149,48 +150,70 @@ describe('event-loop-yield', () => {
                 clearInterval(interval)
             }
 
-            // If yielding were broken, the interval would be starved for the
-            // entire 400ms of blocking work. With yielding, longestDelay should
-            // be bounded by a small multiple of (blockMs + threshold).
             expect(longestDelay).toBeLessThan(totalBlockingWork / 2)
-            // And we should have actually observed multiple interval ticks
-            // during the work (otherwise we don't really know yielding happened).
-            expect(intervalTickCount).toBeGreaterThan(2)
+            // We should have observed at least one interval tick fire while the
+            // workers were busy (otherwise we don't know yielding actually happened).
+            expect(intervalTickCount).toBeGreaterThan(1)
         })
 
-        it('does not unconditionally yield — fast callers below the threshold still return false', async () => {
-            // A caller that does no sync work should normally return false. Even
-            // when it shares state with a slow caller that does yield, fast
-            // callers should at least sometimes get a false back (proving the
-            // helper isn't degenerating into "always yield").
+        it('serialized callers via promise chain keep the loop unblocked', async () => {
+            // To prove the helper actually protects the loop end-to-end (matching
+            // hog-exec.test.ts's longestDelay bound), callers must be serialized
+            // so the setTimeout(0) macrotask can fire between them.
+            const blockMs = 100
+            const numberOfCallers = 10
+            configureEventLoopYield(blockMs)
+
+            let longestDelay = 0
+            let lastTick = performance.now()
+            const interval = setInterval(() => {
+                const now = performance.now()
+                longestDelay = Math.max(longestDelay, now - lastTick)
+                lastTick = now
+            }, 0)
+
+            try {
+                let chain: Promise<void> = Promise.resolve()
+                for (let i = 0; i < numberOfCallers; i++) {
+                    chain = chain.then(() => yieldEventLoopIfNeeded(`caller-${i}`, () => busyWaitMs(blockMs)))
+                }
+                await chain
+                await new Promise((resolve) => setTimeout(resolve, 1))
+                // With serialization, the setTimeout fires between each block,
+                // so longestDelay should be ~ one block + scheduling jitter.
+                expect(longestDelay).toBeLessThan(blockMs * 2.5)
+            } finally {
+                clearInterval(interval)
+            }
+        })
+
+        it('does not unconditionally yield — fast callers below the threshold do not yield', async () => {
+            // A caller that does no sync work should not yield (most of the
+            // time). Even when sharing state with a slow caller that does yield,
+            // fast callers should mostly count as "not waited".
             configureEventLoopYield(20)
 
-            const slowCaller = async (): Promise<boolean[]> => {
-                const results: boolean[] = []
+            const slowCaller = async (): Promise<void> => {
                 for (let i = 0; i < 3; i++) {
-                    busyWaitMs(40)
-                    results.push(await yieldEventLoopIfNeeded('slow'))
+                    await yieldEventLoopIfNeeded('slow', () => busyWaitMs(40))
                 }
-                return results
             }
-
-            const fastCaller = async (): Promise<boolean[]> => {
-                const results: boolean[] = []
+            const fastCaller = async (): Promise<void> => {
                 for (let i = 0; i < 6; i++) {
-                    // No sync work — just keeps polling.
-                    results.push(await yieldEventLoopIfNeeded('fast'))
+                    await yieldEventLoopIfNeeded('fast', () => {})
                 }
-                return results
             }
 
-            const [slow, fast] = await Promise.all([slowCaller(), fastCaller()])
+            const beforeSlowWaited = await getYieldCount('slow', 'true')
+            const beforeFastNot = await getYieldCount('fast', 'false')
+            await Promise.all([slowCaller(), fastCaller()])
+            const afterSlowWaited = await getYieldCount('slow', 'true')
+            const afterFastNot = await getYieldCount('fast', 'false')
 
-            // Slow caller does 40ms sync blocks against a 20ms threshold, so at
-            // least one of its calls must have yielded.
-            expect(slow.some((r) => r)).toBe(true)
-            // Fast caller does no sync work — at least one call must have
-            // returned false.
-            expect(fast.some((r) => r === false)).toBe(true)
+            // At least one slow call must have yielded.
+            expect(afterSlowWaited - beforeSlowWaited).toBeGreaterThan(0)
+            // At least one fast call must NOT have yielded.
+            expect(afterFastNot - beforeFastNot).toBeGreaterThan(0)
         })
     })
 
@@ -253,26 +276,12 @@ describe('event-loop-yield', () => {
             expect(seen).toEqual(['x', 'y', 'z'])
         })
 
-        it('passes the threshold override through to yieldEventLoopIfNeeded', async () => {
-            // Default threshold high; per-call override low. Without the override,
-            // longestDelay would be huge because we'd never yield.
-            configureEventLoopYield(10_000)
-
-            let longestDelay = 0
-            let lastTick = performance.now()
-            const interval = setInterval(() => {
-                const now = performance.now()
-                longestDelay = Math.max(longestDelay, now - lastTick)
-                lastTick = now
-            }, 0)
-
-            try {
-                const items = Array.from({ length: 10 }, (_, i) => i)
-                await yieldEach('test', items, () => busyWaitMs(30), { thresholdMs: 20 })
-                expect(longestDelay).toBeLessThan(120)
-            } finally {
-                clearInterval(interval)
-            }
+        it('handles empty arrays gracefully', async () => {
+            const seen: string[] = []
+            await yieldEach('test', [], (item) => {
+                seen.push(item as string)
+            })
+            expect(seen).toEqual([])
         })
     })
 })

--- a/nodejs/src/utils/event-loop-yield.ts
+++ b/nodejs/src/utils/event-loop-yield.ts
@@ -1,0 +1,68 @@
+import { Counter, Histogram } from 'prom-client'
+
+const DEFAULT_THRESHOLD_MS = 200
+
+let defaultThresholdMs = DEFAULT_THRESHOLD_MS
+
+let state: {
+    startedAt: number
+    promise: Promise<void>
+} | null = null
+
+const eventLoopYieldCounter = new Counter({
+    name: 'event_loop_yield_total',
+    help: 'Total calls to yieldEventLoopIfNeeded, labelled by caller and whether the call actually yielded',
+    labelNames: ['caller', 'waited'],
+})
+
+const eventLoopYieldBlockedMs = new Histogram({
+    name: 'event_loop_yield_blocked_duration_ms',
+    help: 'How long the event loop went without yielding before yieldEventLoopIfNeeded forced a yield',
+    labelNames: ['caller'],
+    buckets: [50, 100, 200, 500, 1000, 2500, 5000, 10000],
+})
+
+const eventLoopYieldWaitMs = new Histogram({
+    name: 'event_loop_yield_wait_duration_ms',
+    help: 'How long the await for setTimeout(0) actually took to resolve once yieldEventLoopIfNeeded forced a yield',
+    labelNames: ['caller'],
+    buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500],
+})
+
+export function configureEventLoopYield(thresholdMs: number): void {
+    defaultThresholdMs = thresholdMs
+}
+
+export function getEventLoopYieldThresholdMs(): number {
+    return defaultThresholdMs
+}
+
+export async function yieldEventLoopIfNeeded(caller: string, options?: { thresholdMs?: number }): Promise<boolean> {
+    const threshold = options?.thresholdMs ?? defaultThresholdMs
+
+    if (!state) {
+        state = {
+            startedAt: performance.now(),
+            promise: new Promise((resolve) => {
+                setTimeout(() => {
+                    state = null
+                    resolve()
+                }, 0)
+            }),
+        }
+    }
+
+    const blockedFor = performance.now() - state.startedAt
+    if (blockedFor < threshold) {
+        eventLoopYieldCounter.inc({ caller, waited: 'false' })
+        return false
+    }
+
+    eventLoopYieldBlockedMs.observe({ caller }, blockedFor)
+
+    const awaitStartedAt = performance.now()
+    await state.promise
+    eventLoopYieldWaitMs.observe({ caller }, performance.now() - awaitStartedAt)
+    eventLoopYieldCounter.inc({ caller, waited: 'true' })
+    return true
+}

--- a/nodejs/src/utils/event-loop-yield.ts
+++ b/nodejs/src/utils/event-loop-yield.ts
@@ -42,10 +42,10 @@ async function yieldIfNeeded(caller: string): Promise<void> {
         state = {
             startedAt: performance.now(),
             promise: new Promise((resolve) => {
-                setTimeout(() => {
+                setImmediate(() => {
                     state = null
                     resolve()
-                }, 0)
+                })
             }),
         }
     }

--- a/nodejs/src/utils/event-loop-yield.ts
+++ b/nodejs/src/utils/event-loop-yield.ts
@@ -93,7 +93,10 @@ export async function yieldEach<T>(
     }
     await yieldIfNeeded(caller)
     for (let i = 0; i < items.length; i++) {
-        await fn(items[i], i)
-        await yieldIfNeeded(caller)
+        try {
+            await fn(items[i], i)
+        } finally {
+            await yieldIfNeeded(caller)
+        }
     }
 }

--- a/nodejs/src/utils/event-loop-yield.ts
+++ b/nodejs/src/utils/event-loop-yield.ts
@@ -66,3 +66,20 @@ export async function yieldEventLoopIfNeeded(caller: string, options?: { thresho
     eventLoopYieldCounter.inc({ caller, waited: 'true' })
     return true
 }
+
+/**
+ * Iterate `items`, calling `fn(item, index)` for each, with a
+ * `yieldEventLoopIfNeeded` between iterations. Use this anywhere you'd write a
+ * `for ... of` over a CPU-bound batch.
+ */
+export async function yieldEach<T>(
+    caller: string,
+    items: ArrayLike<T>,
+    fn: (item: T, index: number) => void | Promise<void>,
+    options?: { thresholdMs?: number }
+): Promise<void> {
+    for (let i = 0; i < items.length; i++) {
+        await fn(items[i], i)
+        await yieldEventLoopIfNeeded(caller, options)
+    }
+}

--- a/nodejs/src/utils/event-loop-yield.ts
+++ b/nodejs/src/utils/event-loop-yield.ts
@@ -37,9 +37,7 @@ export function getEventLoopYieldThresholdMs(): number {
     return defaultThresholdMs
 }
 
-export async function yieldEventLoopIfNeeded(caller: string, options?: { thresholdMs?: number }): Promise<boolean> {
-    const threshold = options?.thresholdMs ?? defaultThresholdMs
-
+async function yieldIfNeeded(caller: string): Promise<void> {
     if (!state) {
         state = {
             startedAt: performance.now(),
@@ -53,9 +51,9 @@ export async function yieldEventLoopIfNeeded(caller: string, options?: { thresho
     }
 
     const blockedFor = performance.now() - state.startedAt
-    if (blockedFor < threshold) {
+    if (blockedFor < defaultThresholdMs) {
         eventLoopYieldCounter.inc({ caller, waited: 'false' })
-        return false
+        return
     }
 
     eventLoopYieldBlockedMs.observe({ caller }, blockedFor)
@@ -64,22 +62,38 @@ export async function yieldEventLoopIfNeeded(caller: string, options?: { thresho
     await state.promise
     eventLoopYieldWaitMs.observe({ caller }, performance.now() - awaitStartedAt)
     eventLoopYieldCounter.inc({ caller, waited: 'true' })
-    return true
 }
 
 /**
- * Iterate `items`, calling `fn(item, index)` for each, with a
- * `yieldEventLoopIfNeeded` between iterations. Use this anywhere you'd write a
- * `for ... of` over a CPU-bound batch.
+ * Run `fn` with event-loop protection: yields before `fn` to ensure any
+ * accumulated sync work from earlier callers is accounted for, and yields
+ * after `fn` (regardless of whether it resolved or threw). The before-yield
+ * also primes the shared state so `fn`'s own runtime accumulates into it.
+ */
+export async function yieldEventLoopIfNeeded<T>(caller: string, fn: () => T | Promise<T>): Promise<T> {
+    await yieldIfNeeded(caller)
+    try {
+        return await fn()
+    } finally {
+        await yieldIfNeeded(caller)
+    }
+}
+
+/**
+ * Iterate `items`, calling `fn(item, index)` for each, with a yield between
+ * iterations. Use this anywhere you'd write a `for ... of` over a CPU-bound batch.
  */
 export async function yieldEach<T>(
     caller: string,
     items: ArrayLike<T>,
-    fn: (item: T, index: number) => void | Promise<void>,
-    options?: { thresholdMs?: number }
+    fn: (item: T, index: number) => void | Promise<void>
 ): Promise<void> {
+    if (items.length === 0) {
+        return
+    }
+    await yieldIfNeeded(caller)
     for (let i = 0; i < items.length; i++) {
         await fn(items[i], i)
-        await yieldEventLoopIfNeeded(caller, options)
+        await yieldIfNeeded(caller)
     }
 }

--- a/nodejs/src/utils/event-loop-yield.ts
+++ b/nodejs/src/utils/event-loop-yield.ts
@@ -42,10 +42,10 @@ async function yieldIfNeeded(caller: string): Promise<void> {
         state = {
             startedAt: performance.now(),
             promise: new Promise((resolve) => {
-                setImmediate(() => {
+                setTimeout(() => {
                     state = null
                     resolve()
-                })
+                }, 0)
             }),
         }
     }


### PR DESCRIPTION
## Problem

Have a sneaking suspicion that some of our more cpu heavy workloads are blocking the event loop to an extent that it causes other callback issues

## Changes
- Adds a new event loop yield which we can add to any looping code to ensure we dont block for too long
- Removes some dead old heartbeat code that did nothing
- Moves some precalc stuff to the yielder to help where I believe we maybe throttling the consumer loop

## How did you test this code?

Tests!

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

 No