### PR TITLE
feat(phai): instruct agent to search for existing insights before creating new ones

### DIFF
--- a/ee/hogai/tools/create_insight.py
+++ b/ee/hogai/tools/create_insight.py
@@ -18,6 +18,8 @@ from ee.hogai.utils.types.base import AssistantNodeName, AssistantState, NodePat
 INSIGHT_TOOL_PROMPT = """
 Use this tool to generate an insight from a structured plan. It will return a visualization that the user can analyze and a textual representation for your analysis. These visualizations are transient and only exist within the current conversation—they are not saved to the project. To save an insight permanently, users should click the open insight icon below the chart in the conversation.
 
+Before creating a new insight, use the search tool with kind="insights" to check if the user's project already has a saved insight that answers their question. If a matching insight is found, use the read_data tool to read and execute it (with execute=true) instead of creating a new transient one. Only use this tool to create a new insight when no suitable existing insight is found.
+
 This tool can also be used to edit the visualization the user is currently viewing on the insight page. In that case, you need to generate a new plan based on the schema of the existing insight.
 
 The tool only generates a single visualization per call. If the user asks for multiple visualizations, you need to decompose a query into multiple subqueries and call the tool for each subquery.


### PR DESCRIPTION
## Problem

When a user asks PostHog AI a data question like "How many monthly active users do we have?", the agent always creates a brand new transient insight from scratch. It never checks if the project already has a saved insight that answers the question — even though `SearchTool(kind="insights")` is already available and performs full-text search across saved insights.

The `UpsertDashboardTool` prompt already instructs the agent to "proactively use list_data and search tools to find existing insights" before creating a dashboard, but `CreateInsightTool` had no equivalent instruction.

## Changes

Added a search-first instruction to `INSIGHT_TOOL_PROMPT` in `CreateInsightTool`, telling the agent to:
1. Use the search tool with `kind="insights"` to check for existing saved insights
2. If a match is found, use `read_data` to read and execute it instead of creating a new transient one
3. Only create a new insight when no suitable existing insight is found

This is a prompt-only change — no tool code, no feature flags, no new dependencies. Follows the same pattern already established by `UpsertDashboardTool`.

## How did you test this code?

This PR was co-authored by an agent (Claude Code).

- Ran `pytest ee/hogai/tools/test/test_create_insight.py` — all 9 existing tests pass
- This is a prompt-only change to the tool description, so it doesn't affect any code paths

## Publish to changelog?

No

## 🤖 Agent context

- **Agent**: Claude Code (Opus 4.6)
- **Key decisions**: During investigation, we found that `InsightSearchNode` (~770 lines of LLM-powered semantic search) was built for this purpose but got disconnected during the Nov-Dec 2025 tool-calling refactor. Rather than re-wiring that complex node, we chose the simpler prompt-based approach since the agent already has access to `SearchTool` and `ReadDataTool` — it just wasn't being instructed to use them before creating.