### PR TITLE
chore(batch-exports): add 'europe-west4' GCS region

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -140,7 +140,8 @@ export function BatchExportsEditFields({
                                     { value: 'me-central-1', label: 'Middle East (Riyadh)' },
                                     { value: 'sa-east-1', label: 'South America (São Paulo)' },
                                     // GCP
-                                    { value: 'us-central1', label: 'US Central (Iowa)' },
+                                    { value: 'us-central1', label: 'GCP — US Central (Iowa)' },
+                                    { value: 'europe-west4', label: 'GCP — Europe (Netherlands)' },
                                     // Cloudflare R2
                                     { value: 'auto', label: 'Automatic (AUTO)' },
                                     { value: 'apac', label: 'Asia Pacific (APAC)' },


### PR DESCRIPTION
## TL;DR
Added support for GCP Europe (Netherlands) region in batch exports and clarified AWS vs GCP region labels to prevent user confusion.

## Problem
Users selecting S3 regions in batch exports could be confused by ambiguous region labels that don't clearly indicate which cloud provider (AWS vs GCP) each region belongs to.

## Changes
- Added `europe-west4` (GCP — Europe (Netherlands)) as a new batch export destination region
- Updated `us-central1` label from "US Central (Iowa)" to "GCP — US Central (Iowa)" for clarity
- Both GCP regions now have "GCP —" prefix to distinguish them from AWS regions in the dropdown

## How did you test this code?
I didn't

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*