### PR TITLE
chore: flag to keep scene tabs mounted to preserve local state on tab switch

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -151,6 +151,7 @@ export const FEATURE_FLAGS = {
     // Eternal feature flags, shouldn't be removed, helpful for debugging/maintenance reasons
     BILLING_FORECASTING_ISSUES: 'billing-forecasting-issues', // owner: #team-billing, see `Billing.tsx`, used to raise a warning when billing is having problems
     HOG: 'hog', // owner: #team-data-tools, see `DebugScene.tsx` and also insights
+    KEEP_SCENE_TABS_MOUNTED: 'keep-scene-tabs-mounted', // owner: #team-product-analytics, see `App.tsx`, keeps each tab's scene tree mounted (hidden when inactive) instead of remounting on tab switch
     NAV_PANEL_CAMPAIGN: 'nav-panel-campaign', // owner: #team-growth, sidebar promotional campaign, payload-driven. See NavPanelAdvertisement.tsx
     QUERY_TIMINGS: 'query-timings', // owner: #team-analytics-platform, usage: see `dataTableLogic.ts`
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith, see `signupLogic.ts`

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -151,7 +151,7 @@ export const FEATURE_FLAGS = {
     // Eternal feature flags, shouldn't be removed, helpful for debugging/maintenance reasons
     BILLING_FORECASTING_ISSUES: 'billing-forecasting-issues', // owner: #team-billing, see `Billing.tsx`, used to raise a warning when billing is having problems
     HOG: 'hog', // owner: #team-data-tools, see `DebugScene.tsx` and also insights
-    KEEP_SCENE_TABS_MOUNTED: 'keep-scene-tabs-mounted', // owner: #team-product-analytics, see `App.tsx`, keeps each tab's scene tree mounted (hidden when inactive) instead of remounting on tab switch
+    KEEP_SCENE_TABS_MOUNTED: 'keep-scene-tabs-mounted', // owner: #team-platform-ux, see `App.tsx`, keeps each tab's scene tree mounted (hidden when inactive) instead of remounting on tab switch
     NAV_PANEL_CAMPAIGN: 'nav-panel-campaign', // owner: #team-growth, sidebar promotional campaign, payload-driven. See NavPanelAdvertisement.tsx
     QUERY_TIMINGS: 'query-timings', // owner: #team-analytics-platform, usage: see `dataTableLogic.ts`
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith, see `signupLogic.ts`

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -16,6 +16,7 @@ import { appScenes } from 'scenes/appScenes'
 import { PostOnboardingModal } from 'scenes/onboarding/PostOnboardingModal'
 import { postOnboardingModalLogic } from 'scenes/onboarding/postOnboardingModalLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { SceneExport, SceneTab } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
@@ -25,6 +26,7 @@ import { Navigation } from '~/layout/navigation-3000/Navigation'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { ImpersonationNotice } from '~/layout/navigation/ImpersonationNotice'
+import { UserType } from '~/types'
 
 import { MaxInstance } from './max/Max'
 
@@ -57,16 +59,20 @@ function AppScene(): JSX.Element | null {
     useMountedLogic(breadcrumbsLogic)
     const { user } = useValues(userLogic)
     const {
+        tabs,
+        activeTabId,
         activeSceneId,
         activeExportedScene,
         activeSceneComponentParamsWithTabId,
         activeSceneLogicPropsWithTabId,
+        exportedScenes,
         sceneConfig,
     } = useValues(sceneLogic)
     const { showingDelayedSpinner, hasExitedAIOnlyMode } = useValues(appLogic)
 
     const { featureFlags } = useValues(featureFlagLogic)
     const { isDarkModeOn } = useValues(themeLogic)
+    const keepTabsMounted = !!featureFlags[FEATURE_FLAGS.KEEP_SCENE_TABS_MOUNTED]
 
     // Highlight any relevant element after navigation from the quick start guide
     useSetupHighlight()
@@ -98,38 +104,59 @@ function AppScene(): JSX.Element | null {
         )
     }
 
-    let sceneElement: JSX.Element
-    if (activeExportedScene?.component) {
-        const { component: SceneComponent } = activeExportedScene
-        sceneElement = (
-            <SceneComponent
-                key={`tab-${activeSceneLogicPropsWithTabId.tabId}`}
-                user={user}
-                {...activeSceneComponentParamsWithTabId}
-            />
+    let wrappedSceneElement: JSX.Element
+
+    if (keepTabsMounted && user) {
+        // Keep each tab's React tree mounted (hidden when inactive) so local state, scroll and form input survive tab switches.
+        const hasActiveLoadedScene = !!activeExportedScene?.component
+        wrappedSceneElement = (
+            <>
+                {tabs.map((tab: SceneTab) => (
+                    <MountedSceneTab
+                        key={tab.id}
+                        tab={tab}
+                        isActive={tab.id === activeTabId}
+                        exportedScene={tab.sceneId ? exportedScenes[tab.sceneId] : undefined}
+                        user={user}
+                    />
+                ))}
+                {!hasActiveLoadedScene && <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />}
+            </>
         )
     } else {
-        sceneElement = <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />
-    }
+        let sceneElement: JSX.Element
+        if (activeExportedScene?.component) {
+            const { component: SceneComponent } = activeExportedScene
+            sceneElement = (
+                <SceneComponent
+                    key={`tab-${activeSceneLogicPropsWithTabId.tabId}`}
+                    user={user}
+                    {...activeSceneComponentParamsWithTabId}
+                />
+            )
+        } else {
+            sceneElement = <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />
+        }
 
-    const wrappedSceneElement = (
-        <ErrorBoundary
-            key={`error-${activeSceneLogicPropsWithTabId.tabId}`}
-            exceptionProps={{ feature: activeSceneId }}
-        >
-            {activeExportedScene?.logic ? (
-                <BindLogic
-                    key={`bind-${activeSceneLogicPropsWithTabId.tabId}`}
-                    logic={activeExportedScene.logic}
-                    props={activeSceneLogicPropsWithTabId}
-                >
-                    {sceneElement}
-                </BindLogic>
-            ) : (
-                sceneElement
-            )}
-        </ErrorBoundary>
-    )
+        wrappedSceneElement = (
+            <ErrorBoundary
+                key={`error-${activeSceneLogicPropsWithTabId.tabId}`}
+                exceptionProps={{ feature: activeSceneId }}
+            >
+                {activeExportedScene?.logic ? (
+                    <BindLogic
+                        key={`bind-${activeSceneLogicPropsWithTabId.tabId}`}
+                        logic={activeExportedScene.logic}
+                        props={activeSceneLogicPropsWithTabId}
+                    >
+                        {sceneElement}
+                    </BindLogic>
+                ) : (
+                    sceneElement
+                )}
+            </ErrorBoundary>
+        )
+    }
 
     if (!user) {
         return sceneConfig?.onlyUnauthenticated || sceneConfig?.allowUnauthenticated ? (
@@ -152,6 +179,40 @@ function AppScene(): JSX.Element | null {
             {featureFlags[FEATURE_FLAGS.EXPERIMENTS_DW_AA_TEST] === 'test' && (
                 <div data-attr="experiments-dw-aa-test-variant" className="hidden" />
             )}
+        </div>
+    )
+}
+
+interface MountedSceneTabProps {
+    tab: SceneTab
+    isActive: boolean
+    exportedScene: SceneExport | undefined
+    user: UserType
+}
+
+function MountedSceneTab({ tab, isActive, exportedScene, user }: MountedSceneTabProps): JSX.Element | null {
+    if (!exportedScene?.component || !tab.sceneId) {
+        return null
+    }
+
+    const SceneComponent = exportedScene.component
+    const sceneParams = tab.sceneParams ?? { params: {}, searchParams: {}, hashParams: {} }
+    const componentProps = { ...sceneParams.params, tabId: tab.id }
+    const logicProps = { tabId: tab.id, ...exportedScene.paramsToProps?.(sceneParams) }
+
+    const sceneElement = <SceneComponent user={user} {...componentProps} />
+
+    return (
+        <div hidden={!isActive} className="contents" data-tab-id={tab.id} aria-hidden={!isActive}>
+            <ErrorBoundary exceptionProps={{ feature: tab.sceneId }}>
+                {exportedScene.logic ? (
+                    <BindLogic logic={exportedScene.logic} props={logicProps}>
+                        {sceneElement}
+                    </BindLogic>
+                ) : (
+                    sceneElement
+                )}
+            </ErrorBoundary>
         </div>
     )
 }

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useMountedLogic, useValues } from 'kea'
+import { useRef } from 'react'
 import { Slide, ToastContainer } from 'react-toastify'
 
 import { Command } from 'lib/components/Command/Command'
@@ -74,6 +75,12 @@ function AppScene(): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const keepTabsMounted = !!featureFlags[FEATURE_FLAGS.KEEP_SCENE_TABS_MOUNTED]
 
+    // Tabs are mounted lazily on first activation, then kept mounted, so inactive tabs the user never visits don't fire API calls on first render.
+    const activatedTabIds = useRef<Set<string>>(new Set())
+    if (keepTabsMounted && activeTabId) {
+        activatedTabIds.current.add(activeTabId)
+    }
+
     // Highlight any relevant element after navigation from the quick start guide
     useSetupHighlight()
 
@@ -111,15 +118,17 @@ function AppScene(): JSX.Element | null {
         const hasActiveLoadedScene = !!activeExportedScene?.component
         wrappedSceneElement = (
             <>
-                {tabs.map((tab: SceneTab) => (
-                    <MountedSceneTab
-                        key={tab.id}
-                        tab={tab}
-                        isActive={tab.id === activeTabId}
-                        exportedScene={tab.sceneId ? exportedScenes[tab.sceneId] : undefined}
-                        user={user}
-                    />
-                ))}
+                {tabs.map((tab: SceneTab) =>
+                    activatedTabIds.current.has(tab.id) ? (
+                        <MountedSceneTab
+                            key={tab.id}
+                            tab={tab}
+                            isActive={tab.id === activeTabId}
+                            exportedScene={tab.sceneId ? exportedScenes[tab.sceneId] : undefined}
+                            user={user}
+                        />
+                    ) : null
+                )}
                 {!hasActiveLoadedScene && <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />}
             </>
         )
@@ -203,7 +212,7 @@ function MountedSceneTab({ tab, isActive, exportedScene, user }: MountedSceneTab
     const sceneElement = <SceneComponent user={user} {...componentProps} />
 
     return (
-        <div hidden={!isActive} className="contents" data-tab-id={tab.id} aria-hidden={!isActive}>
+        <div className={isActive ? 'contents' : 'hidden'} data-tab-id={tab.id} aria-hidden={!isActive}>
             <ErrorBoundary exceptionProps={{ feature: tab.sceneId }}>
                 {exportedScene.logic ? (
                     <BindLogic logic={exportedScene.logic} props={logicProps}>


### PR DESCRIPTION
## Problem

When users switch between tabs in a scene, the React component tree is unmounted and remounted, causing loss of local state, scroll position, and form input values. This creates a poor user experience when navigating between tabs.

## Changes

- Added `KEEP_SCENE_TABS_MOUNTED` feature flag to control the new tab mounting behavior
- Refactored `AppScene` component to conditionally render tabs:
  - When feature flag is enabled: All tabs are kept mounted (hidden when inactive) using a new `MountedSceneTab` component
  - When feature flag is disabled: Uses the existing behavior of mounting/unmounting the active scene
- Created `MountedSceneTab` component that:
  - Wraps each tab's scene in a hidden div when inactive (using `hidden` attribute and `aria-hidden`)
  - Preserves the React tree structure including logic bindings and error boundaries
  - Maintains proper component props and logic props for each tab
- Added imports for `SceneExport`, `SceneTab`, and `UserType` types

The implementation uses CSS `display: contents` on the wrapper div to avoid affecting layout while keeping the component tree mounted.

## How did you test this code?

This change adds a feature flag-gated implementation. The existing behavior remains unchanged when the flag is disabled, so existing tests should continue to pass. The new code path can be tested by enabling the `KEEP_SCENE_TABS_MOUNTED` feature flag and verifying that:
- Switching between tabs preserves scroll position
- Form input values persist when switching tabs
- Local component state is maintained across tab switches
- Error boundaries still function correctly for each tab

## Publish to changelog?

Yes - this improves the user experience by preserving local state when switching between scene tabs.

https://claude.ai/code/session_01BzVsntsmAPfLmBtRGHbhe2