### PR TITLE
refactor(api): hoist project_id/environment_id/organization_id into components.parameters

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -35,6 +35,33 @@ _KNOWN_PATH_PARAMS: dict[str, dict[str, Any]] = {
 }
 
 
+# Canonical parameter component definitions for the highest-frequency path params. drf-spectacular
+# inlines these into every operation that uses them — ``project_id`` alone shows up ~1100 times in
+# the spec, with byte-identical schema and description each time. Hoisting them into
+# ``components.parameters`` and ``$ref``-ing them eliminates the repetition (smaller spec, single
+# source of truth, kills vacuum's ``description-duplication`` for these names) without changing
+# what downstream codegen produces.
+_SHARED_PATH_PARAMS: dict[str, dict[str, Any]] = {
+    "ProjectIdPath": {
+        "in": "path",
+        "name": "project_id",
+        "required": True,
+        "schema": {"type": "string"},
+        "description": "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/.",
+    },
+    "EnvironmentIdPath": {
+        "in": "path",
+        "name": "environment_id",
+        "required": True,
+        "schema": {"type": "string"},
+        "description": "Deprecated. Use /api/projects/{project_id}/ instead.",
+    },
+}
+
+# Reverse lookup keyed by the inlined parameter name.
+_SHARED_PATH_PARAM_REFS: dict[str, str] = {p["name"]: name for name, p in _SHARED_PATH_PARAMS.items()}
+
+
 class _FallbackSerializer(serializers.Serializer):
     """Fallback ``serializer_class`` for ViewSets whose methods declare their own
     ``@extend_schema``.  The component name "Fallback" is valid OpenAPI and will
@@ -1064,22 +1091,8 @@ def custom_postprocessing_hook(result, generator, request, public):
 
             if "parameters" in definition:
                 definition["parameters"] = [
-                    {
-                        "in": "path",
-                        "name": "project_id",
-                        "required": True,
-                        "schema": {"type": "string"},
-                        "description": "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/.",
-                    }
-                    if param["name"] == "project_id"
-                    else {
-                        "in": "path",
-                        "name": "environment_id",
-                        "required": True,
-                        "schema": {"type": "string"},
-                        "description": "Deprecated. Use /api/projects/{project_id}/ instead.",
-                    }
-                    if param["name"] == "environment_id"
+                    {"$ref": f"#/components/parameters/{_SHARED_PATH_PARAM_REFS[param['name']]}"}
+                    if param.get("name") in _SHARED_PATH_PARAM_REFS and param.get("in") == "path"
                     else param
                     for param in definition["parameters"]
                 ]
@@ -1120,10 +1133,17 @@ def custom_postprocessing_hook(result, generator, request, public):
     # ``operation-tag-defined`` rule requires this — operations that use undeclared tags
     # produce a finding per (operation, tag) pair (was 2962 findings for us).
     sorted_tags = sorted(set(all_tags))
+
+    # Hoist shared path parameter definitions into ``components.parameters`` so the per-operation
+    # ``$ref``s emitted earlier resolve correctly.
+    components = dict(result.get("components") or {})
+    components["parameters"] = {**(components.get("parameters") or {}), **_SHARED_PATH_PARAMS}
+
     return {
         **result,
         "info": {"title": "PostHog API", "version": "1.0.0", "description": ""},
         "paths": paths,
+        "components": components,
         "tags": [{"name": tag} for tag in sorted_tags],
         "x-tagGroups": [{"name": "All endpoints", "tags": sorted_tags}],
     }

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -56,6 +56,13 @@ _SHARED_PATH_PARAMS: dict[str, dict[str, Any]] = {
         "schema": {"type": "string"},
         "description": "Deprecated. Use /api/projects/{project_id}/ instead.",
     },
+    "OrganizationIdPath": {
+        "in": "path",
+        "name": "organization_id",
+        "required": True,
+        "schema": {"type": "string"},
+        "description": "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/.",
+    },
 }
 
 # Reverse lookup keyed by the inlined parameter name.

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -118,7 +118,40 @@ function loadOpenApi(): OpenApiSpec {
         console.error(`OpenAPI schema not found at ${OPENAPI_PATH}. Run \`hogli build:openapi-schema\` first.`)
         process.exit(1)
     }
-    return JSON.parse(fs.readFileSync(OPENAPI_PATH, 'utf-8')) as OpenApiSpec
+    const spec = JSON.parse(fs.readFileSync(OPENAPI_PATH, 'utf-8')) as OpenApiSpec
+    inlineParameterRefs(spec)
+    return spec
+}
+
+/**
+ * Replace ``{$ref: '#/components/parameters/...'}`` entries in operation parameters with the
+ * fully resolved parameter object. The rest of this script reads ``parameter.in`` /
+ * ``parameter.name`` directly, which would silently return ``undefined`` for ref-only entries
+ * and cause downstream tools to mis-handle path/query params (e.g. dropping the
+ * ``project_id`` / ``organization_id`` auto-resolved omit).
+ */
+function inlineParameterRefs(spec: OpenApiSpec): void {
+    const parameterComponents = (spec.components as { parameters?: Record<string, unknown> } | undefined)?.parameters
+    if (!parameterComponents) {
+        return
+    }
+    for (const methods of Object.values(spec.paths ?? {})) {
+        for (const op of Object.values(methods ?? {}) as Array<{ parameters?: unknown[] }>) {
+            if (!op?.parameters || !Array.isArray(op.parameters)) {
+                continue
+            }
+            op.parameters = op.parameters.map((param) => {
+                if (param && typeof param === 'object' && '$ref' in param && typeof param.$ref === 'string') {
+                    const name = param.$ref.replace('#/components/parameters/', '')
+                    const resolved = parameterComponents[name]
+                    if (resolved) {
+                        return resolved
+                    }
+                }
+                return param
+            })
+        }
+    }
 }
 
 /**

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -55,7 +55,11 @@ export const OrganizationsProjectsRetrieveParams = /* @__PURE__ */ zod.object({
         .min(organizationsProjectsRetrievePathIdMin)
         .max(organizationsProjectsRetrievePathIdMax)
         .describe('A unique value identifying this project.'),
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 /**
@@ -70,7 +74,11 @@ export const OrganizationsProjectsPartialUpdateParams = /* @__PURE__ */ zod.obje
         .min(organizationsProjectsPartialUpdatePathIdMin)
         .max(organizationsProjectsPartialUpdatePathIdMax)
         .describe('A unique value identifying this project.'),
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 export const organizationsProjectsPartialUpdateBodyNameMax = 200

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -9,7 +9,11 @@
 import * as zod from 'zod'
 
 export const FeatureFlagsCopyFlagsCreateParams = /* @__PURE__ */ zod.object({
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 export const featureFlagsCopyFlagsCreateBodyTargetProjectIdsMax = 50

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -67,7 +67,11 @@ export const RetrieveParams = /* @__PURE__ */ zod.object({
 })
 
 export const MembersListParams = /* @__PURE__ */ zod.object({
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 export const MembersListQueryParams = /* @__PURE__ */ zod.object({
@@ -77,7 +81,11 @@ export const MembersListQueryParams = /* @__PURE__ */ zod.object({
 })
 
 export const RolesListParams = /* @__PURE__ */ zod.object({
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 export const RolesListQueryParams = /* @__PURE__ */ zod.object({
@@ -87,11 +95,19 @@ export const RolesListQueryParams = /* @__PURE__ */ zod.object({
 
 export const RolesRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this role.'),
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 export const RolesRoleMembershipsListParams = /* @__PURE__ */ zod.object({
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
     role_id: zod.string(),
 })
 

--- a/services/mcp/src/generated/proxy-records/api.ts
+++ b/services/mcp/src/generated/proxy-records/api.ts
@@ -12,14 +12,22 @@ import * as zod from 'zod'
  * List all reverse proxies configured for the organization. Returns proxy records along with the maximum number allowed by the current plan.
  */
 export const ProxyRecordsListParams = /* @__PURE__ */ zod.object({
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 /**
  * Create a new managed reverse proxy. Provide the domain you want to proxy through. The response includes the CNAME target you need to add as a DNS record. Once the CNAME is configured, the proxy will be automatically verified and provisioned.
  */
 export const ProxyRecordsCreateParams = /* @__PURE__ */ zod.object({
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 export const ProxyRecordsCreateBody = /* @__PURE__ */ zod.object({
@@ -33,7 +41,11 @@ export const ProxyRecordsCreateBody = /* @__PURE__ */ zod.object({
  */
 export const ProxyRecordsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this proxy record.'),
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 /**
@@ -41,7 +53,11 @@ export const ProxyRecordsRetrieveParams = /* @__PURE__ */ zod.object({
  */
 export const ProxyRecordsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this proxy record.'),
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })
 
 /**
@@ -49,5 +65,9 @@ export const ProxyRecordsDestroyParams = /* @__PURE__ */ zod.object({
  */
 export const ProxyRecordsRetryCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this proxy record.'),
-    organization_id: zod.string(),
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
 })

--- a/tools/openapi-codegen/src/schema.mjs
+++ b/tools/openapi-codegen/src/schema.mjs
@@ -107,6 +107,25 @@ export function filterSchemaByOperationIds(fullSchema, operationIds, options = {
     }
 
     const allSchemas = fullSchema.components?.schemas ?? {}
+    const allParameters = fullSchema.components?.parameters ?? {}
+
+    // Pull in referenced parameter components first — operations may use $ref to shared
+    // path/query parameters defined in components.parameters (e.g. ProjectIdPath). Each
+    // parameter definition can in turn reference component schemas via its inner ``schema``,
+    // so we collect those refs and feed them into the schema resolution below.
+    const filteredParameters = {}
+    for (const ref of refs) {
+        if (!ref.startsWith('#/components/parameters/')) {
+            continue
+        }
+        const paramName = ref.replace('#/components/parameters/', '')
+        const paramDef = allParameters[paramName]
+        if (paramDef) {
+            filteredParameters[paramName] = paramDef
+            collectSchemaRefs(paramDef, refs)
+        }
+    }
+
     const allRefs = resolveNestedRefs(allSchemas, refs)
     const filteredSchemas = {}
 
@@ -117,10 +136,15 @@ export function filterSchemaByOperationIds(fullSchema, operationIds, options = {
         }
     }
 
+    const components = { schemas: filteredSchemas }
+    if (Object.keys(filteredParameters).length > 0) {
+        components.parameters = filteredParameters
+    }
+
     return {
         openapi: fullSchema.openapi,
         info: { ...fullSchema.info, title: `${fullSchema.info?.title ?? 'API'} - ${operationIds.size} ops` },
         paths: filteredPaths,
-        components: { schemas: filteredSchemas },
+        components,
     }
 }

--- a/tools/openapi-codegen/src/schema.mjs
+++ b/tools/openapi-codegen/src/schema.mjs
@@ -114,6 +114,9 @@ export function filterSchemaByOperationIds(fullSchema, operationIds, options = {
     // parameter definition can in turn reference component schemas via its inner ``schema``,
     // so we collect those refs and feed them into the schema resolution below.
     const filteredParameters = {}
+    // Set iteration visits items added mid-loop (insertion-order); schema refs
+    // added by collectSchemaRefs are skipped here by the startsWith guard and
+    // picked up by resolveNestedRefs below.
     for (const ref of refs) {
         if (!ref.startsWith('#/components/parameters/')) {
             continue

--- a/tools/openapi-codegen/tests/schema.test.mjs
+++ b/tools/openapi-codegen/tests/schema.test.mjs
@@ -96,6 +96,53 @@ describe('filterSchemaByOperationIds', () => {
         expect(filtered.components.schemas).not.toHaveProperty('WidgetResponseNested')
     })
 
+    it('preserves component parameters referenced by filtered operations', () => {
+        const spec = buildSpec()
+        spec.paths['/api/widgets/'].post.parameters = [
+            { $ref: '#/components/parameters/ProjectIdPath' },
+            { $ref: '#/components/parameters/UnusedParam' },
+        ]
+        spec.components.parameters = {
+            ProjectIdPath: {
+                in: 'path',
+                name: 'project_id',
+                required: true,
+                schema: { type: 'string' },
+                description: 'The project ID.',
+            },
+            UnusedParam: {
+                in: 'query',
+                name: 'unused',
+                schema: { type: 'string' },
+            },
+            // Param that references a component schema — should pull that schema in too.
+            FilterParam: {
+                in: 'query',
+                name: 'filter',
+                schema: { $ref: '#/components/schemas/WidgetCreateMeta' },
+            },
+        }
+        spec.paths['/api/widgets/'].post.parameters.push({ $ref: '#/components/parameters/FilterParam' })
+
+        const filtered = filterSchemaByOperationIds(spec, new Set(['widgets_create']))
+
+        // Referenced params come along; unreferenced ones don't (UnusedParam is referenced too here,
+        // since the operation declares it — the test really checks that *referenced* params are kept).
+        expect(filtered.components.parameters).toHaveProperty('ProjectIdPath')
+        expect(filtered.components.parameters).toHaveProperty('UnusedParam')
+        expect(filtered.components.parameters).toHaveProperty('FilterParam')
+        expect(filtered.components.parameters.ProjectIdPath.description).toBe('The project ID.')
+
+        // FilterParam's inner schema ref should pull WidgetCreateMeta into the filtered schemas.
+        expect(filtered.components.schemas).toHaveProperty('WidgetCreateMeta')
+    })
+
+    it('omits components.parameters when no operation references one', () => {
+        const filtered = filterSchemaByOperationIds(buildSpec(), new Set(['widgets_create']))
+
+        expect(filtered.components).not.toHaveProperty('parameters')
+    })
+
     it('keeps response status keys and only description when includeResponseSchemas is false', () => {
         const spec = buildSpec()
         spec.paths['/api/widgets/'].post.responses = {

--- a/tools/openapi-codegen/tests/schema.test.mjs
+++ b/tools/openapi-codegen/tests/schema.test.mjs
@@ -100,7 +100,8 @@ describe('filterSchemaByOperationIds', () => {
         const spec = buildSpec()
         spec.paths['/api/widgets/'].post.parameters = [
             { $ref: '#/components/parameters/ProjectIdPath' },
-            { $ref: '#/components/parameters/UnusedParam' },
+            { $ref: '#/components/parameters/FormatQuery' },
+            { $ref: '#/components/parameters/FilterParam' },
         ]
         spec.components.parameters = {
             ProjectIdPath: {
@@ -110,9 +111,9 @@ describe('filterSchemaByOperationIds', () => {
                 schema: { type: 'string' },
                 description: 'The project ID.',
             },
-            UnusedParam: {
+            FormatQuery: {
                 in: 'query',
-                name: 'unused',
+                name: 'format',
                 schema: { type: 'string' },
             },
             // Param that references a component schema — should pull that schema in too.
@@ -121,16 +122,19 @@ describe('filterSchemaByOperationIds', () => {
                 name: 'filter',
                 schema: { $ref: '#/components/schemas/WidgetCreateMeta' },
             },
+            UnreferencedParam: {
+                in: 'query',
+                name: 'stale',
+                schema: { type: 'string' },
+            },
         }
-        spec.paths['/api/widgets/'].post.parameters.push({ $ref: '#/components/parameters/FilterParam' })
 
         const filtered = filterSchemaByOperationIds(spec, new Set(['widgets_create']))
 
-        // Referenced params come along; unreferenced ones don't (UnusedParam is referenced too here,
-        // since the operation declares it — the test really checks that *referenced* params are kept).
         expect(filtered.components.parameters).toHaveProperty('ProjectIdPath')
-        expect(filtered.components.parameters).toHaveProperty('UnusedParam')
+        expect(filtered.components.parameters).toHaveProperty('FormatQuery')
         expect(filtered.components.parameters).toHaveProperty('FilterParam')
+        expect(filtered.components.parameters).not.toHaveProperty('UnreferencedParam')
         expect(filtered.components.parameters.ProjectIdPath.description).toBe('The project ID.')
 
         // FilterParam's inner schema ref should pull WidgetCreateMeta into the filtered schemas.


### PR DESCRIPTION
## Problem

drf-spectacular inlines path parameters into every operation that uses them. ``project_id`` alone shows up ~1100 times in the generated spec, with byte-identical schema and description each pass. ``environment_id`` adds another ~440. ``organization_id`` another 79. Repeating identical parameter blobs ~1,680 times bloats the spec, makes it harder to maintain (one source of truth per param), and lights up Vacuum's ``description-duplication`` rule for the same reason.

## Changes

Hoists the three TeamAndOrgViewSetMixin-resolved path params into ``components.parameters`` and replaces inline copies with ``$ref``. Same params already grouped together in ``generate-tools.ts`` as ``autoResolvedParams`` — this just makes the spec match.

**Why only these three:** they're already hardcoded in the postprocess hook with fixed schema/description. Other path params like ``id`` come straight from drf-spectacular's per-resource introspection — 117 distinct descriptions and 5 distinct schemas across 867 inlines (integer vs UUID, varying per resource). Extracting them would lose precision and break per-resource type accuracy in codegen. Smaller candidates (``short_id``, ``task_id``, ``dashboard_id``, etc.) are uniform but each saves only ~10–50 inlines, so deferring on the long tail.

**Two consumers needed updates** to handle ``$ref`` parameters:

1. ``filterSchemaByOperationIds`` (``tools/openapi-codegen/src/schema.mjs``) didn't preserve ``components.parameters`` in its filtered output — it stripped them entirely. Operations with ``$ref`` parameters then had unresolved refs, and Orval's zod generation hung in an infinite loop trying to resolve them. Fix: walk collected refs, copy referenced parameter components, and recurse into any schema refs they carry. New tests cover the parameter-preservation paths.

2. ``generate-tools.ts`` reads ``parameter.in`` and ``parameter.name`` directly. After this change those return ``undefined`` for ref entries, silently breaking the ``project_id``/``organization_id`` auto-resolved omit. Fix: deref parameter refs at load time so the rest of the script sees fully resolved parameter objects.

## Impact

- **Spec size: 7.6 MB → 7.1 MB** (~6% smaller, ~480 KB saved)
- **Vacuum ``description-duplication``: 7165 → 5568** (~1600 findings gone)
- **Generated MCP tool TypeScript: byte-identical** for project_id/environment_id (verified). organization_id picks up its canonical description in zod schemas (was previously undescribed).

## How did you test this code?

I'm an agent (Claude Code) — manual testing not done. What ran:

- ``bin/hogli build:openapi`` end-to-end, all five steps, no hangs or warnings.
- ``vacuum spectral-report`` to verify the description-duplication drop.
- ``cd tools/openapi-codegen && pnpm test`` — 25 passing, including 2 new tests covering parameter-preservation in filtering.
- Diff-checked generated TypeScript against the parent branch — byte-identical for project_id/environment_id, gains a description on organization_id only.

The hang with Orval was caught during testing and fixed before this PR — not just relying on tests.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs — pure schema correctness, no user-facing behavior change.

## 🤖 Agent context

Stacked on **#56860** (which fixes ``\$ref``-with-siblings, vestigial bounds, and the consistency lint hook). Should be reviewed/merged in order.

Triggered by Vacuum's ``description-duplication`` rule. Initial guess was that the rule itself was bogus (``team_id`` SHOULD be the same description everywhere) — closer look showed the rule is right structurally and OpenAPI 3.0 has a clean fix already (``\$ref`` to shared parameter components). drf-spectacular doesn't do this automatically; this PR adds the smallest postprocess hook that does.