### PR TITLE
Extract log parsing into reusable LogParser module

### DIFF
--- a/ee/hogai/eval/sandboxed/base.py
+++ b/ee/hogai/eval/sandboxed/base.py
@@ -229,6 +229,7 @@ async def SandboxedEval(
                 "last_message": last_message,
                 "messages": messages,
                 "raw_log": result.raw_log,
+                "prompt": eval_case.prompt,
             }
         except Exception as e:
             logger.exception("Eval task failed for '%s'", input.get("name", "?"))

--- a/ee/hogai/eval/sandboxed/log_parser.py
+++ b/ee/hogai/eval/sandboxed/log_parser.py
@@ -1,0 +1,340 @@
+"""Unified log accessor for sandboxed-eval scorers.
+
+Wraps :func:`acp_log.parse_log` with a typed accessor API so scorers can ask
+first-class questions ("was skill X called?", "give me every call to tool X
+with input + result") instead of re-walking the flat message list with
+ad-hoc helpers.
+
+Pure data layer — no Braintrust, PostHog, or model dependency. Same
+contract as ``acp_log`` so this is exercised by the same lightweight unit
+test config.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from .acp_log import parse_log
+
+SKILL_TOOL_NAME = "Skill"
+EXEC_TOOL_NAME = "exec"
+INFO_SYNTHETIC_PREFIX = "__info__:"
+"""Synthetic name assigned when ``exec {command: "info <tool>"}`` is unwrapped.
+
+Lets scorers treat the single-exec CLI's ``info <tool>`` and Claude Code's
+``ToolSearch(select:mcp__posthog__<tool>)`` as interchangeable
+"tool schema loaded" signals via a stable namespaced name.
+"""
+
+
+def normalize_tool_name(name: str | None) -> str:
+    """Strip the Claude-Code MCP namespace prefix from a tool name.
+
+    Claude Code surfaces MCP tools as ``mcp__<server>__<tool>``. Scorers
+    think in bare tool names like ``query-retention``; normalising here
+    keeps the public API simple.
+    """
+    if not name:
+        return ""
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            return parts[2]
+    return name
+
+
+class ToolCall(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    """Normalized tool name. ``mcp__x__y`` → ``y``; ``exec`` is unwrapped to the
+    inner tool when the command shape is recognised (see ``is_exec_unwrapped``)."""
+
+    input: dict[str, Any]
+    """Tool input arguments. For unwrapped exec calls this is the parsed JSON
+    payload from ``call <tool> <json>``."""
+
+    output: str
+    """Tool result content as a string. Dict outputs are ``json.dumps``-ed
+    upstream by the ACP parser."""
+
+    is_error: bool
+    """True when the paired ``tool_result`` had ``is_error: true`` OR when no
+    result was captured (unpaired tool_use)."""
+
+    call_id: str
+    position: int
+    """Index of the enclosing assistant message in the flat message list —
+    preserves chronological order across calls."""
+
+    raw_name: str
+    """Tool name before normalisation / exec-unwrapping (the on-the-wire name)."""
+
+    is_exec_unwrapped: bool
+    """True when this entry was synthesised from an ``exec`` call's command."""
+
+
+class SkillCall(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    """Skill name extracted from the ``Skill`` tool's ``input.skill`` field."""
+
+    args: str | None = None
+    """Optional ``input.args`` string."""
+
+    call_id: str
+    output: str
+    is_error: bool
+    position: int
+
+
+class LogParser:
+    """Public log accessor for scorers, built from raw ACP JSONL.
+
+    Internally delegates to :func:`acp_log.parse_log` and indexes the
+    resulting flat message list. Cheap to construct repeatedly per scorer
+    if needed — most scorers will hold one instance.
+    """
+
+    def __init__(self, raw_log: str, *, initial_prompt: str = "") -> None:
+        self._parsed = parse_log(raw_log, initial_prompt=initial_prompt)
+        self._messages = self._parsed.messages
+        self._initial_prompt = initial_prompt
+        self._tool_results = _index_tool_results(self._messages)
+        self._tool_use_positions = _index_tool_use_positions(self._messages)
+
+    # ------------------------------------------------------------------
+    # Skills
+    # ------------------------------------------------------------------
+    def was_skill_called(self, name: str) -> bool:
+        return any(call.name == name for call in self._iter_skill_calls())
+
+    def get_skill_calls(self, name: str | None = None) -> list[SkillCall]:
+        return [call for call in self._iter_skill_calls() if name is None or call.name == name]
+
+    # ------------------------------------------------------------------
+    # Tools
+    # ------------------------------------------------------------------
+    def get_tool_calls(self, name: str | None = None) -> list[ToolCall]:
+        calls: list[ToolCall] = []
+        for tool_use, position in self._iter_tool_uses():
+            raw_name = str(tool_use.get("name") or "")
+            if raw_name == SKILL_TOOL_NAME:
+                continue
+            normalized = normalize_tool_name(raw_name)
+            tool_input = tool_use.get("input")
+            if not isinstance(tool_input, dict):
+                tool_input = {}
+            tool_call = self._build_tool_call(
+                tool_use=tool_use,
+                raw_name=raw_name,
+                normalized=normalized,
+                tool_input=tool_input,
+                position=position,
+            )
+            if name is None or tool_call.name == name:
+                calls.append(tool_call)
+        return calls
+
+    # ------------------------------------------------------------------
+    # Messages
+    # ------------------------------------------------------------------
+    def get_final_agent_message(self) -> str | None:
+        for msg in reversed(self._messages):
+            if msg.get("role") != "assistant":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            texts = [
+                block.get("text", "") for block in content if isinstance(block, dict) and block.get("type") == "text"
+            ]
+            joined = "\n".join(t for t in texts if t)
+            if joined:
+                return joined
+        return None
+
+    def get_user_prompt(self) -> str:
+        for msg in self._messages:
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text:
+                            return text
+        return self._initial_prompt
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _iter_skill_calls(self) -> list[SkillCall]:
+        calls: list[SkillCall] = []
+        for tool_use, position in self._iter_tool_uses():
+            if tool_use.get("name") != SKILL_TOOL_NAME:
+                continue
+            tool_input = tool_use.get("input") if isinstance(tool_use.get("input"), dict) else {}
+            assert isinstance(tool_input, dict)
+            skill_name = tool_input.get("skill")
+            if not isinstance(skill_name, str) or not skill_name:
+                continue
+            args = tool_input.get("args")
+            args_str = args if isinstance(args, str) else None
+            call_id = str(tool_use.get("id") or "")
+            output, is_error = self._lookup_result(call_id)
+            calls.append(
+                SkillCall(
+                    name=skill_name,
+                    args=args_str,
+                    call_id=call_id,
+                    output=output,
+                    is_error=is_error,
+                    position=position,
+                )
+            )
+        return calls
+
+    def _iter_tool_uses(self):
+        for idx, msg in enumerate(self._messages):
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    yield block, idx
+
+    def _build_tool_call(
+        self,
+        *,
+        tool_use: dict[str, Any],
+        raw_name: str,
+        normalized: str,
+        tool_input: dict[str, Any],
+        position: int,
+    ) -> ToolCall:
+        call_id = str(tool_use.get("id") or "")
+        if normalized == EXEC_TOOL_NAME:
+            command = tool_input.get("command", "")
+            if isinstance(command, str):
+                unwrapped = _parse_exec_command(command)
+                if unwrapped is not None:
+                    inner_name, inner_input = unwrapped
+                    output, is_error = self._lookup_result(call_id)
+                    return ToolCall(
+                        name=inner_name,
+                        input=inner_input,
+                        output=output,
+                        is_error=is_error,
+                        call_id=call_id,
+                        position=position,
+                        raw_name=raw_name,
+                        is_exec_unwrapped=True,
+                    )
+        output, is_error = self._lookup_result(call_id)
+        return ToolCall(
+            name=normalized,
+            input=tool_input,
+            output=output,
+            is_error=is_error,
+            call_id=call_id,
+            position=position,
+            raw_name=raw_name,
+            is_exec_unwrapped=False,
+        )
+
+    def _lookup_result(self, call_id: str) -> tuple[str, bool]:
+        if not call_id:
+            return ("", True)
+        result = self._tool_results.get(call_id)
+        if result is None:
+            return ("", True)
+        content = result.get("content")
+        output = content if isinstance(content, str) else (json.dumps(content) if content is not None else "")
+        return (output, bool(result.get("is_error", False)))
+
+
+def _index_tool_results(messages: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_result":
+                continue
+            call_id = block.get("tool_use_id")
+            if isinstance(call_id, str) and call_id:
+                by_id[call_id] = block
+    return by_id
+
+
+def _index_tool_use_positions(messages: list[dict[str, Any]]) -> dict[str, int]:
+    positions: dict[str, int] = {}
+    for idx, msg in enumerate(messages):
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                call_id = block.get("id")
+                if isinstance(call_id, str) and call_id and call_id not in positions:
+                    positions[call_id] = idx
+    return positions
+
+
+def _parse_exec_command(command: str) -> tuple[str, dict[str, Any]] | None:
+    """Split a CLI-style ``exec`` command string into ``(virtual_name, input)``.
+
+    Recognised shapes (produced by single-exec mode where the agent talks to
+    the PostHog MCP through one ``exec`` tool):
+      - ``"info <tool>"``                    → ``("__info__:<tool>", {})``
+      - ``"call [--json] <tool> <json>"``    → ``("<tool>", parsed_json)``
+
+    Returns ``None`` for anything else (``search``, ``tools``, ``schema``,
+    malformed) so callers can fall through to the raw ``exec`` representation.
+    """
+    stripped = command.strip()
+    if not stripped:
+        return None
+
+    head, _, rest = stripped.partition(" ")
+    head = head.lower()
+
+    if head == "info":
+        tool = rest.strip().split(None, 1)[0] if rest.strip() else ""
+        if tool:
+            return (f"{INFO_SYNTHETIC_PREFIX}{tool}", {})
+        return None
+
+    if head == "call":
+        rest = rest.strip()
+        if rest.startswith("--json"):
+            rest = rest[len("--json") :].lstrip()
+        if not rest:
+            return None
+        tool, _, json_part = rest.partition(" ")
+        tool = tool.strip()
+        if not tool:
+            return None
+        json_part = json_part.strip()
+        parsed: dict[str, Any] = {}
+        if json_part:
+            try:
+                decoded = json.loads(json_part)
+                if isinstance(decoded, dict):
+                    parsed = decoded
+            except json.JSONDecodeError:
+                parsed = {}
+        return (tool, parsed)
+
+    return None

--- a/ee/hogai/eval/sandboxed/log_parser.py
+++ b/ee/hogai/eval/sandboxed/log_parser.py
@@ -107,18 +107,12 @@ class LogParser:
         self._tool_results = _index_tool_results(self._messages)
         self._tool_use_positions = _index_tool_use_positions(self._messages)
 
-    # ------------------------------------------------------------------
-    # Skills
-    # ------------------------------------------------------------------
     def was_skill_called(self, name: str) -> bool:
         return any(call.name == name for call in self._iter_skill_calls())
 
     def get_skill_calls(self, name: str | None = None) -> list[SkillCall]:
         return [call for call in self._iter_skill_calls() if name is None or call.name == name]
 
-    # ------------------------------------------------------------------
-    # Tools
-    # ------------------------------------------------------------------
     def get_tool_calls(self, name: str | None = None) -> list[ToolCall]:
         calls: list[ToolCall] = []
         for tool_use, position in self._iter_tool_uses():
@@ -140,9 +134,6 @@ class LogParser:
                 calls.append(tool_call)
         return calls
 
-    # ------------------------------------------------------------------
-    # Messages
-    # ------------------------------------------------------------------
     def get_final_agent_message(self) -> str | None:
         for msg in reversed(self._messages):
             if msg.get("role") != "assistant":
@@ -173,9 +164,6 @@ class LogParser:
                             return text
         return self._initial_prompt
 
-    # ------------------------------------------------------------------
-    # Internals
-    # ------------------------------------------------------------------
     def _iter_skill_calls(self) -> list[SkillCall]:
         calls: list[SkillCall] = []
         for tool_use, position in self._iter_tool_uses():

--- a/ee/hogai/eval/sandboxed/product_analytics/scorers.py
+++ b/ee/hogai/eval/sandboxed/product_analytics/scorers.py
@@ -13,7 +13,6 @@ and only then runs the actual query tool.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable
 from typing import Any
 
@@ -21,19 +20,13 @@ from autoevals.llm import LLMClassifier
 from braintrust import Score
 from braintrust_core.score import Scorer
 
-from ee.hogai.eval.sandboxed.scorers import iter_successful_tool_calls, normalize_tool_name
+from ee.hogai.eval.sandboxed.log_parser import INFO_SYNTHETIC_PREFIX, LogParser, ToolCall
 
 QUERY_TRENDS_TOOL_NAME = "query-trends"
 QUERY_RETENTION_TOOL_NAME = "query-retention"
 QUERY_FUNNEL_TOOL_NAME = "query-funnel"
 READ_DATA_SCHEMA_TOOL_NAME = "read-data-schema"
 TOOL_SEARCH_TOOL_NAME = "ToolSearch"
-EXEC_TOOL_NAME = "exec"
-# Synthetic prefix assigned to `mcp__posthog__exec {command: "info <tool>"}` so
-# the scorer can treat the exec-wrapped ``info`` command and the per-tool
-# ``ToolSearch(select:mcp__posthog__<tool>)`` as interchangeable "tool schema
-# loaded" signals.
-_INFO_SYNTHETIC_PREFIX = "__info__:"
 
 BINARY_CHOICE_SCORES = {"yes": 1.0, "no": 0.0}
 
@@ -88,6 +81,36 @@ class _JudgedScorer(LLMClassifier):
         raise NotImplementedError
 
 
+def _parser_for(output: dict[str, Any] | None) -> LogParser | None:
+    if not output:
+        return None
+    raw_log = output.get("raw_log")
+    if not raw_log:
+        return None
+    return LogParser(raw_log, initial_prompt=output.get("prompt", "") or "")
+
+
+def _extract_last_successful_input(parser: LogParser | None, tool_name: str) -> dict[str, Any] | None:
+    if parser is None:
+        return None
+    successful = [c for c in parser.get_tool_calls(tool_name) if not c.is_error]
+    if not successful:
+        return None
+    return successful[-1].input
+
+
+def _user_prompt(output: dict[str, Any] | None) -> str:
+    """Return the original user prompt from the eval output dict."""
+    parser = _parser_for(output)
+    if parser is not None:
+        return parser.get_user_prompt()
+    if output:
+        prompt = output.get("prompt")
+        if isinstance(prompt, str):
+            return prompt
+    return ""
+
+
 def extract_last_query_retention_input(output: dict[str, Any] | None) -> dict[str, Any] | None:
     """Return the input dict of the most recent successful ``query-retention`` call.
 
@@ -95,20 +118,7 @@ def extract_last_query_retention_input(output: dict[str, Any] | None) -> dict[st
     that depend on this should short-circuit with ``score=None`` in that case
     rather than counting it as an incorrect retention query.
     """
-    if not output:
-        return None
-    messages = output.get("messages")
-    if not messages:
-        return None
-
-    last_input: dict[str, Any] | None = None
-    for tool_use, _ in iter_successful_tool_calls(messages):
-        if normalize_tool_name(tool_use.get("name")) != QUERY_RETENTION_TOOL_NAME:
-            continue
-        tool_input = tool_use.get("input")
-        if isinstance(tool_input, dict):
-            last_input = tool_input
-    return last_input
+    return _extract_last_successful_input(_parser_for(output), QUERY_RETENTION_TOOL_NAME)
 
 
 class RetentionSchemaAlignment(_JudgedScorer):
@@ -179,7 +189,7 @@ class RetentionTimeRangeRelevancy(_JudgedScorer):
                 score=0.0,
                 metadata={"reason": "Agent never ran query-retention successfully"},
             )
-        prompt = _extract_user_prompt(output)
+        prompt = _user_prompt(output)
         return {
             "output": {
                 "retention_query": actual,
@@ -225,20 +235,7 @@ def extract_last_query_trends_input(output: dict[str, Any] | None) -> dict[str, 
     that depend on this should short-circuit with ``score=None`` in that case
     rather than counting it as an incorrect trends query.
     """
-    if not output:
-        return None
-    messages = output.get("messages")
-    if not messages:
-        return None
-
-    last_input: dict[str, Any] | None = None
-    for tool_use, _ in iter_successful_tool_calls(messages):
-        if normalize_tool_name(tool_use.get("name")) != QUERY_TRENDS_TOOL_NAME:
-            continue
-        tool_input = tool_use.get("input")
-        if isinstance(tool_input, dict):
-            last_input = tool_input
-    return last_input
+    return _extract_last_successful_input(_parser_for(output), QUERY_TRENDS_TOOL_NAME)
 
 
 class TrendsSchemaAlignment(_JudgedScorer):
@@ -314,7 +311,7 @@ class TrendsTimeRangeRelevancy(_JudgedScorer):
                 score=0.0,
                 metadata={"reason": "Agent never ran query-trends successfully"},
             )
-        prompt = _extract_user_prompt(output)
+        prompt = _user_prompt(output)
         return {
             "output": {
                 "trends_query": actual,
@@ -361,20 +358,7 @@ def extract_last_query_funnel_input(output: dict[str, Any] | None) -> dict[str, 
     legitimately answered via HogQL (``execute-sql``); that's covered by the
     exit-code scorer, not by these LLM judges.
     """
-    if not output:
-        return None
-    messages = output.get("messages")
-    if not messages:
-        return None
-
-    last_input: dict[str, Any] | None = None
-    for tool_use, _ in iter_successful_tool_calls(messages):
-        if normalize_tool_name(tool_use.get("name")) != QUERY_FUNNEL_TOOL_NAME:
-            continue
-        tool_input = tool_use.get("input")
-        if isinstance(tool_input, dict):
-            last_input = tool_input
-    return last_input
+    return _extract_last_successful_input(_parser_for(output), QUERY_FUNNEL_TOOL_NAME)
 
 
 class FunnelSchemaAlignment(_JudgedScorer):
@@ -454,7 +438,7 @@ class FunnelTimeRangeRelevancy(_JudgedScorer):
                 score=0.0,
                 metadata={"reason": "Agent never ran query-funnel successfully"},
             )
-        prompt = _extract_user_prompt(output)
+        prompt = _user_prompt(output)
         return {
             "output": {
                 "funnel_query": actual,
@@ -496,136 +480,6 @@ Are the time range AND the conversion window in the actual query consistent with
         )
 
 
-def _extract_user_prompt(output: dict[str, Any] | None) -> str:
-    """Fish the original user prompt out of the sandbox task output.
-
-    The eval harness doesn't surface the prompt on the task return dict, but
-    ``parse_log(..., initial_prompt=eval_case.prompt)`` seeds it as the first
-    user message, so reading ``messages[0]`` is reliable. Keeps the scorer
-    decoupled from how ``base.py`` chooses to expose the prompt.
-    """
-    if not isinstance(output, dict):
-        return ""
-    for key in ("prompt", "input"):
-        value = output.get(key)
-        if isinstance(value, str) and value:
-            return value
-    messages = output.get("messages") or []
-    for msg in messages:
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    return block.get("text", "")
-            # First user message may be tool_results in a multi-turn thread —
-            # in that case keep scanning.
-    return ""
-
-
-def _parse_exec_command(command: str) -> tuple[str, dict[str, Any]] | None:
-    """Split a CLI-style ``exec`` command string into ``(virtual_name, input)``.
-
-    Recognized shapes (produced by single-exec mode where the agent talks to
-    the PostHog MCP through one ``exec`` tool):
-      - ``"info <tool>"``          → ``("__info__:<tool>", {})``
-      - ``"call [--json] <tool> <json>"`` → ``("<tool>", parsed_json)``
-
-    Anything else (``search``, ``tools``, ``schema``, malformed) returns
-    ``None`` so the caller can fall back to emitting the raw ``exec`` call —
-    those commands aren't load-bearing for the ordering checks.
-    """
-    stripped = command.strip()
-    if not stripped:
-        return None
-
-    head, _, rest = stripped.partition(" ")
-    head = head.lower()
-
-    if head == "info":
-        tool = rest.strip().split(None, 1)[0] if rest.strip() else ""
-        if tool:
-            return (f"{_INFO_SYNTHETIC_PREFIX}{tool}", {})
-        return None
-
-    if head == "call":
-        rest = rest.strip()
-        # Optional --json flag
-        if rest.startswith("--json"):
-            rest = rest[len("--json") :].lstrip()
-        if not rest:
-            return None
-        tool, _, json_part = rest.partition(" ")
-        tool = tool.strip()
-        if not tool:
-            return None
-        json_part = json_part.strip()
-        parsed: dict[str, Any] = {}
-        if json_part:
-            try:
-                decoded = json.loads(json_part)
-                if isinstance(decoded, dict):
-                    parsed = decoded
-            except json.JSONDecodeError:
-                parsed = {}
-        return (tool, parsed)
-
-    return None
-
-
-def _enumerate_tool_calls(messages: list[dict[str, Any]]) -> list[tuple[int, str, dict[str, Any]]]:
-    """Return a chronological list of ``(position, normalized_name, tool_use)``.
-
-    Position is the index of the enclosing assistant message inside the flat
-    ``messages`` list, which preserves the execution order the ACP log emits
-    (``base.py`` rebuilds the conversation history in order, so message index
-    ≈ time). Includes only successful calls — error results are skipped the
-    same way ``iter_successful_tool_calls`` does.
-
-    Also unwraps ``mcp__posthog__exec`` calls from single-exec mode: each
-    ``call <tool> <json>`` becomes a synthetic ``(pos, <tool>, parsed_input)``
-    entry, and each ``info <tool>`` becomes ``(pos, "__info__:<tool>", {})``.
-    This way ordering checks don't care whether the agent talks to tools
-    directly or through the CLI wrapper.
-    """
-    positions: dict[str, int] = {}
-    for idx, msg in enumerate(messages):
-        content = msg.get("content")
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "tool_use":
-                call_id = block.get("id")
-                if call_id and call_id not in positions:
-                    positions[call_id] = idx
-
-    ordered: list[tuple[int, str, dict[str, Any]]] = []
-    for tool_use, _result in iter_successful_tool_calls(messages):
-        call_id = tool_use.get("id", "")
-        name = normalize_tool_name(tool_use.get("name"))
-        pos = positions.get(call_id, -1)
-        # Unwrap single-exec CLI commands so downstream checks see the inner tool.
-        if name == EXEC_TOOL_NAME:
-            tool_input = tool_use.get("input") or {}
-            command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
-            parsed = _parse_exec_command(command)
-            if parsed is not None:
-                virtual_name, virtual_input = parsed
-                synthetic_use = {
-                    "id": tool_use.get("id"),
-                    "name": virtual_name,
-                    "input": virtual_input,
-                }
-                ordered.append((pos, virtual_name, synthetic_use))
-                continue
-        ordered.append((pos, name, tool_use))
-    ordered.sort(key=lambda item: item[0])
-    return ordered
-
-
 class SchemaDiscoveryOrder(Scorer):
     """Binary deterministic scorer: did the agent discover before querying?
 
@@ -665,9 +519,9 @@ class SchemaDiscoveryOrder(Scorer):
     def _evaluate(self, output: dict | None, expected: dict | None) -> Score:
         if not output:
             return Score(name=self._name(), score=None, metadata={"reason": "No output"})
-        messages = output.get("messages")
-        if not messages:
-            return Score(name=self._name(), score=None, metadata={"reason": "No parsed messages"})
+        parser = _parser_for(output)
+        if parser is None:
+            return Score(name=self._name(), score=None, metadata={"reason": "No raw log"})
 
         spec = self._spec(expected)
         if spec is None:
@@ -681,7 +535,8 @@ class SchemaDiscoveryOrder(Scorer):
         data_kind = spec.get("data_kind")
         search_any_of = [s.lower() for s in spec.get("data_search_any_of", []) if isinstance(s, str)]
 
-        ordered = _enumerate_tool_calls(messages)
+        # Successful calls only — matches the legacy "skip error results" behaviour.
+        ordered = [c for c in parser.get_tool_calls() if not c.is_error]
 
         tool_search_pos = self._find_tool_search_pos(ordered, query_tool)
         data_schema_pos = self._find_read_data_schema_pos(ordered, data_kind, search_any_of)
@@ -722,29 +577,26 @@ class SchemaDiscoveryOrder(Scorer):
         return spec
 
     @staticmethod
-    def _find_tool_search_pos(ordered: list[tuple[int, str, dict[str, Any]]], query_tool: str) -> int | None:
+    def _find_tool_search_pos(ordered: list[ToolCall], query_tool: str) -> int | None:
         """Match either Claude-Code's ``ToolSearch`` (per-tool MCP mode) or
         the synthetic ``__info__:<tool>`` entry emitted by single-exec's
         ``info <tool>`` command — both represent "tool schema loaded"."""
         needle = query_tool.lower()
-        info_synthetic = f"{_INFO_SYNTHETIC_PREFIX}{query_tool}".lower()
-        for pos, name, tool_use in ordered:
-            if name.lower() == info_synthetic:
-                return pos
-            if name != TOOL_SEARCH_TOOL_NAME:
+        info_synthetic = f"{INFO_SYNTHETIC_PREFIX}{query_tool}".lower()
+        for call in ordered:
+            if call.name.lower() == info_synthetic:
+                return call.position
+            if call.name != TOOL_SEARCH_TOOL_NAME:
                 continue
-            query = ""
-            tool_input = tool_use.get("input")
-            if isinstance(tool_input, dict):
-                raw = tool_input.get("query", "")
-                query = raw.lower() if isinstance(raw, str) else ""
+            raw = call.input.get("query", "")
+            query = raw.lower() if isinstance(raw, str) else ""
             if needle in query:
-                return pos
+                return call.position
         return None
 
     @staticmethod
     def _find_read_data_schema_pos(
-        ordered: list[tuple[int, str, dict[str, Any]]],
+        ordered: list[ToolCall],
         data_kind: str | None,
         search_any_of: Iterable[str],
     ) -> int | None:
@@ -767,35 +619,29 @@ class SchemaDiscoveryOrder(Scorer):
 
         # Pass 1: prefer the call whose search matches a target term.
         if search_terms:
-            for pos, name, tool_use in ordered:
-                if name != READ_DATA_SCHEMA_TOOL_NAME:
+            for call in ordered:
+                if call.name != READ_DATA_SCHEMA_TOOL_NAME:
                     continue
-                tool_input = tool_use.get("input")
-                if not isinstance(tool_input, dict):
-                    continue
-                kind, search_val = _extract(tool_input)
+                kind, search_val = _extract(call.input)
                 if data_kind and kind != data_kind:
                     continue
                 if any(term in search_val for term in search_terms):
-                    return pos
+                    return call.position
 
         # Pass 2: any successful call with the right kind — the response is
         # the full event list, which still lets the agent verify.
-        for pos, name, tool_use in ordered:
-            if name != READ_DATA_SCHEMA_TOOL_NAME:
+        for call in ordered:
+            if call.name != READ_DATA_SCHEMA_TOOL_NAME:
                 continue
-            tool_input = tool_use.get("input")
-            if not isinstance(tool_input, dict):
-                continue
-            kind, _ = _extract(tool_input)
+            kind, _ = _extract(call.input)
             if data_kind and kind != data_kind:
                 continue
-            return pos
+            return call.position
         return None
 
     @staticmethod
-    def _find_query_tool_pos(ordered: list[tuple[int, str, dict[str, Any]]], query_tool: str) -> int | None:
-        for pos, name, _tool_use in ordered:
-            if name == query_tool:
-                return pos
+    def _find_query_tool_pos(ordered: list[ToolCall], query_tool: str) -> int | None:
+        for call in ordered:
+            if call.name == query_tool:
+                return call.position
         return None

--- a/ee/hogai/eval/sandboxed/scorers/__init__.py
+++ b/ee/hogai/eval/sandboxed/scorers/__init__.py
@@ -1,12 +1,14 @@
-from .deterministic import ExitCodeZero, NoToolCall, RequiredToolCall, iter_successful_tool_calls, normalize_tool_name
+from ee.hogai.eval.sandboxed.log_parser import LogParser, normalize_tool_name
+
+from .deterministic import ExitCodeZero, NoToolCall, RequiredToolCall
 from .tracing import TracedScorer, wrap_scorers
 
 __all__ = [
     "ExitCodeZero",
+    "LogParser",
     "NoToolCall",
     "RequiredToolCall",
     "TracedScorer",
-    "iter_successful_tool_calls",
     "normalize_tool_name",
     "wrap_scorers",
 ]

--- a/ee/hogai/eval/sandboxed/scorers/deterministic.py
+++ b/ee/hogai/eval/sandboxed/scorers/deterministic.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any
 
 from braintrust import Score
 from braintrust_core.score import Scorer
+
+from ee.hogai.eval.sandboxed.log_parser import LogParser
 
 
 class ExitCodeZero(Scorer):
@@ -34,14 +35,13 @@ class NoToolCall(Scorer):
     """Binary scorer: did the agent avoid successfully calling any forbidden tool?
 
     Constructed with a set of tool names that must never be successfully
-    invoked. Walks `output["messages"]` (the flat Anthropic message list that
-    `sandboxed/base.py` produces), pairs each `tool_use` with its
-    `tool_result`, and scores `0.0` if any paired result completed without
-    `is_error`. Failed calls (`is_error: true`) are allowed — the model is
-    free to attempt and fail.
+    invoked. Walks the parsed tool-call list from ``LogParser`` and scores
+    ``0.0`` if any successful (``is_error=False``) call's normalized name
+    is in the forbidden set. Failed calls are allowed — the model is free
+    to attempt and fail.
 
     Typical use: sandbox hygiene — forbid MCP tools that would persist state
-    outside the disposable team (e.g. `insight-create`, `insight-update`).
+    outside the disposable team (e.g. ``insight-create``, ``insight-update``).
     """
 
     forbidden: frozenset[str]
@@ -63,14 +63,13 @@ class NoToolCall(Scorer):
     def _evaluate(self, output: dict | None) -> Score:
         if not output:
             return Score(name=self._name(), score=None, metadata={"reason": "No output"})
-        messages = output.get("messages")
-        if not messages:
-            return Score(name=self._name(), score=None, metadata={"reason": "No parsed messages"})
+        raw_log = output.get("raw_log")
+        if not raw_log:
+            return Score(name=self._name(), score=None, metadata={"reason": "No raw log"})
 
+        parser = LogParser(raw_log, initial_prompt=output.get("prompt", "") or "")
         successful_calls: list[str] = [
-            tool_use["name"]
-            for tool_use, _ in iter_successful_tool_calls(messages)
-            if normalize_tool_name(tool_use.get("name")) in self.forbidden
+            call.name for call in parser.get_tool_calls() if not call.is_error and call.name in self.forbidden
         ]
         if successful_calls:
             return Score(
@@ -85,9 +84,9 @@ class RequiredToolCall(Scorer):
     """Binary scorer: did the agent successfully invoke at least one required tool?
 
     Constructed with a set of tool names — at least one of them must appear
-    as a successful `tool_use`/`tool_result` pair in `output["messages"]`.
-    Failed calls (`is_error: true`) don't count; the model must have
-    actually received a non-error result.
+    as a successful (``is_error=False``) call from ``LogParser.get_tool_calls``.
+    Failed calls don't count; the model must have actually received a
+    non-error result.
 
     Typical use: agent hygiene — require ``read-data-schema`` so the agent
     verifies an event/property exists in the team before running a query.
@@ -112,14 +111,13 @@ class RequiredToolCall(Scorer):
     def _evaluate(self, output: dict | None) -> Score:
         if not output:
             return Score(name=self._name(), score=None, metadata={"reason": "No output"})
-        messages = output.get("messages")
-        if not messages:
-            return Score(name=self._name(), score=None, metadata={"reason": "No parsed messages"})
+        raw_log = output.get("raw_log")
+        if not raw_log:
+            return Score(name=self._name(), score=None, metadata={"reason": "No raw log"})
 
+        parser = LogParser(raw_log, initial_prompt=output.get("prompt", "") or "")
         seen: list[str] = [
-            tool_use["name"]
-            for tool_use, _ in iter_successful_tool_calls(messages)
-            if normalize_tool_name(tool_use.get("name")) in self.required
+            call.name for call in parser.get_tool_calls() if not call.is_error and call.name in self.required
         ]
         if seen:
             return Score(
@@ -132,61 +130,3 @@ class RequiredToolCall(Scorer):
             score=0.0,
             metadata={"reason": "No required tool call found", "required": sorted(self.required)},
         )
-
-
-def normalize_tool_name(name: str | None) -> str:
-    """Strip the Claude-Code MCP namespace prefix from a tool name.
-
-    When Claude Code surfaces MCP tools it exposes them as ``mcp__<server>__<tool>``.
-    The sandbox ACP log captures that fully-qualified name on ``tool_use`` blocks,
-    but scorers (and the rest of the repo) think in bare tool names like
-    ``query-retention``. Normalizing here keeps the scorer API simple — callers
-    pass unprefixed names and this function handles both shapes.
-    """
-    if not name:
-        return ""
-    if name.startswith("mcp__"):
-        parts = name.split("__", 2)
-        if len(parts) == 3:
-            return parts[2]
-    return name
-
-
-def iter_successful_tool_calls(messages: list[dict[str, Any]]):
-    """Yield `(tool_use_block, tool_result_block)` pairs for each completed call.
-
-    Only yields pairs where the `tool_result` does not carry `is_error: true`.
-    Unpaired tool_use blocks (call made but no result captured) are skipped —
-    we can't conclude success without the paired result. Shared by scorers
-    that need to inspect the agent's successful MCP interactions.
-    """
-    result_by_id: dict[str, dict[str, Any]] = {}
-    for msg in messages:
-        content = msg.get("content")
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") != "tool_result":
-                continue
-            call_id = block.get("tool_use_id")
-            if call_id:
-                result_by_id[call_id] = block
-
-    for msg in messages:
-        content = msg.get("content")
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") != "tool_use":
-                continue
-            call_id = block.get("id")
-            if not call_id:
-                continue
-            result = result_by_id.get(call_id)
-            if result is None or result.get("is_error"):
-                continue
-            yield block, result

--- a/ee/hogai/test/test_log_parser.py
+++ b/ee/hogai/test/test_log_parser.py
@@ -1,0 +1,457 @@
+"""Unit tests for the unified ACP log accessor used by sandboxed-eval scorers."""
+
+from __future__ import annotations
+
+import json
+
+import unittest
+
+from ee.hogai.eval.sandboxed.log_parser import (
+    EXEC_TOOL_NAME,
+    INFO_SYNTHETIC_PREFIX,
+    SKILL_TOOL_NAME,
+    LogParser,
+    SkillCall,
+    ToolCall,
+    normalize_tool_name,
+)
+
+
+def _notification(**params) -> dict:
+    return {
+        "type": "notification",
+        "timestamp": params.pop("ts"),
+        "notification": {
+            "jsonrpc": "2.0",
+            "method": params.pop("method", "session/update"),
+            "params": params.pop("params", {}),
+        },
+    }
+
+
+def _session_update(ts: str, update: dict) -> str:
+    return json.dumps(_notification(ts=ts, method="session/update", params={"sessionId": "s", "update": update}))
+
+
+def _prompt(ts: str, text: str = "hello") -> str:
+    return json.dumps(
+        _notification(
+            ts=ts,
+            method="session/prompt",
+            params={"sessionId": "s", "prompt": [{"type": "text", "text": text}]},
+        )
+    )
+
+
+def _end_turn(ts: str, usage: dict | None = None) -> str:
+    return json.dumps(
+        {
+            "type": "notification",
+            "timestamp": ts,
+            "notification": {
+                "jsonrpc": "2.0",
+                "result": {
+                    "stopReason": "end_turn",
+                    "usage": usage
+                    or {
+                        "inputTokens": 1,
+                        "outputTokens": 1,
+                        "cachedReadTokens": 0,
+                        "cachedWriteTokens": 0,
+                        "totalTokens": 2,
+                    },
+                },
+            },
+        }
+    )
+
+
+def _tool_call_start(ts: str, call_id: str, name: str) -> str:
+    return _session_update(
+        ts,
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": call_id,
+            "status": "pending",
+            "rawInput": {},
+            "title": name,
+            "_meta": {"claudeCode": {"toolName": name}},
+        },
+    )
+
+
+def _tool_call_input(ts: str, call_id: str, raw_input: dict) -> str:
+    return _session_update(
+        ts,
+        {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": call_id,
+            "status": None,
+            "rawInput": raw_input,
+        },
+    )
+
+
+def _tool_call_completed(ts: str, call_id: str, output: str, status: str = "completed") -> str:
+    return _session_update(
+        ts,
+        {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": call_id,
+            "status": status,
+            "rawOutput": output,
+        },
+    )
+
+
+def _agent_text(ts: str, text: str) -> str:
+    return _session_update(
+        ts,
+        {"sessionUpdate": "agent_message", "content": {"type": "text", "text": text}},
+    )
+
+
+def _join(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
+def _make_tool_log(
+    tool_name: str,
+    raw_input: dict,
+    output: str = "ok",
+    status: str = "completed",
+    call_id: str = "t1",
+) -> str:
+    """Build a minimal one-call session: prompt → tool → final text → end_turn."""
+    return _join(
+        [
+            _prompt("2026-04-15T10:00:00.000Z"),
+            _tool_call_start("2026-04-15T10:00:01.000Z", call_id, tool_name),
+            _tool_call_input("2026-04-15T10:00:01.100Z", call_id, raw_input),
+            _tool_call_completed("2026-04-15T10:00:02.000Z", call_id, output, status=status),
+            _agent_text("2026-04-15T10:00:03.000Z", "done"),
+            _end_turn("2026-04-15T10:00:04.000Z"),
+        ]
+    )
+
+
+class TestLogParserSkillCalls(unittest.TestCase):
+    def test_was_skill_called_returns_true_for_matching_skill(self):
+        raw = _make_tool_log(
+            SKILL_TOOL_NAME,
+            {"skill": "improving-drf-endpoints", "args": ""},
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+        self.assertTrue(parser.was_skill_called("improving-drf-endpoints"))
+
+    def test_was_skill_called_returns_false_for_unmatched_skill(self):
+        raw = _make_tool_log(
+            SKILL_TOOL_NAME,
+            {"skill": "improving-drf-endpoints", "args": ""},
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+        self.assertFalse(parser.was_skill_called("django-migrations"))
+
+    def test_was_skill_called_returns_false_when_no_skill_calls(self):
+        raw = _make_tool_log("query-trends", {"foo": 1})
+        parser = LogParser(raw, initial_prompt="hi")
+        self.assertFalse(parser.was_skill_called("anything"))
+
+    def test_get_skill_calls_returns_chronological_list(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _tool_call_start("2026-04-15T10:00:01.000Z", "s1", SKILL_TOOL_NAME),
+                _tool_call_input("2026-04-15T10:00:01.100Z", "s1", {"skill": "first", "args": "a"}),
+                _tool_call_completed("2026-04-15T10:00:02.000Z", "s1", "r1"),
+                _tool_call_start("2026-04-15T10:00:03.000Z", "s2", SKILL_TOOL_NAME),
+                _tool_call_input("2026-04-15T10:00:03.100Z", "s2", {"skill": "second"}),
+                _tool_call_completed("2026-04-15T10:00:04.000Z", "s2", "r2"),
+                _agent_text("2026-04-15T10:00:05.000Z", "done"),
+                _end_turn("2026-04-15T10:00:06.000Z"),
+            ]
+        )
+
+        parser = LogParser(raw, initial_prompt="hi")
+        calls = parser.get_skill_calls()
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0].name, "first")
+        self.assertEqual(calls[0].args, "a")
+        self.assertEqual(calls[0].output, "r1")
+        self.assertFalse(calls[0].is_error)
+        self.assertEqual(calls[1].name, "second")
+        self.assertIsNone(calls[1].args)
+        self.assertLess(calls[0].position, calls[1].position)
+
+    def test_get_skill_calls_filters_by_name(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _tool_call_start("2026-04-15T10:00:01.000Z", "s1", SKILL_TOOL_NAME),
+                _tool_call_input("2026-04-15T10:00:01.100Z", "s1", {"skill": "first"}),
+                _tool_call_completed("2026-04-15T10:00:02.000Z", "s1", "r1"),
+                _tool_call_start("2026-04-15T10:00:03.000Z", "s2", SKILL_TOOL_NAME),
+                _tool_call_input("2026-04-15T10:00:03.100Z", "s2", {"skill": "second"}),
+                _tool_call_completed("2026-04-15T10:00:04.000Z", "s2", "r2"),
+                _agent_text("2026-04-15T10:00:05.000Z", "done"),
+                _end_turn("2026-04-15T10:00:06.000Z"),
+            ]
+        )
+
+        parser = LogParser(raw, initial_prompt="hi")
+        only_first = parser.get_skill_calls("first")
+
+        self.assertEqual(len(only_first), 1)
+        self.assertEqual(only_first[0].name, "first")
+
+    def test_skill_calls_are_excluded_from_get_tool_calls(self):
+        raw = _make_tool_log(SKILL_TOOL_NAME, {"skill": "x"})
+        parser = LogParser(raw, initial_prompt="hi")
+
+        self.assertEqual(parser.get_tool_calls(), [])
+        self.assertEqual(len(parser.get_skill_calls()), 1)
+
+
+class TestLogParserToolCalls(unittest.TestCase):
+    def test_regular_tool_call_returns_normalized_name_and_input(self):
+        raw = _make_tool_log("query-trends", {"foo": 1})
+        parser = LogParser(raw, initial_prompt="hi")
+
+        calls = parser.get_tool_calls()
+        self.assertEqual(len(calls), 1)
+        call = calls[0]
+        self.assertEqual(call.name, "query-trends")
+        self.assertEqual(call.input, {"foo": 1})
+        self.assertEqual(call.output, "ok")
+        self.assertFalse(call.is_error)
+        self.assertFalse(call.is_exec_unwrapped)
+        self.assertEqual(call.raw_name, "query-trends")
+
+    def test_get_tool_calls_filters_by_normalized_name(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _tool_call_start("2026-04-15T10:00:01.000Z", "t1", "query-trends"),
+                _tool_call_input("2026-04-15T10:00:01.100Z", "t1", {"a": 1}),
+                _tool_call_completed("2026-04-15T10:00:02.000Z", "t1", "r1"),
+                _tool_call_start("2026-04-15T10:00:03.000Z", "t2", "query-funnel"),
+                _tool_call_input("2026-04-15T10:00:03.100Z", "t2", {"b": 2}),
+                _tool_call_completed("2026-04-15T10:00:04.000Z", "t2", "r2"),
+                _agent_text("2026-04-15T10:00:05.000Z", "done"),
+                _end_turn("2026-04-15T10:00:06.000Z"),
+            ]
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        trends = parser.get_tool_calls("query-trends")
+        funnels = parser.get_tool_calls("query-funnel")
+
+        self.assertEqual(len(trends), 1)
+        self.assertEqual(trends[0].input, {"a": 1})
+        self.assertEqual(len(funnels), 1)
+        self.assertEqual(funnels[0].input, {"b": 2})
+
+    def test_failed_tool_calls_surface_with_is_error_true(self):
+        raw = _make_tool_log("query-trends", {"foo": 1}, output="boom", status="failed")
+        parser = LogParser(raw, initial_prompt="hi")
+
+        calls = parser.get_tool_calls()
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0].is_error)
+        self.assertEqual(calls[0].output, "boom")
+
+    def test_unpaired_tool_use_surfaces_with_is_error_true_and_empty_output(self):
+        """When tool_call starts but no completion update arrives, the parser
+        emits a ``tool_use`` block with no matching ``tool_result``. We surface
+        it as ``is_error=True`` so downstream filters can drop it."""
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _tool_call_start("2026-04-15T10:00:01.000Z", "t1", "query-trends"),
+                _tool_call_input("2026-04-15T10:00:01.100Z", "t1", {"foo": 1}),
+                _agent_text("2026-04-15T10:00:03.000Z", "done"),
+                _end_turn("2026-04-15T10:00:04.000Z"),
+            ]
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        calls = parser.get_tool_calls()
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0].is_error)
+        self.assertEqual(calls[0].output, "")
+
+    def test_mcp_prefix_is_stripped_in_normalized_name(self):
+        raw = _make_tool_log("mcp__posthog__query-trends", {"foo": 1})
+        parser = LogParser(raw, initial_prompt="hi")
+
+        call = parser.get_tool_calls()[0]
+        self.assertEqual(call.name, "query-trends")
+        self.assertEqual(call.raw_name, "mcp__posthog__query-trends")
+
+    def test_exec_call_command_is_unwrapped(self):
+        raw = _make_tool_log(
+            EXEC_TOOL_NAME,
+            {"command": 'call query-retention {"foo": 1}'},
+            output="results",
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        calls = parser.get_tool_calls()
+        self.assertEqual(len(calls), 1)
+        call = calls[0]
+        self.assertEqual(call.name, "query-retention")
+        self.assertEqual(call.input, {"foo": 1})
+        self.assertTrue(call.is_exec_unwrapped)
+        self.assertEqual(call.raw_name, EXEC_TOOL_NAME)
+        self.assertEqual(call.output, "results")
+
+    def test_exec_call_with_json_flag_is_unwrapped(self):
+        raw = _make_tool_log(
+            EXEC_TOOL_NAME,
+            {"command": 'call --json query-trends {"x": 2}'},
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        call = parser.get_tool_calls()[0]
+        self.assertEqual(call.name, "query-trends")
+        self.assertEqual(call.input, {"x": 2})
+        self.assertTrue(call.is_exec_unwrapped)
+
+    def test_exec_info_command_produces_synthetic_name(self):
+        raw = _make_tool_log(
+            EXEC_TOOL_NAME,
+            {"command": "info query-trends"},
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        call = parser.get_tool_calls()[0]
+        self.assertEqual(call.name, f"{INFO_SYNTHETIC_PREFIX}query-trends")
+        self.assertEqual(call.input, {})
+        self.assertTrue(call.is_exec_unwrapped)
+
+    def test_exec_unrecognized_command_falls_back_to_raw_exec(self):
+        raw = _make_tool_log(
+            EXEC_TOOL_NAME,
+            {"command": "search foo"},
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        call = parser.get_tool_calls()[0]
+        self.assertEqual(call.name, EXEC_TOOL_NAME)
+        self.assertFalse(call.is_exec_unwrapped)
+        self.assertEqual(call.input, {"command": "search foo"})
+
+    def test_filter_by_name_matches_exec_unwrapped_inner_tool(self):
+        raw = _make_tool_log(
+            EXEC_TOOL_NAME,
+            {"command": 'call query-retention {"foo": 1}'},
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        self.assertEqual(len(parser.get_tool_calls("query-retention")), 1)
+        self.assertEqual(parser.get_tool_calls("exec"), [])
+
+    def test_position_is_chronological(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _tool_call_start("2026-04-15T10:00:01.000Z", "t1", "first"),
+                _tool_call_input("2026-04-15T10:00:01.100Z", "t1", {}),
+                _tool_call_completed("2026-04-15T10:00:02.000Z", "t1", "r1"),
+                _tool_call_start("2026-04-15T10:00:03.000Z", "t2", "second"),
+                _tool_call_input("2026-04-15T10:00:03.100Z", "t2", {}),
+                _tool_call_completed("2026-04-15T10:00:04.000Z", "t2", "r2"),
+                _agent_text("2026-04-15T10:00:05.000Z", "done"),
+                _end_turn("2026-04-15T10:00:06.000Z"),
+            ]
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+
+        calls = parser.get_tool_calls()
+        self.assertEqual([c.name for c in calls], ["first", "second"])
+        self.assertLess(calls[0].position, calls[1].position)
+
+
+class TestLogParserMessages(unittest.TestCase):
+    def test_get_final_agent_message_returns_last_assistant_text(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _agent_text("2026-04-15T10:00:01.000Z", "first reply"),
+                _tool_call_start("2026-04-15T10:00:02.000Z", "t1", "search"),
+                _tool_call_input("2026-04-15T10:00:02.100Z", "t1", {}),
+                _tool_call_completed("2026-04-15T10:00:03.000Z", "t1", "r"),
+                _agent_text("2026-04-15T10:00:04.000Z", "final reply"),
+                _end_turn("2026-04-15T10:00:05.000Z"),
+            ]
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+        self.assertEqual(parser.get_final_agent_message(), "final reply")
+
+    def test_get_final_agent_message_returns_none_when_run_ends_on_tool_use(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _tool_call_start("2026-04-15T10:00:01.000Z", "t1", "search"),
+                _tool_call_input("2026-04-15T10:00:01.100Z", "t1", {}),
+                _tool_call_completed("2026-04-15T10:00:02.000Z", "t1", "r"),
+                _end_turn("2026-04-15T10:00:03.000Z"),
+            ]
+        )
+        parser = LogParser(raw, initial_prompt="hi")
+        self.assertIsNone(parser.get_final_agent_message())
+
+    def test_get_user_prompt_returns_initial_prompt_when_seeded(self):
+        raw = _join(
+            [
+                _prompt("2026-04-15T10:00:00.000Z"),
+                _agent_text("2026-04-15T10:00:01.000Z", "ok"),
+                _end_turn("2026-04-15T10:00:02.000Z"),
+            ]
+        )
+        parser = LogParser(raw, initial_prompt="seeded prompt")
+        self.assertEqual(parser.get_user_prompt(), "seeded prompt")
+
+    def test_get_user_prompt_falls_back_when_no_initial_prompt(self):
+        raw = _join(
+            [
+                _agent_text("2026-04-15T10:00:01.000Z", "ok"),
+                _end_turn("2026-04-15T10:00:02.000Z"),
+            ]
+        )
+        parser = LogParser(raw)
+        self.assertEqual(parser.get_user_prompt(), "")
+
+
+class TestLogParserModels(unittest.TestCase):
+    def test_tool_call_is_frozen(self):
+        call = ToolCall(
+            name="x",
+            input={},
+            output="",
+            is_error=False,
+            call_id="c",
+            position=0,
+            raw_name="x",
+            is_exec_unwrapped=False,
+        )
+        with self.assertRaises(Exception):
+            call.name = "y"  # type: ignore[misc]
+
+    def test_skill_call_is_frozen(self):
+        call = SkillCall(name="x", call_id="c", output="", is_error=False, position=0)
+        with self.assertRaises(Exception):
+            call.name = "y"  # type: ignore[misc]
+
+
+class TestNormalizeToolName(unittest.TestCase):
+    def test_strips_mcp_prefix(self):
+        self.assertEqual(normalize_tool_name("mcp__posthog__query-trends"), "query-trends")
+
+    def test_passes_through_bare_names(self):
+        self.assertEqual(normalize_tool_name("query-trends"), "query-trends")
+
+    def test_handles_empty_and_none(self):
+        self.assertEqual(normalize_tool_name(None), "")
+        self.assertEqual(normalize_tool_name(""), "")


### PR DESCRIPTION
## Problem

The sandboxed eval scorers contain duplicated logic for parsing ACP logs and extracting tool calls. The `scorers.py` module has ad-hoc helpers like `_parse_exec_command`, `_enumerate_tool_calls`, and `_extract_user_prompt` that should be centralized and reusable. This makes the code harder to maintain and test.

## Changes

Created a new `LogParser` module (`ee/hogai/eval/sandboxed/log_parser.py`) that provides a clean, typed API for accessing ACP log data:

- **New `LogParser` class**: Wraps `acp_log.parse_log()` with first-class methods for querying tool calls, skill calls, and messages
- **New data models**: `ToolCall` and `SkillCall` frozen Pydantic models with clear semantics (normalized names, error states, chronological positions)
- **Centralized parsing logic**: Moved `_parse_exec_command()`, `normalize_tool_name()`, and tool result indexing into the module
- **Comprehensive unit tests**: Added 457 lines of test coverage in `test_log_parser.py` covering skill calls, tool calls, exec unwrapping, message extraction, and edge cases

Updated scorers to use the new `LogParser`:
- `product_analytics/scorers.py`: Replaced manual message walking with `LogParser.get_tool_calls()` and `LogParser.get_user_prompt()`
- `deterministic.py`: Simplified `NoToolCall` and `RequiredToolCall` to use the parser instead of `iter_successful_tool_calls()`
- `__init__.py`: Removed deprecated helper exports, now imports from `log_parser`

The new module is pure data layer with no Braintrust or model dependencies, making it lightweight and testable in isolation.

## How did you test this code?

Added comprehensive unit test suite (`test_log_parser.py`) with 457 lines covering:
- Skill call detection and filtering
- Tool call extraction with normalization
- Exec command unwrapping (both `call` and `info` variants)
- Error handling for unpaired tool uses
- Message extraction (final agent message, user prompt)
- Chronological ordering via position tracking
- Model immutability (frozen Pydantic models)

All tests pass and validate the parser behavior against realistic log scenarios.

## Publish to changelog?

No

https://claude.ai/code/session_01EiUVqno4LxeY6QVq8dtKtL