### PR TITLE
fix(flags): only install HyperCacheFlagProvider in US

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -77,15 +77,15 @@ class PostHogConfig(AppConfig):
                     properties={"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
         # Use HyperCache to provide flag definitions instead of per-process API polling.
-        # Falls back to the SDK's emergency API fetch (via personal_api_key) only when
-        # the cache is cold. In E2E testing personal_api_key is None, so a cold cache
-        # will result in no flag definitions being loaded — which is acceptable there.
+        # Only wired up in US, where local team_id=2 corresponds to the PostHog company
+        # project. Outside US the helper returns None so the SDK falls back to its API
+        # path against `posthoganalytics.host` (us.i.posthog.com) — see helper docstring.
         if not posthoganalytics.disabled:
-            from posthog.feature_flags.sdk_cache_provider import HyperCacheFlagProvider
+            from posthog.feature_flags.sdk_cache_provider import get_default_flag_definition_cache_provider
 
-            posthoganalytics.flag_definition_cache_provider = HyperCacheFlagProvider(  # ty: ignore[invalid-assignment]
-                team_id=int(os.environ.get("POSTHOG_SELF_TEAM_ID", "2"))
-            )
+            provider = get_default_flag_definition_cache_provider()
+            if provider is not None:
+                posthoganalytics.flag_definition_cache_provider = provider  # ty: ignore[invalid-assignment]
 
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -80,6 +80,8 @@ class PostHogConfig(AppConfig):
         # Only wired up in US, where local team_id=2 corresponds to the PostHog company
         # project. Outside US the helper returns None so the SDK falls back to its API
         # path against `posthoganalytics.host` (us.i.posthog.com) — see helper docstring.
+        # In E2E testing personal_api_key is None, so the SDK's API fallback is a no-op
+        # and no flag definitions are loaded — which is acceptable there.
         if not posthoganalytics.disabled:
             from posthog.feature_flags.sdk_cache_provider import get_default_flag_definition_cache_provider
 

--- a/posthog/feature_flags/sdk_cache_provider.py
+++ b/posthog/feature_flags/sdk_cache_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Optional
 
 import structlog
@@ -72,3 +73,20 @@ class HyperCacheFlagProvider:
 
     def shutdown(self) -> None:
         pass  # No-op — no locks or resources to release
+
+
+def get_default_flag_definition_cache_provider() -> Optional[HyperCacheFlagProvider]:
+    """Build the flag-definition cache provider for this region, or None to fall back to API polling.
+
+    HyperCache is keyed by team_id (defaults to 2 via POSTHOG_SELF_TEAM_ID), which is only
+    the PostHog company project in US Postgres — in EU and other regions, team 2 is an
+    unrelated org. Returning None outside US lets the SDK poll posthoganalytics.host
+    (us.i.posthog.com) directly via personal_api_key, which is the cross-region behavior
+    that worked before this provider was wired up.
+    """
+    from django.conf import settings
+
+    if settings.CLOUD_DEPLOYMENT != "US":
+        return None
+
+    return HyperCacheFlagProvider(team_id=int(os.environ.get("POSTHOG_SELF_TEAM_ID", "2")))

--- a/posthog/feature_flags/test_sdk_cache_provider.py
+++ b/posthog/feature_flags/test_sdk_cache_provider.py
@@ -213,38 +213,32 @@ class TestSDKClientIntegration(SimpleTestCase):
 class TestGetDefaultFlagDefinitionCacheProvider(SimpleTestCase):
     """The HyperCache provider is only safe to install in US where team_id=2 maps to
     the PostHog company project. Elsewhere it must return None so the SDK falls back
-    to API polling against posthoganalytics.host."""
+    to API polling against posthoganalytics.host. The EU env-override case documents
+    that the gate is regional, not env-overridable."""
 
-    def setUp(self):
-        # Isolate POSTHOG_SELF_TEAM_ID so test order doesn't matter
-        self._env_patcher = patch.dict(os.environ, {}, clear=False)
-        self._env_patcher.start()
-        os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
+    @parameterized.expand(
+        [
+            ("us_default", "US", None, 2),
+            ("us_env_override", "US", "42", 42),
+            ("eu_no_env", "EU", None, None),
+            ("eu_env_override", "EU", "42", None),
+            ("dev", "DEV", None, None),
+            ("e2e", "E2E", None, None),
+            ("self_hosted", None, None, None),
+        ]
+    )
+    @patch.dict(os.environ, {}, clear=False)
+    def test_provider(self, _name, deployment, env_team_id, expected_team_id):
+        if env_team_id is not None:
+            os.environ["POSTHOG_SELF_TEAM_ID"] = env_team_id
+        else:
+            os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
 
-    def tearDown(self):
-        self._env_patcher.stop()
-
-    @override_settings(CLOUD_DEPLOYMENT="US")
-    def test_us_returns_provider_with_default_team_id(self):
-        provider = get_default_flag_definition_cache_provider()
-        assert isinstance(provider, HyperCacheFlagProvider)
-        assert provider._team_id == 2
-
-    @override_settings(CLOUD_DEPLOYMENT="US")
-    def test_us_respects_self_team_id_env_override(self):
-        os.environ["POSTHOG_SELF_TEAM_ID"] = "42"
-        provider = get_default_flag_definition_cache_provider()
-        assert isinstance(provider, HyperCacheFlagProvider)
-        assert provider._team_id == 42
-
-    @parameterized.expand([("EU",), ("DEV",), ("E2E",), (None,)])
-    def test_non_us_regions_return_none(self, deployment):
         with override_settings(CLOUD_DEPLOYMENT=deployment):
-            assert get_default_flag_definition_cache_provider() is None
+            provider = get_default_flag_definition_cache_provider()
 
-    @override_settings(CLOUD_DEPLOYMENT="EU")
-    def test_eu_ignores_self_team_id_env(self):
-        # Even with an explicit team id, EU should not install the provider —
-        # the assumption that local team_id maps to the company project doesn't hold.
-        os.environ["POSTHOG_SELF_TEAM_ID"] = "42"
-        assert get_default_flag_definition_cache_provider() is None
+        if expected_team_id is None:
+            assert provider is None
+        else:
+            assert isinstance(provider, HyperCacheFlagProvider)
+            assert provider._team_id == expected_team_id

--- a/posthog/feature_flags/test_sdk_cache_provider.py
+++ b/posthog/feature_flags/test_sdk_cache_provider.py
@@ -1,11 +1,13 @@
+import os
+
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 from posthoganalytics.client import Client
 
-from posthog.feature_flags.sdk_cache_provider import HyperCacheFlagProvider
+from posthog.feature_flags.sdk_cache_provider import HyperCacheFlagProvider, get_default_flag_definition_cache_provider
 
 
 class TestHyperCacheFlagProvider(SimpleTestCase):
@@ -206,3 +208,43 @@ class TestSDKClientIntegration(SimpleTestCase):
             client._load_feature_flags()
 
             mock_api.assert_called_once()
+
+
+class TestGetDefaultFlagDefinitionCacheProvider(SimpleTestCase):
+    """The HyperCache provider is only safe to install in US where team_id=2 maps to
+    the PostHog company project. Elsewhere it must return None so the SDK falls back
+    to API polling against posthoganalytics.host."""
+
+    def setUp(self):
+        # Isolate POSTHOG_SELF_TEAM_ID so test order doesn't matter
+        self._env_patcher = patch.dict(os.environ, {}, clear=False)
+        self._env_patcher.start()
+        os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
+
+    def tearDown(self):
+        self._env_patcher.stop()
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_us_returns_provider_with_default_team_id(self):
+        provider = get_default_flag_definition_cache_provider()
+        assert isinstance(provider, HyperCacheFlagProvider)
+        assert provider._team_id == 2
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_us_respects_self_team_id_env_override(self):
+        os.environ["POSTHOG_SELF_TEAM_ID"] = "42"
+        provider = get_default_flag_definition_cache_provider()
+        assert isinstance(provider, HyperCacheFlagProvider)
+        assert provider._team_id == 42
+
+    @parameterized.expand([("EU",), ("DEV",), ("E2E",), (None,)])
+    def test_non_us_regions_return_none(self, deployment):
+        with override_settings(CLOUD_DEPLOYMENT=deployment):
+            assert get_default_flag_definition_cache_provider() is None
+
+    @override_settings(CLOUD_DEPLOYMENT="EU")
+    def test_eu_ignores_self_team_id_env(self):
+        # Even with an explicit team id, EU should not install the provider —
+        # the assumption that local team_id maps to the company project doesn't hold.
+        os.environ["POSTHOG_SELF_TEAM_ID"] = "42"
+        assert get_default_flag_definition_cache_provider() is None

--- a/posthog/feature_flags/test_sdk_cache_provider.py
+++ b/posthog/feature_flags/test_sdk_cache_provider.py
@@ -211,30 +211,27 @@ class TestSDKClientIntegration(SimpleTestCase):
 
 
 class TestGetDefaultFlagDefinitionCacheProvider(SimpleTestCase):
-    """The HyperCache provider is only safe to install in US where team_id=2 maps to
-    the PostHog company project. Elsewhere it must return None so the SDK falls back
-    to API polling against posthoganalytics.host. The EU env-override case documents
-    that the gate is regional, not env-overridable."""
-
     @parameterized.expand(
         [
-            ("us_default", "US", None, 2),
-            ("us_env_override", "US", "42", 42),
-            ("eu_no_env", "EU", None, None),
-            ("eu_env_override", "EU", "42", None),
-            ("dev", "DEV", None, None),
-            ("e2e", "E2E", None, None),
-            ("self_hosted", None, None, None),
+            # (name, CLOUD_DEPLOYMENT, env_overrides, expected_team_id)
+            ("us_default", "US", {}, 2),
+            ("us_env_override", "US", {"POSTHOG_SELF_TEAM_ID": "42"}, 42),
+            ("eu_no_env", "EU", {}, None),
+            # documents that the gate is regional, not env-overridable
+            ("eu_env_override", "EU", {"POSTHOG_SELF_TEAM_ID": "42"}, None),
+            ("dev", "DEV", {}, None),
+            ("e2e", "E2E", {}, None),
+            ("local", "LOCAL", {}, None),
+            ("self_hosted", None, {}, None),
         ]
     )
-    @patch.dict(os.environ, {}, clear=False)
-    def test_provider(self, _name, deployment, env_team_id, expected_team_id):
-        if env_team_id is not None:
-            os.environ["POSTHOG_SELF_TEAM_ID"] = env_team_id
-        else:
-            os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
-
-        with override_settings(CLOUD_DEPLOYMENT=deployment):
+    def test_provider(self, _name, deployment, env_overrides, expected_team_id):
+        # clear=True wipes os.environ inside the context (and restores on exit), so the
+        # test sees only env_overrides — no leakage from the outer environment.
+        with (
+            patch.dict(os.environ, env_overrides, clear=True),
+            override_settings(CLOUD_DEPLOYMENT=deployment),
+        ):
             provider = get_default_flag_definition_cache_provider()
 
         if expected_team_id is None:


### PR DESCRIPTION
## Problem

Local feature-flag evaluation in our server-side `posthoganalytics` SDK returns `None` instead of `True`/`False` in EU pods (works in US). Customer-facing example: `posthoganalytics.feature_enabled("persons-on-events-v2-reads-enabled", ..., only_evaluate_locally=True)` finds no flag definition.

`apps.py` keys `HyperCacheFlagProvider` by `team_id=2` (no env override is set anywhere), assuming "local team 2 == PostHog company project". That holds in US Postgres, not in EU. The provider also returns a truthy dict for an empty flags list, so the SDK accepts the EU cache as authoritative and never falls back to its API path.

## Changes

Gate provider install on `settings.CLOUD_DEPLOYMENT == "US"`. Outside US, leave `flag_definition_cache_provider` unset so the SDK polls `posthoganalytics.host` (`us.i.posthog.com`) directly — the cross-region behavior that worked before #50737. Gate lives in a small `get_default_flag_definition_cache_provider()` helper in `sdk_cache_provider.py` so it's testable without invoking `AppConfig.ready()`.

## How did you test this code?

I'm an agent (PostHog Code). Added `TestGetDefaultFlagDefinitionCacheProvider` parameterized over `US` / `EU` / `DEV` / `E2E` / `LOCAL` / unset, with and without `POSTHOG_SELF_TEAM_ID` override (8 cases). Existing tests untouched. Did not run the full pytest suite — sandbox lacked the flox venv. Verified `ruff check` clean and smoke-tested the helper against all 8 cases.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude). Human review required.
- Diagnosis: `apps.py:79-88`, `sdk_cache_provider.py:43-68`, and `posthoganalytics 7.13.0::client.py::_load_feature_flags` (lines 1253-1296 — the truthy-payload-accepted-as-authoritative path).
- Deviation from the originating prompt: the gate was extracted into a small factory rather than placed inline in `apps.py`, because `AppConfig.ready()` forces `posthoganalytics.disabled=True` in `TEST` mode and runs many other side effects, making a true regression test fragile. The factory captures the same semantic gate and is directly testable.
- Reviewer should sanity-check that EU Postgres team 2 isn't the company project (the fix doesn't depend on which team it is, only that it's not the company project — but worth confirming).
- Follow-ups (not in this PR): metric/log when `get_flag_definitions()` returns empty flags; `CLOUD_DEPLOYMENT in {"US"}` allowlist constant for future US-WEST style splits.