### PR TITLE
feat(tasks): add xhigh reasoning effort for opus 4.6 and 4.7

### DIFF
--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -44,6 +44,7 @@ class ReasoningEffort(StrEnum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    XHIGH = "xhigh"
     MAX = "max"
 
 
@@ -51,6 +52,7 @@ PUBLIC_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = (
     ReasoningEffort.LOW,
     ReasoningEffort.MEDIUM,
     ReasoningEffort.HIGH,
+    ReasoningEffort.XHIGH,
     ReasoningEffort.MAX,
 )
 
@@ -71,12 +73,14 @@ CLAUDE_REASONING_EFFORTS_BY_MODEL: dict[str, tuple[ReasoningEffort, ...]] = {
         ReasoningEffort.LOW,
         ReasoningEffort.MEDIUM,
         ReasoningEffort.HIGH,
+        ReasoningEffort.XHIGH,
         ReasoningEffort.MAX,
     ),
     "claude-opus-4-7": (
         ReasoningEffort.LOW,
         ReasoningEffort.MEDIUM,
         ReasoningEffort.HIGH,
+        ReasoningEffort.XHIGH,
         ReasoningEffort.MAX,
     ),
     "claude-sonnet-4-6": (

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -368,6 +368,7 @@ export const ClaudeRuntimeAdapterEnumApi = {
  * * `low` - low
  * `medium` - medium
  * `high` - high
+ * `xhigh` - xhigh
  * `max` - max
  */
 export type ReasoningEffortEnumApi = (typeof ReasoningEffortEnumApi)[keyof typeof ReasoningEffortEnumApi]
@@ -376,6 +377,7 @@ export const ReasoningEffortEnumApi = {
     Low: 'low',
     Medium: 'medium',
     High: 'high',
+    Xhigh: 'xhigh',
     Max: 'max',
 } as const
 
@@ -443,6 +445,7 @@ export interface ClaudeTaskRunCreateSchemaApi {
 * `low` - low
 * `medium` - medium
 * `high` - high
+* `xhigh` - xhigh
 * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
     /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
@@ -526,6 +529,7 @@ export interface CodexTaskRunCreateSchemaApi {
 * `low` - low
 * `medium` - medium
 * `high` - high
+* `xhigh` - xhigh
 * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
     /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
@@ -946,6 +950,7 @@ export interface TaskRunBootstrapCreateRequestApi {
 * `low` - low
 * `medium` - medium
 * `high` - high
+* `xhigh` - xhigh
 * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
     /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -283,11 +283,11 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 ),
             model: zod.string().describe('LLM model identifier to run in the Claude runtime.'),
             reasoning_effort: zod
-                .enum(['low', 'medium', 'high', 'max'])
-                .describe('* `low` - low\n* `medium` - medium\n* `high` - high\n* `max` - max')
+                .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+                .describe('* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max')
                 .optional()
                 .describe(
-                    'Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `max` - max'
+                    'Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max'
                 ),
             github_user_token: zod
                 .string()
@@ -360,11 +360,11 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 ),
             model: zod.string().describe('LLM model identifier to run in the Codex runtime.'),
             reasoning_effort: zod
-                .enum(['low', 'medium', 'high', 'max'])
-                .describe('* `low` - low\n* `medium` - medium\n* `high` - high\n* `max` - max')
+                .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+                .describe('* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max')
                 .optional()
                 .describe(
-                    'Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `max` - max'
+                    'Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max'
                 ),
             github_user_token: zod
                 .string()
@@ -587,11 +587,11 @@ export const TasksRunsCreateBody = /* @__PURE__ */ zod
             ),
         model: zod.string().optional().describe('LLM model identifier to run in the selected runtime.'),
         reasoning_effort: zod
-            .enum(['low', 'medium', 'high', 'max'])
-            .describe('* `low` - low\n* `medium` - medium\n* `high` - high\n* `max` - max')
+            .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+            .describe('* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max')
             .optional()
             .describe(
-                'Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `max` - max'
+                'Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max'
             ),
         github_user_token: zod
             .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7725,6 +7725,7 @@ export namespace Schemas {
      * * `low` - low
     * `medium` - medium
     * `high` - high
+    * `xhigh` - xhigh
     * `max` - max
      */
     export type ReasoningEffortEnum = typeof ReasoningEffortEnum[keyof typeof ReasoningEffortEnum];
@@ -7734,6 +7735,7 @@ export namespace Schemas {
       Low: 'low',
       Medium: 'medium',
       High: 'high',
+      Xhigh: 'xhigh',
       Max: 'max',
     } as const;
 
@@ -7801,6 +7803,7 @@ export namespace Schemas {
     * `low` - low
     * `medium` - medium
     * `high` - high
+    * `xhigh` - xhigh
     * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
@@ -8115,6 +8118,7 @@ export namespace Schemas {
     * `low` - low
     * `medium` - medium
     * `high` - high
+    * `xhigh` - xhigh
     * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
@@ -35973,6 +35977,7 @@ export namespace Schemas {
     * `low` - low
     * `medium` - medium
     * `high` - high
+    * `xhigh` - xhigh
     * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */


### PR DESCRIPTION
## Problem

Tasks API rejects `reasoning_effort=xhigh`, but posthog/code advertises `xhigh` for `claude-opus-4-6` and `claude-opus-4-7`.

## Changes

Add `XHIGH` to `ReasoningEffort`, `PUBLIC_REASONING_EFFORTS`, and the opus-4-6 / opus-4-7 tuples. Other adapters keep rejecting it via the existing validator.

## How did you test this code?

Agent-authored. No new tests — config-only change, existing reasoning-effort tests in `test_api.py` cover the validator wiring. Ran `ruff check` and `ruff format --check`.

## 🤖 Agent context

Agent: PostHog Code. Mirrors `MODELS_WITH_XHIGH_EFFORT` from posthog/code's Claude adapter.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*