### PR TITLE
fix(integrations): use sandbox secret for Stripe sandbox installs

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -676,9 +676,12 @@ class OauthIntegration:
             # Marketplace-initiated installs land on /integrations/stripe/confirm-install
             # without any signal indicating live vs sandbox. If the live secret rejected
             # the code as "does not belong to you", it was minted by the sandbox app -
-            # retry with the sandbox secret.
+            # retry with the sandbox secret. Both sandbox client_id and secret must be
+            # configured: oauth_config_for_kind requires both, so guard on both here to
+            # avoid raising NotImplementedError over the original OAuth error.
             if (
                 res.status_code == 400
+                and settings.STRIPE_APP_SANDBOX_CLIENT_ID
                 and settings.STRIPE_APP_SANDBOX_SECRET_KEY
                 and "does not belong to you" in (res.text or "")
             ):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -556,14 +556,17 @@ class OauthIntegration:
             if not settings.STRIPE_APP_CLIENT_ID or not settings.STRIPE_APP_SECRET_KEY:
                 raise NotImplementedError("Stripe app not configured")
 
-            # Stripe issues separate client_ids for live vs sandbox installs of the
-            # same app. Same authorize endpoint and same client_secret for both.
+            # Stripe issues separate client_id and secret for live vs sandbox installs of the
+            # same app. Sandbox-issued OAuth codes can only be redeemed with the sandbox secret;
+            # using the live secret returns "Authorization code provided does not belong to you".
             if is_sandbox:
-                if not settings.STRIPE_APP_SANDBOX_CLIENT_ID:
-                    raise NotImplementedError("Stripe sandbox client_id not configured")
+                if not settings.STRIPE_APP_SANDBOX_CLIENT_ID or not settings.STRIPE_APP_SANDBOX_SECRET_KEY:
+                    raise NotImplementedError("Stripe sandbox not configured")
                 client_id = settings.STRIPE_APP_SANDBOX_CLIENT_ID
+                client_secret = settings.STRIPE_APP_SANDBOX_SECRET_KEY
             else:
                 client_id = settings.STRIPE_APP_CLIENT_ID
+                client_secret = settings.STRIPE_APP_SECRET_KEY
 
             authorize_url = (
                 settings.STRIPE_APP_OVERRIDE_AUTHORIZE_URL or "https://marketplace.stripe.com/oauth/v2/authorize"
@@ -572,7 +575,7 @@ class OauthIntegration:
                 authorize_url=authorize_url,
                 token_url="https://api.stripe.com/v1/oauth/token",
                 client_id=client_id,
-                client_secret=settings.STRIPE_APP_SECRET_KEY,
+                client_secret=client_secret,
                 scope="",
                 id_path="stripe_user_id",
                 name_path="account_name",
@@ -670,6 +673,24 @@ class OauthIntegration:
                     "grant_type": "authorization_code",
                 },
             )
+            # Marketplace-initiated installs land on /integrations/stripe/confirm-install
+            # without any signal indicating live vs sandbox. If the live secret rejected
+            # the code as "does not belong to you", it was minted by the sandbox app -
+            # retry with the sandbox secret.
+            if (
+                res.status_code == 400
+                and settings.STRIPE_APP_SANDBOX_SECRET_KEY
+                and "does not belong to you" in (res.text or "")
+            ):
+                sandbox_oauth_config = cls.oauth_config_for_kind("stripe", is_sandbox=True)
+                res = requests.post(
+                    sandbox_oauth_config.token_url,
+                    auth=HTTPBasicAuth(sandbox_oauth_config.client_secret, ""),
+                    data={
+                        "code": params["code"],
+                        "grant_type": "authorization_code",
+                    },
+                )
         else:
             redirect_uri = OauthIntegration.redirect_uri(kind)
             res = requests.post(

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -591,7 +591,8 @@ class TestOauthIntegrationModel(BaseTest):
         with self.settings(
             STRIPE_APP_CLIENT_ID="ca_live_clientid",
             STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_test_secret",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
             STRIPE_APP_OVERRIDE_AUTHORIZE_URL="",
         ):
             url = OauthIntegration.authorize_url("stripe", token="state_token", next="/projects/test")
@@ -602,21 +603,111 @@ class TestOauthIntegrationModel(BaseTest):
         with self.settings(
             STRIPE_APP_CLIENT_ID="ca_live_clientid",
             STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_test_secret",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
             STRIPE_APP_OVERRIDE_AUTHORIZE_URL="",
         ):
             url = OauthIntegration.authorize_url("stripe", token="state_token", next="/projects/test", is_sandbox=True)
             assert "client_id=ca_sandbox_clientid" in url
             assert "client_id=ca_live_clientid" not in url
 
+    def test_stripe_oauth_config_uses_sandbox_secret_when_is_sandbox(self):
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
+        ):
+            live_cfg = OauthIntegration.oauth_config_for_kind("stripe")
+            sandbox_cfg = OauthIntegration.oauth_config_for_kind("stripe", is_sandbox=True)
+            assert live_cfg.client_secret == "sk_live_secret"
+            assert sandbox_cfg.client_secret == "sk_test_sandbox_secret"
+
     def test_stripe_authorize_url_raises_when_sandbox_requested_but_not_configured(self):
         with self.settings(
             STRIPE_APP_CLIENT_ID="ca_live_clientid",
             STRIPE_APP_SANDBOX_CLIENT_ID="",
-            STRIPE_APP_SECRET_KEY="sk_test_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
         ):
             with pytest.raises(NotImplementedError, match="sandbox"):
                 OauthIntegration.authorize_url("stripe", token="state_token", is_sandbox=True)
+
+    def test_stripe_authorize_url_raises_when_sandbox_secret_missing(self):
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
+            STRIPE_APP_SANDBOX_SECRET_KEY="",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+        ):
+            with pytest.raises(NotImplementedError, match="sandbox"):
+                OauthIntegration.authorize_url("stripe", token="state_token", is_sandbox=True)
+
+    @patch("posthog.models.integration.requests.post")
+    def test_stripe_token_exchange_falls_back_to_sandbox_on_does_not_belong_error(self, mock_post):
+        # First call (live secret) returns 400 with the marker error - second call should
+        # retry with sandbox config and succeed.
+        first_response = MagicMock(
+            status_code=400,
+            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
+        )
+        first_response.json.return_value = {
+            "error": "invalid_grant",
+            "error_description": "Authorization code provided does not belong to you",
+        }
+        second_response = MagicMock(status_code=200)
+        second_response.json.return_value = {
+            "access_token": "FAKE_SANDBOX_ACCESS",
+            "refresh_token": "FAKE_SANDBOX_REFRESH",
+            "stripe_user_id": "acct_sandbox_123",
+            "account_name": "Sandbox Account",
+            "expires_in": 3600,
+        }
+        mock_post.side_effect = [first_response, second_response]
+
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
+        ):
+            OauthIntegration.integration_from_oauth_response(
+                "stripe",
+                self.team.id,
+                self.user,
+                {"code": "ac_sandbox_code"},
+            )
+
+        assert mock_post.call_count == 2
+        first_call_secret = mock_post.call_args_list[0].kwargs["auth"].username
+        second_call_secret = mock_post.call_args_list[1].kwargs["auth"].username
+        assert first_call_secret == "sk_live_secret"
+        assert second_call_secret == "sk_test_sandbox_secret"
+
+    @patch("posthog.models.integration.requests.post")
+    def test_stripe_token_exchange_does_not_retry_when_sandbox_secret_unset(self, mock_post):
+        first_response = MagicMock(
+            status_code=400,
+            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
+        )
+        first_response.json.return_value = {"error": "invalid_grant"}
+        mock_post.return_value = first_response
+
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="",
+        ):
+            with pytest.raises(Exception, match="Oauth error"):
+                OauthIntegration.integration_from_oauth_response(
+                    "stripe",
+                    self.team.id,
+                    self.user,
+                    {"code": "ac_some_code"},
+                )
+
+        assert mock_post.call_count == 1
 
     @patch("posthog.models.integration.reload_integrations_on_workers")
     @patch("posthog.models.integration.requests.post")

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -709,6 +709,34 @@ class TestOauthIntegrationModel(BaseTest):
 
         assert mock_post.call_count == 1
 
+    @patch("posthog.models.integration.requests.post")
+    def test_stripe_token_exchange_does_not_retry_when_only_sandbox_secret_set(self, mock_post):
+        # If the sandbox secret is set but the sandbox client_id is not, the retry guard
+        # must fail closed - oauth_config_for_kind would otherwise raise NotImplementedError
+        # and mask the original Stripe error.
+        first_response = MagicMock(
+            status_code=400,
+            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
+        )
+        first_response.json.return_value = {"error": "invalid_grant"}
+        mock_post.return_value = first_response
+
+        with self.settings(
+            STRIPE_APP_CLIENT_ID="ca_live_clientid",
+            STRIPE_APP_SANDBOX_CLIENT_ID="",
+            STRIPE_APP_SECRET_KEY="sk_live_secret",
+            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
+        ):
+            with pytest.raises(Exception, match="Oauth error"):
+                OauthIntegration.integration_from_oauth_response(
+                    "stripe",
+                    self.team.id,
+                    self.user,
+                    {"code": "ac_some_code"},
+                )
+
+        assert mock_post.call_count == 1
+
     @patch("posthog.models.integration.reload_integrations_on_workers")
     @patch("posthog.models.integration.requests.post")
     def test_stripe_refresh_access_token_uses_apps_endpoint_and_basic_auth(self, mock_post, mock_reload):

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -73,13 +73,15 @@ ATLASSIAN_APP_CLIENT_SECRET = get_from_env("ATLASSIAN_APP_CLIENT_SECRET", "")
 # - STRIPE_APP_CLIENT_ID: The app's public client ID, used in the OAuth authorize redirect URL
 # - STRIPE_APP_SANDBOX_CLIENT_ID: Separate client ID Stripe issues for sandbox installs of the same app
 # - STRIPE_APP_OVERRIDE_AUTHORIZE_URL: Optional override for testing (e.g., with a channel link URL)
-# - STRIPE_APP_SECRET_KEY: API secret key used for HTTP Basic auth during token exchange/refresh
+# - STRIPE_APP_SECRET_KEY: API secret key used for HTTP Basic auth during live token exchange/refresh
+# - STRIPE_APP_SANDBOX_SECRET_KEY: API secret key used to redeem sandbox-issued OAuth codes (sk_test_*)
 # - STRIPE_POSTHOG_OAUTH_CLIENT_ID: Client ID of the PostHog OAuthApplication for Stripe to authenticate with PostHog APIs
 # - STRIPE_SIGNING_SECRET: Used to verify the authenticity of incoming webhook/agentic provisioning requests from Stripe
 STRIPE_APP_CLIENT_ID = get_from_env("STRIPE_APP_CLIENT_ID", "")
 STRIPE_APP_SANDBOX_CLIENT_ID = get_from_env("STRIPE_APP_SANDBOX_CLIENT_ID", "")
 STRIPE_APP_OVERRIDE_AUTHORIZE_URL = get_from_env("STRIPE_APP_OVERRIDE_AUTHORIZE_URL", "")
 STRIPE_APP_SECRET_KEY = get_from_env("STRIPE_APP_SECRET_KEY", "")
+STRIPE_APP_SANDBOX_SECRET_KEY = get_from_env("STRIPE_APP_SANDBOX_SECRET_KEY", "")
 STRIPE_POSTHOG_OAUTH_CLIENT_ID = get_from_env("STRIPE_POSTHOG_OAUTH_CLIENT_ID", "")
 STRIPE_SIGNING_SECRET = get_from_env("STRIPE_SIGNING_SECRET", "")
 STRIPE_ORCHESTRATOR_CALLBACK_URL = get_from_env("STRIPE_ORCHESTRATOR_CALLBACK_URL", "")


### PR DESCRIPTION
## Problem

PR #56614 added support for the Stripe sandbox `client_id`, but the OAuth token exchange still authenticates with the live secret. Stripe issues separate `client_id` AND `client_secret` pairs for live vs sandbox installs of the same app. Using the live secret to redeem a sandbox-minted code returns:

```
"error":"invalid_grant"
"error_description":"Authorization code provided does not belong to you"
```

This is what users were hitting after installing the app from a Stripe sandbox account: the `/integrations/stripe/confirm-install` flow ran the token exchange with the live secret and Stripe rejected the code.

## Changes

1. **Sandbox secret support** in `oauth_config_for_kind` - when `is_sandbox=True`, return the sandbox `client_secret` (`STRIPE_APP_SANDBOX_SECRET_KEY`) alongside the sandbox `client_id`. Raises `NotImplementedError("Stripe sandbox not configured")` if either is missing.

2. **Fallback retry** in `integration_from_oauth_response` - marketplace-initiated installs (the `/integrations/stripe/confirm-install` flow) come in with no `is_sandbox` signal in the redirect from Stripe, so we can't know upfront which secret to use. When the first token exchange returns 400 with the "does not belong to you" marker, retry once with the sandbox config.

3. New env var `STRIPE_APP_SANDBOX_SECRET_KEY`. In dev this is the same value as `STRIPE_APP_SECRET_KEY` (same Stripe account, test mode). In prod they differ: live is `sk_live_*`, sandbox is `sk_test_*`.

## How did you test this code?

Authored by Claude (Opus 4.7).

- Verified locally via Django shell: `oauth_config_for_kind('stripe', is_sandbox=True)` returns sandbox `client_id` + sandbox `client_secret`; `is_sandbox=False` returns live `client_id` + live `client_secret`.
- Verified the test-mode secret authenticates against Stripe's OAuth endpoint with curl: `curl -u "<sandbox_secret>:" https://api.stripe.com/v1/oauth/token -d "grant_type=refresh_token&refresh_token=fake"` returned `"Refresh token does not exist"` (= secret accepted, refresh_token bogus). Validates the secret pairs with the OAuth endpoint.
- Five new unit tests cover: live by default, sandbox swaps both client_id and secret, raises if sandbox client_id missing, raises if sandbox secret missing, fallback retry on "does not belong to you" succeeds with sandbox config.
- End-to-end roundtrip through Stripe sandbox couldn't run via local dev (Vite mixed-content blocks the React app loading through the ngrok HTTPS proxy). Verification deferred to post-deploy in prod.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by Claude (Opus 4.7, 1M context).
- Follow-up to #56614 which only addressed the client_id half of the sandbox config.
- Assumes the sandbox `client_secret` is the platform's test-mode API secret (`sk_test_*`) of the same Stripe developer account that owns the app. This pairing is consistent with what the dev `.env` already uses.
- The fallback retry only triggers when Stripe returns the specific "does not belong to you" error string. Other failure modes (network errors, code expired, etc.) are not retried.