### PR TITLE
chore(feature-flags): backfill management command for orphan hash key overrides

### DIFF
--- a/posthog/management/commands/backfill_orphan_hash_key_overrides.py
+++ b/posthog/management/commands/backfill_orphan_hash_key_overrides.py
@@ -55,7 +55,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Report orphan counts without deleting any rows.",
+            help=(
+                "Walk the orphan rows without deleting them and log the count per batch. "
+                "Bounded by --max-batches when set; otherwise scans every orphan in the "
+                "selected team(s) using an id-cursor window."
+            ),
         )
         parser.add_argument(
             "--team-id",
@@ -105,6 +109,7 @@ class Command(BaseCommand):
         total_orphans_seen = 0
         total_deleted = 0
         batches_run = 0
+        teams_processed = 0
 
         for current_team_id in team_ids:
             if max_batches is not None and batches_run >= max_batches:
@@ -130,11 +135,13 @@ class Command(BaseCommand):
             total_orphans_seen += team_orphans
             total_deleted += team_deleted
             batches_run += team_batches
+            teams_processed += 1
 
         logger.info(
             "backfill_orphan_hash_key_overrides_complete",
             dry_run=dry_run,
-            teams_processed=len(team_ids),
+            teams_processed=teams_processed,
+            teams_total=len(team_ids),
             orphans_seen=total_orphans_seen,
             rows_deleted=total_deleted,
             batches_run=batches_run,
@@ -150,10 +157,19 @@ class Command(BaseCommand):
         dry_run: bool,
         remaining_batches: int | None,
     ) -> tuple[int, int, int]:
-        """Process one team's orphans. Returns (orphans_seen, rows_deleted, batches_run)."""
+        """Process one team's orphans. Returns (orphans_seen, rows_deleted, batches_run).
+
+        Uses an id-cursor window (``id__gt=last_seen_id``) so dry-run mode can
+        walk the full orphan set without re-selecting the same rows forever
+        (deletion-based windowing isn't available when nothing is being
+        deleted). Real runs benefit too — the cursor shape is the same in
+        both modes, and ``id__gt`` plays well with the ``(id)`` primary-key
+        index.
+        """
         orphans_seen = 0
         rows_deleted = 0
         batches_run = 0
+        last_seen_id = 0
 
         while True:
             if remaining_batches is not None and batches_run >= remaining_batches:
@@ -161,8 +177,9 @@ class Command(BaseCommand):
 
             ids_qs = (
                 FeatureFlagHashKeyOverride.objects.using(PERSONS_DB_FOR_WRITE)
-                .filter(team_id=team_id)
+                .filter(team_id=team_id, id__gt=last_seen_id)
                 .exclude(feature_flag_key__in=keys_to_keep)
+                .order_by("id")
                 .values_list("id", flat=True)[:batch_size]
             )
             ids = list(ids_qs)
@@ -171,6 +188,7 @@ class Command(BaseCommand):
 
             orphans_seen += len(ids)
             batches_run += 1
+            last_seen_id = ids[-1]
 
             if dry_run:
                 logger.info(
@@ -178,22 +196,20 @@ class Command(BaseCommand):
                     team_id=team_id,
                     batch_size=len(ids),
                     batches_run_for_team=batches_run,
+                    cursor=last_seen_id,
                 )
-                # Slide the window: in dry-run we'd otherwise re-select the
-                # same ids forever. Break once we've sampled one batch per
-                # team (the dry-run is a probe, not an exact count).
-                break
-
-            with transaction.atomic(using=PERSONS_DB_FOR_WRITE):
-                deleted, _ = FeatureFlagHashKeyOverride.objects.using(PERSONS_DB_FOR_WRITE).filter(id__in=ids).delete()
-                rows_deleted += deleted
-
-            logger.info(
-                "backfill_orphan_hash_key_overrides_batch",
-                team_id=team_id,
-                rows_deleted=deleted,
-                batches_run_for_team=batches_run,
-            )
+            else:
+                with transaction.atomic(using=PERSONS_DB_FOR_WRITE):
+                    deleted, _ = (
+                        FeatureFlagHashKeyOverride.objects.using(PERSONS_DB_FOR_WRITE).filter(id__in=ids).delete()
+                    )
+                    rows_deleted += deleted
+                logger.info(
+                    "backfill_orphan_hash_key_overrides_batch",
+                    team_id=team_id,
+                    rows_deleted=deleted,
+                    batches_run_for_team=batches_run,
+                )
 
             if sleep_between_batches > 0:
                 time.sleep(sleep_between_batches)

--- a/posthog/management/commands/backfill_orphan_hash_key_overrides.py
+++ b/posthog/management/commands/backfill_orphan_hash_key_overrides.py
@@ -1,0 +1,201 @@
+"""Backfill management command — sweep orphan ``FeatureFlagHashKeyOverride`` rows.
+
+Companion to PR #56521 (write-time cleanup hooks). The hooks only fire on
+product-driven paths (PATCH rename, PATCH soft-delete) on flags whose row
+count for the affected (team, key) tuple is below the inline threshold.
+This command is the safety net for everything else:
+
+1. Orphans accumulated *before* the write-time hooks shipped.
+2. Cases the hooks intentionally skipped because the team's row count
+   exceeded ``HASH_KEY_OVERRIDE_LARGE_TEAM_THRESHOLD`` (50_000).
+3. Hard-delete paths (admin tooling) that bypass the serializer entirely.
+
+An orphan row is a ``FeatureFlagHashKeyOverride`` whose
+``(team_id, feature_flag_key)`` tuple does not match any current flag key
+in that team — including soft-deleted flags' current (suffixed) keys.
+
+Usage examples::
+
+    # Dry-run across all teams; reports counts only.
+    python manage.py backfill_orphan_hash_key_overrides --dry-run
+
+    # Real run, one team at a time, with throttling.
+    python manage.py backfill_orphan_hash_key_overrides \\
+        --team-id 12345 \\
+        --batch-size 5000 \\
+        --sleep-between-batches 0.5
+
+    # Bound the run for an operator who wants to ship a partial sweep.
+    python manage.py backfill_orphan_hash_key_overrides --max-batches 20
+"""
+
+from __future__ import annotations
+
+import time
+
+from django.core.management.base import BaseCommand, CommandParser
+from django.db import transaction
+
+import structlog
+
+from posthog.models.feature_flag.feature_flag import FeatureFlag, FeatureFlagHashKeyOverride
+from posthog.models.team import Team
+from posthog.person_db_router import PERSONS_DB_FOR_WRITE
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_BATCH_SIZE = 10_000
+DEFAULT_SLEEP_BETWEEN_BATCHES = 0.5
+
+
+class Command(BaseCommand):
+    help = "Sweep orphan FeatureFlagHashKeyOverride rows whose feature_flag_key no longer matches any flag in the team."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report orphan counts without deleting any rows.",
+        )
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            default=None,
+            help="Restrict the sweep to a single team. Omit to iterate all teams.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=DEFAULT_BATCH_SIZE,
+            help=f"Rows deleted per atomic block (default {DEFAULT_BATCH_SIZE}).",
+        )
+        parser.add_argument(
+            "--sleep-between-batches",
+            type=float,
+            default=DEFAULT_SLEEP_BETWEEN_BATCHES,
+            help=f"Seconds to sleep between batches to throttle write load (default {DEFAULT_SLEEP_BETWEEN_BATCHES}).",
+        )
+        parser.add_argument(
+            "--max-batches",
+            type=int,
+            default=None,
+            help="Cap the total number of batches across all teams. Omit for unbounded.",
+        )
+
+    def handle(self, *args: object, **options: object) -> None:
+        dry_run: bool = bool(options["dry_run"])
+        team_id: int | None = options["team_id"]  # type: ignore[assignment]
+        batch_size: int = int(options["batch_size"])  # type: ignore[arg-type]
+        sleep_between_batches: float = float(options["sleep_between_batches"])  # type: ignore[arg-type]
+        max_batches: int | None = options["max_batches"]  # type: ignore[assignment]
+
+        if batch_size <= 0:
+            raise ValueError("--batch-size must be positive")
+
+        team_ids = [team_id] if team_id is not None else list(Team.objects.order_by("id").values_list("id", flat=True))
+        logger.info(
+            "backfill_orphan_hash_key_overrides_start",
+            dry_run=dry_run,
+            team_count=len(team_ids),
+            batch_size=batch_size,
+            sleep_between_batches=sleep_between_batches,
+            max_batches=max_batches,
+        )
+
+        total_orphans_seen = 0
+        total_deleted = 0
+        batches_run = 0
+
+        for current_team_id in team_ids:
+            if max_batches is not None and batches_run >= max_batches:
+                logger.info("backfill_orphan_hash_key_overrides_max_batches_reached", batches_run=batches_run)
+                break
+
+            # ``objects_including_soft_deleted`` returns the current key for
+            # every flag in the team, including those whose key was suffixed
+            # with ``:deleted:<id>`` during soft-delete. Override rows whose
+            # key is not in this set are orphans.
+            keys_to_keep = list(
+                FeatureFlag.objects_including_soft_deleted.filter(team_id=current_team_id).values_list("key", flat=True)
+            )
+
+            team_orphans, team_deleted, team_batches = self._sweep_team(
+                team_id=current_team_id,
+                keys_to_keep=keys_to_keep,
+                batch_size=batch_size,
+                sleep_between_batches=sleep_between_batches,
+                dry_run=dry_run,
+                remaining_batches=(max_batches - batches_run) if max_batches is not None else None,
+            )
+            total_orphans_seen += team_orphans
+            total_deleted += team_deleted
+            batches_run += team_batches
+
+        logger.info(
+            "backfill_orphan_hash_key_overrides_complete",
+            dry_run=dry_run,
+            teams_processed=len(team_ids),
+            orphans_seen=total_orphans_seen,
+            rows_deleted=total_deleted,
+            batches_run=batches_run,
+        )
+
+    def _sweep_team(
+        self,
+        *,
+        team_id: int,
+        keys_to_keep: list[str],
+        batch_size: int,
+        sleep_between_batches: float,
+        dry_run: bool,
+        remaining_batches: int | None,
+    ) -> tuple[int, int, int]:
+        """Process one team's orphans. Returns (orphans_seen, rows_deleted, batches_run)."""
+        orphans_seen = 0
+        rows_deleted = 0
+        batches_run = 0
+
+        while True:
+            if remaining_batches is not None and batches_run >= remaining_batches:
+                break
+
+            ids_qs = (
+                FeatureFlagHashKeyOverride.objects.using(PERSONS_DB_FOR_WRITE)
+                .filter(team_id=team_id)
+                .exclude(feature_flag_key__in=keys_to_keep)
+                .values_list("id", flat=True)[:batch_size]
+            )
+            ids = list(ids_qs)
+            if not ids:
+                break
+
+            orphans_seen += len(ids)
+            batches_run += 1
+
+            if dry_run:
+                logger.info(
+                    "backfill_orphan_hash_key_overrides_dry_run_batch",
+                    team_id=team_id,
+                    batch_size=len(ids),
+                    batches_run_for_team=batches_run,
+                )
+                # Slide the window: in dry-run we'd otherwise re-select the
+                # same ids forever. Break once we've sampled one batch per
+                # team (the dry-run is a probe, not an exact count).
+                break
+
+            with transaction.atomic(using=PERSONS_DB_FOR_WRITE):
+                deleted, _ = FeatureFlagHashKeyOverride.objects.using(PERSONS_DB_FOR_WRITE).filter(id__in=ids).delete()
+                rows_deleted += deleted
+
+            logger.info(
+                "backfill_orphan_hash_key_overrides_batch",
+                team_id=team_id,
+                rows_deleted=deleted,
+                batches_run_for_team=batches_run,
+            )
+
+            if sleep_between_batches > 0:
+                time.sleep(sleep_between_batches)
+
+        return orphans_seen, rows_deleted, batches_run

--- a/posthog/management/commands/test/test_backfill_orphan_hash_key_overrides.py
+++ b/posthog/management/commands/test/test_backfill_orphan_hash_key_overrides.py
@@ -117,3 +117,35 @@ class TestBackfillOrphanHashKeyOverrides(APIBaseTest):
 
         assert not FeatureFlagHashKeyOverride.objects.filter(team=self.team, feature_flag_key="orphan-key").exists()
         assert FeatureFlagHashKeyOverride.objects.filter(team=other_team, feature_flag_key="orphan-key").exists()
+
+    def test_max_batches_caps_total_work(self) -> None:
+        """``--max-batches`` is the operator's primary knob for incremental
+        runs. Together with ``--batch-size``, it should cap total deletions to
+        ``max_batches * batch_size``. Locks in the early-termination contract
+        so future refactors of the inner/outer counters can't silently let it
+        run unbounded."""
+        people = [self.person]
+        for i in range(2):
+            people.append(_create_person(team=self.team, distinct_ids=[f"d-extra-{i}"], properties={}))
+        flush_persons_and_events()
+        for p in people:
+            FeatureFlagHashKeyOverride.objects.create(
+                team=self.team, person=p, feature_flag_key="orphan-key", hash_key=f"hk-{p.id}"
+            )
+
+        call_command(
+            "backfill_orphan_hash_key_overrides",
+            "--team-id",
+            str(self.team.id),
+            "--batch-size",
+            "1",
+            "--max-batches",
+            "1",
+            "--sleep-between-batches",
+            "0",
+            stdout=StringIO(),
+        )
+
+        remaining = FeatureFlagHashKeyOverride.objects.filter(team=self.team, feature_flag_key="orphan-key").count()
+        # Started with 3 orphans; max_batches=1 with batch_size=1 means exactly 1 deletion.
+        assert remaining == len(people) - 1

--- a/posthog/management/commands/test/test_backfill_orphan_hash_key_overrides.py
+++ b/posthog/management/commands/test/test_backfill_orphan_hash_key_overrides.py
@@ -1,0 +1,119 @@
+from io import StringIO
+
+from posthog.test.base import APIBaseTest, _create_person, flush_persons_and_events
+
+from django.core.management import call_command
+
+from posthog.models.feature_flag.feature_flag import FeatureFlag, FeatureFlagHashKeyOverride
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+
+
+class TestBackfillOrphanHashKeyOverrides(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.person = _create_person(team=self.team, distinct_ids=["d1"], properties={})
+        flush_persons_and_events()
+
+    def test_deletes_rows_whose_key_does_not_match_any_flag(self) -> None:
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="kept-key",
+            name="Kept",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        # Override row with a key that exists -> kept.
+        FeatureFlagHashKeyOverride.objects.create(
+            team=self.team, person=self.person, feature_flag_key="kept-key", hash_key="hk-1"
+        )
+        # Override row with a key that no longer matches any flag -> orphan, deleted.
+        FeatureFlagHashKeyOverride.objects.create(
+            team=self.team, person=self.person, feature_flag_key="orphan-key", hash_key="hk-2"
+        )
+
+        call_command(
+            "backfill_orphan_hash_key_overrides",
+            "--team-id",
+            str(self.team.id),
+            "--sleep-between-batches",
+            "0",
+            stdout=StringIO(),
+        )
+
+        keys = sorted(
+            FeatureFlagHashKeyOverride.objects.filter(team=self.team).values_list("feature_flag_key", flat=True)
+        )
+        assert keys == ["kept-key"]
+
+    def test_dry_run_does_not_delete(self) -> None:
+        FeatureFlagHashKeyOverride.objects.create(
+            team=self.team, person=self.person, feature_flag_key="orphan-key", hash_key="hk-1"
+        )
+
+        call_command(
+            "backfill_orphan_hash_key_overrides",
+            "--team-id",
+            str(self.team.id),
+            "--dry-run",
+            "--sleep-between-batches",
+            "0",
+            stdout=StringIO(),
+        )
+
+        assert FeatureFlagHashKeyOverride.objects.filter(team=self.team, feature_flag_key="orphan-key").exists()
+
+    def test_keeps_soft_deleted_flag_keys(self) -> None:
+        """A soft-deleted flag's key (with the ``:deleted:<id>`` suffix) is
+        still a current key in the team — override rows under that key are
+        not orphans and must survive the sweep."""
+        soft_deleted_flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="something:deleted:42",
+            name="Soft-deleted",
+            created_by=self.user,
+            deleted=True,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        FeatureFlagHashKeyOverride.objects.create(
+            team=self.team, person=self.person, feature_flag_key=soft_deleted_flag.key, hash_key="hk-1"
+        )
+
+        call_command(
+            "backfill_orphan_hash_key_overrides",
+            "--team-id",
+            str(self.team.id),
+            "--sleep-between-batches",
+            "0",
+            stdout=StringIO(),
+        )
+
+        assert FeatureFlagHashKeyOverride.objects.filter(
+            team=self.team, feature_flag_key=soft_deleted_flag.key
+        ).exists()
+
+    def test_does_not_touch_other_teams(self) -> None:
+        other_org = Organization.objects.create(name="Other")
+        other_team = Team.objects.create_with_data(initiating_user=self.user, organization=other_org, name="Other")
+        other_person = _create_person(team=other_team, distinct_ids=["d2"], properties={})
+        flush_persons_and_events()
+
+        # Other team has no flag for "orphan-key", but the sweep is scoped to self.team.
+        FeatureFlagHashKeyOverride.objects.create(
+            team=other_team, person=other_person, feature_flag_key="orphan-key", hash_key="hk-other"
+        )
+        FeatureFlagHashKeyOverride.objects.create(
+            team=self.team, person=self.person, feature_flag_key="orphan-key", hash_key="hk-self"
+        )
+
+        call_command(
+            "backfill_orphan_hash_key_overrides",
+            "--team-id",
+            str(self.team.id),
+            "--sleep-between-batches",
+            "0",
+            stdout=StringIO(),
+        )
+
+        assert not FeatureFlagHashKeyOverride.objects.filter(team=self.team, feature_flag_key="orphan-key").exists()
+        assert FeatureFlagHashKeyOverride.objects.filter(team=other_team, feature_flag_key="orphan-key").exists()


### PR DESCRIPTION
## Problem

Companion / safety-net to #56521 (write-time cleanup hooks). The hooks fire only on product-driven paths (PATCH rename, PATCH soft-delete) and intentionally skip teams whose row count for the affected (team, key) tuple exceeds the inline threshold (50_000). That leaves three categories the hooks don't cover:

1. **Orphans accumulated before the write-time hooks shipped** — every rename and hard-delete that happened on `master` historically dropped its override rows on the floor.
2. **Cases the hooks intentionally skipped** — the largest teams hold a disproportionate share of the override table, and the inline path bails on them to avoid scanning hundreds of millions of rows on the persons DB / `/decide` path.
3. **Admin-tool hard-deletes** that bypass the serializer entirely.

## Changes

A management command, `python manage.py backfill_orphan_hash_key_overrides`, that sweeps `FeatureFlagHashKeyOverride` rows whose `feature_flag_key` no longer matches any current flag key in the team. Soft-deleted flags' suffixed keys (`<original>:deleted:<id>`) are explicitly preserved — those rows are not orphans.

Flags:

| flag | purpose |
|---|---|
| `--dry-run` | Report orphan counts without deleting any rows |
| `--team-id` | Restrict the sweep to a single team. Omit to iterate all teams |
| `--batch-size` | Rows deleted per atomic block (default 10_000) |
| `--sleep-between-batches` | Throttle between batches (default 0.5s) |
| `--max-batches` | Cap the total number of batches across all teams |

Each batch runs inside its own `transaction.atomic(using=PERSONS_DB_FOR_WRITE)` so row-level locks are released between chunks and concurrent INSERTs from `set_feature_flag_hash_key_overrides` aren't blocked for the duration of the sweep.

## How did you test this code?

Automated tests in `posthog/management/commands/test/test_backfill_orphan_hash_key_overrides.py` cover:

- Deletes rows whose key doesn't match any flag in the team.
- `--dry-run` does not delete.
- Soft-deleted flags' (suffixed) keys are preserved.
- Cross-team scoping: rows in another team with the same key survive.

I am an agent and have not run this command against any real environment — local stack hasn't been exercised against the persons DB. Recommend reviewers do a `--dry-run` against staging before any live sweep, and pick a conservative `--max-batches` for the first real run.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7) at the request of @ricardothe3rd as a follow-up to https://github.com/PostHog/posthog/pull/56521 — @haacked explicitly asked for the operational story (write-time best-effort + offline backfill for skipped cases) to be visible during review. Opening as draft so the link is present on #56521 from the start; happy to iterate on scope, defaults, and argument ergonomics here based on team-feature-flags' preferences.