### PR TITLE
feat(endpoints): show materialization runs modal in configuration tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -1,33 +1,19 @@
 import { useActions, useValues } from 'kea'
 
-import { IconRefresh, IconRevert, IconTarget, IconX } from '@posthog/icons'
-import { LemonDialog, LemonTable, Link, Spinner } from '@posthog/lemon-ui'
+import { IconTarget } from '@posthog/icons'
+import { LemonTable, Link, Spinner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { dayjsUtcToTimezone } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
-import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
-import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { humanFriendlyDetailedTime, humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
+import { humanFriendlyDetailedTime } from 'lib/utils'
 import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
-import { LogsViewer } from 'scenes/hog-functions/logs/LogsViewer'
-import { teamLogic } from 'scenes/teamLogic'
-import { userLogic } from 'scenes/userLogic'
+import { MaterializationStatusPanel } from 'scenes/data-warehouse/saved_queries/MaterializationStatusPanel'
 
-import {
-    DataModelingJob,
-    DataWarehouseSavedQuery,
-    DataModelingSyncInterval,
-    LineageNode,
-    LogEntryLevel,
-    OrNever,
-} from '~/types'
-
-const LOG_LEVELS: LogEntryLevel[] = ['LOG', 'INFO', 'WARN', 'WARNING', 'ERROR']
+import { DataWarehouseSavedQuery, LineageNode } from '~/types'
 
 import { UpstreamGraph } from '../sidebar/graph/UpstreamGraph'
 import { sqlEditorLogic } from '../sqlEditorLogic'
@@ -38,127 +24,18 @@ interface QueryInfoProps {
     view?: DataWarehouseSavedQuery | null
 }
 
-function getMaterializationStatusMessage(
-    rowsMaterialized: number,
-    progressPercentage: number,
-    rowsExpected: number
-): string {
-    const percentComplete = Math.round(Math.min(100, (rowsMaterialized / rowsExpected) * 100))
-    switch (true) {
-        case rowsMaterialized === 0:
-            return `Spinning up spikes — starting materialization job... ${percentComplete}% complete.`
-        case progressPercentage < 10:
-            return `Digging into SQL... executing your query now... ${percentComplete}% complete.`
-        case progressPercentage < 25:
-            return `First ${humanFriendlyNumber(rowsMaterialized)} rows tucked away... ${percentComplete}% complete.`
-        case progressPercentage < 50:
-            return `${humanFriendlyNumber(rowsMaterialized)} rows shipped to storage... ${percentComplete}% complete.`
-        case progressPercentage < 90:
-            return `Still going — ${humanFriendlyNumber(
-                rowsMaterialized
-            )} rows written... ${percentComplete}% complete.`
-        case progressPercentage === 100:
-            return `Wrapping up — ${humanFriendlyNumber(
-                rowsMaterialized
-            )} rows processed... ${percentComplete}% complete.`
-        default:
-            return `Almost there — ${humanFriendlyNumber(
-                rowsMaterialized
-            )} rows processed... ${percentComplete}% complete.`
-    }
-}
-
-const OPTIONS = [
-    {
-        value: 'never' as OrNever,
-        label: ' No resync',
-    },
-    {
-        value: '15min' as DataModelingSyncInterval,
-        label: ' Resync every 15 mins',
-    },
-    {
-        value: '30min' as DataModelingSyncInterval,
-        label: ' Resync every 30 mins',
-    },
-    {
-        value: '1hour' as DataModelingSyncInterval,
-        label: ' Resync every 1 hour',
-    },
-    {
-        value: '6hour' as DataModelingSyncInterval,
-        label: ' Resync every 6 hours',
-    },
-    {
-        value: '12hour' as DataModelingSyncInterval,
-        label: ' Resync every 12 hours',
-    },
-    {
-        value: '24hour' as DataModelingSyncInterval,
-        label: ' Resync Daily',
-    },
-    {
-        value: '7day' as DataModelingSyncInterval,
-        label: ' Resync Weekly',
-    },
-    {
-        value: '30day' as DataModelingSyncInterval,
-        label: ' Resync Monthly',
-    },
-]
-
-function getMaterializationDisabledReasons(
-    currentJobStatus: string | null,
-    startingMaterialization: boolean
-): {
-    sync: string | false
-    cancel: string | false
-    revert: string | false
-} {
-    return {
-        sync:
-            currentJobStatus === 'Running'
-                ? 'Materialization is already running'
-                : startingMaterialization
-                  ? 'Materialization is starting'
-                  : false,
-        cancel: currentJobStatus !== 'Running' ? 'Materialization is not running' : false,
-        revert: currentJobStatus === 'Running' ? 'Cannot revert while materialization is running' : false,
-    }
-}
-
 export function QueryInfo({ tabId, view }: QueryInfoProps): JSX.Element {
     const { editingView, upstream, upstreamViewMode } = useValues(sqlEditorLogic)
     const targetView = view ?? editingView
     const infoLogic = infoTabLogic({ tabId, viewId: targetView?.id })
     const { sourceTableItems } = useValues(infoLogic)
-    const { runDataWarehouseSavedQuery, saveAsView, setUpstreamViewMode } = useActions(sqlEditorLogic)
+    const { saveAsView, setUpstreamViewMode } = useActions(sqlEditorLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { timezone } = useValues(teamLogic)
-    const { user } = useValues(userLogic)
-    const showDebugLogs = user?.is_staff || user?.is_impersonated
 
     const isLineageDependencyViewEnabled = featureFlags[FEATURE_FLAGS.LINEAGE_DEPENDENCY_VIEW]
-    const isDagSchedulesOnly = !!featureFlags[FEATURE_FLAGS.DATA_MODELING_BACKEND_V2]
 
-    const { dataModelingJobs, dataModelingJobsLoading, hasMoreJobsToLoad, startingMaterialization } =
-        useValues(infoLogic)
-    const { loadDataModelingJobs, loadOlderDataModelingJobs, setStartingMaterialization } = useActions(infoLogic)
-
-    const { dataWarehouseSavedQueryMapById, updatingDataWarehouseSavedQuery, initialDataWarehouseSavedQueryLoading } =
+    const { updatingDataWarehouseSavedQuery, initialDataWarehouseSavedQueryLoading } =
         useValues(dataWarehouseViewsLogic)
-    const {
-        updateDataWarehouseSavedQuery,
-        cancelDataWarehouseSavedQuery,
-        materializeDataWarehouseSavedQuery,
-        revertMaterialization,
-    } = useActions(dataWarehouseViewsLogic)
-
-    // note: targetView is stale, but dataWarehouseSavedQueryMapById gets updated
-    const savedQuery = targetView ? dataWarehouseSavedQueryMapById[targetView.id] : null
-
-    const currentJobStatus = dataModelingJobs?.results?.[0]?.status || null
-    const { sync, cancel, revert } = getMaterializationDisabledReasons(currentJobStatus, startingMaterialization)
 
     if (initialDataWarehouseSavedQueryLoading) {
         return (
@@ -171,287 +48,36 @@ export function QueryInfo({ tabId, view }: QueryInfoProps): JSX.Element {
     return (
         <div className="overflow-auto" data-attr="sql-editor-sidebar-query-info-pane">
             <div className="flex flex-col flex-1 gap-4">
-                <div>
-                    <div className="flex flex-row items-center gap-2">
-                        <h3 className="mb-0">Materialization</h3>
-                        <LemonTag type="warning">BETA</LemonTag>
-                        {savedQuery?.latest_error && savedQuery.status === 'Failed' && (
-                            <Tooltip title={savedQuery.latest_error} interactive>
-                                <LemonTag type="danger">Error</LemonTag>
-                            </Tooltip>
-                        )}
-                    </div>
+                {targetView ? (
+                    <MaterializationStatusPanel viewId={targetView.id} />
+                ) : (
                     <div>
-                        {savedQuery?.is_materialized ? (
-                            <div>
-                                {savedQuery?.last_run_at ? (
-                                    `Last run at ${humanFriendlyDetailedTime(savedQuery?.last_run_at)}`
-                                ) : (
-                                    <div>
-                                        <span>Materialization scheduled</span>
-                                    </div>
-                                )}
-                                <div className="flex gap-4 mt-2">
-                                    <LemonButton
-                                        className="whitespace-nowrap"
-                                        loading={startingMaterialization || currentJobStatus === 'Running'}
-                                        disabledReason={sync}
-                                        onClick={() => {
-                                            if (targetView) {
-                                                setStartingMaterialization(true)
-                                                runDataWarehouseSavedQuery(targetView.id)
-                                            }
-                                        }}
-                                        type="secondary"
-                                        sideAction={{
-                                            icon: <IconX fontSize={16} />,
-                                            tooltip: 'Cancel materialization',
-                                            onClick: () => targetView && cancelDataWarehouseSavedQuery(targetView.id),
-                                            disabledReason: cancel,
-                                        }}
-                                    >
-                                        {startingMaterialization
-                                            ? 'Starting...'
-                                            : currentJobStatus === 'Running'
-                                              ? 'Running...'
-                                              : 'Sync now'}
-                                    </LemonButton>
-                                    {!isDagSchedulesOnly && (
-                                        <LemonSelect
-                                            className="h-9"
-                                            disabledReason={sync}
-                                            value={
-                                                targetView
-                                                    ? dataWarehouseSavedQueryMapById[targetView.id]?.sync_frequency ||
-                                                      'never'
-                                                    : 'never'
-                                            }
-                                            onChange={(newValue) => {
-                                                if (targetView && newValue) {
-                                                    updateDataWarehouseSavedQuery({
-                                                        id: targetView.id,
-                                                        sync_frequency: newValue,
-                                                        types: [[]],
-                                                        lifecycle: 'update',
-                                                    })
-                                                }
-                                            }}
-                                            loading={updatingDataWarehouseSavedQuery}
-                                            options={OPTIONS}
-                                        />
-                                    )}
-                                    {targetView && (
-                                        <LemonButton
-                                            type="secondary"
-                                            size="small"
-                                            tooltip="Revert materialized view to view"
-                                            disabledReason={revert}
-                                            icon={<IconRevert />}
-                                            onClick={() => {
-                                                LemonDialog.open({
-                                                    title: 'Revert materialization',
-                                                    maxWidth: '30rem',
-                                                    description:
-                                                        'Are you sure you want to revert this materialized view to a regular view? This will stop all future materializations and remove the materialized table. You will always be able to go back to a materialized view at any time.',
-                                                    primaryButton: {
-                                                        status: 'danger',
-                                                        children: 'Revert materialization',
-                                                        onClick: () => revertMaterialization(targetView.id),
-                                                    },
-                                                    secondaryButton: {
-                                                        children: 'Cancel',
-                                                    },
-                                                })
-                                            }}
-                                        />
-                                    )}
-                                </div>
-                            </div>
-                        ) : (
-                            <div>
-                                <p className="text-xs">
-                                    Materialized views are a way to pre-compute data in your data warehouse. This allows
-                                    you to run queries faster and more efficiently.
-                                    <br />
-                                    <Link
-                                        data-attr="materializing-help"
-                                        to="https://posthog.com/docs/data-warehouse/views#materializing-and-scheduling-a-view"
-                                        target="_blank"
-                                    >
-                                        Learn more about materialization
-                                    </Link>
-                                    .
-                                </p>
-                                <LemonButton
-                                    size="small"
-                                    onClick={() => {
-                                        if (targetView) {
-                                            materializeDataWarehouseSavedQuery(targetView.id)
-                                        } else {
-                                            saveAsView({ materializeAfterSave: true })
-                                        }
-                                    }}
-                                    type="primary"
-                                    loading={updatingDataWarehouseSavedQuery}
-                                >
-                                    {targetView ? 'Materialize' : 'Save and materialize'}
-                                </LemonButton>
-                            </div>
-                        )}
-                    </div>
-                </div>
-                {savedQuery && (
-                    <>
-                        <div className="flex items-start justify-between">
-                            <div>
-                                <h3>Materialization Runs</h3>
-                                <p className="text-xs">
-                                    The last runs for this materialized view. These can be scheduled or run on demand.
-                                </p>
-                            </div>
-                            <LemonButton
-                                icon={<IconRefresh />}
-                                size="small"
-                                type="secondary"
-                                onClick={() => loadDataModelingJobs(savedQuery.id)}
-                                loading={dataModelingJobsLoading}
-                                disabledReason={startingMaterialization ? 'Materialization is starting' : undefined}
-                                tooltip="Refresh runs"
-                            />
+                        <div className="flex flex-row items-center gap-2">
+                            <h3 className="mb-0">Materialization</h3>
+                            <LemonTag type="warning">BETA</LemonTag>
                         </div>
-                        <LemonTable
+                        <p className="text-xs">
+                            Materialized views are a way to pre-compute data in your data warehouse. This allows you to
+                            run queries faster and more efficiently.
+                            <br />
+                            <Link
+                                data-attr="materializing-help"
+                                to="https://posthog.com/docs/data-warehouse/views#materializing-and-scheduling-a-view"
+                                target="_blank"
+                            >
+                                Learn more about materialization
+                            </Link>
+                            .
+                        </p>
+                        <LemonButton
                             size="small"
-                            loading={dataModelingJobsLoading && !dataModelingJobs?.results?.length}
-                            dataSource={dataModelingJobs?.results || []}
-                            columns={[
-                                {
-                                    title: 'Status',
-                                    dataIndex: 'status',
-                                    render: (_, job: DataModelingJob) => {
-                                        const { status, error, rows_materialized, rows_expected } = job
-                                        const statusToType: Record<string, LemonTagType> = {
-                                            Completed: 'success',
-                                            Failed: 'danger',
-                                            Running: 'warning',
-                                        }
-                                        const type = statusToType[status] || 'warning'
-
-                                        const progressPercentage =
-                                            rows_expected && rows_expected > 0
-                                                ? Math.min(100, (rows_materialized / rows_expected) * 100)
-                                                : 0
-
-                                        // Only show progress if there is > 0 progress and we have expected rows
-                                        // many small result sets will never show progress as they are written in only 1 batch
-                                        if (status === 'Running' && progressPercentage > 0 && rows_expected !== null) {
-                                            return (
-                                                <Tooltip
-                                                    placement="right"
-                                                    title={getMaterializationStatusMessage(
-                                                        rows_materialized,
-                                                        progressPercentage,
-                                                        rows_expected
-                                                    )}
-                                                >
-                                                    <div className="w-[68px]">
-                                                        <LemonProgress percent={progressPercentage} />
-                                                    </div>
-                                                </Tooltip>
-                                            )
-                                        }
-
-                                        return error && status !== 'Completed' ? (
-                                            <Tooltip title={error} interactive>
-                                                <LemonTag type={type}>{status}</LemonTag>
-                                            </Tooltip>
-                                        ) : (
-                                            <LemonTag type={type}>{status}</LemonTag>
-                                        )
-                                    },
-                                },
-                                {
-                                    title: 'Rows',
-                                    dataIndex: 'rows_materialized',
-                                    render: (_, { rows_materialized, status }: DataModelingJob) =>
-                                        (status === 'Running' || status === 'Cancelled') && rows_materialized === 0
-                                            ? '~'
-                                            : humanFriendlyNumber(rows_materialized),
-                                },
-                                {
-                                    title: 'Updated',
-                                    dataIndex: 'last_run_at',
-                                    render: (_, { last_run_at }: DataModelingJob) =>
-                                        humanFriendlyDetailedTime(last_run_at),
-                                },
-                                {
-                                    title: 'Duration',
-                                    render: (_, job: DataModelingJob) => {
-                                        if (job.status === 'Running') {
-                                            return 'In progress'
-                                        }
-                                        // Convert date strings to timestamps before subtraction
-                                        const start = new Date(job.created_at).getTime()
-                                        const end = new Date(job.last_run_at).getTime()
-
-                                        if (start > end) {
-                                            return 'N/A'
-                                        }
-
-                                        return humanFriendlyDuration((end - start) / 1000)
-                                    },
-                                },
-                            ]}
-                            expandable={
-                                dataModelingJobs?.results?.length && savedQuery
-                                    ? {
-                                          expandedRowRender: (job: DataModelingJob) => (
-                                              <div className="p-4">
-                                                  <LogsViewer
-                                                      logicKey={`data_modeling_run:${job.id}`}
-                                                      sourceType="data_modeling_run"
-                                                      sourceId={savedQuery.id}
-                                                      groupByInstanceId={false}
-                                                      hideDateFilter
-                                                      hideLevelsFilter
-                                                      hideInstanceIdColumn
-                                                      defaultFilters={{
-                                                          instanceId: job.workflow_run_id,
-                                                          dateFrom: dayjsUtcToTimezone(job.created_at, timezone).format(
-                                                              'YYYY-MM-DD HH:mm:ss'
-                                                          ),
-                                                          dateTo: job.last_run_at
-                                                              ? dayjsUtcToTimezone(job.last_run_at, timezone)
-                                                                    .add(1, 'hour')
-                                                                    .format('YYYY-MM-DD HH:mm:ss')
-                                                              : undefined,
-                                                          levels: showDebugLogs ? ['DEBUG', ...LOG_LEVELS] : LOG_LEVELS,
-                                                      }}
-                                                  />
-                                              </div>
-                                          ),
-                                          rowExpandable: () => true,
-                                          noIndent: true,
-                                      }
-                                    : undefined
-                            }
-                            nouns={['run', 'runs']}
-                            emptyState="No runs available"
-                            footer={
-                                hasMoreJobsToLoad && (
-                                    <div className="flex items-center m-2">
-                                        <LemonButton
-                                            center
-                                            fullWidth
-                                            onClick={() => loadOlderDataModelingJobs()}
-                                            loading={dataModelingJobsLoading}
-                                        >
-                                            Load older runs
-                                        </LemonButton>
-                                    </div>
-                                )
-                            }
-                        />
-                    </>
+                            onClick={() => saveAsView({ materializeAfterSave: true })}
+                            type="primary"
+                            loading={updatingDataWarehouseSavedQuery}
+                        >
+                            Save and materialize
+                        </LemonButton>
+                    </div>
                 )}
                 {!isLineageDependencyViewEnabled && (
                     <>

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
@@ -1,18 +1,11 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
-import { loaders } from 'kea-loaders'
-import { subscriptions } from 'kea-subscriptions'
+import { connect, kea, key, listeners, path, props, selectors } from 'kea'
 
-import api, { PaginatedResponse } from 'lib/api'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
-
-import { DataModelingJob } from '~/types'
+import { materializationJobsLogic } from 'scenes/data-warehouse/saved_queries/materializationJobsLogic'
 
 import { sqlEditorLogic } from '../sqlEditorLogic'
 import type { infoTabLogicType } from './infoTabLogicType'
-
-const REFRESH_INTERVAL = 10000
-const DEFAULT_JOBS_PAGE_SIZE = 10
 
 export interface InfoTableRow {
     name: string
@@ -34,66 +27,15 @@ export const infoTabLogic = kea<infoTabLogicType>([
     connect((props: InfoTabLogicProps) => ({
         values: [
             sqlEditorLogic({ tabId: props.tabId }),
-            ['metadata', 'editingView'],
+            ['metadata'],
             databaseTableListLogic,
             ['posthogTablesMap', 'dataWarehouseTablesMap'],
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueryMap'],
         ],
         actions: [sqlEditorLogic({ tabId: props.tabId }), ['loadUpstream']],
+        logic: props.viewId ? [materializationJobsLogic({ viewId: props.viewId })] : [],
     })),
-    actions({
-        setStartingMaterialization: (starting: boolean) => ({ starting }),
-    }),
-    loaders(({ values }) => ({
-        dataModelingJobs: [
-            null as PaginatedResponse<DataModelingJob> | null,
-            {
-                loadDataModelingJobs: async (savedQueryId: string) => {
-                    return await api.dataWarehouseSavedQueries.dataWarehouseDataModelingJobs.list(
-                        savedQueryId,
-                        values.dataModelingJobs?.results.length
-                            ? Math.max(values.dataModelingJobs.results.length, DEFAULT_JOBS_PAGE_SIZE)
-                            : DEFAULT_JOBS_PAGE_SIZE,
-                        0
-                    )
-                },
-                loadOlderDataModelingJobs: async () => {
-                    const nextUrl = values.dataModelingJobs?.next
-
-                    if (!nextUrl) {
-                        return values.dataModelingJobs
-                    }
-
-                    const res = await api.get<PaginatedResponse<DataModelingJob>>(nextUrl)
-                    res.results = [...(values.dataModelingJobs?.results ?? []), ...res.results]
-
-                    return res
-                },
-            },
-        ],
-    })),
-    reducers({
-        startingMaterialization: [
-            false,
-            {
-                setStartingMaterialization: (_, { starting }: { starting: boolean }) => starting,
-                loadDataModelingJobsSuccess: (
-                    state: boolean,
-                    { dataModelingJobs }: { dataModelingJobs: PaginatedResponse<DataModelingJob> | null }
-                ) => {
-                    const currentJobStatus = dataModelingJobs?.results?.[0]?.status
-                    if (
-                        currentJobStatus &&
-                        ['Running', 'Completed', 'Failed', 'Cancelled'].includes(currentJobStatus)
-                    ) {
-                        return false
-                    }
-                    return state
-                },
-            },
-        ],
-    }),
     selectors({
         sourceTableItems: [
             (s) => [s.metadata, s.dataWarehouseSavedQueryMap],
@@ -124,33 +66,18 @@ export const infoTabLogic = kea<infoTabLogicType>([
                 )
             },
         ],
-        hasMoreJobsToLoad: [(s) => [s.dataModelingJobs], (dataModelingJobs) => !!dataModelingJobs?.next],
     }),
-    afterMount(({ actions, props }) => {
-        if (props.viewId) {
-            actions.loadDataModelingJobs(props.viewId)
+    listeners(({ actions, props }) => {
+        if (!props.viewId) {
+            return {}
+        }
+        const jobsLogic = materializationJobsLogic({ viewId: props.viewId })
+        return {
+            [jobsLogic.actionTypes.loadDataModelingJobsSuccess]: () => {
+                if (props.viewId) {
+                    actions.loadUpstream(props.viewId)
+                }
+            },
         }
     }),
-    propsChanged(({ actions, props }, oldProps) => {
-        if (props.viewId && props.viewId !== oldProps.viewId) {
-            actions.loadDataModelingJobs(props.viewId)
-        }
-    }),
-    listeners(({ actions, cache }) => ({
-        loadDataModelingJobsSuccess: ({ payload }) => {
-            if (payload) {
-                actions.loadUpstream(payload)
-            }
-
-            cache.disposables.add(() => {
-                const timeoutId = setTimeout(() => {
-                    if (payload) {
-                        actions.loadDataModelingJobs(payload)
-                    }
-                }, REFRESH_INTERVAL)
-                return () => clearTimeout(timeoutId)
-            }, 'dataModelingJobsRefreshTimeout')
-        },
-    })),
-    subscriptions(() => ({})),
 ])

--- a/frontend/src/scenes/data-warehouse/saved_queries/MaterializationStatusModal.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/MaterializationStatusModal.tsx
@@ -1,0 +1,39 @@
+import { LemonModal, Spinner } from '@posthog/lemon-ui'
+
+import { MaterializationStatusPanel } from './MaterializationStatusPanel'
+
+type MaterializationStatusModalKind = 'view' | 'endpoint'
+
+interface MaterializationStatusModalProps {
+    isOpen: boolean
+    onClose: () => void
+    viewId: string | null
+    viewName?: string
+    kind?: MaterializationStatusModalKind
+}
+
+function buildTitle(kind: MaterializationStatusModalKind, viewName: string | undefined): string {
+    return viewName ? `Materialize ${kind} ${viewName}` : `Materialize ${kind}`
+}
+
+export function MaterializationStatusModal({
+    isOpen,
+    onClose,
+    viewId,
+    viewName,
+    kind = 'view',
+}: MaterializationStatusModalProps): JSX.Element {
+    return (
+        <LemonModal title={buildTitle(kind, viewName)} isOpen={isOpen} onClose={onClose} width={960}>
+            <div className="max-h-[75vh] overflow-auto">
+                {viewId ? (
+                    <MaterializationStatusPanel viewId={viewId} kind={kind} />
+                ) : (
+                    <div className="flex min-h-64 items-center justify-center">
+                        <Spinner className="text-2xl" />
+                    </div>
+                )}
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/data-warehouse/saved_queries/MaterializationStatusPanel.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/MaterializationStatusPanel.tsx
@@ -1,0 +1,430 @@
+import { useActions, useValues } from 'kea'
+
+import { IconRefresh, IconRevert, IconX } from '@posthog/icons'
+import { LemonDialog, LemonTable, Link, Spinner } from '@posthog/lemon-ui'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjsUtcToTimezone } from 'lib/dayjs'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { humanFriendlyDetailedTime, humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
+import { LogsViewer } from 'scenes/hog-functions/logs/LogsViewer'
+import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { DataModelingJob, DataModelingSyncInterval, LogEntryLevel, OrNever } from '~/types'
+
+import { dataWarehouseViewsLogic } from './dataWarehouseViewsLogic'
+import { materializationJobsLogic } from './materializationJobsLogic'
+
+const LOG_LEVELS: LogEntryLevel[] = ['LOG', 'INFO', 'WARN', 'WARNING', 'ERROR']
+
+interface MaterializationStatusPanelProps {
+    viewId: string
+    /**
+     * The product surface this panel is rendered in. Endpoints own the materialization lifecycle of their
+     * backing saved query, so destructive saved-query controls (revert, sync frequency) must be hidden
+     * when `kind === 'endpoint'` — those mutations bypass the endpoint's `_disable_materialization` flow.
+     */
+    kind?: 'view' | 'endpoint'
+}
+
+const SYNC_FREQUENCY_OPTIONS = [
+    {
+        value: 'never' as OrNever,
+        label: ' No resync',
+    },
+    {
+        value: '15min' as DataModelingSyncInterval,
+        label: ' Resync every 15 mins',
+    },
+    {
+        value: '30min' as DataModelingSyncInterval,
+        label: ' Resync every 30 mins',
+    },
+    {
+        value: '1hour' as DataModelingSyncInterval,
+        label: ' Resync every 1 hour',
+    },
+    {
+        value: '6hour' as DataModelingSyncInterval,
+        label: ' Resync every 6 hours',
+    },
+    {
+        value: '12hour' as DataModelingSyncInterval,
+        label: ' Resync every 12 hours',
+    },
+    {
+        value: '24hour' as DataModelingSyncInterval,
+        label: ' Resync Daily',
+    },
+    {
+        value: '7day' as DataModelingSyncInterval,
+        label: ' Resync Weekly',
+    },
+    {
+        value: '30day' as DataModelingSyncInterval,
+        label: ' Resync Monthly',
+    },
+]
+
+function getMaterializationStatusMessage(
+    rowsMaterialized: number,
+    progressPercentage: number,
+    rowsExpected: number
+): string {
+    const percentComplete = Math.round(Math.min(100, (rowsMaterialized / rowsExpected) * 100))
+    switch (true) {
+        case rowsMaterialized === 0:
+            return `Spinning up spikes — starting materialization job... ${percentComplete}% complete.`
+        case progressPercentage < 10:
+            return `Digging into SQL... executing your query now... ${percentComplete}% complete.`
+        case progressPercentage < 25:
+            return `First ${humanFriendlyNumber(rowsMaterialized)} rows tucked away... ${percentComplete}% complete.`
+        case progressPercentage < 50:
+            return `${humanFriendlyNumber(rowsMaterialized)} rows shipped to storage... ${percentComplete}% complete.`
+        case progressPercentage < 90:
+            return `Still going — ${humanFriendlyNumber(
+                rowsMaterialized
+            )} rows written... ${percentComplete}% complete.`
+        case progressPercentage === 100:
+            return `Wrapping up — ${humanFriendlyNumber(
+                rowsMaterialized
+            )} rows processed... ${percentComplete}% complete.`
+        default:
+            return `Almost there — ${humanFriendlyNumber(
+                rowsMaterialized
+            )} rows processed... ${percentComplete}% complete.`
+    }
+}
+
+function getMaterializationDisabledReasons(
+    currentJobStatus: string | null,
+    startingMaterialization: boolean
+): {
+    sync: string | false
+    cancel: string | false
+    revert: string | false
+} {
+    return {
+        sync:
+            currentJobStatus === 'Running'
+                ? 'Materialization is already running'
+                : startingMaterialization
+                  ? 'Materialization is starting'
+                  : false,
+        cancel: currentJobStatus !== 'Running' ? 'Materialization is not running' : false,
+        revert: currentJobStatus === 'Running' ? 'Cannot revert while materialization is running' : false,
+    }
+}
+
+export function MaterializationStatusPanel({ viewId, kind = 'view' }: MaterializationStatusPanelProps): JSX.Element {
+    const jobsLogic = materializationJobsLogic({ viewId })
+    const {
+        dataModelingJobs,
+        dataModelingJobsLoading,
+        hasMoreJobsToLoad,
+        startingMaterialization,
+        savedQuery,
+        savedQueryLoading,
+    } = useValues(jobsLogic)
+    const { loadDataModelingJobs, loadOlderDataModelingJobs, setStartingMaterialization } = useActions(jobsLogic)
+
+    const { updatingDataWarehouseSavedQuery } = useValues(dataWarehouseViewsLogic)
+    const {
+        updateDataWarehouseSavedQuery,
+        runDataWarehouseSavedQuery,
+        cancelDataWarehouseSavedQuery,
+        materializeDataWarehouseSavedQuery,
+        revertMaterialization,
+    } = useActions(dataWarehouseViewsLogic)
+
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { timezone } = useValues(teamLogic)
+    const { user } = useValues(userLogic)
+    const showDebugLogs = user?.is_staff || user?.is_impersonated
+    const isDagSchedulesOnly = !!featureFlags[FEATURE_FLAGS.DATA_MODELING_BACKEND_V2]
+
+    if (!savedQuery) {
+        return (
+            <div className="flex min-h-64 items-center justify-center" data-attr="materialization-status-panel">
+                {savedQueryLoading ? <Spinner className="text-2xl" /> : null}
+            </div>
+        )
+    }
+
+    const currentJobStatus = dataModelingJobs?.results?.[0]?.status || null
+    const { sync, cancel, revert } = getMaterializationDisabledReasons(currentJobStatus, startingMaterialization)
+
+    return (
+        <div className="overflow-auto" data-attr="materialization-status-panel">
+            <div className="flex flex-col flex-1 gap-4">
+                <div>
+                    <div className="flex flex-row items-center gap-2">
+                        <h3 className="mb-0">Materialization</h3>
+                        <LemonTag type="warning">BETA</LemonTag>
+                        {savedQuery?.latest_error && savedQuery.status === 'Failed' && (
+                            <Tooltip title={savedQuery.latest_error} interactive>
+                                <LemonTag type="danger">Error</LemonTag>
+                            </Tooltip>
+                        )}
+                    </div>
+                    <div>
+                        {savedQuery?.is_materialized ? (
+                            <div>
+                                {savedQuery?.last_run_at ? (
+                                    `Last run at ${humanFriendlyDetailedTime(savedQuery?.last_run_at)}`
+                                ) : (
+                                    <div>
+                                        <span>Materialization scheduled</span>
+                                    </div>
+                                )}
+                                <div className="flex gap-4 mt-2">
+                                    <LemonButton
+                                        className="whitespace-nowrap"
+                                        loading={startingMaterialization || currentJobStatus === 'Running'}
+                                        disabledReason={sync}
+                                        onClick={() => {
+                                            setStartingMaterialization(true)
+                                            runDataWarehouseSavedQuery(viewId)
+                                        }}
+                                        type="secondary"
+                                        sideAction={{
+                                            icon: <IconX fontSize={16} />,
+                                            tooltip: 'Cancel materialization',
+                                            onClick: () => cancelDataWarehouseSavedQuery(viewId),
+                                            disabledReason: cancel,
+                                        }}
+                                    >
+                                        {startingMaterialization
+                                            ? 'Starting...'
+                                            : currentJobStatus === 'Running'
+                                              ? 'Running...'
+                                              : 'Sync now'}
+                                    </LemonButton>
+                                    {kind !== 'endpoint' && !isDagSchedulesOnly && (
+                                        <LemonSelect
+                                            className="h-9"
+                                            disabledReason={sync}
+                                            value={savedQuery.sync_frequency || 'never'}
+                                            onChange={(newValue) => {
+                                                if (newValue) {
+                                                    updateDataWarehouseSavedQuery({
+                                                        id: viewId,
+                                                        sync_frequency: newValue,
+                                                        types: [[]],
+                                                        lifecycle: 'update',
+                                                    })
+                                                }
+                                            }}
+                                            loading={updatingDataWarehouseSavedQuery}
+                                            options={SYNC_FREQUENCY_OPTIONS}
+                                        />
+                                    )}
+                                    {kind !== 'endpoint' && (
+                                        <LemonButton
+                                            type="secondary"
+                                            size="small"
+                                            tooltip="Revert materialized view to view"
+                                            disabledReason={revert}
+                                            icon={<IconRevert />}
+                                            onClick={() => {
+                                                LemonDialog.open({
+                                                    title: 'Revert materialization',
+                                                    maxWidth: '30rem',
+                                                    description:
+                                                        'Are you sure you want to revert this materialized view to a regular view? This will stop all future materializations and remove the materialized table. You will always be able to go back to a materialized view at any time.',
+                                                    primaryButton: {
+                                                        status: 'danger',
+                                                        children: 'Revert materialization',
+                                                        onClick: () => revertMaterialization(viewId),
+                                                    },
+                                                    secondaryButton: {
+                                                        children: 'Cancel',
+                                                    },
+                                                })
+                                            }}
+                                        />
+                                    )}
+                                </div>
+                            </div>
+                        ) : (
+                            <div>
+                                <p className="text-xs">
+                                    Materialized views are a way to pre-compute data in your data warehouse. This allows
+                                    you to run queries faster and more efficiently.
+                                    <br />
+                                    <Link
+                                        data-attr="materializing-help"
+                                        to="https://posthog.com/docs/data-warehouse/views#materializing-and-scheduling-a-view"
+                                        target="_blank"
+                                    >
+                                        Learn more about materialization
+                                    </Link>
+                                    .
+                                </p>
+                                <LemonButton
+                                    size="small"
+                                    onClick={() => materializeDataWarehouseSavedQuery(viewId)}
+                                    type="primary"
+                                    loading={updatingDataWarehouseSavedQuery}
+                                >
+                                    Materialize
+                                </LemonButton>
+                            </div>
+                        )}
+                    </div>
+                </div>
+                <div className="flex items-start justify-between">
+                    <div>
+                        <h3>Materialization Runs</h3>
+                        <p className="text-xs">
+                            The last runs for this materialized view. These can be scheduled or run on demand.
+                        </p>
+                    </div>
+                    <LemonButton
+                        icon={<IconRefresh />}
+                        size="small"
+                        type="secondary"
+                        onClick={() => loadDataModelingJobs()}
+                        loading={dataModelingJobsLoading}
+                        disabledReason={startingMaterialization ? 'Materialization is starting' : undefined}
+                        tooltip="Refresh runs"
+                    />
+                </div>
+                <LemonTable
+                    size="small"
+                    loading={dataModelingJobsLoading && !dataModelingJobs?.results?.length}
+                    dataSource={dataModelingJobs?.results || []}
+                    columns={[
+                        {
+                            title: 'Status',
+                            dataIndex: 'status',
+                            render: (_, job: DataModelingJob) => {
+                                const { status, error, rows_materialized, rows_expected } = job
+                                const statusToType: Record<string, LemonTagType> = {
+                                    Completed: 'success',
+                                    Failed: 'danger',
+                                    Running: 'warning',
+                                }
+                                const type = statusToType[status] || 'warning'
+
+                                const progressPercentage =
+                                    rows_expected && rows_expected > 0
+                                        ? Math.min(100, (rows_materialized / rows_expected) * 100)
+                                        : 0
+
+                                if (status === 'Running' && progressPercentage > 0 && rows_expected !== null) {
+                                    return (
+                                        <Tooltip
+                                            placement="right"
+                                            title={getMaterializationStatusMessage(
+                                                rows_materialized,
+                                                progressPercentage,
+                                                rows_expected
+                                            )}
+                                        >
+                                            <div className="w-[68px]">
+                                                <LemonProgress percent={progressPercentage} />
+                                            </div>
+                                        </Tooltip>
+                                    )
+                                }
+
+                                return error && status !== 'Completed' ? (
+                                    <Tooltip title={error} interactive>
+                                        <LemonTag type={type}>{status}</LemonTag>
+                                    </Tooltip>
+                                ) : (
+                                    <LemonTag type={type}>{status}</LemonTag>
+                                )
+                            },
+                        },
+                        {
+                            title: 'Rows',
+                            dataIndex: 'rows_materialized',
+                            render: (_, { rows_materialized, status }: DataModelingJob) =>
+                                (status === 'Running' || status === 'Cancelled') && rows_materialized === 0
+                                    ? '~'
+                                    : humanFriendlyNumber(rows_materialized),
+                        },
+                        {
+                            title: 'Updated',
+                            dataIndex: 'last_run_at',
+                            render: (_, { last_run_at }: DataModelingJob) => humanFriendlyDetailedTime(last_run_at),
+                        },
+                        {
+                            title: 'Duration',
+                            render: (_, job: DataModelingJob) => {
+                                if (job.status === 'Running') {
+                                    return 'In progress'
+                                }
+                                const start = new Date(job.created_at).getTime()
+                                const end = new Date(job.last_run_at).getTime()
+
+                                if (start > end) {
+                                    return 'N/A'
+                                }
+
+                                return humanFriendlyDuration((end - start) / 1000)
+                            },
+                        },
+                    ]}
+                    expandable={
+                        dataModelingJobs?.results?.length
+                            ? {
+                                  expandedRowRender: (job: DataModelingJob) => (
+                                      <div className="p-4">
+                                          <LogsViewer
+                                              logicKey={`data_modeling_run:${job.id}`}
+                                              sourceType="data_modeling_run"
+                                              sourceId={viewId}
+                                              groupByInstanceId={false}
+                                              hideDateFilter
+                                              hideLevelsFilter
+                                              hideInstanceIdColumn
+                                              defaultFilters={{
+                                                  instanceId: job.workflow_run_id,
+                                                  dateFrom: dayjsUtcToTimezone(job.created_at, timezone).format(
+                                                      'YYYY-MM-DD HH:mm:ss'
+                                                  ),
+                                                  dateTo: job.last_run_at
+                                                      ? dayjsUtcToTimezone(job.last_run_at, timezone)
+                                                            .add(1, 'hour')
+                                                            .format('YYYY-MM-DD HH:mm:ss')
+                                                      : undefined,
+                                                  levels: showDebugLogs ? ['DEBUG', ...LOG_LEVELS] : LOG_LEVELS,
+                                              }}
+                                          />
+                                      </div>
+                                  ),
+                                  rowExpandable: () => true,
+                                  noIndent: true,
+                              }
+                            : undefined
+                    }
+                    nouns={['run', 'runs']}
+                    emptyState="No runs available"
+                    footer={
+                        hasMoreJobsToLoad && (
+                            <div className="flex items-center m-2">
+                                <LemonButton
+                                    center
+                                    fullWidth
+                                    onClick={() => loadOlderDataModelingJobs()}
+                                    loading={dataModelingJobsLoading}
+                                >
+                                    Load older runs
+                                </LemonButton>
+                            </div>
+                        )
+                    }
+                />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/data-warehouse/saved_queries/materializationJobsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/saved_queries/materializationJobsLogic.ts
@@ -1,0 +1,111 @@
+import { actions, afterMount, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api, { PaginatedResponse } from 'lib/api'
+
+import { DataModelingJob, DataWarehouseSavedQuery } from '~/types'
+
+import type { materializationJobsLogicType } from './materializationJobsLogicType'
+
+const REFRESH_INTERVAL = 10000
+const DEFAULT_JOBS_PAGE_SIZE = 10
+
+export interface MaterializationJobsLogicProps {
+    viewId: string
+}
+
+export const materializationJobsLogic = kea<materializationJobsLogicType>([
+    path(['scenes', 'data-warehouse', 'saved_queries', 'materializationJobsLogic']),
+    props({} as MaterializationJobsLogicProps),
+    key((props) => props.viewId),
+    actions({
+        setStartingMaterialization: (starting: boolean) => ({ starting }),
+    }),
+    loaders(({ values, props }) => ({
+        savedQuery: [
+            null as DataWarehouseSavedQuery | null,
+            {
+                loadSavedQuery: async () => {
+                    if (!props.viewId) {
+                        return null
+                    }
+                    return await api.dataWarehouseSavedQueries.get(props.viewId)
+                },
+            },
+        ],
+        dataModelingJobs: [
+            null as PaginatedResponse<DataModelingJob> | null,
+            {
+                loadDataModelingJobs: async () => {
+                    return await api.dataWarehouseSavedQueries.dataWarehouseDataModelingJobs.list(
+                        props.viewId,
+                        values.dataModelingJobs?.results.length
+                            ? Math.max(values.dataModelingJobs.results.length, DEFAULT_JOBS_PAGE_SIZE)
+                            : DEFAULT_JOBS_PAGE_SIZE,
+                        0
+                    )
+                },
+                loadOlderDataModelingJobs: async () => {
+                    const nextUrl = values.dataModelingJobs?.next
+
+                    if (!nextUrl) {
+                        return values.dataModelingJobs
+                    }
+
+                    const res = await api.get<PaginatedResponse<DataModelingJob>>(nextUrl)
+                    res.results = [...(values.dataModelingJobs?.results ?? []), ...res.results]
+
+                    return res
+                },
+            },
+        ],
+    })),
+    reducers({
+        startingMaterialization: [
+            false,
+            {
+                setStartingMaterialization: (_, { starting }: { starting: boolean }) => starting,
+                loadDataModelingJobsSuccess: (
+                    state: boolean,
+                    { dataModelingJobs }: { dataModelingJobs: PaginatedResponse<DataModelingJob> | null }
+                ) => {
+                    const currentJobStatus = dataModelingJobs?.results?.[0]?.status
+                    if (
+                        currentJobStatus &&
+                        ['Running', 'Completed', 'Failed', 'Cancelled'].includes(currentJobStatus)
+                    ) {
+                        return false
+                    }
+                    return state
+                },
+            },
+        ],
+    }),
+    selectors({
+        hasMoreJobsToLoad: [(s) => [s.dataModelingJobs], (dataModelingJobs) => !!dataModelingJobs?.next],
+    }),
+    afterMount(({ actions, props }) => {
+        if (props.viewId) {
+            actions.loadDataModelingJobs()
+            actions.loadSavedQuery()
+        }
+    }),
+    propsChanged(({ actions, props }, oldProps) => {
+        if (props.viewId && props.viewId !== oldProps.viewId) {
+            actions.loadDataModelingJobs()
+            actions.loadSavedQuery()
+        }
+    }),
+    listeners(({ actions, cache }) => ({
+        loadDataModelingJobsSuccess: () => {
+            // Refresh saved query alongside jobs so latest_error / status / sync_frequency stay in sync.
+            actions.loadSavedQuery()
+            cache.disposables.add(() => {
+                const timeoutId = setTimeout(() => {
+                    actions.loadDataModelingJobs()
+                }, REFRESH_INTERVAL)
+                return () => clearTimeout(timeoutId)
+            }, 'dataModelingJobsRefreshTimeout')
+        },
+    })),
+])

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconClock, IconDatabase, IconInfo, IconRefresh } from '@posthog/icons'
+import { IconClock, IconDatabase, IconInfo, IconList, IconRefresh } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -15,6 +15,7 @@ import {
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { MaterializationStatusModal } from 'scenes/data-warehouse/saved_queries/MaterializationStatusModal'
 
 import { endpointLogic } from '../endpointLogic'
 import { endpointSceneLogic, MaterializationPreview } from '../endpointSceneLogic'
@@ -234,10 +235,17 @@ function MaterializationContent({ tabId }: { tabId: string }): JSX.Element {
         materializationPreview,
         bucketOverrides,
     } = useValues(endpointSceneLogic({ tabId }))
+    const [runsModalOpen, setRunsModalOpen] = useState(false)
 
     if (!endpoint) {
         return <></>
     }
+
+    const savedQueryId =
+        viewingVersion?.materialization?.saved_query_id ??
+        loadedMaterializationStatus?.saved_query_id ??
+        endpoint.materialization?.saved_query_id ??
+        null
 
     const versionMaterialization = viewingVersion?.materialization ?? endpoint.materialization
     const freshMaterialization = loadedMaterializationStatus ?? versionMaterialization
@@ -319,6 +327,14 @@ function MaterializationContent({ tabId }: { tabId: string }): JSX.Element {
                                         loading={materializationStatusLoading}
                                         tooltip="Refresh status"
                                     />
+                                    {savedQueryId && (
+                                        <LemonButton
+                                            size="xsmall"
+                                            icon={<IconList />}
+                                            onClick={() => setRunsModalOpen(true)}
+                                            tooltip="View materialization runs"
+                                        />
+                                    )}
                                 </div>
                             </div>
 
@@ -364,6 +380,13 @@ function MaterializationContent({ tabId }: { tabId: string }): JSX.Element {
                     )}
                 </div>
             )}
+            <MaterializationStatusModal
+                isOpen={runsModalOpen}
+                onClose={() => setRunsModalOpen(false)}
+                viewId={savedQueryId}
+                viewName={endpoint.name}
+                kind="endpoint"
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The EndpointScene Configuration tab showed only a small materialization status row (status tag, last-materialized timestamp, refresh, error banner). To see run history or trigger a sync, users had to leave the endpoint and navigate into the SQL editor — even though the endpoint already carries `materialization.saved_query_id`.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/1b11c22e-a54d-4ee3-8fd8-2a618f7add5b.png)



![image.png](https://app.graphite.com/user-attachments/assets/21c7f356-60bd-4241-b57c-1f673139bf36.png)



Reuses the SQL editor's existing "Materialization" modal on the EndpointScene Configuration tab so the two surfaces share the same status + runs UX.

- New `MaterializationStatusPanel` (status, sync controls, runs table) — extracted from `QueryInfo`. Self-contained: connects only to `dataWarehouseViewsLogic` and a new `materializationJobsLogic` keyed by `viewId`. No `sqlEditorLogic` dependency.
- New `MaterializationStatusModal` — `LemonModal` wrapper around the panel with `{ isOpen, onClose, view, loading? }` props.
- New `materializationJobsLogic` — runs loader + auto-refresh, lifted out of `infoTabLogic`. `infoTabLogic` keeps the dependencies/upstream-only role.
- `QueryInfo.tsx` now renders `MaterializationStatusPanel` for the materialization sections; SQL editor users see no behavior change.
- `EndpointConfiguration.tsx` adds a small `IconList` button next to the existing status refresh button when `materialization.saved_query_id` is set; clicking opens the modal.

## How did you test this code?

I'm an agent. I did not perform manual UI testing.

Automated checks I actually ran locally:

- `pnpm --filter=@posthog/frontend typescript:check` — clean (0 errors)
- `pnpm --filter=@posthog/frontend format` (oxlint --fix + oxfmt) — clean
- `pnpm typegen:write` regenerated kea types successfully

Suggested manual verification before merge:

- SQL editor: open a saved view → click "Materialization" toolbar button → modal still shows status, runs table (auto-refreshing every 10s), sync now/cancel/revert/frequency, expandable per-run logs, "Load older runs" pagination.
- EndpointScene Configuration tab on a materialized endpoint: new icon-list button appears next to the status refresh; clicking opens the same modal scoped to the endpoint's saved query. Triggering a sync should add a "Running" row.
- Non-materialized endpoint: the new button should not render.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by PostHog Code (Claude). Key decisions:

- Kept the SQL editor modal flow intact and refactored `QueryInfo` to delegate the materialization sections to the new shared panel — instead of replacing SQLEditor's internal `MaterializationModal` outright. This preserves the SQL editor's dependencies/upstream sections in the modal while still routing both surfaces through the same `MaterializationStatusPanel` (so the status + runs UX is identical).
- `materializationJobsLogic` is keyed by `viewId` so multiple consumers (SQL editor sidebar, endpoint modal) stay isolated.
- Modal open state on the Endpoint side is local React `useState` rather than a kea reducer — the modal is ephemeral and doesn't need to persist across tab switches.