### PR TITLE
fix(phrocs): use truecolor for sidebar selection bg

### DIFF
--- a/tools/phrocs/internal/palette/palette.go
+++ b/tools/phrocs/internal/palette/palette.go
@@ -35,14 +35,21 @@ var (
 	ColorMagenta       color.Color = lipgloss.Magenta                                   // ANSI 5: (unused)
 	ColorCyan          color.Color = lipgloss.Cyan                                      // ANSI 6: (unused)
 	ColorWhite         color.Color = lipgloss.White                                     // ANSI 7: secondary text, inactive items
-	ColorBrightBlack   color.Color = brightOr(lipgloss.BrightBlack, lipgloss.Black)     // ANSI 8: selection background (dark)
+	ColorBrightBlack   color.Color = brightOr(lipgloss.BrightBlack, lipgloss.Black)     // ANSI 8: subtle text/borders (dark)
 	ColorBrightRed     color.Color = brightOr(lipgloss.BrightRed, lipgloss.Red)         // ANSI 9: (unused)
 	ColorBrightGreen   color.Color = brightOr(lipgloss.BrightGreen, lipgloss.Green)     // ANSI 10: (unused)
 	ColorBrightYellow  color.Color = brightOr(lipgloss.BrightYellow, lipgloss.Yellow)   // ANSI 11: (unused)
 	ColorBrightBlue    color.Color = brightOr(lipgloss.BrightBlue, lipgloss.Blue)       // ANSI 12: (unused)
 	ColorBrightMagenta color.Color = brightOr(lipgloss.BrightMagenta, lipgloss.Magenta) // ANSI 13: (unused)
 	ColorBrightCyan    color.Color = brightOr(lipgloss.BrightCyan, lipgloss.Cyan)       // ANSI 14: (unused)
-	ColorBrightWhite   color.Color = brightOr(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: selection background (light)
+	ColorBrightWhite   color.Color = brightOr(lipgloss.BrightWhite, lipgloss.White)     // ANSI 15: subtle text/borders (light)
+
+	// Selection backgrounds use explicit RGB to dodge the Cursor terminal's
+	// SGR 100-107 (bright background) rendering bug — the regular-variant
+	// fallback above is invisible against typical dark/light terminal bgs,
+	// and TrueColor (SGR 48;2;r;g;b) is unaffected by the bug.
+	SelectionBgDark  color.Color = lipgloss.Color("#3a3a3a")
+	SelectionBgLight color.Color = lipgloss.Color("#d4d4d4")
 )
 
 const (

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -30,6 +30,8 @@ var (
 	colorBrightWhite  = sharedpalette.ColorBrightWhite
 	colorBrightBlack  = sharedpalette.ColorBrightBlack
 	colorBrightYellow = sharedpalette.ColorBrightYellow
+	selectionBgDark   = sharedpalette.SelectionBgDark
+	selectionBgLight  = sharedpalette.SelectionBgLight
 	brandYellow       = sharedpalette.BrandYellow
 	brandBlue         = sharedpalette.BrandBlue
 	brandRed          = sharedpalette.BrandRed
@@ -169,6 +171,16 @@ func subtleBg(isDark bool) color.Color {
 	return colorBrightWhite
 }
 
+// Selection fill color for highlighted rows. Uses TrueColor RGB rather than
+// ANSI bright black/white so it renders consistently in Cursor's terminal,
+// where SGR 100-107 bright background codes are buggy.
+func selectionBg(isDark bool) color.Color {
+	if isDark {
+		return selectionBgDark
+	}
+	return selectionBgLight
+}
+
 // borderFor returns the border style with a foreground appropriate for the
 // current terminal background.
 func borderFor(isDark, focused bool) lipgloss.Style {
@@ -192,7 +204,7 @@ type sidebarRow struct {
 
 func renderSidebarRow(r sidebarRow) string {
 	nameW := max(r.innerW-2, 0) // 1 padding + 1 icon
-	selBg := subtleBg(r.isDark)
+	selBg := selectionBg(r.isDark)
 
 	iconStyle := lipgloss.NewStyle().PaddingLeft(1).Foreground(r.iconColor)
 	if r.selected {


### PR DESCRIPTION
## Problem

The Cursor terminal has a rendering bug with SGR 100-107 (ANSI bright background codes), causing selection backgrounds to render incorrectly. The current implementation uses `ColorBrightBlack` and `ColorBrightWhite` for selection backgrounds, which are invisible against typical dark/light terminal backgrounds in Cursor.

## Changes

- Added explicit RGB color definitions (`SelectionBgDark` and `SelectionBgLight`) to the palette that use TrueColor (SGR 48;2;r;g;b) instead of ANSI bright background codes
- Created a new `selectionBg()` function in styles.go that returns the appropriate selection background color based on terminal theme
- Updated `renderSidebarRow()` to use `selectionBg()` instead of `subtleBg()` for row selection highlighting
- Updated palette comments to clarify that `ColorBrightBlack` and `ColorBrightWhite` are now used for subtle text/borders, not selection backgrounds

The TrueColor approach is unaffected by the Cursor terminal's SGR 100-107 bug and renders consistently across different terminal backgrounds.

## How did you test this code?

No testing needed — this is a straightforward color constant addition and function refactor. The change is isolated to UI styling and will be visually verified during normal usage.

## Publish to changelog?

No

https://claude.ai/code/session_01PyVSwKboQBeq8Zs3Wg5o1w