### PR TITLE
feat(notebooks): new sql editor in notebooks

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -377,6 +377,7 @@ export const FEATURE_FLAGS = {
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux
     NEW_TEAM_CORE_EVENTS: 'new-team-core-events', // owner: @jabahamondes #team-web-analytics
     NOTEBOOK_PYTHON: 'notebook-python', // owner: #team-data-tools
+    NOTEBOOK_SQL_EDITOR: 'notebook-sql-editor', // owner: #team-data-tools
     NOTEBOOKS_COLLABORATION: 'notebooks-collaboration', // owner: #team-platform-features
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @benjackwhite
     ONBOARDING_DATA_WAREHOUSE_VALUE_PROP: 'onboarding-data-warehouse-value-prop', // owner: @fercgomes #team-growth multivariate=control,table,query

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -20,6 +20,7 @@ interface QueryPaneProps {
     originalValue?: string
     onRun?: () => void
     editorVimModeEnabled?: boolean
+    constrainHeight?: boolean
 }
 
 export function QueryPane(props: QueryPaneProps): JSX.Element {
@@ -34,7 +35,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{
                     height: `${queryPaneHeight}px`,
-                    maxHeight: queryPaneDesiredSize === null ? '35%' : undefined,
+                    maxHeight: props.constrainHeight !== false && queryPaneDesiredSize === null ? '35%' : undefined,
                 }}
                 ref={queryPaneResizerProps.containerRef}
             >

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -40,6 +40,8 @@ interface QueryWindowProps {
     mode?: SQLEditorMode
     showDatabaseTree: boolean
     onShowDatabaseTree: () => void
+    showQueryPanel?: boolean
+    showOutputPanel?: boolean
 }
 
 export function QueryWindow({
@@ -48,6 +50,8 @@ export function QueryWindow({
     mode,
     showDatabaseTree,
     onShowDatabaseTree,
+    showQueryPanel = true,
+    showOutputPanel = true,
 }: QueryWindowProps): JSX.Element {
     const codeEditorKey = `hogql-editor-${tabId}`
 
@@ -138,117 +142,122 @@ export function QueryWindow({
 
     return (
         <div className="flex grow flex-col overflow-hidden">
-            <div
-                className={cn(
-                    'flex flex-row justify-start align-center w-full pl-2 pr-2 bg-white dark:bg-black border-b border-t py-1',
-                    isDatabaseTreeCollapsed || mode !== SQLEditorMode.FullScene ? '' : 'rounded-tl-lg'
-                )}
-            >
-                <div className="flex items-center gap-2">
-                    <ExpandDatabaseTreeButton
-                        showDatabaseTree={showDatabaseTree}
-                        onShowDatabaseTree={onShowDatabaseTree}
-                    />
-                    <RunButton />
-                    <CollapsedConnectionSelector mode={mode} isDirectQueryEnabled={isDirectQueryEnabled} />
-                    <LemonDivider vertical />
-                    <QueryVariablesMenu
-                        disabledReason={editingView ? 'Variables are not allowed in views.' : undefined}
-                    />
-                    <QueryFiltersMenu />
-                    {editingView ? (
-                        <LemonButton
-                            type="secondary"
-                            size="small"
-                            icon={<IconDatabase />}
-                            onClick={() => openMaterializationModal(editingView)}
-                            data-attr="sql-editor-materialization-button"
-                        >
-                            Materialization
-                        </LemonButton>
-                    ) : null}
-                </div>
-
-                <div className="ml-auto flex items-center gap-2">
-                    <FixErrorButton type="secondary" size="small" source="action-bar" />
-                    {editorSettingsItems.length > 0 ? (
-                        <LemonMenu items={editorSettingsItems} closeOnClickInside={false} placement="bottom-end">
+            {showQueryPanel ? (
+                <div
+                    className={cn(
+                        'flex flex-row justify-start align-center w-full pl-2 pr-2 bg-white dark:bg-black border-b border-t py-1',
+                        isDatabaseTreeCollapsed || mode !== SQLEditorMode.FullScene ? '' : 'rounded-tl-lg'
+                    )}
+                >
+                    <div className="flex items-center gap-2">
+                        <ExpandDatabaseTreeButton
+                            showDatabaseTree={showDatabaseTree}
+                            onShowDatabaseTree={onShowDatabaseTree}
+                        />
+                        <RunButton />
+                        <CollapsedConnectionSelector mode={mode} isDirectQueryEnabled={isDirectQueryEnabled} />
+                        <LemonDivider vertical />
+                        <QueryVariablesMenu
+                            disabledReason={editingView ? 'Variables are not allowed in views.' : undefined}
+                        />
+                        <QueryFiltersMenu />
+                        {editingView ? (
                             <LemonButton
-                                icon={<IconGear />}
                                 type="secondary"
                                 size="small"
-                                tooltip="Editor settings"
-                                data-attr="sql-editor-settings-toggle"
+                                icon={<IconDatabase />}
+                                onClick={() => openMaterializationModal(editingView)}
+                                data-attr="sql-editor-materialization-button"
+                            >
+                                Materialization
+                            </LemonButton>
+                        ) : null}
+                    </div>
+
+                    <div className="ml-auto flex items-center gap-2">
+                        <FixErrorButton type="secondary" size="small" source="action-bar" />
+                        {editorSettingsItems.length > 0 ? (
+                            <LemonMenu items={editorSettingsItems} closeOnClickInside={false} placement="bottom-end">
+                                <LemonButton
+                                    icon={<IconGear />}
+                                    type="secondary"
+                                    size="small"
+                                    tooltip="Editor settings"
+                                    data-attr="sql-editor-settings-toggle"
+                                />
+                            </LemonMenu>
+                        ) : null}
+                        {mode === SQLEditorMode.Embedded && (
+                            <SceneTitlePanelButton
+                                buttonClassName="size-[26px]"
+                                maxToolProps={{
+                                    identifier: 'execute_sql',
+                                    context: {
+                                        current_query: queryInput,
+                                    },
+                                    contextDescription: {
+                                        text: 'Current query',
+                                        icon: iconForType('sql_editor'),
+                                    },
+                                    callback: (toolOutput: string) => {
+                                        setSuggestedQueryInput(toolOutput, 'max_ai')
+                                    },
+                                    suggestions: [],
+                                    onMaxOpen: () => {
+                                        reportAIQueryPromptOpen()
+                                    },
+                                    introOverride: {
+                                        headline: 'What data do you want to analyze?',
+                                        description: 'Let me help you quickly write SQL, and tweak it.',
+                                    },
+                                }}
                             />
-                        </LemonMenu>
-                    ) : null}
-                    {mode === SQLEditorMode.Embedded && (
-                        <SceneTitlePanelButton
-                            buttonClassName="size-[26px]"
-                            maxToolProps={{
-                                identifier: 'execute_sql',
-                                context: {
-                                    current_query: queryInput,
-                                },
-                                contextDescription: {
-                                    text: 'Current query',
-                                    icon: iconForType('sql_editor'),
-                                },
-                                callback: (toolOutput: string) => {
-                                    setSuggestedQueryInput(toolOutput, 'max_ai')
-                                },
-                                suggestions: [],
-                                onMaxOpen: () => {
-                                    reportAIQueryPromptOpen()
-                                },
-                                introOverride: {
-                                    headline: 'What data do you want to analyze?',
-                                    description: 'Let me help you quickly write SQL, and tweak it.',
-                                },
-                            }}
-                        />
-                    )}
+                        )}
+                    </div>
                 </div>
-            </div>
+            ) : null}
 
-            <QueryPane
-                originalValue={originalQueryInput ?? ''}
-                queryInput={(suggestedQueryInput || queryInput) ?? ''}
-                sourceQuery={sourceQuery.source}
-                promptError={null}
-                onRun={runQuery}
-                editorVimModeEnabled={vimModeFeatureEnabled && editorVimModeEnabled}
-                codeEditorProps={{
-                    queryKey: codeEditorKey,
-                    metadataQuery: activeQueryText ?? undefined,
-                    metadataQueryOffset: activeQueryOffset,
-                    onChange: (v) => {
-                        setQueryInput(v ?? '')
-                    },
-                    onMount: (editor, monaco) => {
-                        onSetMonacoAndEditor(monaco, editor)
-                    },
-                    onPressCmdEnter: (value, selectionType) => {
-                        if (value && selectionType === 'selection') {
-                            runQuery(value)
-                        } else {
-                            runQuery()
-                        }
-                    },
-                    onPressCmdShiftEnter: runSubquery,
-                    onError: (error) => {
-                        setError(error)
-                    },
-                    onMetadata: (metadata) => {
-                        setMetadata(metadata)
-                    },
-                    onMetadataLoading: (loading) => {
-                        setMetadataLoading(loading)
-                    },
-                }}
-            />
+            {showQueryPanel ? (
+                <QueryPane
+                    originalValue={originalQueryInput ?? ''}
+                    queryInput={(suggestedQueryInput || queryInput) ?? ''}
+                    sourceQuery={sourceQuery.source}
+                    promptError={null}
+                    onRun={runQuery}
+                    editorVimModeEnabled={vimModeFeatureEnabled && editorVimModeEnabled}
+                    constrainHeight={showOutputPanel}
+                    codeEditorProps={{
+                        queryKey: codeEditorKey,
+                        metadataQuery: activeQueryText ?? undefined,
+                        metadataQueryOffset: activeQueryOffset,
+                        onChange: (v) => {
+                            setQueryInput(v ?? '')
+                        },
+                        onMount: (editor, monaco) => {
+                            onSetMonacoAndEditor(monaco, editor)
+                        },
+                        onPressCmdEnter: (value, selectionType) => {
+                            if (value && selectionType === 'selection') {
+                                runQuery(value)
+                            } else {
+                                runQuery()
+                            }
+                        },
+                        onPressCmdShiftEnter: runSubquery,
+                        onError: (error) => {
+                            setError(error)
+                        },
+                        onMetadata: (metadata) => {
+                            setMetadata(metadata)
+                        },
+                        onMetadataLoading: (loading) => {
+                            setMetadataLoading(loading)
+                        },
+                    }}
+                />
+            ) : null}
 
-            <InternalQueryWindow tabId={tabId} />
+            {showOutputPanel ? <InternalQueryWindow tabId={tabId} /> : null}
         </div>
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -32,17 +32,25 @@ import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogi
 import { ViewLinkModal } from '../ViewLinkModal'
 import { editorSizingLogic } from './editorSizingLogic'
 import { QueryInfo } from './output-pane-tabs/QueryInfo'
+import { OutputPane } from './OutputPane'
 import { outputPaneLogic } from './outputPaneLogic'
 import { QueryHistoryModal } from './QueryHistoryModal'
 import { QueryWindow } from './QueryWindow'
 import { sqlEditorLogic } from './sqlEditorLogic'
 import { SQLEditorMode } from './sqlEditorModes'
 
+export enum SQLEditorPanel {
+    Full = 'full',
+    Query = 'query',
+    Output = 'output',
+}
+
 interface SQLEditorProps {
     tabId?: string
     mode?: SQLEditorMode
     showDatabaseTree?: boolean
     defaultShowDatabaseTree?: boolean
+    panel?: SQLEditorPanel
 }
 
 export function SQLEditor({
@@ -50,6 +58,7 @@ export function SQLEditor({
     mode = SQLEditorMode.FullScene,
     showDatabaseTree,
     defaultShowDatabaseTree = true,
+    panel = SQLEditorPanel.Full,
 }: SQLEditorProps): JSX.Element {
     const ref = useRef(null)
     const navigatorRef = useRef(null)
@@ -59,6 +68,10 @@ export function SQLEditor({
     const [hasShownDatabaseTree, setHasShownDatabaseTree] = useState(defaultShowDatabaseTree)
 
     const shouldShowDatabaseTree = showDatabaseTree ?? hasShownDatabaseTree
+    const showQueryPanel = panel !== SQLEditorPanel.Output
+    const showOutputPanel = panel !== SQLEditorPanel.Query
+    const showSceneTitle = panel === SQLEditorPanel.Full
+    const showDatabaseTreePanel = showQueryPanel && shouldShowDatabaseTree
 
     const editorSizingLogicProps = useMemo(
         () => ({
@@ -164,41 +177,49 @@ export function SQLEditor({
     }
 
     return (
-        <BindLogic logic={editorSizingLogic} props={editorSizingLogicProps}>
-            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-                <BindLogic logic={dataVisualizationLogic} props={dataVisualizationLogicProps}>
-                    <BindLogic logic={displayLogic} props={{ key: dataVisualizationLogicProps.key }}>
-                        <BindLogic logic={variablesLogic} props={variablesLogicProps}>
-                            <BindLogic logic={variableModalLogic} props={{ key: dataVisualizationLogicProps.key }}>
-                                <BindLogic logic={outputPaneLogic} props={{ tabId }}>
-                                    <BindLogic logic={sqlEditorLogic} props={{ tabId, mode, monaco, editor }}>
-                                        <VariablesQuerySync />
+        <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+            <BindLogic logic={dataVisualizationLogic} props={dataVisualizationLogicProps}>
+                <BindLogic logic={displayLogic} props={{ key: dataVisualizationLogicProps.key }}>
+                    <BindLogic logic={variablesLogic} props={variablesLogicProps}>
+                        <BindLogic logic={variableModalLogic} props={{ key: dataVisualizationLogicProps.key }}>
+                            <BindLogic logic={outputPaneLogic} props={{ tabId }}>
+                                <BindLogic logic={sqlEditorLogic} props={{ tabId, mode, monaco, editor }}>
+                                    <VariablesQuerySync />
+                                    {panel === SQLEditorPanel.Output ? (
                                         <div className="flex h-full min-h-0 flex-col overflow-hidden">
-                                            <SQLEditorSceneTitle />
-                                            <div className="flex min-h-0 flex-1">
-                                                {shouldShowDatabaseTree && (
-                                                    <DatabaseTree databaseTreeRef={databaseTreeRef} />
-                                                )}
-                                                <div
-                                                    data-attr="editor-scene"
-                                                    className="EditorScene flex min-h-0 grow flex-row overflow-hidden"
-                                                    ref={ref}
-                                                >
-                                                    <QueryWindow
-                                                        mode={mode}
-                                                        tabId={tabId || ''}
-                                                        showDatabaseTree={shouldShowDatabaseTree}
-                                                        onShowDatabaseTree={() => setHasShownDatabaseTree(true)}
-                                                        onSetMonacoAndEditor={(nextMonaco, nextEditor) =>
-                                                            setMonacoAndEditor([nextMonaco, nextEditor])
-                                                        }
-                                                    />
+                                            <OutputPane tabId={tabId || ''} />
+                                        </div>
+                                    ) : (
+                                        <BindLogic logic={editorSizingLogic} props={editorSizingLogicProps}>
+                                            <div className="flex h-full min-h-0 flex-col overflow-hidden">
+                                                {showSceneTitle ? <SQLEditorSceneTitle /> : null}
+                                                <div className="flex min-h-0 flex-1">
+                                                    {showDatabaseTreePanel && (
+                                                        <DatabaseTree databaseTreeRef={databaseTreeRef} />
+                                                    )}
+                                                    <div
+                                                        data-attr="editor-scene"
+                                                        className="EditorScene flex min-h-0 grow flex-row overflow-hidden"
+                                                        ref={ref}
+                                                    >
+                                                        <QueryWindow
+                                                            mode={mode}
+                                                            tabId={tabId || ''}
+                                                            showDatabaseTree={showDatabaseTreePanel}
+                                                            onShowDatabaseTree={() => setHasShownDatabaseTree(true)}
+                                                            showQueryPanel={showQueryPanel}
+                                                            showOutputPanel={showOutputPanel}
+                                                            onSetMonacoAndEditor={(nextMonaco, nextEditor) =>
+                                                                setMonacoAndEditor([nextMonaco, nextEditor])
+                                                            }
+                                                        />
+                                                    </div>
                                                 </div>
                                             </div>
-                                        </div>
-                                        <MaterializationModal tabId={tabId || ''} />
-                                        {!mode || mode === SQLEditorMode.FullScene ? <ViewLinkModal /> : null}
-                                    </BindLogic>
+                                        </BindLogic>
+                                    )}
+                                    <MaterializationModal tabId={tabId || ''} />
+                                    {!mode || mode === SQLEditorMode.FullScene ? <ViewLinkModal /> : null}
                                 </BindLogic>
                             </BindLogic>
                         </BindLogic>

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -53,6 +53,9 @@ export const DEFAULT_QUERY: QuerySchema = {
     },
 }
 
+const NOTEBOOK_SQL_EDITOR_DEFAULT_HEIGHT = 500
+const NOTEBOOK_SQL_EDITOR_MIN_HEIGHT = 200
+
 const getNotebookSqlEditorTabId = (nodeId: string | null | undefined): string => `notebook-sql-${nodeId ?? 'new'}`
 
 const getSqlEditorSourceQuery = (query: QuerySchema): DataVisualizationNode | null => {
@@ -157,9 +160,13 @@ function NotebookSQLEditorSettings({
         return <></>
     }
 
+    const editorHeight = attributes.height ?? NOTEBOOK_SQL_EDITOR_DEFAULT_HEIGHT
+
     return (
         <div
-            className="h-96 min-h-72 overflow-hidden"
+            className="h-full min-h-0 overflow-hidden"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ height: editorHeight, minHeight: NOTEBOOK_SQL_EDITOR_MIN_HEIGHT }}
             onMouseDown={(event) => event.stopPropagation()}
             onDragStart={(event) => event.stopPropagation()}
         >
@@ -427,8 +434,8 @@ export const NotebookNodeQuery = createPostHogWidgetNode<NotebookNodeQueryAttrib
     nodeType: NotebookNodeType.Query,
     titlePlaceholder: 'Query',
     Component,
-    heightEstimate: 500,
-    minHeight: 200,
+    heightEstimate: NOTEBOOK_SQL_EDITOR_DEFAULT_HEIGHT,
+    minHeight: NOTEBOOK_SQL_EDITOR_MIN_HEIGHT,
     resizeable: true,
     startExpanded: true,
     attributes: {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo } from 'react'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { SQLEditor, SQLEditorPanel } from 'scenes/data-warehouse/editor/SQLEditor'
 import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
 import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
@@ -190,6 +191,7 @@ const Component = ({
     const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
     const { canvasFiltersOverride } = useValues(notebookLogic)
+    const isNotebookSqlEditorEnabled = useFeatureFlag('NOTEBOOK_SQL_EDITOR')
 
     const insightLogicProps = {
         dashboardItemId: query.kind === NodeKind.SavedInsightNode ? query.shortId : ('new' as const),
@@ -259,7 +261,7 @@ const Component = ({
         return null
     }
 
-    if (getSqlEditorSourceQuery(query)) {
+    if (isNotebookSqlEditorEnabled && getSqlEditorSourceQuery(query)) {
         return (
             <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
                 <NotebookSQLEditorOutput attributes={attributes} updateAttributes={updateAttributes} />
@@ -317,6 +319,7 @@ export const Settings = ({
     const nodeLogic = useMountedLogic(notebookNodeLogic)
     const { notebookLogic } = useValues(nodeLogic)
     const { canvasFiltersOverride } = useValues(notebookLogic)
+    const isNotebookSqlEditorEnabled = useFeatureFlag('NOTEBOOK_SQL_EDITOR')
 
     const modifiedQuery = useMemo(() => {
         const modifiedQuery = { ...query, full: false }
@@ -377,7 +380,7 @@ export const Settings = ({
         }
     }
 
-    const isSqlEditorQuery = !!getSqlEditorSourceQuery(query)
+    const isSqlEditorQuery = isNotebookSqlEditorEnabled && !!getSqlEditorSourceQuery(query)
 
     return isSavedInsightNode(attributes.query) ? (
         <div className="p-3 deprecated-space-y-2">

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -1,10 +1,14 @@
 import { JSONContent } from '@tiptap/core'
+import equal from 'fast-deep-equal'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { useEffect, useMemo } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+import { SQLEditor, SQLEditorPanel } from 'scenes/data-warehouse/editor/SQLEditor'
+import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
+import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
@@ -12,10 +16,19 @@ import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
-import { DataTableNode, InsightQueryNode, InsightVizNode, NodeKind, QuerySchema } from '~/queries/schema/schema-general'
+import {
+    DataTableNode,
+    DataVisualizationNode,
+    InsightQueryNode,
+    InsightVizNode,
+    NodeKind,
+    QuerySchema,
+} from '~/queries/schema/schema-general'
 import {
     containsHogQLQuery,
+    convertDataTableNodeToDataVisualizationNode,
     isActorsQuery,
+    isDataVisualizationNode,
     isDataTableNode,
     isEventsQuery,
     isHogQLQuery,
@@ -23,7 +36,7 @@ import {
     isNodeWithSource,
     isSavedInsightNode,
 } from '~/queries/utils'
-import { InsightLogicProps, InsightShortId } from '~/types'
+import { ChartDisplayType, InsightLogicProps, InsightShortId } from '~/types'
 
 import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
@@ -38,6 +51,128 @@ export const DEFAULT_QUERY: QuerySchema = {
         after: '-24h',
         limit: 100,
     },
+}
+
+const getNotebookSqlEditorTabId = (nodeId: string | null | undefined): string => `notebook-sql-${nodeId ?? 'new'}`
+
+const getSqlEditorSourceQuery = (query: QuerySchema): DataVisualizationNode | null => {
+    const convertedQuery = convertDataTableNodeToDataVisualizationNode(query)
+
+    if (isDataVisualizationNode(convertedQuery) && isHogQLQuery(convertedQuery.source)) {
+        return convertedQuery
+    }
+
+    if (isHogQLQuery(query)) {
+        return {
+            kind: NodeKind.DataVisualizationNode,
+            source: query,
+            display: ChartDisplayType.ActionsTable,
+        }
+    }
+
+    return null
+}
+
+function useNotebookSQLEditorSync({
+    attributes,
+    updateAttributes,
+    tabId,
+}: NotebookNodeAttributeProperties<NotebookNodeQueryAttributes> & { tabId: string }): DataVisualizationNode | null {
+    const editorSourceQuery = useMemo(() => getSqlEditorSourceQuery(attributes.query), [attributes.query])
+    const logic = sqlEditorLogic({ tabId, mode: SQLEditorMode.Embedded })
+    const { queryInput, sourceQuery } = useValues(logic)
+    const { initialize, runQuery, setQueryInput, setSourceQuery } = useActions(logic)
+
+    useEffect(() => {
+        initialize()
+    }, [initialize])
+
+    useEffect(() => {
+        if (!editorSourceQuery || queryInput !== null) {
+            return
+        }
+
+        setQueryInput(editorSourceQuery.source.query)
+        setSourceQuery(editorSourceQuery)
+        runQuery(editorSourceQuery.source.query)
+    }, [editorSourceQuery, queryInput, runQuery, setQueryInput, setSourceQuery])
+
+    useEffect(() => {
+        if (!editorSourceQuery || queryInput === null) {
+            return
+        }
+
+        const nextQuery: DataVisualizationNode = {
+            ...sourceQuery,
+            source: {
+                ...sourceQuery.source,
+                query: queryInput,
+            },
+            display: sourceQuery.display ?? editorSourceQuery.display ?? ChartDisplayType.ActionsTable,
+        }
+
+        if (!equal(nextQuery, editorSourceQuery)) {
+            updateAttributes({ query: nextQuery })
+        }
+    }, [editorSourceQuery, queryInput, sourceQuery, updateAttributes])
+
+    return editorSourceQuery
+}
+
+function NotebookSQLEditorOutput({
+    attributes,
+    updateAttributes,
+}: NotebookNodeProps<NotebookNodeQueryAttributes>): JSX.Element | null {
+    const tabId = useMemo(() => getNotebookSqlEditorTabId(attributes.nodeId), [attributes.nodeId])
+    const editorSourceQuery = useNotebookSQLEditorSync({ attributes, updateAttributes, tabId })
+
+    if (!editorSourceQuery) {
+        return null
+    }
+
+    return (
+        <div
+            className="flex h-full min-h-0 flex-col"
+            onMouseDown={(event) => event.stopPropagation()}
+            onDragStart={(event) => event.stopPropagation()}
+        >
+            <SQLEditor
+                tabId={tabId}
+                mode={SQLEditorMode.Embedded}
+                panel={SQLEditorPanel.Output}
+                defaultShowDatabaseTree={false}
+            />
+        </div>
+    )
+}
+
+function NotebookSQLEditorSettings({
+    attributes,
+    updateAttributes,
+}: NotebookNodeAttributeProperties<NotebookNodeQueryAttributes>): JSX.Element {
+    const tabId = useMemo(() => getNotebookSqlEditorTabId(attributes.nodeId), [attributes.nodeId])
+    const editorSourceQuery = useNotebookSQLEditorSync({ attributes, updateAttributes, tabId })
+
+    if (!editorSourceQuery) {
+        return <></>
+    }
+
+    return (
+        <div
+            className="p-3"
+            onMouseDown={(event) => event.stopPropagation()}
+            onDragStart={(event) => event.stopPropagation()}
+        >
+            <div className="h-96 min-h-72 overflow-hidden rounded border">
+                <SQLEditor
+                    tabId={tabId}
+                    mode={SQLEditorMode.Embedded}
+                    panel={SQLEditorPanel.Query}
+                    defaultShowDatabaseTree={false}
+                />
+            </div>
+        </div>
+    )
 }
 
 const Component = ({
@@ -117,6 +252,14 @@ const Component = ({
 
     if (!expanded) {
         return null
+    }
+
+    if (getSqlEditorSourceQuery(query)) {
+        return (
+            <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
+                <NotebookSQLEditorOutput attributes={attributes} updateAttributes={updateAttributes} />
+            </div>
+        )
     }
 
     const isInsightViz = isInsightVizNode(modifiedQuery) || isSavedInsightNode(modifiedQuery)
@@ -229,6 +372,8 @@ export const Settings = ({
         }
     }
 
+    const isSqlEditorQuery = !!getSqlEditorSourceQuery(query)
+
     return isSavedInsightNode(attributes.query) ? (
         <div className="p-3 deprecated-space-y-2">
             <div className="text-lg font-semibold">Insight created outside of this notebook</div>
@@ -258,6 +403,8 @@ export const Settings = ({
                 </LemonButton>
             </div>
         </div>
+    ) : isSqlEditorQuery ? (
+        <NotebookSQLEditorSettings attributes={attributes} updateAttributes={updateAttributes} />
     ) : (
         <div className="p-3">
             <Query

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -159,18 +159,16 @@ function NotebookSQLEditorSettings({
 
     return (
         <div
-            className="p-3"
+            className="h-96 min-h-72 overflow-hidden"
             onMouseDown={(event) => event.stopPropagation()}
             onDragStart={(event) => event.stopPropagation()}
         >
-            <div className="h-96 min-h-72 overflow-hidden rounded border">
-                <SQLEditor
-                    tabId={tabId}
-                    mode={SQLEditorMode.Embedded}
-                    panel={SQLEditorPanel.Query}
-                    defaultShowDatabaseTree={false}
-                />
-            </div>
+            <SQLEditor
+                tabId={tabId}
+                mode={SQLEditorMode.Embedded}
+                panel={SQLEditorPanel.Query}
+                defaultShowDatabaseTree={false}
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

This doesn't look so good anymore

<img width="1490" height="578" alt="image" src="https://github.com/user-attachments/assets/22527db0-c91d-49c7-9cd2-0319b052172c" />


## Changes

All behind the feature flag `notebook-sql-editor `

Use the modern SQL editor in notebooks

<img width="1499" height="1014" alt="Screenshot 2026-04-28 at 15 32 07" src="https://github.com/user-attachments/assets/941b86c2-c028-43e5-aea6-55909ff9a913" />

## How did you test this code?

Clicked around locally. Want to get it live behind a flag to make sure AI features, etc, work well, before releasing it.

## Publish to changelog?

no
## Docs update
no
