### PR TITLE
fix(experiments): smart default variant selection when ending experiments

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -68,7 +68,7 @@ import { canArchiveExperiment, confirmArchiveExperiment, confirmDeleteExperiment
 import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatusColor, getExperimentStatusLabel } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
-import { getVariantColor, isLegacyExperiment } from '../utils'
+import { getDefaultVariantToKeep, getVariantColor, isLegacyExperiment } from '../utils'
 
 export function VariantTag({
     variantKey,
@@ -659,18 +659,9 @@ export function FinishExperimentModal(): JSX.Element {
     const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
 
     useEffect(() => {
-        const variants = experiment.parameters?.feature_flag_variants
-        if (!variants?.length) {
-            return
-        }
-        if (experiment.conclusion === ExperimentConclusion.Lost) {
-            // The test variant(s) underperformed, so default to keeping the control
-            const controlVariant = variants.find((v) => v.key === 'control') ?? variants[0]
-            setSelectedVariantKey(controlVariant.key)
-        } else if (variants.length > 1) {
-            // First test variant selected by default
-            setSelectedVariantKey(variants[1].key)
-        }
+        setSelectedVariantKey(
+            getDefaultVariantToKeep(experiment.parameters?.feature_flag_variants, experiment.conclusion)
+        )
     }, [
         experiment.id,
         experiment.conclusion,

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -659,12 +659,21 @@ export function FinishExperimentModal(): JSX.Element {
     const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
 
     useEffect(() => {
-        if (experiment.parameters?.feature_flag_variants?.length > 1) {
+        const variants = experiment.parameters?.feature_flag_variants
+        if (!variants?.length) {
+            return
+        }
+        if (experiment.conclusion === ExperimentConclusion.Lost) {
+            // The test variant(s) underperformed, so default to keeping the control
+            const controlVariant = variants.find((v) => v.key === 'control') ?? variants[0]
+            setSelectedVariantKey(controlVariant.key)
+        } else if (variants.length > 1) {
             // First test variant selected by default
-            setSelectedVariantKey(experiment.parameters.feature_flag_variants[1].key)
+            setSelectedVariantKey(variants[1].key)
         }
     }, [
         experiment.id,
+        experiment.conclusion,
         experiment.parameters?.feature_flag_variants?.length,
         experiment.parameters?.feature_flag_variants,
     ])

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -17,6 +17,7 @@ import {
 import {
     AccessControlLevel,
     Experiment,
+    ExperimentConclusion,
     ExperimentMetricMathType,
     FeatureFlagBucketingIdentifier,
     FeatureFlagEvaluationRuntime,
@@ -31,6 +32,7 @@ import {
     exposureConfigToFilter,
     featureFlagEligibleForExperiment,
     filterToExposureConfig,
+    getDefaultVariantToKeep,
     getOrderedMetricsWithResults,
     getViewRecordingFilters,
     getViewRecordingFiltersLegacy,
@@ -63,6 +65,66 @@ describe('utils', () => {
             expect(percentageDistribution(18)).toEqual([6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5])
             expect(percentageDistribution(19)).toEqual([6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5])
             expect(percentageDistribution(20)).toEqual([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5])
+        })
+    })
+
+    describe('getDefaultVariantToKeep', () => {
+        const variants = [
+            { key: 'control', rollout_percentage: 50 },
+            { key: 'test', rollout_percentage: 50 },
+        ]
+        const multiVariantTest = [
+            { key: 'control', rollout_percentage: 25 },
+            { key: 'test-a', rollout_percentage: 25 },
+            { key: 'test-b', rollout_percentage: 25 },
+            { key: 'test-c', rollout_percentage: 25 },
+        ]
+
+        it.each([
+            { conclusion: ExperimentConclusion.Won, expected: 'test' },
+            { conclusion: ExperimentConclusion.Lost, expected: 'control' },
+            { conclusion: ExperimentConclusion.Inconclusive, expected: 'control' },
+            { conclusion: ExperimentConclusion.StoppedEarly, expected: 'control' },
+            { conclusion: ExperimentConclusion.Invalid, expected: 'control' },
+            { conclusion: undefined, expected: 'test' },
+            { conclusion: null, expected: 'test' },
+        ])('maps conclusion=$conclusion to "$expected" with a control + test pair', ({ conclusion, expected }) => {
+            expect(getDefaultVariantToKeep(variants, conclusion)).toBe(expected)
+        })
+
+        it('picks the first non-control variant for "Won" in multi-variant experiments', () => {
+            expect(getDefaultVariantToKeep(multiVariantTest, ExperimentConclusion.Won)).toBe('test-a')
+        })
+
+        it('picks control for any non-positive conclusion regardless of variant count', () => {
+            for (const conclusion of [
+                ExperimentConclusion.Lost,
+                ExperimentConclusion.Inconclusive,
+                ExperimentConclusion.StoppedEarly,
+                ExperimentConclusion.Invalid,
+            ]) {
+                expect(getDefaultVariantToKeep(multiVariantTest, conclusion)).toBe('control')
+            }
+        })
+
+        it('falls back to the first variant when no key is named "control"', () => {
+            const unconventional = [
+                { key: 'baseline', rollout_percentage: 50 },
+                { key: 'experimental', rollout_percentage: 50 },
+            ]
+            expect(getDefaultVariantToKeep(unconventional, ExperimentConclusion.Lost)).toBe('baseline')
+            expect(getDefaultVariantToKeep(unconventional, ExperimentConclusion.Won)).toBe('experimental')
+        })
+
+        it('returns the only variant when there is just one (degenerate case)', () => {
+            const single = [{ key: 'control', rollout_percentage: 100 }]
+            expect(getDefaultVariantToKeep(single, ExperimentConclusion.Won)).toBe('control')
+            expect(getDefaultVariantToKeep(single, ExperimentConclusion.Lost)).toBe('control')
+        })
+
+        it('returns null for empty or missing variants', () => {
+            expect(getDefaultVariantToKeep([], ExperimentConclusion.Won)).toBeNull()
+            expect(getDefaultVariantToKeep(undefined, ExperimentConclusion.Won)).toBeNull()
         })
     })
 

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -96,15 +96,13 @@ describe('utils', () => {
             expect(getDefaultVariantToKeep(multiVariantTest, ExperimentConclusion.Won)).toBe('test-a')
         })
 
-        it('picks control for any non-positive conclusion regardless of variant count', () => {
-            for (const conclusion of [
-                ExperimentConclusion.Lost,
-                ExperimentConclusion.Inconclusive,
-                ExperimentConclusion.StoppedEarly,
-                ExperimentConclusion.Invalid,
-            ]) {
-                expect(getDefaultVariantToKeep(multiVariantTest, conclusion)).toBe('control')
-            }
+        it.each([
+            { conclusion: ExperimentConclusion.Lost },
+            { conclusion: ExperimentConclusion.Inconclusive },
+            { conclusion: ExperimentConclusion.StoppedEarly },
+            { conclusion: ExperimentConclusion.Invalid },
+        ])('picks control for $conclusion regardless of variant count', ({ conclusion }) => {
+            expect(getDefaultVariantToKeep(multiVariantTest, conclusion)).toBe('control')
         })
 
         it('falls back to the first variant when no key is named "control"', () => {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -31,6 +31,7 @@ import { isFunnelsQuery, isNodeWithSource, isTrendsQuery, isValidQueryForExperim
 import {
     ChartDisplayType,
     Experiment,
+    ExperimentConclusion,
     ExperimentMetricGoal,
     ExperimentMetricMathType,
     FeatureFlagType,
@@ -76,6 +77,38 @@ export function getExposureConfigDisplayName(config: ExperimentExposureConfig): 
 export function getVariantColor(variantKey: string, featureFlagVariants: MultivariateFlagVariant[]): string {
     const variantIndex = featureFlagVariants.findIndex((v) => v.key === variantKey)
     return variantIndex !== -1 ? getSeriesColor(variantIndex) : 'var(--text-muted)'
+}
+
+/**
+ * Picks a sensible default for the "Variant to keep" selector when ending an
+ * experiment, based on the chosen conclusion. Only `Won` implies positive
+ * evidence to ship a change; everything else defaults to control so we don't
+ * encourage rolling out an unproven variant.
+ */
+export function getDefaultVariantToKeep(
+    variants: MultivariateFlagVariant[] | undefined,
+    conclusion: ExperimentConclusion | null | undefined
+): string | null {
+    if (!variants?.length) {
+        return null
+    }
+    const controlVariant = variants.find((v) => v.key === 'control') ?? variants[0]
+    const firstTestVariant = variants.find((v) => v.key !== controlVariant.key)
+    const fallbackTestKey = firstTestVariant?.key ?? controlVariant.key
+
+    switch (conclusion) {
+        case ExperimentConclusion.Lost:
+        case ExperimentConclusion.Inconclusive:
+        case ExperimentConclusion.StoppedEarly:
+        case ExperimentConclusion.Invalid:
+            return controlVariant.key
+        case ExperimentConclusion.Won:
+            return fallbackTestKey
+        default:
+            // No conclusion picked yet: keep the historical default of suggesting
+            // a test variant, since most users open this modal to ship a winner.
+            return fallbackTestKey
+    }
 }
 
 export function formatUnitByQuantity(value: number, unit: string): string {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -103,7 +103,6 @@ export function getDefaultVariantToKeep(
         case ExperimentConclusion.Invalid:
             return controlVariant.key
         case ExperimentConclusion.Won:
-            return fallbackTestKey
         default:
             // No conclusion picked yet: keep the historical default of suggesting
             // a test variant, since most users open this modal to ship a winner.


### PR DESCRIPTION
## Problem

When ending an experiment, the "Variant to keep" selector should intelligently default based on the experiment's conclusion. Currently, it always defaults to the second variant (first test variant), regardless of whether the experiment was won or lost. This can mislead users into rolling out unproven variants when an experiment didn't succeed.

## Changes

Added `getDefaultVariantToKeep()` utility function that selects a sensible default variant based on the experiment conclusion:
- **Won**: Suggests the first non-control test variant (the winner to ship)
- **Lost/Inconclusive/Stopped Early/Invalid**: Defaults to control (safest option)
- **No conclusion yet**: Defaults to first test variant (historical behavior for users actively shipping)

Updated `FinishExperimentModal` to use this function instead of always defaulting to the second variant, and added `experiment.conclusion` to the dependency array to re-evaluate when the conclusion changes.

## How did you test this code?

Added comprehensive unit tests covering:
- All conclusion types mapping to correct variants
- Multi-variant experiments (3+ variants)
- Edge cases (unconventional variant names, single variant, empty/undefined variants)
- Null/undefined conclusion handling

All tests pass and validate the logic for both standard (control + test) and multi-variant scenarios.

## Publish to changelog?

Yes - this improves the UX for experiment conclusion workflows by preventing accidental rollout of losing variants.

https://claude.ai/code/session_01UsyYYsdfAFhM3TorWpSCVq