### PR TITLE
test(dagster): speed up clickhouse tests

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -604,6 +604,7 @@ class MutationNotFound(Exception):
 class MutationWaiter:
     table: str
     mutation_ids: Set[str]
+    poll_interval: float = field(default=15.0, kw_only=True)
 
     def __call__(self, client: Client) -> None:
         return self.wait(client)
@@ -634,7 +635,7 @@ class MutationWaiter:
 
     def wait(self, client: Client) -> None:
         while not self.is_done(client):
-            time.sleep(15.0)
+            time.sleep(self.poll_interval)
 
 
 @dataclass
@@ -643,6 +644,7 @@ class MutationRunner(abc.ABC):
     parameters: Mapping[str, Any] = field(default_factory=dict, kw_only=True)
     settings: Mapping[str, Any] = field(default_factory=dict, kw_only=True)
     force: bool = field(default=False, kw_only=True)  # whether to force the mutation to run even if it already exists
+    poll_interval: float = field(default_factory=lambda: 0.1 if settings.TEST else 15.0, kw_only=True)
 
     @abc.abstractmethod
     def get_all_commands(self) -> Set[str]:
@@ -677,7 +679,7 @@ class MutationRunner(abc.ABC):
 
         commands_to_enqueue = expected_commands - mutations_running.keys()
         if not commands_to_enqueue:
-            return MutationWaiter(self.table, set(mutations_running.values()))
+            return MutationWaiter(self.table, set(mutations_running.values()), poll_interval=self.poll_interval)
 
         client.execute(self.get_statement(commands_to_enqueue), self.parameters, settings=self.settings)
 
@@ -686,7 +688,7 @@ class MutationRunner(abc.ABC):
         for _ in range(5):
             mutations_running = self.find_existing_mutations(client, expected_commands)
             if mutations_running.keys() == expected_commands:
-                return MutationWaiter(self.table, set(mutations_running.values()))
+                return MutationWaiter(self.table, set(mutations_running.values()), poll_interval=self.poll_interval)
             time.sleep(1.0)
 
         raise Exception(

--- a/posthog/dags/tests/conftest.py
+++ b/posthog/dags/tests/conftest.py
@@ -1,8 +1,3 @@
-# explicit fixture import is needed as autodiscovery doesn't work due to package layout
-from posthog.conftest import django_db_setup
-
-__all__ = ["django_db_setup"]
-
 from collections.abc import Iterator
 
 import pytest
@@ -10,6 +5,7 @@ from posthog.test.base import reset_clickhouse_database
 from unittest.mock import patch
 
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
+from posthog.conftest import reset_clickhouse_tables
 
 # Import the shared Dagster PostgreSQL fixtures so they apply to all tests
 # in this directory. Direct import (rather than pytest_plugins) is required
@@ -18,6 +14,26 @@ from posthog.dags.tests.dagster_pg_fixtures import (  # noqa: F401
     _dagster_postgres_instance,
     _use_postgres_dagster_instance,
 )
+
+TRUNCATE_CLICKHOUSE_RESET_MARKER = "truncate_clickhouse_reset"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _reset_clickhouse_schema_for_truncate_cluster_tests(request: pytest.FixtureRequest) -> Iterator[None]:
+    module_items = getattr(request.node, "items", [])
+    if not any(
+        "cluster" in item.fixturenames and item.get_closest_marker(TRUNCATE_CLICKHOUSE_RESET_MARKER)
+        for item in module_items
+    ):
+        yield
+        return
+
+    request.getfixturevalue("django_db_setup")
+    reset_clickhouse_database()
+    try:
+        yield
+    finally:
+        reset_clickhouse_database()
 
 
 def _patched_get_cluster_hosts(self, client, cluster, retry_policy=None):
@@ -40,12 +56,17 @@ def _patched_get_cluster_hosts(self, client, cluster, retry_policy=None):
 
 
 @pytest.fixture
-def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
+def cluster(request: pytest.FixtureRequest, django_db_setup) -> Iterator[ClickhouseCluster]:
     """
     Cluster fixture with macOS Docker-compatible hostname resolution.
     Patches ClickhouseCluster to use host_name instead of host_address.
     """
-    reset_clickhouse_database()
+    reset_clickhouse = (
+        reset_clickhouse_tables
+        if request.node.get_closest_marker(TRUNCATE_CLICKHOUSE_RESET_MARKER)
+        else reset_clickhouse_database
+    )
+    reset_clickhouse()
     try:
         with patch.object(
             ClickhouseCluster,
@@ -54,4 +75,4 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
         ):
             yield get_cluster()
     finally:
-        reset_clickhouse_database()
+        reset_clickhouse()

--- a/posthog/dags/tests/test_backfill_materialized_column.py
+++ b/posthog/dags/tests/test_backfill_materialized_column.py
@@ -20,6 +20,8 @@ from posthog.dags.backfill_materialized_column import (
     run_materialize_mutations,
 )
 
+pytestmark = pytest.mark.truncate_clickhouse_reset
+
 
 def test_join_mappings():
     assert join_mappings({}) == {}

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -24,6 +24,8 @@ from posthog.models.data_deletion_request import DataDeletionRequest, ExecutionM
 
 TEAM_ID = 99999
 
+pytestmark = pytest.mark.truncate_clickhouse_reset
+
 
 def _insert_events(events: list[tuple], client: Client) -> None:
     client.execute(

--- a/posthog/dags/tests/test_distinct_id_usage.py
+++ b/posthog/dags/tests/test_distinct_id_usage.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 
+import pytest
 from unittest import mock
 
 import dagster
@@ -18,6 +19,8 @@ from posthog.dags.distinct_id_usage import (
     truncate_distinct_id,
 )
 from posthog.models.distinct_id_usage.sql import DATA_TABLE_NAME
+
+pytestmark = pytest.mark.truncate_clickhouse_reset
 
 
 class TestTruncateDistinctId:

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from uuid import UUID
 
+import pytest
+
 import dagster
 from clickhouse_driver import Client
 
@@ -16,6 +18,8 @@ from posthog.dags.person_overrides import (
     squash_person_overrides,
     wait_for_overrides_delete_mutations,
 )
+
+pytestmark = pytest.mark.truncate_clickhouse_reset
 
 
 def test_full_job(cluster: ClickhouseCluster):

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -39,6 +39,8 @@ from posthog.dags.person_property_reconciliation import (
     update_person_with_version_check,
 )
 
+pytestmark = pytest.mark.truncate_clickhouse_reset
+
 
 class TestClickHouseResultParsing:
     """Test that ClickHouse query results are correctly parsed into PersonPropertyDiffs objects."""

--- a/posthog/dags/tests/test_person_property_reconciliation_restore.py
+++ b/posthog/dags/tests/test_person_property_reconciliation_restore.py
@@ -22,6 +22,8 @@ from posthog.dags.person_property_reconciliation_restore import (
 from posthog.models import Organization, Person, Team
 from posthog.person_db_router import PERSONS_DB_FOR_WRITE
 
+pytestmark = pytest.mark.truncate_clickhouse_reset
+
 
 def create_backup_entry(
     cursor,

--- a/posthog/dags/tests/test_property_definitions.py
+++ b/posthog/dags/tests/test_property_definitions.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from uuid import UUID
 
+import pytest
+
 import dagster
 
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
@@ -15,6 +17,8 @@ from posthog.dags.property_definitions import (
 )
 
 from products.event_definitions.backend.models.property_definition import PropertyDefinition
+
+pytestmark = pytest.mark.truncate_clickhouse_reset
 
 
 @dataclass

--- a/posthog/dags/tests/test_sessions_v1_cleanup.py
+++ b/posthog/dags/tests/test_sessions_v1_cleanup.py
@@ -10,6 +10,8 @@ from posthog.clickhouse.cluster import ClickhouseCluster
 from posthog.dags.sessions_v1_cleanup import sessions_v1_cleanup_job
 from posthog.models.sessions.sql import ALLOWED_TEAM_IDS, SESSIONS_DATA_TABLE
 
+pytestmark = pytest.mark.truncate_clickhouse_reset
+
 
 def generate_test_prefix() -> str:
     """Generate a unique prefix for test session IDs to avoid conflicts."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ markers =
     skip_on_multitenancy
     async_migrations
     requires_secrets: test needs internal secrets or infra and is skipped on external PRs
+    truncate_clickhouse_reset: cluster tests that can reset ClickHouse with truncate instead of full schema recreation
 
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = module


### PR DESCRIPTION
## Problem

Dagster CI spends too much wall-clock time in ClickHouse-heavy tests due to slow mutation polling and repeated full ClickHouse schema resets.

## Changes

- Poll ClickHouse mutations faster in test runs while keeping production polling unchanged.
- Add an opt-in `truncate_clickhouse_reset` marker for Dagster cluster tests that can safely use truncate-based reset.
- Remove duplicated Dagster `django_db_setup` fixture wiring.

## How did you test this code?

Agent-tested with:

- `ruff check` on touched Python files
- `pytest posthog/dags/tests/test_data_deletion_requests.py ...`
- `pytest posthog/dags/tests/test_deletes.py posthog/dags/tests/test_sessions_v1_cleanup.py posthog/dags/tests/test_person_overrides.py posthog/dags/tests/test_distinct_id_usage.py posthog/dags/tests/test_property_definitions.py posthog/dags/tests/test_backfill_materialized_column.py ...`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

Codex investigated Dagster CI wall-clock time and found test-only ClickHouse mutation polling and full cluster resets as avoidable costs. `test_deletes.py` was intentionally left on full reset after truncate reset caused failures from async delete state.