### PR TITLE
fix(hog-charts): match legacy chart visuals on dashboards

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -425,77 +425,77 @@ snapshots:
     components-hedgehogmode--static-hedgehog--light:
         hash: v1.k794b7964.43d71f5c3ad02bd9e1fa87433d34df79e0de653c4b55004188bed5de78a2c3f5.i2ATBYyqY7uq7UxwlL2Rdte6AuMyySa8Jnbeb1VouoQ
     components-hogcharts-confidenceintervals--area-chart-with-hatching--dark:
-        hash: v1.k794b7964.9367992be81e2b1e550150e768396d54fafc56dfbf9e78c35b37d30b0d534ee9.H7Ci7Bras6vx2r1EykrONgyVx1P8AxH3q83SWjCx6i4
+        hash: v1.k794b7964.0eb9f320b5b581fef06635fb79b8a6a937545b83e861cbf100a340c884efadc8.Al3L-yUledHXLcoTns1l9mnWYeuG5uA5dBhSox3l0H4
     components-hogcharts-confidenceintervals--area-chart-with-hatching--light:
-        hash: v1.k794b7964.7157245b2621c9f4192740658b4a193f6ee23b1435f1004cd0a3c69c443a10fa.asDrCXaNbG4uUGqkwCPcNuBUJswJZTkVMBswM0dpOB8
+        hash: v1.k794b7964.2531a9ed46e4b3c25f079b18363a98e1e55b11539297c5e27754ae936cd5cf1b.SVd4nhHy1M-Z5cpUMFS8TDfyFW2a9PF5t2HIicIijfA
     components-hogcharts-confidenceintervals--multi-series-with-ci--dark:
-        hash: v1.k794b7964.7ed6372407cb90533231db34d4b5e84ff8671243f8751755266f18f496f41aaa.BAfg5oY5IdR_67i-WQ8MXJM_2o4cULh9NO97-txAutg
+        hash: v1.k794b7964.a9ba033b1974bbfe126f1343b402c0f1b67d02ee6b1d99f489768aeba077ff44.9-3d5yrHuEr1YCyzhl-LaigDyenW6MWdfYdAV1mftt4
     components-hogcharts-confidenceintervals--multi-series-with-ci--light:
-        hash: v1.k794b7964.bbaac9d54e87d0ac68442e4e09c0dde19d9ebe2580e1f520d55059072e4ae6de.Phia7sfVw9Rf_J4m6vQ8ZyN2gPeonkt22Ftfl5sbSuE
+        hash: v1.k794b7964.c7ed1aa2b2e7adde128703393c70da1411df3b7ef2d003011c611aa8977ab24c.9xGz0-JizhacccQg60no1VJQRhUI2n_xiaHW25VCG_E
     components-hogcharts-confidenceintervals--with-confidence-interval--dark:
-        hash: v1.k794b7964.2e36c5af53a5e6301fb3dbdf043eac50d93eb9085b06949b59ba85f3825c020c.jdCPkkeVr1036Fy1JhWLYhvCkHOIZ1aioT_Hfya1ru4
+        hash: v1.k794b7964.a5d1c6025fdaea66abdbe3489a2ac8ce7263a3f1d8033cfd10847814b5484909.OY9NAORVj5yyISdGnUebRQ_46GRUY6ODpyqeoOMaw7k
     components-hogcharts-confidenceintervals--with-confidence-interval--light:
-        hash: v1.k794b7964.53f9106d6da9ea21ab25d645245eec3edabc4dfd3809f8c1ba4168bedfa12a55.w8neWNb6zOIhRUh3bS3fKf4Zqec3dKWwXVVC3d12V_c
+        hash: v1.k794b7964.2c6fbb402ad80d420aee251b6c2630a980e92292424e381a3b9742e839cbc175.9XI8X-3m7ifzGKDKUETPMxIFY9anqdrQbv55LYvlDKA
     components-hogcharts-referenceline--fill-sides--dark:
-        hash: v1.k794b7964.1cdea28042be80a089f2c5ec7cce5c36f36ccef93aec34fd4dac31ad0e2c1e8b.ihDUZG_Gy5iXdcfx8K0WEaT2YDMqiKnP79J9_wYzSko
+        hash: v1.k794b7964.6842b004f884e08b3cc324761f4de7a0c97c6c6d99cd42608d709d4264cb26d5.3uwtIIjAtF8_6dYGAR-mLH6CBP2KvWbWoVF-zCpRknQ
     components-hogcharts-referenceline--fill-sides--light:
-        hash: v1.k794b7964.9e5e2b4a13cd89e2109e642de0da444cf03ff03504c5e83eca17b597534704df.Xatux5E7pltIFHKAdPPZocRC78pHt9DZmDM_etY2vt0
+        hash: v1.k794b7964.a71ab0c23a7c7222476deb4460e75c8a89ff7682f140a034421418202c4b6afc.8l3ygmUZLRyjknLjF-GH3adEfkcX1W2NrY380Dq3Sz0
     components-hogcharts-referenceline--horizontal-goal--dark:
-        hash: v1.k794b7964.0315db025d5e9ab82ef9b0e4b5a902575ebc845d9f3a4c0cb89c048c93977200.IuGXsCX7EeKVPF_mMXCBKTFWB2EitOOD0lK5A2za4VI
+        hash: v1.k794b7964.83fa17c0f03b963a700ef6e6398de8fc3737efc2ef97b23b6e9b503786e024cb.pNUQwHq07K1d1WSLCCjcxq24XhWHcAg5-0SoOpVXNtg
     components-hogcharts-referenceline--horizontal-goal--light:
-        hash: v1.k794b7964.3e43b413e1a8661829dc96d1529b52fd0c8aafb9e9dbf1c59b7f2723cf8bc535.KPjhCIi4tDQ7Ks2bLGe4hc2IqOkaUSYv-grW_I4qF3U
+        hash: v1.k794b7964.60564511fae1b64d2ec4bed069d247101bfa599c2c05290c06e0251dc61cc07c.csySfcl9y3wcKY5Aexk7p_oBEZM4UxtOk3uvyC0ktWk
     components-hogcharts-referenceline--horizontal-variants--dark:
-        hash: v1.k794b7964.468b0c6ac2a25e2e7fec39660284b4145f6ab7817cd32a0030e3e88b4194d23c.VwxKnFEkiBdIPLD22_MEz0SVz3ykMb9YE9HSNsQtT-E
+        hash: v1.k794b7964.8713696652e356b4f10d80faa70c5f18c55f8fc4b16f35e2fecf0dabed9e7ead.SFeODsf4V7sbr3_NHYTcKrFRa92rvpAhMXoPwQSt3gs
     components-hogcharts-referenceline--horizontal-variants--light:
-        hash: v1.k794b7964.a354277e7db9f920b18880573d12bb4e42ba4db2a4dd6a4b72bea2d00f696efa.Qu56wxBDEaIUDl40I1waBcau4sdmNviVdXwBsd0D3Vo
+        hash: v1.k794b7964.e9bd58e91c90ea3881adb25bb844bca46ccdbd14d5b67ce62d146fecf4ef49a6.W1Vbocbn01QPSDg3-UYJgymoa5ixZCosmDzSGBdbAPA
     components-hogcharts-referenceline--label-start-vs-end--dark:
-        hash: v1.k794b7964.9366a24066c1e8094e337b7fe9e2c26b284c1ae4c49b0bd9dd45861687233fdc.ycrIPSljh7TL4TWK6fohNpUrLGLW7xY9PF7n7b0FHYU
+        hash: v1.k794b7964.4c48df534bb8147df03d77abf2f221cac15e32957f71af45e378702502f0604d.I1LhvB-FE09wjxMpkez1LkMvyvyrj0dp5MYTAZ0UAxo
     components-hogcharts-referenceline--label-start-vs-end--light:
-        hash: v1.k794b7964.5a5aac543719a4a941b11f2e8c1b6552004f030f77a0fab1fc20e21adaed264c.Vcw6SE01Eo9VupnjUO_Zy-d-swyHqUSaShX1wa8AIYY
+        hash: v1.k794b7964.f9e96a9ea2c20280604d7fb14f799da60a7021985374e4c550b64549806133cb.EjRgeSRVB5vUIW2RKCYCYs4kA9IQfqhJ9PrS4sPRByQ
     components-hogcharts-referenceline--vertical-reference-lines--dark:
-        hash: v1.k794b7964.61cfe187b6ffb1afbbe249728e25564b649d867594361c942f272177a30a2512.DcZXxZ_ile6MrnQzOW4qcytPJNg_6XmoWp0quap7xyc
+        hash: v1.k794b7964.ec1a39ae511e6a3c73dc1633d9c2f49c3805aba382131a6435de46326390ab66.8zBFF69Bl1yEv3OWi5-inUSg8BujD-P_71h1SdfUDaQ
     components-hogcharts-referenceline--vertical-reference-lines--light:
-        hash: v1.k794b7964.57e8def3f05c5ce3e99c0683e22615bdb04488249dc65b8ea0b7478a4808a94f.4_lE_Bg7_SUhLYhtKvMXD_yFzvqdBbC9npoDyMjFVbA
+        hash: v1.k794b7964.12ee9bdb34e0a1350d67ef73abd8621dd428d7fb565b713c61a2003db02b2091.-cD8-EsT_newJlN05zXLQ5sTZ_6RteILczqWSvQ5osE
     components-hogcharts-trendlines--multi-series-with-trend-lines--dark:
-        hash: v1.k794b7964.78033802ebf740d7ab89be2be4f2193c43a14966c0402026bd45dddbb4269396.RUWWv6pYa_wo0a1Usu3f62Wk4EvQ0rGgPfKIf3UQJDc
+        hash: v1.k794b7964.f7e2ebb25221124fc70bcfaf7acc13c8392ba309634bb6feec2f6a06d5821b03.X-pRpaY5rnjIt6O4iSTcPguMZWW2kQWI2aZFSq2Jy64
     components-hogcharts-trendlines--multi-series-with-trend-lines--light:
-        hash: v1.k794b7964.ba1dd4a8fa2093e58823dbeaccea10509d588023fae750089fcd3caed6e05de2.dH5SqXb2RXB8MCVqO-0Z5rVWBUlFUbA0hlXuZjzgyao
+        hash: v1.k794b7964.b5ff3b2eadc5ab0aee4ed2c38b5f41974452f429adc68e1a1c03357b1e8e9fc3.FsSXW-ULWLC9xrZJi8DMaewkru57GvY25GP2tB6BPuk
     components-hogcharts-trendlines--trend-line-with-incomplete-period--dark:
-        hash: v1.k794b7964.04241a23b9362ec83f80d010699220a08fbc9d3904718780fc6abf26d4a0dd4c.eUPFh_Gb0JsPkx0jz0HMEkNi0srWCh7faDntW1Uv-28
+        hash: v1.k794b7964.b77746e1a1c6606876d8d68acb1558cdef2565eb533ece8a85536f0b19d560af.toiSfjGjMRHO13FZ4IMO8s5HCRUrv4ZdR_8zdaCj6EA
     components-hogcharts-trendlines--trend-line-with-incomplete-period--light:
-        hash: v1.k794b7964.71a62e5f098e7ff225ee1a222242e60eafd0bceda1316b1af89254bd5fa845de.dy66a2lxQ9B2eVXUo_rUqpMSCuO24AAAiFx2LPVcD1Q
+        hash: v1.k794b7964.c86f2feb2f761b56d2828fc63cf8def695a682b3784f51ecb7bae82b155f3531.SOsy4fk0TmnKWkFjSPazPJhkPUCGlqpnoJGSMqMtPxQ
     components-hogcharts-trendlines--with-trend-line--dark:
-        hash: v1.k794b7964.da7509fa2d50594b97da227743df5d6c8dc2fba68319cdb63e0c0a783a9e8a56.VyeZQIl63pbC3dTu5fIiBCqjLA97n2KDMSesUBp-3yc
+        hash: v1.k794b7964.15b3d6602cebd061962ce0d72e14a736a9a975ea03a6f0f7fe0ac82c306b1188.bdrQKBriBnrL3jb8fZHvQ8oq8el9n4Y5ImFJ43z1HfA
     components-hogcharts-trendlines--with-trend-line--light:
-        hash: v1.k794b7964.276799f30320d0d543bbad2ab88ae343d86e5bc2b6deb8e64db0c27b96beab8a.54U0eAaXpU1eM76JrzJxGfYdtTlQ3nPCHmTuv_lgwjc
+        hash: v1.k794b7964.031d098b111eda98755473f6d42b857a48fcfcc4d140f66ee92ea68fd6637073.I4KaJxlhrj5keiC7WykaUmlCbcBu8WoO1HL8hiaqGU4
     components-hogcharts-valuelabels--cross-series-overlap-removal--dark:
-        hash: v1.k794b7964.799f31e4dc256ac96259ef607fe7fc18956bb718f241c0a8ad5500fad58f2cc3.VG2XlenGJw2qM7AwqLpQuaMzzOYsWE3mCJPVj850wTQ
+        hash: v1.k794b7964.3d90bcc9693aee720d3f4c5cc6b3be8cf8a9e33ba1163df5585ed759e4e9e9b8.Wpss8nGjTBCUENrPpWax81SpmA_KMQFRvdZzvY549og
     components-hogcharts-valuelabels--cross-series-overlap-removal--light:
-        hash: v1.k794b7964.7c06a59994d41f58719408240137e5f2fbbe940769fa65582b5b690ecceb33d2.4FmQ3AWIzWDCzJNrY3MFk-c5hrrNKTL-CV3owENmCR0
+        hash: v1.k794b7964.cff06072d78522c0c6a15e08e74dba88f3248cb14b08d572ca800dbf910be563.zIlE9_jkswGcT8QC-x1i1PsKRIU7s_HA17ZNBPh5pUc
     components-hogcharts-valuelabels--dual-y-axes--dark:
-        hash: v1.k794b7964.820b754c7e27a3bd835daa8b217a46170f0dad0bbbdb8b4b0bd9194131096ace.NGYMLvWcfskYKlWgd6xlqgN7v7B59DFNHDoF2NlckfE
+        hash: v1.k794b7964.7bf38541b500014aee037838a4ba2e9c8940f909385d2d7abc410507edbc5195.kC6oTfF3YbyStZyWp5hZ4j9xtHJb3lQOKgOQEWth42U
     components-hogcharts-valuelabels--dual-y-axes--light:
-        hash: v1.k794b7964.433862c9f6cc50f900cda19439ff884174130a1609fdda2b5b1ed8e5c6ebea16.1UdoW6_nHJNobxMCD45AQFFFa9R_NF2GTAIRCpHxUww
+        hash: v1.k794b7964.4386469f5e098a7368f916b4831fc163c5ec7f7dc19761e62e3fc653b874a93e.vdXaWL7pLGhw96-xmxt4PK-XKiD3AvahstM6a_-F5rM
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--dark:
-        hash: v1.k794b7964.890e491c0f372189b0d2c4d42c0af8a5f33a0d049b7ada43f6f176a8de2fc47e.0AbXt5oM5Xw1J0YotpVjzJVE8QcBJvdG8YDjkRcPG4g
+        hash: v1.k794b7964.98227edf79690e1fd5cedc1ea411a21855025e630dba667c27fd0f6f389b5a58.LpSsqMQk6SELgqi_n4IMVVw50twcVdS291eHqo5D5RM
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--light:
-        hash: v1.k794b7964.e9e62d5efcc036a043c83e06935eb5af0f2855c564c11d6661cbc9005ec5929f.6H1j8onyrLfm_trH8ffwTB7H2U4BwbkIUfpSHAxCHWw
+        hash: v1.k794b7964.1d21d670655079b968c7a32f49af34c4c5fde6d2cb2ffb437201d4c766250aea.NYWcvSRwJFCcjBfJnp0fOpmWZpQ1CN7JWk0yn3N2u2Q
     components-hogcharts-valuelabels--multi-series-collision--dark:
-        hash: v1.k794b7964.6db9a0acc564d5199edaadb8a13146071a592ec6dabba3f4737d53a24017eac6.yM7CPQS1PNFfU12NMHVpRgqKDZqdmam-mAZteEV05PY
+        hash: v1.k794b7964.c884d2f3bbb6c78cf62b8fcacfc03fd705be2328b98a8c5be86138e6f8a36b75.hoILWJkaC8Wt87lizo_MJT_FPodjBolDUwVwMoDYN1Q
     components-hogcharts-valuelabels--multi-series-collision--light:
-        hash: v1.k794b7964.ca19c9456e9bcfa51f46d0e22e5d11043a5b920388d772316d028e45fa31b106.7NtlqmH3x4_MXlMRTsARKQjcNZzQAK5FkpcARDo1CTY
+        hash: v1.k794b7964.cbb2de65e2334b96bf752473e861e12826cd089ea8c427d404f89e3febfb719d.LF1QrV8BLIPslpRJMADQNr2gYgzyGdBBbPV-q1uKUY0
     components-hogcharts-valuelabels--negative-values--dark:
-        hash: v1.k794b7964.a335df8c818b43a382ae53e316b4123f0e428705477f03f232066a203de5fa31.5dstERo_g_Hq78fsXXfsf42i8scCoFARVl8ixeVCcjo
+        hash: v1.k794b7964.f0861706b533a3c4172e46584fcc977d50a97000a460014985aea8337855bfe6.ggPRuqg-llkvyGNzLTAFLPYgq-3WkSttVyu4f6Nm3Us
     components-hogcharts-valuelabels--negative-values--light:
-        hash: v1.k794b7964.654ebd6a453569e41162add82d95b21762b61dcd647260ad05a976f10c04cfb0.edfzJ9gwdfkrBa4RFefPcFrnJhEZb5lcSfm0di6IBRE
+        hash: v1.k794b7964.4cb29caf9337c3c23ac16658ccf2df46865c440170febede1842f7a293c830ef.UjUgL5B54SbOYJYEnntavnsZZxZMP4ZcxJEhLQM-nIk
     components-hogcharts-valuelabels--single-series--dark:
-        hash: v1.k794b7964.b27d07dfe155c4d7e4e80a35e6baf603ca3141432326191975c04d8423491bfb.fI4a-OrVBhNmXoTljuOE1tTsYk7XHbLetAkwIWeRiXQ
+        hash: v1.k794b7964.6a609ae0671c46d3d96b8db43130691a0d144ce79b9e2c710f2ddac232b34b3a.Tm_tRi8aRB2bXskGZlBoVAo5itlJgMB4WKDMF0y3Oic
     components-hogcharts-valuelabels--single-series--light:
-        hash: v1.k794b7964.aec3219140fdd35e81dd41f650cb366a119380fb83692aec2aa224671a2f3391.xu8B3M9GDZmzAaQNrsKkvviIOOkLO2NLfQhIXPTAFIQ
+        hash: v1.k794b7964.5b00b365741d5bd03b112455e14f735077dab9fd4f0f7b7224a7921e3da88785.Kc87s1yKUIjsG3YpBaC3yAXfJYqQvyirhH9v0e54AjY
     components-hogcharts-valuelabels--with-custom-formatter--dark:
-        hash: v1.k794b7964.dbd82a191a12ab8eade23946c2f58f1f9567133d48b7595217fbdc188e4f3537.OTuVVTwDMYbZdd8MBAar78JPqqO27xwX6FOqiBsq1LY
+        hash: v1.k794b7964.b029a01d670f92b8df1a20ef42c38d73f3e417928dccf91c3e2607795cde6bf6.en2mgQBAUOGIu0q2n8RyQHMSHXN3yzvcQXR5HVvV72c
     components-hogcharts-valuelabels--with-custom-formatter--light:
-        hash: v1.k794b7964.28134b45d1dc2d7cf3a20227f134d1b7c6ccd546a9f778f4ac0186158510dbdc.Q0x7saWTVtFZhUoqN9wwvowjAXMDhKeiG08lpSK59t4
+        hash: v1.k794b7964.818c9c01d63fc7cc299b13bfb29bcefa0e02eb6aa9732b56a73037e5f4b96a60.gFgqVn2RSJGVjYsTP_qBRlMqk8nDrboIYuJl7vPJwwU
     components-hogfetti--hogfetti--dark:
         hash: v1.k794b7964.dc6868e284e60433ae001da81ba90cf3f05eef1dae1765a849c6e9c63f1ae2ea.T9sV0zE441WqbpRr2zp64VZZfC1xlzxST-bxbW2egvI
     components-hogfetti--hogfetti--light:
@@ -1593,17 +1593,17 @@ snapshots:
     insights-insightstable--is-legend--light:
         hash: v1.k794b7964.d9eec920b0b2f3c9ea87c9e0d2b298bc37339217e4211d0cf1a147630f09b75d.xGcJlQO8pvoNnHyoMNZ4F58uqKh5PDg_UiGlO5bAMn8
     insights-trendslinechart--breakdown--dark:
-        hash: v1.k794b7964.387cc7a7d8bb6415de59aa9c83338a048f553470864229a5683d35f11cc57323.d_wMI_eqzESXc8o9d9f94At9w5bd7CdycMOg2OLCuTY
+        hash: v1.k794b7964.511667c66648a8740d48cea9425dd7f30c0583db207e58aab0ee46cbec27a9a9.3lZjOZDN3Svay1SdE1xjxOqA4oboAADP18FT7C2Bsg4
     insights-trendslinechart--breakdown--light:
-        hash: v1.k794b7964.43f5bd8a76c37619febc27195fba8a173b021a4894078670379791da5e3729af.qyLnBMVy_lPm25Qff_IOmIDuchynGbfCyMADd1vxsSo
+        hash: v1.k794b7964.6edbc2691567ff4887b89913cb2cd3832ee94711e2a68628f8b490aa8378cd5a.oSLvbdT_KENf9RQAJfCSxLjiV8MtSB_3RLys4J2VcKE
     insights-trendslinechart--default--dark:
-        hash: v1.k794b7964.e60c7e31c5f57da6cdb31c3ecacec19e1cc7a040f323dcd84b1aa0aa3e315f88.sayO3c8NnP6y4xw7PvHmE--XPmrW0Ss29Ks6W4pzHwg
+        hash: v1.k794b7964.ba01f9e7b22b990a71f1cea64557844040e3d9dfb6a024daa63626544a619223.kP9RKJQyHMnzhRJDn7r18PNpiIo9sT5wIzx3h0Z-098
     insights-trendslinechart--default--light:
-        hash: v1.k794b7964.90a4e15f1ad98e1891dddf3be7abd078c2c36b136c5380143c24db7ddb780c80.pN4-UVwWvHFd3JZdInXmiymuyAzNLh-LB__B9VbAcMg
+        hash: v1.k794b7964.0caa0e62bdbd9da9b2bf7294f895fdbbe95df3da6ae9d6434fa941e4449adb3f.6v-VukuxHu0mue3SlYmq_1tYmVEEqTX7LC4LM_vOlrE
     insights-trendslinechart--single-series--dark:
-        hash: v1.k794b7964.aa944593aba5114f92c2bcf9a0d387a8127858d5a0400c1fa8fbacaf2adb632e.VEsS_ZBrSu6R2P3xN_DJ97t5-M-IGmyCPl59RFvV5no
+        hash: v1.k794b7964.7e0638961c239dd28313d9fad1ed6a4620022d85fab8f586670a71630b3add47.ORbg_Aka6pqgmoTpV2WaXTBv_bh399-2CPXaFW4aOAg
     insights-trendslinechart--single-series--light:
-        hash: v1.k794b7964.de01e8eeecd42f4ddaa8c615020d0b7ab3d5d44048f62850a9c598f2a6ea5d69.BcFSMoEqgKyxmRbGHHVmoyzR0YeGOr8Ug10l0pUOfsA
+        hash: v1.k794b7964.a235f28f74910bed6c83cc436b679a63fc1260b42600f42ff82691ec37f2efd5.PjjqM5m0C95JG6jLmuKHcqg4CWvDbaB0v4TvHAptUuU
     layout-feature-previews--basic--dark:
         hash: v1.k794b7964.65cb2d154c4f630bc48a9f6b45b24e641c97b4412ca5170e0c1de8bc5c7d759d.vu2XHwyh2oLXbqNS7NdZd2tABaC8nM7J0iJps6FVYl8
     layout-feature-previews--basic--light:

--- a/frontend/src/lib/hog-charts/__tests__/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/canvas-renderer.test.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3'
 
-import { drawArea, drawLine, type DrawContext } from '../core/canvas-renderer'
+import { drawArea, drawGrid, drawLine, type DrawContext } from '../core/canvas-renderer'
 import type { ChartDimensions, Series } from '../core/types'
 
 const dimensions: ChartDimensions = {
@@ -450,6 +450,42 @@ describe('hog-charts canvas-renderer', () => {
                 gapValues.size > 0 ? makeDrawContextWithGaps(ctx, labels, gapValues) : makeDrawContext(ctx, labels)
             drawArea(drawCtx, series)
             expect(ctx.fill).toHaveBeenCalledTimes(expectedFillCount)
+        })
+    })
+
+    describe('drawGrid', () => {
+        it('draws a horizontal line at every y-tick', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+            drawGrid(drawCtx)
+            const tickCount = ctx.moveTo.mock.calls.length - 1
+            expect(tickCount).toBeGreaterThan(0)
+            for (let i = 0; i < tickCount; i++) {
+                const [moveX, moveY] = ctx.moveTo.mock.calls[i] as [number, number]
+                const [lineX, lineY] = ctx.lineTo.mock.calls[i] as [number, number]
+                expect(moveX).toBe(dimensions.plotLeft)
+                expect(lineX).toBe(dimensions.plotLeft + dimensions.plotWidth)
+                expect(moveY).toBe(lineY)
+            }
+        })
+
+        it('draws a vertical y-axis line at plotLeft as the final stroke', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+            drawGrid(drawCtx)
+            const lastMoveTo = ctx.moveTo.mock.calls[ctx.moveTo.mock.calls.length - 1] as [number, number]
+            const lastLineTo = ctx.lineTo.mock.calls[ctx.lineTo.mock.calls.length - 1] as [number, number]
+            expect(lastMoveTo[0]).toBe(dimensions.plotLeft + 0.5)
+            expect(lastMoveTo[1]).toBe(dimensions.plotTop)
+            expect(lastLineTo[0]).toBe(dimensions.plotLeft + 0.5)
+            expect(lastLineTo[1]).toBe(dimensions.plotTop + dimensions.plotHeight)
+        })
+
+        it('uses the provided gridColor', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+            drawGrid(drawCtx, { gridColor: 'rgb(1, 2, 3)' })
+            expect(ctx.strokeStyle).toBe('rgb(1, 2, 3)')
         })
     })
 })

--- a/frontend/src/lib/hog-charts/__tests__/scales.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/scales.test.ts
@@ -5,6 +5,7 @@ import {
     createScales,
     createXScale,
     createYScale,
+    yTickCountForHeight,
 } from '../core/scales'
 import { DEFAULT_Y_AXIS_ID } from '../core/types'
 import { dimensions, makeSeries } from '../test-helpers'
@@ -115,11 +116,29 @@ describe('hog-charts scales', () => {
             expect('base' in scale).toBe(true)
         })
 
-        it('clamps minimum to 1e-10 to avoid log(0)', () => {
-            const series = [makeSeries({ key: 's1', data: [0, 10, 100] })]
+        it('uses one decade below smallest non-zero value as domain min', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 4, 21] })]
+            const scale = createYScale(series, dimensions, { scaleType: 'log' })
+            expect(scale.domain()[0]).toBe(1)
+        })
+
+        it('rounds domain max up to next nice multiple within its decade', () => {
+            const series = [makeSeries({ key: 's1', data: [4, 21] })]
+            const scale = createYScale(series, dimensions, { scaleType: 'log' })
+            expect(scale.domain()[1]).toBe(30)
+        })
+
+        it('handles sub-unit data by picking a fractional domain min', () => {
+            const series = [makeSeries({ key: 's1', data: [0.5, 8] })]
+            const scale = createYScale(series, dimensions, { scaleType: 'log' })
+            expect(scale.domain()[0]).toBeCloseTo(0.1, 10)
+        })
+
+        it('clamps zero values to the domain min via clamp(true)', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 4, 21] })]
             const scale = createYScale(series, dimensions, { scaleType: 'log' })
             const [domainMin] = scale.domain()
-            expect(domainMin).toBeGreaterThanOrEqual(1e-10)
+            expect(scale(0)).toBeCloseTo(scale(domainMin), 5)
         })
 
         it('maps higher values to lower pixel positions (top of chart)', () => {
@@ -128,13 +147,11 @@ describe('hog-charts scales', () => {
             expect(scale(100)).toBeLessThan(scale(1))
         })
 
-        it('falls back to a linear scale when all data is non-positive (log undefined)', () => {
+        it('falls back to a linear scale when no positive values exist', () => {
             const series = [makeSeries({ key: 's1', data: [-100, -50, -10] })]
             const scale = createYScale(series, dimensions, { scaleType: 'log' })
-            // Linear domain spans the data; not collapsed to a 1e-10 single point.
             const [domainMin, domainMax] = scale.domain()
             expect(domainMin).toBeLessThan(domainMax)
-            // The fallback is linear, so different inputs produce different outputs (not collapsed).
             expect(scale(-100)).not.toBeCloseTo(scale(-10), 0)
         })
     })
@@ -384,6 +401,20 @@ describe('hog-charts scales', () => {
             for (const v of result.get('r1')!.top) {
                 expect(v).toBeCloseTo(1, 5)
             }
+        })
+    })
+
+    describe('yTickCountForHeight', () => {
+        it.each([
+            { plotHeight: 0, expected: 2 },
+            { plotHeight: 80, expected: 2 },
+            { plotHeight: 160, expected: 2 },
+            { plotHeight: 240, expected: 3 },
+            { plotHeight: 480, expected: 6 },
+            { plotHeight: 640, expected: 8 },
+            { plotHeight: 1600, expected: 8 },
+        ])('plotHeight $plotHeight → $expected ticks', ({ plotHeight, expected }) => {
+            expect(yTickCountForHeight(plotHeight)).toBe(expected)
         })
     })
 

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -3,7 +3,12 @@ import React, { useCallback, useMemo, useRef } from 'react'
 import { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from '../core/canvas-renderer'
 import type { DrawContext } from '../core/canvas-renderer'
 import { Chart } from '../core/Chart'
-import { computePercentStackData, computeStackData, createScales as createLineScales } from '../core/scales'
+import {
+    computePercentStackData,
+    computeStackData,
+    createScales as createLineScales,
+    yTickCountForHeight,
+} from '../core/scales'
 import type { ScaleSet, StackedBand } from '../core/scales'
 import { DEFAULT_Y_AXIS_ID } from '../core/types'
 import type {
@@ -85,13 +90,15 @@ export function LineChart<Meta = unknown>({
             })
             d3ScalesRef.current = d3Scales
 
+            const yTickCount = yTickCountForHeight(dimensions.plotHeight)
+
             let yAxes: Record<string, YAxisScale> | undefined
             if (d3Scales.yAxes) {
                 yAxes = {}
                 for (const [axisId, { scale, position }] of Object.entries(d3Scales.yAxes)) {
                     yAxes[axisId] = {
                         scale: (value: number) => scale(value),
-                        ticks: () => scale.ticks?.() ?? [],
+                        ticks: () => scale.ticks?.(yTickCount) ?? [],
                         position,
                     }
                 }
@@ -100,7 +107,7 @@ export function LineChart<Meta = unknown>({
             return {
                 x: (label: string) => d3Scales.x(label),
                 y: (value: number) => d3Scales.y(value),
-                yTicks: () => d3Scales.y.ticks?.() ?? [],
+                yTicks: () => d3Scales.y.ticks?.(yTickCount) ?? [],
                 yAxes,
             }
         },

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -109,7 +109,7 @@ export function Chart<Meta = unknown>({
         if (max < 0) {
             max = 0
         }
-        const ticks = d3.ticks(min, max, 6)
+        const ticks = d3.scaleLinear().domain([min, max]).nice(6).ticks(6)
         if (ticks.length === 0) {
             return 0
         }

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -1,6 +1,7 @@
+import * as d3 from 'd3'
 import React, { useCallback, useMemo, useRef } from 'react'
 
-import { AxisLabels } from '../overlays/AxisLabels'
+import { AxisLabels, measureLabelWidth } from '../overlays/AxisLabels'
 import { Crosshair } from '../overlays/Crosshair'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { Tooltip } from '../overlays/Tooltip'
@@ -73,10 +74,14 @@ export function Chart<Meta = unknown>({
         yTickFormatter,
         hideXAxis = false,
         hideYAxis = false,
-        showTooltip = true,
-        pinnableTooltip = false,
+        tooltip: tooltipConfig,
         showCrosshair = false,
     } = config ?? {}
+    const {
+        enabled: showTooltip = true,
+        pinnable: pinnableTooltip = false,
+        placement: tooltipPlacement = 'follow-data',
+    } = tooltipConfig ?? {}
 
     const hasMultipleAxes = useMemo(() => {
         const axisIds = new Set(
@@ -85,6 +90,53 @@ export function Chart<Meta = unknown>({
         return axisIds.size > 1
     }, [series])
 
+    const yLabelWidth = useMemo<number>(() => {
+        if (hideYAxis) {
+            return 0
+        }
+        const allValues = series
+            .filter((s) => !s.visibility?.excluded)
+            .flatMap((s) => s.data)
+            .filter((v) => v != null && isFinite(v))
+        if (allValues.length === 0) {
+            return 0
+        }
+        let min = Math.min(...allValues)
+        let max = Math.max(...allValues)
+        if (min > 0) {
+            min = 0
+        }
+        if (max < 0) {
+            max = 0
+        }
+        const ticks = d3.ticks(min, max, 6)
+        if (ticks.length === 0) {
+            return 0
+        }
+        const domainMax = Math.abs(Math.max(...ticks))
+        const formatter = yTickFormatter ?? ((v: number) => autoFormatYTick(v, domainMax))
+        let widest = 0
+        for (const t of ticks) {
+            widest = Math.max(widest, measureLabelWidth(formatter(t)))
+        }
+        return widest
+    }, [series, yTickFormatter, hideYAxis])
+
+    const xLabelHalfWidth = useMemo<number>(() => {
+        if (hideXAxis || labels.length === 0) {
+            return 0
+        }
+        let widest = 0
+        for (let i = 0; i < labels.length; i++) {
+            const text = xTickFormatter ? xTickFormatter(labels[i], i) : labels[i]
+            if (text === null) {
+                continue
+            }
+            widest = Math.max(widest, measureLabelWidth(text))
+        }
+        return Math.ceil(widest / 2)
+    }, [labels, xTickFormatter, hideXAxis])
+
     const margins = useMemo<ChartMargins>(() => {
         const m = { ...DEFAULT_MARGINS }
         if (hideXAxis) {
@@ -92,12 +144,16 @@ export function Chart<Meta = unknown>({
         }
         if (hideYAxis) {
             m.left = 8
+        } else {
+            m.left = Math.max(20, Math.ceil(yLabelWidth) + 12, xLabelHalfWidth + 4)
         }
         if (hasMultipleAxes && !hideYAxis) {
-            m.right = 48
+            m.right = Math.max(48, xLabelHalfWidth + 4)
+        } else {
+            m.right = Math.max(DEFAULT_MARGINS.right, xLabelHalfWidth + 4)
         }
         return m
-    }, [hideXAxis, hideYAxis, hasMultipleAxes])
+    }, [hideXAxis, hideYAxis, hasMultipleAxes, yLabelWidth, xLabelHalfWidth])
 
     const { canvasRef, wrapperRef, dimensions, ctx } = useChartCanvas({ margins })
 
@@ -208,7 +264,14 @@ export function Chart<Meta = unknown>({
                     <div
                         ref={wrapperRef}
                         className={className}
-                        style={{ position: 'relative', width: '100%', flex: 1, minHeight: 0, cursor: cursorStyle }}
+                        style={{
+                            position: 'relative',
+                            width: '100%',
+                            flex: 1,
+                            minHeight: 0,
+                            overflow: 'hidden',
+                            cursor: cursorStyle,
+                        }}
                         onMouseMove={handlers.onMouseMove}
                         onMouseLeave={handlers.onMouseLeave}
                         onClick={handlers.onClick}
@@ -241,7 +304,11 @@ export function Chart<Meta = unknown>({
                                 {children}
 
                                 {tooltipCtx && showTooltip && (
-                                    <Tooltip context={tooltipCtx} renderTooltip={renderTooltip} />
+                                    <Tooltip
+                                        context={tooltipCtx}
+                                        renderTooltip={renderTooltip}
+                                        placement={tooltipPlacement}
+                                    />
                                 )}
                             </OverlayLayer>
                         )}

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -1,5 +1,6 @@
 import * as d3 from 'd3'
 
+import { yTickCountForHeight } from './scales'
 import type { ChartDimensions, Series } from './types'
 
 export interface DrawContext {
@@ -288,7 +289,7 @@ export function drawGrid(drawCtx: DrawContext, options: { gridColor?: string } =
     const { ctx, yScale, dimensions } = drawCtx
     const gridColor = options.gridColor ?? 'rgba(0, 0, 0, 0.1)'
 
-    const yTicks = (yScale as d3.ScaleLinear<number, number>).ticks?.() ?? []
+    const yTicks = (yScale as d3.ScaleLinear<number, number>).ticks?.(yTickCountForHeight(dimensions.plotHeight)) ?? []
 
     ctx.strokeStyle = gridColor
     ctx.lineWidth = 1
@@ -301,6 +302,12 @@ export function drawGrid(drawCtx: DrawContext, options: { gridColor?: string } =
         ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, y)
         ctx.stroke()
     }
+
+    const axisX = Math.round(dimensions.plotLeft) + 0.5
+    ctx.beginPath()
+    ctx.moveTo(axisX, dimensions.plotTop)
+    ctx.lineTo(axisX, dimensions.plotTop + dimensions.plotHeight)
+    ctx.stroke()
 }
 
 export function drawHighlightPoint(

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -99,8 +99,12 @@ export function useChartInteraction<Meta = unknown>({
         }
 
         const handleClickOutside = (e: MouseEvent): void => {
+            const target = e.target
+            if (target instanceof Element && target.closest('[data-hog-charts-tooltip]')) {
+                return
+            }
             const wrapper = wrapperRef.current
-            if (wrapper && !wrapper.contains(e.target as Node)) {
+            if (wrapper && !wrapper.contains(target as Node)) {
                 clearTooltip()
             }
         }

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -20,6 +20,10 @@ export function createXScale(labels: string[], dimensions: ChartDimensions): d3.
         .padding(0)
 }
 
+export function yTickCountForHeight(plotHeight: number): number {
+    return Math.max(2, Math.min(8, Math.floor(plotHeight / 80)))
+}
+
 export function createYScale(
     series: Series[],
     dimensions: ChartDimensions,
@@ -29,12 +33,13 @@ export function createYScale(
     } = {}
 ): d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number> {
     const { scaleType = 'linear', percentStack = false } = options
+    const tickCount = yTickCountForHeight(dimensions.plotHeight)
 
     if (percentStack) {
         return d3
             .scaleLinear()
             .domain([0, 1])
-            .nice()
+            .nice(tickCount)
             .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
     }
 
@@ -52,20 +57,21 @@ export function createYScale(
     let max = d3.max(allValues) ?? 1
 
     if (scaleType === 'log') {
-        if (max <= 0) {
-            // Log of non-positive data is undefined — fall back to linear so the
-            // chart still shows something useful instead of collapsing to a line.
+        const positives = allValues.filter((v) => v > 0)
+        if (positives.length === 0) {
             return d3
                 .scaleLinear()
                 .domain([min, max])
-                .nice()
+                .nice(tickCount)
                 .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
         }
-        min = Math.max(min, 1e-10)
+        const minPositive = Math.min(...positives)
+        const niceMin = Math.pow(10, Math.ceil(Math.log10(minPositive)) - 1)
+        const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
+        const niceMax = Math.ceil(max / maxDecade) * maxDecade
         return d3
             .scaleLog()
-            .domain([min, max])
-            .nice()
+            .domain([niceMin, niceMax])
             .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
             .clamp(true)
     }
@@ -79,7 +85,7 @@ export function createYScale(
     return d3
         .scaleLinear()
         .domain([min, max])
-        .nice()
+        .nice(tickCount)
         .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
 }
 

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -142,12 +142,21 @@ export interface ChartConfig {
 
     /** Show horizontal grid lines at y-axis tick positions. */
     showGrid?: boolean
-    /** Show a tooltip on hover. Defaults to true. Use the `tooltip` prop to customize content. */
-    showTooltip?: boolean
-    /** When true, clicking a data point with multiple series pins the tooltip in place. */
-    pinnableTooltip?: boolean
+    /** Tooltip behaviour. Defaults to enabled with no pinning and `follow-data` placement. */
+    tooltip?: TooltipConfig
     /** Show a vertical crosshair line that follows the cursor. */
     showCrosshair?: boolean
+}
+
+export interface TooltipConfig {
+    /** Show a tooltip on hover. Defaults to true. Use the `tooltip` render prop on Chart to customize content. */
+    enabled?: boolean
+    /** When true, clicking a data point with multiple series pins the tooltip in place. */
+    pinnable?: boolean
+    /** Where the tooltip anchors vertically. `follow-data` (default) tracks the highest data point
+     *  at the hovered x; `top` fixes the tooltip to the top of the chart so it doesn't jump
+     *  vertically as the cursor moves between data points. */
+    placement?: 'follow-data' | 'top'
 }
 
 export interface LineChartConfig extends ChartConfig {

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -12,7 +12,8 @@ interface AxisLabelsProps {
     axisColor?: string
 }
 
-const LABEL_FONT = '11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
+export const LABEL_FONT =
+    '12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
 const LABEL_PADDING = 20
 
 let measureCtx: CanvasRenderingContext2D | null = null
@@ -21,6 +22,15 @@ function getMeasureCtx(): CanvasRenderingContext2D | null {
         measureCtx = document.createElement('canvas').getContext('2d')
     }
     return measureCtx
+}
+
+export function measureLabelWidth(text: string, font: string = LABEL_FONT): number {
+    const ctx = getMeasureCtx()
+    if (!ctx) {
+        return text.length * 7
+    }
+    ctx.font = font
+    return ctx.measureText(text).width
 }
 
 export function computeVisibleXLabels(
@@ -71,7 +81,7 @@ export function computeVisibleXLabels(
 
 const TICK_STYLE_BASE: React.CSSProperties = {
     position: 'absolute',
-    fontSize: 11,
+    fontSize: 12,
     pointerEvents: 'none',
     whiteSpace: 'nowrap',
 }

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -31,7 +31,7 @@ export function Tooltip<Meta = unknown>({
                 }
             },
         }),
-        [context.position.x, context.position.y, context.canvasBounds, placement]
+        [context.position.x, placement === 'follow-data' ? context.position.y : null, context.canvasBounds, placement]
     )
 
     const { refs, floatingStyles } = useFloating({

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { flip, offset, shift, useFloating, type VirtualElement } from '@floating-ui/react'
+import { flip, FloatingPortal, offset, shift, useFloating, type VirtualElement } from '@floating-ui/react'
 import React, { useLayoutEffect, useMemo } from 'react'
 
 import type { TooltipContext } from '../core/types'
@@ -6,14 +6,19 @@ import type { TooltipContext } from '../core/types'
 interface TooltipProps<Meta> {
     context: TooltipContext<Meta>
     renderTooltip: (ctx: TooltipContext<Meta>) => React.ReactNode
+    placement?: 'follow-data' | 'top'
 }
 
-export function Tooltip<Meta = unknown>({ context, renderTooltip }: TooltipProps<Meta>): React.ReactElement {
+export function Tooltip<Meta = unknown>({
+    context,
+    renderTooltip,
+    placement = 'follow-data',
+}: TooltipProps<Meta>): React.ReactElement {
     const virtualReference = useMemo<VirtualElement>(
         () => ({
             getBoundingClientRect() {
                 const x = context.canvasBounds.left + context.position.x
-                const y = context.canvasBounds.top + context.position.y
+                const y = placement === 'top' ? context.canvasBounds.top : context.canvasBounds.top + context.position.y
                 return {
                     x,
                     y,
@@ -26,37 +31,37 @@ export function Tooltip<Meta = unknown>({ context, renderTooltip }: TooltipProps
                 }
             },
         }),
-        [context.position.x, context.position.y, context.canvasBounds]
+        [context.position.x, context.position.y, context.canvasBounds, placement]
     )
 
     const { refs, floatingStyles } = useFloating({
-        placement: 'right',
+        placement: placement === 'top' ? 'right-start' : 'right',
         strategy: 'fixed',
         middleware: [offset(12), flip(), shift({ padding: 8 })],
     })
 
-    // useLayoutEffect runs synchronously before paint, so floating-ui has the
-    // virtual reference ready by the first frame — no positioning flash.
     useLayoutEffect(() => {
         refs.setPositionReference(virtualReference)
     }, [virtualReference, refs])
 
     return (
-        <div
-            ref={refs.setFloating}
-            // Marker so the interaction hook can distinguish scroll events that originate
-            // inside the tooltip (e.g. scrollable long content) from chart/page scrolls,
-            // which should dismiss a pinned tooltip.
-            data-hog-charts-tooltip=""
-            className={context.isPinned ? 'hog-charts-tooltip--pinned' : undefined}
-            style={{
-                ...floatingStyles,
-                pointerEvents: context.isPinned ? 'auto' : 'none',
-                width: 'max-content',
-                zIndex: 10,
-            }}
-        >
-            {renderTooltip(context)}
-        </div>
+        <FloatingPortal>
+            <div
+                ref={refs.setFloating}
+                // Marker so useChartInteraction can identify events originating inside the
+                // tooltip — it lives outside the chart wrapper via FloatingPortal, so DOM
+                // ancestry can't be used to detect it.
+                data-hog-charts-tooltip=""
+                className={context.isPinned ? 'hog-charts-tooltip--pinned' : undefined}
+                style={{
+                    ...floatingStyles,
+                    pointerEvents: context.isPinned ? 'auto' : 'none',
+                    width: 'max-content',
+                    zIndex: 'var(--z-tooltip)',
+                }}
+            >
+                {renderTooltip(context)}
+            </div>
+        </FloatingPortal>
     )
 }

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -82,10 +82,10 @@ describe('ValueLabels', () => {
         expect(divs.map((d) => d.textContent)).toEqual(expected)
     })
 
-    it('renders zero values as legitimate data points', () => {
+    it('skips zero values', () => {
         const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [10, 0, 30, 0, 50] }]
         const { container } = renderInChart(makeContext(series), <ValueLabels />)
-        expect(labelDivs(container).map((d) => d.textContent)).toEqual(['10', '0', '30', '0', '50'])
+        expect(labelDivs(container).map((d) => d.textContent)).toEqual(['10', '30', '50'])
     })
 
     it('skips non-finite values (NaN, Infinity)', () => {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -71,7 +71,7 @@ function buildCandidates(
 
         for (let dIdx = 0; dIdx < s.data.length && dIdx < labels.length; dIdx++) {
             const rawValue = s.data[dIdx]
-            if (typeof rawValue !== 'number' || !isFinite(rawValue)) {
+            if (typeof rawValue !== 'number' || !isFinite(rawValue) || rawValue === 0) {
                 continue
             }
             const yValue = resolveValue(s, dIdx)

--- a/frontend/src/scenes/trends/viz/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChart.tsx
@@ -214,7 +214,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         () => ({
             showGrid: true,
             showCrosshair: true,
-            pinnableTooltip: true,
+            tooltip: { pinnable: true, placement: 'top' },
             yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
             percentStackView: isPercentStackView,
             xTickFormatter,


### PR DESCRIPTION
## Problem

The `product-analytics-hog-charts` flag swap exposed a bunch of visual regressions vs. the legacy Chart.js trends chart when the new chart is dropped into a dashboard tile: tooltips clipped by the card edge, tooltip jumping vertically with the data, font sizes off, log scale collapsing to powers of 10, zero labels rendering, the y-axis line missing, edge x-tick labels triggering a horizontal scrollbar via `.InsightCard__viz { overflow: auto }`, and a cosmetic gap between the canvas left edge and the y-axis labels.

## Changes

- **Tooltip:** render through `FloatingPortal` so dashboard card overflow can't clip it; nest config under `tooltip: { enabled, pinnable, placement }`; add `placement: 'top'` to anchor to the chart top (matches legacy fixed-height behavior). `TrendsLineChart` opts in.
- **Margins:** size `margins.left`/`margins.right` dynamically from the widest y-tick label and half the widest x-tick label, so short labels no longer leave a 26px gutter on the left and edge x-labels stop poking past the wrapper.
- **Y ticks:** target ~80px between ticks (clamped 2–8) instead of d3's default ~10, so a 0–21 range gets nice 0/5/10/15/20/25 ticks instead of 12 ticks at step 2.
- **Log scale:** legacy formula for the domain — `niceMin = 10^(ceil(log10(minPositive))-1)` and `niceMax` rounded up within its decade — and drop `.nice()` so domain stops snapping to powers of 10. Zeros clamp to the bottom via `.clamp(true)`.
- **Drawing:** vertical y-axis line at `plotLeft` in `drawGrid`; bump axis label font 11px → 12px to match legacy.
- **Value labels:** skip zero values (matches legacy `datum !== 0`).
- **Wrapper:** `overflow: hidden` on the chart wrapper so `AnnotationsOverlay` badges (which extend past the chart width by design) don't trigger a horizontal scrollbar on the tile. With the dynamic-margin fix in place, edge tick labels stay inside the wrapper and aren't clipped.

## How did you test this code?

I'm an agent. Ran the affected Jest suites:

\`\`\`
pnpm --dir frontend exec jest --testPathPattern='hog-charts/(__tests__/scales|__tests__/canvas-renderer|overlays/ValueLabels)'
→ 3 suites, 121 tests passed
\`\`\`

Updated tests:
- \`overlays/ValueLabels.test.tsx\` — flipped *renders zero values* → *skips zero values*.
- \`__tests__/scales.test.ts\` — replaced the 1e-10 clamp test with cases covering \`niceMin\`, \`niceMax\` rounding, sub-unit data, zero clamping, and the no-positives fallback.

Added tests:
- \`__tests__/scales.test.ts\` \`yTickCountForHeight\` — boundary table.
- \`__tests__/canvas-renderer.test.ts\` \`drawGrid\` — horizontal grid line per tick, final vertical y-axis line at \`plotLeft + 0.5\`, theme \`gridColor\` honored.

The user verified each change visually in their dev environment as we went (DOM dumps + screenshots in the session); no Playwright runs.

## Publish to changelog?

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Sam drove and verified each change against a live dashboard in dev — every fix in this PR was confirmed visually by him before commit. Notable judgment calls:

- Picked `tooltip.placement = 'top'` as opt-in via config rather than the default, so non-trends consumers keep the data-anchored tooltip.
- Chose dynamic margin sizing over a fixed wider default — wide labels (e.g. \`1,234,567\`) still fit, short labels don't leave dead space.
- Used `overflow: hidden` on the wrapper for the AnnotationsOverlay overflow rather than reworking AnnotationsOverlay itself, mirroring how the legacy LineGraph wrapper does it.