### PR TITLE
feat: add metabase:login, :cookie, :databases, :query commands

### DIFF
--- a/.agents/skills/query-clickhouse-via-metabase/SKILL.md
+++ b/.agents/skills/query-clickhouse-via-metabase/SKILL.md
@@ -21,24 +21,28 @@ those and uses the same Metabase API surface.
 
 ## Environment
 
-| Region | Metabase URL                           | ClickHouse DB ID for `query_log`       |
-| ------ | -------------------------------------- | -------------------------------------- |
-| US     | `https://metabase.prod-us.posthog.dev` | `42`                                   |
-| EU     | `https://metabase.prod-eu.posthog.dev` | `35` (query tier) — or `2` (data tier) |
+| Region | Metabase URL                           |
+| ------ | -------------------------------------- |
+| US     | `https://metabase.prod-us.posthog.dev` |
+| EU     | `https://metabase.prod-eu.posthog.dev` |
 
-For `query_log` analysis, **use `35` on EU**. The `2` data-tier DB exists for
-direct table reads (events, persons, etc.) and is only needed when you're
-querying production data, not the logs.
+**Database IDs are not stable** — they change when Metabase's metadata DB is
+rebuilt or connections are re-added. Never hardcode an ID. Always discover
+the current list:
 
-EU's Metabase also exposes additional databases that may be useful for
-broader investigations (not `query_log`):
+```bash
+hogli metabase:databases --region us
+hogli metabase:databases --region eu
+```
 
-- DB `100` — ClickHouse ingestion layer
-- DB `70` — ClickHouse migrations EKS
-- DB `34` — PostgreSQL (the PostHog app DB)
+Regional layout (names may vary; re-check with `metabase:databases`):
 
-US Metabase only exposes one ClickHouse DB (`42`); other backends are
-queried via separate datasources you'll discover from `/api/database`.
+- **US** exposes one ClickHouse database (used for `query_log` and data reads).
+- **EU** exposes two ClickHouse databases — a **query tier** (use for
+  `query_log` analysis) and a **data tier** (production reads: events,
+  persons, etc.). Pick the one whose name indicates the query tier.
+- Both Metabases also expose Postgres databases (the app DB) and, on EU,
+  the ingestion-layer and migrations databases.
 
 ## Authentication
 
@@ -52,45 +56,31 @@ at `~/.config/posthog/metabase/cookie-{region}` (mode `0600`).
 # is cheap.
 hogli metabase:login --region us
 hogli metabase:login --region eu
-
-# In scripts: read the cached cookie header for the region you're querying.
-COOKIE_HEADER="$(hogli metabase:cookie --region us)"
 ```
 
-If the cookie has expired, `hogli metabase:cookie --check` exits non-zero
-with a "no longer valid — run `hogli metabase:login`" message. **Prompt the
-user to run `hogli metabase:login` themselves** — the harness blocks Keychain
-access from agent shells, so the user has to authenticate interactively.
+**Prompt the user to run `hogli metabase:login` themselves** — the harness
+blocks Keychain access from agent shells, so the user has to authenticate
+interactively.
+
+### Agents: use `metabase:query`
+
+`hogli metabase:query` reads the cached cookie internally and only emits
+results — the session value never appears in the agent's transcript.
+`metabase:cookie` exists for humans who want to hand-roll `curl` against
+Metabase.
 
 ## Running an ad-hoc query
 
-Pick the region's DB ID and base URL, build the JSON payload, POST to
-`/api/dataset`. The cookie header is the only auth.
-
-**Important:** the cookie cache is per-region. When switching regions,
-update **all four** of `REGION`, `DB_ID`, `BASE`, and re-fetch
-`COOKIE_HEADER`. Mixing a US cookie with an EU URL fails at the ALB.
+1. Discover the current ClickHouse DB ID: `hogli metabase:databases --region <region>`.
+2. Pass that ID into `hogli metabase:query`. Pipe SQL via stdin or `--file`.
 
 ```bash
-# US
-REGION=us; DB_ID=42; BASE="https://metabase.prod-us.posthog.dev"
-# EU (query_log lives in DB 35)
-# REGION=eu; DB_ID=35; BASE="https://metabase.prod-eu.posthog.dev"
+# 1. Find the ClickHouse database ID for your region
+hogli metabase:databases --region us
+# e.g. output row:  42  ClickHouse  clickhouse
 
-COOKIE_HEADER="$(hogli metabase:cookie --region $REGION)"
-
-python3 -c "
-import json, sys
-print(json.dumps({
-    'database': int(sys.argv[1]),
-    'type': 'native',
-    'native': {'query': sys.stdin.read(), 'template-tags': {}}
-}))
-" "$DB_ID" <<'SQL' | curl -sS -X POST \
-    -H "Cookie: $COOKIE_HEADER" \
-    -H "Content-Type: application/json" \
-    -d @- \
-    "$BASE/api/dataset"
+# 2. Run the query. The cookie is read internally; nothing leaks to stdout.
+hogli metabase:query --region us --database-id 42 --save /tmp/out.tsv <<'SQL'
 SELECT
     JSONExtractInt(log_comment, 'team_id') AS team_id,
     count() AS query_count,
@@ -107,6 +97,14 @@ SQL
 
 `clusterAllReplicas(posthog, system, query_log)` is the standard table reference —
 it fans out across the cluster.
+
+For large result sets, use `--save <path>` so rows land in a file rather
+than streaming through the terminal/transcript. Default output is TSV;
+`--format json` gives you the raw `/api/dataset` response body.
+
+If the DB ID is wrong, `metabase:query` exits non-zero with a pointer back
+to `metabase:databases`. Fail-fast is intentional — silently querying the
+wrong database is worse than failing.
 
 ## What counts as a slow query
 

--- a/.agents/skills/query-clickhouse-via-metabase/SKILL.md
+++ b/.agents/skills/query-clickhouse-via-metabase/SKILL.md
@@ -224,11 +224,9 @@ for row in d['data']['rows']:
 
 1. **Frame the question.** Slow per-team? Specific query pattern? Cost/memory regression?
 2. **Pick the smallest time window** that still answers the question — `query_log` is large; default to 1h–24h, expand only when needed.
-3. **Apply standard noise filters** (above) so offline/temporal traffic doesn't pollute results.
-4. **Filter to `type = 'QueryFinish'`** for "what actually ran" — there are also `QueryStart` and `ExceptionBeforeStart` rows.
-5. **Group then drill in.** First a per-team or per-pattern aggregate, then `WHERE` by the worst offender to see individual queries.
-6. **Cross-region check.** If a regression looks region-specific, run the same query against the other region's DB ID.
-7. **Capture `query_id` examples** in any writeup so reviewers can pull the full row from `query_log` themselves.
+3. **Filter to `type = 'QueryFinish'`** for "what actually ran" — there are also `QueryStart` and `ExceptionBeforeStart` rows.
+4. **Group then drill in.** First a per-team or per-pattern aggregate, then `WHERE` by the worst offender to see individual queries.
+5. **Capture `query_id` examples** in any writeup so reviewers can pull the full row from `query_log` themselves.
 
 ## Known limitations
 

--- a/.agents/skills/query-clickhouse-via-metabase/SKILL.md
+++ b/.agents/skills/query-clickhouse-via-metabase/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: query-clickhouse-via-metabase
+description: >
+  Run ClickHouse `system.query_log` analysis via the internal Metabase API.
+  Use when investigating slow queries, materialization candidates, per-team
+  query performance, ClickHouse cost or memory issues, or any system.query_log
+  question. Covers prod-us and prod-eu, SSO-gated cookie auth via `hogli`,
+  and ready-to-run query patterns.
+---
+
+# Querying ClickHouse via Metabase
+
+PostHog's production ClickHouse clusters are reachable for ad-hoc analysis through
+internal Metabase instances. Both Metabases sit behind an AWS ALB with Cognito
+OAuth, so authentication is **SSO-gated** — Metabase API keys alone won't work.
+
+This skill is for `system.query_log` analysis from inside the posthog repo.
+For pre-built canned queries (slow query summaries, materialization analysis),
+see the `query-performance-analysis` repo, which is the source of truth for
+those and uses the same Metabase API surface.
+
+## Environment
+
+| Region | Metabase URL                           | ClickHouse DB ID for `query_log`       |
+| ------ | -------------------------------------- | -------------------------------------- |
+| US     | `https://metabase.prod-us.posthog.dev` | `42`                                   |
+| EU     | `https://metabase.prod-eu.posthog.dev` | `35` (query tier) — or `2` (data tier) |
+
+For `query_log` analysis, **use `35` on EU**. The `2` data-tier DB exists for
+direct table reads (events, persons, etc.) and is only needed when you're
+querying production data, not the logs.
+
+EU's Metabase also exposes additional databases that may be useful for
+broader investigations (not `query_log`):
+
+- DB `100` — ClickHouse ingestion layer
+- DB `70` — ClickHouse migrations EKS
+- DB `34` — PostgreSQL (the PostHog app DB)
+
+US Metabase only exposes one ClickHouse DB (`42`); other backends are
+queried via separate datasources you'll discover from `/api/database`.
+
+## Authentication
+
+Use `hogli` to get a valid cookie. It opens the system browser for SSO,
+captures cookies from the user's logged-in browser profile, and caches them
+at `~/.config/posthog/metabase/cookie-{region}` (mode `0600`).
+
+```bash
+# Log in once per region. --region is required (no default — you pick which one).
+# Already-valid sessions are fast-pathed (no browser tab opens), so re-running
+# is cheap.
+hogli metabase:login --region us
+hogli metabase:login --region eu
+
+# In scripts: read the cached cookie header for the region you're querying.
+COOKIE_HEADER="$(hogli metabase:cookie --region us)"
+```
+
+If the cookie has expired, `hogli metabase:cookie --check` exits non-zero
+with a "no longer valid — run `hogli metabase:login`" message. **Prompt the
+user to run `hogli metabase:login` themselves** — the harness blocks Keychain
+access from agent shells, so the user has to authenticate interactively.
+
+## Running an ad-hoc query
+
+Pick the region's DB ID and base URL, build the JSON payload, POST to
+`/api/dataset`. The cookie header is the only auth.
+
+**Important:** the cookie cache is per-region. When switching regions,
+update **all four** of `REGION`, `DB_ID`, `BASE`, and re-fetch
+`COOKIE_HEADER`. Mixing a US cookie with an EU URL fails at the ALB.
+
+```bash
+# US
+REGION=us; DB_ID=42; BASE="https://metabase.prod-us.posthog.dev"
+# EU (query_log lives in DB 35)
+# REGION=eu; DB_ID=35; BASE="https://metabase.prod-eu.posthog.dev"
+
+COOKIE_HEADER="$(hogli metabase:cookie --region $REGION)"
+
+python3 -c "
+import json, sys
+print(json.dumps({
+    'database': int(sys.argv[1]),
+    'type': 'native',
+    'native': {'query': sys.stdin.read(), 'template-tags': {}}
+}))
+" "$DB_ID" <<'SQL' | curl -sS -X POST \
+    -H "Cookie: $COOKIE_HEADER" \
+    -H "Content-Type: application/json" \
+    -d @- \
+    "$BASE/api/dataset"
+SELECT
+    JSONExtractInt(log_comment, 'team_id') AS team_id,
+    count() AS query_count,
+    formatReadableSize(sum(read_bytes)) AS total_bytes
+FROM clusterAllReplicas(posthog, system, query_log)
+WHERE event_time > now() - INTERVAL 1 DAY
+    AND is_initial_query
+    AND query_duration_ms > 30000
+GROUP BY team_id
+ORDER BY query_count DESC
+LIMIT 20
+SQL
+```
+
+`clusterAllReplicas(posthog, system, query_log)` is the standard table reference —
+it fans out across the cluster.
+
+## What counts as a slow query
+
+```sql
+query_duration_ms > 30000
+OR exception_code IN (159, 160, 241)
+```
+
+| Code | Meaning               |
+| ---- | --------------------- |
+| 159  | TIMEOUT_EXCEEDED      |
+| 160  | TOO_SLOW              |
+| 241  | MEMORY_LIMIT_EXCEEDED |
+
+## Useful query patterns
+
+### Top slow queries in the last 24h
+
+```sql
+SELECT
+    query_id,
+    JSONExtractInt(log_comment, 'team_id') AS team_id,
+    query_duration_ms,
+    formatReadableSize(memory_usage) AS memory,
+    formatReadableSize(read_bytes) AS read_bytes,
+    exception_code,
+    substring(query, 1, 200) AS query_preview
+FROM clusterAllReplicas(posthog, system, query_log)
+WHERE event_time > now() - INTERVAL 1 DAY
+    AND type = 'QueryFinish'
+    AND (query_duration_ms > 30000 OR exception_code IN (159, 160, 241))
+    AND JSONExtractString(log_comment, 'workload') NOT IN ('Workload.OFFLINE', 'OFFLINE')
+    AND JSONExtractString(log_comment, 'kind') NOT IN ('temporal')
+    AND JSONExtractString(log_comment, 'access_method') NOT IN ('personal_api_key')
+    AND is_initial_query
+    AND JSONExtractInt(log_comment, 'team_id') != 0
+ORDER BY query_duration_ms DESC
+LIMIT 100
+```
+
+### Per-team query cost summary (7d)
+
+```sql
+SELECT
+    JSONExtractInt(log_comment, 'team_id') AS team_id,
+    count() AS queries,
+    countIf(query_duration_ms > 30000) AS slow_queries,
+    formatReadableSize(sum(read_bytes)) AS total_read,
+    formatReadableSize(max(memory_usage)) AS peak_memory,
+    quantile(0.95)(query_duration_ms) AS p95_duration_ms
+FROM clusterAllReplicas(posthog, system, query_log)
+WHERE event_time > now() - INTERVAL 7 DAY
+    AND type = 'QueryFinish'
+    AND JSONExtractString(log_comment, 'workload') NOT IN ('Workload.OFFLINE', 'OFFLINE')
+    AND JSONExtractString(log_comment, 'kind') NOT IN ('temporal')
+    AND JSONExtractString(log_comment, 'access_method') NOT IN ('personal_api_key')
+    AND is_initial_query
+    AND JSONExtractInt(log_comment, 'team_id') != 0
+GROUP BY team_id
+ORDER BY total_read DESC
+LIMIT 20
+```
+
+### Look up a specific query by `query_id`
+
+Saved card available in both regions — match the URL to where the query ran:
+
+```text
+# US
+https://metabase.prod-us.posthog.dev/question/795-look-up-query-by-query-id?query_id=<ID>&include_query_start=No&event_date=<YYYY-MM-DD>
+
+# EU (same card ID may differ — find it in EU Metabase if 795 doesn't resolve)
+https://metabase.prod-eu.posthog.dev/question/795-look-up-query-by-query-id?query_id=<ID>&include_query_start=No&event_date=<YYYY-MM-DD>
+```
+
+The same can be reproduced programmatically with a `WHERE query_id = '...'`
+clause via `/api/dataset` against the right region's DB ID.
+
+## Parsing Metabase responses
+
+```json
+{
+  "data": {
+    "cols": [{"name": "team_id", "base_type": "type/Integer"}, ...],
+    "rows": [[55348, 142, "1.23 TiB"], ...]
+  },
+  "status": "completed",
+  "row_count": 20
+}
+```
+
+Quick TSV pipe:
+
+```bash
+... | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+cols = [c['name'] for c in d['data']['cols']]
+print('\t'.join(cols))
+for row in d['data']['rows']:
+    print('\t'.join(str(v) for v in row))
+"
+```
+
+### Error responses
+
+| Symptom                        | Cause                                  | Fix                                                              |
+| ------------------------------ | -------------------------------------- | ---------------------------------------------------------------- |
+| HTTP 302 to `/auth/...`        | Cookie expired or missing              | Tell user to run `hogli metabase:login --region <region>`        |
+| HTTP 401                       | Cookie rejected by ALB                 | Same as 302                                                      |
+| `"status": "failed"` + `error` | ClickHouse error (syntax, table, etc.) | Read `error`; fix SQL                                            |
+| Hangs / timeout                | Wide `query_log` scan                  | Narrow `event_time` range, add `team_id` filter, use `cluster()` |
+
+## Investigation workflow
+
+1. **Frame the question.** Slow per-team? Specific query pattern? Cost/memory regression?
+2. **Pick the smallest time window** that still answers the question — `query_log` is large; default to 1h–24h, expand only when needed.
+3. **Apply standard noise filters** (above) so offline/temporal traffic doesn't pollute results.
+4. **Filter to `type = 'QueryFinish'`** for "what actually ran" — there are also `QueryStart` and `ExceptionBeforeStart` rows.
+5. **Group then drill in.** First a per-team or per-pattern aggregate, then `WHERE` by the worst offender to see individual queries.
+6. **Cross-region check.** If a regression looks region-specific, run the same query against the other region's DB ID.
+7. **Capture `query_id` examples** in any writeup so reviewers can pull the full row from `query_log` themselves.
+
+## Known limitations
+
+- **Metabase response timeout.** Default is ~60s for native queries; very wide scans will be cut off. Narrow time range or use sampled tables.
+- **`log_comment` JSON drift.** New fields appear over time; `JSONExtractString(log_comment, 'foo')` returns `''` if missing — always include an `IS NOT NULL` / `!= ''` guard if filtering on it.
+- **Cookie scope.** Each region has its own cookie cache. Run `hogli metabase:login --region <region>` for every region you need; `--region` is required.

--- a/common/hogli/commands.py
+++ b/common/hogli/commands.py
@@ -45,6 +45,7 @@ from hogli import (
     build,  # noqa: F401
     devbox,  # noqa: F401
     doctor,  # noqa: F401
+    metabase,  # noqa: F401
     migrations,  # noqa: F401
     product,  # noqa: F401
     telemetry_commands,  # noqa: F401

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -586,6 +586,8 @@ quality:
 auth:
     metabase:login: null # Click-defined, placed here for categorization
     metabase:cookie: null # Click-defined, placed here for categorization
+    metabase:databases: null # Click-defined, placed here for categorization
+    metabase:query: null # Click-defined, placed here for categorization
 tools:
     doctor: null # Click-defined, placed here for categorization
     tool:temporal-codec-server:

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -24,6 +24,8 @@ metadata:
           title: Docker-based service orchestration
         - key: deploy
           title: Deploy PostHog to remote instances
+        - key: auth
+          title: Authenticate to internal services
         - key: tools
           title: Developer tools and utilities
         - key: utilities
@@ -581,6 +583,9 @@ quality:
     format:mcp:
         cmd: pnpm run --filter @posthog/mcp format
         description: Format MCP files
+auth:
+    metabase:login: null # Click-defined, placed here for categorization
+    metabase:cookie: null # Click-defined, placed here for categorization
 tools:
     doctor: null # Click-defined, placed here for categorization
     tool:temporal-codec-server:

--- a/common/hogli/metabase.py
+++ b/common/hogli/metabase.py
@@ -19,6 +19,7 @@ prefer it over `cookie` when automation is running the query.
 
 from __future__ import annotations
 
+import os
 import sys
 import json
 import time
@@ -131,11 +132,25 @@ def _load_cookies_from_browser(domain: str, browser: str | None) -> dict[str, st
     return found
 
 
+def _secure_write(path: Path, content: str) -> None:
+    """Write `content` to `path` atomically at mode 0600.
+
+    `Path.write_text` goes through open(2) with the process umask, so the file
+    is briefly world-readable before we could chmod it. `os.open` with an
+    explicit mode dodges the TOCTOU window — callers storing session cookies
+    or query results must use this instead of `write_text`.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, content.encode())
+    finally:
+        os.close(fd)
+
+
 def _write_cookie_file(region: str, cookie_header: str) -> Path:
     path = _cookie_path(region)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(cookie_header)
-    path.chmod(0o600)
+    _secure_write(path, cookie_header)
     return path
 
 
@@ -194,9 +209,7 @@ def _wait_for_valid_cookie(
                 last_header = cookie_header
                 if _check_cookie(domain, cookie_header):
                     return cookie_header
-                status = "Cookies present but session not yet valid; still waiting..."
-            else:
-                status = "Cookies present but session not yet valid; still waiting..."
+            status = "Cookies present but session not yet valid; still waiting..."
         else:
             status = f"Waiting for cookies: missing {missing}..."
 
@@ -276,8 +289,8 @@ def metabase_login(region: str, browser: str | None, no_open: bool, timeout: flo
 @click.option(
     "--region",
     type=click.Choice(sorted(REGIONS.keys())),
-    default="us",
-    show_default=True,
+    required=True,
+    help="Region whose cached cookie to print (us or eu)",
 )
 @click.option("--check/--no-check", default=False, help="Validate the cookie before printing")
 def metabase_cookie(region: str, check: bool) -> None:
@@ -496,7 +509,7 @@ def metabase_query(
         rendered = _render_rows_tsv(body)
 
     if save:
-        Path(save).write_text(rendered)
+        _secure_write(Path(save), rendered)
         row_count = body.get("row_count", "?")
         click.echo(f"Wrote {row_count} rows to {save}")
     else:

--- a/common/hogli/metabase.py
+++ b/common/hogli/metabase.py
@@ -1,4 +1,4 @@
-"""Authenticate to internal Metabase via SSO and cache the session cookie.
+"""Authenticate to internal Metabase via SSO and run queries against it.
 
 Production Metabase sits behind ALB Cognito OAuth, so callers need both the
 ALB session cookies (`ph_int_auth-0`, `ph_int_auth-1`) and the Metabase
@@ -6,20 +6,25 @@ application cookies (`metabase.SESSION`, `metabase.DEVICE`). API keys alone
 won't pass the ALB.
 
 Workflow:
-    hogli metabase:login [--region us|eu]   # opens system browser, captures cookies
-    hogli metabase:cookie [--region us|eu]  # prints cached cookie header
-
-Scripts can then use:
-    METABASE_COOKIE="$(hogli metabase:cookie --region us)" curl ...
+    hogli metabase:login --region us|eu         # opens browser, captures cookies
+    hogli metabase:databases --region us|eu     # list databases with current IDs
+    hogli metabase:query --region us|eu \\      # run SQL against /api/dataset
+        --database-id <id> < query.sql
+    hogli metabase:cookie --region us|eu        # print cached cookie header (humans)
 
 Cookies are cached at ~/.config/posthog/metabase/cookie-{region} with mode 0600.
+The `query` command reads the cookie internally so callers never see it —
+prefer it over `cookie` when automation is running the query.
 """
 
 from __future__ import annotations
 
+import sys
+import json
 import time
 import webbrowser
 from pathlib import Path
+from typing import Any
 
 import click
 from hogli.core.cli import cli
@@ -288,3 +293,211 @@ def metabase_cookie(region: str, check: bool) -> None:
         )
     # No trailing newline so $(hogli metabase:cookie) yields a clean header.
     click.echo(cookie_header, nl=False)
+
+
+def _require_cookie_header(region: str) -> str:
+    """Return the cached cookie header or raise with a clear re-login message."""
+    cookie_header = _read_cookie_file(region)
+    if cookie_header is None:
+        raise click.ClickException(
+            f"No cached cookie for region {region}. Run `hogli metabase:login --region {region}`.",
+        )
+    return cookie_header
+
+
+def _metabase_get(region: str, path: str, timeout: float = 30.0) -> Any:
+    """GET `path` on the region's Metabase, return parsed JSON.
+
+    Callers never see the cookie — it's read, used, and discarded internally.
+    """
+    import requests
+
+    domain = REGIONS[region]
+    cookie_header = _require_cookie_header(region)
+    response = requests.get(
+        f"https://{domain}{path}",
+        headers={"Cookie": cookie_header, "Accept": "application/json"},
+        timeout=timeout,
+        allow_redirects=False,
+    )
+    if response.status_code in (301, 302):
+        raise click.ClickException(
+            f"Session redirected to auth for region {region}. "
+            f"Run `hogli metabase:login --region {region}` to refresh cookies.",
+        )
+    if response.status_code == 401:
+        raise click.ClickException(
+            f"Session rejected (401) for region {region}. "
+            f"Run `hogli metabase:login --region {region}` to refresh cookies.",
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _metabase_post_dataset(region: str, database_id: int, sql: str, timeout: float = 120.0) -> Any:
+    """POST a native SQL query to /api/dataset; return parsed JSON (incl. error body)."""
+    import requests
+
+    domain = REGIONS[region]
+    cookie_header = _require_cookie_header(region)
+    payload = {
+        "database": database_id,
+        "type": "native",
+        "native": {"query": sql, "template-tags": {}},
+    }
+    response = requests.post(
+        f"https://{domain}/api/dataset",
+        headers={
+            "Cookie": cookie_header,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        json=payload,
+        timeout=timeout,
+        allow_redirects=False,
+    )
+    if response.status_code in (301, 302):
+        raise click.ClickException(
+            f"Session redirected to auth for region {region}. "
+            f"Run `hogli metabase:login --region {region}` to refresh cookies.",
+        )
+    if response.status_code == 401:
+        raise click.ClickException(
+            f"Session rejected (401) for region {region}. "
+            f"Run `hogli metabase:login --region {region}` to refresh cookies.",
+        )
+    if response.status_code == 404:
+        raise click.ClickException(
+            f"Database {database_id} not found in region {region}. "
+            f"Run `hogli metabase:databases --region {region}` to see current IDs.",
+        )
+    # Metabase sometimes returns 202 / 200 with a {status: failed, error: ...} body.
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise click.ClickException(
+            f"Metabase returned non-JSON response (HTTP {response.status_code}): {response.text[:200]}",
+        ) from exc
+    return body
+
+
+def _render_rows_tsv(body: dict[str, Any]) -> str:
+    """Render /api/dataset JSON to a header-prefixed TSV string."""
+    data = body.get("data") or {}
+    cols = [c["name"] for c in data.get("cols") or []]
+    rows = data.get("rows") or []
+    out = ["\t".join(cols)]
+    for row in rows:
+        out.append("\t".join("" if v is None else str(v) for v in row))
+    return "\n".join(out) + "\n"
+
+
+@cli.command(
+    name="metabase:databases",
+    help="List Metabase databases (id, name, engine) for a region",
+)
+@click.option(
+    "--region",
+    type=click.Choice(sorted(REGIONS.keys())),
+    required=True,
+    help="Region to inspect (us or eu)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    show_default=True,
+)
+def metabase_databases(region: str, output_format: str) -> None:
+    """Print current databases from /api/database. IDs change when Metabase's metadata DB is rebuilt or connections are re-added, so always run this before passing --database-id to metabase:query."""
+    body = _metabase_get(region, "/api/database")
+    # Metabase wraps the list in {data: [...], total: N}; older versions return a bare list.
+    entries = body["data"] if isinstance(body, dict) and "data" in body else body
+
+    if output_format == "json":
+        click.echo(json.dumps([{"id": e["id"], "name": e["name"], "engine": e["engine"]} for e in entries], indent=2))
+        return
+
+    header = f"{'ID':>4}  {'NAME':<40}  ENGINE"
+    click.echo(header)
+    click.echo("-" * len(header))
+    for e in entries:
+        click.echo(f"{e['id']:>4}  {e['name']:<40}  {e['engine']}")
+
+
+@cli.command(
+    name="metabase:query",
+    help="Run a SQL query against Metabase /api/dataset; results to stdout",
+)
+@click.option(
+    "--region",
+    type=click.Choice(sorted(REGIONS.keys())),
+    required=True,
+    help="Region to query (us or eu)",
+)
+@click.option(
+    "--database-id",
+    type=int,
+    required=True,
+    help="Database ID (get from `hogli metabase:databases --region <region>`)",
+)
+@click.option(
+    "--file",
+    "sql_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="Read SQL from this file (default: read from stdin)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["tsv", "json"]),
+    default="tsv",
+    show_default=True,
+)
+@click.option(
+    "--save",
+    type=click.Path(dir_okay=False, writable=True),
+    default=None,
+    help="Write output to this file instead of stdout (avoids dumping large results into terminals/logs)",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=120.0,
+    show_default=True,
+    help="HTTP timeout in seconds",
+)
+def metabase_query(
+    region: str,
+    database_id: int,
+    sql_file: str | None,
+    output_format: str,
+    save: str | None,
+    timeout: float,
+) -> None:
+    """Run SQL against the given database ID and emit results. Cookie stays internal."""
+    if sql_file:
+        sql = Path(sql_file).read_text()
+    else:
+        sql = sys.stdin.read()
+    if not sql.strip():
+        raise click.ClickException("No SQL provided. Pipe via stdin or use --file.")
+
+    body = _metabase_post_dataset(region, database_id, sql, timeout=timeout)
+    if body.get("status") == "failed" or body.get("error"):
+        error_msg = body.get("error") or body.get("status")
+        raise click.ClickException(f"Query failed: {error_msg}")
+
+    if output_format == "json":
+        rendered = json.dumps(body, indent=2) + "\n"
+    else:
+        rendered = _render_rows_tsv(body)
+
+    if save:
+        Path(save).write_text(rendered)
+        row_count = body.get("row_count", "?")
+        click.echo(f"Wrote {row_count} rows to {save}")
+    else:
+        click.echo(rendered, nl=False)

--- a/common/hogli/metabase.py
+++ b/common/hogli/metabase.py
@@ -38,7 +38,6 @@ _CHROMIUM_PROFILE_ROOTS: dict[str, list[Path]] = {
     "chrome": [_HOME / "Library/Application Support/Google/Chrome"],
     "chromium": [_HOME / "Library/Application Support/Chromium"],
     "brave": [_HOME / "Library/Application Support/BraveSoftware/Brave-Browser"],
-    "edge": [_HOME / "Library/Application Support/Microsoft Edge"],
 }
 
 REGIONS: dict[str, str] = {
@@ -51,7 +50,7 @@ REQUIRED_COOKIES: tuple[str, ...] = (
     "ph_int_auth-0",
     "ph_int_auth-1",
 )
-SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "edge", "firefox", "safari")
+SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "firefox", "safari")
 CACHE_DIR: Path = Path.home() / ".config" / "posthog" / "metabase"
 
 
@@ -66,7 +65,7 @@ def _format_cookie_header(cookies: dict[str, str]) -> str:
 def _enumerate_cookie_files(browser: str | None) -> list[tuple[str, Path]]:
     """Return (loader_name, cookie_file_path) pairs for every browser profile to try.
 
-    Chromium-family browsers (Chrome, Brave, Edge, Chromium) keep a `Cookies`
+    Chromium-family browsers (Chrome, Brave, Chromium) keep a `Cookies`
     SQLite db per profile (`Default`, `Profile 1`, ...). We glob each profile
     directory so users with multiple profiles (work + personal) don't have to
     care which one they logged in with.

--- a/common/hogli/metabase.py
+++ b/common/hogli/metabase.py
@@ -1,0 +1,291 @@
+"""Authenticate to internal Metabase via SSO and cache the session cookie.
+
+Production Metabase sits behind ALB Cognito OAuth, so callers need both the
+ALB session cookies (`ph_int_auth-0`, `ph_int_auth-1`) and the Metabase
+application cookies (`metabase.SESSION`, `metabase.DEVICE`). API keys alone
+won't pass the ALB.
+
+Workflow:
+    hogli metabase:login [--region us|eu]   # opens system browser, captures cookies
+    hogli metabase:cookie [--region us|eu]  # prints cached cookie header
+
+Scripts can then use:
+    METABASE_COOKIE="$(hogli metabase:cookie --region us)" curl ...
+
+Cookies are cached at ~/.config/posthog/metabase/cookie-{region} with mode 0600.
+"""
+
+from __future__ import annotations
+
+import time
+import webbrowser
+from pathlib import Path
+
+import click
+from hogli.core.cli import cli
+
+LOGIN_TIMEOUT_SECONDS: float = 180.0
+LOGIN_POLL_INTERVAL_SECONDS: float = 1.0
+# Chrome buffers cookies in memory and flushes to SQLite roughly every 30s.
+# After this many seconds without progress we hint at closing the tab to
+# force a flush.
+FLUSH_HINT_AFTER_SECONDS: float = 8.0
+
+# Per-browser profile-cookie locations. Each entry is (loader_name, base_directory).
+# We glob `<base>/*/Cookies` to discover every profile (Default, Profile 1, ...).
+_HOME = Path.home()
+_CHROMIUM_PROFILE_ROOTS: dict[str, list[Path]] = {
+    "chrome": [_HOME / "Library/Application Support/Google/Chrome"],
+    "chromium": [_HOME / "Library/Application Support/Chromium"],
+    "brave": [_HOME / "Library/Application Support/BraveSoftware/Brave-Browser"],
+    "edge": [_HOME / "Library/Application Support/Microsoft Edge"],
+}
+
+REGIONS: dict[str, str] = {
+    "us": "metabase.prod-us.posthog.dev",
+    "eu": "metabase.prod-eu.posthog.dev",
+}
+REQUIRED_COOKIES: tuple[str, ...] = (
+    "metabase.SESSION",
+    "metabase.DEVICE",
+    "ph_int_auth-0",
+    "ph_int_auth-1",
+)
+SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "edge", "firefox", "safari")
+CACHE_DIR: Path = Path.home() / ".config" / "posthog" / "metabase"
+
+
+def _cookie_path(region: str) -> Path:
+    return CACHE_DIR / f"cookie-{region}"
+
+
+def _format_cookie_header(cookies: dict[str, str]) -> str:
+    return "; ".join(f"{name}={value}" for name, value in cookies.items())
+
+
+def _enumerate_cookie_files(browser: str | None) -> list[tuple[str, Path]]:
+    """Return (loader_name, cookie_file_path) pairs for every browser profile to try.
+
+    Chromium-family browsers (Chrome, Brave, Edge, Chromium) keep a `Cookies`
+    SQLite db per profile (`Default`, `Profile 1`, ...). We glob each profile
+    directory so users with multiple profiles (work + personal) don't have to
+    care which one they logged in with.
+
+    Firefox and Safari fall back to the default `browser_cookie3` loader.
+    """
+    targets: list[tuple[str, Path]] = []
+    selected = SUPPORTED_BROWSERS if browser is None else (browser,)
+    for name in selected:
+        if name in _CHROMIUM_PROFILE_ROOTS:
+            for root in _CHROMIUM_PROFILE_ROOTS[name]:
+                if not root.exists():
+                    continue
+                for cookies_db in sorted(root.glob("*/Cookies")):
+                    targets.append((name, cookies_db))
+        else:
+            targets.append((name, Path()))
+    return targets
+
+
+def _load_cookies_from_browser(domain: str, browser: str | None) -> dict[str, str]:
+    """Read cookies for `domain` from the user's system browser cookie store.
+
+    Decrypting Chromium cookies on macOS triggers a one-time Keychain prompt
+    per profile; users who pick "Always allow" won't see it again.
+    """
+    try:
+        import browser_cookie3
+    except ImportError as exc:
+        raise click.ClickException(
+            "browser-cookie3 is not installed. Run `uv sync` to install dev dependencies.",
+        ) from exc
+
+    if browser is not None and browser not in SUPPORTED_BROWSERS:
+        raise click.ClickException(f"Unsupported browser: {browser}")
+
+    targets = _enumerate_cookie_files(browser)
+    found: dict[str, str] = {}
+    errors: list[str] = []
+    for loader_name, cookie_file in targets:
+        loader = getattr(browser_cookie3, loader_name, None)
+        if loader is None:
+            continue
+        kwargs: dict = {"domain_name": domain}
+        if cookie_file != Path():
+            kwargs["cookie_file"] = str(cookie_file)
+        try:
+            jar = loader(**kwargs)
+        except Exception as exc:
+            errors.append(f"{loader_name} ({cookie_file or 'default'}): {exc}")
+            continue
+        for cookie in jar:
+            if cookie.name in REQUIRED_COOKIES and cookie.value:
+                found[cookie.name] = cookie.value
+
+    if not found and errors:
+        click.echo("\n".join(f"  warn: {e}" for e in errors), err=True)
+    return found
+
+
+def _write_cookie_file(region: str, cookie_header: str) -> Path:
+    path = _cookie_path(region)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(cookie_header)
+    path.chmod(0o600)
+    return path
+
+
+def _read_cookie_file(region: str) -> str | None:
+    path = _cookie_path(region)
+    if not path.exists():
+        return None
+    return path.read_text().strip()
+
+
+def _check_cookie(domain: str, cookie_header: str, timeout: float = 5.0) -> bool:
+    """Hit /api/user/current to confirm the cookie is still valid."""
+    import requests
+
+    try:
+        response = requests.get(
+            f"https://{domain}/api/user/current",
+            headers={"Cookie": cookie_header},
+            timeout=timeout,
+            allow_redirects=False,
+        )
+    except requests.RequestException:
+        return False
+    return response.status_code == 200
+
+
+def _wait_for_valid_cookie(
+    domain: str,
+    browser: str | None,
+    timeout: float,
+    interval: float,
+) -> str:
+    """Poll the browser cookie store until a valid Metabase session appears.
+
+    Returns the cookie header on success. Raises `click.ClickException` after
+    `timeout` seconds without finding a valid session.
+
+    Chrome flushes cookies to its on-disk SQLite store roughly every 30s, so a
+    freshly-set `metabase.SESSION` can be invisible to us for a while. After
+    `FLUSH_HINT_AFTER_SECONDS` we surface a hint suggesting the user close the
+    Metabase tab — closing a tab forces an immediate flush.
+    """
+    start = time.monotonic()
+    deadline = start + timeout
+    last_status = ""
+    last_header: str | None = None
+    flush_hint_shown = False
+    while True:
+        cookies = _load_cookies_from_browser(domain, browser)
+        missing = [name for name in REQUIRED_COOKIES if name not in cookies]
+        if not missing:
+            cookie_header = _format_cookie_header(cookies)
+            # Avoid pinging /api/user/current with the same header repeatedly
+            # when the user already had a stale cookie set on disk.
+            if cookie_header != last_header:
+                last_header = cookie_header
+                if _check_cookie(domain, cookie_header):
+                    return cookie_header
+                status = "Cookies present but session not yet valid; still waiting..."
+            else:
+                status = "Cookies present but session not yet valid; still waiting..."
+        else:
+            status = f"Waiting for cookies: missing {missing}..."
+
+        if status != last_status:
+            click.echo(status)
+            last_status = status
+
+        if not flush_hint_shown and time.monotonic() - start >= FLUSH_HINT_AFTER_SECONDS:
+            click.echo(
+                "  hint: if you've already signed in, close the Metabase tab — "
+                "Chrome only flushes cookies to disk every ~30s, but closing a tab forces it.",
+            )
+            flush_hint_shown = True
+
+        if time.monotonic() >= deadline:
+            raise click.ClickException(
+                f"Timed out after {timeout:.0f}s waiting for SSO. "
+                "Make sure you completed login in the browser, or rerun with --browser to "
+                "target a specific browser.",
+            )
+        time.sleep(interval)
+
+
+def _login_region(region: str, browser: str | None, no_open: bool, timeout: float) -> None:
+    """Authenticate one region: fast-path if already logged in, else open browser and wait."""
+    domain = REGIONS[region]
+
+    cookies = _load_cookies_from_browser(domain, browser)
+    if all(name in cookies for name in REQUIRED_COOKIES):
+        header = _format_cookie_header(cookies)
+        if _check_cookie(domain, header):
+            path = _write_cookie_file(region, header)
+            click.echo(f"[{region}] already logged in; saved cookie to {path}")
+            return
+
+    if not no_open:
+        click.echo(f"[{region}] opening https://{domain} in your default browser.")
+        webbrowser.open(f"https://{domain}")
+    click.echo(f"[{region}] complete SSO in the browser; capturing automatically when ready.")
+
+    cookie_header = _wait_for_valid_cookie(domain, browser, timeout, LOGIN_POLL_INTERVAL_SECONDS)
+    path = _write_cookie_file(region, cookie_header)
+    click.echo(f"[{region}] saved cookie to {path}")
+
+
+@cli.command(name="metabase:login", help="Log in to Metabase via SSO and cache the session cookie")
+@click.option(
+    "--region",
+    type=click.Choice(sorted(REGIONS.keys())),
+    required=True,
+    help="Region to authenticate (one at a time, e.g. --region us or --region eu)",
+)
+@click.option(
+    "--browser",
+    type=click.Choice(SUPPORTED_BROWSERS),
+    default=None,
+    help="Read cookies from this browser only (default: scan all supported browsers)",
+)
+@click.option("--no-open", is_flag=True, help="Skip opening the browser; just capture cookies")
+@click.option(
+    "--timeout",
+    type=float,
+    default=LOGIN_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Seconds to wait for SSO to complete before giving up",
+)
+def metabase_login(region: str, browser: str | None, no_open: bool, timeout: float) -> None:
+    """Open Metabase in the default browser; capture cookies as soon as SSO completes.
+
+    Already-valid sessions are fast-pathed (no browser tab opens),
+    so re-running is cheap. Run once per region (us, eu).
+    """
+    _login_region(region, browser, no_open, timeout)
+
+
+@cli.command(name="metabase:cookie", help="Print the cached Metabase cookie header")
+@click.option(
+    "--region",
+    type=click.Choice(sorted(REGIONS.keys())),
+    default="us",
+    show_default=True,
+)
+@click.option("--check/--no-check", default=False, help="Validate the cookie before printing")
+def metabase_cookie(region: str, check: bool) -> None:
+    """Print the cached cookie header to stdout. Suitable for `METABASE_COOKIE=$(...)`."""
+    cookie_header = _read_cookie_file(region)
+    if cookie_header is None:
+        raise click.ClickException(
+            f"No cached cookie for region {region}. Run `hogli metabase:login --region {region}`.",
+        )
+    if check and not _check_cookie(REGIONS[region], cookie_header):
+        raise click.ClickException(
+            f"Cached cookie for {region} is no longer valid. Run `hogli metabase:login --region {region}` to refresh.",
+        )
+    # No trailing newline so $(hogli metabase:cookie) yields a clean header.
+    click.echo(cookie_header, nl=False)

--- a/common/hogli/tests/test_metabase.py
+++ b/common/hogli/tests/test_metabase.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+
+import click
+from click.testing import CliRunner
+from hogli import metabase
+from hogli.core.cli import cli
+
+
+class _FakeCookie:
+    def __init__(self, name: str, value: str) -> None:
+        self.name = name
+        self.value = value
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    monkeypatch.setattr(metabase, "CACHE_DIR", tmp_path)
+    yield tmp_path
+
+
+def test_format_cookie_header_joins_with_semicolons() -> None:
+    header = metabase._format_cookie_header({"a": "1", "b": "2"})
+    assert header == "a=1; b=2"
+
+
+def test_cookie_path_per_region(cache_dir: Path) -> None:
+    assert metabase._cookie_path("us") == cache_dir / "cookie-us"
+    assert metabase._cookie_path("eu") == cache_dir / "cookie-eu"
+
+
+def test_write_cookie_file_is_owner_only(cache_dir: Path) -> None:
+    path = metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    assert path.read_text() == "metabase.SESSION=abc"
+    mode = path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_read_cookie_file_returns_none_when_missing(cache_dir: Path) -> None:
+    assert metabase._read_cookie_file("us") is None
+
+
+def test_read_cookie_file_strips_trailing_whitespace(cache_dir: Path) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc\n")
+    assert metabase._read_cookie_file("us") == "metabase.SESSION=abc"
+
+
+def test_load_cookies_filters_to_required_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_jar = [
+        _FakeCookie("metabase.SESSION", "s"),
+        _FakeCookie("metabase.DEVICE", "d"),
+        _FakeCookie("ph_int_auth-0", "a0"),
+        _FakeCookie("ph_int_auth-1", "a1"),
+        _FakeCookie("unrelated", "x"),
+    ]
+
+    class FakeBC3:
+        @staticmethod
+        def chrome(domain_name: str, cookie_file: str | None = None) -> list[_FakeCookie]:
+            assert domain_name == "metabase.prod-us.posthog.dev"
+            assert cookie_file == "/fake/profile/Cookies"
+            return fake_jar
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "browser_cookie3", FakeBC3)
+    monkeypatch.setattr(
+        metabase,
+        "_enumerate_cookie_files",
+        lambda browser: [("chrome", Path("/fake/profile/Cookies"))],
+    )
+    cookies = metabase._load_cookies_from_browser("metabase.prod-us.posthog.dev", "chrome")
+    assert cookies == {
+        "metabase.SESSION": "s",
+        "metabase.DEVICE": "d",
+        "ph_int_auth-0": "a0",
+        "ph_int_auth-1": "a1",
+    }
+
+
+def test_enumerate_cookie_files_globs_chromium_profiles(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    chrome_root = tmp_path / "Chrome"
+    (chrome_root / "Default").mkdir(parents=True)
+    (chrome_root / "Default" / "Cookies").touch()
+    (chrome_root / "Profile 1").mkdir()
+    (chrome_root / "Profile 1" / "Cookies").touch()
+    monkeypatch.setattr(metabase, "_CHROMIUM_PROFILE_ROOTS", {"chrome": [chrome_root]})
+
+    targets = metabase._enumerate_cookie_files("chrome")
+    cookie_files = [str(p) for _, p in targets]
+    assert any("Default/Cookies" in p for p in cookie_files)
+    assert any("Profile 1/Cookies" in p for p in cookie_files)
+
+
+def test_load_cookies_unsupported_browser_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeBC3:
+        pass
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "browser_cookie3", FakeBC3)
+    with pytest.raises(click.ClickException, match="Unsupported browser"):
+        metabase._load_cookies_from_browser("metabase.prod-us.posthog.dev", "lynx")
+
+
+def test_metabase_cookie_command_errors_when_no_cache(cache_dir: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:cookie", "--region", "us"])
+    assert result.exit_code != 0
+    assert "No cached cookie" in result.output
+
+
+def test_metabase_cookie_command_prints_cached_value(cache_dir: Path) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc; metabase.DEVICE=def")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:cookie", "--region", "us"])
+    assert result.exit_code == 0, result.output
+    assert "metabase.SESSION=abc; metabase.DEVICE=def" in result.output
+
+
+def test_metabase_cookie_check_validates_via_http(cache_dir: Path) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc; metabase.DEVICE=d; ph_int_auth-0=a; ph_int_auth-1=b")
+    runner = CliRunner()
+    with patch.object(metabase, "_check_cookie", return_value=False) as check:
+        result = runner.invoke(cli, ["metabase:cookie", "--region", "us", "--check"])
+    assert result.exit_code != 0
+    assert "no longer valid" in result.output
+    check.assert_called_once()
+
+
+def test_metabase_login_writes_cookie_after_validation(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {
+        "metabase.SESSION": "s",
+        "metabase.DEVICE": "d",
+        "ph_int_auth-0": "a0",
+        "ph_int_auth-1": "a1",
+    }
+    monkeypatch.setattr(metabase, "_load_cookies_from_browser", lambda domain, browser: captured)
+    monkeypatch.setattr(metabase, "_check_cookie", lambda domain, header: True)
+    monkeypatch.setattr(metabase.webbrowser, "open", lambda url: True)
+    monkeypatch.setattr(metabase.time, "sleep", lambda _: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:login", "--region", "eu", "--no-open"])
+    assert result.exit_code == 0, result.output
+
+    saved = (cache_dir / "cookie-eu").read_text()
+    assert saved == "metabase.SESSION=s; metabase.DEVICE=d; ph_int_auth-0=a0; ph_int_auth-1=a1"
+    mode = os.stat(cache_dir / "cookie-eu").st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_metabase_login_requires_region_flag() -> None:
+    """`metabase:login` without --region should fail with a clear error."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:login", "--no-open"])
+    assert result.exit_code != 0
+    assert "--region" in result.output
+
+
+def test_metabase_login_fast_paths_already_valid_session(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If cookies are already valid, login should not open the browser."""
+    captured = {name: f"{name}-val" for name in metabase.REQUIRED_COOKIES}
+    monkeypatch.setattr(metabase, "_load_cookies_from_browser", lambda domain, browser: captured)
+    monkeypatch.setattr(metabase, "_check_cookie", lambda domain, header: True)
+    monkeypatch.setattr(metabase.time, "sleep", lambda _: None)
+    opens: list[str] = []
+    monkeypatch.setattr(metabase.webbrowser, "open", lambda url: opens.append(url) or True)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:login", "--region", "us"])
+    assert result.exit_code == 0, result.output
+    assert opens == [], "browser should not open when session is already valid"
+    assert "already logged in" in result.output
+
+
+def test_wait_for_valid_cookie_returns_when_session_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cookies appear progressively (none → partial → all four), then validate succeeds."""
+    sequence = [
+        {},
+        {"metabase.SESSION": "s"},
+        {name: name + "-val" for name in metabase.REQUIRED_COOKIES},
+    ]
+    calls = iter(sequence)
+    monkeypatch.setattr(metabase, "_load_cookies_from_browser", lambda d, b: next(calls))
+    monkeypatch.setattr(metabase, "_check_cookie", lambda d, h: True)
+    monkeypatch.setattr(metabase.time, "sleep", lambda _: None)
+
+    header = metabase._wait_for_valid_cookie("metabase.example", None, timeout=10.0, interval=0.0)
+    expected = metabase._format_cookie_header({name: name + "-val" for name in metabase.REQUIRED_COOKIES})
+    assert header == expected
+
+
+def test_wait_for_valid_cookie_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If cookies never appear, wait raises a ClickException after the timeout."""
+    monkeypatch.setattr(metabase, "_load_cookies_from_browser", lambda d, b: {})
+    monkeypatch.setattr(metabase, "_check_cookie", lambda d, h: False)
+    monkeypatch.setattr(metabase.time, "sleep", lambda _: None)
+
+    fake_now = iter([0.0, 0.0, 100.0])  # checked twice (entry + after first sleep), then expired
+    monkeypatch.setattr(metabase.time, "monotonic", lambda: next(fake_now))
+
+    with pytest.raises(click.ClickException, match="Timed out"):
+        metabase._wait_for_valid_cookie("metabase.example", None, timeout=10.0, interval=0.0)

--- a/common/hogli/tests/test_metabase.py
+++ b/common/hogli/tests/test_metabase.py
@@ -157,7 +157,6 @@ def test_metabase_login_writes_cookie_after_validation(cache_dir: Path, monkeypa
 
 
 def test_metabase_login_requires_region_flag() -> None:
-    """`metabase:login` without --region should fail with a clear error."""
     runner = CliRunner()
     result = runner.invoke(cli, ["metabase:login", "--no-open"])
     assert result.exit_code != 0
@@ -165,7 +164,6 @@ def test_metabase_login_requires_region_flag() -> None:
 
 
 def test_metabase_login_fast_paths_already_valid_session(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """If cookies are already valid, login should not open the browser."""
     captured = {name: f"{name}-val" for name in metabase.REQUIRED_COOKIES}
     monkeypatch.setattr(metabase, "_load_cookies_from_browser", lambda domain, browser: captured)
     monkeypatch.setattr(metabase, "_check_cookie", lambda domain, header: True)
@@ -181,7 +179,6 @@ def test_metabase_login_fast_paths_already_valid_session(cache_dir: Path, monkey
 
 
 def test_wait_for_valid_cookie_returns_when_session_valid(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Cookies appear progressively (none → partial → all four), then validate succeeds."""
     sequence = [
         {},
         {"metabase.SESSION": "s"},
@@ -198,7 +195,6 @@ def test_wait_for_valid_cookie_returns_when_session_valid(monkeypatch: pytest.Mo
 
 
 def test_wait_for_valid_cookie_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
-    """If cookies never appear, wait raises a ClickException after the timeout."""
     monkeypatch.setattr(metabase, "_load_cookies_from_browser", lambda d, b: {})
     monkeypatch.setattr(metabase, "_check_cookie", lambda d, h: False)
     monkeypatch.setattr(metabase.time, "sleep", lambda _: None)

--- a/common/hogli/tests/test_metabase.py
+++ b/common/hogli/tests/test_metabase.py
@@ -176,7 +176,12 @@ def test_metabase_login_fast_paths_already_valid_session(cache_dir: Path, monkey
     monkeypatch.setattr(metabase, "_check_cookie", lambda domain, header: True)
     monkeypatch.setattr(metabase.time, "sleep", lambda _: None)
     opens: list[str] = []
-    monkeypatch.setattr(metabase.webbrowser, "open", lambda url: opens.append(url) or True)
+
+    def record_open(url: str) -> bool:
+        opens.append(url)
+        return True
+
+    monkeypatch.setattr(metabase.webbrowser, "open", record_open)
 
     runner = CliRunner()
     result = runner.invoke(cli, ["metabase:login", "--region", "us"])

--- a/common/hogli/tests/test_metabase.py
+++ b/common/hogli/tests/test_metabase.py
@@ -204,3 +204,118 @@ def test_wait_for_valid_cookie_times_out(monkeypatch: pytest.MonkeyPatch) -> Non
 
     with pytest.raises(click.ClickException, match="Timed out"):
         metabase._wait_for_valid_cookie("metabase.example", None, timeout=10.0, interval=0.0)
+
+
+def test_require_cookie_header_errors_when_missing(cache_dir: Path) -> None:
+    with pytest.raises(click.ClickException, match="No cached cookie"):
+        metabase._require_cookie_header("us")
+
+
+def test_require_cookie_header_returns_cached(cache_dir: Path) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    assert metabase._require_cookie_header("us") == "metabase.SESSION=abc"
+
+
+def test_render_rows_tsv_formats_cols_and_rows() -> None:
+    body = {
+        "data": {
+            "cols": [{"name": "team_id"}, {"name": "count"}, {"name": "label"}],
+            "rows": [[1, 10, "a"], [2, None, "b"]],
+        },
+        "status": "completed",
+    }
+    out = metabase._render_rows_tsv(body)
+    assert out == "team_id\tcount\tlabel\n1\t10\ta\n2\t\tb\n"
+
+
+def test_metabase_databases_prints_table(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    fake = {
+        "data": [
+            {"id": 42, "name": "ClickHouse", "engine": "clickhouse"},
+            {"id": 38, "name": "Postgres", "engine": "postgres"},
+        ]
+    }
+    monkeypatch.setattr(metabase, "_metabase_get", lambda region, path, timeout=30.0: fake)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:databases", "--region", "us"])
+    assert result.exit_code == 0, result.output
+    assert "42" in result.output and "ClickHouse" in result.output
+    assert "38" in result.output and "Postgres" in result.output
+
+
+def test_metabase_databases_json_format(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    fake = [{"id": 42, "name": "ClickHouse", "engine": "clickhouse"}]  # bare-list form
+    monkeypatch.setattr(metabase, "_metabase_get", lambda region, path, timeout=30.0: fake)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:databases", "--region", "us", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    parsed = _json.loads(result.output)
+    assert parsed == [{"id": 42, "name": "ClickHouse", "engine": "clickhouse"}]
+
+
+def test_metabase_query_requires_database_id() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:query", "--region", "us"], input="SELECT 1\n")
+    assert result.exit_code != 0
+    assert "--database-id" in result.output
+
+
+def test_metabase_query_emits_tsv(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    fake = {
+        "status": "completed",
+        "row_count": 2,
+        "data": {"cols": [{"name": "x"}], "rows": [[1], [2]]},
+    }
+    monkeypatch.setattr(metabase, "_metabase_post_dataset", lambda region, db, sql, timeout=120.0: fake)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:query", "--region", "us", "--database-id", "42"], input="SELECT 1\n")
+    assert result.exit_code == 0, result.output
+    assert result.output == "x\n1\n2\n"
+
+
+def test_metabase_query_surface_query_failure(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    fake = {"status": "failed", "error": "syntax error near 'SELEKT'"}
+    monkeypatch.setattr(metabase, "_metabase_post_dataset", lambda region, db, sql, timeout=120.0: fake)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:query", "--region", "us", "--database-id", "42"], input="SELEKT 1\n")
+    assert result.exit_code != 0
+    assert "syntax error" in result.output
+
+
+def test_metabase_query_save_to_file(cache_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    fake = {
+        "status": "completed",
+        "row_count": 1,
+        "data": {"cols": [{"name": "x"}], "rows": [[42]]},
+    }
+    monkeypatch.setattr(metabase, "_metabase_post_dataset", lambda region, db, sql, timeout=120.0: fake)
+
+    out_path = tmp_path / "out.tsv"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["metabase:query", "--region", "us", "--database-id", "42", "--save", str(out_path)],
+        input="SELECT 42\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert out_path.read_text() == "x\n42\n"
+    assert "42" not in result.output.replace("Wrote", "")  # value didn't leak to stdout
+
+
+def test_metabase_query_rejects_empty_sql(cache_dir: Path) -> None:
+    metabase._write_cookie_file("us", "metabase.SESSION=abc")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:query", "--region", "us", "--database-id", "42"], input="")
+    assert result.exit_code != 0
+    assert "No SQL provided" in result.output

--- a/common/hogli/tests/test_metabase.py
+++ b/common/hogli/tests/test_metabase.py
@@ -134,6 +134,13 @@ def test_metabase_cookie_check_validates_via_http(cache_dir: Path) -> None:
     check.assert_called_once()
 
 
+def test_metabase_cookie_requires_region_flag() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["metabase:cookie"])
+    assert result.exit_code != 0
+    assert "--region" in result.output
+
+
 def test_metabase_login_writes_cookie_after_validation(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     captured = {
         "metabase.SESSION": "s",
@@ -199,8 +206,16 @@ def test_wait_for_valid_cookie_times_out(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(metabase, "_check_cookie", lambda d, h: False)
     monkeypatch.setattr(metabase.time, "sleep", lambda _: None)
 
-    fake_now = iter([0.0, 0.0, 100.0])  # checked twice (entry + after first sleep), then expired
-    monkeypatch.setattr(metabase.time, "monotonic", lambda: next(fake_now))
+    # Return 0.0 twice (start + flush-hint check), then saturate past the deadline.
+    # Saturating instead of exhausting the iterator keeps the test resilient if
+    # someone adds another `time.monotonic()` call inside the loop later.
+    call_count = {"n": 0}
+
+    def fake_monotonic() -> float:
+        call_count["n"] += 1
+        return 0.0 if call_count["n"] <= 2 else 100.0
+
+    monkeypatch.setattr(metabase.time, "monotonic", fake_monotonic)
 
     with pytest.raises(click.ClickException, match="Timed out"):
         metabase._wait_for_valid_cookie("metabase.example", None, timeout=10.0, interval=0.0)
@@ -311,6 +326,8 @@ def test_metabase_query_save_to_file(cache_dir: Path, monkeypatch: pytest.Monkey
     assert result.exit_code == 0, result.output
     assert out_path.read_text() == "x\n42\n"
     assert "42" not in result.output.replace("Wrote", "")  # value didn't leak to stdout
+    mode = out_path.stat().st_mode & 0o777
+    assert mode == 0o600, f"--save output must be owner-only, got {oct(mode)}"
 
 
 def test_metabase_query_rejects_empty_sql(cache_dir: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ dev = [
     "aioresponses==0.7.6",
     "autoevals==0.0.129",
     "boto3-stubs[s3]~=1.38.30",
+    "browser-cookie3~=0.20",
     "braintrust==0.2.4",
     "braintrust-langchain==0.0.4",
     "dagster-dg-cli~=1.10.18",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-20T23:18:39.268157Z"
+exclude-newer = "2026-04-21T18:46:39.646944Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -682,6 +682,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
     { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
     { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+]
+
+[[package]]
+name = "browser-cookie3"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jeepney", marker = "'bsd' in sys_platform or sys_platform == 'linux'" },
+    { name = "lz4" },
+    { name = "pycryptodomex" },
+    { name = "shadowcopy", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e1/652adea0ce25948e613ef78294c8ceaf4b32844aae00680d3a1712dde444/browser_cookie3-0.20.1.tar.gz", hash = "sha256:6d8d0744bf42a5327c951bdbcf77741db3455b8b4e840e18bab266d598368a12", size = 22665, upload-time = "2024-12-20T00:31:30.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/57/2a716f4ecf6c50b2dbe27439507c480bb7ca5725edef82349ecdcfcdd084/browser_cookie3-0.20.1-py3-none-any.whl", hash = "sha256:4b38bf669d386250733c8339f0036e1cf09c3d8e4d326fd507b9afb84def13d6", size = 17229, upload-time = "2025-01-04T14:46:14.753Z" },
 ]
 
 [[package]]
@@ -3187,6 +3202,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -5175,6 +5199,7 @@ dev = [
     { name = "boto3-stubs", extra = ["s3"] },
     { name = "braintrust" },
     { name = "braintrust-langchain" },
+    { name = "browser-cookie3" },
     { name = "dagster-dg-cli" },
     { name = "datamodel-code-generator" },
     { name = "debugpy" },
@@ -5431,6 +5456,7 @@ dev = [
     { name = "boto3-stubs", extras = ["s3"], specifier = "~=1.38.30" },
     { name = "braintrust", specifier = "==0.2.4" },
     { name = "braintrust-langchain", specifier = "==0.0.4" },
+    { name = "browser-cookie3", specifier = "~=0.20" },
     { name = "dagster-dg-cli", specifier = "~=1.10.18" },
     { name = "datamodel-code-generator", specifier = "~=0.36.0" },
     { name = "debugpy", specifier = "~=1.8.0" },
@@ -5781,6 +5807,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
 ]
 
 [[package]]
@@ -6842,6 +6887,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "shadowcopy"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wmi", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/32/fdea8e7f7b2b8bae13ee6ab7df1a10d28a24dbeb03a62ff033563f95d77c/shadowcopy-0.0.4-py3-none-any.whl", hash = "sha256:fc51e59a639dc6a5a3a7a9b4e3ecadc71989e339f2d995d90aaa491acd4ba4eb", size = 4212, upload-time = "2023-07-08T00:01:34.042Z" },
 ]
 
 [[package]]
@@ -8251,6 +8308,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/9e/b0/21547e16a47206ccd
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/96/55a14b5c0e90439951f4a72672223bba81a5f882033c5850f8a6c7f4308b/win_precise_time-1.4.2-cp312-cp312-win32.whl", hash = "sha256:0210dcea88a520c91de1708ae4c881e3c0ddc956daa08b9eabf2b7c35f3109f5", size = 14694, upload-time = "2023-10-08T17:08:09.275Z" },
     { url = "https://files.pythonhosted.org/packages/17/19/7ea9a22a69fc23d5ca02e8edf65e4a335a210497794af1af0ef8fda91fa0/win_precise_time-1.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:85670f77cc8accd8f1e6d05073999f77561c23012a9ee988cbd44bb7ce655062", size = 14913, upload-time = "2023-10-08T17:08:10.677Z" },
+]
+
+[[package]]
+name = "wmi"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/b9/a80d1ed4d115dac8e2ac08d16af046a77ab58e3d186e22395bf2add24090/WMI-1.5.1-py2.py3-none-any.whl", hash = "sha256:1d6b085e5c445141c475476000b661f60fff1aaa19f76bf82b7abb92e0ff4942", size = 28912, upload-time = "2020-04-28T08:22:56.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

ClickHouse `system.query_log` analysis against internal Metabase requires browser session cookies. Today the workflow is either click through the UI or manually copy cookies out of Chrome's dev tools into a file which is slow. 

This PR adds `hogli` commands for authenticating into Metabase via SSO and running queries from the CLI.

New hogli commands: 
- `hogli metabase:login --region <us|eu>` - SSO via system browser, captures cookies from the browser store, writes `~/.config/posthog/metabase/cookie-<region>` 
- `hogli metabase:databases --region <us|eu>` - lists `(id, name, engine)` from `/api/database`
- `hogli metabase:query --region <us|eu> --database-id <n>` - reads SQL via stdin/`--file`, POSTs `/api/dataset` using the cached cookie internally and emits TSV/JSON`
- `hogli metabase:cookie --region <us|eu>` - prints cookie header for humans hand-rolling curl

New skill: 
- Adds `.agents/skills/query-clickhouse-via-metabase/SKILL.md` with the auth/discovery workflow, ready-to-run `system.query_log` patterns, and error handling.


## How did you test this code?

Manually verified locally by signing out of metabase then running 
```
hogli metabase:login --region us

/query-clickhouse-via-metabase find the longest query from team_id 2 in the last 24hrs
```

<img width="1468" height="528" alt="Screenshot 2026-04-28 at 3 48 19 PM" src="https://github.com/user-attachments/assets/def104fd-f585-42f7-9e94-c69be81fc517" />

## Publish to changelog?

no 

## Docs update

N/A
