### PR TITLE
fix(persons): Tag persons UUID HogQL query

### DIFF
--- a/frontend/src/lib/utils/aiEventsUtils.test.ts
+++ b/frontend/src/lib/utils/aiEventsUtils.test.ts
@@ -1,7 +1,7 @@
+import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 
 import { useMocks } from '~/mocks/jest'
-import * as queryModule from '~/queries/query'
 import { initKeaTests } from '~/test/init'
 
 import { AI_EVENT_NAMES, hasRecentAIEvents } from './aiEventsUtils'
@@ -37,12 +37,12 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            const hogqlQuerySpy = jest.spyOn(queryModule, 'hogqlQuery')
+            const queryApiSpy = jest.spyOn(api, 'query')
 
             const result = await hasRecentAIEvents()
 
             expect(result).toBe(true)
-            expect(hogqlQuerySpy).not.toHaveBeenCalled()
+            expect(queryApiSpy).not.toHaveBeenCalled()
         })
 
         it('returns true for $ai_trace event type', async () => {
@@ -86,14 +86,14 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            const hogqlQuerySpy = jest.spyOn(queryModule, 'hogqlQuery').mockResolvedValue({
+            const queryApiSpy = jest.spyOn(api, 'query').mockResolvedValue({
                 results: [[1]],
             } as any)
 
             const result = await hasRecentAIEvents()
 
             expect(result).toBe(true)
-            expect(hogqlQuerySpy).toHaveBeenCalled()
+            expect(queryApiSpy).toHaveBeenCalled()
         })
 
         it('falls back to ClickHouse when no EventDefinition exists', async () => {
@@ -106,14 +106,14 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            const hogqlQuerySpy = jest.spyOn(queryModule, 'hogqlQuery').mockResolvedValue({
+            const queryApiSpy = jest.spyOn(api, 'query').mockResolvedValue({
                 results: [[1]],
             } as any)
 
             const result = await hasRecentAIEvents()
 
             expect(result).toBe(true)
-            expect(hogqlQuerySpy).toHaveBeenCalled()
+            expect(queryApiSpy).toHaveBeenCalled()
         })
 
         it('returns false when neither Postgres nor ClickHouse has AI events', async () => {
@@ -126,7 +126,7 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            jest.spyOn(queryModule, 'hogqlQuery').mockResolvedValue({
+            jest.spyOn(api, 'query').mockResolvedValue({
                 results: [],
             } as any)
 
@@ -153,14 +153,14 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            const hogqlQuerySpy = jest.spyOn(queryModule, 'hogqlQuery').mockResolvedValue({
+            const queryApiSpy = jest.spyOn(api, 'query').mockResolvedValue({
                 results: [],
             } as any)
 
             const result = await hasRecentAIEvents()
 
             expect(result).toBe(false)
-            expect(hogqlQuerySpy).toHaveBeenCalled()
+            expect(queryApiSpy).toHaveBeenCalled()
         })
 
         it('handles null results from ClickHouse gracefully', async () => {
@@ -173,7 +173,7 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            jest.spyOn(queryModule, 'hogqlQuery').mockResolvedValue({
+            jest.spyOn(api, 'query').mockResolvedValue({
                 results: null,
             } as any)
 
@@ -192,7 +192,7 @@ describe('aiEventsUtils', () => {
                 },
             })
 
-            jest.spyOn(queryModule, 'hogqlQuery').mockResolvedValue({} as any)
+            jest.spyOn(api, 'query').mockResolvedValue({} as any)
 
             const result = await hasRecentAIEvents()
 

--- a/frontend/src/lib/utils/aiEventsUtils.ts
+++ b/frontend/src/lib/utils/aiEventsUtils.ts
@@ -1,6 +1,6 @@
 import api from 'lib/api'
 
-import { hogqlQuery } from '~/queries/query'
+import { HogQLQuery, NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
 import { EventDefinitionType } from '~/types'
 
@@ -31,10 +31,13 @@ export async function hasRecentAIEvents(): Promise<boolean> {
     }
 
     // Fallback: query ClickHouse directly for recent events (new users)
-    const response = await hogqlQuery(
-        hogql`SELECT 1 FROM events WHERE event IN ${[...AI_EVENT_NAMES]} AND timestamp > now() - INTERVAL 3 HOUR LIMIT 1`,
-        undefined,
-        'force_blocking'
+    const response = await api.query<HogQLQuery>(
+        {
+            kind: NodeKind.HogQLQuery,
+            query: hogql`SELECT 1 FROM events WHERE event IN ${[...AI_EVENT_NAMES]} AND timestamp > now() - INTERVAL 3 HOUR LIMIT 1`,
+            tags: { productKey: ProductKey.LLM_ANALYTICS },
+        },
+        { refresh: 'force_blocking' }
     )
 
     return (response.results?.length ?? 0) > 0

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -17,8 +17,7 @@ import { urls } from 'scenes/urls'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
-import { hogqlQuery } from '~/queries/query'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { DataTableNode, HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 import {
     ActivityScope,
     AnyPropertyFilter,
@@ -30,6 +29,8 @@ import {
     PersonType,
     PersonsTabType,
 } from '~/types'
+
+import { CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS } from 'products/customer_analytics/frontend/constants'
 
 import {
     asDisplay,
@@ -194,7 +195,15 @@ export const personsLogic = kea<personsLogicType>([
                     return person
                 },
                 loadPersonUUID: async ({ uuid }): Promise<PersonType | null> => {
-                    const response = await hogqlQuery(getHogqlQueryStringForPersonId(), { id: uuid }, 'blocking')
+                    const response = await api.query<HogQLQuery>(
+                        {
+                            kind: NodeKind.HogQLQuery,
+                            query: getHogqlQueryStringForPersonId(),
+                            values: { id: uuid },
+                            tags: CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS,
+                        },
+                        { refresh: 'blocking' }
+                    )
                     const row = response?.results?.[0]
                     if (row) {
                         const person = parsePersonFromHogQLRow(row)

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -490,6 +490,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         ],
     )
     def list(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)
         team = self.team
         filter = Filter(request=request, team=self.team)
 


### PR DESCRIPTION
## Problem
A few queries in person profiles are untagged, so they were failing in local dev.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Tagged the queries that were erroring.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- Updating unit tests
- Accessing person profiles without errors
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
