### PR TITLE
fix(ci): wait for status-job before capturing run conclusion

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -639,7 +639,7 @@ jobs:
         name: Capture run time
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        needs: [changes, playwright]
+        needs: [changes, playwright, playwright_tests]
         if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)
             always() && github.actor != 'dependabot[bot]' &&
             needs.changes.outputs.shouldRun == 'true' && (

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -349,7 +349,7 @@ jobs:
 
     calculate-running-time:
         name: Calculate running time
-        needs: [jest, frontend-typescript-checks, frontend-format, frontend-bundle-size, changes]
+        needs: [jest, frontend-typescript-checks, frontend-format, frontend-bundle-size, frontend_tests, changes]
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -510,7 +510,7 @@ jobs:
 
     calculate-running-time:
         name: Calculate running time
-        needs: [visual-regression, changes]
+        needs: [visual-regression, visual_regression_tests, changes]
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)


### PR DESCRIPTION
## Problem

The "CI failure rate on master by workflow" dashboard on PostHog's DevEx project shows Storybook and E2E CI Playwright pegged at 100% failure rate since ~Apr 21, and Frontend CI partially understated. The dashboard description blames a "known emitter gap," but the gap is actually in the workflow needs graph, not the action.

## Root cause

`PostHog/posthog-github-action@v1.2.0` queries the GitHub API once for the conclusion of the job named in `status-job:`. If that job hasn't completed yet, the API returns `null`, and the captured event has `conclusion=null`; silently excluded from the dashboard's `failures / (failures + successes)` formula.

Backend got fixed in #44864 by depending on the aggregator job (`django_tests`) directly. #46859 added `status-job` to the other three workflows but didn't update their `needs:` lists, so the capture job races the aggregator. Failures usually win the race (the aggregator exits early on the first failed dependency), successes usually don't — which matches the observed asymmetry: failures land, successes go to null.

## Fix

Add the aggregator job_id to each capture job's `needs:`. Three-line change.

| Workflow                | Aggregator added          |
| ----------------------- | ------------------------- |
| `ci-frontend.yml`       | `frontend_tests`          |
| `ci-storybook.yml`      | `visual_regression_tests` |
| `ci-e2e-playwright.yml` | `playwright_tests`        |

Verified by querying `posthog-ci-running-time` events on the DevEx project: Backend (which already has the aggregator in `needs:`) has 0 nulls; the other three have ~85–100% nulls on success-conclusion events.