### PR TITLE
fix(llma): empty traces page when capture buffer overflows limit

### DIFF
--- a/posthog/hogql_queries/ai/test/__snapshots__/test_traces_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_traces_query_runner.ambr
@@ -11,6 +11,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -78,6 +79,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -145,6 +147,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_0`, 'org:acme')))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -212,6 +215,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_0`, 'org:widgets')))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -279,6 +283,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_1`, 'project:alpha')))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -346,6 +351,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_0`, 'nonexistent')))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -372,6 +378,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 5)
   LIMIT 100 SETTINGS readonly=2,
@@ -439,6 +446,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 10)
   LIMIT 100 SETTINGS readonly=2,
@@ -506,6 +514,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-16 00:00:59', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2025-01-09 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 15)
   LIMIT 100 SETTINGS readonly=2,
@@ -573,6 +582,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0)))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:10:00', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -640,6 +650,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'baz'), 0)))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:10:00', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -707,6 +718,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'barz'), 0)))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:10:00', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -733,6 +745,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), 'runnable'), 0)))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:10:00', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -800,6 +813,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0)))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:10:00', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
@@ -867,6 +881,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), 'runnable'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0))))
      GROUP BY trace_id
+     HAVING and(lessOrEquals(min(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:10:00', 'UTC'))), greaterOrEquals(max(toTimeZone(events.timestamp, 'UTC')), assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))))
      ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,

--- a/posthog/hogql_queries/ai/test/test_traces_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_traces_query_runner.py
@@ -594,6 +594,52 @@ class TestTracesQueryRunner(ClickhouseTestMixin, BaseTest):
         self.assertIn("trace1", result_ids)
         self.assertIn("trace3", result_ids)
 
+    def test_trailing_buffer_does_not_swallow_window_traces(self):
+        # Regression: when more traces exist in the +10 min trailing capture
+        # buffer than the page size, the trace_ids subquery's `ORDER BY
+        # min(timestamp) DESC LIMIT N` used to pick exclusively buffer traces,
+        # which were then dropped by the overlap post-filter — producing an
+        # empty page even though the user window contained valid traces.
+        _create_person(distinct_ids=["person1"], team=self.team)
+
+        for i in range(5):
+            _create_ai_generation_event(
+                distinct_id="person1",
+                team=self.team,
+                trace_id=f"in_window_{i}",
+                timestamp=datetime(2024, 12, 1, 10, 10 * i),
+            )
+
+        # 6 traces in (date_to, date_to + 10 min] — all newer than the in-window
+        # ones, so a naive `ORDER BY min(timestamp) DESC LIMIT 5` would pick them.
+        for i in range(6):
+            _create_ai_generation_event(
+                distinct_id="person1",
+                team=self.team,
+                trace_id=f"buffer_{i}",
+                timestamp=datetime(2024, 12, 1, 11, 1 + i),
+            )
+
+        response = TracesQueryRunner(
+            team=self.team,
+            query=TracesQuery(
+                limit=4,  # pagination_limit = 4 + 0 + 1 = 5; smaller than the buffer count
+                dateRange=DateRange(
+                    date_from="2024-12-01T10:00:00Z",
+                    date_to="2024-12-01T11:00:00Z",
+                ),
+            ),
+        ).calculate()
+
+        result_ids = [t.id for t in response.results]
+        self.assertEqual(
+            len(response.results),
+            5,
+            f"expected 5 in-window traces; got {len(response.results)}: {result_ids}",
+        )
+        for rid in result_ids:
+            self.assertTrue(rid.startswith("in_window_"), f"unexpected trace id {rid} in results")
+
     def test_overlap_semantics_trace_started_before_window(self):
         _create_person(distinct_ids=["person1"], team=self.team)
 

--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -45,6 +45,22 @@ class TracesQueryDateRange(QueryDateRange):
     def date_to_for_filtering(self) -> datetime:
         return super().date_to()
 
+    def date_from_for_filtering_as_hogql(self) -> ast.Expr:
+        return ast.Call(
+            name="assumeNotNull",
+            args=[
+                ast.Call(name="toDateTime", args=[ast.Constant(value=self.format_date(self.date_from_for_filtering()))])
+            ],
+        )
+
+    def date_to_for_filtering_as_hogql(self) -> ast.Expr:
+        return ast.Call(
+            name="assumeNotNull",
+            args=[
+                ast.Call(name="toDateTime", args=[ast.Constant(value=self.format_date(self.date_to_for_filtering()))])
+            ],
+        )
+
     def date_from(self) -> datetime:
         return super().date_from() - timedelta(minutes=self.CAPTURE_RANGE_MINUTES)
 
@@ -84,6 +100,12 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             # produces overlapping or missing traces across pages.
             order_clause = "rand()" if self.query.randomOrder else "min(timestamp) DESC"
 
+            # The HAVING clause enforces the same overlap semantics as the post-filter
+            # in `_map_results` (a trace counts if any of its events overlap the user
+            # window). Without it, the LIMIT runs over the buffered window — so for a
+            # high-volume team a `date_to`-anchored filter (e.g. "yesterday") can have
+            # its entire LIMIT consumed by traces in the trailing +10 min capture buffer,
+            # which the post-filter then drops, producing an empty page.
             trace_ids_query = parse_select(
                 f"""
                 SELECT
@@ -99,6 +121,8 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                     WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                       AND {{conditions}}
                     GROUP BY trace_id
+                    HAVING min(timestamp) <= {{unbuffered_date_to}}
+                       AND max(timestamp) >= {{unbuffered_date_from}}
                     ORDER BY {order_clause}
                     LIMIT {{limit}}
                 )
@@ -111,6 +135,8 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                 placeholders={
                     "conditions": self._get_subquery_filter(),
                     "limit": ast.Constant(value=pagination_limit),
+                    "unbuffered_date_from": self._date_range.date_from_for_filtering_as_hogql(),
+                    "unbuffered_date_to": self._date_range.date_to_for_filtering_as_hogql(),
                 },
                 team=self.team,
                 timings=self.timings,


### PR DESCRIPTION
## Problem

The Traces tab returns an empty page for any date filter whose `date_to` lands in the past on high-volume teams — most visibly "yesterday", but also "specific hours earlier today" or any custom range whose end isn't anchored to _now_. The Generations tab works fine on the same filter.

`TracesQuery` runs in two passes: a subquery picks N candidate trace IDs, then a main query loads their details. The subquery widens the date window by ±10 min (the "capture buffer") so a trace whose last event lands just past `date_to` isn't truncated. The main query's results then go through a post-filter that drops traces outside the _un-buffered_ user window.

This works — until the trailing capture buffer alone contains more traces than the page size:

```mermaid
flowchart TD
    A["User filter: yesterday<br/>(00:00 → 23:59:59 PT)"] --> B["Subquery scans the buffered window<br/>day-before 23:50 → today 00:09:59"]
    B --> C["568k traces start in yesterday<br/>5,034 traces start in the +10 min trailing buffer"]
    C --> D["ORDER BY min(timestamp) DESC LIMIT N+1<br/>picks the newest"]
    D --> E["All picks land inside the buffer<br/>(5,034 ≫ 51 in those 10 min alone)"]
    E --> F["Post-filter:<br/>first_timestamp &gt; date_to → drop"]
    F --> G[("Empty page 😞")]
    style G fill:#fbb,stroke:#900
```

Default-anchored filters ("last 24h", "last hour") are _not_ affected — they anchor `date_to` to `now`, so the trailing buffer is `(now, now+10min)` which sits in the future and is empty. That's why this hid for a while: the bad cases are explicit-`date_to` filters.

### When this was introduced

Bug shipped with the two-pass query design in #38825 (Sep 30 2025) — `_get_trace_ids`, the buffered subquery, and the `first_timestamp > date_to` post-filter all landed together. The bug was latent until trailing-buffer trace volume crossed the page-size LIMIT.

Distinct trace count in the +10 min trailing buffer per day on PostHog.com:

| Date                     | Trailing-buffer traces | Status at LIMIT 101 (page=100) | Status at LIMIT 51 (page=50) |
| ------------------------ | ---------------------- | ------------------------------ | ---------------------------- |
| 2026-01-19 → ~2026-02-09 | 14 – 216               | OK                             | borderline                   |
| 2026-02-10               | 61                     | OK                             | **broken**                   |
| 2026-02-11               | 1,097                  | **broken**                     | broken                       |
| 2026-02-13               | 614                    | broken                         | broken                       |
| 2026-02-14 → 2026-04-28  | 1k – 6k                | broken                         | broken                       |
| 2026-04-27 (yesterday)   | 5,034                  | broken                         | broken                       |

So this has been visibly broken for "yesterday"-style filters on PostHog.com since ~Feb 11-13 2026. #53799 (April 16, page size 100 → 50) didn't change anything for this team — buffer was already in the thousands.

Validated against prod (team 2, "yesterday" 2026-04-27 PT):

| bucket                     | trace count |
| -------------------------- | ----------- |
| in yesterday (user window) | 568,146     |
| in trailing +10 min buffer | 5,034       |
| in leading −10 min buffer  | 2,364       |

5,034 ≫ 51 → all 51 subquery picks were buffer traces → all dropped by the post-filter → empty page.

## Changes

Add `HAVING` to the trace-ids subquery so the `LIMIT` is applied _after_ the same overlap predicate the post-filter uses:

```sql
  GROUP BY trace_id
+ HAVING min(timestamp) <= unbuffered_date_to
+    AND max(timestamp) >= unbuffered_date_from
  ORDER BY min(timestamp) DESC
  LIMIT N
```

The buffered date filter on events is preserved — that's still needed so a trace's span events past `date_to` get included when the main query computes `last_timestamp`. Performance impact is negligible: `min`/`max` are already aggregated in the subquery, HAVING runs on the aggregated rows (one per trace), and the resulting trace-id list passed to the main query is now strictly smaller (no destined-to-be-dropped traces leak through).

I validated the fix against prod by running the corrected subquery before coding it — it returned yesterday's late-day traces (`23:59:5x` Pacific) instead of the trailing-buffer traces.

## How did you test this code?

Agent-authored — automated tests only:

- Added `test_trailing_buffer_does_not_swallow_window_traces`: 5 traces inside the user window + 6 newer traces inside the +10 min buffer with `limit=4` (so `pagination_limit=5`). Runs **red** against pre-fix (`0 != 5`), **green** with the fix.
- All adjacent date/overlap tests pass locally with the new `HAVING`: `test_capture_range`, `test_overlap_semantics_trace_started_before_window`, `test_event_property_filters`, `test_person_property_filters`, `test_properties_filter_with_multiple_events_in_group`.
- `test_traces_query_runner.ambr` snapshots updated for the new `HAVING` clause.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code with Carlos. Flow:

1. Read the CH queries from the bug report; noticed the second query covered a 20-min slice (`23:59:46 → 00:19:58`) while the first covered buffered yesterday — implies `min/max_timestamp` from the first query collapsed onto the trailing buffer.
2. Located the two-step query in `posthog/hogql_queries/ai/traces_query_runner.py:72-130` and the post-filter in `_map_results`.
3. Validated against prod team 2: 5,034 trailing-buffer traces (≫ LIMIT 51).
4. Validated the `HAVING` fix against prod before coding it.
5. Built a red regression test, applied the fix, confirmed green, patched snapshots.
