### PR TITLE
chore(ci): bump docker/depot/aws/slack/octokit actions to node24

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -51,24 +51,24 @@ runs:
           uses: actions/checkout@v6
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+          uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
         - name: Set up QEMU
-          uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+          uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
         - name: Set up Depot CLI
-          uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
+          uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
         - name: Configure AWS credentials
           if: ${{ inputs.push-image == 'true' }}
-          uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+          uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
           with:
               role-to-assume: ${{ inputs.aws-role-to-assume }}
               aws-region: us-east-1
 
         - name: Login to DockerHub
           if: ${{ inputs.push-image == 'true' }}
-          uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+          uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
           with:
               username: ${{ inputs.dockerhub-username }}
               password: ${{ inputs.dockerhub-password }}
@@ -76,7 +76,7 @@ runs:
         - name: Login to Amazon ECR
           if: ${{ inputs.push-image == 'true' }}
           id: aws-ecr
-          uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+          uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
         - name: Emit image tag
           id: emit
@@ -97,7 +97,7 @@ runs:
 
         - name: Build image
           id: build
-          uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
+          uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
           with:
               context: .
               buildx-fallback: false # buildx is so slow it's better to just fail

--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -49,17 +49,17 @@ runs:
     using: 'composite'
     steps:
         - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+          uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
           with:
               role-to-assume: ${{ inputs.aws-role-to-assume }}
               aws-region: us-east-1
 
         - name: Login to Amazon ECR
           id: aws-ecr
-          uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+          uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
         - name: Login to ghcr.io
-          uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+          uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
           with:
               registry: ghcr.io
               username: ${{ github.actor }}
@@ -67,7 +67,7 @@ runs:
               logout: false
 
         - name: Login to DockerHub
-          uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+          uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
           with:
               username: ${{ inputs.dockerhub-username }}
               password: ${{ inputs.dockerhub-password }}
@@ -101,7 +101,7 @@ runs:
 
         - name: Docker meta
           id: meta
-          uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+          uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
           with:
               images: ${{ steps.images.outputs.list }}
               tags: |

--- a/.github/actions/get-pr-labels/action.yml
+++ b/.github/actions/get-pr-labels/action.yml
@@ -14,7 +14,7 @@ runs:
     steps:
         - name: Get PR associated with the last commit
           id: pr-info
-          uses: octokit/request-action@05a2312de9f8207044c4c9e41fe19703986acc13 # v2.x
+          uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
           with:
               route: GET /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls
           env:

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -154,7 +154,7 @@ jobs:
             - name: Post commit-failure-streak alert to Slack
               if: steps.check.outputs.commit_failure_streak_action == 'create'
               id: slack_commit_streak
-              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
               with:
                   method: chat.postMessage
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
 
             - name: Update commit-failure-streak Slack message
               if: steps.check.outputs.commit_failure_streak_action == 'update'
-              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
               with:
                   method: chat.update
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -212,7 +212,7 @@ jobs:
 
             - name: Update commit-failure-streak Slack to resolved
               if: steps.check.outputs.commit_failure_streak_action == 'resolve'
-              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
               with:
                   method: chat.update
                   token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/terragrunt-posthog.yaml
+++ b/.github/workflows/terragrunt-posthog.yaml
@@ -91,7 +91,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Configure AWS Credentials
-              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708
+              uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
               with:
                   aws-region: ${{ secrets.POSTHOG_PROVIDER_TF_STATE_REGION }}
                   role-to-assume: ${{ secrets.POSTHOG_PROVIDER_TF_AWS_ROLE_ARN }}


### PR DESCRIPTION
## Problem

Final cleanup pass for the node20 → node24 migration. After #54777 (slack/aws/buf/flox)
and #54780 (upload-artifact/download-artifact), a handful of pinned actions inside
two composite actions, three missed slack refs, the terragrunt workflow, and one
octokit composite were still on node20. GitHub is
[deprecating node20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/),
so we want every workflow on node24 ahead of that.

## Changes

Stacks on top of #54777 and #54780. Where possible, target SHAs are already
pinned elsewhere in the repo so this introduces no new third-party SHAs — just
consolidates onto versions we already trust.

**`.github/actions/build-n-cache-image/action.yml`**
- `docker/setup-buildx-action` v3.12.0 → v4.0.0
- `docker/setup-qemu-action` v3.7.0 → v4.0.0
- `depot/setup-action` v1.6.0 → v1.7.1
- `aws-actions/configure-aws-credentials` v5.1.1 → v6.1.0
- `docker/login-action` v3.6.0 → v4.1.0
- `aws-actions/amazon-ecr-login` v2.0.1 → v2.1.2
- `depot/build-push-action` v1.16.2 → v1.17.0

**`.github/actions/docker-meta/action.yml`**
- `aws-actions/configure-aws-credentials` v5.1.1 → v6.1.0
- `aws-actions/amazon-ecr-login` v2.0.1 → v2.1.2
- `docker/login-action` v3.7.0 → v4.1.0 (×2)
- `docker/metadata-action` v5.10.0 → v6.0.0

**`.github/workflows/ci-alerts-devex.yml`**
- `slackapi/slack-github-action` v2.1.1 → v3.0.1 (×3, "commit failure streak"
  section — missed by #54777). Per the
  [v3.0.0 release notes](https://github.com/slackapi/slack-github-action/releases/tag/v3.0.0),
  the only breaking change is the node24 runtime; the
  `method: chat.{postMessage,update}` input contract is unchanged. Same shape
  #54777 already shipped successfully for the other 5 refs in this file.

**`.github/workflows/terragrunt-posthog.yaml`**
- `aws-actions/configure-aws-credentials` (unpinned SHA = v5.1.1) → v6.1.0,
  with a proper `# v6.1.0` comment for visibility. Inputs `aws-region`,
  `role-to-assume`, `role-duration-seconds` are unchanged across v5 → v6
  ([v6.0.0 release notes](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0)
  call out only the node24 runtime as breaking).

**`.github/actions/get-pr-labels/action.yml`**
- `octokit/request-action` v2.x → v3.0.0
  ([v3.0.0 release notes](https://github.com/octokit/request-action/releases/tag/v3.0.0)
  list only the node24 runtime as breaking; `route:` input + `GITHUB_TOKEN`
  env are unchanged).

**Verified safe (no input contract changes for our usage):**
- `docker/setup-buildx-action` v4.0.0 removed deprecated `config`,
  `config-inline`, `install` inputs — every call site in the repo invokes
  this action bare with no `with:` block, so we're unaffected.
- All other v3 → v4 / v5 → v6 / v1.x → v1.y bumps either preserve inputs or
  the relevant inputs aren't used here.

After this lands, the only remaining node20 references are upstream-blocked —
`iFaxity/wait-on-action`, `tlambert03/setup-qt-libs`,
`inkeep/inkeep-agents-action`, `fountainhead/action-wait-for-check`,
`c2corg/browserslist-update-action`. None have a node24 release yet.

## How did you test this code?

I'm an agent. No manual testing — verified statically:
- All target SHAs (except `octokit/request-action` v3.0.0, freshly pinned)
  already exist on `master` in other workflows, so they're known-good
- Reread #54777's diff to confirm the slack v2→v3 input shape matches; #54777
  has been merged and running on the same input pattern with no regressions
- Read v3.0.0/v4.0.0/v6.0.0 release notes for slack-github-action,
  setup-buildx-action, configure-aws-credentials, and request-action —
  each calls out only the node24 runtime as breaking
- Confirmed every `docker/setup-buildx-action` call in the repo passes no
  inputs, so the deprecated input removals in v4.0.0 don't affect us

CI on this PR will exercise the composite actions via the existing
image-build, terragrunt, and label-fetch workflows.

## Publish to changelog?

no

## 🤖 Agent context

Co-authored with Claude Code (Opus 4.7). Agent did the inventory of remaining
node20 refs across all workflows and composite actions, looked up existing
pinned SHAs to reuse, fetched release notes to verify each major bump was
input-compatible, and authored the diffs.

Decisions confirmed by me before each push:
- Reuse SHAs already pinned elsewhere rather than introducing latest patch
  SHAs (consistency with the rest of the repo)
- Bump only where a node24 upstream release exists; defer the 5
  upstream-blocked actions
- For each major-version bump, read upstream release notes and cross-checked
  against our usage before committing