### PR TITLE
feat(experiments/MCP): Improve agentic guidance for uneven split experiments

### DIFF
--- a/products/experiments/skills/configuring-experiment-analytics/SKILL.md
+++ b/products/experiments/skills/configuring-experiment-analytics/SKILL.md
@@ -23,7 +23,14 @@ Two options:
 When a user is exposed to multiple variants (e.g., due to flag changes or race conditions):
 
 - **Exclude multivariate users** — removes these users from the analysis entirely. Cleaner data, smaller sample.
-- **First seen variant** — assigns users to the first variant they were exposed to. Keeps all users in the analysis.
+- **First seen variant** — assigns users to the first variant they were exposed to. Keeps all users in the analysis. Note that "first seen" can introduce other biases as
+  behavior cannot be clearly attributed to a single variant and is not recommended unless necessary.
+
+**Bias risk on uneven splits.** "Exclude multivariate users" combined with an uneven variant split can
+introduce bias — multi-variant users are dropped asymmetrically and the smaller variant loses a larger
+fraction of its assignments. If the experiment's variant split is uneven, the recommended fix is to
+switch to an equal split (see `configuring-experiment-rollout` especially if changed mid-experiment); switching this setting to "First seen
+variant" is the alternative when the uneven split must stay.
 
 ### Filter test accounts
 

--- a/products/experiments/skills/configuring-experiment-analytics/SKILL.md
+++ b/products/experiments/skills/configuring-experiment-analytics/SKILL.md
@@ -28,9 +28,18 @@ When a user is exposed to multiple variants (e.g., due to flag changes or race c
 
 **Bias risk on uneven splits.** "Exclude multivariate users" combined with an uneven variant split can
 introduce bias — multi-variant users are dropped asymmetrically and the smaller variant loses a larger
-fraction of its assignments. If the experiment's variant split is uneven, the recommended fix is to
-switch to an equal split (see `configuring-experiment-rollout` especially if changed mid-experiment); switching this setting to "First seen
-variant" is the alternative when the uneven split must stay.
+fraction of its assignments. If those users behave differently from the rest, the smaller variant's
+metrics will be skewed.
+
+The right mitigation depends on experiment state:
+
+- **Not yet launched, or only exposed to a few users so far** — switch to an even variant split and
+  use the overall rollout percentage to limit test-variant exposure. This removes the bias and
+  preserves statistical power. See `configuring-experiment-rollout`.
+- **Live experiment with significant exposures** — changing the split mid-run reassigns users across
+  variants, which is bad for user experience and data quality. Switch this setting to "First seen
+  variant" instead — it keeps already-assigned users in their original variant (no reassignment) and
+  removes the asymmetric exclusion.
 
 ### Filter test accounts
 

--- a/products/experiments/skills/configuring-experiment-rollout/SKILL.md
+++ b/products/experiments/skills/configuring-experiment-rollout/SKILL.md
@@ -19,6 +19,22 @@ Why equal splits are better:
 
 Always default to an equal split unless the user explicitly requests otherwise.
 
+## When an uneven split is required
+
+Uneven splits combined with the default "Exclude multivariate users" handling can introduce bias.
+If the experiment observes multi-variant users (users exposed to more than one variant) then those are
+dropped asymmetrically - the smaller variant loses a larger fraction of its assignments. If those users
+behave differently from the rest, the smaller variant's metrics will be skewed.
+
+Suggest the following in this order:
+
+1. **Use an equal split and reduce the overall rollout instead.** Achieves the same test-variant
+   exposure without the bias and preserves statistical power — see the disambiguation question below.
+2. **If the uneven split must stay, switch multivariate handling to "First seen variant".** Keeps all
+   users in the analysis and avoids asymmetric exclusion. See `configuring-experiment-analytics` for
+   how to set this. Note however that "first seen" handling can introduce other biases and is not
+   recommended unless necessary.
+
 ## The two rollout controls
 
 There are two separate controls that determine who sees what. Both are set via `parameters`.
@@ -53,28 +69,71 @@ These two controls multiply:
 
 ## The disambiguation question
 
-When a user mentions a specific percentage (e.g. "roll out to 25%", "test on 25% of users"), this is **always ambiguous**. You MUST ask before proceeding:
+**CRITICAL**: If the user requests an uneven variant split (e.g. "60/40", "70/20/10") or mentions a
+specific percentage that could refer to either the split or the rollout (e.g. "roll out to 25%"), you
+MUST clarify before proceeding. This covers two cases:
+
+### Case 1: Single percentage ("25%", "roll out to 40%")
+
+The percentage is ambiguous — it could mean a variant split or a rollout change. Ask:
 
 > There are two ways to get 25% of users seeing the test variant:
 >
-> 1. **Reduced rollout with equal split** (recommended): 50% overall rollout with a 50/50 control/test split.
->    Only 50% of users enter the experiment, and of those, half see test.
->    Result: 25% see test, 50% are in the analysis.
->    This is the recommended approach — equal splits maximize statistical power.
-> 2. **Asymmetric split**: 100% overall rollout with a 75/25 control/test split.
->    All users enter the experiment, but only 25% see test.
->    Result: 25% see test, 100% are in the analysis.
->    Asymmetric splits reduce statistical power on the smaller variant.
->
-> Both achieve the same user-facing outcome. The difference:
->
-> - **Who sees what variant?** — same in both options
-> - **Who is included in the analysis?** — option 1: 50% of users, option 2: all users
-> - **Statistical power** — option 1 gives equal power to each variant; option 2 favors control
+> 1. **Reduced rollout with equal split** (recommended): reduce the overall rollout and split
+>    variants equally. Only a subset of users enter the experiment, and of those, each variant
+>    gets the same share.
+>    Equal splits maximize statistical power and avoid bias.
+> 2. **Asymmetric split**: keep 100% rollout but give the test variant only 25%.
+>    All users enter the experiment, but the uneven split reduces power on the smaller variant
+>    and risks bias.
 >
 > Which approach do you prefer?
 
 Adjust the numbers to match whatever percentage the user requested.
+
+### Case 2: Uneven ratio ("60/40", "70/30", "80/20", etc.)
+
+The ratio looks like an explicit variant split, but a reduced rollout with an equal split is almost
+always better. Explain the trade-off and recommend the alternative:
+
+> An uneven variant split works, but an equal split with reduced rollout is recommended:
+>
+> 1. **Equal split + reduced rollout** (recommended): reduce the overall rollout so that the same
+>    fraction of users sees the test variant, but split variants equally within the experiment.
+>    Equal splits maximize statistical power and avoid bias from asymmetric multivariate exclusion.
+> 2. **Uneven split**.
+>    Achieves the same user-facing outcome, but reduces power on the smaller variant and risks bias.
+>
+> Would you like the equal split approach, or do you have a specific reason for the uneven split?
+
+Adjust the numbers to match the ratio. For experiments with more than two variants, "equal" means
+each variant gets the same share (e.g. 34/33/33 for three variants). If the user confirms they want
+the uneven split after seeing the trade-off, proceed — but DO NOT skip the next section.
+
+### After the user picks the uneven split
+
+If the user proceeds with an uneven split (option 2 in either case above), you MUST surface the
+multivariate-handling implication BEFORE creating or updating the experiment. The user has chosen
+the riskier rollout path and needs to make an informed choice about how to mitigate.
+
+Ask:
+
+> One more thing — with an uneven split, the default "Exclude multivariate users" handling drops
+> users exposed to multiple variants asymmetrically. The smaller variant loses a larger fraction of
+> its assignments, which can skew its metrics if those users behave differently from the rest.
+>
+> Two options:
+>
+> 1. **Switch multivariate handling to "First seen variant"** (recommended for uneven splits) —
+>    keeps all users in the analysis and avoids asymmetric exclusion. Has its own caveats (other
+>    biases can creep in) but is preferable to the default for uneven splits.
+> 2. **Keep the default "Exclude" handling** and accept the bias risk.
+>
+> Which would you like?
+
+See `configuring-experiment-analytics` for how to set the multivariate handling. Apply the choice
+as part of the same operation (creation or update) — do not leave the user with an uneven split
+under default handling without an explicit, informed decision.
 
 ## Persist flag across authentication steps
 
@@ -105,5 +164,13 @@ Present the warning covering both perspectives:
 2. **Who is in my analysis?** — how does this affect data quality?
 
 **Exception**: Increasing rollout (without changing the split) is generally safe — no users switch variants, more users are added cleanly.
+
+**Mid-experiment fix for uneven-split bias**: switching multivariate handling from "Exclude" to "First
+seen variant" is a low-disruption way to mitigate already-observed bias on a running experiment with
+an uneven split — no users switch variants and all already-collected data stays in the analysis.
+The alternative (changing the split to be even) is an anti-pattern mid-run and typically requires
+resetting or ending the experiment. If the experiment has not been exposed to many users yet, applying
+an even split however is preferred. See `configuring-experiment-analytics` for how to change the
+handling.
 
 See `references/changing-distribution-after-launch.md` for detailed warnings, what to tell the user, and when to recommend alternatives.

--- a/products/experiments/skills/configuring-experiment-rollout/SKILL.md
+++ b/products/experiments/skills/configuring-experiment-rollout/SKILL.md
@@ -23,17 +23,20 @@ Always default to an equal split unless the user explicitly requests otherwise.
 
 Uneven splits combined with the default "Exclude multivariate users" handling can introduce bias.
 If the experiment observes multi-variant users (users exposed to more than one variant) then those are
-dropped asymmetrically - the smaller variant loses a larger fraction of its assignments. If those users
+dropped asymmetrically — the smaller variant loses a larger fraction of its assignments. If those users
 behave differently from the rest, the smaller variant's metrics will be skewed.
 
-Suggest the following in this order:
+The right mitigation depends on experiment state:
 
-1. **Use an equal split and reduce the overall rollout instead.** Achieves the same test-variant
-   exposure without the bias and preserves statistical power — see the disambiguation question below.
-2. **If the uneven split must stay, switch multivariate handling to "First seen variant".** Keeps all
-   users in the analysis and avoids asymmetric exclusion. See `configuring-experiment-analytics` for
-   how to set this. Note however that "first seen" handling can introduce other biases and is not
-   recommended unless necessary.
+1. **Pre-launch, or live but with few exposures so far — use an equal split and reduce the overall
+   rollout.** Achieves the same test-variant exposure without the bias and preserves statistical
+   power. See the disambiguation question below.
+2. **Live experiment with significant exposures — switch multivariate handling to "First seen
+   variant".** Changing the split mid-run reassigns users across variants (anti-pattern; see
+   "Changing rollout on a running experiment" below). Switching handling instead keeps everyone in
+   their original variant and avoids the asymmetric exclusion. See `configuring-experiment-analytics`
+   for how to set this. Note that "first seen" handling can introduce other biases, but it's
+   preferable to mid-run reassignment.
 
 ## The two rollout controls
 
@@ -166,11 +169,9 @@ Present the warning covering both perspectives:
 **Exception**: Increasing rollout (without changing the split) is generally safe — no users switch variants, more users are added cleanly.
 
 **Mid-experiment fix for uneven-split bias**: switching multivariate handling from "Exclude" to "First
-seen variant" is a low-disruption way to mitigate already-observed bias on a running experiment with
-an uneven split — no users switch variants and all already-collected data stays in the analysis.
-The alternative (changing the split to be even) is an anti-pattern mid-run and typically requires
-resetting or ending the experiment. If the experiment has not been exposed to many users yet, applying
-an even split however is preferred. See `configuring-experiment-analytics` for how to change the
-handling.
+seen variant" is the recommended mitigation for already-launched experiments — no users switch variants
+and all collected data stays in the analysis. Changing the split to be even is an anti-pattern mid-run
+(typically requires resetting or ending the experiment) and is only preferred if the experiment hasn't
+been exposed to many users yet. See `configuring-experiment-analytics` for how to change the handling.
 
 See `references/changing-distribution-after-launch.md` for detailed warnings, what to tell the user, and when to recommend alternatives.

--- a/products/experiments/skills/creating-experiments/SKILL.md
+++ b/products/experiments/skills/creating-experiments/SKILL.md
@@ -30,16 +30,15 @@ If the user gives enough context to infer these, don't ask — just proceed.
 
 ### Step 2: Who sees what variant?
 
-This is about rollout configuration. **Load the `configuring-experiment-rollout` skill** for guidance.
+This is about rollout configuration.
 
-Key decision points:
+**Before asking any rollout question, load `configuring-experiment-rollout`.** The disambiguation wording, recommendations, and post-answer branches live there — do not formulate rollout questions yourself, and do not assume an example you remember covers the user's path.
+
+Key decision points (covered in detail by `configuring-experiment-rollout`):
 
 - Variant split (how many variants, what percentage each)
 - Overall rollout percentage (what % of all users enter the experiment)
 - Whether to persist the flag across authentication steps
-
-**CRITICAL**: If the user mentions a specific percentage (e.g. "roll out to 25%"), this is ambiguous.
-You MUST clarify before proceeding — see the `configuring-experiment-rollout` skill.
 
 If the user doesn't mention rollout specifics, use defaults: 50/50 control/test, 100% rollout.
 
@@ -92,33 +91,3 @@ Key details:
 3. **Guide through metrics** if not yet configured — load the `configuring-experiment-analytics` skill.
 
 4. **Launch** when ready — use the `experiment-launch` tool.
-
-## Example interaction
-
-```text
-User: "Create an experiment to test our new checkout flow with 25% rollout"
-
-Agent thinks: User mentioned a percentage — this is ambiguous. Load configuring-experiment-rollout.
-
-Agent responds:
-  "Before I create this, I need to clarify the 25% rollout. There are two ways to achieve this:
-
-  1. **Reduced rollout** (recommended): 50% overall rollout with a 50/50 control/test split.
-     25% of all users see the new checkout, and only the 50% in the experiment are analyzed.
-
-  2. **Variant split**: 100% rollout with a 75/25 control/test split.
-     25% of all users see the new checkout, but ALL users are included in the analysis.
-
-  Which approach do you prefer?"
-
-User: "Option 1"
-
-Agent: Creates experiment with overall rollout_percentage: 50, 50/50 variant split, no metrics.
-  "Created draft experiment 'New checkout flow test':
-  http://localhost:8010/project/1/experiments/123
-
-  Next steps:
-  1. Implement the flag in your code — see the experiment page for SDK snippets
-  2. Add metrics — what event represents a successful checkout?
-  3. Launch when ready"
-```


### PR DESCRIPTION
## Problem

Uneven splits are an anti-pattern and can have bias, the agents response wasn't guiding enough.

## Changes

- Agent warns about the potential bias (similar to UI showing a banner introduced in https://github.com/PostHog/posthog/pull/56697)
- The agent now understands the even variants as a recommendation rather than a simple choice
- The agent is now less likely to skip asking clarification (rollout vs split)

## How did you test this code?

Local MCP

<img width="615" height="666" alt="agent-dialog" src="https://github.com/user-attachments/assets/6f829792-a8b3-42dc-bee5-5b0107131c27" />


## Publish to changelog?

No