### PR TITLE
chore(hogli): opt out auto-invoked commands from telemetry

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -354,7 +354,7 @@ fi
 # Clean old flox log files (>7 days). Fire-and-forget after activation.
 (
   if [[ -x "$UV_PROJECT_ENVIRONMENT/bin/python" && -f "$FLOX_ENV_PROJECT/bin/hogli" ]]; then
-    PYTHONPATH="$FLOX_ENV_PROJECT/common" "$UV_PROJECT_ENVIRONMENT/bin/python" \
+    POSTHOG_TELEMETRY_OPT_OUT=1 PYTHONPATH="$FLOX_ENV_PROJECT/common" "$UV_PROJECT_ENVIRONMENT/bin/python" \
       -m hogli.core doctor:disk --area=flox-logs --yes >/dev/null 2>&1
   else
     find "$FLOX_ENV_PROJECT/.flox/log" -name "*.log" -type f -mtime +7 -delete 2>/dev/null

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,10 +5,14 @@
 # not just your changes, making it slow and pointless
 [ -f "$(git rev-parse --git-path MERGE_HEAD 2>/dev/null)" ] && exit 0
 
+# Auto-invoked formatter/linter calls during commit are not explicit user
+# commands -- skip telemetry so the dashboard reflects intentional usage only.
+export POSTHOG_TELEMETRY_OPT_OUT=1
+
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
 if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
-    exec "$(command -v flox)" activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
+    exec "$(command -v flox)" activate -- bash -c "POSTHOG_TELEMETRY_OPT_OUT=1 NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
 else
     # Fallback: run without Flox (for non-Flox users or if already activated)
     NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged

--- a/bin/start
+++ b/bin/start
@@ -162,7 +162,7 @@ else
     # Generate/regenerate config using hogli (defaults to product_analytics if no config exists)
     # HOGLI_PROCESS_MANAGER is picked up by dev:generate for telemetry
     if command -v hogli &>/dev/null; then
-        HOGLI_PROCESS_MANAGER="$PROCESS_MANAGER" hogli dev:generate 2>/dev/null || true
+        POSTHOG_TELEMETRY_OPT_OUT=1 HOGLI_PROCESS_MANAGER="$PROCESS_MANAGER" hogli dev:generate 2>/dev/null || true
     fi
 
     if [[ -f "$GENERATED_CONFIG" ]]; then


### PR DESCRIPTION
## Problem

Auto-invoked hogli commands inflate the DevEx dashboard. `doctor:disk` was the top command (4.8k runs / 3ms median) — purely the flox on-activate cleanup hook. `format:*` / `lint:*:fix` are dominated by lint-staged on commit, and `dev:generate` is fired by `bin/start`, not users.

## Changes

Set `POSTHOG_TELEMETRY_OPT_OUT=1` at the three known auto-invocation sites. The env var is already supported by `common/hogli/telemetry.py` — config-only change.

- `.flox/env/on-activate.sh`
- `.husky/pre-commit`
- `bin/start`

CI is already excluded via the `CI=*` precedence.

## How did you test this code?

Agent-authored (Claude Code). Verified the opt-out path in `telemetry.py:88-95` and confirmed via SQL on project 347861 that these are the only auto-invocation sites producing inflated counts. Post-merge: `doctor:disk` / `format:*` / `lint:*:fix` / `dev:generate` volume should drop sharply.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) for @rnegron. Diagnosed via dashboard 1375143. Human review required.