### PR TITLE
fix(activity): gate legacy and advanced endpoints on audit_logs

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1057,9 +1057,9 @@ snapshots:
     components-search--product-recents-and-starred--light:
         hash: v1.k794b7964.6d7ebbb457b003a589697f6dd6c054fdc6405868b4c6b3a616b004b8faa97ebd.klxLctEaGXfv7Ndvi9IfZL2U7iMfOdJjO805z_Kk8-U
     components-search--searching--dark:
-        hash: v1.k794b7964.68ab8bef374ab0313369c61df847587f087b2657f4ec43ebbcc532cce3cb3abc.uoWd0-vG62pjMtGu2nsyYEiFqI3jtQPMv_O-TI5MiTA
+        hash: v1.k794b7964.6bdb745d1eef8c2715e14fa7c3fcf5e2587be684ad61b4c5d508d4480ac16651.KMHF_iUkPFcKN8dxYuB55Dj7rfS92_DNvfTITHBDVgE
     components-search--searching--light:
-        hash: v1.k794b7964.2be6650cb02240a39b0f23299c69dee87714f03945033a4148806f0ee019a28c.A9vA6qIPU4HeLq9Y0466x4vAYIuyzxEObnR5JVl5XNw
+        hash: v1.k794b7964.3d77f5613150c35c1cc81363c28df7174cfecedd49e349affa41ecab43026e9a.wShurb5MR7IrIJVPnZlZwbnhACY1VUswSpMuADwa9po
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.9d72ed5224f75be3f53f1ba8edc2547978e519aa46a57cc97eef9087b403cb7d.3yHHiA7NW-p6vVSlM-2nPx7Nbk7wuTr5SA9Av2nW--g
     components-sentencelist--full-sentence--light:
@@ -5335,9 +5335,9 @@ snapshots:
     scenes-app-sidepanels--side-panel-access-control--light:
         hash: v1.k794b7964.777356b238972f05cbbb8d756b05cbeed404180f4fd941fbf5c51cabe6dd6012.MeIc1YJ6YAQXRKaPGqw3k1I2vUH3tR2ZBCaTWWvxwSI
     scenes-app-sidepanels--side-panel-activity--dark:
-        hash: v1.k794b7964.7d20ed837f40eee2532fee1396f569bafd73a7c47c004e07319ff1bf1eb9a3af.tueE6RbIw4NBfYRfn0x3w61BvmT1eq2NypFydT245TA
+        hash: v1.k794b7964.30121cde2b8e93c94e26f222ca0102e4d4b75a2c9069c1553ea39743c2bc16f0.w5tAMZVSTh0GGtn-f7S5cJt7pWzlEqAsN4ocnzKkkEo
     scenes-app-sidepanels--side-panel-activity--light:
-        hash: v1.k794b7964.d8a51a44687f6f3dfc90518f27ef72f0b13c225580696ae31716f12929a57869.bQecqpC75DWOeIqfeAPyHOwxC6kPFR5dVLkjLyIpkio
+        hash: v1.k794b7964.a443109d2e56f444e3522cc3d034228832ccfe3d2bfc9eeab84c9209b32b6911._r7-lytHSIjxhB70q5N3wqO0pAozdpvf5KJIZ_4XIBk
     scenes-app-sidepanels--side-panel-discussion--dark:
         hash: v1.k794b7964.e1ab04b4156e125a539f49afbd0ef80529be2fc788a7337ded22ae272a6a0d35.C8n8I-wIhaR0Z_813QhUEbHgZbCVVDuL7QRiv4lXaRM
     scenes-app-sidepanels--side-panel-discussion--light:

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -15,7 +15,6 @@ import { IconWithCount } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import {
     SidePanelActivityTab,
@@ -53,7 +52,6 @@ export const SidePanelActivity = (): JSX.Element => {
 
     const { closeSidePanel } = useActions(sidePanelStateLogic)
 
-    const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const hasAccess = userHasAccess(AccessControlResourceType.ActivityLog, AccessControlLevel.Viewer)
@@ -101,7 +99,7 @@ export const SidePanelActivity = (): JSX.Element => {
             <PayGateMini
                 feature={AvailableFeature.AUDIT_LOGS}
                 className="flex flex-col flex-1 overflow-hidden"
-                overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
+                overrideShouldShowGate={!!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
             >
                 <div className="flex flex-col flex-1 overflow-hidden">
                     <div className="mx-2 shrink-0">

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -4,9 +4,10 @@ import { combineUrl, router, urlToAction } from 'kea-router'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
-import { SidePanelTab } from '~/types'
+import { AvailableFeature, SidePanelTab } from '~/types'
 
 import { sidePanelContextLogic } from './sidePanelContextLogic'
 import type { sidePanelLogicType } from './sidePanelLogicType'
@@ -35,14 +36,22 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             ['scenePanelIsPresent'],
             preflightLogic,
             ['isCloudOrDev'],
+            userLogic,
+            ['hasAvailableFeature'],
         ],
         actions: [sidePanelStateLogic, ['closeSidePanel', 'openSidePanel']],
     })),
 
     selectors({
         enabledTabs: [
-            (s) => [s.sceneSidePanelContext, s.currentTeam, s.scenePanelIsPresent, s.isCloudOrDev],
-            (sceneSidePanelContext, currentTeam, scenePanelIsPresent, isCloudOrDev) => {
+            (s) => [
+                s.sceneSidePanelContext,
+                s.currentTeam,
+                s.scenePanelIsPresent,
+                s.isCloudOrDev,
+                s.hasAvailableFeature,
+            ],
+            (sceneSidePanelContext, currentTeam, scenePanelIsPresent, isCloudOrDev, hasAvailableFeature) => {
                 const tabs: SidePanelTab[] = []
 
                 if (scenePanelIsPresent) {
@@ -52,7 +61,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 tabs.push(SidePanelTab.Max)
                 tabs.push(SidePanelTab.Notebooks)
 
-                if (sceneSidePanelContext?.activity_scope) {
+                if (sceneSidePanelContext?.activity_scope && hasAvailableFeature(AvailableFeature.AUDIT_LOGS)) {
                     tabs.push(SidePanelTab.Activity)
                 }
                 tabs.push(SidePanelTab.Discussion)

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -21,7 +21,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { billingLogic } from 'scenes/billing/billingLogic'
-import { userLogic } from 'scenes/userLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, AvailableFeature } from '~/types'
@@ -260,7 +259,6 @@ export const ActivityLogRow = ({
 export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLogProps): JSX.Element | null => {
     const logic = activityLogLogic({ scope, id, caption, startingPage })
     const { humanizedActivity, activityLoading, pagination, highlightedActivityId } = useValues(logic)
-    const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { billingLoading } = useValues(billingLogic)
 
@@ -280,7 +278,7 @@ export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLo
             ) : (
                 <PayGateMini
                     feature={AvailableFeature.AUDIT_LOGS}
-                    overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
+                    overrideShouldShowGate={!!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
                 >
                     {humanizedActivity.length === 0 ? (
                         <Empty scope={scope} />

--- a/posthog/api/advanced_activity_logs/viewset.py
+++ b/posthog/api/advanced_activity_logs/viewset.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.constants import AvailableFeature
 from posthog.exceptions_capture import capture_exception
 from posthog.models import NotificationViewed
 from posthog.models.activity_logging.activity_log import (
@@ -23,6 +24,7 @@ from posthog.models.activity_logging.activity_log import (
     apply_activity_visibility_restrictions,
 )
 from posthog.models.exported_asset import ExportedAsset
+from posthog.permissions import PremiumFeaturePermission
 from posthog.tasks import exporter
 
 from .field_discovery import AdvancedActivityLogFieldDiscovery
@@ -144,6 +146,8 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
     serializer_class = ActivityLogSerializer
     pagination_class = ActivityLogPagination
     filter_rewrite_rules = {"project_id": "team_id"}
+    permission_classes = [PremiumFeaturePermission]
+    premium_feature_on_cloud = AvailableFeature.AUDIT_LOGS
 
     @extend_schema(parameters=[ActivityLogQueryParamsSerializer])
     def list(self, request, *args, **kwargs):
@@ -282,6 +286,8 @@ class AdvancedActivityLogsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSe
     scope_object = "activity_log"
     scope_object_read_actions = ["list", "retrieve", "available_filters"]
     queryset = ActivityLog.objects.all()
+    permission_classes = [PremiumFeaturePermission]
+    premium_feature_on_cloud = AvailableFeature.AUDIT_LOGS
 
     def _should_skip_parents_filter(self) -> bool:
         """

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -5,8 +5,10 @@ from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory, TickingDateTimeFactory
 from posthog.test.base import APIBaseTest, QueryMatchingTest
 
+from parameterized import parameterized
 from rest_framework import status
 
+from posthog.constants import AvailableFeature
 from posthog.models import User
 
 
@@ -191,3 +193,35 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         assert res.status_code == status.HTTP_200_OK
         assert len(res.json()["results"]) == 6
         assert [r["scope"] for r in res.json()["results"]] == ["FeatureFlag"] * 6
+
+
+class TestActivityLogAuditLogsGate(APIBaseTest):
+    @parameterized.expand([("activity_log",), ("advanced_activity_logs",)])
+    def test_endpoint_blocked_on_cloud_without_audit_logs_feature(self, endpoint: str) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        with self.is_cloud(True):
+            res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
+
+        assert res.status_code == status.HTTP_402_PAYMENT_REQUIRED
+
+    @parameterized.expand([("activity_log",), ("advanced_activity_logs",)])
+    def test_endpoint_allowed_on_cloud_with_audit_logs_feature(self, endpoint: str) -> None:
+        self.organization.available_product_features = [{"key": AvailableFeature.AUDIT_LOGS, "name": "Activity logs"}]
+        self.organization.save()
+
+        with self.is_cloud(True):
+            res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
+
+        assert res.status_code == status.HTTP_200_OK
+
+    @parameterized.expand([("activity_log",), ("advanced_activity_logs",)])
+    def test_endpoint_allowed_on_self_hosted_without_audit_logs_feature(self, endpoint: str) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        with self.is_cloud(False):
+            res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
+
+        assert res.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Problem

Activity logs (side panel and dedicated page) are reachable by orgs without the `audit_logs` entitlement. The legacy `/activity_log/` endpoint has no feature check, the advanced endpoint uses the feature only for lookback (returning unrestricted history when absent), and the frontend skips the paywall whenever an instance admin impersonates a customer.

## Changes

- Gate `ActivityLogViewSet` and `AdvancedActivityLogsViewSet` with `PremiumFeaturePermission` (cloud-only, `audit_logs`)
- Re-gate the side panel Activity tab on `audit_logs`
- Stop bypassing the activity-log paywall for impersonators (keep the `audit-logs-access` feature flag bypass for staff debugging)

## How did you test this code?

- 6 parametrized tests added (cloud-blocked / cloud-allowed / self-hosted-allowed × both endpoints)
- Existing API tests unchanged: `posthog/api/test/test_activity_log.py` (8/8), `posthog/api/advanced_activity_logs/` (18/18), `test_activity_log_access_restricted_for_users_without_access`
- No manual browser verification

## Publish to changelog?

no