### PR TITLE
Add OpenAPI response validation during tests and upload CI reports

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -436,6 +436,14 @@ jobs:
                   include-hidden-files: true
                   retention-days: 2
 
+            - name: Upload OpenAPI response validation report
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always()
+              with:
+                  name: openapi-response-validation-products-${{ strategy.job-index }}
+                  path: '**/openapi_response_validation_report.json'
+                  if-no-files-found: warn
+
             - name: Verify new snapshots for flakiness
               if: ${{ always() && needs.detect-snapshot-mode.outputs.mode == 'update' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
               shell: bash
@@ -1426,6 +1434,14 @@ jobs:
               with:
                   name: junit-results-backend-${{ matrix.artifact_key }}
                   path: junit-*.xml
+
+            - name: Upload OpenAPI response validation report
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always()
+              with:
+                  name: openapi-response-validation-backend-${{ matrix.artifact_key }}
+                  path: openapi_response_validation_report.json
+                  if-no-files-found: warn
 
     # Aggregate and commit snapshot changes from all matrix jobs
 

--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -16,7 +16,7 @@ from products.experiments.backend.models.experiment import ExperimentHoldout, ho
 
 
 class ExperimentHoldoutSerializer(serializers.ModelSerializer):
-    created_by = UserBasicSerializer(read_only=True)
+    created_by = UserBasicSerializer(read_only=True, allow_null=True)
 
     class Meta:
         model = ExperimentHoldout

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -46,7 +46,7 @@ class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):
 class ExperimentSavedMetricSerializer(
     UserAccessControlSerializerMixin, TaggedItemSerializerMixin, serializers.ModelSerializer
 ):
-    created_by = UserBasicSerializer(read_only=True)
+    created_by = UserBasicSerializer(read_only=True, allow_null=True)
 
     class Meta:
         model = ExperimentSavedMetric

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -104,9 +104,9 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             "Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible."
         ),
     )
-    created_by = UserBasicSerializer(read_only=True)
+    created_by = UserBasicSerializer(read_only=True, allow_null=True)
     feature_flag = MinimalFeatureFlagSerializer(read_only=True)
-    holdout = ExperimentHoldoutSerializer(read_only=True)
+    holdout = ExperimentHoldoutSerializer(read_only=True, allow_null=True)
     holdout_id = TeamScopedPrimaryKeyRelatedField(
         queryset=ExperimentHoldout.objects.all(),
         source="holdout",

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -15,7 +15,7 @@ from django.db.models import Count, Prefetch, Q, QuerySet, deletion
 
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse, extend_schema_field
 from prometheus_client import Counter
 from rest_framework import exceptions, request, serializers, status, viewsets
 from rest_framework.permissions import BasePermission
@@ -742,16 +742,20 @@ class FeatureFlagSerializer(
             )
         )
 
-    def get_features(self, feature_flag: FeatureFlag) -> dict:
+    @extend_schema_field({"type": "array", "items": {"type": "object"}})
+    def get_features(self, feature_flag: FeatureFlag) -> list[dict]:
         from products.early_access_features.backend.api import MinimalEarlyAccessFeatureSerializer
 
-        return MinimalEarlyAccessFeatureSerializer(feature_flag.features, many=True).data
+        return MinimalEarlyAccessFeatureSerializer(feature_flag.features, many=True).data  # ty: ignore[invalid-return-type]
 
-    def get_surveys(self, feature_flag: FeatureFlag) -> dict:
+    @extend_schema_field({"type": "array", "items": {"type": "object"}})
+    def get_surveys(self, feature_flag: FeatureFlag) -> list[dict]:
         from products.surveys.backend.api.survey import SurveyAPISerializer
 
-        return SurveyAPISerializer(feature_flag.surveys_linked_flag, many=True).data
-        # ignoring type because mypy doesn't know about the surveys_linked_flag `related_name` relationship
+        # ``.data`` returns DRF's ``ReturnList`` (a list subclass); annotated as ``list[dict]``
+        # for the schema generator. The ``ignoring type`` comment below references the
+        # ``surveys_linked_flag`` reverse relation which mypy can't follow.
+        return SurveyAPISerializer(feature_flag.surveys_linked_flag, many=True).data  # ty: ignore[invalid-return-type]
 
     def get_is_used_in_replay_settings(self, feature_flag: FeatureFlag) -> bool:
         """Check if this feature flag is used in any team's session recording linked flag setting."""

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -14,7 +14,7 @@ from infi.clickhouse_orm import Database
 from rest_framework.test import APIClient
 
 from posthog.clickhouse.client import sync_execute
-from posthog.test.openapi_response_validation import build_openapi_response_validator
+from posthog.test.openapi_response_validation import build_openapi_response_validator, set_current_test_id
 
 
 def create_clickhouse_tables():
@@ -478,6 +478,10 @@ def validate_api_responses_against_openapi_spec(
     if "skip_openapi_response_validation" in request.keywords:
         return
 
+    # Stamp every event captured during this test with the pytest node id, so failures in the
+    # report can be traced back to the originating test (useful for triaging false positives).
+    set_current_test_id(request.node.nodeid)
+
     validator = build_openapi_response_validator()
     original_request = APIClient.request
 
@@ -501,6 +505,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                     "exitstatus": exitstatus,
                     "summary": report["summary"],
                 },
-                sort_keys=True,
+                # Preserve the priority ordering of by_reason established in the recorder.
+                sort_keys=False,
             )
         )

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -1,4 +1,5 @@
 import os
+import json
 import subprocess
 from urllib.parse import quote_plus
 
@@ -10,8 +11,10 @@ from django.core.management.commands.flush import Command as FlushCommand
 from django.db import connections
 
 from infi.clickhouse_orm import Database
+from rest_framework.test import APIClient
 
 from posthog.clickhouse.client import sync_execute
+from posthog.test.openapi_response_validation import build_openapi_response_validator
 
 
 def create_clickhouse_tables():
@@ -445,6 +448,10 @@ def pytest_configure(config):
     # Set default databases for Django test classes
     TestCase.databases = {"default", "persons_db_writer", "persons_db_reader"}
     TransactionTestCase.databases = {"default", "persons_db_writer", "persons_db_reader"}
+    config.addinivalue_line(
+        "markers",
+        "skip_openapi_response_validation: skip OpenAPI response validation for this test",
+    )
 
 
 def _runs_on_internal_pr() -> bool:
@@ -462,3 +469,38 @@ def _runs_on_internal_pr() -> bool:
 def pytest_runtest_setup(item: pytest.Item) -> None:
     if "requires_secrets" in item.keywords and not _runs_on_internal_pr():
         pytest.skip("Skipping test that requires internal secrets on external PRs")
+
+
+@pytest.fixture(autouse=True)
+def validate_api_responses_against_openapi_spec(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> None:
+    if "skip_openapi_response_validation" in request.keywords:
+        return
+
+    validator = build_openapi_response_validator()
+    original_request = APIClient.request
+
+    def wrapped_request(client: APIClient, **kwargs: object) -> object:
+        response = original_request(client, **kwargs)
+        validator.validate_response(response)
+        return response
+
+    monkeypatch.setattr(APIClient, "request", wrapped_request)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    validator = build_openapi_response_validator()
+    report = validator.recorder.write_machine_readable_report("openapi_response_validation_report.json")
+    terminal_reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if terminal_reporter is not None:
+        terminal_reporter.write_line(
+            json.dumps(
+                {
+                    "event": "openapi_response_validation_summary",
+                    "exitstatus": exitstatus,
+                    "summary": report["summary"],
+                },
+                sort_keys=True,
+            )
+        )

--- a/posthog/test/openapi_response_validation.py
+++ b/posthog/test/openapi_response_validation.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import os
+import re
+import json
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from typing import Any
+
+from django.http import HttpResponse
+
+from drf_spectacular.generators import SchemaGenerator
+from jsonschema import ValidationError
+from jsonschema.validators import Draft7Validator, RefResolver
+
+_JSON_CONTENT_TYPES: tuple[str, ...] = ("application/json", "application/problem+json")
+
+
+@dataclass
+class OpenAPIValidationEvent:
+    event: str
+    method: str
+    path: str
+    status_code: int
+    reason: str
+    details: str | None = None
+
+
+class OpenAPIValidationRecorder:
+    def __init__(self) -> None:
+        self.events: list[OpenAPIValidationEvent] = []
+
+    def record(
+        self,
+        *,
+        event: str,
+        method: str,
+        path: str,
+        status_code: int,
+        reason: str,
+        details: str | None = None,
+    ) -> None:
+        self.events.append(
+            OpenAPIValidationEvent(
+                event=event,
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason=reason,
+                details=details,
+            )
+        )
+
+    def write_machine_readable_report(self, output_path: str) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        for item in self.events:
+            counts[item.reason] = counts.get(item.reason, 0) + 1
+
+        report: dict[str, Any] = {
+            "events": [asdict(item) for item in self.events],
+            "summary": {
+                "total": len(self.events),
+                "by_reason": counts,
+            },
+        }
+
+        with open(output_path, "w", encoding="utf-8") as file_handle:
+            json.dump(report, file_handle, sort_keys=True)
+            file_handle.write("\n")
+
+        return report
+
+
+class OpenAPIResponseValidator:
+    def __init__(self, schema: dict[str, Any], recorder: OpenAPIValidationRecorder, strict: bool = False) -> None:
+        self.schema = schema
+        self.recorder = recorder
+        self.strict = strict
+        self._compiled_paths = self._compile_paths(schema.get("paths", {}))
+        self._resolver = RefResolver.from_schema(schema)
+
+    def validate_response(self, response: HttpResponse) -> None:
+        request = getattr(response, "wsgi_request", None)
+        if request is None:
+            return
+
+        method = request.method.upper()
+        path = request.path
+        status_code = response.status_code
+
+        if not path.startswith("/api/"):
+            return
+
+        if path == "/api/schema/":
+            return
+
+        path_item = self._find_path_item(path)
+        if path_item is None:
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="path_not_in_schema",
+            )
+            return
+
+        operation = path_item.get(method.lower())
+        if not isinstance(operation, dict):
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="method_not_in_schema",
+            )
+            return
+
+        response_schema = self._get_response_schema(operation, status_code)
+        if response_schema is None:
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="response_schema_not_declared",
+            )
+            return
+
+        if self._is_empty_response(response):
+            self.recorder.record(
+                event="validated",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="empty_body",
+            )
+            return
+
+        if not self._is_json_response(response):
+            self.recorder.record(
+                event="skip",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="non_json_response",
+            )
+            return
+
+        try:
+            payload = json.loads(response.content.decode(response.charset or "utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            message = f"unable to decode JSON body: {error}"
+            self.recorder.record(
+                event="failed",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="invalid_json_body",
+                details=message,
+            )
+            if self.strict:
+                raise AssertionError(
+                    self._failure_json(method, path, status_code, "invalid_json_body", message)
+                ) from error
+            return
+
+        try:
+            self._validate_payload(payload, response_schema)
+        except ValidationError as error:
+            message = self._format_validation_error(error)
+            self.recorder.record(
+                event="failed",
+                method=method,
+                path=path,
+                status_code=status_code,
+                reason="schema_validation_failed",
+                details=message,
+            )
+            if self.strict:
+                raise AssertionError(
+                    self._failure_json(method, path, status_code, "schema_validation_failed", message)
+                ) from error
+            return
+
+        self.recorder.record(
+            event="validated",
+            method=method,
+            path=path,
+            status_code=status_code,
+            reason="schema_validation_passed",
+        )
+
+    def _validate_payload(self, payload: Any, schema: dict[str, Any]) -> None:
+        if schema.get("nullable") and payload is None:
+            return
+
+        normalized_schema = self._normalize_nullable(schema)
+        validator = Draft7Validator(normalized_schema, resolver=self._resolver)
+        validator.validate(payload)
+
+    @staticmethod
+    def _normalize_nullable(schema: Any) -> Any:
+        if isinstance(schema, list):
+            return [OpenAPIResponseValidator._normalize_nullable(item) for item in schema]
+
+        if not isinstance(schema, dict):
+            return schema
+
+        transformed: dict[str, Any] = {k: OpenAPIResponseValidator._normalize_nullable(v) for k, v in schema.items()}
+        nullable = transformed.pop("nullable", False)
+
+        if nullable is True:
+            if "$ref" in transformed:
+                return {"anyOf": [transformed, {"type": "null"}]}
+
+            existing_type = transformed.get("type")
+            if isinstance(existing_type, str):
+                transformed["type"] = [existing_type, "null"]
+            elif isinstance(existing_type, list) and "null" not in existing_type:
+                transformed["type"] = [*existing_type, "null"]
+            else:
+                transformed = {"anyOf": [transformed, {"type": "null"}]}
+
+        return transformed
+
+    @staticmethod
+    def _compile_paths(paths: dict[str, Any]) -> list[tuple[re.Pattern[str], dict[str, Any]]]:
+        compiled: list[tuple[re.Pattern[str], dict[str, Any]]] = []
+        for openapi_path, path_item in paths.items():
+            if not isinstance(path_item, dict):
+                continue
+
+            pattern = re.sub(r"\{[^/]+\}", r"[^/]+", openapi_path)
+            compiled.append((re.compile(f"^{pattern}$"), path_item))
+
+        return compiled
+
+    def _find_path_item(self, path: str) -> dict[str, Any] | None:
+        for pattern, path_item in self._compiled_paths:
+            if pattern.match(path):
+                return path_item
+        return None
+
+    @staticmethod
+    def _is_json_response(response: HttpResponse) -> bool:
+        content_type = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        return content_type in _JSON_CONTENT_TYPES
+
+    @staticmethod
+    def _is_empty_response(response: HttpResponse) -> bool:
+        if response.status_code in {204, 304}:
+            return True
+        return response.content in (b"", None)
+
+    @staticmethod
+    def _get_response_schema(operation: dict[str, Any], status_code: int) -> dict[str, Any] | None:
+        responses = operation.get("responses")
+        if not isinstance(responses, dict):
+            return None
+
+        response_obj = responses.get(str(status_code)) or responses.get("default")
+        if not isinstance(response_obj, dict):
+            return None
+
+        content = response_obj.get("content")
+        if not isinstance(content, dict):
+            return None
+
+        media_type = content.get("application/json") or content.get("application/problem+json")
+        if not isinstance(media_type, dict):
+            return None
+
+        schema = media_type.get("schema")
+        if not isinstance(schema, dict):
+            return None
+
+        return schema
+
+    @staticmethod
+    def _format_validation_error(error: ValidationError) -> str:
+        path_segments = [str(segment) for segment in error.path]
+        error_path = ".".join(path_segments) if path_segments else "$"
+        return f"path={error_path}; message={error.message}"
+
+    @staticmethod
+    def _failure_json(method: str, path: str, status_code: int, reason: str, details: str) -> str:
+        return json.dumps(
+            {
+                "event": "failed",
+                "method": method,
+                "path": path,
+                "status_code": status_code,
+                "reason": reason,
+                "details": details,
+            },
+            sort_keys=True,
+        )
+
+
+@lru_cache(maxsize=1)
+def build_openapi_response_validator() -> OpenAPIResponseValidator:
+    schema = SchemaGenerator().get_schema(request=None, public=True)
+    if schema is None:
+        raise RuntimeError("OpenAPI schema generation returned None")
+
+    recorder = OpenAPIValidationRecorder()
+    strict = os.getenv("OPENAPI_RESPONSE_VALIDATION_STRICT", "").lower() in {"1", "true", "yes"}
+    return OpenAPIResponseValidator(schema=schema, recorder=recorder, strict=strict)

--- a/posthog/test/openapi_response_validation.py
+++ b/posthog/test/openapi_response_validation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import json
+import contextvars
 from dataclasses import asdict, dataclass
 from functools import lru_cache
 from typing import Any
@@ -16,6 +17,63 @@ from jsonschema.validators import Draft7Validator, RefResolver
 _JSON_CONTENT_TYPES: tuple[str, ...] = ("application/json", "application/problem+json")
 
 
+# Reason codes use a 4-tier prefix taxonomy so related entries group naturally when the report
+# is sorted alphabetically and so a glance at the prefix tells you what kind of finding it is:
+#
+#   validated_*  — response was checked against the spec and passed (or had nothing to check).
+#   failed_*     — response was checked and diverged from the spec. Highest signal: real bug.
+#   gap_*        — the spec was missing something we'd have needed to validate. Actionable on
+#                  the viewset/serializer side (annotate the response, declare the status, etc.).
+#   unmatched_*  — couldn't connect the request to anything in the spec at all. Lowest signal —
+#                  often a validator-side limitation (path pattern, content type) rather than a
+#                  real defect.
+#
+# Priority drives summary ordering: higher = more interesting. Within a tier we still order by
+# count so the largest bucket inside the tier surfaces first.
+_REASON_PRIORITY: dict[str, int] = {
+    # failed_* — real divergence between response and spec.
+    "failed_nullability": 100,
+    "failed_type": 100,
+    "failed_missing_required": 100,
+    "failed_unexpected_property": 100,
+    "failed_enum": 100,
+    "failed_polymorphic": 100,
+    "failed_format": 100,
+    "failed_other": 100,
+    "failed_invalid_json": 100,
+    # validated_* — checked successfully.
+    "validated": 60,
+    "validated_empty_body": 60,
+    # gap_* — spec annotation gap. Status-class-specific buckets so a missing 2xx (response
+    # shape we actually return) doesn't drown in the noise of missing 4xx error annotations.
+    "gap_status_2xx": 50,
+    "gap_no_responses": 40,
+    "gap_no_schema": 40,
+    "gap_no_json_media": 40,
+    "gap_status_5xx": 35,
+    "gap_status_3xx": 25,
+    "gap_status_4xx": 15,
+    # unmatched_* — couldn't even connect the request to the spec.
+    "unmatched_non_json": 10,
+    "unmatched_method": 5,
+    "unmatched_path": 0,
+}
+
+
+# Set by the conftest fixture before each test runs so events captured during the test can be
+# attributed back to a specific pytest node id (e.g. ``ee/.../test_x.py::TestY::test_z``).
+# A ContextVar is used so concurrent tests under pytest-xdist or anyio-style fixtures don't
+# leak each other's IDs.
+_current_test_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "openapi_validation_test_id", default=None
+)
+
+
+def set_current_test_id(test_id: str | None) -> None:
+    """Set (or clear) the pytest node id attached to subsequent validation events."""
+    _current_test_id.set(test_id)
+
+
 @dataclass
 class OpenAPIValidationEvent:
     event: str
@@ -24,6 +82,7 @@ class OpenAPIValidationEvent:
     status_code: int
     reason: str
     details: str | None = None
+    test_id: str | None = None
 
 
 class OpenAPIValidationRecorder:
@@ -48,6 +107,7 @@ class OpenAPIValidationRecorder:
                 status_code=status_code,
                 reason=reason,
                 details=details,
+                test_id=_current_test_id.get(),
             )
         )
 
@@ -56,16 +116,27 @@ class OpenAPIValidationRecorder:
         for item in self.events:
             counts[item.reason] = counts.get(item.reason, 0) + 1
 
+        # Sort by descending priority (real bugs first), then descending count, then name.
+        # Coverage gaps like ``unmatched_path`` end up at the bottom by design — when we
+        # ran out of ways to match a request to the spec, that's the least interesting bucket.
+        ordered_counts = dict(
+            sorted(
+                counts.items(),
+                key=lambda kv: (-_REASON_PRIORITY.get(kv[0], 0), -kv[1], kv[0]),
+            )
+        )
+
         report: dict[str, Any] = {
             "events": [asdict(item) for item in self.events],
             "summary": {
                 "total": len(self.events),
-                "by_reason": counts,
+                "by_reason": ordered_counts,
             },
         }
 
+        # ``sort_keys=False`` to preserve the priority ordering above.
         with open(output_path, "w", encoding="utf-8") as file_handle:
-            json.dump(report, file_handle, sort_keys=True)
+            json.dump(report, file_handle, sort_keys=False)
             file_handle.write("\n")
 
         return report
@@ -73,11 +144,14 @@ class OpenAPIValidationRecorder:
 
 class OpenAPIResponseValidator:
     def __init__(self, schema: dict[str, Any], recorder: OpenAPIValidationRecorder, strict: bool = False) -> None:
-        self.schema = schema
+        # Normalize OpenAPI 3.0's `nullable: true` into JSON Schema `type: [..., "null"]`
+        # across the entire spec — including component schemas reached via $ref. Doing this
+        # once up front avoids reasoning about ref resolution per-request.
+        self.schema = self._normalize_nullable(schema)
         self.recorder = recorder
         self.strict = strict
-        self._compiled_paths = self._compile_paths(schema.get("paths", {}))
-        self._resolver = RefResolver.from_schema(schema)
+        self._compiled_paths = self._compile_paths(self.schema.get("paths", {}))
+        self._resolver = RefResolver.from_schema(self.schema)
 
     def validate_response(self, response: HttpResponse) -> None:
         request = getattr(response, "wsgi_request", None)
@@ -101,7 +175,7 @@ class OpenAPIResponseValidator:
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="path_not_in_schema",
+                reason="unmatched_path",
             )
             return
 
@@ -112,18 +186,21 @@ class OpenAPIResponseValidator:
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="method_not_in_schema",
+                reason="unmatched_method",
             )
             return
 
-        response_schema = self._get_response_schema(operation, status_code)
+        response_schema, missing_reason = self._get_response_schema(operation, status_code)
         if response_schema is None:
+            assert missing_reason is not None
+            if missing_reason == "gap_status":
+                missing_reason = self._classify_status_gap(status_code)
             self.recorder.record(
                 event="skip",
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="response_schema_not_declared",
+                reason=missing_reason,
             )
             return
 
@@ -133,7 +210,7 @@ class OpenAPIResponseValidator:
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="empty_body",
+                reason="validated_empty_body",
             )
             return
 
@@ -143,7 +220,7 @@ class OpenAPIResponseValidator:
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="non_json_response",
+                reason="unmatched_non_json",
             )
             return
 
@@ -156,31 +233,30 @@ class OpenAPIResponseValidator:
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="invalid_json_body",
+                reason="failed_invalid_json",
                 details=message,
             )
             if self.strict:
                 raise AssertionError(
-                    self._failure_json(method, path, status_code, "invalid_json_body", message)
+                    self._failure_json(method, path, status_code, "failed_invalid_json", message)
                 ) from error
             return
 
         try:
             self._validate_payload(payload, response_schema)
         except ValidationError as error:
+            reason = self._classify_validation_error(error)
             message = self._format_validation_error(error)
             self.recorder.record(
                 event="failed",
                 method=method,
                 path=path,
                 status_code=status_code,
-                reason="schema_validation_failed",
+                reason=reason,
                 details=message,
             )
             if self.strict:
-                raise AssertionError(
-                    self._failure_json(method, path, status_code, "schema_validation_failed", message)
-                ) from error
+                raise AssertionError(self._failure_json(method, path, status_code, reason, message)) from error
             return
 
         self.recorder.record(
@@ -188,15 +264,12 @@ class OpenAPIResponseValidator:
             method=method,
             path=path,
             status_code=status_code,
-            reason="schema_validation_passed",
+            reason="validated",
         )
 
     def _validate_payload(self, payload: Any, schema: dict[str, Any]) -> None:
-        if schema.get("nullable") and payload is None:
-            return
-
-        normalized_schema = self._normalize_nullable(schema)
-        validator = Draft7Validator(normalized_schema, resolver=self._resolver)
+        # Schema (including any $ref targets) was already normalized at construction time.
+        validator = Draft7Validator(schema, resolver=self._resolver)
         validator.validate(payload)
 
     @staticmethod
@@ -237,9 +310,18 @@ class OpenAPIResponseValidator:
         return compiled
 
     def _find_path_item(self, path: str) -> dict[str, Any] | None:
-        for pattern, path_item in self._compiled_paths:
-            if pattern.match(path):
-                return path_item
+        # Try the path as-is, then with/without a trailing slash. Test traffic frequently
+        # drops the trailing slash that drf-spectacular emits in the spec.
+        candidates = [path]
+        if path.endswith("/"):
+            candidates.append(path.rstrip("/"))
+        else:
+            candidates.append(path + "/")
+
+        for candidate in candidates:
+            for pattern, path_item in self._compiled_paths:
+                if pattern.match(candidate):
+                    return path_item
         return None
 
     @staticmethod
@@ -254,28 +336,92 @@ class OpenAPIResponseValidator:
         return response.content in (b"", None)
 
     @staticmethod
-    def _get_response_schema(operation: dict[str, Any], status_code: int) -> dict[str, Any] | None:
+    def _get_response_schema(operation: dict[str, Any], status_code: int) -> tuple[dict[str, Any] | None, str | None]:
+        """Return ``(schema, None)`` when found, otherwise ``(None, reason)`` so the caller
+        can record a precise reason for why the spec didn't yield a schema. Each reason
+        maps to a specific actionable fix:
+
+        * ``gap_no_responses`` — operation has no ``responses`` key.
+        * ``gap_status`` — status code (and ``default``) absent from ``responses``. The caller
+          refines this into ``gap_status_2xx``/``3xx``/``4xx``/``5xx`` based on the status class.
+        * ``gap_no_json_media`` — status declared, but no JSON media type for it.
+        * ``gap_no_schema`` — JSON media type declared, but it has no ``schema``.
+        """
         responses = operation.get("responses")
         if not isinstance(responses, dict):
-            return None
+            return None, "gap_no_responses"
 
         response_obj = responses.get(str(status_code)) or responses.get("default")
         if not isinstance(response_obj, dict):
-            return None
+            return None, "gap_status"
 
         content = response_obj.get("content")
         if not isinstance(content, dict):
-            return None
+            # No content key — usually means operation declares an empty body for this status.
+            return None, "gap_no_json_media"
 
-        media_type = content.get("application/json") or content.get("application/problem+json")
+        # Use explicit membership checks: an empty dict ``{}`` declared for the media type is
+        # truthy presence but falsy under ``or``, which would silently misclassify the case.
+        for content_type in _JSON_CONTENT_TYPES:
+            if content_type in content:
+                media_type = content[content_type]
+                break
+        else:
+            return None, "gap_no_json_media"
+
         if not isinstance(media_type, dict):
-            return None
+            return None, "gap_no_json_media"
 
         schema = media_type.get("schema")
         if not isinstance(schema, dict):
-            return None
+            return None, "gap_no_schema"
 
-        return schema
+        return schema, None
+
+    @staticmethod
+    def _classify_status_gap(status_code: int) -> str:
+        """Pick a status-class-specific bucket so a 2xx gap (real undocumented response
+        shape) doesn't drown in the noise of 4xx gaps (error responses are routinely
+        unannotated in drf-spectacular output).
+        """
+        if 200 <= status_code < 300:
+            return "gap_status_2xx"
+        if 300 <= status_code < 400:
+            return "gap_status_3xx"
+        if 400 <= status_code < 500:
+            return "gap_status_4xx"
+        if 500 <= status_code < 600:
+            return "gap_status_5xx"
+        return "gap_status"
+
+    @staticmethod
+    def _classify_validation_error(error: ValidationError) -> str:
+        """Bucket ``jsonschema`` validation errors into actionable categories. The fallback
+        ``failed_other`` covers anything that doesn't fit one of the known error shapes.
+        """
+        validator = error.validator
+        if validator == "type":
+            # ``None is not of type 'string'`` is the dominant case; the response field is
+            # null but the spec didn't mark it nullable. Worth its own bucket because the
+            # fix is mechanical (annotate ``allow_null=True`` / ``nullable: true``).
+            if error.instance is None:
+                return "failed_nullability"
+            return "failed_type"
+        if validator == "required":
+            return "failed_missing_required"
+        if validator == "additionalProperties":
+            return "failed_unexpected_property"
+        if validator == "enum":
+            return "failed_enum"
+        if validator in {"oneOf", "anyOf"}:
+            # Polymorphic union: the response shape didn't match any declared variant.
+            # Usually means the spec's union list is missing a variant the code returns.
+            return "failed_polymorphic"
+        if validator in {"format", "pattern", "minimum", "maximum", "minLength", "maxLength", "minItems", "maxItems"}:
+            # Value-level constraint failures (regex, range, length). Grouped because the
+            # fix is "loosen the constraint" or "tighten the response", not annotation.
+            return "failed_format"
+        return "failed_other"
 
     @staticmethod
     def _format_validation_error(error: ValidationError) -> str:
@@ -300,6 +446,12 @@ class OpenAPIResponseValidator:
 
 @lru_cache(maxsize=1)
 def build_openapi_response_validator() -> OpenAPIResponseValidator:
+    # Include INTERNAL-scoped endpoints in the spec so we can validate test traffic that
+    # hits them. Mirrors the flags used by `hogli build:openapi-schema` — the mock secret
+    # lets schema generation walk views that require InternalAPIAuthentication.
+    os.environ.setdefault("OPENAPI_INCLUDE_INTERNAL", "1")
+    os.environ.setdefault("OPENAPI_MOCK_INTERNAL_API_SECRET", "1")
+
     schema = SchemaGenerator().get_schema(request=None, public=True)
     if schema is None:
         raise RuntimeError("OpenAPI schema generation returned None")

--- a/posthog/test/test_openapi_response_validation.py
+++ b/posthog/test/test_openapi_response_validation.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 
 import pytest
 
-from posthog.test.openapi_response_validation import OpenAPIResponseValidator, OpenAPIValidationRecorder
+from posthog.test.openapi_response_validation import (
+    OpenAPIResponseValidator,
+    OpenAPIValidationRecorder,
+    set_current_test_id,
+)
 
 
 @dataclass
@@ -67,7 +71,7 @@ def test_validates_dynamic_openapi_paths(base_schema: dict) -> None:
 
     validator.validate_response(response)
 
-    assert recorder.events[-1].reason == "schema_validation_passed"
+    assert recorder.events[-1].reason == "validated"
 
 
 def test_records_schema_mismatch_without_failing_in_default_mode(base_schema: dict) -> None:
@@ -82,7 +86,7 @@ def test_records_schema_mismatch_without_failing_in_default_mode(base_schema: di
     )
 
     validator.validate_response(response)
-    assert recorder.events[-1].reason == "schema_validation_failed"
+    assert recorder.events[-1].reason == "failed_type"
 
 
 def test_raises_machine_readable_error_on_schema_mismatch_in_strict_mode(base_schema: dict) -> None:
@@ -96,8 +100,275 @@ def test_raises_machine_readable_error_on_schema_mismatch_in_strict_mode(base_sc
         content=json.dumps({"id": "not-an-integer", "name": "Widget"}).encode("utf-8"),
     )
 
-    with pytest.raises(AssertionError, match='"reason": "schema_validation_failed"'):
+    with pytest.raises(AssertionError, match='"reason": "failed_type"'):
         validator.validate_response(response)
+
+
+def _build_validator(schema: dict) -> tuple[OpenAPIResponseValidator, OpenAPIValidationRecorder]:
+    recorder = OpenAPIValidationRecorder()
+    return OpenAPIResponseValidator(schema, recorder), recorder
+
+
+def _response(method: str, path: str, status_code: int, body: object) -> _FakeResponse:
+    return _FakeResponse(
+        wsgi_request=_FakeRequest(method=method, path=path),
+        status_code=status_code,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps(body).encode("utf-8"),
+    )
+
+
+def test_classifies_nullability_mismatch_distinctly_from_type_mismatch(base_schema: dict) -> None:
+    validator, recorder = _build_validator(base_schema)
+
+    validator.validate_response(_response("GET", "/api/projects/1/widgets/", 200, {"id": None, "name": "Widget"}))
+
+    assert recorder.events[-1].reason == "failed_nullability"
+
+
+def test_classifies_missing_required_field(base_schema: dict) -> None:
+    validator, recorder = _build_validator(base_schema)
+
+    validator.validate_response(_response("GET", "/api/projects/1/widgets/", 200, {"id": 1}))
+
+    assert recorder.events[-1].reason == "failed_missing_required"
+
+
+def test_classifies_unexpected_property(base_schema: dict) -> None:
+    validator, recorder = _build_validator(base_schema)
+
+    validator.validate_response(
+        _response("GET", "/api/projects/1/widgets/", 200, {"id": 1, "name": "Widget", "extra": True})
+    )
+
+    assert recorder.events[-1].reason == "failed_unexpected_property"
+
+
+def test_event_records_current_test_id(base_schema: dict) -> None:
+    validator, recorder = _build_validator(base_schema)
+
+    set_current_test_id("path/to/test.py::TestSomething::test_case")
+    try:
+        validator.validate_response(_response("GET", "/api/projects/1/widgets/", 200, {"id": 1, "name": "W"}))
+    finally:
+        set_current_test_id(None)
+
+    assert recorder.events[-1].test_id == "path/to/test.py::TestSomething::test_case"
+
+
+def test_classifies_polymorphic_mismatch() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "oneOf": [
+                                            {"type": "object", "properties": {"kind": {"const": "a"}}},
+                                            {"type": "object", "properties": {"kind": {"const": "b"}}},
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+    validator, recorder = _build_validator(schema)
+
+    validator.validate_response(_response("GET", "/api/widgets/", 200, {"kind": "c"}))
+
+    assert recorder.events[-1].reason == "failed_polymorphic"
+
+
+def test_classifies_format_mismatch() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"name": {"type": "string", "maxLength": 3}},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+    validator, recorder = _build_validator(schema)
+
+    validator.validate_response(_response("GET", "/api/widgets/", 200, {"name": "too long"}))
+
+    assert recorder.events[-1].reason == "failed_format"
+
+
+def test_classifies_enum_mismatch() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"status": {"type": "string", "enum": ["a", "b"]}},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+    validator, recorder = _build_validator(schema)
+
+    validator.validate_response(_response("GET", "/api/widgets/", 200, {"status": "c"}))
+
+    assert recorder.events[-1].reason == "failed_enum"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_reason"),
+    [
+        (201, "gap_status_2xx"),
+        (302, "gap_status_3xx"),
+        (404, "gap_status_4xx"),
+        (502, "gap_status_5xx"),
+    ],
+)
+def test_status_class_skip_reasons(base_schema: dict, status_code: int, expected_reason: str) -> None:
+    validator, recorder = _build_validator(base_schema)
+
+    # base_schema only declares 200 — anything else falls into a status-class-specific bucket.
+    validator.validate_response(_response("GET", "/api/projects/1/widgets/", status_code, {"detail": "x"}))
+
+    assert recorder.events[-1].reason == expected_reason
+
+
+def test_distinguishes_gap_no_json_media() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {"text/csv": {"schema": {"type": "string"}}},
+                        }
+                    }
+                }
+            }
+        },
+    }
+    validator, recorder = _build_validator(schema)
+
+    validator.validate_response(_response("GET", "/api/widgets/", 200, {"id": 1}))
+
+    assert recorder.events[-1].reason == "gap_no_json_media"
+
+
+def test_distinguishes_gap_no_schema() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/widgets/": {
+                "get": {
+                    "responses": {"200": {"content": {"application/json": {}}}},
+                }
+            }
+        },
+    }
+    validator, recorder = _build_validator(schema)
+
+    validator.validate_response(_response("GET", "/api/widgets/", 200, {"id": 1}))
+
+    assert recorder.events[-1].reason == "gap_no_schema"
+
+
+def test_gap_no_responses_when_no_responses_key() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {"/api/widgets/": {"get": {}}},
+    }
+    validator, recorder = _build_validator(schema)
+
+    validator.validate_response(_response("GET", "/api/widgets/", 200, {"id": 1}))
+
+    assert recorder.events[-1].reason == "gap_no_responses"
+
+
+def test_nullable_inside_referenced_component_is_supported() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/projects/{team_id}/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Widget"}}}}
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Widget": {
+                    "type": "object",
+                    "properties": {
+                        "start_date": {"type": "string", "nullable": True},
+                    },
+                    "required": ["start_date"],
+                }
+            }
+        },
+    }
+
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/1/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"start_date": None}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+
+    assert recorder.events[-1].reason == "validated"
+
+
+def test_path_lookup_normalizes_trailing_slash(base_schema: dict) -> None:
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(base_schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/123/widgets"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"id": 1, "name": "Widget"}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+
+    assert recorder.events[-1].reason == "validated"
 
 
 def test_nullable_schema_is_supported() -> None:
@@ -138,4 +409,4 @@ def test_nullable_schema_is_supported() -> None:
 
     validator.validate_response(response)
 
-    assert recorder.events[-1].reason == "schema_validation_passed"
+    assert recorder.events[-1].reason == "validated"

--- a/posthog/test/test_openapi_response_validation.py
+++ b/posthog/test/test_openapi_response_validation.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from posthog.test.openapi_response_validation import OpenAPIResponseValidator, OpenAPIValidationRecorder
+
+
+@dataclass
+class _FakeRequest:
+    method: str
+    path: str
+
+
+@dataclass
+class _FakeResponse:
+    wsgi_request: _FakeRequest
+    status_code: int
+    headers: dict[str, str]
+    content: bytes
+    charset: str = "utf-8"
+
+
+@pytest.fixture
+def base_schema() -> dict:
+    return {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/projects/{team_id}/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "integer"},
+                                            "name": {"type": "string"},
+                                        },
+                                        "required": ["id", "name"],
+                                        "additionalProperties": False,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {},
+    }
+
+
+def test_validates_dynamic_openapi_paths(base_schema: dict) -> None:
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(base_schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/123/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"id": 1, "name": "Widget"}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+
+    assert recorder.events[-1].reason == "schema_validation_passed"
+
+
+def test_records_schema_mismatch_without_failing_in_default_mode(base_schema: dict) -> None:
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(base_schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/123/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"id": "not-an-integer", "name": "Widget"}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+    assert recorder.events[-1].reason == "schema_validation_failed"
+
+
+def test_raises_machine_readable_error_on_schema_mismatch_in_strict_mode(base_schema: dict) -> None:
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(base_schema, recorder, strict=True)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/123/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"id": "not-an-integer", "name": "Widget"}).encode("utf-8"),
+    )
+
+    with pytest.raises(AssertionError, match='"reason": "schema_validation_failed"'):
+        validator.validate_response(response)
+
+
+def test_nullable_schema_is_supported() -> None:
+    schema = {
+        "openapi": "3.0.3",
+        "paths": {
+            "/api/projects/{team_id}/widgets/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "optional_name": {"type": "string", "nullable": True},
+                                        },
+                                        "required": ["optional_name"],
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+    recorder = OpenAPIValidationRecorder()
+    validator = OpenAPIResponseValidator(schema, recorder)
+
+    response = _FakeResponse(
+        wsgi_request=_FakeRequest(method="GET", path="/api/projects/1/widgets/"),
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"optional_name": None}).encode("utf-8"),
+    )
+
+    validator.validate_response(response)
+
+    assert recorder.events[-1].reason == "schema_validation_passed"

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -76,7 +76,7 @@ export interface ExperimentHoldoutApi {
      */
     description?: string | null
     filters?: unknown
-    readonly created_by: UserBasicApi
+    readonly created_by: UserBasicApi | null
     readonly created_at: string
     readonly updated_at: string
 }
@@ -100,7 +100,7 @@ export interface PatchedExperimentHoldoutApi {
      */
     description?: string | null
     filters?: unknown
-    readonly created_by?: UserBasicApi
+    readonly created_by?: UserBasicApi | null
     readonly created_at?: string
     readonly updated_at?: string
 }
@@ -118,7 +118,7 @@ export interface ExperimentSavedMetricApi {
      */
     description?: string | null
     query: unknown
-    readonly created_by: UserBasicApi
+    readonly created_by: UserBasicApi | null
     readonly created_at: string
     readonly updated_at: string
     tags?: unknown[]
@@ -151,7 +151,7 @@ export interface PatchedExperimentSavedMetricApi {
      */
     description?: string | null
     query?: unknown
-    readonly created_by?: UserBasicApi
+    readonly created_by?: UserBasicApi | null
     readonly created_at?: string
     readonly updated_at?: string
     tags?: unknown[]
@@ -524,7 +524,7 @@ export interface ExperimentApi {
     /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
     feature_flag_key: string
     readonly feature_flag: MinimalFeatureFlagApi
-    readonly holdout: ExperimentHoldoutApi
+    readonly holdout: ExperimentHoldoutApi | null
     /**
      * ID of a holdout group to exclude from the experiment.
      * @nullable
@@ -546,7 +546,7 @@ export interface ExperimentApi {
     archived?: boolean
     /** @nullable */
     deleted?: boolean | null
-    readonly created_by: UserBasicApi
+    readonly created_by: UserBasicApi | null
     readonly created_at: string
     readonly updated_at: string
     /** Experiment type: web for frontend UI changes, product for backend/API changes.
@@ -622,7 +622,7 @@ export interface PatchedExperimentApi {
     /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
     feature_flag_key?: string
     readonly feature_flag?: MinimalFeatureFlagApi
-    readonly holdout?: ExperimentHoldoutApi
+    readonly holdout?: ExperimentHoldoutApi | null
     /**
      * ID of a holdout group to exclude from the experiment.
      * @nullable
@@ -644,7 +644,7 @@ export interface PatchedExperimentApi {
     archived?: boolean
     /** @nullable */
     deleted?: boolean | null
-    readonly created_by?: UserBasicApi
+    readonly created_by?: UserBasicApi | null
     readonly created_at?: string
     readonly updated_at?: string
     /** Experiment type: web for frontend UI changes, product for backend/API changes.

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -157,9 +157,9 @@ export type FeatureFlagApiFilters = { [key: string]: unknown }
 
 export type FeatureFlagApiExperimentSetMetadataItem = { [key: string]: unknown }
 
-export type FeatureFlagApiSurveys = { [key: string]: unknown }
+export type FeatureFlagApiSurveysItem = { [key: string]: unknown }
 
-export type FeatureFlagApiFeatures = { [key: string]: unknown }
+export type FeatureFlagApiFeaturesItem = { [key: string]: unknown }
 
 /**
  * Serializer mixin that handles tags for objects.
@@ -183,8 +183,8 @@ export interface FeatureFlagApi {
     ensure_experience_continuity?: boolean | null
     readonly experiment_set: readonly number[]
     readonly experiment_set_metadata: readonly FeatureFlagApiExperimentSetMetadataItem[]
-    readonly surveys: FeatureFlagApiSurveys
-    readonly features: FeatureFlagApiFeatures
+    readonly surveys: readonly FeatureFlagApiSurveysItem[]
+    readonly features: readonly FeatureFlagApiFeaturesItem[]
     rollback_conditions?: unknown | null
     /** @nullable */
     performed_rollback?: boolean | null

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ markers =
     skip_on_multitenancy
     async_migrations
     requires_secrets: test needs internal secrets or infra and is skipped on external PRs
+    skip_openapi_response_validation: skip OpenAPI response validation for this test
 
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = module

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16209,7 +16209,7 @@ export namespace Schemas {
        */
       description?: string | null;
       filters?: unknown;
-      readonly created_by: UserBasic;
+      readonly created_by: UserBasic | null;
       readonly created_at: string;
       readonly updated_at: string;
     }
@@ -16421,7 +16421,7 @@ export namespace Schemas {
       /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
       feature_flag_key: string;
       readonly feature_flag: MinimalFeatureFlag;
-      readonly holdout: ExperimentHoldout;
+      readonly holdout: ExperimentHoldout | null;
       /**
        * ID of a holdout group to exclude from the experiment.
        * @nullable
@@ -16443,7 +16443,7 @@ export namespace Schemas {
       archived?: boolean;
       /** @nullable */
       deleted?: boolean | null;
-      readonly created_by: UserBasic;
+      readonly created_by: UserBasic | null;
       readonly created_at: string;
       readonly updated_at: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
@@ -16615,7 +16615,7 @@ export namespace Schemas {
        */
       description?: string | null;
       query: unknown;
-      readonly created_by: UserBasic;
+      readonly created_by: UserBasic | null;
       readonly created_at: string;
       readonly updated_at: string;
       tags?: unknown[];
@@ -17127,9 +17127,9 @@ export namespace Schemas {
 
     export type FeatureFlagExperimentSetMetadataItem = {[key: string]: unknown};
 
-    export type FeatureFlagSurveys = {[key: string]: unknown};
+    export type FeatureFlagSurveysItem = { [key: string]: unknown };
 
-    export type FeatureFlagFeatures = {[key: string]: unknown};
+    export type FeatureFlagFeaturesItem = { [key: string]: unknown };
 
     /**
      * * `feature_flags` - feature_flags
@@ -17173,8 +17173,8 @@ export namespace Schemas {
       ensure_experience_continuity?: boolean | null;
       readonly experiment_set: readonly number[];
       readonly experiment_set_metadata: readonly FeatureFlagExperimentSetMetadataItem[];
-      readonly surveys: FeatureFlagSurveys;
-      readonly features: FeatureFlagFeatures;
+      readonly surveys: readonly FeatureFlagSurveysItem[];
+      readonly features: readonly FeatureFlagFeaturesItem[];
       rollback_conditions?: unknown | null;
       /** @nullable */
       performed_rollback?: boolean | null;
@@ -26903,7 +26903,7 @@ export namespace Schemas {
       /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
       feature_flag_key?: string;
       readonly feature_flag?: MinimalFeatureFlag;
-      readonly holdout?: ExperimentHoldout;
+      readonly holdout?: ExperimentHoldout | null;
       /**
        * ID of a holdout group to exclude from the experiment.
        * @nullable
@@ -26925,7 +26925,7 @@ export namespace Schemas {
       archived?: boolean;
       /** @nullable */
       deleted?: boolean | null;
-      readonly created_by?: UserBasic;
+      readonly created_by?: UserBasic | null;
       readonly created_at?: string;
       readonly updated_at?: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
@@ -26979,7 +26979,7 @@ export namespace Schemas {
        */
       description?: string | null;
       filters?: unknown;
-      readonly created_by?: UserBasic;
+      readonly created_by?: UserBasic | null;
       readonly created_at?: string;
       readonly updated_at?: string;
     }
@@ -26997,7 +26997,7 @@ export namespace Schemas {
        */
       description?: string | null;
       query?: unknown;
-      readonly created_by?: UserBasic;
+      readonly created_by?: UserBasic | null;
       readonly created_at?: string;
       readonly updated_at?: string;
       tags?: unknown[];


### PR DESCRIPTION
### Motivation
- Ensure API responses produced by tests conform to the generated OpenAPI schema and record mismatches for investigation.
- Surface validation results as CI artifacts so failures or regressions can be inspected post-run.

### Description
- Add an OpenAPI response validator and recorder implementation in `posthog/test/openapi_response_validation.py` that validates JSON responses against the DRF spectacular generated schema and can emit a machine-readable report.
- Integrate validation into the test runtime by adding an autouse pytest fixture in `posthog/conftest.py` that wraps `APIClient.request` and validates responses, and add a `pytest_sessionfinish` hook to write `openapi_response_validation_report.json`.
- Add a pytest marker `skip_openapi_response_validation` and register it in `pytest_configure`, and update `pytest.ini` to document the marker.
- Add unit tests for the validator behavior in `posthog/test/test_openapi_response_validation.py` and update the GitHub Actions workflow `ci-backend.yml` to upload `openapi_response_validation_report.json` from relevant matrix jobs as CI artifacts.

### Testing
- Added unit tests in `posthog/test/test_openapi_response_validation.py` and executed `pytest posthog/test/test_openapi_response_validation.py`, which passed.
- CI workflow was updated to collect the validation report as an artifact so validation runs will be available from backend matrix jobs (artifact upload steps added and set to `if: always()`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaca14464832eae72255f30f0cef7)