### PR TITLE
feat(web-analytics): Add city breakdown to the live dashboard

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -212,9 +212,9 @@ export const FEATURE_FLAGS = {
     STARTUP_PROGRAM_INTENT: 'startup-program-intent', // owner: @pawel-cebula #team-billing
     SURVEYS_ACTIONS: 'surveys-actions', // owner: #team-surveys
     SURVEYS_ADAPTIVE_LIMITS: 'surveys-adaptive-limits', // owner: #team-surveys
-    SURVEYS_TRANSLATIONS: 'surveys-translations', // owner: #team-surveys
     SURVEYS_AI_FIRST_EMPTY_STATE: 'surveys-ai-first-empty-state', // owner: #team-surveys, enables ai-first empty state
     SURVEYS_REDESIGNED_VIEW: 'surveys-redesigned-view', // owner: #team-surveys, enables the redesigned survey view with sidebar
+    SURVEYS_TRANSLATIONS: 'surveys-translations', // owner: #team-surveys
     TRACK_DETACHED_ELEMENTS: 'track-detached-elements', // owner: @pauldambra #team-replay
     TRACK_MEMORY_USAGE: 'track-memory-usage', // owner: @pauldambra #team-replay
     TRACK_REACT_FRAMERATE: 'track-react-framerate', // owner: @pauldambra #team-replay
@@ -489,6 +489,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_FILTERS_V2: 'web-analytics-filters-v2', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_INCLUDE_HOST: 'web-analytics-include-host', // owner: @lricoy #team-web-analytics
+    WEB_ANALYTICS_LIVE_CITY_BREAKDOWN: 'web-analytics-live-city-breakdown', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_DOMAIN_FILTER: 'web-analytics-live-domain-filter', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_EDIT_LAYOUT: 'web-analytics-live-edit-layout', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_MAP: 'web-analytics-live-map', // owner: @jordanm-posthog #team-web-analytics

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import React, { useMemo } from 'react'
+import React, { ReactNode, useMemo } from 'react'
 
 import { Spinner, Tooltip } from '@posthog/lemon-ui'
 
@@ -11,7 +11,7 @@ interface BreakdownItem {
 }
 
 interface BreakdownLiveCardProps<T extends BreakdownItem> {
-    title: string
+    title: ReactNode
     data: T[]
     getKey: (item: T) => string
     getLabel: (item: T) => string
@@ -68,7 +68,7 @@ const BreakdownLiveCardInner = <T extends BreakdownItem>({
     return (
         <div className="bg-bg-light rounded-lg border border-border p-4 h-full min-h-[340px] flex flex-col">
             <div className="mb-4">
-                <h3 className="text-sm font-semibold text-default">{title}</h3>
+                {typeof title === 'string' ? <h3 className="text-sm font-semibold text-default">{title}</h3> : title}
             </div>
 
             {isLoading ? (

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveLocationsCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveLocationsCard.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+
+import { IconGlobe } from '@posthog/icons'
+import { LemonTabs } from '@posthog/lemon-ui'
+
+import { COUNTRY_CODE_TO_LONG_NAME, countryCodeToFlag } from 'lib/utils/geography/country'
+
+import { BreakdownLiveCard } from './BreakdownLiveCard'
+import { buildCityKey, CityBreakdownItem, CountryBreakdownItem } from './LiveWebAnalyticsMetricsTypes'
+
+type LocationTab = 'country' | 'city'
+
+interface LiveLocationsCardProps {
+    countryData: CountryBreakdownItem[]
+    cityData: CityBreakdownItem[]
+    isLoading?: boolean
+}
+
+const renderFlagOrGlobe = (countryCode: string): JSX.Element => {
+    if (!countryCode || countryCode === 'Other') {
+        return <IconGlobe className="w-4 h-4 flex-shrink-0 text-muted" />
+    }
+    return (
+        <span
+            className="w-4 h-4 inline-flex items-center justify-center text-base leading-none flex-shrink-0"
+            aria-hidden
+        >
+            {countryCodeToFlag(countryCode)}
+        </span>
+    )
+}
+
+const getCountryKey = (d: CountryBreakdownItem): string => d.country
+const getCountryLabel = (d: CountryBreakdownItem): string => COUNTRY_CODE_TO_LONG_NAME[d.country] ?? d.country
+const renderCountryIcon = (d: CountryBreakdownItem): JSX.Element => renderFlagOrGlobe(d.country)
+
+const getCityKey = (d: CityBreakdownItem): string =>
+    d.cityName === 'Other' ? 'Other' : buildCityKey(d.cityName, d.countryCode)
+const getCityLabel = (d: CityBreakdownItem): string => {
+    if (d.cityName === 'Other') {
+        return 'Other'
+    }
+    return d.countryCode ? `${d.cityName}, ${d.countryCode}` : d.cityName
+}
+const renderCityIcon = (d: CityBreakdownItem): JSX.Element =>
+    renderFlagOrGlobe(d.cityName === 'Other' ? 'Other' : d.countryCode)
+
+export const LiveLocationsCard = ({ countryData, cityData, isLoading }: LiveLocationsCardProps): JSX.Element => {
+    const [activeTab, setActiveTab] = useState<LocationTab>('country')
+
+    const tabs = (
+        <LemonTabs<LocationTab>
+            activeKey={activeTab}
+            onChange={setActiveTab}
+            size="small"
+            tabs={[
+                { key: 'country', label: 'Country' },
+                { key: 'city', label: 'City' },
+            ]}
+        />
+    )
+
+    if (activeTab === 'city') {
+        return (
+            <BreakdownLiveCard<CityBreakdownItem>
+                title={tabs}
+                data={cityData}
+                getKey={getCityKey}
+                getLabel={getCityLabel}
+                renderIcon={renderCityIcon}
+                emptyMessage="No city data"
+                statLabel="unique visitors"
+                isLoading={isLoading}
+            />
+        )
+    }
+
+    return (
+        <BreakdownLiveCard<CountryBreakdownItem>
+            title={tabs}
+            data={countryData}
+            getKey={getCountryKey}
+            getLabel={getCountryLabel}
+            renderIcon={renderCountryIcon}
+            emptyMessage="No country data"
+            statLabel="unique visitors"
+            isLoading={isLoading}
+        />
+    )
+}

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
@@ -3,7 +3,10 @@ import { BotCategory, CATEGORY_LABELS } from 'lib/utils/botDetection'
 import {
     BotBreakdownItem,
     BrowserBreakdownItem,
+    buildCityKey,
+    CityBreakdownItem,
     CountryBreakdownItem,
+    parseCityKey,
     ReferrerItem,
     SlidingWindowBucket,
 } from './LiveWebAnalyticsMetricsTypes'
@@ -17,6 +20,7 @@ export class LiveMetricsSlidingWindow {
     private deviceBucketCounts = new Map<string, Map<string, number>>()
     private browserBucketCounts = new Map<string, Map<string, number>>()
     private countryBucketCounts = new Map<string, Map<string, number>>()
+    private cityBucketCounts = new Map<string, Map<string, number>>()
 
     // Incrementally-maintained aggregates
     private _totalPageviews = 0
@@ -85,6 +89,14 @@ export class LiveMetricsSlidingWindow {
         this.addCountryToBucket(bucket, countryCode, distinctId)
     }
 
+    addCityDataPoint(eventTs: number, cityName: string, countryCode: string, distinctId: string): void {
+        if (!cityName || !distinctId) {
+            return
+        }
+        const bucket = this.getOrCreateBucket(eventTs)
+        this.addCityToBucket(bucket, cityName, countryCode, distinctId)
+    }
+
     extendBucketData(eventTs: number, data: SlidingWindowBucket): void {
         const bucket = this.getOrCreateBucket(eventTs)
 
@@ -133,6 +145,15 @@ export class LiveMetricsSlidingWindow {
             for (const [countryCode, userIds] of data.countries) {
                 for (const userId of userIds) {
                     this.addCountryToBucket(bucket, countryCode, userId)
+                }
+            }
+        }
+
+        if (data.cities) {
+            for (const [cityKey, userIds] of data.cities) {
+                const { cityName, countryCode } = parseCityKey(cityKey)
+                for (const userId of userIds) {
+                    this.addCityToBucket(bucket, cityName, countryCode, userId)
                 }
             }
         }
@@ -216,6 +237,28 @@ export class LiveMetricsSlidingWindow {
         }
     }
 
+    private addCityToBucket(
+        bucket: SlidingWindowBucket,
+        cityName: string,
+        countryCode: string,
+        distinctId: string
+    ): void {
+        if (!bucket.cities) {
+            bucket.cities = new Map<string, Set<string>>()
+        }
+        const cityKey = buildCityKey(cityName, countryCode)
+        const bucketUserIds = bucket.cities.get(cityKey) ?? new Set<string>()
+
+        if (!bucketUserIds.has(distinctId)) {
+            bucketUserIds.add(distinctId)
+            bucket.cities.set(cityKey, bucketUserIds)
+
+            const cityCounts = this.cityBucketCounts.get(cityKey) ?? new Map<string, number>()
+            cityCounts.set(distinctId, (cityCounts.get(distinctId) || 0) + 1)
+            this.cityBucketCounts.set(cityKey, cityCounts)
+        }
+    }
+
     private removeUsersFromTracking(bucket: SlidingWindowBucket): void {
         for (const userId of bucket.uniqueUsers) {
             const count = this.userBucketCounts.get(userId) || 0
@@ -275,6 +318,31 @@ export class LiveMetricsSlidingWindow {
         }
     }
 
+    private removeCitiesFromTracking(bucket: SlidingWindowBucket): void {
+        if (!bucket.cities) {
+            return
+        }
+        for (const [cityKey, userIds] of bucket.cities) {
+            const cityCounts = this.cityBucketCounts.get(cityKey)
+            if (!cityCounts) {
+                continue
+            }
+
+            for (const userId of userIds) {
+                const count = cityCounts.get(userId) || 0
+                if (count <= 1) {
+                    cityCounts.delete(userId)
+                } else {
+                    cityCounts.set(userId, count - 1)
+                }
+            }
+
+            if (cityCounts.size === 0) {
+                this.cityBucketCounts.delete(cityKey)
+            }
+        }
+    }
+
     private decrementGlobalCounts(bucketMap: Map<string, number>, globalMap: Map<string, number>): void {
         for (const [key, count] of bucketMap) {
             const globalCount = globalMap.get(key) || 0
@@ -295,6 +363,7 @@ export class LiveMetricsSlidingWindow {
                 this.removeItemsFromTracking(bucket.devices, this.deviceBucketCounts)
                 this.removeItemsFromTracking(bucket.browsers, this.browserBucketCounts)
                 this.removeCountriesFromTracking(bucket)
+                this.removeCitiesFromTracking(bucket)
                 this.decrementGlobalCounts(bucket.paths, this._globalPathCounts)
                 this.decrementGlobalCounts(bucket.referrers, this._globalReferrerCounts)
                 if (bucket.bots) {
@@ -439,6 +508,31 @@ export class LiveMetricsSlidingWindow {
             .sort((a, b) => b.count - a.count)
     }
 
+    getCityBreakdown(): CityBreakdownItem[] {
+        let total = 0
+        const counts: { cityName: string; countryCode: string; count: number }[] = []
+
+        for (const [cityKey, userIdCounts] of this.cityBucketCounts) {
+            const count = userIdCounts.size
+            total += count
+            const { cityName, countryCode } = parseCityKey(cityKey)
+            counts.push({ cityName, countryCode, count })
+        }
+
+        if (total === 0) {
+            return []
+        }
+
+        return counts
+            .map(({ cityName, countryCode, count }) => ({
+                cityName,
+                countryCode,
+                count,
+                percentage: (count / total) * 100,
+            }))
+            .sort((a, b) => b.count - a.count)
+    }
+
     getTotalUniqueUsers(): number {
         return this.userBucketCounts.size
     }
@@ -512,6 +606,7 @@ export class LiveMetricsSlidingWindow {
                 referrers: new Map<string, number>(),
                 uniqueUsers: new Set<string>(),
                 countries: new Map<string, Set<string>>(),
+                cities: new Map<string, Set<string>>(),
                 bots: new Map<string, { count: number; category: string }>(),
             }
             this.buckets.set(bucketTs, bucket)

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -28,6 +28,7 @@ import { getBrowserLogo } from './browserLogos'
 import { LiveBotTrafficCard } from './LiveBotTrafficCard'
 import { CONTENT_CARD_SPAN, LiveContentCardId, LiveStatCardId } from './liveCards'
 import { LiveChartCard } from './LiveChartCard'
+import { LiveLocationsCard } from './LiveLocationsCard'
 import { LiveStatCard, LiveStatDivider } from './LiveStatCard'
 import { LiveTopPathsTable } from './LiveTopPathsTable'
 import { LiveTopReferrersTable } from './LiveTopReferrersTable'
@@ -117,6 +118,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
         browserBreakdown,
         countryBreakdown,
         topCountryBreakdown,
+        topCityBreakdown,
         topPaths,
         topReferrers,
         totalPageviews,
@@ -230,15 +232,24 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                     />
                 )
             case 'top_countries':
+                if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN]) {
+                    return (
+                        <BreakdownLiveCard<CountryBreakdownItem>
+                            title="Countries"
+                            data={topCountryBreakdown}
+                            getKey={getCountryKey}
+                            getLabel={getCountryLabel}
+                            renderIcon={renderCountryIcon}
+                            emptyMessage="No country data"
+                            statLabel="unique visitors"
+                            isLoading={isLoading}
+                        />
+                    )
+                }
                 return (
-                    <BreakdownLiveCard<CountryBreakdownItem>
-                        title="Countries"
-                        data={topCountryBreakdown}
-                        getKey={getCountryKey}
-                        getLabel={getCountryLabel}
-                        renderIcon={renderCountryIcon}
-                        emptyMessage="No country data"
-                        statLabel="unique visitors"
+                    <LiveLocationsCard
+                        countryData={topCountryBreakdown}
+                        cityData={topCityBreakdown}
                         isLoading={isLoading}
                     />
                 )

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
@@ -42,6 +42,8 @@ export interface SlidingWindowBucket {
     referrers: Map<string, number>
     uniqueUsers: Set<string>
     countries: Map<string, Set<string>>
+    // Optional to keep existing test fixtures and backfill helpers concise. Keyed via `buildCityKey`.
+    cities?: Map<string, Set<string>>
     // Optional so that existing tests and backfill helpers don't have to
     // construct bot maps when they are not asserting on bot traffic.
     bots?: Map<string, { count: number; category: string }>
@@ -58,6 +60,26 @@ export interface CountryBreakdownItem {
     country: string
     count: number
     percentage: number
+}
+
+export interface CityBreakdownItem {
+    cityName: string
+    countryCode: string
+    count: number
+    percentage: number
+}
+
+export const CITY_KEY_SEPARATOR = '|'
+
+export const buildCityKey = (cityName: string, countryCode: string): string =>
+    `${cityName}${CITY_KEY_SEPARATOR}${countryCode}`
+
+export const parseCityKey = (key: string): { cityName: string; countryCode: string } => {
+    const sepIdx = key.lastIndexOf(CITY_KEY_SEPARATOR)
+    if (sepIdx === -1) {
+        return { cityName: key, countryCode: '' }
+    }
+    return { cityName: key.slice(0, sepIdx), countryCode: key.slice(sepIdx + 1) }
 }
 
 export interface LiveGeoEvent {

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -31,6 +31,7 @@ import {
     BotBreakdownItem,
     BrowserBreakdownItem,
     ChartDataPoint,
+    CityBreakdownItem,
     CountryBreakdownItem,
     DeviceBreakdownItem,
     DIRECT_REFERRER,
@@ -52,6 +53,29 @@ const FLUSH_INTERVAL_MS = 300
 const COOKIELESS_TRANSFORM_PREFIX = 'cookieless_transform'
 const COOKIELESS_TRANSFORM_SEPARATOR = '|||'
 const COUNTRY_BREAKDOWN_LIMIT = 6
+const CITY_BREAKDOWN_LIMIT = 6
+
+const collapseTopWithOther = <T extends { count: number; percentage: number }>(
+    items: T[],
+    limit: number,
+    makeOther: (count: number, percentage: number) => T
+): T[] => {
+    if (items.length <= limit) {
+        return items
+    }
+    const top = items.slice(0, limit)
+    const rest = items.slice(limit)
+    let othersCount = 0
+    let othersPercentage = 0
+    for (const item of rest) {
+        othersCount += item.count
+        othersPercentage += item.percentage
+    }
+    if (othersCount === 0) {
+        return top
+    }
+    return [...top, makeOther(othersCount, othersPercentage)]
+}
 
 export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType>([
     path(['scenes', 'web-analytics', 'livePageviewsLogic']),
@@ -151,6 +175,14 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                                 referringDomain: normalizedReferrer,
                                 bot: botData,
                             })
+
+                            // City breakdown rides on the regular event stream because the geo SSE
+                            // (which drives lat/lng + country) doesn't include city information.
+                            const cityName = event.properties?.$geoip_city_name as string | undefined
+                            const cityCountryCode = event.properties?.$geoip_country_code as string | undefined
+                            if (cityName) {
+                                window.addCityDataPoint(eventTs, cityName, cityCountryCode ?? '', event.distinct_id)
+                            }
                         }
                     }
 
@@ -260,26 +292,28 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         ],
         topCountryBreakdown: [
             (s) => [s.countryBreakdown],
-            (countryBreakdown: CountryBreakdownItem[]): CountryBreakdownItem[] => {
-                if (countryBreakdown.length <= COUNTRY_BREAKDOWN_LIMIT) {
-                    return countryBreakdown
-                }
-                const top = countryBreakdown.slice(0, COUNTRY_BREAKDOWN_LIMIT)
-                const rest = countryBreakdown.slice(COUNTRY_BREAKDOWN_LIMIT)
-                const othersCount = rest.reduce((sum, item) => sum + item.count, 0)
-                if (othersCount === 0) {
-                    return top
-                }
-                const othersPercentage = rest.reduce((sum, item) => sum + item.percentage, 0)
-                return [
-                    ...top,
-                    {
-                        country: 'Other',
-                        count: othersCount,
-                        percentage: othersPercentage,
-                    },
-                ]
-            },
+            (countryBreakdown: CountryBreakdownItem[]): CountryBreakdownItem[] =>
+                collapseTopWithOther(countryBreakdown, COUNTRY_BREAKDOWN_LIMIT, (count, percentage) => ({
+                    country: 'Other',
+                    count,
+                    percentage,
+                })),
+            { resultEqualityCheck: equal },
+        ],
+        cityBreakdown: [
+            (s) => [s.slidingWindow, s.eventsVersion],
+            (slidingWindow: LiveMetricsSlidingWindow): CityBreakdownItem[] => slidingWindow.getCityBreakdown(),
+            { resultEqualityCheck: equal },
+        ],
+        topCityBreakdown: [
+            (s) => [s.cityBreakdown],
+            (cityBreakdown: CityBreakdownItem[]): CityBreakdownItem[] =>
+                collapseTopWithOther(cityBreakdown, CITY_BREAKDOWN_LIMIT, (count, percentage) => ({
+                    cityName: 'Other',
+                    countryCode: '',
+                    count,
+                    percentage,
+                })),
             { resultEqualityCheck: equal },
         ],
         topPaths: [
@@ -374,7 +408,13 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     geoResponse,
                     recentUsersResponse,
                     botResponse,
-                ] = await loadQueryData(dateFrom, handoff, values.selectedHost)
+                    cityResponse,
+                ] = await loadQueryData(
+                    dateFrom,
+                    handoff,
+                    values.selectedHost,
+                    !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN]
+                )
 
                 const bucketMap = new Map<number, SlidingWindowBucket>()
 
@@ -384,6 +424,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 addPathDataToBuckets(pathsResponse, bucketMap)
                 addReferrerDataToBuckets(referrerResponse, bucketMap)
                 addGeoDataToBuckets(geoResponse, bucketMap)
+                addCityDataToBuckets(cityResponse, bucketMap)
                 addBotDataToBuckets(botResponse, bucketMap)
 
                 actions.setInitialData(
@@ -412,10 +453,12 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             }
 
             const url = new URL(`${host}/events`)
-            url.searchParams.append(
-                'columns',
+            const baseColumns =
                 '$pathname,$current_url,$host,$device_type,$device_id,$browser,$ip,$raw_user_agent,$referring_domain'
-            )
+            const cityColumns = values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN]
+                ? ',$geoip_city_name,$geoip_country_code'
+                : ''
+            url.searchParams.append('columns', `${baseColumns}${cityColumns}`)
             if (values.selectedHost) {
                 url.searchParams.append('property', `$host=${values.selectedHost}`)
             }
@@ -575,7 +618,8 @@ const startFlushInterval = (cache: FlushCache, actions: FlushActions): void => {
 const loadQueryData = async (
     dateFrom: Date,
     dateTo: Date,
-    host: string | null
+    host: string | null,
+    includeCity: boolean
 ): Promise<
     [
         HogQLQueryResponse,
@@ -586,6 +630,7 @@ const loadQueryData = async (
         HogQLQueryResponse,
         HogQLQueryResponse | null,
         HogQLQueryResponse,
+        HogQLQueryResponse | null,
     ]
 > => {
     const hostFilterClause = host ? `AND properties.$host = {host}` : ''
@@ -768,6 +813,46 @@ const loadQueryData = async (
         },
     }
 
+    const cityQuery: HogQLQuery | null = includeCity
+        ? {
+              kind: NodeKind.HogQLQuery,
+              query: `SELECT
+                    minute_bucket,
+                    mapFromArrays(
+                        groupArray(city_key),
+                        groupArray(distinct_ids)
+                    ) AS ids_by_city
+                FROM
+                (
+                    SELECT
+                        toStartOfMinute(timestamp) AS minute_bucket,
+                        concat(
+                            properties.$geoip_city_name,
+                            '|',
+                            ifNull(properties.$geoip_country_code, '')
+                        ) AS city_key,
+                        arrayDistinct(groupArray(distinct_id)) AS distinct_ids
+                    FROM events
+                    WHERE
+                        timestamp >= toDateTime({dateFrom})
+                        AND timestamp <= toDateTime({dateTo})
+                        AND properties.$geoip_city_name IS NOT NULL
+                        AND properties.$geoip_city_name != ''
+                        ${hostFilterClause}
+                    GROUP BY
+                        minute_bucket,
+                        city_key
+                )
+                GROUP BY minute_bucket
+                ORDER BY minute_bucket ASC`,
+              values: {
+                  dateFrom: dateFrom.toISOString(),
+                  dateTo: dateTo.toISOString(),
+                  ...hostValues,
+              },
+          }
+        : null
+
     const recentUsersQuery: HogQLQuery | null = host
         ? {
               kind: NodeKind.HogQLQuery,
@@ -796,6 +881,7 @@ const loadQueryData = async (
         performQuery(geoQuery),
         recentUsersQuery ? performQuery(recentUsersQuery) : Promise.resolve(null),
         performQuery(botQuery),
+        cityQuery ? performQuery(cityQuery) : Promise.resolve(null),
     ])
 }
 
@@ -901,6 +987,33 @@ const addGeoDataToBuckets = (geoResponse: HogQLQueryResponse, bucketMap: Map<num
     }
 }
 
+const addCityDataToBuckets = (
+    cityResponse: HogQLQueryResponse | null,
+    bucketMap: Map<number, SlidingWindowBucket>
+): void => {
+    if (!cityResponse) {
+        return
+    }
+    const results = cityResponse.results as [string, Record<string, string[]>][]
+
+    for (const [timestampStr, idsByCityKey] of results) {
+        const timestamp = Date.parse(timestampStr)
+        const bucket = getOrCreateBucket(bucketMap, timestamp)
+
+        if (!bucket.cities) {
+            bucket.cities = new Map<string, Set<string>>()
+        }
+
+        for (const [cityKey, distinctIds] of Object.entries(idsByCityKey)) {
+            const cityUsers = bucket.cities.get(cityKey) ?? new Set<string>()
+            for (const distinctId of distinctIds) {
+                cityUsers.add(distinctId)
+            }
+            bucket.cities.set(cityKey, cityUsers)
+        }
+    }
+}
+
 const addBotDataToBuckets = (botResponse: HogQLQueryResponse, bucketMap: Map<number, SlidingWindowBucket>): void => {
     const results = botResponse.results as [string, string, string, number][]
 
@@ -950,6 +1063,7 @@ const createEmptyBucket = (): SlidingWindowBucket => {
         referrers: new Map<string, number>(),
         uniqueUsers: new Set<string>(),
         countries: new Map<string, Set<string>>(),
+        cities: new Map<string, Set<string>>(),
         bots: new Map<string, { count: number; category: string }>(),
     }
 }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -31,6 +31,7 @@ import {
     BotBreakdownItem,
     BrowserBreakdownItem,
     ChartDataPoint,
+    CITY_KEY_SEPARATOR,
     CityBreakdownItem,
     CountryBreakdownItem,
     DeviceBreakdownItem,
@@ -828,7 +829,7 @@ const loadQueryData = async (
                         toStartOfMinute(timestamp) AS minute_bucket,
                         concat(
                             properties.$geoip_city_name,
-                            '|',
+                            {citySeparator},
                             ifNull(properties.$geoip_country_code, '')
                         ) AS city_key,
                         arrayDistinct(groupArray(distinct_id)) AS distinct_ids
@@ -848,6 +849,7 @@ const loadQueryData = async (
               values: {
                   dateFrom: dateFrom.toISOString(),
                   dateTo: dateTo.toISOString(),
+                  citySeparator: CITY_KEY_SEPARATOR,
                   ...hostValues,
               },
           }


### PR DESCRIPTION
## Problem
There is no way to see live traffic breakdown by city, let's change that!

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add new city breakdown on the live page.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
