### PR TITLE
fix(cloud-agent): retry terminated sandbox streams

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -359,6 +359,17 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.1
   '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.2
+  '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
@@ -377,7 +388,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -392,7 +411,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -402,8 +421,15 @@
                             and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
             quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
                             0) AS previous_avg_time_on_page
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
      GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
   LEFT JOIN
     (SELECT breakdown_value AS breakdown_value,
@@ -414,7 +440,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -424,7 +456,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -314,7 +314,7 @@ async def _relay_loop(
                 )
                 await asyncio.sleep(min(reconnect_count * 2, 10))
 
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as e:
+            except (httpx.TransportError, httpx_sse.SSEError) as e:
                 reconnect_count += 1
                 logger.warning(
                     "relay_sandbox_events_connection_error",

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import AsyncMock
 
 import httpx
+import httpx_sse
 from parameterized import parameterized
 
 from products.tasks.backend.temporal.process_task import workflow as process_task_workflow_module
@@ -230,7 +231,19 @@ class TestRelaySandboxEventsCancellation:
 
 
 class TestRelaySandboxEventsErrorHandling:
-    async def test_relay_loop_retries_transport_terminated_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @parameterized.expand(
+        [
+            ("read_error", httpx.ReadError),
+            ("connect_error", httpx.ConnectError),
+            ("remote_protocol_error", httpx.RemoteProtocolError),
+            ("sse_error", httpx_sse.SSEError),
+        ],
+    )
+    async def test_relay_loop_retries_retryable_stream_errors(
+        self,
+        _name: str,
+        exception_class: type[Exception],
+    ) -> None:
         redis_stream = SimpleNamespace(
             write_event=AsyncMock(),
             mark_complete=AsyncMock(),
@@ -244,7 +257,7 @@ class TestRelaySandboxEventsErrorHandling:
 
         class FailingEventSource:
             async def __aenter__(self) -> "FailingEventSource":
-                raise httpx.ReadError("terminated")
+                raise exception_class("terminated")
 
             async def __aexit__(self, *_args: object) -> None:
                 return None
@@ -271,18 +284,19 @@ class TestRelaySandboxEventsErrorHandling:
         async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
             return None
 
-        monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
-        monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
-        monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
+            monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
+            monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
 
-        await _relay_loop(
-            events_url="https://sandbox.example/events",
-            headers={"Authorization": "Bearer token"},
-            params={},
-            redis_stream=cast(TaskRunRedisStream, redis_stream),
-            run_id="run-id",
-            task_id="task-id",
-        )
+            await _relay_loop(
+                events_url="https://sandbox.example/events",
+                headers={"Authorization": "Bearer token"},
+                params={},
+                redis_stream=cast(TaskRunRedisStream, redis_stream),
+                run_id="run-id",
+                task_id="task-id",
+            )
 
         assert connect_attempts == 2
         sleep_mock.assert_awaited_once_with(2)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -6,6 +6,7 @@ from typing import cast
 import pytest
 from unittest.mock import AsyncMock
 
+import httpx
 from parameterized import parameterized
 
 from products.tasks.backend.temporal.process_task import workflow as process_task_workflow_module
@@ -16,6 +17,7 @@ from products.tasks.backend.temporal.process_task.activities.relay_sandbox_event
     _is_end_of_turn,
     _is_session_update,
     _mark_error_unless_run_is_terminal,
+    _relay_loop,
     relay_sandbox_events,
 )
 from products.tasks.backend.temporal.process_task.activities.start_agent_server import StartAgentServerOutput
@@ -228,6 +230,66 @@ class TestRelaySandboxEventsCancellation:
 
 
 class TestRelaySandboxEventsErrorHandling:
+    async def test_relay_loop_retries_transport_terminated_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis_stream = SimpleNamespace(
+            write_event=AsyncMock(),
+            mark_complete=AsyncMock(),
+            mark_error=AsyncMock(),
+        )
+        sleep_mock = AsyncMock()
+        connect_attempts = 0
+        terminal_event = SimpleNamespace(
+            data='{"type":"notification","notification":{"method":"_posthog/task_complete"}}'
+        )
+
+        class FailingEventSource:
+            async def __aenter__(self) -> "FailingEventSource":
+                raise httpx.ReadError("terminated")
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+        class SuccessfulEventSource:
+            response = SimpleNamespace(raise_for_status=lambda: None)
+
+            async def __aenter__(self) -> "SuccessfulEventSource":
+                return self
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+            async def aiter_sse(self):
+                yield terminal_event
+
+        def fake_connect_sse(*_args: object, **_kwargs: object):
+            nonlocal connect_attempts
+            connect_attempts += 1
+            if connect_attempts == 1:
+                return FailingEventSource()
+            return SuccessfulEventSource()
+
+        async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
+        monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
+        monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
+
+        await _relay_loop(
+            events_url="https://sandbox.example/events",
+            headers={"Authorization": "Bearer token"},
+            params={},
+            redis_stream=cast(TaskRunRedisStream, redis_stream),
+            run_id="run-id",
+            task_id="task-id",
+        )
+
+        assert connect_attempts == 2
+        sleep_mock.assert_awaited_once_with(2)
+        redis_stream.write_event.assert_awaited_once()
+        redis_stream.mark_complete.assert_awaited_once()
+        redis_stream.mark_error.assert_not_awaited()
+
     async def test_terminal_run_marks_stream_complete_on_late_relay_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problem

cloud task relays could treat sandbox stream transport termination as a terminal relay failure. In practice, `httpx.ReadError("terminated")` can happen during stream reconnects and should follow the existing reconnect path instead of leaving the run disconnected while the workflow continues