### PR TITLE
feat(propdefs): tune consumer rebalancing; apply lifecycle for graceful shutdown

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7264,7 +7264,6 @@ dependencies = [
  "serve-metrics",
  "sqlx",
  "thiserror 2.0.18",
- "time",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7253,7 +7253,7 @@ dependencies = [
  "common-metrics",
  "envconfig",
  "futures",
- "health",
+ "lifecycle",
  "metrics",
  "personhog-proto",
  "quick_cache",

--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -56,6 +56,25 @@ pub struct ConsumerConfig {
     pub kafka_consumer_fetch_min_bytes: Option<u32>,
 
     pub kafka_consumer_fetch_max_bytes: Option<u32>,
+
+    pub kafka_consumer_max_partition_fetch_bytes: Option<u32>,
+
+    // Consumer group protocol tuning for WarpStream rebalance resilience.
+    // Set to a stable pod identity to enable static group membership (avoids
+    // rebalances when a pod restarts within the session timeout window).
+    pub kafka_consumer_group_instance_id: Option<String>,
+
+    // Override partition assignment strategy, e.g. "cooperative-sticky" for
+    // incremental rebalancing instead of the default eager "range" protocol.
+    // During migration, use "range,cooperative-sticky" then drop "range".
+    pub kafka_consumer_partition_strategy: Option<String>,
+
+    // WarpStream recommends "0" so the kernel auto-tunes TCP buffers.
+    pub kafka_consumer_socket_send_buffer_bytes: Option<String>,
+    pub kafka_consumer_socket_receive_buffer_bytes: Option<String>,
+
+    // WarpStream recommends 60000 for faster Agent scaling responsiveness.
+    pub kafka_consumer_metadata_refresh_interval_ms: Option<u32>,
 }
 
 impl ConsumerConfig {

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -93,6 +93,25 @@ impl SingleTopicConsumer {
         if let Some(v) = consumer_config.kafka_consumer_fetch_max_bytes {
             client_config.set("fetch.max.bytes", v.to_string());
         }
+        if let Some(v) = consumer_config.kafka_consumer_max_partition_fetch_bytes {
+            client_config.set("max.partition.fetch.bytes", v.to_string());
+        }
+
+        if let Some(ref id) = consumer_config.kafka_consumer_group_instance_id {
+            client_config.set("group.instance.id", id);
+        }
+        if let Some(ref strategy) = consumer_config.kafka_consumer_partition_strategy {
+            client_config.set("partition.assignment.strategy", strategy);
+        }
+        if let Some(ref v) = consumer_config.kafka_consumer_socket_send_buffer_bytes {
+            client_config.set("socket.send.buffer.bytes", v);
+        }
+        if let Some(ref v) = consumer_config.kafka_consumer_socket_receive_buffer_bytes {
+            client_config.set("socket.receive.buffer.bytes", v);
+        }
+        if let Some(v) = consumer_config.kafka_consumer_metadata_refresh_interval_ms {
+            client_config.set("topic.metadata.refresh.interval.ms", v.to_string());
+        }
 
         let consumer: StreamConsumer = client_config.create()?;
         consumer.subscribe(&[consumer_config.kafka_consumer_topic.as_str()])?;

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -14,7 +14,6 @@ tracing-subscriber = { workspace = true }
 sqlx = { workspace = true }
 futures = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
-time = { workspace = true }
 axum = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }
 metrics = { workspace = true }

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -13,7 +13,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 sqlx = { workspace = true }
 futures = { workspace = true }
-health = { path = "../common/health" }
+lifecycle = { path = "../common/lifecycle" }
 time = { workspace = true }
 axum = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }

--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -1,17 +1,13 @@
 use crate::{
     api::v1::query::Manager, config::Config, group_type_resolver::GroupTypeResolver, types::Update,
 };
-use health::{HealthHandle, HealthRegistry};
 use sqlx::{postgres::PgPoolOptions, PgPool};
-use time::Duration;
 
 pub struct AppContext {
     // this points to the original (shared) CLOUD DB instance in prod deployments
     pub pool: PgPool,
 
     pub query_manager: Manager,
-    pub liveness: HealthRegistry,
-    pub worker_liveness: HealthHandle,
     pub skip_writes: bool,
     pub skip_reads: bool,
 
@@ -30,18 +26,11 @@ impl AppContext {
         let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
         let pool = options.connect(&config.database_url).await?;
 
-        let liveness: HealthRegistry = HealthRegistry::new("liveness");
-        let worker_liveness = liveness
-            .register("worker".to_string(), Duration::seconds(60))
-            .await;
-
         let group_type_resolver = GroupTypeResolver::new(config);
 
         Ok(Self {
             pool,
             query_manager: qmgr,
-            liveness,
-            worker_liveness,
             skip_writes: config.skip_writes,
             skip_reads: config.skip_reads,
             enable_mirror: config.enable_mirror,

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -162,12 +162,15 @@ pub async fn update_producer_loop(
     let mut batch = AHashSet::with_capacity(config.compaction_batch_size);
     let mut last_send = tokio::time::Instant::now();
     loop {
-        if handle.is_shutting_down() {
-            info!("Producer loop shutting down");
-            return;
-        }
+        let recv_result = tokio::select! {
+            _ = handle.shutdown_recv() => {
+                info!("Producer loop shutting down");
+                return;
+            }
+            r = consumer.json_recv() => r,
+        };
 
-        let (event, offset): (Event, _) = match consumer.json_recv().await {
+        let (event, offset): (Event, _) = match recv_result {
             Ok(r) => r,
             Err(RecvErr::Empty) => {
                 warn!("Received empty event");
@@ -253,9 +256,9 @@ pub async fn update_producer_loop(
                     Err(TrySendError::Full(update)) => {
                         warn!("Worker blocked");
                         metrics::counter!(WORKER_BLOCKED).increment(1);
-                        // Workers should just die if the channel is dropped, since that indicates
-                        // the main loop is dead.
-                        channel.send(update).await.unwrap();
+                        if channel.send(update).await.is_err() {
+                            return;
+                        }
                     }
                     Err(e) => {
                         warn!("Coordinator send failed: {:?}", e);

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -14,7 +14,7 @@ use types::{Event, Update};
 
 use ahash::AHashSet;
 use tokio::sync::mpsc::error::TrySendError;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use update_cache::Cache;
 
 use crate::{
@@ -37,7 +37,9 @@ pub async fn update_consumer_loop(
     cache: Arc<Cache>,
     context: Arc<AppContext>,
     mut channel: MeasuringReceiver<Update>,
+    handle: lifecycle::Handle,
 ) {
+    let _guard = handle.process_scope();
     let mut prev_hits = [0u64; 3];
     let mut prev_misses = [0u64; 3];
 
@@ -47,7 +49,7 @@ pub async fn update_consumer_loop(
         let batch_start = tokio::time::Instant::now();
         let batch_time = common_metrics::timing_guard(BATCH_ACQUIRE_TIME, &[]);
         while batch.len() < config.update_batch_size {
-            context.worker_liveness.report_healthy().await;
+            handle.report_healthy();
 
             metrics::gauge!(CHANNEL_MESSAGES_IN_FLIGHT)
                 .set(channel.get_inflight_messages_count() as f64);
@@ -58,10 +60,14 @@ pub async fn update_consumer_loop(
             let sleep = tokio::time::sleep(Duration::from_secs(1));
 
             tokio::select! {
+                _ = handle.shutdown_recv() => {
+                    info!("Consumer loop received shutdown signal");
+                    return;
+                }
                 got = recv => {
                     if got == 0 {
-                        // Indicates all workers have exited, so we should too
-                        panic!("Coordinator recv failed, dying");
+                        info!("Channel closed, all producers exited");
+                        return;
                     }
                     metrics::gauge!(RECV_DEQUEUED).set(got as f64);
                     continue;
@@ -76,6 +82,10 @@ pub async fn update_consumer_loop(
             }
         }
         batch_time.fin();
+
+        if batch.is_empty() {
+            continue;
+        }
 
         // We de-duplicate the batch, in case racing inserts slipped through the shared-cache filter. This
         // is important because duplicate updates touch the same row, and we issue in parallel, so we'd end
@@ -146,10 +156,17 @@ pub async fn update_producer_loop(
     consumer: SingleTopicConsumer,
     shared_cache: Arc<Cache>,
     channel: MeasuringSender<Update>,
+    handle: lifecycle::Handle,
 ) {
+    let _guard = handle.process_scope();
     let mut batch = AHashSet::with_capacity(config.compaction_batch_size);
     let mut last_send = tokio::time::Instant::now();
     loop {
+        if handle.is_shutting_down() {
+            info!("Producer loop shutting down");
+            return;
+        }
+
         let (event, offset): (Event, _) = match consumer.json_recv().await {
             Ok(r) => r,
             Err(RecvErr::Empty) => {
@@ -163,7 +180,8 @@ pub async fn update_producer_loop(
                 continue;
             }
             Err(RecvErr::Kafka(e)) => {
-                panic!("Kafka error: {e:?}"); // We just panic if we fail to recv from kafka, if it's down, we're down
+                handle.signal_failure(format!("Kafka error: {e:?}"));
+                return;
             }
         };
 

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -1,11 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
-use axum::{routing::get, Router};
+use axum::{response::IntoResponse, routing::get, Router};
 use common_kafka::kafka_consumer::SingleTopicConsumer;
-
-use futures::future::ready;
+use lifecycle::{ComponentOptions, Manager};
 use property_defs_rs::{
-    api::v1::{query::Manager, routing::apply_routes},
+    api::v1::{query::Manager as QueryManager, routing::apply_routes},
     app_context::AppContext,
     config::Config,
     measuring_channel::measuring_channel,
@@ -14,9 +13,9 @@ use property_defs_rs::{
     update_consumer_loop, update_producer_loop,
 };
 
-use serve_metrics::{serve, setup_metrics_routes};
+use serve_metrics::setup_metrics_routes;
 use sqlx::postgres::PgPoolOptions;
-use tokio::task::JoinHandle;
+use tokio::net::TcpListener;
 use tracing::level_filters::LevelFilter;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
@@ -37,28 +36,6 @@ pub async fn index() -> &'static str {
     "property definitions service"
 }
 
-fn start_server(config: &Config, context: Arc<AppContext>) -> JoinHandle<()> {
-    let api_ctx = context.clone();
-
-    let router = Router::new()
-        .route("/", get(index))
-        .route("/_readiness", get(index))
-        .route(
-            "/_liveness",
-            get(move || ready(context.liveness.get_status())),
-        );
-    let router = apply_routes(router, api_ctx);
-    let router = setup_metrics_routes(router);
-
-    let bind = format!("{}:{}", config.host, config.port);
-
-    tokio::task::spawn(async move {
-        serve(router, &bind)
-            .await
-            .expect("failed to start serving metrics");
-    })
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     setup_tracing();
@@ -75,6 +52,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
+    // -- Lifecycle manager: signals, health monitoring, coordinated shutdown --
+    let mut manager = Manager::builder("property-defs-rs")
+        .with_global_shutdown_timeout(Duration::from_secs(60))
+        .build();
+
+    let producer_handle = manager.register(
+        "producer",
+        ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(30)),
+    );
+
+    let consumer_handle = manager.register(
+        "consumer",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(30))
+            .with_liveness_deadline(Duration::from_secs(60))
+            .with_stall_threshold(3),
+    );
+
+    let metrics_handle =
+        manager.register("metrics", ComponentOptions::new().is_observability(true));
+
+    let readiness = manager.readiness_handler();
+    let liveness = manager.liveness_handler();
+
     let consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
 
     // dedicated PG conn pool for serving propdefs API queries only (not currently live in prod)
@@ -82,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // DBs after those migrations are completed, prior to deployment
     let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
     let api_pool = options.connect(&config.database_url).await?;
-    let query_manager = Manager::new(api_pool).await?;
+    let query_manager = QueryManager::new(api_pool).await?;
 
     let context = Arc::new(AppContext::new(&config, query_manager).await?);
 
@@ -90,8 +91,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Subscribed to topic: {}",
         config.consumer.kafka_consumer_topic
     );
-
-    start_server(&config, context.clone());
 
     let (tx, rx) = measuring_channel(config.update_batch_size * config.channel_slots_per_worker);
 
@@ -103,43 +102,79 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cache = Arc::new(cache);
 
-    let mut handles = Vec::new();
+    // Start the lifecycle monitor before spawning components
+    let guard = manager.monitor_background();
 
+    // Spawn N producer loops (Kafka consumers -> channel)
     for _ in 0..config.worker_loop_count {
-        let handle = tokio::spawn(update_producer_loop(
+        let h = producer_handle.clone();
+        tokio::spawn(update_producer_loop(
             config.clone(),
             consumer.clone(),
             cache.clone(),
             tx.clone(),
+            h,
         ));
-
-        handles.push(handle);
     }
+    drop(producer_handle);
 
     // Publish the tx capacity metric every 10 seconds
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(Duration::from_secs(10)).await;
-            metrics::gauge!(CHANNEL_CAPACITY).set(tx.capacity() as f64);
+    tokio::spawn({
+        let tx = tx.clone();
+        async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                metrics::gauge!(CHANNEL_CAPACITY).set(tx.capacity() as f64);
+            }
         }
     });
+    drop(tx);
 
-    handles.push(tokio::spawn(update_consumer_loop(
+    // Spawn the consumer loop (channel -> DB)
+    tokio::spawn(update_consumer_loop(
         config.clone(),
         cache,
-        context,
+        context.clone(),
         rx,
-    )));
+        consumer_handle,
+    ));
 
-    // if any handle returns, abort the other ones, and then return an error
-    let (result, _, others) = futures::future::select_all(handles).await;
-    warn!(
-        "update loop process is shutting down with result: {:?}",
-        result
-    );
+    // Build HTTP server with lifecycle readiness/liveness
+    let app = Router::new()
+        .route("/", get(index))
+        .route(
+            "/_readiness",
+            get({
+                let r = readiness.clone();
+                move || {
+                    let r = r.clone();
+                    async move { r.check().await }
+                }
+            }),
+        )
+        .route(
+            "/_liveness",
+            get({
+                let l = liveness.clone();
+                move || {
+                    let l = l.clone();
+                    async move { l.check().into_response() }
+                }
+            }),
+        );
+    let app = apply_routes(app, context);
+    let app = setup_metrics_routes(app);
 
-    for handle in others {
-        handle.abort();
-    }
-    Ok(result?)
+    let bind = format!("{}:{}", config.host, config.port);
+    info!(address = %bind, "HTTP server starting");
+    let listener = TcpListener::bind(&bind).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(metrics_handle.shutdown_signal())
+        .await?;
+    metrics_handle.work_completed();
+
+    guard.wait().await?;
+
+    info!("property-defs-rs stopped");
+    Ok(())
 }


### PR DESCRIPTION
## Problem
We'd like to tune away long rebalance and consumer lag storms on deploy in the `property-defs-rs` service.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose new consumer configs required to tune via related charts PR
* Implement `common/lifecycle` to handle consumer shutdown during deploy transitions and minimize rebalance storms
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test deploys after
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
N/A
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
