### PR TITLE
feat(rbac): dashboard + insight backend for guest mode

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -255,6 +255,10 @@ export interface OrganizationInviteApi {
     message?: string | null
     /** List of team IDs and corresponding access levels to private projects. */
     private_project_access?: unknown | null
+    /** List of {team_id, resource, resource_id, access_level?} dicts describing resource grants the invitee should receive on acceptance. A non-empty list marks the invite as a guest invite. */
+    guest_resources?: unknown
+    /** If true, the membership created on acceptance can authenticate with password even when the organization enforces SSO. Meaningful for guest invites where the invitee is external and may not be in the SSO directory. */
+    bypass_sso?: boolean
     send_email?: boolean
     combine_pending_invites?: boolean
 }
@@ -2955,6 +2959,8 @@ export interface PendingInviteApi {
  */
 export type UserApiNotificationSettings = { [key: string]: unknown }
 
+export type UserApiGuestGrantsItem = { [key: string]: unknown }
+
 export interface UserApi {
     readonly date_joined: string
     readonly uuid: string
@@ -3021,6 +3027,18 @@ export interface UserApi {
     /** @nullable */
     readonly is_organization_first_user: boolean | null
     readonly pending_invites: readonly PendingInviteApi[]
+    readonly is_guest_in_current_project: boolean
+    /** Build the frontend-facing grant list directly from AccessControl rows.
+
+The AC table stores the numeric PK in `resource_id`, but the FE uses URL-style
+identifiers (short_id for insight/notebook, PK for dashboard). We translate per
+resource type here so the landing scene can build correct links.
+
+Only dashboard/insight/notebook rows are exposed — these are the resource types
+guest invites can grant. The insight rows produced by the dashboard-tile cascade are
+intentionally filtered out so the landing scene doesn't show redundant entries for
+every tile in a granted dashboard. */
+    readonly guest_grants: readonly UserApiGuestGrantsItem[]
 }
 
 export interface PaginatedUserListApi {
@@ -3036,6 +3054,8 @@ export interface PaginatedUserListApi {
  * Map of notification preferences. Keys include `plugin_disabled`, `all_weekly_report_disabled`, `project_weekly_digest_disabled`, `error_tracking_weekly_digest_project_enabled`, `web_analytics_weekly_digest_project_enabled`, `organization_member_join_email_disabled`, `data_pipeline_error_threshold` (number between 0.0 and 1.0), and other per-topic switches. Values are either booleans, or (for per-project/per-resource keys) a map of IDs to booleans. Only the keys you send are updated — other preferences stay as-is.
  */
 export type PatchedUserApiNotificationSettings = { [key: string]: unknown }
+
+export type PatchedUserApiGuestGrantsItem = { [key: string]: unknown }
 
 export interface PatchedUserApi {
     readonly date_joined?: string
@@ -3103,6 +3123,18 @@ export interface PatchedUserApi {
     /** @nullable */
     readonly is_organization_first_user?: boolean | null
     readonly pending_invites?: readonly PendingInviteApi[]
+    readonly is_guest_in_current_project?: boolean
+    /** Build the frontend-facing grant list directly from AccessControl rows.
+
+The AC table stores the numeric PK in `resource_id`, but the FE uses URL-style
+identifiers (short_id for insight/notebook, PK for dashboard). We translate per
+resource type here so the landing scene can build correct links.
+
+Only dashboard/insight/notebook rows are exposed — these are the resource types
+guest invites can grant. The insight rows produced by the dashboard-tile cascade are
+intentionally filtered out so the landing scene doesn't show redundant entries for
+every tile in a granted dashboard. */
+    readonly guest_grants?: readonly PatchedUserApiGuestGrantsItem[]
 }
 
 export type SubscriptionsDeliveriesListParams = {

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -121,6 +121,18 @@ export const InvitesCreateBody = /* @__PURE__ */ zod.object({
         .unknown()
         .nullish()
         .describe('List of team IDs and corresponding access levels to private projects.'),
+    guest_resources: zod
+        .unknown()
+        .optional()
+        .describe(
+            'List of {team_id, resource, resource_id, access_level?} dicts describing resource grants the invitee should receive on acceptance. A non-empty list marks the invite as a guest invite.'
+        ),
+    bypass_sso: zod
+        .boolean()
+        .optional()
+        .describe(
+            'If true, the membership created on acceptance can authenticate with password even when the organization enforces SSO. Meaningful for guest invites where the invitee is external and may not be in the SSO directory.'
+        ),
     send_email: zod.boolean().default(invitesCreateBodySendEmailDefault),
     combine_pending_invites: zod.boolean().default(invitesCreateBodyCombinePendingInvitesDefault),
 })
@@ -144,6 +156,18 @@ export const InvitesBulkCreateBody = /* @__PURE__ */ zod.object({
         .unknown()
         .nullish()
         .describe('List of team IDs and corresponding access levels to private projects.'),
+    guest_resources: zod
+        .unknown()
+        .optional()
+        .describe(
+            'List of {team_id, resource, resource_id, access_level?} dicts describing resource grants the invitee should receive on acceptance. A non-empty list marks the invite as a guest invite.'
+        ),
+    bypass_sso: zod
+        .boolean()
+        .optional()
+        .describe(
+            'If true, the membership created on acceptance can authenticate with password even when the organization enforces SSO. Meaningful for guest invites where the invitee is external and may not be in the SSO directory.'
+        ),
     send_email: zod.boolean().default(invitesBulkCreateBodySendEmailDefault),
     combine_pending_invites: zod.boolean().default(invitesBulkCreateBodyCombinePendingInvitesDefault),
 })

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1908,7 +1908,7 @@ When set, the specified dashboard's filters and date range override will be appl
         )
         return activity_page_response(activity_page, limit, page, request)
 
-    @action(methods=["POST"], detail=False)
+    @action(methods=["POST"], detail=False, required_scopes=["insight:read"])
     @monitor(feature=Feature.INSIGHT, endpoint="insight", method="CANCEL")
     def cancel(self, request: request.Request, **kwargs):
         if "client_query_id" not in request.data:
@@ -1917,7 +1917,7 @@ When set, the specified dashboard's filters and date range override will be appl
         return Response(status=status.HTTP_201_CREATED)
 
     @extend_schema(exclude=True)  # internal endpoint, not for public use
-    @action(methods=["POST"], detail=False)
+    @action(methods=["POST"], detail=False, required_scopes=["insight:read"])
     def timing(self, request: request.Request, **kwargs):
         from posthog.kafka_client.routing import get_producer
         from posthog.models.event.util import format_clickhouse_timestamp

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -90,12 +90,32 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
         # confusing "0 grants" badge on every regular member row.
         if not instance.is_guest:
             return None
+        # Tile-cascade rows are excluded from the count — they're implied by the parent
+        # dashboard grant and surfacing them would inflate the "you're about to revoke N
+        # grants" warning misleadingly.
+        from products.dashboards.backend.models.dashboard_tile import DashboardTile
+
         from ee.models.rbac.access_control import AccessControl
 
-        return AccessControl.objects.filter(
-            organization_member=instance,
-            resource="notebook",
-        ).count()
+        ac_rows = list(
+            AccessControl.objects.filter(
+                organization_member=instance,
+                resource__in=("dashboard", "insight", "notebook"),
+            ).values_list("resource", "resource_id")
+        )
+        dashboard_pks = [int(rid) for r, rid in ac_rows if r == "dashboard" and rid and rid.isdigit()]
+        tile_insight_ids = (
+            {
+                str(pk)
+                for pk in DashboardTile.objects.filter(
+                    dashboard_id__in=dashboard_pks, insight__isnull=False
+                ).values_list("insight_id", flat=True)
+                if pk is not None
+            }
+            if dashboard_pks
+            else set()
+        )
+        return sum(1 for r, rid in ac_rows if not (r == "insight" and rid in tile_insight_ids))
 
     def update(self, instance: OrganizationMembership, validated_data: dict[str, object]) -> OrganizationMembership:
         updated_membership = instance

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -74,7 +74,7 @@ class TestOrganizationAPI(APIBaseTest):
         )
         AccessControl.objects.create(
             team=self.team,
-            resource="notebook",
+            resource="dashboard",
             resource_id="1",
             organization_member=guest_membership,
             access_level="viewer",

--- a/posthog/api/test/test_organization_invite_guest.py
+++ b/posthog/api/test/test_organization_invite_guest.py
@@ -6,7 +6,7 @@ from posthog.constants import AvailableFeature
 from posthog.models import OrganizationInvite, OrganizationMembership
 from posthog.models.user import User
 
-from products.notebooks.backend.models import Notebook
+from products.dashboards.backend.models.dashboard import Dashboard
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -21,7 +21,7 @@ class TestOrganizationInviteGuest(APIBaseTest):
         OrganizationMembership.objects.filter(organization=self.organization, user=self.user).update(
             level=OrganizationMembership.Level.ADMIN
         )
-        self.notebook = Notebook.objects.create(team=self.team, title="Granted notebook", short_id="INVT0001")
+        self.dashboard = Dashboard.objects.create(team=self.team, name="Granted dashboard")
 
     def _base_payload(self, **overrides) -> dict:
         payload = {
@@ -30,8 +30,8 @@ class TestOrganizationInviteGuest(APIBaseTest):
             "guest_resources": [
                 {
                     "team_id": self.team.pk,
-                    "resource": "notebook",
-                    "resource_id": self.notebook.short_id,
+                    "resource": "dashboard",
+                    "resource_id": str(self.dashboard.pk),
                 }
             ],
         }
@@ -64,7 +64,7 @@ class TestOrganizationInviteGuest(APIBaseTest):
         res = self.client.post(
             f"/api/organizations/{self.organization.id}/invites/",
             self._base_payload(
-                guest_resources=[{"team_id": self.team.pk, "resource": "notebook", "resource_id": "ZZZZZZZZ"}]
+                guest_resources=[{"team_id": self.team.pk, "resource": "dashboard", "resource_id": "99999"}]
             ),
             format="json",
         )
@@ -78,8 +78,8 @@ class TestOrganizationInviteGuest(APIBaseTest):
             guest_resources=[
                 {
                     "team_id": self.team.pk,
-                    "resource": "notebook",
-                    "resource_id": self.notebook.short_id,
+                    "resource": "dashboard",
+                    "resource_id": str(self.dashboard.pk),
                     "access_level": "editor",
                 }
             ]
@@ -123,8 +123,8 @@ class TestOrganizationInviteGuest(APIBaseTest):
         self.assertTrue(
             AccessControl.objects.filter(
                 organization_member=membership,
-                resource="notebook",
-                resource_id=str(self.notebook.pk),
+                resource="dashboard",
+                resource_id=str(self.dashboard.pk),
                 access_level="viewer",
             ).exists()
         )

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -9,6 +9,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.models.insight import Insight
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.user import User
 from posthog.models.webauthn_credential import WebauthnCredential
@@ -537,25 +538,47 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
 
     def test_member_payload_carries_guest_grant_count_for_guests(self):
         # The Guests tab promote-to-member dialog uses this count to warn the admin how many
-        # grants will be revoked.
-        from products.notebooks.backend.models import Notebook
+        # grants will be revoked. Tile-cascade rows are excluded so the number reflects what
+        # the admin granted, not the underlying AC plumbing.
+        from products.dashboards.backend.models.dashboard import Dashboard
+        from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
         from ee.models.rbac.access_control import AccessControl
 
         _user, membership = self._make_guest("countable-guest@posthog.com")
-        notebook_a = Notebook.objects.create(team=self.team, title="A", short_id="NCNT0001")
-        notebook_b = Notebook.objects.create(team=self.team, title="B", short_id="NCNT0002")
+        dashboard = Dashboard.objects.create(team=self.team, name="With tiles")
+        # Two top-level grants.
         AccessControl.objects.create(
             team=self.team,
-            resource="notebook",
-            resource_id=str(notebook_a.pk),
+            resource="dashboard",
+            resource_id=str(dashboard.pk),
+            organization_member=membership,
+            access_level="viewer",
+        )
+        insight_top = Insight.objects.create(team=self.team, name="Top-level insight", short_id="GRANT001")
+        AccessControl.objects.create(
+            team=self.team,
+            resource="insight",
+            resource_id=str(insight_top.pk),
+            organization_member=membership,
+            access_level="viewer",
+        )
+        # Two tile-cascade rows that must NOT be counted.
+        tile_insight_a = Insight.objects.create(team=self.team, name="Tile A", short_id="TILEA001")
+        tile_insight_b = Insight.objects.create(team=self.team, name="Tile B", short_id="TILEB001")
+        DashboardTile.objects.create(dashboard=dashboard, insight=tile_insight_a)
+        DashboardTile.objects.create(dashboard=dashboard, insight=tile_insight_b)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="insight",
+            resource_id=str(tile_insight_a.pk),
             organization_member=membership,
             access_level="viewer",
         )
         AccessControl.objects.create(
             team=self.team,
-            resource="notebook",
-            resource_id=str(notebook_b.pk),
+            resource="insight",
+            resource_id=str(tile_insight_b.pk),
             organization_member=membership,
             access_level="viewer",
         )
@@ -565,6 +588,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         rows = {row["user"]["email"]: row for row in response.json()["results"]}
         guest_row = rows["countable-guest@posthog.com"]
         self.assertEqual(guest_row["is_guest"], True)
+        # 2 = the dashboard grant + the top-level insight grant. Tile cascade rows excluded.
         self.assertEqual(guest_row["guest_grant_count"], 2)
 
     def test_member_payload_returns_null_grant_count_for_regular_members(self):

--- a/posthog/api/test/test_promote_guest.py
+++ b/posthog/api/test/test_promote_guest.py
@@ -7,7 +7,7 @@ from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.user import User
 from posthog.rbac.guest_grants import create_grant
 
-from products.notebooks.backend.models import Notebook
+from products.dashboards.backend.models.dashboard import Dashboard
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -24,12 +24,12 @@ class TestPromoteGuest(APIBaseTest):
         self.guest_membership = OrganizationMembership.objects.create(
             organization=self.organization, user=self.guest_user, is_guest=True
         )
-        notebook = Notebook.objects.create(team=self.team, title="Granted", short_id="PRMT0001")
+        dashboard = Dashboard.objects.create(team=self.team, name="Granted")
         create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=notebook.short_id,
+            resource="dashboard",
+            resource_id=str(dashboard.pk),
             created_by=self.user,
         )
 
@@ -53,7 +53,7 @@ class TestPromoteGuest(APIBaseTest):
         self.assertFalse(
             AccessControl.objects.filter(
                 organization_member=self.guest_membership,
-                resource="notebook",
+                resource="dashboard",
             ).exists()
         )
 

--- a/posthog/api/test/test_user_guest_payload.py
+++ b/posthog/api/test/test_user_guest_payload.py
@@ -12,9 +12,11 @@ from rest_framework import status
 
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership
+from posthog.models.insight import Insight
 from posthog.models.user import User
 from posthog.rbac.guest_grants import create_grant
 
+from products.dashboards.backend.models.dashboard import Dashboard
 from products.notebooks.backend.models import Notebook
 
 
@@ -23,6 +25,8 @@ class TestUserGuestPayload(APIBaseTest):
 
     def setUp(self) -> None:
         super().setUp()
+        # ACCESS_CONTROL is the gate that flips AC-row resolution on; without it the
+        # default access level path bypasses the guest-aware branches entirely.
         self.organization.available_product_features = [
             {"key": AvailableFeature.ACCESS_CONTROL, "name": "Access control"}
         ]
@@ -44,6 +48,53 @@ class TestUserGuestPayload(APIBaseTest):
         self.assertEqual(res.status_code, status.HTTP_200_OK, res.content)
         return res.json()
 
+    def test_dashboard_grant_carries_resource_name(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Q4 KPIs")
+        create_grant(
+            membership=self.guest_membership,
+            team=self.team,
+            resource="dashboard",
+            resource_id=str(dashboard.pk),
+            created_by=self.user,
+            access_level="viewer",
+        )
+        grants = self._payload()["guest_grants"]
+        self.assertEqual(len(grants), 1)
+        self.assertEqual(grants[0]["resource"], "dashboard")
+        self.assertEqual(grants[0]["resource_id_url"], str(dashboard.pk))
+        self.assertEqual(grants[0]["resource_name"], "Q4 KPIs")
+
+    def test_insight_grant_carries_name_and_short_id(self) -> None:
+        insight = Insight.objects.create(team=self.team, name="Activation funnel", short_id="ACTIV001")
+        create_grant(
+            membership=self.guest_membership,
+            team=self.team,
+            resource="insight",
+            resource_id=insight.short_id,
+            created_by=self.user,
+            access_level="viewer",
+        )
+        grants = self._payload()["guest_grants"]
+        self.assertEqual(len(grants), 1)
+        self.assertEqual(grants[0]["resource"], "insight")
+        self.assertEqual(grants[0]["resource_id_url"], "ACTIV001")
+        self.assertEqual(grants[0]["resource_name"], "Activation funnel")
+
+    def test_insight_grant_falls_back_to_derived_name(self) -> None:
+        # Saved insights without an explicit name surface their `derived_name` (e.g. the auto-
+        # generated "$pageview total volume"). The payload must prefer name → derived_name → null.
+        insight = Insight.objects.create(team=self.team, name="", derived_name="$pageview totals", short_id="DRVD0001")
+        create_grant(
+            membership=self.guest_membership,
+            team=self.team,
+            resource="insight",
+            resource_id=insight.short_id,
+            created_by=self.user,
+            access_level="viewer",
+        )
+        grants = self._payload()["guest_grants"]
+        self.assertEqual(grants[0]["resource_name"], "$pageview totals")
+
     def test_notebook_grant_carries_title_and_short_id(self) -> None:
         notebook = Notebook.objects.create(team=self.team, title="Onboarding playbook", short_id="NBOOK001")
         create_grant(
@@ -60,20 +111,20 @@ class TestUserGuestPayload(APIBaseTest):
         self.assertEqual(grants[0]["resource_id_url"], "NBOOK001")
         self.assertEqual(grants[0]["resource_name"], "Onboarding playbook")
 
-    def test_notebook_with_empty_title_returns_none(self) -> None:
-        # Notebook.title is nullable — payload surfaces None when empty so the FE can fall
-        # back to the resource id on the landing card.
-        notebook = Notebook.objects.create(team=self.team, title="", short_id="NBOOK002")
+    def test_dashboard_with_unnamed_target_returns_empty_string_name(self) -> None:
+        # Dashboard.name is a CharField with default="" — falsy but not None. The serializer
+        # surfaces it as-is so the FE can decide whether to fall back to the resource id.
+        dashboard = Dashboard.objects.create(team=self.team, name="")
         create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=notebook.short_id,
+            resource="dashboard",
+            resource_id=str(dashboard.pk),
             created_by=self.user,
             access_level="viewer",
         )
         grants = self._payload()["guest_grants"]
-        self.assertIsNone(grants[0]["resource_name"])
+        self.assertEqual(grants[0]["resource_name"], "")
 
     def test_non_guest_user_returns_empty_grants(self) -> None:
         # Regular members must never get a `guest_grants` array populated, even if AC rows

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -380,11 +380,16 @@ class UserSerializer(serializers.ModelSerializer):
         """Build the frontend-facing grant list directly from AccessControl rows.
 
         The AC table stores the numeric PK in `resource_id`, but the FE uses URL-style
-        identifiers (notebook short_id). Translate before emitting so the landing scene
-        can build correct links.
+        identifiers (short_id for insight/notebook, PK for dashboard). We translate per
+        resource type here so the landing scene can build correct links.
 
-        Scope: notebook only — dashboard / insight rows land in the follow-up PR.
+        Only dashboard/insight/notebook rows are exposed — these are the resource types
+        guest invites can grant. The insight rows produced by the dashboard-tile cascade are
+        intentionally filtered out so the landing scene doesn't show redundant entries for
+        every tile in a granted dashboard.
         """
+        from posthog.models.insight import Insight
+
         from products.notebooks.backend.models import Notebook
 
         from ee.models.rbac.access_control import AccessControl
@@ -413,27 +418,79 @@ class UserSerializer(serializers.ModelSerializer):
         ac_rows = list(
             AccessControl.objects.filter(
                 organization_member=membership,
-                resource="notebook",
+                resource__in=("dashboard", "insight", "notebook"),
             ).select_related("team")
         )
 
-        notebook_ac_pk_strs = [ac.resource_id for ac in ac_rows if ac.resource_id]
+        # Identify tile-cascade insight rows so we don't surface them as top-level grants on
+        # the landing scene — they're implied by their parent dashboard entry.
+        from products.dashboards.backend.models.dashboard_tile import DashboardTile
+
+        dashboard_pk_strs = {ac.resource_id for ac in ac_rows if ac.resource == "dashboard"}
+        tile_insight_pk_strs: set[str] = set()
+        if dashboard_pk_strs:
+            dashboard_pks = [int(p) for p in dashboard_pk_strs if p and p.isdigit()]
+            if dashboard_pks:
+                tile_insight_pk_strs = {
+                    str(pk)
+                    for pk in DashboardTile.objects.filter(
+                        dashboard_id__in=dashboard_pks, insight__isnull=False
+                    ).values_list("insight_id", flat=True)
+                    if pk is not None
+                }
+
+        # Pre-fetch short_ids and display names for insight/notebook rows (FE links by short_id
+        # and renders the resource's user-facing name on the landing card). Dashboards are
+        # batched separately because they're addressed by numeric PK.
+        from products.dashboards.backend.models.dashboard import Dashboard
+
+        # Insight and Dashboard PKs are integers; Notebook's PK is a UUID. The AC table stores
+        # the model's primary key as a string regardless of its underlying type, so we lookup
+        # by the string PK directly to support both shapes.
+        insight_ac_pks = [
+            int(ac.resource_id)
+            for ac in ac_rows
+            if ac.resource == "insight" and ac.resource_id and ac.resource_id.isdigit()
+        ]
+        dashboard_ac_pks = [
+            int(ac.resource_id)
+            for ac in ac_rows
+            if ac.resource == "dashboard" and ac.resource_id and ac.resource_id.isdigit()
+        ]
+        notebook_ac_pk_strs = [ac.resource_id for ac in ac_rows if ac.resource == "notebook" and ac.resource_id]
+        insight_meta = {
+            row[0]: row
+            for row in Insight.objects.filter(id__in=insight_ac_pks).values_list(
+                "id", "short_id", "name", "derived_name"
+            )
+        }
         notebook_meta = {
             str(row[0]): row
             for row in Notebook.objects.filter(id__in=notebook_ac_pk_strs).values_list("id", "short_id", "title")
         }
+        dashboard_names = dict(Dashboard.objects.filter(id__in=dashboard_ac_pks).values_list("id", "name"))
 
         out: list[dict] = []
         for ac in ac_rows:
+            if ac.resource == "insight" and ac.resource_id in tile_insight_pk_strs:
+                continue
             resource_id_pk = ac.resource_id
             url_id = resource_id_pk
             resource_name: str | None = None
-            if resource_id_pk:
+            if ac.resource == "insight" and resource_id_pk and resource_id_pk.isdigit():
+                meta = insight_meta.get(int(resource_id_pk))
+                if meta:
+                    _id, short_id, name, derived_name = meta
+                    url_id = short_id or resource_id_pk
+                    resource_name = name or derived_name or None
+            elif ac.resource == "notebook" and resource_id_pk:
                 meta = notebook_meta.get(resource_id_pk)
                 if meta:
                     _id, short_id, title = meta
                     url_id = short_id or resource_id_pk
                     resource_name = title or None
+            elif ac.resource == "dashboard" and resource_id_pk and resource_id_pk.isdigit():
+                resource_name = dashboard_names.get(int(resource_id_pk))
             out.append(
                 {
                     "team_id": ac.team_id,

--- a/posthog/middleware_guest.py
+++ b/posthog/middleware_guest.py
@@ -7,12 +7,12 @@ SPA routes (so the FE scene allowlist/landing page can take over).
 
 Since `is_guest=True` now flips the AC layer's default from allow to deny, the per-resource
 rules below are just a thin adapter: they pull `team_id` and `resource_id` out of the URL
-and ask `UserAccessControl.access_level_for_object` whether the guest has any non-`none`
-level on that specific object.
+(or the `X-PostHog-Scene-Resource` header for query endpoints) and ask
+`UserAccessControl.access_level_for_object` whether the guest has any non-`none` level on
+that specific object. All the AC-table + dashboard-tile cascade semantics live in the AC
+layer itself (tile AC rows are written by `guest_grants.create_grant` at grant time).
 
-Scope: notebook only. Dashboard, insight, and the scene-bound `/query/` rule (with the
-embedded-resource AC cascade and query-body rescoper that go with them) land in a
-follow-up PR — see #55468 description for the stack layout.
+Adding support for a new resource type is a single entry in `GUEST_RULES`.
 """
 
 import re
@@ -25,10 +25,12 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 
 from posthog.models import OrganizationMembership
+from posthog.models.insight import Insight
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, UserAccessControl
 
+from products.dashboards.backend.models.dashboard import Dashboard
 from products.notebooks.backend.models import Notebook
 
 from ee.models.rbac.access_control import AccessControl
@@ -91,6 +93,14 @@ def _resolve_object(resource: str, resource_id: str, team_id: int):
     """Resolve a URL-style resource identifier to a concrete model instance we can pass to
     `UserAccessControl.access_level_for_object`. Returns `None` when the resource doesn't
     exist — the caller treats that as "not allowed" (guests can't enumerate)."""
+    if resource == "dashboard":
+        if not resource_id.isdigit():
+            return None
+        return Dashboard.objects.filter(id=int(resource_id), team_id=team_id).first()
+    if resource == "insight":
+        if resource_id.isdigit():
+            return Insight.objects.filter(id=int(resource_id), team_id=team_id).first()
+        return Insight.objects.filter(short_id=resource_id, team_id=team_id).first()
     if resource == "notebook":
         # Notebook PK is a UUID, so an integer-style resource_id can only be a short_id.
         return Notebook.objects.filter(short_id=resource_id, team_id=team_id).first()
@@ -101,7 +111,9 @@ def _guest_has_access_to(user: User, team_id: int, resource: str, resource_id: s
     """Single decision point reused by every resource-bound rule.
 
     Returns True iff `UserAccessControl.access_level_for_object` resolves to a non-`none`
-    level for the (guest, team, resource, resource_id) tuple.
+    level for the (guest, team, resource, resource_id) tuple. The dashboard-tile cascade is
+    already handled inside the AC layer because `create_grant` writes tile AC rows at grant
+    time; the middleware itself never needs to check parent dashboards.
     """
     membership = _guest_membership_for_team(user, team_id)
     if membership is None:
@@ -129,6 +141,24 @@ class TeamScopedMetadataRead(GuestRule):
 
     def matches(self, request: HttpRequest) -> re.Match | None:
         if request.method != "GET":
+            return None
+        return super().matches(request)
+
+    def allows(self, request: HttpRequest, user: User, match: re.Match) -> bool:
+        team_id = int(match.group("team_id"))
+        return _has_any_team_ac_row(user, team_id)
+
+
+class TeamScopedPostSubAction(GuestRule):
+    """POST-only team-scoped sub-actions a viewer triggers automatically while interacting
+    with a dashboard tile (cancel a running query, record query timing, mark insight as
+    viewed). Same gate as `TeamScopedMetadataRead`: allowed iff the guest has any AC row
+    on this team. The sub-actions don't take a resource id and don't return resource data,
+    so the gate doesn't need to be tighter than "guest has any reason to be in this team."
+    """
+
+    def matches(self, request: HttpRequest) -> re.Match | None:
+        if request.method != "POST":
             return None
         return super().matches(request)
 
@@ -175,6 +205,35 @@ class GrantBoundListFilter(GuestRule):
         return _guest_has_access_to(user, team_id, self._resource, filter_value)
 
 
+class SceneBoundQuery(GuestRule):
+    """`POST|GET /api/.../query[/<kind>]/` — allowed iff the `X-PostHog-Scene-Resource` header
+    identifies a resource the AC layer grants this guest. Header format: `resource:resource_id`.
+
+    The query rescoper (PR #3) applies further team/object-level filters to the query body;
+    this middleware rule only guards the endpoint reachability.
+    """
+
+    _SCENE_HEADER = "X-PostHog-Scene-Resource"
+    _VALID_RESOURCES = ("dashboard", "insight", "notebook")
+
+    def matches(self, request: HttpRequest) -> re.Match | None:
+        if request.method not in {"POST", "GET"}:
+            return None
+        return super().matches(request)
+
+    def allows(self, request: HttpRequest, user: User, match: re.Match) -> bool:
+        header = request.headers.get(self._SCENE_HEADER)
+        if not header or ":" not in header:
+            return False
+        resource, _, resource_id = header.partition(":")
+        resource = resource.strip()
+        resource_id = resource_id.strip()
+        if not resource_id or resource not in self._VALID_RESOURCES:
+            return False
+        team_id = int(match.group("team_id"))
+        return _guest_has_access_to(user, team_id, resource, resource_id)
+
+
 _METADATA_ENDPOINTS = (
     "data_color_themes",
     "insight_variables",
@@ -184,9 +243,24 @@ _METADATA_ENDPOINTS = (
     "tags",
 )
 
+# (resource, sub_action) tuples — POST endpoints that the viewer client fires automatically
+# while a dashboard tile re-renders. None of them return resource data; cancel aborts a running
+# query the guest themselves issued, timing posts FE telemetry, viewed marks an insight as seen.
+# Adding a new endpoint here should be done sparingly and only for non-mutating telemetry-style
+# sub-actions whose abuse surface is empty.
+_TEAM_SCOPED_POST_SUBACTIONS = (
+    ("insights", "cancel"),
+    ("insights", "timing"),
+    ("insights", "viewed"),
+)
+
 
 def _metadata_pattern(endpoint: str) -> str:
     return rf"^/api/(?:environments|projects)/(?P<team_id>\d+)/{endpoint}/?$"
+
+
+def _post_subaction_pattern(resource: str, action: str) -> str:
+    return rf"^/api/(?:environments|projects)/(?P<team_id>\d+)/{resource}/{action}/?$"
 
 
 GUEST_RULES: list[GuestRule] = [
@@ -205,14 +279,35 @@ GUEST_RULES: list[GuestRule] = [
     AlwaysAllowed(r"^/favicon\.ico$"),
     AlwaysAllowed(r"^/guest(/.*)?$"),
     *[TeamScopedMetadataRead(_metadata_pattern(endpoint)) for endpoint in _METADATA_ENDPOINTS],
+    *[
+        TeamScopedPostSubAction(_post_subaction_pattern(resource, action))
+        for resource, action in _TEAM_SCOPED_POST_SUBACTIONS
+    ],
+    # Anchored with `$` so sub-actions (e.g. `/dashboards/4/sharing/`, `/dashboards/4/collaborators/`)
+    # do NOT inherit the grant — they need their own rule if we ever want to expose them.
+    # Viewers don't need sub-actions; without this anchor a dashboard grant would leak the sharing
+    # config and collaborator list for the granted dashboard.
+    GrantBoundResource(
+        "dashboard",
+        r"^/api/(?:environments|projects)/(?P<team_id>\d+)/dashboards/(?P<resource_id>\d+)/?$",
+    ),
+    GrantBoundResource(
+        "insight",
+        r"^/api/(?:environments|projects)/(?P<team_id>\d+)/insights/(?P<resource_id>[A-Za-z0-9]+)/?$",
+    ),
     GrantBoundResource(
         "notebook",
         r"^/api/(?:environments|projects)/(?P<team_id>\d+)/notebooks/(?P<resource_id>[A-Za-z0-9-]+)/?$",
     ),
     GrantBoundListFilter(
+        "insight",
+        r"^/api/(?:environments|projects)/(?P<team_id>\d+)/insights/?$",
+    ),
+    GrantBoundListFilter(
         "notebook",
         r"^/api/(?:environments|projects)/(?P<team_id>\d+)/notebooks/?$",
     ),
+    SceneBoundQuery(r"^/api/(?:environments|projects)/(?P<team_id>\d+)/query(/[A-Z][A-Za-z]*)?/?$"),
 ]
 
 

--- a/posthog/rbac/guest_access_policy.py
+++ b/posthog/rbac/guest_access_policy.py
@@ -20,10 +20,8 @@ from posthog.models.user import User
 from posthog.scopes import APIScopeObject
 
 # Resources a guest can be granted explicit access to via an `AccessControl` row.
-# Anything not in this set is implicitly denied for guests. Scope: notebook only —
-# dashboard, insight, and the embedded-resource cascade for notebook nodes land in a
-# follow-up PR.
-GUEST_GRANTABLE_RESOURCES: frozenset[APIScopeObject] = frozenset({"notebook"})
+# Anything not in this set is implicitly denied for guests.
+GUEST_GRANTABLE_RESOURCES: frozenset[APIScopeObject] = frozenset({"dashboard", "insight", "notebook"})
 
 # Frame-level resources without per-row AC entries — guests must still be allowed
 # the project shell so their granted dashboards/insights can render. The

--- a/posthog/rbac/guest_grants.py
+++ b/posthog/rbac/guest_grants.py
@@ -3,9 +3,8 @@
 A guest's access is expressed as `AccessControl` rows scoped to their OrganizationMembership.
 The inversion in `UserAccessControl` flips the default for guests from "allow" to "deny", so
 an AC row is both necessary and sufficient: this module is a thin wrapper around AC writes
-plus the notebook embedded-node cascade (centralized in `notebook_cascade.py`).
-
-Scope: notebook only. Dashboard and insight grants land in a follow-up PR.
+plus the dashboard-tile cascade and the notebook embedded-node cascade (centralized in
+`notebook_cascade.py`).
 
 Adding a new resource type means accepting it in `VALID_RESOURCES` and ensuring the
 `_ac_resource_id` translation matches how the URL-side identifier differs from the AC PK.
@@ -20,28 +19,43 @@ from rest_framework import exceptions
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
+from posthog.models.insight import Insight
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.notebooks.backend.models import Notebook
 
 from ee.models.rbac.access_control import AccessControl
 
-VALID_RESOURCES: tuple[str, ...] = ("notebook",)
+VALID_RESOURCES: tuple[str, ...] = ("dashboard", "insight", "notebook")
 VALID_GUEST_ACCESS_LEVELS: tuple[str, ...] = ("viewer", "editor")
 GUEST_VIEWER_ACCESS_LEVEL = "viewer"
 
 
 def _resource_exists_in_team(resource: str, resource_id: str, team_id: int) -> bool:
-    """Does the grant target actually exist? Notebook URL identifiers are `short_id`, but
-    legacy numeric PK addressing is also allowed."""
+    """Does the grant target actually exist? URL identifiers differ by resource:
+
+    - dashboard: stringified numeric PK
+    - insight / notebook: `short_id`, but legacy numeric PK addressing is also allowed
+    """
     value = str(resource_id)
-    if resource != "notebook":
+    if resource == "dashboard":
+        if not value.isdigit():
+            return False
+        return Dashboard.objects.filter(id=int(value), team_id=team_id).exists()
+    model: Any
+    if resource == "insight":
+        model = Insight
+    elif resource == "notebook":
+        model = Notebook
+    else:
         return False
-    if value.isdigit() and Notebook.objects.filter(id=int(value), team_id=team_id).exists():
+    if value.isdigit() and model.objects.filter(id=int(value), team_id=team_id).exists():
         return True
-    return Notebook.objects.filter(short_id=value, team_id=team_id).exists()
+    return model.objects.filter(short_id=value, team_id=team_id).exists()
 
 
 def validate_invite_grants(organization: Organization, guest_resources: list[dict[str, Any]]) -> None:
@@ -86,7 +100,12 @@ def create_grant(
     created_by: User,
     access_level: str = GUEST_VIEWER_ACCESS_LEVEL,
 ) -> AccessControl:
-    """Write a single `AccessControl` row for this guest membership."""
+    """Write a single `AccessControl` row for this guest membership.
+
+    For dashboards, also cascade AC rows at the same level to each tile insight so the
+    insight scene resolves correctly on the frontend. Tiles added after the grant is created
+    will NOT auto-propagate — documented v1 limitation.
+    """
     if resource not in VALID_RESOURCES:
         raise exceptions.ValidationError(f"Invalid resource: {resource}")
     if access_level not in VALID_GUEST_ACCESS_LEVELS:
@@ -113,7 +132,21 @@ def create_grant(
         access_control.access_level = access_level
         access_control.save(update_fields=["access_level", "updated_at"])
 
-    if resource == "notebook":
+    if resource == "dashboard":
+        # Tile cascade is always viewer-level, regardless of the dashboard's grant level.
+        # An editor grant on the dashboard means "edit dashboard layout / metadata"; it does
+        # NOT extend the editor capability to the underlying tile insights, which would let
+        # the guest rename/mutate/soft-delete each insight individually via its own URL.
+        # If a guest needs editor access to a specific insight, that's a separate explicit
+        # grant — not an implicit cascade.
+        _cascade_ac_to_dashboard_tiles(
+            team=team,
+            dashboard_id=str(resource_id),
+            membership=membership,
+            created_by=created_by,
+            access_level=GUEST_VIEWER_ACCESS_LEVEL,
+        )
+    elif resource == "notebook":
         # Cascade AC rows to every cascadeable embedded resource referenced in the notebook
         # content (saved insights, recordings, cohorts, feature flags, etc.) at viewer level.
         # The embed map is centralized in `posthog/rbac/notebook_cascade.py`.
@@ -132,14 +165,55 @@ def create_grant(
 
 
 def _ac_resource_id(resource: str, grant_resource_id: str, team_id: int) -> str | None:
-    """Guest grants accept URL identifiers (short_id for notebooks), while the AC table
-    uses the numeric PK. Translate before writing AC rows."""
-    if resource != "notebook":
-        return None
+    """Guest grants accept URL identifiers (numeric PK for dashboards, short_id for
+    insights/notebooks), while the AC table uses the numeric PK for all resources.
+    Translate before writing AC rows."""
+    if resource == "dashboard":
+        return grant_resource_id if grant_resource_id.isdigit() else None
+    model: Any
+    if resource == "insight":
+        model = Insight
+    elif resource == "notebook":
+        model = Notebook
+    else:
+        return grant_resource_id
     if grant_resource_id.isdigit():
         return grant_resource_id
-    pk = Notebook.objects.filter(short_id=grant_resource_id, team_id=team_id).values_list("id", flat=True).first()
+    pk = model.objects.filter(short_id=grant_resource_id, team_id=team_id).values_list("id", flat=True).first()
     return str(pk) if pk is not None else None
+
+
+def _cascade_ac_to_dashboard_tiles(
+    *,
+    team: Team,
+    dashboard_id: str,
+    membership: OrganizationMembership,
+    created_by: User,
+    access_level: str = GUEST_VIEWER_ACCESS_LEVEL,
+) -> None:
+    """Write one viewer-level AC row per tile insight on the dashboard.
+
+    The `access_level` parameter is reserved for future curated-grant flows and defaults
+    to viewer. Today, every caller (the only one being `create_grant` for a dashboard)
+    pins it to viewer regardless of the parent dashboard's grant level — see the
+    comment in `create_grant` for the rationale.
+    """
+    if not dashboard_id.isdigit():
+        return
+    # `insight__isnull=False` already filters out tiles without an insight, so every
+    # `insight_id` we read here is non-null.
+    tile_insight_pks = DashboardTile.objects.filter(dashboard_id=int(dashboard_id), insight__isnull=False).values_list(
+        "insight_id", flat=True
+    )
+    for pk in tile_insight_pks:
+        AccessControl.objects.get_or_create(
+            team=team,
+            resource="insight",
+            resource_id=str(pk),
+            organization_member=membership,
+            role=None,
+            defaults={"access_level": access_level, "created_by": created_by},
+        )
 
 
 @transaction.atomic

--- a/posthog/rbac/test/test_guest_access_policy.py
+++ b/posthog/rbac/test/test_guest_access_policy.py
@@ -19,14 +19,14 @@ from posthog.rbac.guest_access_policy import (
 from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, default_access_level
 from posthog.scopes import APIScopeObject
 
-from products.notebooks.backend.models import Notebook
+from products.dashboards.backend.models.dashboard import Dashboard
 
 from ee.models.rbac.access_control import AccessControl
 
 
 class TestGuestAccessPolicyConstants(BaseTest):
     def test_grantable_resources_set(self):
-        self.assertEqual(GUEST_GRANTABLE_RESOURCES, frozenset({"notebook"}))
+        self.assertEqual(GUEST_GRANTABLE_RESOURCES, frozenset({"dashboard", "insight", "notebook"}))
 
     def test_frame_level_resources_set_excludes_plugin(self):
         # Plugin is intentionally NOT in this set — guests don't access plugin endpoints today
@@ -41,7 +41,7 @@ class TestGuestAccessPolicyConstants(BaseTest):
 class TestGuestObjectAccessLevel(BaseTest):
     def test_per_object_resource_returns_no_access(self):
         # Resources that have per-object AC rows: deny by default for guests.
-        for resource in ("notebook", "dashboard", "insight", "feature_flag"):
+        for resource in ("dashboard", "insight", "notebook", "feature_flag"):
             self.assertEqual(
                 guest_object_access_level(resource, explicit=False),
                 NO_ACCESS_LEVEL,
@@ -49,7 +49,7 @@ class TestGuestObjectAccessLevel(BaseTest):
             )
 
     def test_per_object_resource_explicit_returns_none(self):
-        self.assertIsNone(guest_object_access_level("notebook", explicit=True))
+        self.assertIsNone(guest_object_access_level("dashboard", explicit=True))
 
     def test_frame_level_resource_falls_through_to_default(self):
         # Project = frame-level → guest gets the regular default (so the project shell renders).
@@ -94,11 +94,11 @@ class TestGuestEffectiveTeamMembershipLevel(BaseTest):
         )
 
     def test_returns_member_when_guest_has_grant_on_team(self):
-        n = Notebook.objects.create(team=self.team, title="N", short_id="POL00001")
+        d = Dashboard.objects.create(team=self.team, name="D")
         AccessControl.objects.create(
             team=self.team,
-            resource="notebook",
-            resource_id=str(n.id),
+            resource="dashboard",
+            resource_id=str(d.id),
             organization_member=self.guest_membership,
             access_level="viewer",
             created_by=self.user,
@@ -116,21 +116,22 @@ class TestGuestEffectiveTeamMembershipLevel(BaseTest):
         from posthog.models.team.team import Team
 
         other_team = Team.objects.create(organization=self.organization, name="other")
-        n = Notebook.objects.create(team=other_team, title="N", short_id="POL00002")
+        d = Dashboard.objects.create(team=other_team, name="D")
         AccessControl.objects.create(
             team=other_team,
-            resource="notebook",
-            resource_id=str(n.id),
+            resource="dashboard",
+            resource_id=str(d.id),
             organization_member=self.guest_membership,
             access_level="viewer",
             created_by=self.user,
         )
         self.assertIsNone(guest_effective_team_membership_level(self.guest_membership, self.team.id))
 
-    def test_notebook_grant_counts_as_membership(self):
+    @parameterized.expand([("dashboard",), ("insight",), ("notebook",)])
+    def test_any_grantable_resource_counts_as_membership(self, resource: str):
         AccessControl.objects.create(
             team=self.team,
-            resource="notebook",
+            resource=resource,
             resource_id="42",
             organization_member=self.guest_membership,
             access_level="viewer",

--- a/posthog/rbac/test/test_guest_grants.py
+++ b/posthog/rbac/test/test_guest_grants.py
@@ -4,6 +4,7 @@ from rest_framework import exceptions
 
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership
+from posthog.models.insight import Insight
 from posthog.models.user import User
 from posthog.rbac.guest_grants import (
     GUEST_VIEWER_ACCESS_LEVEL,
@@ -14,7 +15,8 @@ from posthog.rbac.guest_grants import (
     validate_invite_grants,
 )
 
-from products.notebooks.backend.models import Notebook
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -33,19 +35,19 @@ class TestGuestGrants(BaseTest):
         self.guest_membership = OrganizationMembership.objects.create(
             organization=self.organization, user=self.guest_user, is_guest=True
         )
-        self.notebook = Notebook.objects.create(team=self.team, title="N", short_id="NBK00001")
+        self.dashboard = Dashboard.objects.create(team=self.team, name="Dash")
 
     def test_create_grant_writes_ac_row_at_viewer_by_default(self) -> None:
         ac = create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=self.notebook.short_id,
+            resource="dashboard",
+            resource_id=str(self.dashboard.pk),
             created_by=self.user,
         )
 
-        self.assertEqual(ac.resource, "notebook")
-        self.assertEqual(ac.resource_id, str(self.notebook.pk))
+        self.assertEqual(ac.resource, "dashboard")
+        self.assertEqual(ac.resource_id, str(self.dashboard.pk))
         self.assertEqual(ac.access_level, GUEST_VIEWER_ACCESS_LEVEL)
         self.assertEqual(ac.organization_member, self.guest_membership)
 
@@ -53,8 +55,8 @@ class TestGuestGrants(BaseTest):
         ac = create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=self.notebook.short_id,
+            resource="dashboard",
+            resource_id=str(self.dashboard.pk),
             created_by=self.user,
             access_level="editor",
         )
@@ -66,36 +68,56 @@ class TestGuestGrants(BaseTest):
             create_grant(
                 membership=self.guest_membership,
                 team=self.team,
-                resource="notebook",
-                resource_id=self.notebook.short_id,
+                resource="dashboard",
+                resource_id=str(self.dashboard.pk),
                 created_by=self.user,
-                access_level="manager",
+                access_level="manager",  # not a guest-allowed level
             )
 
-    def test_create_grant_rejects_unknown_resource(self) -> None:
-        with self.assertRaises(exceptions.ValidationError):
-            create_grant(
-                membership=self.guest_membership,
-                team=self.team,
-                resource="dashboard",
-                resource_id="1",
-                created_by=self.user,
-            )
+    def test_create_dashboard_grant_cascades_tile_insights_at_viewer(self) -> None:
+        # Cascade is always viewer regardless of the parent dashboard's grant level. Editor on
+        # the dashboard means "edit dashboard layout/metadata"; tile insights stay read-only so
+        # an editor guest can't rename or soft-delete each tile insight individually via its own
+        # URL.
+        insight_a = Insight.objects.create(team=self.team, name="A")
+        insight_b = Insight.objects.create(team=self.team, name="B")
+        DashboardTile.objects.create(dashboard=self.dashboard, insight=insight_a)
+        DashboardTile.objects.create(dashboard=self.dashboard, insight=insight_b)
+
+        create_grant(
+            membership=self.guest_membership,
+            team=self.team,
+            resource="dashboard",
+            resource_id=str(self.dashboard.pk),
+            created_by=self.user,
+            access_level="editor",
+        )
+
+        insight_acs = AccessControl.objects.filter(
+            team=self.team,
+            resource="insight",
+            organization_member=self.guest_membership,
+        )
+        levels = set(insight_acs.values_list("access_level", flat=True))
+        ids = set(insight_acs.values_list("resource_id", flat=True))
+        self.assertEqual(levels, {"viewer"})
+        self.assertIn(str(insight_a.pk), ids)
+        self.assertIn(str(insight_b.pk), ids)
 
     def test_revoke_deletes_all_ac_rows_for_membership(self) -> None:
         create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=self.notebook.short_id,
+            resource="dashboard",
+            resource_id=str(self.dashboard.pk),
             created_by=self.user,
         )
-        other_notebook = Notebook.objects.create(team=self.team, title="O", short_id="NBK00002")
+        other_dashboard = Dashboard.objects.create(team=self.team, name="Other")
         create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=other_notebook.short_id,
+            resource="dashboard",
+            resource_id=str(other_dashboard.pk),
             created_by=self.user,
         )
 
@@ -108,8 +130,8 @@ class TestGuestGrants(BaseTest):
         create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=self.notebook.short_id,
+            resource="dashboard",
+            resource_id=str(self.dashboard.pk),
             created_by=self.user,
         )
 
@@ -127,48 +149,40 @@ class TestGuestGrants(BaseTest):
             promote_to_member(regular, by=self.user)
 
     def test_apply_invite_grants_creates_ac_rows_for_each_entry(self) -> None:
-        notebook_short_id = self.notebook.short_id
-        team_pk = self.team.pk
-        invite_user = self.user
-
         class _FakeInvite:
             guest_resources = [
-                {"team_id": team_pk, "resource": "notebook", "resource_id": notebook_short_id},
+                {"team_id": self.team.pk, "resource": "dashboard", "resource_id": str(self.dashboard.pk)},
             ]
-            created_by = invite_user
+            created_by = self.user
 
         created = apply_invite_grants(_FakeInvite(), self.guest_membership)
         self.assertEqual(len(created), 1)
         self.assertTrue(
             AccessControl.objects.filter(
                 organization_member=self.guest_membership,
-                resource="notebook",
-                resource_id=str(self.notebook.pk),
+                resource="dashboard",
+                resource_id=str(self.dashboard.pk),
                 access_level=GUEST_VIEWER_ACCESS_LEVEL,
             ).exists()
         )
 
     def test_apply_invite_grants_respects_per_entry_access_level(self) -> None:
-        notebook_short_id = self.notebook.short_id
-        team_pk = self.team.pk
-        invite_user = self.user
-
         class _FakeInvite:
             guest_resources = [
                 {
-                    "team_id": team_pk,
-                    "resource": "notebook",
-                    "resource_id": notebook_short_id,
+                    "team_id": self.team.pk,
+                    "resource": "dashboard",
+                    "resource_id": str(self.dashboard.pk),
                     "access_level": "editor",
                 },
             ]
-            created_by = invite_user
+            created_by = self.user
 
         apply_invite_grants(_FakeInvite(), self.guest_membership)
         ac = AccessControl.objects.get(
             organization_member=self.guest_membership,
-            resource="notebook",
-            resource_id=str(self.notebook.pk),
+            resource="dashboard",
+            resource_id=str(self.dashboard.pk),
         )
         self.assertEqual(ac.access_level, "editor")
 
@@ -178,30 +192,34 @@ class TestGuestGrants(BaseTest):
         with self.assertRaises(exceptions.ValidationError):
             validate_invite_grants(
                 self.organization,
-                [{"team_id": self.team.pk, "resource": "notebook", "resource_id": self.notebook.short_id}],
+                [{"team_id": self.team.pk, "resource": "dashboard", "resource_id": str(self.dashboard.pk)}],
             )
 
     def test_validate_invite_grants_rejects_unknown_team(self) -> None:
         with self.assertRaises(exceptions.ValidationError):
             validate_invite_grants(
                 self.organization,
-                [{"team_id": 99999, "resource": "notebook", "resource_id": self.notebook.short_id}],
+                [{"team_id": 99999, "resource": "dashboard", "resource_id": str(self.dashboard.pk)}],
             )
 
     def test_validate_invite_grants_rejects_unknown_resource_type(self) -> None:
         with self.assertRaises(exceptions.ValidationError):
             validate_invite_grants(
                 self.organization,
-                [{"team_id": self.team.pk, "resource": "dashboard", "resource_id": "1"}],
+                [{"team_id": self.team.pk, "resource": "experiment", "resource_id": "1"}],
             )
 
     def test_validate_invite_grants_rejects_missing_resource_id(self) -> None:
         with self.assertRaises(exceptions.ValidationError):
             validate_invite_grants(
                 self.organization,
-                [{"team_id": self.team.pk, "resource": "notebook", "resource_id": "ZZZZZZZZ"}],
+                [{"team_id": self.team.pk, "resource": "dashboard", "resource_id": "99999"}],
             )
 
     def test_validate_invite_grants_requires_at_least_one_entry(self) -> None:
         with self.assertRaises(exceptions.ValidationError):
             validate_invite_grants(self.organization, [])
+
+
+# Tests for `filter_and_sanitize_teams_for_guest_access` and the rest of the guest
+# access policy live in `posthog/rbac/test/test_guest_access_policy.py`.

--- a/posthog/test/test_guest_deflection_middleware.py
+++ b/posthog/test/test_guest_deflection_middleware.py
@@ -5,10 +5,12 @@ from rest_framework import status
 
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership
+from posthog.models.insight import Insight
 from posthog.models.user import User
 from posthog.rbac.guest_grants import create_grant
 
-from products.notebooks.backend.models import Notebook
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
 
 class TestGuestDeflectionMiddleware(APIBaseTest):
@@ -16,18 +18,20 @@ class TestGuestDeflectionMiddleware(APIBaseTest):
 
     Setup wires up:
     - one guest user with an optional grant list
-    - one granted notebook + one ungranted notebook as a foil
+    - one granted dashboard + one "tile" insight inheriting access via dashboard cascade
+    - one ungranted dashboard / insight / notebook as foils
     """
 
     def setUp(self) -> None:
         super().setUp()
         # Advanced permissions feature is required for the UserAccessControl layer to honor
         # per-object AC rows. Without it the AC layer short-circuits and guests look no
-        # different from members without grants.
+        # different from members without grants — breaks the cascade tests.
         self.organization.available_product_features = [
             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
         ]
         self.organization.save()
+        # Promote the base test user to an admin and create a separate guest user.
         OrganizationMembership.objects.filter(organization=self.organization, user=self.user).update(
             level=OrganizationMembership.Level.ADMIN
         )
@@ -39,8 +43,11 @@ class TestGuestDeflectionMiddleware(APIBaseTest):
             organization=self.organization, user=self.guest_user, is_guest=True
         )
 
-        self.granted_notebook = Notebook.objects.create(team=self.team, title="Granted", short_id="GRNT0001")
-        self.ungranted_notebook = Notebook.objects.create(team=self.team, title="Ungranted", short_id="HIDD0001")
+        self.granted_dashboard = Dashboard.objects.create(team=self.team, name="Granted dashboard")
+        self.ungranted_dashboard = Dashboard.objects.create(team=self.team, name="Ungranted dashboard")
+        self.ungranted_insight = Insight.objects.create(team=self.team, name="Ungranted insight")
+        self.tile_insight = Insight.objects.create(team=self.team, name="Tile insight")
+        DashboardTile.objects.create(dashboard=self.granted_dashboard, insight=self.tile_insight)
 
     def _login_guest(self) -> None:
         self.client.force_login(self.guest_user)
@@ -48,23 +55,38 @@ class TestGuestDeflectionMiddleware(APIBaseTest):
     def _login_regular(self) -> None:
         self.client.force_login(self.user)
 
-    def _grant_notebook(self) -> None:
+    def _grant(self, resource: str, resource_id: str) -> None:
+        # Write via the service so the AC rows + dashboard-tile cascade match what the invite
+        # flow would produce. The middleware reads AC rows now that `is_guest=True` inverts
+        # the AC default.
+        target_pk: int
+        if resource == "dashboard":
+            target_pk = Dashboard.objects.get(pk=int(resource_id)).pk
+        elif resource == "insight":
+            target_pk = (
+                Insight.objects.get(pk=int(resource_id)).pk
+                if resource_id.isdigit()
+                else Insight.objects.get(short_id=resource_id).pk
+            )
+        else:
+            raise AssertionError(f"Unsupported resource in test helper: {resource}")
         create_grant(
             membership=self.guest_membership,
             team=self.team,
-            resource="notebook",
-            resource_id=self.granted_notebook.short_id,
+            resource=resource,
+            resource_id=str(target_pk),
             created_by=self.user,
         )
 
     def test_non_guest_user_is_never_deflected(self) -> None:
         self._login_regular()
-        res = self.client.get(f"/api/projects/{self.team.pk}/notebooks/{self.ungranted_notebook.short_id}/")
+        res = self.client.get(f"/api/projects/{self.team.pk}/dashboards/{self.ungranted_dashboard.pk}/")
+        # Regular admin can read any dashboard they have AC on; the middleware doesn't deflect them.
         self.assertNotEqual(res.status_code, 404)
 
     def test_guest_user_without_grants_is_deflected_from_api(self) -> None:
         self._login_guest()
-        res = self.client.get(f"/api/projects/{self.team.pk}/notebooks/{self.ungranted_notebook.short_id}/")
+        res = self.client.get(f"/api/projects/{self.team.pk}/dashboards/{self.ungranted_dashboard.pk}/")
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_guest_user_without_grants_is_redirected_on_spa_route(self) -> None:
@@ -79,21 +101,98 @@ class TestGuestDeflectionMiddleware(APIBaseTest):
     def test_guest_landing_page_is_not_deflected(self) -> None:
         self._login_guest()
         res = self.client.get("/guest", follow=False)
+        # Route exists in frontend only, but middleware must not redirect; Django should reach
+        # the SPA/catch-all handler. We only care that the status is not a 302 to /guest.
         self.assertNotEqual(res.status_code, status.HTTP_302_FOUND)
 
+    def test_guest_with_dashboard_grant_can_read_granted_dashboard(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.get(f"/api/projects/{self.team.pk}/dashboards/{self.granted_dashboard.pk}/")
+        self.assertNotEqual(res.status_code, 404)
+
+    def test_guest_with_dashboard_grant_cannot_read_other_dashboard(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.get(f"/api/projects/{self.team.pk}/dashboards/{self.ungranted_dashboard.pk}/")
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_query_with_matching_scene_header_is_allowed(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/query/",
+            data={"query": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+            content_type="application/json",
+            HTTP_X_POSTHOG_SCENE_RESOURCE=f"dashboard:{self.granted_dashboard.pk}",
+        )
+        self.assertNotEqual(res.status_code, 404)
+
+    def test_query_with_mismatched_scene_header_is_deflected(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/query/",
+            data={"query": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+            content_type="application/json",
+            HTTP_X_POSTHOG_SCENE_RESOURCE=f"dashboard:{self.ungranted_dashboard.pk}",
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_query_without_scene_header_is_deflected(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/query/",
+            data={"query": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_query_with_malformed_scene_header_is_deflected(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/query/",
+            data={"query": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+            content_type="application/json",
+            HTTP_X_POSTHOG_SCENE_RESOURCE="garbage-no-colon",
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_themes_metadata_is_allowed_for_guest_with_any_grant(self) -> None:
-        self._grant_notebook()
+        self._grant("dashboard", str(self.granted_dashboard.pk))
         self._login_guest()
         res = self.client.get(f"/api/projects/{self.team.pk}/data_color_themes/")
         self.assertNotEqual(res.status_code, 404)
 
     def test_themes_metadata_post_is_deflected(self) -> None:
-        self._grant_notebook()
+        self._grant("dashboard", str(self.granted_dashboard.pk))
         self._login_guest()
         res = self.client.post(
             f"/api/projects/{self.team.pk}/data_color_themes/",
             data={},
             content_type="application/json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_tile_insight_is_allowed_when_parent_dashboard_is_granted(self) -> None:
+        # Dashboard grant cascades AC rows to tile insights; the middleware's list filter
+        # resolves the insight by short_id and the AC row lets it through.
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.get(
+            f"/api/projects/{self.team.pk}/insights/",
+            {"short_id": self.tile_insight.short_id},
+        )
+        self.assertNotEqual(res.status_code, 404)
+
+    def test_non_tile_insight_is_deflected_with_only_dashboard_grant(self) -> None:
+        self._grant("dashboard", str(self.granted_dashboard.pk))
+        self._login_guest()
+        res = self.client.get(
+            f"/api/projects/{self.team.pk}/insights/",
+            {"short_id": self.ungranted_insight.short_id},
         )
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -109,6 +208,9 @@ class TestGuestDeflectionMiddleware(APIBaseTest):
 
     @parameterized.expand(
         [
+            # Each endpoint is only registered on one of the routers (projects vs environments).
+            # We pair the endpoint with the scope where Django actually has a URL pattern —
+            # otherwise a regular Django 404 is indistinguishable from a middleware 404.
             ("annotations", "projects"),
             ("cohorts", "projects"),
             ("tags", "projects"),
@@ -118,12 +220,14 @@ class TestGuestDeflectionMiddleware(APIBaseTest):
         ]
     )
     def test_metadata_endpoints_require_any_grant(self, endpoint: str, scope: str) -> None:
+        # No grants yet — middleware should deflect even though the endpoint is in the
+        # metadata allowlist (guests with zero grants have no business in team metadata).
         self._login_guest()
         url = f"/api/{scope}/{self.team.pk}/{endpoint}/"
         res_without_grant = self.client.get(url)
         self.assertEqual(res_without_grant.status_code, status.HTTP_404_NOT_FOUND)
 
-        self._grant_notebook()
+        self._grant("dashboard", str(self.granted_dashboard.pk))
         res_with_grant = self.client.get(url)
         self.assertNotEqual(res_with_grant.status_code, 404)
 
@@ -138,7 +242,9 @@ class TestGuestDeflectionCrossOrgScoping(APIBaseTest):
 
     def setUp(self) -> None:
         super().setUp()
+        # Original `self.organization` is org A — promote `self.user` to a guest there.
         OrganizationMembership.objects.filter(organization=self.organization, user=self.user).update(is_guest=True)
+        # Org B with a separate team where the same user is a regular member.
         from posthog.models import Organization, Team
 
         self.org_b = Organization.objects.create(name="Org B")
@@ -149,17 +255,22 @@ class TestGuestDeflectionCrossOrgScoping(APIBaseTest):
             level=OrganizationMembership.Level.ADMIN,
         )
         self.team_b = Team.objects.create_with_data(organization=self.org_b, name="Team B", initiating_user=self.user)
-        self.notebook_b = Notebook.objects.create(team=self.team_b, title="Org B notebook", short_id="ORGB0001")
+        self.dashboard_b = Dashboard.objects.create(team=self.team_b, name="Org B dashboard")
 
     def test_guest_in_other_org_is_not_deflected_on_target_org_paths(self) -> None:
+        # User is a guest in org A but a regular admin in org B. Hitting an org-B path
+        # must not invoke guest deflection — they're a normal member there.
         self.client.force_login(self.user)
-        res = self.client.get(f"/api/projects/{self.team_b.pk}/notebooks/{self.notebook_b.short_id}/")
+        res = self.client.get(f"/api/projects/{self.team_b.pk}/dashboards/{self.dashboard_b.pk}/")
+        # Either 200 (admin can read) or any non-404 — the key invariant is "not deflected."
         self.assertNotEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_guest_in_same_org_is_deflected_on_ungranted_paths(self) -> None:
+        # On their guest-org's paths the user IS a guest and gets deflected for
+        # ungranted resources — the cross-org carve-out doesn't widen anything.
         self.client.force_login(self.user)
-        ungranted_notebook = Notebook.objects.create(team=self.team, title="Ungranted", short_id="UNGR0001")
-        res = self.client.get(f"/api/projects/{self.team.pk}/notebooks/{ungranted_notebook.short_id}/")
+        ungranted_dashboard = Dashboard.objects.create(team=self.team, name="Ungranted")
+        res = self.client.get(f"/api/projects/{self.team.pk}/dashboards/{ungranted_dashboard.pk}/")
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
 
@@ -179,11 +290,13 @@ class TestGuestDeflectionRuleLoop(APIBaseTest):
         guest = User.objects.create_user(email="ruleloop-guest@example.com", first_name="G", password="p")
         OrganizationMembership.objects.create(organization=self.organization, user=guest, is_guest=True)
 
+        # Build a request that the rule pair both match.
         request = HttpRequest()
         request.method = "GET"
-        request.path = f"/api/projects/{self.team.pk}/notebooks/foo/"
+        request.path = f"/api/projects/{self.team.pk}/dashboards/1/"
         request.user = guest
 
+        # Spy on the wrapped get_response to confirm the deny rule short-circuits.
         forwarded = {"called": False}
 
         def fake_get_response(_req):
@@ -192,12 +305,12 @@ class TestGuestDeflectionRuleLoop(APIBaseTest):
 
         middleware = GuestDeflectionMiddleware(fake_get_response)
         middleware._rules = [
-            AlwaysDenies(r"^/api/projects/\d+/notebooks/.*$"),
-            AlwaysAllowed(r"^/api/projects/\d+/notebooks/.*$"),
+            AlwaysDenies(r"^/api/projects/\d+/dashboards/.*$"),
+            AlwaysAllowed(r"^/api/projects/\d+/dashboards/.*$"),
         ]
 
         response = middleware(request)
-        self.assertFalse(forwarded["called"])
+        self.assertFalse(forwarded["called"])  # never reached the inner view
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
@@ -220,8 +333,11 @@ class TestGuestDeflectionNotebookGrants(APIBaseTest):
             organization=self.organization, user=self.guest_user, is_guest=True
         )
 
+        from products.notebooks.backend.models import Notebook
+
         self.granted_notebook = Notebook.objects.create(team=self.team, title="Granted", short_id="GRNT0001")
         self.ungranted_notebook = Notebook.objects.create(team=self.team, title="Hidden", short_id="HIDD0001")
+        # Grant via the service so the AC row matches the production flow (UUID PK stored).
         create_grant(
             membership=self.guest_membership,
             team=self.team,
@@ -242,6 +358,108 @@ class TestGuestDeflectionNotebookGrants(APIBaseTest):
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_notebook_uuid_in_url_is_deflected(self) -> None:
+        # Notebook URLs are addressed by short_id; a guest who has the granted notebook's UUID
+        # cannot use it as the URL identifier — middleware looks up by short_id only.
         self.client.force_login(self.guest_user)
         res = self.client.get(f"/api/projects/{self.team.pk}/notebooks/{self.granted_notebook.id}/")
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class TestGuestDeflectionTeamScopedPostSubActions(APIBaseTest):
+    """`/insights/cancel/`, `/insights/timing/`, `/insights/viewed/` are POST sub-actions
+    a viewer client fires automatically while interacting with a dashboard tile (cancel a
+    running query, record query timing, mark insight as viewed). The middleware must allow
+    them when the guest has any AC row in the team — without this, changing the date picker
+    on a granted dashboard fails because the FE-issued cancel hits 404, leaving the previous
+    query running and the new one stalled.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        self.organization.save()
+
+        self.guest_user_with_grant = User.objects.create_user(
+            email="grant-guest@example.com", first_name="G", password="password123"
+        )
+        self.guest_membership_with_grant = OrganizationMembership.objects.create(
+            organization=self.organization, user=self.guest_user_with_grant, is_guest=True
+        )
+        # Grant a dashboard with at least one tile, so the cascade writes a viewer-level
+        # insight AC row. This mirrors production: the FE only fires `cancel`/`timing` while
+        # tile queries are running, so the realistic permission check has the cascade row to
+        # satisfy `has_any_specific_access("insight", "viewer")`.
+        from posthog.models.insight import Insight
+
+        from products.dashboards.backend.models.dashboard_tile import DashboardTile
+
+        self.granted_dashboard = Dashboard.objects.create(team=self.team, name="Granted")
+        tile_insight = Insight.objects.create(team=self.team, name="Tile")
+        DashboardTile.objects.create(dashboard=self.granted_dashboard, insight=tile_insight)
+        create_grant(
+            membership=self.guest_membership_with_grant,
+            team=self.team,
+            resource="dashboard",
+            resource_id=str(self.granted_dashboard.pk),
+            created_by=self.user,
+            access_level="viewer",
+        )
+
+        self.guest_user_no_grant = User.objects.create_user(
+            email="nogrant-guest@example.com", first_name="N", password="password123"
+        )
+        OrganizationMembership.objects.create(
+            organization=self.organization, user=self.guest_user_no_grant, is_guest=True
+        )
+
+    @parameterized.expand([("cancel",), ("timing",), ("viewed",)])
+    def test_post_subaction_forwarded_for_guest_with_grant(self, subaction: str) -> None:
+        self.client.force_login(self.guest_user_with_grant)
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/insights/{subaction}/",
+            data={"client_query_id": "test-query-id"},
+            content_type="application/json",
+        )
+        # Viewset may 400 on missing payload fields, but the request must REACH the viewset
+        # (i.e. middleware must not 404 it AND the AC permission layer must not 403 it).
+        # `cancel` and `timing` declare `required_scopes=["insight:read"]` so guests with any
+        # specific insight access (including the dashboard-tile cascade) pass the resource
+        # check; `viewed` already declared the same scope before this PR.
+        self.assertNotEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertNotEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cancel_returns_201_for_guest_with_tile_cascade(self) -> None:
+        # End-to-end success check: cancel takes a `client_query_id` and signals ClickHouse
+        # to abort. With the tile cascade row in place, the guest passes both the middleware
+        # gate AND the AC `has_any_specific_access("insight", "viewer")` check. 201 confirms
+        # the action ran (it doesn't matter that no query is actually running — cancel is
+        # idempotent).
+        self.client.force_login(self.guest_user_with_grant)
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/insights/cancel/",
+            data={"client_query_id": "test-query-id"},
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+    @parameterized.expand([("cancel",), ("timing",), ("viewed",)])
+    def test_post_subaction_deflected_for_guest_without_any_team_ac_row(self, subaction: str) -> None:
+        # A guest with zero AC rows in this team has no business hitting team-scoped POST
+        # endpoints. Same gate as the metadata-read rule.
+        self.client.force_login(self.guest_user_no_grant)
+        res = self.client.post(
+            f"/api/projects/{self.team.pk}/insights/{subaction}/",
+            data={"client_query_id": "test-query-id"},
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_on_post_subaction_path_is_deflected(self) -> None:
+        # The rule is POST-only — a GET on the same path falls through to the next rule
+        # (GrantBoundResource("insight")), which tries to look up an insight with short_id
+        # equal to the action name and fails.
+        self.client.force_login(self.guest_user_with_grant)
+        res = self.client.get(f"/api/projects/{self.team.pk}/insights/cancel/")
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -66,6 +66,23 @@ export interface UserBasicApi {
     role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi | null
 }
 
+/**
+ * Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from
+nested user-serializer payloads when the requester is a guest.
+
+Declare which fields hold serialized users in `guest_redacted_user_fields`:
+
+    class NotebookMinimalSerializer(
+        GuestRedactedUserFieldsMixin,
+        serializers.ModelSerializer,
+        UserAccessControlSerializerMixin,
+    ):
+        guest_redacted_user_fields = ("created_by", "last_modified_by")
+
+Place this mixin BEFORE `serializers.ModelSerializer` in the MRO so its
+`to_representation` runs after the base implementation has already produced the
+serialized dict.
+ */
 export interface NotebookMinimalApi {
     /** UUID of the notebook. */
     readonly id: string
@@ -99,6 +116,23 @@ export interface PaginatedNotebookMinimalListApi {
     results: NotebookMinimalApi[]
 }
 
+/**
+ * Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from
+nested user-serializer payloads when the requester is a guest.
+
+Declare which fields hold serialized users in `guest_redacted_user_fields`:
+
+    class NotebookMinimalSerializer(
+        GuestRedactedUserFieldsMixin,
+        serializers.ModelSerializer,
+        UserAccessControlSerializerMixin,
+    ):
+        guest_redacted_user_fields = ("created_by", "last_modified_by")
+
+Place this mixin BEFORE `serializers.ModelSerializer` in the MRO so its
+`to_representation` runs after the base implementation has already produced the
+serialized dict.
+ */
 export interface NotebookApi {
     /** UUID of the notebook. */
     readonly id: string
@@ -137,6 +171,23 @@ export interface NotebookApi {
     _create_in_folder?: string
 }
 
+/**
+ * Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from
+nested user-serializer payloads when the requester is a guest.
+
+Declare which fields hold serialized users in `guest_redacted_user_fields`:
+
+    class NotebookMinimalSerializer(
+        GuestRedactedUserFieldsMixin,
+        serializers.ModelSerializer,
+        UserAccessControlSerializerMixin,
+    ):
+        guest_redacted_user_fields = ("created_by", "last_modified_by")
+
+Place this mixin BEFORE `serializers.ModelSerializer` in the MRO so its
+`to_representation` runs after the base implementation has already produced the
+serialized dict.
+ */
 export interface PatchedNotebookApi {
     /** UUID of the notebook. */
     readonly id?: string

--- a/products/notebooks/frontend/generated/api.zod.ts
+++ b/products/notebooks/frontend/generated/api.zod.ts
@@ -17,21 +17,25 @@ export const notebooksCreateBodyTitleMax = 256
 export const notebooksCreateBodyVersionMin = -2147483648
 export const notebooksCreateBodyVersionMax = 2147483647
 
-export const NotebooksCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksCreateBodyVersionMin)
-        .max(notebooksCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksCreateBodyVersionMin)
+            .max(notebooksCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -41,21 +45,25 @@ export const notebooksUpdateBodyTitleMax = 256
 export const notebooksUpdateBodyVersionMin = -2147483648
 export const notebooksUpdateBodyVersionMax = 2147483647
 
-export const NotebooksUpdateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksUpdateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksUpdateBodyVersionMin)
-        .max(notebooksUpdateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksUpdateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksUpdateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksUpdateBodyVersionMin)
+            .max(notebooksUpdateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -65,21 +73,25 @@ export const notebooksPartialUpdateBodyTitleMax = 256
 export const notebooksPartialUpdateBodyVersionMin = -2147483648
 export const notebooksPartialUpdateBodyVersionMax = 2147483647
 
-export const NotebooksPartialUpdateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksPartialUpdateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksPartialUpdateBodyVersionMin)
-        .max(notebooksPartialUpdateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksPartialUpdateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksPartialUpdateBodyVersionMin)
+            .max(notebooksPartialUpdateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -107,21 +119,25 @@ export const notebooksHogqlExecuteCreateBodyTitleMax = 256
 export const notebooksHogqlExecuteCreateBodyVersionMin = -2147483648
 export const notebooksHogqlExecuteCreateBodyVersionMax = 2147483647
 
-export const NotebooksHogqlExecuteCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksHogqlExecuteCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksHogqlExecuteCreateBodyVersionMin)
-        .max(notebooksHogqlExecuteCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksHogqlExecuteCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksHogqlExecuteCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksHogqlExecuteCreateBodyVersionMin)
+            .max(notebooksHogqlExecuteCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -131,21 +147,25 @@ export const notebooksKernelConfigCreateBodyTitleMax = 256
 export const notebooksKernelConfigCreateBodyVersionMin = -2147483648
 export const notebooksKernelConfigCreateBodyVersionMax = 2147483647
 
-export const NotebooksKernelConfigCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksKernelConfigCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksKernelConfigCreateBodyVersionMin)
-        .max(notebooksKernelConfigCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksKernelConfigCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksKernelConfigCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksKernelConfigCreateBodyVersionMin)
+            .max(notebooksKernelConfigCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -155,21 +175,25 @@ export const notebooksKernelExecuteCreateBodyTitleMax = 256
 export const notebooksKernelExecuteCreateBodyVersionMin = -2147483648
 export const notebooksKernelExecuteCreateBodyVersionMax = 2147483647
 
-export const NotebooksKernelExecuteCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksKernelExecuteCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksKernelExecuteCreateBodyVersionMin)
-        .max(notebooksKernelExecuteCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksKernelExecuteCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksKernelExecuteCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksKernelExecuteCreateBodyVersionMin)
+            .max(notebooksKernelExecuteCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -179,25 +203,29 @@ export const notebooksKernelExecuteStreamCreateBodyTitleMax = 256
 export const notebooksKernelExecuteStreamCreateBodyVersionMin = -2147483648
 export const notebooksKernelExecuteStreamCreateBodyVersionMax = 2147483647
 
-export const NotebooksKernelExecuteStreamCreateBody = /* @__PURE__ */ zod.object({
-    title: zod
-        .string()
-        .max(notebooksKernelExecuteStreamCreateBodyTitleMax)
-        .nullish()
-        .describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksKernelExecuteStreamCreateBodyVersionMin)
-        .max(notebooksKernelExecuteStreamCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksKernelExecuteStreamCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod
+            .string()
+            .max(notebooksKernelExecuteStreamCreateBodyTitleMax)
+            .nullish()
+            .describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksKernelExecuteStreamCreateBodyVersionMin)
+            .max(notebooksKernelExecuteStreamCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -207,21 +235,25 @@ export const notebooksKernelRestartCreateBodyTitleMax = 256
 export const notebooksKernelRestartCreateBodyVersionMin = -2147483648
 export const notebooksKernelRestartCreateBodyVersionMax = 2147483647
 
-export const NotebooksKernelRestartCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksKernelRestartCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksKernelRestartCreateBodyVersionMin)
-        .max(notebooksKernelRestartCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksKernelRestartCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksKernelRestartCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksKernelRestartCreateBodyVersionMin)
+            .max(notebooksKernelRestartCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -231,21 +263,25 @@ export const notebooksKernelStartCreateBodyTitleMax = 256
 export const notebooksKernelStartCreateBodyVersionMin = -2147483648
 export const notebooksKernelStartCreateBodyVersionMax = 2147483647
 
-export const NotebooksKernelStartCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksKernelStartCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksKernelStartCreateBodyVersionMin)
-        .max(notebooksKernelStartCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksKernelStartCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksKernelStartCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksKernelStartCreateBodyVersionMin)
+            .max(notebooksKernelStartCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -255,18 +291,22 @@ export const notebooksKernelStopCreateBodyTitleMax = 256
 export const notebooksKernelStopCreateBodyVersionMin = -2147483648
 export const notebooksKernelStopCreateBodyVersionMax = 2147483647
 
-export const NotebooksKernelStopCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksKernelStopCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksKernelStopCreateBodyVersionMin)
-        .max(notebooksKernelStopCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-    _create_in_folder: zod.string().optional(),
-})
+export const NotebooksKernelStopCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksKernelStopCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksKernelStopCreateBodyVersionMin)
+            .max(notebooksKernelStopCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+        _create_in_folder: zod.string().optional(),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = (\"created_by\", \"last_modified_by\")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -396,6 +396,9 @@ export interface OrganizationMemberApi {
     readonly is_2fa_enabled: boolean
     readonly has_social_auth: boolean
     readonly last_login: string
+    readonly is_guest: boolean
+    /** @nullable */
+    readonly guest_grant_count: number | null
 }
 
 export interface PaginatedOrganizationMemberListApi {
@@ -420,6 +423,9 @@ export interface PatchedOrganizationMemberApi {
     readonly is_2fa_enabled?: boolean
     readonly has_social_auth?: boolean
     readonly last_login?: string
+    readonly is_guest?: boolean
+    /** @nullable */
+    readonly guest_grant_count?: number | null
 }
 
 export type RoleApiMembersItem = { [key: string]: unknown }
@@ -815,7 +821,6 @@ export type ActivityLogListParams = {
 
 * `Cohort` - Cohort
 * `FeatureFlag` - FeatureFlag
-* `GuestResourceGrant` - GuestResourceGrant
 * `Person` - Person
 * `Group` - Group
 * `Insight` - Insight
@@ -889,7 +894,6 @@ export type ActivityLogListScope = (typeof ActivityLogListScope)[keyof typeof Ac
 export const ActivityLogListScope = {
     Cohort: 'Cohort',
     FeatureFlag: 'FeatureFlag',
-    GuestResourceGrant: 'GuestResourceGrant',
     Person: 'Person',
     Group: 'Group',
     Insight: 'Insight',
@@ -950,7 +954,6 @@ export const ActivityLogListScope = {
 /**
  * * `Cohort` - Cohort
  * `FeatureFlag` - FeatureFlag
- * `GuestResourceGrant` - GuestResourceGrant
  * `Person` - Person
  * `Group` - Group
  * `Insight` - Insight
@@ -1012,7 +1015,6 @@ export type ActivityLogListScopesItem = (typeof ActivityLogListScopesItem)[keyof
 export const ActivityLogListScopesItem = {
     Cohort: 'Cohort',
     FeatureFlag: 'FeatureFlag',
-    GuestResourceGrant: 'GuestResourceGrant',
     Person: 'Person',
     Group: 'Group',
     Insight: 'Insight',

--- a/products/platform_features/frontend/generated/api.ts
+++ b/products/platform_features/frontend/generated/api.ts
@@ -446,6 +446,32 @@ export const membersDestroy = async (
     })
 }
 
+/**
+ * Promote a guest membership to a regular member.
+
+Deletes all `AccessControl` rows scoped to this membership and flips the `is_guest`
+flag. The caller-facing UI should warn that promotion resets the user's access
+controls — after promotion, the new regular member has no explicit AC rows and
+relies on default project access instead. Admin+ only.
+ */
+export const getMembersPromoteGuestCreateUrl = (organizationId: string, userUuid: string) => {
+    return `/api/organizations/${organizationId}/members/${userUuid}/promote_guest/`
+}
+
+export const membersPromoteGuestCreate = async (
+    organizationId: string,
+    userUuid: string,
+    organizationMemberApi: NonReadonly<OrganizationMemberApi>,
+    options?: RequestInit
+): Promise<OrganizationMemberApi> => {
+    return apiMutator<OrganizationMemberApi>(getMembersPromoteGuestCreateUrl(organizationId, userUuid), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(organizationMemberApi),
+    })
+}
+
 export const getMembersScopedApiKeysRetrieveUrl = (organizationId: string, userUuid: string) => {
     return `/api/organizations/${organizationId}/members/${userUuid}/scoped_api_keys/`
 }

--- a/products/platform_features/frontend/generated/api.zod.ts
+++ b/products/platform_features/frontend/generated/api.zod.ts
@@ -169,6 +169,21 @@ export const MembersPartialUpdateBody = /* @__PURE__ */ zod.object({
         .optional(),
 })
 
+/**
+ * Promote a guest membership to a regular member.
+
+Deletes all `AccessControl` rows scoped to this membership and flips the `is_guest`
+flag. The caller-facing UI should warn that promotion resets the user's access
+controls — after promotion, the new regular member has no explicit AC rows and
+relies on default project access instead. Admin+ only.
+ */
+export const MembersPromoteGuestCreateBody = /* @__PURE__ */ zod.object({
+    level: zod
+        .union([zod.literal(1), zod.literal(8), zod.literal(15)])
+        .describe('* `1` - member\n* `8` - administrator\n* `15` - owner')
+        .optional(),
+})
+
 export const rolesCreateBodyNameMax = 200
 
 export const RolesCreateBody = /* @__PURE__ */ zod.object({

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -232,6 +232,9 @@ tools:
     members-partial-update:
         operation: members_partial_update
         enabled: false
+    members-promote-guest-create:
+        operation: members_promote_guest_create
+        enabled: false
     members-scoped-api-keys:
         operation: members_scoped_api_keys_retrieve
         enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -392,6 +392,9 @@ tools:
     members-partial-update:
         operation: members_partial_update
         enabled: false
+    members-promote-guest-create:
+        operation: members_promote_guest_create
+        enabled: false
     members-scoped-api-keys-retrieve:
         operation: members_scoped_api_keys_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21930,6 +21930,23 @@ export namespace Schemas {
       readonly sync_interval: string | null;
     }
 
+    /**
+     * Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from
+    nested user-serializer payloads when the requester is a guest.
+
+    Declare which fields hold serialized users in `guest_redacted_user_fields`:
+
+        class NotebookMinimalSerializer(
+            GuestRedactedUserFieldsMixin,
+            serializers.ModelSerializer,
+            UserAccessControlSerializerMixin,
+        ):
+            guest_redacted_user_fields = ("created_by", "last_modified_by")
+
+    Place this mixin BEFORE `serializers.ModelSerializer` in the MRO so its
+    `to_representation` runs after the base implementation has already produced the
+    serialized dict.
+     */
     export interface Notebook {
       /** UUID of the notebook. */
       readonly id: string;
@@ -21988,6 +22005,23 @@ export namespace Schemas {
       cursor_head?: number | null;
     }
 
+    /**
+     * Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from
+    nested user-serializer payloads when the requester is a guest.
+
+    Declare which fields hold serialized users in `guest_redacted_user_fields`:
+
+        class NotebookMinimalSerializer(
+            GuestRedactedUserFieldsMixin,
+            serializers.ModelSerializer,
+            UserAccessControlSerializerMixin,
+        ):
+            guest_redacted_user_fields = ("created_by", "last_modified_by")
+
+    Place this mixin BEFORE `serializers.ModelSerializer` in the MRO so its
+    `to_representation` runs after the base implementation has already produced the
+    serialized dict.
+     */
     export interface NotebookMinimal {
       /** UUID of the notebook. */
       readonly id: string;
@@ -22330,6 +22364,10 @@ export namespace Schemas {
       message?: string | null;
       /** List of team IDs and corresponding access levels to private projects. */
       private_project_access?: unknown | null;
+      /** List of {team_id, resource, resource_id, access_level?} dicts describing resource grants the invitee should receive on acceptance. A non-empty list marks the invite as a guest invite. */
+      guest_resources?: unknown;
+      /** If true, the membership created on acceptance can authenticate with password even when the organization enforces SSO. Meaningful for guest invites where the invitee is external and may not be in the SSO directory. */
+      bypass_sso?: boolean;
       send_email?: boolean;
       combine_pending_invites?: boolean;
     }
@@ -22347,6 +22385,9 @@ export namespace Schemas {
       readonly is_2fa_enabled: boolean;
       readonly has_social_auth: boolean;
       readonly last_login: string;
+      readonly is_guest: boolean;
+      /** @nullable */
+      readonly guest_grant_count: number | null;
     }
 
     /**
@@ -25432,6 +25473,8 @@ export namespace Schemas {
      */
     export type UserNotificationSettings = {[key: string]: unknown};
 
+    export type UserGuestGrantsItem = {[key: string]: unknown};
+
     export interface User {
       readonly date_joined: string;
       readonly uuid: string;
@@ -25498,6 +25541,18 @@ export namespace Schemas {
       /** @nullable */
       readonly is_organization_first_user: boolean | null;
       readonly pending_invites: readonly PendingInvite[];
+      readonly is_guest_in_current_project: boolean;
+      /** Build the frontend-facing grant list directly from AccessControl rows.
+
+    The AC table stores the numeric PK in `resource_id`, but the FE uses URL-style
+    identifiers (short_id for insight/notebook, PK for dashboard). We translate per
+    resource type here so the landing scene can build correct links.
+
+    Only dashboard/insight/notebook rows are exposed — these are the resource types
+    guest invites can grant. The insight rows produced by the dashboard-tile cascade are
+    intentionally filtered out so the landing scene doesn't show redundant entries for
+    every tile in a granted dashboard. */
+      readonly guest_grants: readonly UserGuestGrantsItem[];
     }
 
     export interface PaginatedUserList {
@@ -28013,6 +28068,23 @@ export namespace Schemas {
       readonly sync_interval?: string | null;
     }
 
+    /**
+     * Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from
+    nested user-serializer payloads when the requester is a guest.
+
+    Declare which fields hold serialized users in `guest_redacted_user_fields`:
+
+        class NotebookMinimalSerializer(
+            GuestRedactedUserFieldsMixin,
+            serializers.ModelSerializer,
+            UserAccessControlSerializerMixin,
+        ):
+            guest_redacted_user_fields = ("created_by", "last_modified_by")
+
+    Place this mixin BEFORE `serializers.ModelSerializer` in the MRO so its
+    `to_representation` runs after the base implementation has already produced the
+    serialized dict.
+     */
     export interface PatchedNotebook {
       /** UUID of the notebook. */
       readonly id?: string;
@@ -28195,6 +28267,9 @@ export namespace Schemas {
       readonly is_2fa_enabled?: boolean;
       readonly has_social_auth?: boolean;
       readonly last_login?: string;
+      readonly is_guest?: boolean;
+      /** @nullable */
+      readonly guest_grant_count?: number | null;
     }
 
     export interface PatchedPersistedFolder {
@@ -30700,6 +30775,8 @@ export namespace Schemas {
      */
     export type PatchedUserNotificationSettings = {[key: string]: unknown};
 
+    export type PatchedUserGuestGrantsItem = {[key: string]: unknown};
+
     export interface PatchedUser {
       readonly date_joined?: string;
       readonly uuid?: string;
@@ -30766,6 +30843,18 @@ export namespace Schemas {
       /** @nullable */
       readonly is_organization_first_user?: boolean | null;
       readonly pending_invites?: readonly PendingInvite[];
+      readonly is_guest_in_current_project?: boolean;
+      /** Build the frontend-facing grant list directly from AccessControl rows.
+
+    The AC table stores the numeric PK in `resource_id`, but the FE uses URL-style
+    identifiers (short_id for insight/notebook, PK for dashboard). We translate per
+    resource type here so the landing scene can build correct links.
+
+    Only dashboard/insight/notebook rows are exposed — these are the resource types
+    guest invites can grant. The insight rows produced by the dashboard-tile cascade are
+    intentionally filtered out so the landing scene doesn't show redundant entries for
+    every tile in a granted dashboard. */
+      readonly guest_grants?: readonly PatchedUserGuestGrantsItem[];
     }
 
     export interface PatchedUserInterview {
@@ -40848,7 +40937,6 @@ export namespace Schemas {
 
     * `Cohort` - Cohort
     * `FeatureFlag` - FeatureFlag
-    * `GuestResourceGrant` - GuestResourceGrant
     * `Person` - Person
     * `Group` - Group
     * `Insight` - Insight
@@ -40923,7 +41011,6 @@ export namespace Schemas {
     export const ActivityLogListScope = {
       Cohort: 'Cohort',
       FeatureFlag: 'FeatureFlag',
-      GuestResourceGrant: 'GuestResourceGrant',
       Person: 'Person',
       Group: 'Group',
       Insight: 'Insight',
@@ -40984,7 +41071,6 @@ export namespace Schemas {
     /**
      * * `Cohort` - Cohort
     * `FeatureFlag` - FeatureFlag
-    * `GuestResourceGrant` - GuestResourceGrant
     * `Person` - Person
     * `Group` - Group
     * `Insight` - Insight
@@ -41047,7 +41133,6 @@ export namespace Schemas {
     export const ActivityLogListScopesItem = {
       Cohort: 'Cohort',
       FeatureFlag: 'FeatureFlag',
-      GuestResourceGrant: 'GuestResourceGrant',
       Person: 'Person',
       Group: 'Group',
       Insight: 'Insight',

--- a/services/mcp/src/generated/notebooks/api.ts
+++ b/services/mcp/src/generated/notebooks/api.ts
@@ -53,20 +53,24 @@ export const notebooksCreateBodyTitleMax = 256
 export const notebooksCreateBodyVersionMin = -2147483648
 export const notebooksCreateBodyVersionMax = 2147483647
 
-export const NotebooksCreateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksCreateBodyVersionMin)
-        .max(notebooksCreateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-})
+export const NotebooksCreateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksCreateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksCreateBodyVersionMin)
+            .max(notebooksCreateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = ("created_by", "last_modified_by")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
@@ -97,20 +101,24 @@ export const notebooksPartialUpdateBodyTitleMax = 256
 export const notebooksPartialUpdateBodyVersionMin = -2147483648
 export const notebooksPartialUpdateBodyVersionMax = 2147483647
 
-export const NotebooksPartialUpdateBody = /* @__PURE__ */ zod.object({
-    title: zod.string().max(notebooksPartialUpdateBodyTitleMax).nullish().describe('Title of the notebook.'),
-    content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
-    text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
-    version: zod
-        .number()
-        .min(notebooksPartialUpdateBodyVersionMin)
-        .max(notebooksPartialUpdateBodyVersionMax)
-        .optional()
-        .describe(
-            'Version number for optimistic concurrency control. Must match the current version when updating content.'
-        ),
-    deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
-})
+export const NotebooksPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        title: zod.string().max(notebooksPartialUpdateBodyTitleMax).nullish().describe('Title of the notebook.'),
+        content: zod.unknown().nullish().describe('Notebook content as a ProseMirror JSON document structure.'),
+        text_content: zod.string().nullish().describe('Plain text representation of the notebook content for search.'),
+        version: zod
+            .number()
+            .min(notebooksPartialUpdateBodyVersionMin)
+            .max(notebooksPartialUpdateBodyVersionMax)
+            .optional()
+            .describe(
+                'Version number for optimistic concurrency control. Must match the current version when updating content.'
+            ),
+        deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
+    })
+    .describe(
+        'Serializer mixin that redacts PII (email, uuid, distinct_id, role, ...) from\nnested user-serializer payloads when the requester is a guest.\n\nDeclare which fields hold serialized users in `guest_redacted_user_fields`:\n\n    class NotebookMinimalSerializer(\n        GuestRedactedUserFieldsMixin,\n        serializers.ModelSerializer,\n        UserAccessControlSerializerMixin,\n    ):\n        guest_redacted_user_fields = ("created_by", "last_modified_by")\n\nPlace this mixin BEFORE `serializers.ModelSerializer` in the MRO so its\n`to_representation` runs after the base implementation has already produced the\nserialized dict.'
+    )
 
 /**
  * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 15 enabled ops
+ * PostHog API - MCP 19 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -57,6 +57,15 @@ export const ChangeRequestsRetrieveParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+export const ListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const RetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this organization.'),
+})
+
 export const MembersListParams = /* @__PURE__ */ zod.object({
     organization_id: zod.string(),
 })
@@ -64,6 +73,7 @@ export const MembersListParams = /* @__PURE__ */ zod.object({
 export const MembersListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order: zod.string().optional().describe('Sort order. Defaults to `-joined_at`.'),
 })
 
 export const RolesListParams = /* @__PURE__ */ zod.object({
@@ -120,7 +130,6 @@ export const ActivityLogListQueryParams = /* @__PURE__ */ zod.object({
         .enum([
             'Cohort',
             'FeatureFlag',
-            'GuestResourceGrant',
             'Person',
             'Group',
             'Insight',
@@ -147,6 +156,7 @@ export const ActivityLogListQueryParams = /* @__PURE__ */ zod.object({
             'Project',
             'ErrorTrackingIssue',
             'DataWarehouseSavedQuery',
+            'LegalDocument',
             'Organization',
             'OrganizationDomain',
             'OrganizationMembership',
@@ -178,7 +188,7 @@ export const ActivityLogListQueryParams = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            'Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".\n\n* `Cohort` - Cohort\n* `FeatureFlag` - FeatureFlag\n* `GuestResourceGrant` - GuestResourceGrant\n* `Person` - Person\n* `Group` - Group\n* `Insight` - Insight\n* `Plugin` - Plugin\n* `PluginConfig` - PluginConfig\n* `HogFunction` - HogFunction\n* `HogFlow` - HogFlow\n* `DataManagement` - DataManagement\n* `EventDefinition` - EventDefinition\n* `PropertyDefinition` - PropertyDefinition\n* `Notebook` - Notebook\n* `Endpoint` - Endpoint\n* `EndpointVersion` - EndpointVersion\n* `Dashboard` - Dashboard\n* `Replay` - Replay\n* `Experiment` - Experiment\n* `ExperimentHoldout` - ExperimentHoldout\n* `ExperimentSavedMetric` - ExperimentSavedMetric\n* `Survey` - Survey\n* `EarlyAccessFeature` - EarlyAccessFeature\n* `SessionRecordingPlaylist` - SessionRecordingPlaylist\n* `Comment` - Comment\n* `Team` - Team\n* `Project` - Project\n* `ErrorTrackingIssue` - ErrorTrackingIssue\n* `DataWarehouseSavedQuery` - DataWarehouseSavedQuery\n* `Organization` - Organization\n* `OrganizationDomain` - OrganizationDomain\n* `OrganizationMembership` - OrganizationMembership\n* `Role` - Role\n* `UserGroup` - UserGroup\n* `BatchExport` - BatchExport\n* `BatchImport` - BatchImport\n* `Integration` - Integration\n* `Annotation` - Annotation\n* `Tag` - Tag\n* `TaggedItem` - TaggedItem\n* `Subscription` - Subscription\n* `PersonalAPIKey` - PersonalAPIKey\n* `ProjectSecretAPIKey` - ProjectSecretAPIKey\n* `User` - User\n* `Action` - Action\n* `AlertConfiguration` - AlertConfiguration\n* `Threshold` - Threshold\n* `AlertSubscription` - AlertSubscription\n* `ExternalDataSource` - ExternalDataSource\n* `ExternalDataSchema` - ExternalDataSchema\n* `LLMTrace` - LLMTrace\n* `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset\n* `CustomerProfileConfig` - CustomerProfileConfig\n* `Log` - Log\n* `LogsAlertConfiguration` - LogsAlertConfiguration\n* `ProductTour` - ProductTour\n* `Ticket` - Ticket'
+            'Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".\n\n* `Cohort` - Cohort\n* `FeatureFlag` - FeatureFlag\n* `Person` - Person\n* `Group` - Group\n* `Insight` - Insight\n* `Plugin` - Plugin\n* `PluginConfig` - PluginConfig\n* `HogFunction` - HogFunction\n* `HogFlow` - HogFlow\n* `DataManagement` - DataManagement\n* `EventDefinition` - EventDefinition\n* `PropertyDefinition` - PropertyDefinition\n* `Notebook` - Notebook\n* `Endpoint` - Endpoint\n* `EndpointVersion` - EndpointVersion\n* `Dashboard` - Dashboard\n* `Replay` - Replay\n* `Experiment` - Experiment\n* `ExperimentHoldout` - ExperimentHoldout\n* `ExperimentSavedMetric` - ExperimentSavedMetric\n* `Survey` - Survey\n* `EarlyAccessFeature` - EarlyAccessFeature\n* `SessionRecordingPlaylist` - SessionRecordingPlaylist\n* `Comment` - Comment\n* `Team` - Team\n* `Project` - Project\n* `ErrorTrackingIssue` - ErrorTrackingIssue\n* `DataWarehouseSavedQuery` - DataWarehouseSavedQuery\n* `LegalDocument` - LegalDocument\n* `Organization` - Organization\n* `OrganizationDomain` - OrganizationDomain\n* `OrganizationMembership` - OrganizationMembership\n* `Role` - Role\n* `UserGroup` - UserGroup\n* `BatchExport` - BatchExport\n* `BatchImport` - BatchImport\n* `Integration` - Integration\n* `Annotation` - Annotation\n* `Tag` - Tag\n* `TaggedItem` - TaggedItem\n* `Subscription` - Subscription\n* `PersonalAPIKey` - PersonalAPIKey\n* `ProjectSecretAPIKey` - ProjectSecretAPIKey\n* `User` - User\n* `Action` - Action\n* `AlertConfiguration` - AlertConfiguration\n* `Threshold` - Threshold\n* `AlertSubscription` - AlertSubscription\n* `ExternalDataSource` - ExternalDataSource\n* `ExternalDataSchema` - ExternalDataSchema\n* `LLMTrace` - LLMTrace\n* `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset\n* `CustomerProfileConfig` - CustomerProfileConfig\n* `Log` - Log\n* `LogsAlertConfiguration` - LogsAlertConfiguration\n* `ProductTour` - ProductTour\n* `Ticket` - Ticket'
         ),
     scopes: zod
         .array(
@@ -186,7 +196,6 @@ export const ActivityLogListQueryParams = /* @__PURE__ */ zod.object({
                 .enum([
                     'Cohort',
                     'FeatureFlag',
-                    'GuestResourceGrant',
                     'Person',
                     'Group',
                     'Insight',
@@ -213,6 +222,7 @@ export const ActivityLogListQueryParams = /* @__PURE__ */ zod.object({
                     'Project',
                     'ErrorTrackingIssue',
                     'DataWarehouseSavedQuery',
+                    'LegalDocument',
                     'Organization',
                     'OrganizationDomain',
                     'OrganizationMembership',
@@ -243,7 +253,7 @@ export const ActivityLogListQueryParams = /* @__PURE__ */ zod.object({
                     'Ticket',
                 ])
                 .describe(
-                    '* `Cohort` - Cohort\n* `FeatureFlag` - FeatureFlag\n* `GuestResourceGrant` - GuestResourceGrant\n* `Person` - Person\n* `Group` - Group\n* `Insight` - Insight\n* `Plugin` - Plugin\n* `PluginConfig` - PluginConfig\n* `HogFunction` - HogFunction\n* `HogFlow` - HogFlow\n* `DataManagement` - DataManagement\n* `EventDefinition` - EventDefinition\n* `PropertyDefinition` - PropertyDefinition\n* `Notebook` - Notebook\n* `Endpoint` - Endpoint\n* `EndpointVersion` - EndpointVersion\n* `Dashboard` - Dashboard\n* `Replay` - Replay\n* `Experiment` - Experiment\n* `ExperimentHoldout` - ExperimentHoldout\n* `ExperimentSavedMetric` - ExperimentSavedMetric\n* `Survey` - Survey\n* `EarlyAccessFeature` - EarlyAccessFeature\n* `SessionRecordingPlaylist` - SessionRecordingPlaylist\n* `Comment` - Comment\n* `Team` - Team\n* `Project` - Project\n* `ErrorTrackingIssue` - ErrorTrackingIssue\n* `DataWarehouseSavedQuery` - DataWarehouseSavedQuery\n* `Organization` - Organization\n* `OrganizationDomain` - OrganizationDomain\n* `OrganizationMembership` - OrganizationMembership\n* `Role` - Role\n* `UserGroup` - UserGroup\n* `BatchExport` - BatchExport\n* `BatchImport` - BatchImport\n* `Integration` - Integration\n* `Annotation` - Annotation\n* `Tag` - Tag\n* `TaggedItem` - TaggedItem\n* `Subscription` - Subscription\n* `PersonalAPIKey` - PersonalAPIKey\n* `ProjectSecretAPIKey` - ProjectSecretAPIKey\n* `User` - User\n* `Action` - Action\n* `AlertConfiguration` - AlertConfiguration\n* `Threshold` - Threshold\n* `AlertSubscription` - AlertSubscription\n* `ExternalDataSource` - ExternalDataSource\n* `ExternalDataSchema` - ExternalDataSchema\n* `LLMTrace` - LLMTrace\n* `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset\n* `CustomerProfileConfig` - CustomerProfileConfig\n* `Log` - Log\n* `LogsAlertConfiguration` - LogsAlertConfiguration\n* `ProductTour` - ProductTour\n* `Ticket` - Ticket'
+                    '* `Cohort` - Cohort\n* `FeatureFlag` - FeatureFlag\n* `Person` - Person\n* `Group` - Group\n* `Insight` - Insight\n* `Plugin` - Plugin\n* `PluginConfig` - PluginConfig\n* `HogFunction` - HogFunction\n* `HogFlow` - HogFlow\n* `DataManagement` - DataManagement\n* `EventDefinition` - EventDefinition\n* `PropertyDefinition` - PropertyDefinition\n* `Notebook` - Notebook\n* `Endpoint` - Endpoint\n* `EndpointVersion` - EndpointVersion\n* `Dashboard` - Dashboard\n* `Replay` - Replay\n* `Experiment` - Experiment\n* `ExperimentHoldout` - ExperimentHoldout\n* `ExperimentSavedMetric` - ExperimentSavedMetric\n* `Survey` - Survey\n* `EarlyAccessFeature` - EarlyAccessFeature\n* `SessionRecordingPlaylist` - SessionRecordingPlaylist\n* `Comment` - Comment\n* `Team` - Team\n* `Project` - Project\n* `ErrorTrackingIssue` - ErrorTrackingIssue\n* `DataWarehouseSavedQuery` - DataWarehouseSavedQuery\n* `LegalDocument` - LegalDocument\n* `Organization` - Organization\n* `OrganizationDomain` - OrganizationDomain\n* `OrganizationMembership` - OrganizationMembership\n* `Role` - Role\n* `UserGroup` - UserGroup\n* `BatchExport` - BatchExport\n* `BatchImport` - BatchImport\n* `Integration` - Integration\n* `Annotation` - Annotation\n* `Tag` - Tag\n* `TaggedItem` - TaggedItem\n* `Subscription` - Subscription\n* `PersonalAPIKey` - PersonalAPIKey\n* `ProjectSecretAPIKey` - ProjectSecretAPIKey\n* `User` - User\n* `Action` - Action\n* `AlertConfiguration` - AlertConfiguration\n* `Threshold` - Threshold\n* `AlertSubscription` - AlertSubscription\n* `ExternalDataSource` - ExternalDataSource\n* `ExternalDataSchema` - ExternalDataSchema\n* `LLMTrace` - LLMTrace\n* `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset\n* `CustomerProfileConfig` - CustomerProfileConfig\n* `Log` - Log\n* `LogsAlertConfiguration` - LogsAlertConfiguration\n* `ProductTour` - ProductTour\n* `Ticket` - Ticket'
                 )
         )
         .optional()
@@ -262,6 +272,7 @@ export const AdvancedActivityLogsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const advancedActivityLogsListQueryActivitiesDefault = []
+export const advancedActivityLogsListQueryClientsDefault = []
 export const advancedActivityLogsListQueryItemIdsDefault = []
 export const advancedActivityLogsListQueryPageSizeDefault = 100
 export const advancedActivityLogsListQueryPageSizeMax = 1000
@@ -271,6 +282,7 @@ export const advancedActivityLogsListQueryUsersDefault = []
 
 export const AdvancedActivityLogsListQueryParams = /* @__PURE__ */ zod.object({
     activities: zod.array(zod.string()).default(advancedActivityLogsListQueryActivitiesDefault),
+    clients: zod.array(zod.string()).default(advancedActivityLogsListQueryClientsDefault),
     detail_filters: zod.string().optional(),
     end_date: zod.iso.datetime({}).optional(),
     hogql_filter: zod.string().optional(),
@@ -347,5 +359,156 @@ export const CommentsCountRetrieveParams = /* @__PURE__ */ zod.object({
         .string()
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Get the authenticated user's pinned sidebar tabs and configured homepage for the current team. Pass `@me` as the UUID.
+ */
+export const UserHomeSettingsRetrieveParams = /* @__PURE__ */ zod.object({
+    uuid: zod.string(),
+})
+
+/**
+ * Update the authenticated user's pinned sidebar tabs and/or homepage for the current team. Pass `@me` as the UUID. Send `tabs` to replace the pinned tab list, `homepage` to set the home destination (any PostHog URL — dashboard, insight, search results, scene). Either field may be omitted to leave it unchanged; sending `homepage: null` or `{}` clears the homepage.
+ */
+export const UserHomeSettingsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    uuid: zod.string(),
+})
+
+export const UserHomeSettingsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    tabs: zod
+        .array(
+            zod.object({
+                id: zod
+                    .string()
+                    .optional()
+                    .describe('Stable identifier for the tab. Generated client-side; safe to omit on create.'),
+                pathname: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'URL pathname the tab points at — for example `/project/123/dashboard/45` or `/project/123/insights`. Combined with `search` and `hash` to reconstruct the destination.'
+                    ),
+                search: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'Query string portion of the URL, including the leading `?`. Empty string when there is no query.'
+                    ),
+                hash: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'Fragment portion of the URL, including the leading `#`. Empty string when there is no fragment.'
+                    ),
+                title: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'Default tab title derived from the destination scene. Used when `customTitle` is not set.'
+                    ),
+                customTitle: zod
+                    .string()
+                    .nullish()
+                    .describe('Optional user-provided title that overrides `title` in the navigation UI.'),
+                iconType: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'Icon key shown next to the tab in the sidebar — for example `dashboard`, `insight`, `blank`.'
+                    ),
+                sceneId: zod
+                    .string()
+                    .nullish()
+                    .describe(
+                        'Scene identifier resolved from the pathname when known — used by the frontend for icon/title hints.'
+                    ),
+                sceneKey: zod
+                    .string()
+                    .nullish()
+                    .describe(
+                        'Scene key (logic key) for the destination, paired with `sceneParams` for deeper routing context.'
+                    ),
+                sceneParams: zod
+                    .unknown()
+                    .optional()
+                    .describe(
+                        'Free-form scene parameters captured at pin time, used by the frontend to rehydrate the destination.'
+                    ),
+                pinned: zod
+                    .boolean()
+                    .optional()
+                    .describe('Whether this entry is pinned. Always coerced to true on save — pass true or omit.'),
+            })
+        )
+        .optional()
+        .describe(
+            'Ordered list of pinned navigation tabs shown in the sidebar for the authenticated user within the current team. Send the full list to replace the existing pins; omit to leave them unchanged.'
+        ),
+    homepage: zod
+        .object({
+            id: zod
+                .string()
+                .optional()
+                .describe('Stable identifier for the tab. Generated client-side; safe to omit on create.'),
+            pathname: zod
+                .string()
+                .optional()
+                .describe(
+                    'URL pathname the tab points at — for example `/project/123/dashboard/45` or `/project/123/insights`. Combined with `search` and `hash` to reconstruct the destination.'
+                ),
+            search: zod
+                .string()
+                .optional()
+                .describe(
+                    'Query string portion of the URL, including the leading `?`. Empty string when there is no query.'
+                ),
+            hash: zod
+                .string()
+                .optional()
+                .describe(
+                    'Fragment portion of the URL, including the leading `#`. Empty string when there is no fragment.'
+                ),
+            title: zod
+                .string()
+                .optional()
+                .describe('Default tab title derived from the destination scene. Used when `customTitle` is not set.'),
+            customTitle: zod
+                .string()
+                .nullish()
+                .describe('Optional user-provided title that overrides `title` in the navigation UI.'),
+            iconType: zod
+                .string()
+                .optional()
+                .describe(
+                    'Icon key shown next to the tab in the sidebar — for example `dashboard`, `insight`, `blank`.'
+                ),
+            sceneId: zod
+                .string()
+                .nullish()
+                .describe(
+                    'Scene identifier resolved from the pathname when known — used by the frontend for icon/title hints.'
+                ),
+            sceneKey: zod
+                .string()
+                .nullish()
+                .describe(
+                    'Scene key (logic key) for the destination, paired with `sceneParams` for deeper routing context.'
+                ),
+            sceneParams: zod
+                .unknown()
+                .optional()
+                .describe(
+                    'Free-form scene parameters captured at pin time, used by the frontend to rehydrate the destination.'
+                ),
+            pinned: zod
+                .boolean()
+                .optional()
+                .describe('Whether this entry is pinned. Always coerced to true on save — pass true or omit.'),
+        })
+        .nullish()
+        .describe(
+            "Tab descriptor for the user's chosen home page — the destination opened when they click the PostHog logo or hit `/`. Set to a tab descriptor to pick a homepage, send `null` or `{}` to clear it and fall back to the project default."
         ),
 })


### PR DESCRIPTION
## Problem

Adds dashboard and insight grant support to guest mode on top of the notebook-only foundation in #55466. Split out for review so the notebook ship lands first; this PR re-introduces the broader resource surface.

## The stack

See #55466 for the full stack layout. Base: #55466.

## Changes

- Re-add `dashboard` and `insight` to `VALID_RESOURCES` in the grant service
- `GUEST_RULES`: add `GrantBoundResource` rules for dashboard / insight, `SceneBoundQuery` for `/query/`, `TeamScopedPostSubAction` for `/insights/cancel|timing|viewed`
- Dashboard tile cascade — granting a dashboard writes one viewer-level AC row per tile insight; pinned to viewer regardless of parent grant level (editor on a dashboard means edit dashboard layout, not edit each tile insight)
- Tighten `required_scopes` on `cancel` / `timing` so guests with cascaded tile-insight rows pass the AC check
- `get_guest_grants` and `get_guest_grant_count` re-add dashboard / insight metadata lookup with tile-cascade row filtering so the landing scene and promote-dialog count don't double-count
- Member payload, user payload, organization payload tests cover dashboard + insight + tile-cascade interaction

## How did you test this code?

- Reverts the slim commit on #55466. Restores 1100+ lines of tile-cascade, dashboard / insight grant flow, scene-bound query rule, and POST sub-action coverage. Test counts match pre-split.

## Publish to changelog?

no