### PR TITLE
feat(llma): per-team strip-heavy AI event splitting

### DIFF
--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -92,7 +92,7 @@ function buildPipeline(configOverrides: Partial<AiEventSubpipelineConfig> = {}) 
             updatePersonWithPropertiesDiffForUpdate: jest.fn().mockResolvedValue([existingPerson, [], false]),
         } as any,
         groupStore: {} as any,
-        splitAiEventsConfig: { enabled: false, enabledTeams: '*', stripHeavyProperties: false },
+        splitAiEventsConfig: { enabled: false, enabledTeams: '*', stripHeavyTeams: new Set() },
         groupId: 'test-group',
         topHog: (step) => step,
         ...configOverrides,

--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -92,7 +92,7 @@ function buildPipeline(configOverrides: Partial<AiEventSubpipelineConfig> = {}) 
             updatePersonWithPropertiesDiffForUpdate: jest.fn().mockResolvedValue([existingPerson, [], false]),
         } as any,
         groupStore: {} as any,
-        splitAiEventsConfig: { enabled: false, enabledTeams: '*', stripHeavyTeams: new Set() },
+        splitAiEventsConfig: { enabled: false, enabledTeams: '*', stripHeavyTeams: [] },
         groupId: 'test-group',
         topHog: (step) => step,
         ...configOverrides,

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -160,7 +160,12 @@ export type IngestionConsumerConfig = {
     INGESTION_AI_EVENT_SPLITTING_ENABLED: boolean
     /** '*' for all teams, or comma-separated team IDs */
     INGESTION_AI_EVENT_SPLITTING_TEAMS: string
-    INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY: boolean
+    /**
+     * Teams whose events copy should have heavy AI properties stripped — i.e. the post-migration final state
+     * where heavy columns live only in the AI events table. '*' for all teams, or comma-separated team IDs.
+     * Defaults to '' (no stripping → double-write the full event for everyone).
+     */
+    INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS: string
 
     // Clickhouse topics
     CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: string
@@ -259,7 +264,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         // AI event splitting config
         INGESTION_AI_EVENT_SPLITTING_ENABLED: false,
         INGESTION_AI_EVENT_SPLITTING_TEAMS: '*',
-        INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY: false,
+        INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS: '',
 
         // Clickhouse topics
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
@@ -26,8 +26,12 @@ function createProcessedEvent(
     }
 }
 
-const ENABLED_FOR_ALL: SplitAiEventsStepConfig = { enabled: true, enabledTeams: '*', stripHeavyProperties: true }
-const ENABLED_NO_STRIP: SplitAiEventsStepConfig = { enabled: true, enabledTeams: '*', stripHeavyProperties: false }
+const ENABLED_FOR_ALL: SplitAiEventsStepConfig = { enabled: true, enabledTeams: '*', stripHeavyTeams: '*' }
+const ENABLED_NO_STRIP: SplitAiEventsStepConfig = {
+    enabled: true,
+    enabledTeams: '*',
+    stripHeavyTeams: new Set(),
+}
 
 describe('split-ai-events-step', () => {
     describe('parseSplitAiEventsConfig', () => {
@@ -35,42 +39,45 @@ describe('split-ai-events-step', () => {
             {
                 enabled: true,
                 teams: '*',
-                strip: false,
-                expected: { enabled: true, enabledTeams: '*', stripHeavyProperties: false },
+                stripTeams: '',
+                expected: { enabled: true, enabledTeams: '*', stripHeavyTeams: new Set() },
             },
             {
                 enabled: false,
                 teams: '*',
-                strip: false,
-                expected: { enabled: false, enabledTeams: '*', stripHeavyProperties: false },
+                stripTeams: '',
+                expected: { enabled: false, enabledTeams: '*', stripHeavyTeams: new Set() },
             },
             {
                 enabled: true,
                 teams: '1,2,3',
-                strip: true,
-                expected: { enabled: true, enabledTeams: new Set([1, 2, 3]), stripHeavyProperties: true },
+                stripTeams: '*',
+                expected: { enabled: true, enabledTeams: new Set([1, 2, 3]), stripHeavyTeams: '*' },
             },
             {
                 enabled: true,
                 teams: ' 1 , 2 ',
-                strip: false,
-                expected: { enabled: true, enabledTeams: new Set([1, 2]), stripHeavyProperties: false },
+                stripTeams: '2',
+                expected: { enabled: true, enabledTeams: new Set([1, 2]), stripHeavyTeams: new Set([2]) },
             },
             {
                 enabled: true,
                 teams: '',
-                strip: false,
-                expected: { enabled: true, enabledTeams: new Set(), stripHeavyProperties: false },
+                stripTeams: '',
+                expected: { enabled: true, enabledTeams: new Set(), stripHeavyTeams: new Set() },
             },
             {
                 enabled: true,
                 teams: 'abc,1',
-                strip: false,
-                expected: { enabled: true, enabledTeams: new Set([1]), stripHeavyProperties: false },
+                stripTeams: 'abc,2',
+                expected: { enabled: true, enabledTeams: new Set([1]), stripHeavyTeams: new Set([2]) },
             },
-        ])('should parse enabled=$enabled teams=$teams strip=$strip', ({ enabled, teams, strip, expected }) => {
-            expect(parseSplitAiEventsConfig(enabled, teams, strip)).toEqual(expected)
-        })
+        ])(
+            'should parse enabled=$enabled teams=$teams stripTeams=$stripTeams',
+            ({ enabled, teams, stripTeams, expected }) => {
+                expect(parseSplitAiEventsConfig(enabled, teams, stripTeams)).toEqual(expected)
+            }
+        )
     })
 
     describe('feature flag behavior', () => {
@@ -78,7 +85,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: false,
                 enabledTeams: '*',
-                stripHeavyProperties: false,
+                stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
 
@@ -96,7 +103,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
                 enabledTeams: new Set([99, 100]),
-                stripHeavyProperties: false,
+                stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input' })
 
@@ -113,7 +120,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
                 enabledTeams: new Set([1, 2]),
-                stripHeavyProperties: true,
+                stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
 
@@ -130,7 +137,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
                 enabledTeams: '*',
-                stripHeavyProperties: true,
+                stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
 
@@ -351,7 +358,7 @@ describe('split-ai-events-step', () => {
         })
     })
 
-    describe('non-stripping mode (stripHeavyProperties=false)', () => {
+    describe('non-stripping mode (stripHeavyTeams empty)', () => {
         const step = createSplitAiEventsStep(ENABLED_NO_STRIP)
 
         it('should send AI event with heavy properties unchanged to both outputs', async () => {
@@ -406,6 +413,48 @@ describe('split-ai-events-step', () => {
             expect(eventsToEmit).toHaveLength(2)
             expect(eventsToEmit[0].output).toBe(EVENTS_OUTPUT)
             expect(eventsToEmit[1].output).toBe(AI_EVENTS_OUTPUT)
+        })
+    })
+
+    describe('per-team strip allowlist', () => {
+        const step = createSplitAiEventsStep({
+            enabled: true,
+            enabledTeams: '*',
+            stripHeavyTeams: new Set([2]),
+        })
+
+        it('should strip heavy props for a team in stripHeavyTeams', async () => {
+            const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
+
+            const result = await step({ eventsToEmit: [{ event, output: EVENTS_OUTPUT }], teamId: 2 })
+            expect(isOkResult(result)).toBe(true)
+            if (!isOkResult(result)) {
+                return
+            }
+
+            const { eventsToEmit } = result.value
+            expect(eventsToEmit).toHaveLength(2)
+            expect(eventsToEmit[0].output).toBe(EVENTS_OUTPUT)
+            expect(eventsToEmit[0].event.properties).not.toHaveProperty('$ai_input')
+            expect(eventsToEmit[1].output).toBe(AI_EVENTS_OUTPUT)
+            expect(eventsToEmit[1].event.properties).toHaveProperty('$ai_input', 'large input')
+        })
+
+        it('should double-write unchanged for teams not in stripHeavyTeams', async () => {
+            const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
+
+            const result = await step({ eventsToEmit: [{ event, output: EVENTS_OUTPUT }], teamId: 1 })
+            expect(isOkResult(result)).toBe(true)
+            if (!isOkResult(result)) {
+                return
+            }
+
+            const { eventsToEmit } = result.value
+            expect(eventsToEmit).toHaveLength(2)
+            expect(eventsToEmit[0].event).toBe(event)
+            expect(eventsToEmit[0].event.properties).toHaveProperty('$ai_input', 'large input')
+            expect(eventsToEmit[1].event).toBe(event)
+            expect(eventsToEmit[1].event.properties).toHaveProperty('$ai_input', 'large input')
         })
     })
 })

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
@@ -30,7 +30,7 @@ const ENABLED_FOR_ALL: SplitAiEventsStepConfig = { enabled: true, enabledTeams: 
 const ENABLED_NO_STRIP: SplitAiEventsStepConfig = {
     enabled: true,
     enabledTeams: '*',
-    stripHeavyTeams: new Set(),
+    stripHeavyTeams: [],
 }
 
 describe('split-ai-events-step', () => {
@@ -40,37 +40,37 @@ describe('split-ai-events-step', () => {
                 enabled: true,
                 teams: '*',
                 stripTeams: '',
-                expected: { enabled: true, enabledTeams: '*', stripHeavyTeams: new Set() },
+                expected: { enabled: true, enabledTeams: '*', stripHeavyTeams: [] },
             },
             {
                 enabled: false,
                 teams: '*',
                 stripTeams: '',
-                expected: { enabled: false, enabledTeams: '*', stripHeavyTeams: new Set() },
+                expected: { enabled: false, enabledTeams: '*', stripHeavyTeams: [] },
             },
             {
                 enabled: true,
                 teams: '1,2,3',
                 stripTeams: '*',
-                expected: { enabled: true, enabledTeams: new Set([1, 2, 3]), stripHeavyTeams: '*' },
+                expected: { enabled: true, enabledTeams: [1, 2, 3], stripHeavyTeams: '*' },
             },
             {
                 enabled: true,
                 teams: ' 1 , 2 ',
                 stripTeams: '2',
-                expected: { enabled: true, enabledTeams: new Set([1, 2]), stripHeavyTeams: new Set([2]) },
+                expected: { enabled: true, enabledTeams: [1, 2], stripHeavyTeams: [2] },
             },
             {
                 enabled: true,
                 teams: '',
                 stripTeams: '',
-                expected: { enabled: true, enabledTeams: new Set(), stripHeavyTeams: new Set() },
+                expected: { enabled: true, enabledTeams: [], stripHeavyTeams: [] },
             },
             {
                 enabled: true,
                 teams: 'abc,1',
                 stripTeams: 'abc,2',
-                expected: { enabled: true, enabledTeams: new Set([1]), stripHeavyTeams: new Set([2]) },
+                expected: { enabled: true, enabledTeams: [1], stripHeavyTeams: [2] },
             },
         ])(
             'should parse enabled=$enabled teams=$teams stripTeams=$stripTeams',
@@ -99,10 +99,10 @@ describe('split-ai-events-step', () => {
             expect(result.value.eventsToEmit[0].event.properties).toHaveProperty('$ai_input')
         })
 
-        it('should pass through unchanged when team is not in the enabled set', async () => {
+        it('should pass through unchanged when team is not in the enabled list', async () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
-                enabledTeams: new Set([99, 100]),
+                enabledTeams: [99, 100],
                 stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input' })
@@ -116,10 +116,10 @@ describe('split-ai-events-step', () => {
             expect(result.value.eventsToEmit).toHaveLength(1)
         })
 
-        it('should split when team is in the enabled set', async () => {
+        it('should split when team is in the enabled list', async () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
-                enabledTeams: new Set([1, 2]),
+                enabledTeams: [1, 2],
                 stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
@@ -358,7 +358,7 @@ describe('split-ai-events-step', () => {
         })
     })
 
-    describe('non-stripping mode (stripHeavyTeams empty)', () => {
+    describe('non-stripping mode (stripHeavyTeams empty array)', () => {
         const step = createSplitAiEventsStep(ENABLED_NO_STRIP)
 
         it('should send AI event with heavy properties unchanged to both outputs', async () => {
@@ -420,7 +420,7 @@ describe('split-ai-events-step', () => {
         const step = createSplitAiEventsStep({
             enabled: true,
             enabledTeams: '*',
-            stripHeavyTeams: new Set([2]),
+            stripHeavyTeams: [2],
         })
 
         it('should strip heavy props for a team in stripHeavyTeams', async () => {

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
@@ -16,14 +16,17 @@ const LARGE_AI_PROPERTIES = new Set([
 
 export interface SplitAiEventsStepConfig {
     enabled: boolean
-    /** '*' for all teams, or a Set of enabled team IDs */
-    enabledTeams: Set<number> | '*'
+    /**
+     * '*' for all teams, or a small array of enabled team IDs.
+     * Hot-path lookup uses Array.includes; expected size is ~3–10, which beats Set in V8.
+     */
+    enabledTeams: number[] | '*'
     /**
      * Teams whose events copy should have heavy AI properties stripped — i.e. the post-migration final state
-     * where heavy columns live only in the AI events table. '*' for all teams, or a Set of team IDs.
+     * where heavy columns live only in the AI events table. '*' for all teams, or a small array of team IDs.
      * Teams not listed here keep double-writing the full event to both outputs.
      */
-    stripHeavyTeams: Set<number> | '*'
+    stripHeavyTeams: number[] | '*'
 }
 
 export interface SplitAiEventsStepInput {
@@ -76,16 +79,14 @@ function maybeStripAiProperties(
     ]
 }
 
-function parseTeamsList(teamsStr: string): Set<number> | '*' {
+function parseTeamsList(teamsStr: string): number[] | '*' {
     if (teamsStr === '*') {
         return '*'
     }
-    return new Set(
-        teamsStr
-            .split(',')
-            .map((s) => parseInt(s.trim(), 10))
-            .filter((n) => !isNaN(n))
-    )
+    return teamsStr
+        .split(',')
+        .map((s) => parseInt(s.trim(), 10))
+        .filter((n) => !isNaN(n))
 }
 
 export function parseSplitAiEventsConfig(
@@ -104,11 +105,11 @@ export function createSplitAiEventsStep<T extends SplitAiEventsStepInput>(
     config: SplitAiEventsStepConfig
 ): ProcessingStep<T, T & SplitAiEventsStepOutput> {
     return function splitAiEventsStep(input) {
-        if (!config.enabled || (config.enabledTeams !== '*' && !config.enabledTeams.has(input.teamId))) {
+        if (!config.enabled || (config.enabledTeams !== '*' && !config.enabledTeams.includes(input.teamId))) {
             return Promise.resolve(ok(input))
         }
 
-        const stripHeavyForTeam = config.stripHeavyTeams === '*' || config.stripHeavyTeams.has(input.teamId)
+        const stripHeavyForTeam = config.stripHeavyTeams === '*' || config.stripHeavyTeams.includes(input.teamId)
 
         return Promise.resolve(
             ok({

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
@@ -18,8 +18,12 @@ export interface SplitAiEventsStepConfig {
     enabled: boolean
     /** '*' for all teams, or a Set of enabled team IDs */
     enabledTeams: Set<number> | '*'
-    /** When true, strip heavy AI properties from the events copy. When false, send unchanged to both outputs. */
-    stripHeavyProperties: boolean
+    /**
+     * Teams whose events copy should have heavy AI properties stripped — i.e. the post-migration final state
+     * where heavy columns live only in the AI events table. '*' for all teams, or a Set of team IDs.
+     * Teams not listed here keep double-writing the full event to both outputs.
+     */
+    stripHeavyTeams: Set<number> | '*'
 }
 
 export interface SplitAiEventsStepInput {
@@ -42,7 +46,7 @@ function hasLargeAiProperties(properties: Record<string, unknown>): boolean {
 
 function maybeStripAiProperties(
     entry: EventToEmit<EventOutput>,
-    stripHeavyProperties: boolean
+    stripHeavyForTeam: boolean
 ): EventToEmit<EventOutput | AiEventOutput>[] {
     const properties = entry.event.properties ?? {}
     const isAiEvent = AI_EVENT_TYPES.has(entry.event.event)
@@ -51,12 +55,12 @@ function maybeStripAiProperties(
         return [entry]
     }
 
-    if (!stripHeavyProperties || !hasLargeAiProperties(properties)) {
+    if (!stripHeavyForTeam || !hasLargeAiProperties(properties)) {
         // Duplicate unchanged to both outputs
         return [entry, { event: entry.event, output: AI_EVENTS_OUTPUT }]
     }
 
-    // Strip heavy props from events copy (only when stripHeavyProperties is true)
+    // Strip heavy props from events copy (only when team is in stripHeavyTeams)
     const stripped: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(properties)) {
         if (!LARGE_AI_PROPERTIES.has(key)) {
@@ -72,21 +76,28 @@ function maybeStripAiProperties(
     ]
 }
 
-export function parseSplitAiEventsConfig(
-    enabled: boolean,
-    teamsStr: string,
-    stripHeavy: boolean
-): SplitAiEventsStepConfig {
+function parseTeamsList(teamsStr: string): Set<number> | '*' {
     if (teamsStr === '*') {
-        return { enabled, enabledTeams: '*', stripHeavyProperties: stripHeavy }
+        return '*'
     }
-    const enabledTeams = new Set(
+    return new Set(
         teamsStr
             .split(',')
             .map((s) => parseInt(s.trim(), 10))
             .filter((n) => !isNaN(n))
     )
-    return { enabled, enabledTeams, stripHeavyProperties: stripHeavy }
+}
+
+export function parseSplitAiEventsConfig(
+    enabled: boolean,
+    teamsStr: string,
+    stripHeavyTeamsStr: string
+): SplitAiEventsStepConfig {
+    return {
+        enabled,
+        enabledTeams: parseTeamsList(teamsStr),
+        stripHeavyTeams: parseTeamsList(stripHeavyTeamsStr),
+    }
 }
 
 export function createSplitAiEventsStep<T extends SplitAiEventsStepInput>(
@@ -97,12 +108,12 @@ export function createSplitAiEventsStep<T extends SplitAiEventsStepInput>(
             return Promise.resolve(ok(input))
         }
 
+        const stripHeavyForTeam = config.stripHeavyTeams === '*' || config.stripHeavyTeams.has(input.teamId)
+
         return Promise.resolve(
             ok({
                 ...input,
-                eventsToEmit: input.eventsToEmit.flatMap((entry) =>
-                    maybeStripAiProperties(entry, config.stripHeavyProperties)
-                ),
+                eventsToEmit: input.eventsToEmit.flatMap((entry) => maybeStripAiProperties(entry, stripHeavyForTeam)),
             })
         )
     }

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -899,7 +899,7 @@ describe('IngestionConsumer', () => {
             await ingester.stop()
             hub.INGESTION_AI_EVENT_SPLITTING_ENABLED = true
             hub.INGESTION_AI_EVENT_SPLITTING_TEAMS = '*'
-            hub.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY = true
+            hub.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS = '*'
             ingester = await createIngestionConsumer(hub)
 
             const events = [

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -261,7 +261,7 @@ export class IngestionConsumer {
             splitAiEventsConfig: parseSplitAiEventsConfig(
                 this.config.INGESTION_AI_EVENT_SPLITTING_ENABLED,
                 this.config.INGESTION_AI_EVENT_SPLITTING_TEAMS,
-                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY
+                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS
             ),
             perDistinctIdOptions: {
                 SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: this.config.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -329,7 +329,7 @@ export class IngestionApiServer implements NodeServer {
             splitAiEventsConfig: parseSplitAiEventsConfig(
                 this.config.INGESTION_AI_EVENT_SPLITTING_ENABLED,
                 this.config.INGESTION_AI_EVENT_SPLITTING_TEAMS,
-                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY
+                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS
             ),
             perDistinctIdOptions: {
                 SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: this.config.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,


### PR DESCRIPTION
## Problem

We are rolling out the dedicated `ai_events` ClickHouse table by double-writing AI events to both `events` and `ai_events`. Today the only way to flip from "double-write everything" to "strip the heavy columns from the `events` copy" (the post-migration final state) is a single boolean `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY` that toggles for everyone at once. That makes the cutover risky — we want to validate the strip-only path on PostHog's own team 2 first while the rest of the world keeps double-writing.

## Changes

- `SplitAiEventsStepConfig.stripHeavyProperties: boolean` becomes `stripHeavyTeams: number[] | '*'`, the same shape as `enabledTeams`.
- The `splitAiEventsStep` decides per-team whether to strip heavy AI properties from the `events` copy.
- Replaces the `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY` boolean with `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS` (default `''` → no team is stripped, i.e. full double-write preserved).
- Switches `enabledTeams` / `stripHeavyTeams` from `Set<number>` to `number[]` with `Array.includes` lookup — for ~3–10 entries this beats `Set.has` in V8 and keeps the hot path lean.
- Updates the two consumer wiring sites (`ingestion-consumer.ts` and `servers/ingestion-api-server.ts`) plus existing tests.

Rollout shape: keep `INGESTION_AI_EVENT_SPLITTING_TEAMS=*` for double-write, then add team 2 to `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS` to graduate just team 2 into the post-migration shape; expand the list as confidence grows.

The old boolean was never set in charts (`argocd/ingestion/config/ingestion.prod-us.yaml` only references `_ENABLED` and `_TEAMS`), so there is nothing to migrate on the chart side. A follow-up chart PR will add `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS: "2"` once this lands.

## How did you test this code?

I'm an agent (Claude). Automated tests only:

- `pnpm exec jest src/ingestion/event-processing/split-ai-events-step.test.ts` — 37/37 passing, including new `per-team strip allowlist` cases that prove team 2 strips while team 1 double-writes unchanged.
- Updated the `ingestion-consumer.test.ts` and `ai-event-subpipeline.integration.test.ts` fixtures for the new field; not re-run end-to-end here.

No manual production testing.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored with Claude Code (Opus 4.7) in an interactive session with @carlos-marchal-ph. Key decisions: (1) replace the boolean with a teams-string instead of stacking a second boolean, because the existing `enabledTeams` pattern is already proven for AI-events config and gives us `'*'` / list / empty in one knob; default `''` keeps current prod behavior unchanged. (2) Followed up by swapping `Set<number>` → `number[]` for the team lookups because expected sizes are ~3–10 and this is the ingestion hot path.