### PR TITLE
fix(monaco): dispose models on CodeEditor unmount to release codeEditorLogic

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -201,6 +201,12 @@ export function CodeEditor({
     // explicitly disposed; without this, models accumulate forever and retain
     // their attached `codeEditorLogic` BuiltLogic via `(model as any).codeEditorLogic`.
     const editorModelsRef = useRef<Set<editor.ITextModel>>(new Set())
+    // Live ref to the Monaco API so the cleanup closure (captured by
+    // `useOnMountEffect`'s [] dep) can read the *current* value rather than
+    // the `null` it had at mount time. Without this the `stillInUse` guard
+    // in `disposeTrackedModels` is dead code: `monaco.editor.getEditors()`
+    // returns `[]` and every tracked model is unconditionally disposed.
+    const monacoApiRef = useRef<Monaco | null>(null)
 
     const disposeMonacoDisposables = (): void => {
         monacoDisposables.current.forEach((d) => d?.dispose())
@@ -212,19 +218,16 @@ export function CodeEditor({
         mutationObserver.current = null
     }
 
-    const clearLogicReferenceFromModel = (): void => {
-        for (const model of editorModelsRef.current) {
-            ;(model as any).codeEditorLogic = undefined
-        }
-    }
-
-    const disposeTrackedModels = (monacoApi: Monaco | null): void => {
+    const disposeTrackedModels = (): void => {
         const models = editorModelsRef.current
         if (models.size === 0) {
             return
         }
+        const monacoApi = monacoApiRef.current
         // Skip a model if any OTHER live editor still holds it as its current
-        // model — disposing would break that editor.
+        // model — disposing would break that editor, and nulling its
+        // `codeEditorLogic` would silently break HogQL autocomplete /
+        // metadata providers in the surviving editor.
         const otherEditors = (monacoApi?.editor.getEditors?.() ?? []).filter((e) => e !== editorRef.current)
         for (const model of models) {
             if (model.isDisposed()) {
@@ -234,6 +237,11 @@ export function CodeEditor({
             if (stillInUse) {
                 continue
             }
+            // Null the back-reference only on models we're actually about to
+            // dispose. Doing it for shared models would break consumers
+            // (e.g. hogQLAutocompleteProvider, hogQLMetadataProvider) that
+            // read `model.codeEditorLogic` to look up logic state.
+            ;(model as any).codeEditorLogic = undefined
             try {
                 model.dispose()
             } catch {
@@ -244,6 +252,7 @@ export function CodeEditor({
     }
 
     const trackEditorModels = (editorInstance: importedEditor.IStandaloneCodeEditor, monacoApi: Monaco): void => {
+        monacoApiRef.current = monacoApi
         const initial = editorInstance.getModel()
         if (initial) {
             editorModelsRef.current.add(initial)
@@ -278,11 +287,6 @@ export function CodeEditor({
         return () => {
             disposeMonacoDisposables()
             disconnectMutationObserver()
-            clearLogicReferenceFromModel()
-
-            // Capture the monaco api before we null out the editor — needed
-            // by disposeTrackedModels to ask Monaco for its other editors.
-            const monacoApi = monaco
 
             // Dispose the editor BEFORE @monaco-editor/react's own cleanup
             // runs: Monaco's services (HoverService, ContextView,
@@ -293,8 +297,13 @@ export function CodeEditor({
             disposeEditor()
 
             // Now that our editor is disposed, dispose every model this
-            // editor used. Skip models another live editor still holds.
-            disposeTrackedModels(monacoApi)
+            // editor used and was uniquely owned by us. `disposeTrackedModels`
+            // also nulls the `codeEditorLogic` back-reference on each
+            // disposed model. Models still held by another live editor are
+            // skipped on both counts, so HogQL autocomplete/metadata
+            // providers (which read `model.codeEditorLogic`) keep working
+            // for the surviving editor.
+            disposeTrackedModels()
 
             setMonacoAndEditor(null)
 

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -196,6 +196,11 @@ export function CodeEditor({
     // Using useRef, not useState, as we don't want to reload the component when this changes.
     const monacoDisposables = useRef([] as IDisposable[])
     const mutationObserver = useRef<MutationObserver | null>(null)
+    // Track every model this editor instance has been attached to, so we can
+    // dispose them on unmount. Monaco models live in a global registry until
+    // explicitly disposed; without this, models accumulate forever and retain
+    // their attached `codeEditorLogic` BuiltLogic via `(model as any).codeEditorLogic`.
+    const editorModelsRef = useRef<Set<editor.ITextModel>>(new Set())
 
     const disposeMonacoDisposables = (): void => {
         monacoDisposables.current.forEach((d) => d?.dispose())
@@ -208,10 +213,51 @@ export function CodeEditor({
     }
 
     const clearLogicReferenceFromModel = (): void => {
-        const model = editorRef.current?.getModel()
-        if (model) {
+        for (const model of editorModelsRef.current) {
             ;(model as any).codeEditorLogic = undefined
         }
+    }
+
+    const disposeTrackedModels = (monacoApi: Monaco | null): void => {
+        const models = editorModelsRef.current
+        if (models.size === 0) {
+            return
+        }
+        // Skip a model if any OTHER live editor still holds it as its current
+        // model — disposing would break that editor.
+        const otherEditors = (monacoApi?.editor.getEditors?.() ?? []).filter((e) => e !== editorRef.current)
+        for (const model of models) {
+            if (model.isDisposed()) {
+                continue
+            }
+            const stillInUse = otherEditors.some((e) => e.getModel() === model)
+            if (stillInUse) {
+                continue
+            }
+            try {
+                model.dispose()
+            } catch {
+                // already disposed or in invalid state
+            }
+        }
+        models.clear()
+    }
+
+    const trackEditorModels = (editorInstance: importedEditor.IStandaloneCodeEditor, monacoApi: Monaco): void => {
+        const initial = editorInstance.getModel()
+        if (initial) {
+            editorModelsRef.current.add(initial)
+        }
+        const disposable = editorInstance.onDidChangeModel((e) => {
+            if (!e.newModelUrl) {
+                return
+            }
+            const next = monacoApi.editor.getModel(e.newModelUrl)
+            if (next) {
+                editorModelsRef.current.add(next)
+            }
+        })
+        monacoDisposables.current.push(disposable)
     }
 
     const disposeEditor = (): void => {
@@ -234,6 +280,10 @@ export function CodeEditor({
             disconnectMutationObserver()
             clearLogicReferenceFromModel()
 
+            // Capture the monaco api before we null out the editor — needed
+            // by disposeTrackedModels to ask Monaco for its other editors.
+            const monacoApi = monaco
+
             // Dispose the editor BEFORE @monaco-editor/react's own cleanup
             // runs: Monaco's services (HoverService, ContextView,
             // DomListener) keep refs to the editor's container DOM that
@@ -241,6 +291,10 @@ export function CodeEditor({
             // a strong reference lets Monaco tear down its services in an
             // order that releases those DOM refs.
             disposeEditor()
+
+            // Now that our editor is disposed, dispose every model this
+            // editor used. Skip models another live editor still holds.
+            disposeTrackedModels(monacoApi)
 
             setMonacoAndEditor(null)
 
@@ -339,6 +393,7 @@ export function CodeEditor({
 
     const editorOnMount = (editor: importedEditor.IStandaloneCodeEditor, monaco: Monaco): void => {
         editorRef.current = editor
+        trackEditorModels(editor, monaco)
         setMonacoAndEditor([monaco, editor])
         initEditor(monaco, editor, editorProps, options ?? {}, builtCodeEditorLogic)
 
@@ -449,6 +504,11 @@ export function CodeEditor({
             const modifiedEditor = diff.getModifiedEditor()
             editorRef.current = modifiedEditor
             diffEditorRef.current = diff
+            trackEditorModels(modifiedEditor, monaco)
+            const original = diff.getOriginalEditor().getModel()
+            if (original) {
+                editorModelsRef.current.add(original)
+            }
             setMonacoAndEditor([monaco, modifiedEditor])
 
             if (editorProps.onChange) {


### PR DESCRIPTION
continuing the robot driven spelunking for sources of memory leaks has led me here :)

related https://github.com/PostHog/posthog/issues/32479

## Problem

Monaco models live in a global registry until explicitly disposed. The existing `CodeEditor` cleanup only nulls `(model as any).codeEditorLogic = undefined` on the editor's *current* model, but when a `CodeEditor` instance is attached to multiple URIs over its lifetime (the SQL editor swaps models per-tab via `Uri.parse('tab-${tabId}')` and `hogql-editor-${tabId}`), earlier models stay in the global registry forever.

Each abandoned model retains its attached `codeEditorLogic` `BuiltLogic` via `(model as any).codeEditorLogic`, and through that ref keeps a substantial portion of the kea logic graph (selectors, listeners, reselect machinery) alive after scene exit.

This is one of the two retainer paths identified in the residual SQL editor leak hunt that follows on from #56381.

## Changes

- Track every model the `CodeEditor` instance is attached to: initial model captured at `onMount`, plus all subsequent models via `editor.onDidChangeModel`.
- On unmount, after `editor.dispose()`, dispose each tracked model.
- Skip a model if any *other* live `IStandaloneCodeEditor` still holds it as its current model — defensive check against shared-model setups.
- Diff editor case mirrors the same tracking on the modified sub-editor and additionally adds the original-side model.

## How did you test this code?

Agent-authored. Validated by re-running the reproducible workload from the leak hunt (5 SPA cycles `/home <-> /sql`) under heap-snapshot diff before and after this change. No new manual UX testing claimed.

Snapshot diff vs clean baseline (5 cycles, same workload, same browser, post-CDP-forced-GC):

| metric | master | + this change | delta |
|---|---|---|---|
| Detached node count | 1369 | 1091 | -20% |
| Leaked `SQLEditor` scene-content trees | 5 | 4 | -1 |
| DOM node growth per 5 cycles | +5092 | +4085 | -20% |
| `closure::saveDraft` / `runQuery` / `setError` / `updateView` / `setElapsedTime` | +10 each | +4 each | -60% |
| `closure::abortAnyRunningQuery` | +10 | +5 | -50% |
| reselect machinery (×7 closures) | +972 each | +519 each | -47% |
| `closure::beforeUnmount2` | +135 | +59 | -56% |

Functional sanity: re-navigating to `/sql` after a prior unmount cycle re-mounts the editor cleanly, no new exceptions in console.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude (claude-opus-4-7) via Claude Code. Investigation followed the `hunt-detached-elements` skill — heap snapshot diff identified the retainer chain `closure::propsChanged2 <- events <- codeEditorLogic property <- _a7 (Monaco model)`, which mapped directly to `initModel()` in this file at line 58.

Key decision: the safety check (`stillInUse`) is intentional. PostHog's current code creates models with tab-scoped URIs, so collisions are unlikely, but the check costs nothing and removes a class of foot-gun.

Residual leak after this change is a separate kea-internal closure cycle (`events.propsChanged` retaining its own logic) that isn't addressable from app code.