### PR TITLE
fix: remove duplicated parameter in customer.io source

### DIFF
--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -92,7 +92,6 @@ Once created, copy the **Signing key** from the webhook details page and add it 
                         required=True,
                         secret=True,
                         placeholder="Customer.io reporting webhook signing key",
-                        secret=True,
                     ),
                 ],
             ),


### PR DESCRIPTION
## Problem

Removes a duplicate `secret=True` keyword argument in the Customer.io webhook source configuration that would cause a `SyntaxError` or unexpected behavior at runtime.

## Changes

- Removed the duplicated `secret=True` parameter from the Customer.io reporting webhook signing key field definition in `posthog/temporal/data_imports/sources/customer_io/source.py`

## How did you test this code?

This is an agent-authored fix. The change removes a syntactically duplicate keyword argument. No automated tests were run as the fix is a single-line removal of a redundant parameter.

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (claude-sonnet-4-6). Fix identified from the modified file in the working tree. The duplicate `secret=True` kwarg on line 95 was a copy-paste error — the argument already appeared two lines above it.