### PR TITLE
Validate API responses against OpenAPI schema during tests

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1427,6 +1427,14 @@ jobs:
                   name: junit-results-backend-${{ matrix.artifact_key }}
                   path: junit-*.xml
 
+            - name: Upload OpenAPI response validation report
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always()
+              with:
+                  name: openapi-response-validation-backend-${{ matrix.artifact_key }}
+                  path: openapi_response_validation_report.json
+                  if-no-files-found: warn
+
     # Aggregate and commit snapshot changes from all matrix jobs
 
     get_clickhouse_versions:

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -1,4 +1,5 @@
 import os
+import json
 import subprocess
 from urllib.parse import quote_plus
 
@@ -10,8 +11,10 @@ from django.core.management.commands.flush import Command as FlushCommand
 from django.db import connections
 
 from infi.clickhouse_orm import Database
+from rest_framework.test import APIClient
 
 from posthog.clickhouse.client import sync_execute
+from posthog.test.openapi_response_validation import build_openapi_response_validator
 
 
 def create_clickhouse_tables():
@@ -445,6 +448,10 @@ def pytest_configure(config):
     # Set default databases for Django test classes
     TestCase.databases = {"default", "persons_db_writer", "persons_db_reader"}
     TransactionTestCase.databases = {"default", "persons_db_writer", "persons_db_reader"}
+    config.addinivalue_line(
+        "markers",
+        "skip_openapi_response_validation: skip OpenAPI response validation for this test",
+    )
 
 
 def _runs_on_internal_pr() -> bool:
@@ -462,3 +469,38 @@ def _runs_on_internal_pr() -> bool:
 def pytest_runtest_setup(item: pytest.Item) -> None:
     if "requires_secrets" in item.keywords and not _runs_on_internal_pr():
         pytest.skip("Skipping test that requires internal secrets on external PRs")
+
+
+@pytest.fixture(autouse=True)
+def validate_api_responses_against_openapi_spec(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> None:
+    if "skip_openapi_response_validation" in request.keywords:
+        return
+
+    validator = build_openapi_response_validator()
+    original_request = APIClient.request
+
+    def wrapped_request(client: APIClient, **kwargs: object) -> object:
+        response = original_request(client, **kwargs)
+        validator.validate_response(response)
+        return response
+
+    monkeypatch.setattr(APIClient, "request", wrapped_request)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    validator = build_openapi_response_validator()
+    report = validator.recorder.write_machine_readable_report("openapi_response_validation_report.json")
+    terminal_reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if terminal_reporter is not None:
+        terminal_reporter.write_line(
+            json.dumps(
+                {
+                    "event": "openapi_response_validation_summary",
+                    "exitstatus": exitstatus,
+                    "summary": report["summary"],
+                },
+                sort_keys=True,
+            )
+        )

--- a/posthog/test/openapi_response_validation.py
+++ b/posthog/test/openapi_response_validation.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import re
+import json
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from typing import Any
+
+from django.http import HttpResponse
+
+from drf_spectacular.generators import SchemaGenerator
+from jsonschema import ValidationError
+from jsonschema.validators import Draft7Validator, RefResolver
+
+_JSON_CONTENT_TYPES: tuple[str, ...] = ("application/json", "application/problem+json")
+
+
+@dataclass
+class OpenAPIValidationEvent:
+    event: str
+    method: str
+    path: str
+    status_code: int
+    reason: str
+    details: str | None = None
+
+
+class OpenAPIValidationRecorder:
+    def __init__(self) -> None:
+        self.events: list[OpenAPIValidationEvent] = []
+
+    def record(
+        self,
+        *,
+        event: str,
+        method: str,
+        path: str,
+        status_code: int,
+        reason: str,
+        details: str | None = None,
+    ) -> None:
+        self.events.append(
+            OpenAPIValidationEvent(
+                event=event,
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason=reason,
+                details=details,
+            )
+        )
+
+    def write_machine_readable_report(self, output_path: str) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        for item in self.events:
+            counts[item.reason] = counts.get(item.reason, 0) + 1
+
+        report: dict[str, Any] = {
+            "events": [asdict(item) for item in self.events],
+            "summary": {
+                "total": len(self.events),
+                "by_reason": counts,
+            },
+        }
+
+        with open(output_path, "w", encoding="utf-8") as file_handle:
+            json.dump(report, file_handle, sort_keys=True)
+            file_handle.write("\n")
+
+        return report
+
+
+class OpenAPIResponseValidator:
+    def __init__(self, schema: dict[str, Any], recorder: OpenAPIValidationRecorder) -> None:
+        self.schema = schema
+        self.recorder = recorder
+        self._compiled_paths = self._compile_paths(schema.get("paths", {}))
+        self._resolver = RefResolver.from_schema(schema)
+
+    def validate_response(self, response: HttpResponse) -> None:
+        request = getattr(response, "wsgi_request", None)
+        if request is None:
+            return
+
+        method = request.method.upper()
+        path = request.path
+        status_code = response.status_code
+
+        if not path.startswith("/api/"):
+            return
+
+        if path == "/api/schema/":
+            return
+
+        path_item = self._find_path_item(path)
+        if path_item is None:
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="path_not_in_schema",
+            )
+            return
+
+        operation = path_item.get(method.lower())
+        if not isinstance(operation, dict):
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="method_not_in_schema",
+            )
+            return
+
+        response_schema = self._get_response_schema(operation, status_code)
+        if response_schema is None:
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="response_schema_not_declared",
+            )
+            return
+
+        if self._is_empty_response(response):
+            self.recorder.record(
+                event="validated",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="empty_body",
+            )
+            return
+
+        if not self._is_json_response(response):
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="non_json_response",
+            )
+            return
+
+        try:
+            payload = json.loads(response.content.decode(response.charset or "utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            message = f"unable to decode JSON body: {error}"
+            self.recorder.record(
+                event="failed",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="invalid_json_body",
+                details=message,
+            )
+            raise AssertionError(self._failure_json(method, path, status_code, "invalid_json_body", message)) from error
+
+        try:
+            self._validate_payload(payload, response_schema)
+        except ValidationError as error:
+            message = self._format_validation_error(error)
+            self.recorder.record(
+                event="failed",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="schema_validation_failed",
+                details=message,
+            )
+            raise AssertionError(
+                self._failure_json(method, path, status_code, "schema_validation_failed", message)
+            ) from error
+
+        self.recorder.record(
+            event="validated",
+            method=method,
+            path=path,
+            status_code=status_code,
+            reason="schema_validation_passed",
+        )
+
+    def _validate_payload(self, payload: Any, schema: dict[str, Any]) -> None:
+        if schema.get("nullable") and payload is None:
+            return
+
+        normalized_schema = self._normalize_nullable(schema)
+        validator = Draft7Validator(normalized_schema, resolver=self._resolver)
+        validator.validate(payload)
+
+    @staticmethod
+    def _normalize_nullable(schema: Any) -> Any:
+        if isinstance(schema, list):
+            return [OpenAPIResponseValidator._normalize_nullable(item) for item in schema]
+
+        if not isinstance(schema, dict):
+            return schema
+
+        transformed: dict[str, Any] = {k: OpenAPIResponseValidator._normalize_nullable(v) for k, v in schema.items()}
+        nullable = transformed.pop("nullable", False)
+
+        if nullable is True:
+            if "$ref" in transformed:
+                return {"anyOf": [transformed, {"type": "null"}]}
+
+            existing_type = transformed.get("type")
+            if isinstance(existing_type, str):
+                transformed["type"] = [existing_type, "null"]
+            elif isinstance(existing_type, list) and "null" not in existing_type:
+                transformed["type"] = [*existing_type, "null"]
+            else:
+                transformed = {"anyOf": [transformed, {"type": "null"}]}
+
+        return transformed
+
+    @staticmethod
+    def _compile_paths(paths: dict[str, Any]) -> list[tuple[re.Pattern[str], dict[str, Any]]]:
+        compiled: list[tuple[re.Pattern[str], dict[str, Any]]] = []
+        for openapi_path, path_item in paths.items():
+            if not isinstance(path_item, dict):
+                continue
+
+            pattern = re.sub(r"\{[^/]+\}", r"[^/]+", openapi_path)
+            compiled.append((re.compile(f"^{pattern}$"), path_item))
+
+        return compiled
+
+    def _find_path_item(self, path: str) -> dict[str, Any] | None:
+        for pattern, path_item in self._compiled_paths:
+            if pattern.match(path):
+                return path_item
+        return None
+
+    @staticmethod
+    def _is_json_response(response: HttpResponse) -> bool:
+        content_type = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        return content_type in _JSON_CONTENT_TYPES
+
+    @staticmethod
+    def _is_empty_response(response: HttpResponse) -> bool:
+        if response.status_code in {204, 304}:
+            return True
+        return response.content in (b"", None)
+
+    @staticmethod
+    def _get_response_schema(operation: dict[str, Any], status_code: int) -> dict[str, Any] | None:
+        responses = operation.get("responses")
+        if not isinstance(responses, dict):
+            return None
+
+        response_obj = responses.get(str(status_code)) or responses.get("default")
+        if not isinstance(response_obj, dict):
+            return None
+
+        content = response_obj.get("content")
+        if not isinstance(content, dict):
+            return None
+
+        media_type = content.get("application/json") or content.get("application/problem+json")
+        if not isinstance(media_type, dict):
+            return None
+
+        schema = media_type.get("schema")
+        if not isinstance(schema, dict):
+            return None
+
+        return schema
+
+    @staticmethod
+    def _format_validation_error(error: ValidationError) -> str:
+        path_segments = [str(segment) for segment in error.path]
+        error_path = ".".join(path_segments) if path_segments else "$"
+        return f"path={error_path}; message={error.message}"
+
+    @staticmethod
+    def _failure_json(method: str, path: str, status_code: int, reason: str, details: str) -> str:
+        return json.dumps(
+            {
+                "event": "failed",
+                "method": method,
+                "path": path,
+                "status_code": status_code,
+                "reason": reason,
+                "details": details,
+            },
+            sort_keys=True,
+        )
+
+
+@lru_cache(maxsize=1)
+def build_openapi_response_validator() -> OpenAPIResponseValidator:
+    schema = SchemaGenerator().get_schema(request=None, public=True)
+    if schema is None:
+        raise RuntimeError("OpenAPI schema generation returned None")
+
+    recorder = OpenAPIValidationRecorder()
+    return OpenAPIResponseValidator(schema=schema, recorder=recorder)

--- a/posthog/test/test_openapi_response_validation.py
+++ b/posthog/test/test_openapi_response_validation.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from posthog.test.openapi_response_validation import OpenAPIResponseValidator, OpenAPIValidationRecorder
+
+
+@dataclass
+class _FakeRequest:
+    method: str
+    path: str
+
+
+@dataclass
+class _FakeResponse:
+    wsgi_request: _FakeRequest
+    status_code: int
+    headers: dict[str, str]
+    content: bytes
+    charset: str = "utf-8"
+
+
+@pytest.fixture
+def base_schema() -> dict:
+    return {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/projects/{team_id}/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "integer"},
+                                            "name": {"type": "string"},
+                                        },
+                                        "required": ["id", "name"],
+                                        "additionalProperties": False,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {},
+    }
+
+
+def test_validates_dynamic_openapi_paths(base_schema: dict) -> None:
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(base_schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/123/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"id": 1, "name": "Widget"}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+
+    assert recorder.events[-1].reason == "schema_validation_passed"
+
+
+def test_raises_machine_readable_error_on_schema_mismatch(base_schema: dict) -> None:
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(base_schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/123/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"id": "not-an-integer", "name": "Widget"}).encode("utf-8"),
+    )
+
+    with pytest.raises(AssertionError, match='"reason": "schema_validation_failed"'):
+        validator.validate_response(response)
+
+
+def test_nullable_schema_is_supported() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/projects/{team_id}/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "optional_name": {"type": "string", "nullable": True},
+                                        },
+                                        "required": ["optional_name"],
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/1/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"optional_name": None}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+
+    assert recorder.events[-1].reason == "schema_validation_passed"

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ markers =
     skip_on_multitenancy
     async_migrations
     requires_secrets: test needs internal secrets or infra and is skipped on external PRs
+    skip_openapi_response_validation: skip OpenAPI response validation for this test
 
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = module


### PR DESCRIPTION
### Motivation
- Add automatic validation of HTTP responses produced by tests against the generated OpenAPI schema to catch contract mismatches early and produce a machine-readable validation report.
- Allow opting out of this validation per-test via a pytest marker to avoid noise for intentionally undocumented or exceptional endpoints.

### Description
- Introduce `posthog/test/openapi_response_validation.py` implementing `OpenAPIResponseValidator` and `OpenAPIValidationRecorder` to validate responses, handle nullable schemas, dynamic path matching, and produce structured events.
- Add an autouse pytest fixture `validate_api_responses_against_openapi_spec` in `conftest.py` that monkeypatches `APIClient.request` to validate responses during tests and register the `skip_openapi_response_validation` marker.
- Write a machine-readable summary report `openapi_response_validation_report.json` at test session end via `pytest_sessionfinish` and emit a brief summary to the terminal reporter.
- Add unit tests in `posthog/test/test_openapi_response_validation.py` covering dynamic path validation, schema mismatch errors, and nullable field handling, and update `pytest.ini` to document the new marker.

### Testing
- Ran the new unit tests with `pytest posthog/test/test_openapi_response_validation.py` and they passed. 
- The validation logic was exercised by the tests and produced expected `schema_validation_passed` and `schema_validation_failed` events. 
- The test session write step creates `openapi_response_validation_report.json` containing a machine-readable summary of validation events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaca14464832eae72255f30f0cef7)