### PR TITLE
chore(devex): drop tach.toml from soft codeowners

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -149,7 +149,6 @@ docker-compose\*.yml @PostHog/team-devex
 mypy.ini @PostHog/team-devex
 posthog/management/migration_analysis/ @PostHog/team-devex
 common/hogli/ @PostHog/team-devex
-tach.toml @PostHog/team-devex
 bin/ @PostHog/team-devex
 CODEOWNERS-soft @PostHog/team-devex
 CODEOWNERS @PostHog/team-devex


### PR DESCRIPTION
## Problem

`.github/CODEOWNERS-soft` auto-assigns @PostHog/team-devex to any PR touching `tach.toml`. In practice, `tach.toml` changes are almost always a single `[[modules]]` block being added when a new product is bootstrapped — structural validity is already enforced by `common/hogli/product/checks.py`, so the auto-assigned review adds little. Recent examples: #56697, #56296, #56258.

This is a follow-up to #56672, which removed `pyproject.toml`, `uv.lock`, `package.json`, `package-lock.json` and tightened `.agents/` → `.agents/*`.

## Changes

Drop `tach.toml @PostHog/team-devex`.

`bin/` is intentionally kept in place — keeping eyes on changes to the directory is still valuable, and a richer narrowing strategy (e.g. negation patterns in the soft-codeowners script) is being discussed separately.

## How did you test this code?

I'm an agent. No automated test exists for `CODEOWNERS-soft`. The script that consumes it (`.github/scripts/assign-reviewers.js`) only runs from `master` via `pull_request_target`, so the change takes effect on merge.

## Publish to changelog?

No

## 🤖 Agent context

Agent: Claude Code. Author: rnegron.