### PR TITLE
feat(duckling): add ducklake version field and version-aware backfill routing

### DIFF
--- a/posthog/admin/admins/ducklake_catalog_admin.py
+++ b/posthog/admin/admins/ducklake_catalog_admin.py
@@ -8,13 +8,14 @@ class DuckLakeCatalogAdmin(admin.ModelAdmin):
         "organization_id",
         "db_host",
         "db_database",
+        "ducklake_version",
         "bucket",
         "bucket_region",
         "cross_account_role_arn",
         "created_at",
         "updated_at",
     )
-    list_filter = ("bucket_region",)
+    list_filter = ("bucket_region", "ducklake_version")
     search_fields = ("=team__id", "=organization__id", "db_host", "bucket", "cross_account_role_arn")
     readonly_fields = ("id", "created_at", "updated_at")
     raw_id_fields = ("team", "organization")
@@ -23,7 +24,7 @@ class DuckLakeCatalogAdmin(admin.ModelAdmin):
         (
             None,
             {
-                "fields": ("id", "team", "organization"),
+                "fields": ("id", "team", "organization", "ducklake_version"),
             },
         ),
         (

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -84,8 +84,8 @@ DUCKDB_MEMORY_LIMIT = "4GB"
 # via the community extension registry, and the extension version must match
 # the catalog version on the duckling's RDS Postgres.
 DUCKDB_VERSION_TO_DUCKLAKE: dict[str, int] = {
-    "1.5.1": 40,  # ducklake 0.4
-    "1.5.2": 100,  # ducklake 1.0
+    "1.5.1": DuckLakeCatalog.DuckLakeVersion.V0_4,
+    "1.5.2": DuckLakeCatalog.DuckLakeVersion.V1_0,
 }
 
 
@@ -111,6 +111,7 @@ def get_runtime_ducklake_version() -> int | None:
 def check_ducklake_version_compatible(
     catalog: DuckLakeCatalog,
     context: AssetExecutionContext,
+    team_id: int,
 ) -> bool:
     """Check if the current runtime is compatible with a catalog's ducklake version.
 
@@ -122,6 +123,43 @@ def check_ducklake_version_compatible(
     """
     if catalog.ducklake_version is None:
         return True
+
+    runtime_version = get_runtime_ducklake_version()
+    if runtime_version is None:
+        context.log.warning(
+            f"Unknown DuckLake version for team_id={team_id}: "
+            f"catalog requires version {catalog.ducklake_version} but this runtime "
+            f"has duckdb {duckdb.__version__} which is not in the known version mapping. "
+            f"Skipping to avoid potential incompatibility."
+        )
+        logger.warning(
+            "duckling_unknown_runtime_version",
+            team_id=team_id,
+            catalog_version=catalog.ducklake_version,
+            duckdb_version=duckdb.__version__,
+        )
+        return False
+
+    if catalog.ducklake_version != runtime_version:
+        context.log.error(
+            f"DuckLake version mismatch for team_id={team_id}: "
+            f"catalog requires version {catalog.ducklake_version} but this runtime "
+            f"supports version {runtime_version} (duckdb {duckdb.__version__}). "
+            f"Run this backfill on the correct container image."
+        )
+        logger.error(
+            "duckling_version_mismatch",
+            team_id=team_id,
+            catalog_version=catalog.ducklake_version,
+            runtime_version=runtime_version,
+            duckdb_version=duckdb.__version__,
+        )
+        return False
+
+    context.log.info(
+        f"DuckLake version check passed: runtime {runtime_version} matches catalog version {catalog.ducklake_version}"
+    )
+    return True
 
     runtime_version = get_runtime_ducklake_version()
     if runtime_version is None:
@@ -1575,7 +1613,7 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     # with "skipped_version_mismatch" metadata so the wrong-version runtime
     # doesn't burn retries. The correct-version runtime will pick it up via
     # the sensor's retry-on-failure logic.
-    if not check_ducklake_version_compatible(catalog, context):
+    if not check_ducklake_version_compatible(catalog, context, team_id):
         context.log.warning(
             f"Skipping duckling events backfill for team_id={team_id}: "
             f"catalog version {catalog.ducklake_version} is incompatible with this runtime"
@@ -1733,7 +1771,7 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
     # with "skipped_version_mismatch" metadata so the wrong-version runtime
     # doesn't burn retries. The correct-version runtime will pick it up via
     # the sensor's retry-on-failure logic.
-    if not check_ducklake_version_compatible(catalog, context):
+    if not check_ducklake_version_compatible(catalog, context, team_id):
         context.log.warning(
             f"Skipping duckling persons backfill for team_id={team_id}: "
             f"catalog version {catalog.ducklake_version} is incompatible with this runtime"

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -101,8 +101,8 @@ def get_runtime_ducklake_version() -> int | None:
         current duckdb version isn't in the known mapping.
     """
     version = duckdb.__version__
-    for prefix, dl_version in DUCKDB_VERSION_TO_DUCKLAKE.items():
-        if version.startswith(prefix):
+    for expected_version, dl_version in DUCKDB_VERSION_TO_DUCKLAKE.items():
+        if version == expected_version:
             return dl_version
 
     logger.warning(
@@ -119,18 +119,30 @@ def check_ducklake_version_compatible(
 ) -> bool:
     """Check if the current runtime is compatible with a catalog's ducklake version.
 
-    When the catalog has no version set (None), we proceed without warning
-    for backward compatibility (dev mode, unset catalogs).
+    When the catalog has no version set (None), we proceed for backward
+    compatibility (dev mode, unset catalogs). When the catalog version is set
+    but the runtime version is unknown, we skip to avoid potential incompatibility.
 
-    Returns True if compatible or version is unknown, False if incompatible.
-    Logs and returns False when there's a clear mismatch.
+    Returns True if compatible, False if incompatible or unknown.
     """
     if catalog.ducklake_version is None:
         return True
 
     runtime_version = get_runtime_ducklake_version()
     if runtime_version is None:
-        return True
+        context.log.warning(
+            f"Unknown DuckLake version for team_id={catalog.team_id}: "
+            f"catalog requires version {catalog.ducklake_version} but this runtime "
+            f"has duckdb {duckdb.__version__} which is not in the known version mapping. "
+            f"Skipping to avoid potential incompatibility."
+        )
+        logger.warning(
+            "duckling_unknown_runtime_version",
+            team_id=catalog.team_id,
+            catalog_version=catalog.ducklake_version,
+            duckdb_version=duckdb.__version__,
+        )
+        return False
 
     if catalog.ducklake_version != runtime_version:
         context.log.error(

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -115,6 +115,10 @@ def check_ducklake_version_compatible(
 ) -> bool:
     """Check if the current runtime is compatible with a catalog's ducklake version.
 
+    Accepts team_id from the caller rather than using catalog.team_id because
+    catalog.team_id is deprecated and nullable (org-scoped catalogs may have
+    team_id=None).
+
     When the catalog has no version set (None), we proceed for backward
     compatibility (dev mode, unset catalogs). When the catalog version is set
     but the runtime version is unknown, we skip to avoid potential incompatibility.
@@ -150,43 +154,6 @@ def check_ducklake_version_compatible(
         logger.error(
             "duckling_version_mismatch",
             team_id=team_id,
-            catalog_version=catalog.ducklake_version,
-            runtime_version=runtime_version,
-            duckdb_version=duckdb.__version__,
-        )
-        return False
-
-    context.log.info(
-        f"DuckLake version check passed: runtime {runtime_version} matches catalog version {catalog.ducklake_version}"
-    )
-    return True
-
-    runtime_version = get_runtime_ducklake_version()
-    if runtime_version is None:
-        context.log.warning(
-            f"Unknown DuckLake version for team_id={catalog.team_id}: "
-            f"catalog requires version {catalog.ducklake_version} but this runtime "
-            f"has duckdb {duckdb.__version__} which is not in the known version mapping. "
-            f"Skipping to avoid potential incompatibility."
-        )
-        logger.warning(
-            "duckling_unknown_runtime_version",
-            team_id=catalog.team_id,
-            catalog_version=catalog.ducklake_version,
-            duckdb_version=duckdb.__version__,
-        )
-        return False
-
-    if catalog.ducklake_version != runtime_version:
-        context.log.error(
-            f"DuckLake version mismatch for team_id={catalog.team_id}: "
-            f"catalog requires version {catalog.ducklake_version} but this runtime "
-            f"supports version {runtime_version} (duckdb {duckdb.__version__}). "
-            f"Run this backfill on the correct container image."
-        )
-        logger.error(
-            "duckling_version_mismatch",
-            team_id=catalog.team_id,
             catalog_version=catalog.ducklake_version,
             runtime_version=runtime_version,
             duckdb_version=duckdb.__version__,

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -79,6 +79,80 @@ logger = structlog.get_logger(__name__)
 # for Python, Dagster framework, and ClickHouse client overhead.
 DUCKDB_MEMORY_LIMIT = "4GB"
 
+# Mapping from duckdb Python package version to the DuckLake catalog version
+# it supports. Each duckdb release ships a specific ducklake extension version
+# via the community extension registry, and the extension version must match
+# the catalog version on the duckling's RDS Postgres.
+DUCKDB_VERSION_TO_DUCKLAKE: dict[str, int] = {
+    "1.5.1": 40,  # ducklake 0.4
+    "1.5.2": 100,  # ducklake 1.0
+}
+
+
+def get_runtime_ducklake_version() -> int | None:
+    """Detect which DuckLake catalog version this runtime can handle.
+
+    Uses the duckdb Python package version to infer the ducklake extension
+    version, since each duckdb release pins one ducklake extension version
+    in the community extension registry.
+
+    Returns:
+        40 for ducklake 0.4, 100 for ducklake 1.0, or None if the
+        current duckdb version isn't in the known mapping.
+    """
+    version = duckdb.__version__
+    for prefix, dl_version in DUCKDB_VERSION_TO_DUCKLAKE.items():
+        if version.startswith(prefix):
+            return dl_version
+
+    logger.warning(
+        "duckling_unknown_duckdb_version",
+        duckdb_version=version,
+        known_versions=list(DUCKDB_VERSION_TO_DUCKLAKE.keys()),
+    )
+    return None
+
+
+def check_ducklake_version_compatible(
+    catalog,
+    context: AssetExecutionContext,
+) -> bool:
+    """Check if the current runtime is compatible with a catalog's ducklake version.
+
+    When the catalog has no version set (None), we proceed without warning
+    for backward compatibility (dev mode, unset catalogs).
+
+    Returns True if compatible or version is unknown, False if incompatible.
+    Logs and returns False when there's a clear mismatch.
+    """
+    if catalog.ducklake_version is None:
+        return True
+
+    runtime_version = get_runtime_ducklake_version()
+    if runtime_version is None:
+        return True
+
+    if catalog.ducklake_version != runtime_version:
+        context.log.error(
+            f"DuckLake version mismatch for team_id={catalog.team_id}: "
+            f"catalog requires version {catalog.ducklake_version} but this runtime "
+            f"supports version {runtime_version} (duckdb {duckdb.__version__}). "
+            f"Run this backfill on the correct container image."
+        )
+        logger.error(
+            "duckling_version_mismatch",
+            team_id=catalog.team_id,
+            catalog_version=catalog.ducklake_version,
+            runtime_version=runtime_version,
+            duckdb_version=duckdb.__version__,
+        )
+        return False
+
+    context.log.info(
+        f"DuckLake version check passed: runtime {runtime_version} matches catalog version {catalog.ducklake_version}"
+    )
+    return True
+
 
 @retry(
     stop=stop_after_attempt(3),
@@ -1489,6 +1563,22 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
 
     context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
 
+    # Verify ducklake version compatibility before proceeding
+    if not check_ducklake_version_compatible(catalog, context):
+        context.log.warning(
+            f"Skipping duckling events backfill for team_id={team_id}: "
+            f"catalog version {catalog.ducklake_version} is incompatible with this runtime"
+        )
+        context.add_output_metadata(
+            {
+                "team_id": team_id,
+                "partition_key": context.partition_key,
+                "status": "skipped_version_mismatch",
+                "catalog_version": catalog.ducklake_version,
+            }
+        )
+        return
+
     # Delete events table if requested (dangerous - loses all data)
     if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
         context.log.warning("delete_tables=True: Deleting events table...")
@@ -1626,6 +1716,23 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
 
     context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
+
+    # Verify ducklake version compatibility before proceeding
+    if not check_ducklake_version_compatible(catalog, context):
+        context.log.warning(
+            f"Skipping duckling persons backfill for team_id={team_id}: "
+            f"catalog version {catalog.ducklake_version} is incompatible with this runtime"
+        )
+        context.add_output_metadata(
+            {
+                "team_id": team_id,
+                "partition_key": context.partition_key,
+                "export_mode": export_mode,
+                "status": "skipped_version_mismatch",
+                "catalog_version": catalog.ducklake_version,
+            }
+        )
+        return
 
     # Delete persons table if requested (dangerous - loses all data)
     if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -105,16 +105,11 @@ def get_runtime_ducklake_version() -> int | None:
         if version == expected_version:
             return dl_version
 
-    logger.warning(
-        "duckling_unknown_duckdb_version",
-        duckdb_version=version,
-        known_versions=list(DUCKDB_VERSION_TO_DUCKLAKE.keys()),
-    )
     return None
 
 
 def check_ducklake_version_compatible(
-    catalog,
+    catalog: DuckLakeCatalog,
     context: AssetExecutionContext,
 ) -> bool:
     """Check if the current runtime is compatible with a catalog's ducklake version.
@@ -1575,7 +1570,11 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
 
     context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
 
-    # Verify ducklake version compatibility before proceeding
+    # Verify ducklake version compatibility before proceeding.
+    # We deliberately return (not raise) on mismatch: the partition succeeds
+    # with "skipped_version_mismatch" metadata so the wrong-version runtime
+    # doesn't burn retries. The correct-version runtime will pick it up via
+    # the sensor's retry-on-failure logic.
     if not check_ducklake_version_compatible(catalog, context):
         context.log.warning(
             f"Skipping duckling events backfill for team_id={team_id}: "
@@ -1729,7 +1728,11 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
 
     context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
 
-    # Verify ducklake version compatibility before proceeding
+    # Verify ducklake version compatibility before proceeding.
+    # We deliberately return (not raise) on mismatch: the partition succeeds
+    # with "skipped_version_mismatch" metadata so the wrong-version runtime
+    # doesn't burn retries. The correct-version runtime will pick it up via
+    # the sensor's retry-on-failure logic.
     if not check_ducklake_version_compatible(catalog, context):
         context.log.warning(
             f"Skipping duckling persons backfill for team_id={team_id}: "

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -21,10 +21,12 @@ from posthog.dags.events_backfill_to_duckling import (
     _is_transaction_conflict,
     _set_table_partitioning,
     _validate_identifier,
+    check_ducklake_version_compatible,
     delete_events_partition_data,
     delete_persons_partition_data,
     duckling_events_full_backfill_sensor,
     get_months_in_range,
+    get_runtime_ducklake_version,
     get_s3_url_for_clickhouse,
     is_full_export_partition,
     parse_partition_key,
@@ -967,3 +969,83 @@ class TestDuckLakeAddDataFilesPartitioning:
                 f"CALL ducklake_add_data_files('test_lake', 'events', '{path}',"
                 f" schema => 'posthog', hive_partitioning => false)"
             )
+
+
+class TestGetRuntimeDucklakeVersion:
+    @parameterized.expand(
+        [
+            ("known_1_5_1", "1.5.1", 40),
+            ("known_1_5_2", "1.5.2", 100),
+            ("unknown_1_5_10", "1.5.10", None),
+            ("unknown_2_0_0", "2.0.0", None),
+            ("unknown_garbage", "not.a.version", None),
+        ]
+    )
+    def test_maps_duckdb_version_to_ducklake(self, _name: str, duckdb_version: str, expected: int | None):
+        with patch("duckdb.__version__", duckdb_version):
+            assert get_runtime_ducklake_version() == expected
+
+
+class TestCheckDucklakeVersionCompatible:
+    def _make_catalog(self, ducklake_version: int | None):
+        catalog = MagicMock()
+        catalog.ducklake_version = ducklake_version
+        return catalog
+
+    def _make_context(self) -> MagicMock:
+        context = MagicMock()
+        return context
+
+    @parameterized.expand(
+        [
+            ("catalog_unset", None, "1.5.1", 123, True),
+            ("match_0_4", 40, "1.5.1", 123, True),
+            ("match_1_0", 100, "1.5.2", 123, True),
+            ("mismatch_runtime_0_4_catalog_1_0", 100, "1.5.1", 456, False),
+            ("mismatch_runtime_1_0_catalog_0_4", 40, "1.5.2", 456, False),
+            ("unknown_runtime", 40, "1.5.10", 789, False),
+        ]
+    )
+    def test_compatibility(
+        self,
+        _name: str,
+        catalog_version: int | None,
+        duckdb_version: str,
+        team_id: int,
+        expected: bool,
+    ):
+        catalog = self._make_catalog(catalog_version)
+        context = self._make_context()
+
+        with patch("duckdb.__version__", duckdb_version):
+            assert check_ducklake_version_compatible(catalog, context, team_id) == expected
+
+    def test_logs_error_on_mismatch(self):
+        catalog = self._make_catalog(100)
+        context = self._make_context()
+
+        with patch("duckdb.__version__", "1.5.1"):
+            result = check_ducklake_version_compatible(catalog, context, 456)
+            assert result is False
+            context.log.error.assert_called_once()
+            assert "team_id=456" in str(context.log.error.call_args)
+
+    def test_logs_warning_on_unknown_runtime(self):
+        catalog = self._make_catalog(40)
+        context = self._make_context()
+
+        with patch("duckdb.__version__", "1.5.10"):
+            result = check_ducklake_version_compatible(catalog, context, 789)
+            assert result is False
+            context.log.warning.assert_called_once()
+            assert "team_id=789" in str(context.log.warning.call_args)
+
+    def test_no_logging_when_catalog_unset(self):
+        catalog = self._make_catalog(None)
+        context = self._make_context()
+
+        with patch("duckdb.__version__", "1.5.10"):
+            result = check_ducklake_version_compatible(catalog, context, 123)
+            assert result is True
+            context.log.warning.assert_not_called()
+            context.log.error.assert_not_called()

--- a/posthog/ducklake/models.py
+++ b/posthog/ducklake/models.py
@@ -21,6 +21,10 @@ class DuckLakeCatalog(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     environment variable configuration.
     """
 
+    class DuckLakeVersion(models.IntegerChoices):
+        V0_4 = 40, "0.4"
+        V1_0 = 100, "1.0"
+
     # Deprecated: use organization instead. Kept nullable for backward compatibility.
     team = models.OneToOneField(
         "posthog.Team",
@@ -33,6 +37,18 @@ class DuckLakeCatalog(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
         "posthog.Organization",
         on_delete=models.CASCADE,
         related_name="ducklake_catalog",
+    )
+
+    ducklake_version = models.IntegerField(
+        choices=DuckLakeVersion.choices,
+        null=True,
+        blank=True,
+        default=None,
+        help_text=(
+            "DuckLake catalog version deployed on this duckling. "
+            "Determines which DuckDB version must be used for backfill jobs. "
+            "0.4 requires duckdb 1.5.1; 1.0 requires duckdb 1.5.2."
+        ),
     )
 
     # Database connection settings

--- a/posthog/ducklake/models.py
+++ b/posthog/ducklake/models.py
@@ -43,7 +43,6 @@ class DuckLakeCatalog(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
         choices=DuckLakeVersion.choices,
         null=True,
         blank=True,
-        default=None,
         help_text=(
             "DuckLake catalog version deployed on this duckling. "
             "Determines which DuckDB version must be used for backfill jobs. "

--- a/posthog/migrations/1130_ducklake_catalog_version.py
+++ b/posthog/migrations/1130_ducklake_catalog_version.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1129_userintegration"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ducklakecatalog",
+            name="ducklake_version",
+            field=models.IntegerField(
+                blank=True,
+                choices=[(40, "0.4"), (100, "1.0")],
+                default=None,
+                help_text=(
+                    "DuckLake catalog version deployed on this duckling. "
+                    "Determines which DuckDB version must be used for backfill jobs. "
+                    "0.4 requires duckdb 1.5.1; 1.0 requires duckdb 1.5.2."
+                ),
+                null=True,
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1129_userintegration
+1130_ducklake_catalog_version


### PR DESCRIPTION
## Problem

Some ducklings run DuckLake 0.4 while others have been upgraded to DuckLake 1.0. The ducklake extension version is tied to the duckdb release (1.5.1 ships ducklake 0.4, 1.5.2 ships ducklake 1.0), and the extension version must match the catalog version. Without version-aware routing, the Dagster backfill job fails when the wrong duckdb/ducklake version is used against a catalog.

## Changes

- Added ducklake_version IntegerField with choices (40=0.4, 100=1.0) to DuckLakeCatalog model, including a Django migration (1130)
- Added version detection logic to the backfill DAG: maps duckdb.__version__ to expected ducklake catalog version, with a check_ducklake_version_compatible() guard
- Both duckling_events_backfill and duckling_persons_backfill assets now check compatibility before executing any DuckLake operations, skipping with status: skipped_version_mismatch in metadata when incompatible
- Proceeds normally when the catalog version is unset (backward compatible)
- Updated Django admin to show and filter by ducklake_version

## How did you test this code?

- Ruff lint and format pass cleanly on all modified files

## Agent context

- Agent: opencode (deepseek-v4-pro)
- Key decisions: Used integer choices (40/100) to avoid float precision issues; version guard runs before any DuckLake I/O to fail fast; unset version falls through for backward compatibility with dev mode and unconfigured catalogs