### PR TITLE
feat(trends): allow multi-breakdown for data warehouse insights

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py
@@ -101,45 +101,43 @@ class TestValidateDataWarehouseBreakdown(BaseTest):
             ["data_warehouse_series_unsupported_breakdown"],
         )
 
-    def test_disallows_multi_breakdowns_for_data_warehouse_series(self) -> None:
-        query = TrendsQuery(
-            series=self._data_warehouse_series(),
-            breakdownFilter=BreakdownFilter(
-                breakdowns=[
-                    Breakdown(property="$browser", type=BreakdownType.EVENT),
-                    Breakdown(property="$geoip_country_code", type=BreakdownType.PERSON),
-                ]
-            ),
-        )
-
-        with self.assertRaises(ValidationError) as context:
-            ValidateDataWarehouseBreakdown().validate(self._context(query))
-
-        self.assertIn(
-            "Multi-breakdowns not supported for trends insights with a data warehouse series.",
-            str(context.exception),
-        )
-        self.assertEqual(
-            context.exception.get_codes(),
-            ["data_warehouse_series_unsupported_breakdown"],
-        )
-
     @parameterized.expand(
         [
             (
-                "data_warehouse_type",
-                Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE),
+                "single_data_warehouse_type",
+                [Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE)],
             ),
             (
-                "hogql_type",
-                Breakdown(property="status", type=MultipleBreakdownType.HOGQL),
+                "single_hogql_type",
+                [Breakdown(property="status", type=MultipleBreakdownType.HOGQL)],
+            ),
+            (
+                "multiple_data_warehouse_types",
+                [
+                    Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE),
+                    Breakdown(property="status", type=MultipleBreakdownType.DATA_WAREHOUSE),
+                ],
+            ),
+            (
+                "multiple_hogql_types",
+                [
+                    Breakdown(property="properties.plan", type=MultipleBreakdownType.HOGQL),
+                    Breakdown(property="properties.status", type=MultipleBreakdownType.HOGQL),
+                ],
+            ),
+            (
+                "multiple_mixed_supported_types",
+                [
+                    Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE),
+                    Breakdown(property="properties.status", type=MultipleBreakdownType.HOGQL),
+                ],
             ),
         ]
     )
-    def test_allows_supported_single_item_multi_breakdown(self, _name: str, breakdown: Breakdown) -> None:
+    def test_allows_supported_multi_breakdowns(self, _name: str, breakdowns: list[Breakdown]) -> None:
         query = TrendsQuery(
             series=self._data_warehouse_series(),
-            breakdownFilter=BreakdownFilter(breakdowns=[breakdown]),
+            breakdownFilter=BreakdownFilter(breakdowns=breakdowns),
         )
 
         ValidateDataWarehouseBreakdown().validate(self._context(query))
@@ -147,27 +145,41 @@ class TestValidateDataWarehouseBreakdown(BaseTest):
     @parameterized.expand(
         [
             (
-                "default_event_type",
-                Breakdown(property="$browser"),
+                "single_default_event_type",
+                [Breakdown(property="$browser")],
             ),
             (
-                "explicit_event_type",
-                Breakdown(property="$browser", type=MultipleBreakdownType.EVENT),
+                "single_explicit_event_type",
+                [Breakdown(property="$browser", type=MultipleBreakdownType.EVENT)],
             ),
             (
-                "person_type",
-                Breakdown(property="$geoip_country_code", type=MultipleBreakdownType.PERSON),
+                "single_person_type",
+                [Breakdown(property="$geoip_country_code", type=MultipleBreakdownType.PERSON)],
             ),
             (
-                "data_warehouse_person_property_type",
-                Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE_PERSON_PROPERTY),
+                "single_data_warehouse_person_property_type",
+                [Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE_PERSON_PROPERTY)],
+            ),
+            (
+                "multiple_with_unsupported_second_item",
+                [
+                    Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE),
+                    Breakdown(property="$browser", type=MultipleBreakdownType.EVENT),
+                ],
+            ),
+            (
+                "multiple_with_unsupported_first_item",
+                [
+                    Breakdown(property="$browser", type=MultipleBreakdownType.EVENT),
+                    Breakdown(property="plan", type=MultipleBreakdownType.DATA_WAREHOUSE),
+                ],
             ),
         ]
     )
-    def test_disallows_unsupported_single_item_multi_breakdown(self, _name: str, breakdown: Breakdown) -> None:
+    def test_disallows_unsupported_multi_breakdown_items(self, _name: str, breakdowns: list[Breakdown]) -> None:
         query = TrendsQuery(
             series=self._data_warehouse_series(),
-            breakdownFilter=BreakdownFilter(breakdowns=[breakdown]),
+            breakdownFilter=BreakdownFilter(breakdowns=breakdowns),
         )
 
         with self.assertRaises(ValidationError) as context:

--- a/posthog/hogql_queries/insights/trends/trend_validation_rules.py
+++ b/posthog/hogql_queries/insights/trends/trend_validation_rules.py
@@ -35,13 +35,7 @@ class ValidateDataWarehouseBreakdown:
 
         if has_multi_breakdown(breakdown_filter):
             assert breakdown_filter.breakdowns is not None  # type checking
-            if len(breakdown_filter.breakdowns) > 1:
-                raise ValidationError(
-                    f"Multi-breakdowns not supported for {insight_name} with a data warehouse series.",
-                    code=self.code,
-                )
-
-            if breakdown_filter.breakdowns[0].type not in supported_multi_types:
+            if any(breakdown.type not in supported_multi_types for breakdown in breakdown_filter.breakdowns):
                 raise ValidationError(
                     f"Event based breakdowns are not supported for {insight_name} with a data warehouse series.",
                     code=self.code,


### PR DESCRIPTION
### Motivation

- Previously multi-property breakdowns were entirely disallowed for trends insights with a `DataWarehouseNode` series, but `hogql` and data-warehouse breakdown types are safe to use together with a data warehouse series.

### Description

- Update `ValidateDataWarehouseBreakdown.validate` to allow multi-breakdowns when every breakdown's `type` is one of `MultipleBreakdownType.DATA_WAREHOUSE` or `MultipleBreakdownType.HOGQL`, instead of rejecting any multi-breakdown unconditionally.
- Keep single-breakdown restrictions by validating `breakdownFilter.breakdown_type` against supported single types `{BreakdownType.DATA_WAREHOUSE, BreakdownType.HOGQL}`.
- Adjust validation error messages to reflect that event-based breakdowns are not supported with data warehouse series and to validate per-item types in multi-breakdowns.
- Update tests in `posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py` to use lists of `Breakdown` for multi-breakdown scenarios, add cases for multiple supported types and mixed unsupported items, and rename tests to match the new behavior.

### Testing

- Ran unit tests for the trends validation rules with `pytest posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f108dc78848332b3346517baf512b7)