### PR TITLE
feat(mcp): expose connectionId for Postgres/DuckDB direct queries

### DIFF
--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2321,7 +2321,7 @@
         }
     },
     "hogql-schema": {
-        "description": "Return the HogQL catalog for the active project: every queryable table (PostHog, system, warehouse, view, materialized view, batch export, endpoint) keyed by name, with each table's fields, plus the join graph between data-warehouse tables. Call this once up front when building a HogQL query from scratch so you pick real table and column names on the first attempt instead of guessing. Cheap — no ClickHouse cost.",
+        "description": "Return the HogQL catalog for the active project: every queryable table (PostHog, system, warehouse, view, materialized view, batch export, endpoint) keyed by name, with each table's fields, plus the join graph between data-warehouse tables. Call this once up front when building a HogQL query from scratch so you pick real table and column names on the first attempt instead of guessing. Cheap — no ClickHouse cost. Pass 'connectionId' to introspect a Postgres or DuckDB direct-query data warehouse source instead of the ClickHouse catalog (use external-data-sources-list to find ids).",
         "category": "Insights & analytics",
         "summary": "List tables and columns available to HogQL queries.",
         "feature": "insights",
@@ -3522,7 +3522,7 @@
         "system_prompt_hint": "User return patterns over time"
     },
     "query-run": {
-        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. For existing PostHog-created data, use system tables with the system. prefix; for example, count SQL insight variables with SELECT count() AS total FROM system.insight_variables. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps.",
+        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. For existing PostHog-created data, use system tables with the system. prefix; for example, count SQL insight variables with SELECT count() AS total FROM system.insight_variables. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps. To target a Postgres or DuckDB direct-query data warehouse source instead of ClickHouse, set 'connectionId' on a HogQLQuery (call external-data-sources-list to discover ids).",
         "category": "Insights & analytics",
         "summary": "Run a trend, funnel, paths or HogQL query.",
         "feature": "insights",
@@ -3601,7 +3601,7 @@
         "system_prompt_hint": "List persons behind a trends data point"
     },
     "query-validate": {
-        "description": "Dry-run a HogQL query: parse and type-check it without executing, so there is no ClickHouse cost and no 202 polling. Returns structured errors (with character positions), warnings, notices, and the list of tables the query references. Use this before 'query-run' on any non-trivial HogQL to catch column typos, missing tables, and syntax issues up front instead of iterating on opaque execution errors. Accepts the same language values as the HogQL editor: 'hogQL' (default, full SELECT), 'hogQLExpr' (bare expression), 'hog', or 'hogTemplate'.",
+        "description": "Dry-run a HogQL query: parse and type-check it without executing, so there is no ClickHouse cost and no 202 polling. Returns structured errors (with character positions), warnings, notices, and the list of tables the query references. Use this before 'query-run' on any non-trivial HogQL to catch column typos, missing tables, and syntax issues up front instead of iterating on opaque execution errors. Accepts the same language values as the HogQL editor: 'hogQL' (default, full SELECT), 'hogQLExpr' (bare expression), 'hog', or 'hogTemplate'. Pass 'connectionId' to validate against a Postgres or DuckDB direct-query data warehouse source instead of the ClickHouse catalog (use external-data-sources-list to find ids).",
         "category": "Insights & analytics",
         "summary": "Validate a HogQL query without executing it.",
         "feature": "insights",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -60,7 +60,7 @@
         }
     },
     "query-run": {
-        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. For existing PostHog-created data, use system tables with the system. prefix; for example, count SQL insight variables with SELECT count() AS total FROM system.insight_variables. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps.",
+        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. For existing PostHog-created data, use system tables with the system. prefix; for example, count SQL insight variables with SELECT count() AS total FROM system.insight_variables. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps. To target a Postgres or DuckDB direct-query data warehouse source instead of ClickHouse, set 'connectionId' on a HogQLQuery (call external-data-sources-list to discover ids).",
         "category": "Insights & analytics",
         "summary": "Run a trend, funnel, paths or HogQL query.",
         "feature": "insights",
@@ -75,7 +75,7 @@
         }
     },
     "query-validate": {
-        "description": "Dry-run a HogQL query: parse and type-check it without executing, so there is no ClickHouse cost and no 202 polling. Returns structured errors (with character positions), warnings, notices, and the list of tables the query references. Use this before 'query-run' on any non-trivial HogQL to catch column typos, missing tables, and syntax issues up front instead of iterating on opaque execution errors. Accepts the same language values as the HogQL editor: 'hogQL' (default, full SELECT), 'hogQLExpr' (bare expression), 'hog', or 'hogTemplate'.",
+        "description": "Dry-run a HogQL query: parse and type-check it without executing, so there is no ClickHouse cost and no 202 polling. Returns structured errors (with character positions), warnings, notices, and the list of tables the query references. Use this before 'query-run' on any non-trivial HogQL to catch column typos, missing tables, and syntax issues up front instead of iterating on opaque execution errors. Accepts the same language values as the HogQL editor: 'hogQL' (default, full SELECT), 'hogQLExpr' (bare expression), 'hog', or 'hogTemplate'. Pass 'connectionId' to validate against a Postgres or DuckDB direct-query data warehouse source instead of the ClickHouse catalog (use external-data-sources-list to find ids).",
         "category": "Insights & analytics",
         "summary": "Validate a HogQL query without executing it.",
         "feature": "insights",
@@ -90,7 +90,7 @@
         }
     },
     "hogql-schema": {
-        "description": "Return the HogQL catalog for the active project: every queryable table (PostHog, system, warehouse, view, materialized view, batch export, endpoint) keyed by name, with each table's fields, plus the join graph between data-warehouse tables. Call this once up front when building a HogQL query from scratch so you pick real table and column names on the first attempt instead of guessing. Cheap — no ClickHouse cost.",
+        "description": "Return the HogQL catalog for the active project: every queryable table (PostHog, system, warehouse, view, materialized view, batch export, endpoint) keyed by name, with each table's fields, plus the join graph between data-warehouse tables. Call this once up front when building a HogQL query from scratch so you pick real table and column names on the first attempt instead of guessing. Cheap — no ClickHouse cost. Pass 'connectionId' to introspect a Postgres or DuckDB direct-query data warehouse source instead of the ClickHouse catalog (use external-data-sources-list to find ids).",
         "category": "Insights & analytics",
         "summary": "List tables and columns available to HogQL queries.",
         "feature": "insights",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -826,7 +826,12 @@
         },
         "HogQLSchemaInputSchema": {
             "type": "object",
-            "properties": {}
+            "properties": {
+                "connectionId": {
+                    "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, returns the schema of that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.",
+                    "type": "string"
+                }
+            }
         },
         "InsightGenerateHogQLFromQuestionSchema": {
             "type": "object",
@@ -2494,6 +2499,10 @@
                                                     "type": "boolean"
                                                 }
                                             }
+                                        },
+                                        "connectionId": {
+                                            "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, the query runs against that source instead of ClickHouse. Use external-data-sources-list to discover available connection ids.",
+                                            "type": "string"
                                         }
                                     },
                                     "required": ["kind", "query"]
@@ -2654,6 +2663,10 @@
                                             "type": "boolean"
                                         }
                                     }
+                                },
+                                "connectionId": {
+                                    "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, the query runs against that source instead of ClickHouse. Use external-data-sources-list to discover available connection ids.",
+                                    "type": "string"
                                 }
                             },
                             "required": ["kind", "query"]
@@ -2676,6 +2689,10 @@
                     "description": "Language to validate. Defaults to 'hogQL' (full SELECT statements). Use 'hogQLExpr' for a bare expression, 'hog' or 'hogTemplate' for Hog source.",
                     "type": "string",
                     "enum": ["hogQL", "hogQLExpr", "hog", "hogTemplate"]
+                },
+                "connectionId": {
+                    "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, validates against that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.",
+                    "type": "string"
                 }
             },
             "required": ["query"]

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -859,9 +859,11 @@ export class ApiClient {
             validate: async ({
                 query,
                 language,
+                connectionId,
             }: {
                 query: string
                 language: 'hogQL' | 'hogQLExpr' | 'hog' | 'hogTemplate'
+                connectionId?: string
             }): Promise<
                 Result<{
                     isValid: boolean
@@ -879,9 +881,13 @@ export class ApiClient {
                 }>
             > => {
                 const url = `${this.baseUrl}/api/environments/${projectId}/query/`
+                const queryBody: Record<string, unknown> = { kind: 'HogQLMetadata', language, query }
+                if (connectionId) {
+                    queryBody.connectionId = connectionId
+                }
                 return this.fetchJson(url, {
                     method: 'POST',
-                    body: JSON.stringify({ query: { kind: 'HogQLMetadata', language, query } }),
+                    body: JSON.stringify({ query: queryBody }),
                 })
             },
 

--- a/services/mcp/src/schema/query.ts
+++ b/services/mcp/src/schema/query.ts
@@ -161,6 +161,12 @@ const HogQLQuerySchema = z.object({
     kind: z.literal('HogQLQuery'),
     query: z.string(),
     filters: HogQLFilters.optional(),
+    connectionId: z
+        .string()
+        .optional()
+        .describe(
+            'Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, the query runs against that source instead of ClickHouse. Use external-data-sources-list to discover available connection ids.'
+        ),
 })
 
 // Funnels filter

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -356,7 +356,14 @@ export const QueryRunInputSchema = z.object({
     query: QueryRunQuerySchema,
 })
 
-export const HogQLSchemaInputSchema = z.object({})
+export const HogQLSchemaInputSchema = z.object({
+    connectionId: z
+        .string()
+        .optional()
+        .describe(
+            'Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, returns the schema of that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.'
+        ),
+})
 
 export const QueryValidateInputSchema = z.object({
     query: z
@@ -370,6 +377,12 @@ export const QueryValidateInputSchema = z.object({
         .default('hogQL')
         .describe(
             "Language to validate. Defaults to 'hogQL' (full SELECT statements). Use 'hogQLExpr' for a bare expression, 'hog' or 'hogTemplate' for Hog source."
+        ),
+    connectionId: z
+        .string()
+        .optional()
+        .describe(
+            'Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, validates against that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.'
         ),
 })
 

--- a/services/mcp/src/tools/query/schema.ts
+++ b/services/mcp/src/tools/query/schema.ts
@@ -1,7 +1,11 @@
+import type { z } from 'zod'
+
 import { HogQLSchemaInputSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = HogQLSchemaInputSchema
+
+type Params = z.infer<typeof schema>
 
 interface DatabaseSchemaField {
     name: string
@@ -36,11 +40,17 @@ interface SchemaResult {
     joins: DataWarehouseViewLink[]
 }
 
-export const hogqlSchemaHandler: ToolBase<typeof schema, SchemaResult>['handler'] = async (context: Context) => {
+export const hogqlSchemaHandler: ToolBase<typeof schema, SchemaResult>['handler'] = async (
+    context: Context,
+    params: Params
+) => {
+    const { connectionId } = params
     const projectId = await context.stateManager.getProjectId()
-    const result = await context.api.insights({ projectId }).query({
-        query: { kind: 'DatabaseSchemaQuery' },
-    })
+    const queryBody: Record<string, unknown> = { kind: 'DatabaseSchemaQuery' }
+    if (connectionId) {
+        queryBody.connectionId = connectionId
+    }
+    const result = await context.api.insights({ projectId }).query({ query: queryBody })
     if (!result.success) {
         throw new Error(`Failed to fetch HogQL schema: ${result.error.message}`)
     }

--- a/services/mcp/src/tools/query/validate.ts
+++ b/services/mcp/src/tools/query/validate.ts
@@ -28,11 +28,11 @@ export const queryValidateHandler: ToolBase<typeof schema, ValidateResult>['hand
     context: Context,
     params: Params
 ) => {
-    const { query, language } = params
+    const { query, language, connectionId } = params
 
     const projectId = await context.stateManager.getProjectId()
 
-    const result = await context.api.insights({ projectId }).validate({ query, language })
+    const result = await context.api.insights({ projectId }).validate({ query, language, connectionId })
 
     if (!result.success) {
         throw new Error(`Failed to validate query: ${result.error.message}`)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/hogql-schema.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/hogql-schema.json
@@ -1,5 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {},
+    "properties": {
+        "connectionId": {
+            "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, returns the schema of that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.",
+            "type": "string"
+        }
+    },
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/query-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/query-run.json
@@ -1379,6 +1379,10 @@
                         },
                         "source": {
                             "properties": {
+                                "connectionId": {
+                                    "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, the query runs against that source instead of ClickHouse. Use external-data-sources-list to discover available connection ids.",
+                                    "type": "string"
+                                },
                                 "filters": {
                                     "properties": {
                                         "dateRange": {
@@ -1540,6 +1544,10 @@
                 },
                 {
                     "properties": {
+                        "connectionId": {
+                            "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, the query runs against that source instead of ClickHouse. Use external-data-sources-list to discover available connection ids.",
+                            "type": "string"
+                        },
                         "filters": {
                             "properties": {
                                 "dateRange": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/query-validate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/query-validate.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "connectionId": {
+            "description": "Optional id of an external data source (e.g. a Postgres or DuckDB direct-query connection). When set, validates against that source instead of the ClickHouse catalog. Use external-data-sources-list to discover available connection ids.",
+            "type": "string"
+        },
         "language": {
             "default": "hogQL",
             "description": "Language to validate. Defaults to 'hogQL' (full SELECT statements). Use 'hogQLExpr' for a bare expression, 'hog' or 'hogTemplate' for Hog source.",


### PR DESCRIPTION
## Problem

Postgres and DuckDB direct-query data warehouse connections are fully supported on the backend (`HogQLQuery`, `HogQLMetadata`, and `DatabaseSchemaQuery` all accept `connectionId`), but the MCP-side zod schemas didn't include the field. zod strips unknown keys by default, so any agent attempt to target a direct source got silently downgraded to ClickHouse — making the entire direct-query feature invisible from MCP clients.

## Changes

Pass `connectionId` through the three HogQL-shaped MCP tools:

- **`query-run`** — added `connectionId` to `HogQLQuerySchema`. Flows through automatically since the schema is part of `QueryRunInputSchema`'s discriminated union.
- **`query-validate`** — added `connectionId` to `QueryValidateInputSchema` and forwarded through the typed `validate()` client method.
- **`hogql-schema`** — added `connectionId` to `HogQLSchemaInputSchema` and forwarded into the `DatabaseSchemaQuery` body.

Tool descriptions now point agents at `external-data-sources-list` to discover available connection ids.

`sendRawQuery` (native-SQL passthrough on `HogQLQuery`) was considered but deliberately deferred: the backend `HogQLMetadata` schema is `extra="forbid"` with no equivalent field, so exposing `sendRawQuery` on `query-run` without a matching path on `query-validate` would break the validate-first pattern this work is built around. Add to both at once when the backend metadata path supports raw-query validation.

## How did you test this code?

Automated tests only — I'm an agent, no manual MCP Inspector / Claude Desktop runs.

- `pnpm --filter=@posthog/mcp typecheck` is clean.
- No backend changes; no Python tests required.

## Publish to changelog?

Yes.

## 🤖 LLM context

Co-authored with Claude Code in the same session as #56185. The bug was discovered while listing follow-up MCP work — the backend already accepted `connectionId` end-to-end, but no MCP tool exposed it.