### PR TITLE
fix(mcp): remove 'introspection' from OAUTH_SCOPES_SUPPORTED

### DIFF
--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -90,7 +90,6 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'openid',
     'profile',
     'email',
-    'introspection',
     'alert:read',
     'alert:write',
     'annotation:read',


### PR DESCRIPTION
## Problem

Closes #55307.

`mcp.posthog.com/.well-known/oauth-protected-resource` advertises `introspection` in `scopes_supported`, but the authorization server at `oauth.posthog.com/.well-known/oauth-authorization-server` does not recognize it as a grantable scope.

Per [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728), spec-compliant MCP clients (including Claude Code) read `scopes_supported` from the protected resource and include every listed scope in the `authorize` request. The auth server then rejects the flow with `?error=invalid_scope`, leaving sign-in unrecoverable from the client side. Live diff at filing time:

```
$ comm -23 \
    <(curl -s https://mcp.posthog.com/.well-known/oauth-protected-resource | jq -r '.scopes_supported[]' | sort) \
    <(curl -sL https://mcp.posthog.com/.well-known/oauth-authorization-server | jq -r '.scopes_supported[]' | sort)
introspection
```

`introspection` is the OAuth 2.0 Token Introspection **endpoint** ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)), correctly already exposed as `introspection_endpoint` in the AS metadata ([RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414)). It should not also appear as a grantable scope.

This re-applies the fix from [PR #55673](https://github.com/PostHog/posthog/pull/55673) (withdrawn after the external contributor deleted their fork branch).

## Changes

Remove `'introspection'` from `OAUTH_SCOPES_SUPPORTED` in `services/mcp/src/lib/constants.ts` (one line).

## How did you test this code?

Agent-authored. No manual testing.

The MCP unit test `OAUTH_SCOPES_SUPPORTED completeness` in `tests/unit/tool-filtering.test.ts` enforces one direction (every scope referenced by a tool's `required_scopes` must appear in `OAUTH_SCOPES_SUPPORTED`). No tool definition has `introspection` in `required_scopes`, so removing it does not break that test. The other `introspection` references in the repo (`ApiOAuthIntrospection`, `StateManager._api.oauth().introspect()`, `api/client.ts oauth().introspect()`) all target the OAuth introspection **endpoint** and are independent of the grantable-scope list.

After this change, the live diff above goes empty and OAuth completes for spec-compliant clients.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at Matt's direction, in response to an in-house Slack report from Edwin about Claude Code hitting `OAuth error: invalid_scope` against the PostHog MCP server. Re-applies the diff from #55673 verbatim.

A follow-up PR will address the structural problem — `OAUTH_SCOPES_SUPPORTED` is currently hand-maintained in parallel with the Django source of truth (`posthog/scopes.py` `APIScopeObject`), which is how this drift snuck in.