### PR TITLE
fix(mcp): skip group types fetch when token lacks group:read scope

### DIFF
--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -543,11 +543,16 @@ export class MCP extends McpAgent<Env> {
 
         // Fetch group types and metadata in parallel (cache is now seeded)
         const resolvedProjectId = projectId || (await this.cache.get('projectId'))
-        const apiKey = await context.stateManager.getApiKey()
         const [groupTypes, metadata] = await Promise.all([
-            resolvedProjectId && hasScope(apiKey.scopes, 'group:read')
-                ? context.stateManager.getOrFetchGroupTypes(resolvedProjectId)
-                : Promise.resolve(undefined),
+            (async () => {
+                if (!resolvedProjectId) {
+                    return undefined
+                }
+                const apiKey = await context.stateManager.getApiKey()
+                return hasScope(apiKey.scopes, 'group:read')
+                    ? context.stateManager.getOrFetchGroupTypes(resolvedProjectId)
+                    : undefined
+            })(),
             context.stateManager.getEnvironmentPrompt(),
         ])
         // When project ID is provided, both switch tools are removed (project implies org).

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,6 +14,7 @@ import {
     isFeatureFlagEnabled,
     type MCPAnalyticsContext,
 } from '@/lib/analytics'
+import { hasScope } from '@/lib/api'
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
 import { MCPClientProfile } from '@/lib/client-detection'
@@ -542,8 +543,9 @@ export class MCP extends McpAgent<Env> {
 
         // Fetch group types and metadata in parallel (cache is now seeded)
         const resolvedProjectId = projectId || (await this.cache.get('projectId'))
+        const apiKey = await context.stateManager.getApiKey()
         const [groupTypes, metadata] = await Promise.all([
-            resolvedProjectId
+            resolvedProjectId && hasScope(apiKey.scopes, 'group:read')
                 ? context.stateManager.getOrFetchGroupTypes(resolvedProjectId)
                 : Promise.resolve(undefined),
             context.stateManager.getEnvironmentPrompt(),


### PR DESCRIPTION
## Problem

The MCP Cloudflare Worker is producing persistent error log spam:

```
[API] Permission denied on GET /api/projects/{id}/groups_types/: API key missing required scope 'group:read'
```

This affects users whose OAuth tokens were issued before `group:read` was added to `OAUTH_SCOPES_SUPPORTED` (March 24, commit b2134439). Refreshed tokens inherit the original grant's scopes, so affected users keep getting 403s on the groups_types endpoint until their 30-day refresh token expires and they fully re-authenticate.

## Changes

Guard the `getOrFetchGroupTypes` call in `init()` with a `hasScope(apiKey.scopes, 'group:read')` check. When the token doesn't have the scope, the fetch is skipped entirely — avoiding both the unnecessary API request and the error log. The group types data is only used for enriching the system prompt with "Defined group types: ..." and the server already handles `undefined` gracefully.

## How did you test this code?

I'm an agent. Automated verification:
- TypeScript type-check passes (`npx tsc --noEmit`)
- lint-staged passed on commit

No manual testing was performed.

## Publish to changelog?

No

## 🤖 Agent context

- **Agent:** Claude Code (Opus 4.6)
- **Key decisions:** Rather than suppressing the 403 error or changing error log levels, the fix prevents the API call entirely when the scope is missing. This is the most efficient approach — no network round-trip, no error handling, and the `hasScope` helper already exists in the codebase.
- **Investigation:** Traced the error from Cloudflare Worker logs → MCP `StateManager.getOrFetchGroupTypes()` → `ApiClient.getGroupTypes()` → PostHog API `groups_types` endpoint (requires `group:read`) → scope missing from OAuth token because it was issued before the scope was added to `OAUTH_SCOPES_SUPPORTED`.