### PR TITLE
Document Docker Compose profile strategy and deprecate profiles.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,12 @@
 # PostHog has sunset support for self-hosted K8s deployments.
 # See: https://posthog.com/blog/sunsetting-helm-support-posthog
 #
+# Profile guidance:
+#   New optional services should declare `profiles:` directly on the service
+#   here (see capture, plugins, ingestion-* for examples).
+#   docker-compose.profiles.yml is a legacy overlay that retroactively gates
+#   older services; do not add new entries there.
+#
 
 services:
     proxy:

--- a/docker-compose.profiles.yml
+++ b/docker-compose.profiles.yml
@@ -1,10 +1,17 @@
-# Docker Compose profile overlay — gates non-core services behind profiles.
+# Docker Compose profile overlay — historical backwards-compatibility layer.
 #
-# Used by hogli dev:start and CI workflows to start only what's needed.
-# Running `docker compose -f docker-compose.dev.yml up` without this overlay
-# will start ALL services as before (backward compatible).
+# This file exists only to retroactively gate services that were added to
+# docker-compose.dev.yml before per-service `profiles:` was adopted there.
+# It shadows those service definitions with a `profiles:` constraint so that
+# `hogli dev:start` and CI can start only what's needed without breaking
+# users who run `docker compose -f docker-compose.dev.yml up` directly
+# (they get all services, same as before).
 #
-# Usage:
+# DO NOT add new services here. New profile-gated services should define
+# `profiles:` directly in docker-compose.dev.yml (see capture, plugins,
+# ingestion-* for examples of the current pattern).
+#
+# Usage (legacy, for services still listed below):
 #   docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml \
 #     --profile temporal up
 #


### PR DESCRIPTION
## Problem

The Docker Compose profile configuration has evolved, but the documentation and guidance for developers was unclear about which approach to use for new optional services. This led to inconsistent patterns across the codebase.

## Changes

Updated documentation in both `docker-compose.dev.yml` and `docker-compose.profiles.yml` to clarify the current strategy:

- **docker-compose.profiles.yml**: Clarified that this file is a legacy backwards-compatibility layer for services added before per-service `profiles:` support was adopted. Added explicit guidance that new services should NOT be added here.
- **docker-compose.dev.yml**: Added profile guidance section directing developers to declare `profiles:` directly on new optional services (with references to existing examples like `capture`, `plugins`, and `ingestion-*`), and noting that `docker-compose.profiles.yml` is the legacy approach.

These changes establish a clear, forward-looking pattern while maintaining backwards compatibility for existing services.

## How did you test this code?

N/A — Documentation-only changes. No functional behavior modified.

## Publish to changelog?

No

https://claude.ai/code/session_01Qf93wEh2pPmPJFcyHtggqj