### PR TITLE
fix(ci): use github app token for canary team membership checks

### DIFF
--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -76,12 +76,22 @@ jobs:
                           content: 'eyes'
                       });
 
+            # GitHub App token is required because GITHUB_TOKEN can't read
+            # org-private team memberships (returns 404, looks like "not a member").
+            - name: Get app token for team membership check
+              id: app-token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+
             - name: Parse command and validate
               id: command
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   ACTOR: ${{ github.actor }}
               with:
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const prNumber = context.payload.issue.number;
                       const body = context.payload.comment.body.trim();
@@ -141,7 +151,7 @@ jobs:
                               } else {
                                   core.setFailed(
                                       `Failed to check team membership for PostHog/${team}: ${e.message}. ` +
-                                      `The GITHUB_TOKEN may lack Organization > Members > Read permission.`
+                                      `The GH_APP_POSTHOG_ASSIGN_REVIEWERS app may lack Organization > Members > Read permission.`
                                   );
                                   return;
                               }
@@ -377,12 +387,24 @@ jobs:
 
                       console.log(`PR #${prNumber} approved. SHA: ${headSha}`);
 
+            # GitHub App token is required because GITHUB_TOKEN can't read
+            # org-private team memberships (returns 404, looks like "not a member").
+            # Shared by "Verify canary label was authorized" and "Verify team membership".
+            - name: Get app token for team membership check
+              id: app-token
+              if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+
             - name: Verify canary label was authorized
               if: github.event_name == 'pull_request'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   PR_NUMBER: ${{ steps.pr_info.outputs.pr_number }}
               with:
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const prNumber = parseInt(process.env.PR_NUMBER);
 
@@ -476,6 +498,7 @@ jobs:
               env:
                   ACTOR: ${{ github.actor }}
               with:
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const actor = process.env.ACTOR;
                       const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
@@ -495,7 +518,7 @@ jobs:
                               } else {
                                   core.setFailed(
                                       `Failed to check team membership for PostHog/${team}: ${e.message}. ` +
-                                      `The GITHUB_TOKEN may lack Organization > Members > Read permission.`
+                                      `The GH_APP_POSTHOG_ASSIGN_REVIEWERS app may lack Organization > Members > Read permission.`
                                   );
                                   return;
                               }


### PR DESCRIPTION
## Problem

`/pr-canary` comments on PRs in this repo fail with **"Not a member of an authorized team"** even when the commenter is a member of `team-feature-flags` or `team-flags-platform`.

Root cause: the workflow calls `github.rest.teams.getMembershipForUserInOrg(...)` using the default `GITHUB_TOKEN`. That token only has repo-scoped permissions and cannot read org-private team memberships. The API returns `404` (not `403`) when it can't see the membership, and the catch block at `canary-flags-enable.yml:138-148` treats `404` as "not a member" — producing the misleading error.

The same issue affects:
- `/pr-canary` comment handling (`handle_comment` job)
- Manual `canary-flags` label adds (`Verify canary label was authorized` step)
- `workflow_dispatch` actor checks (`Verify team membership` step)

This is the pattern already documented in `.github/workflows/auto-assign-reviewers.yml:27`: the default `GITHUB_TOKEN` cannot perform org-scoped operations, so a GitHub App token is required.

## Changes

- Add `actions/create-github-app-token` steps using the existing `GH_APP_POSTHOG_ASSIGN_REVIEWERS` app credentials (the same app used by `auto-assign-reviewers.yml` and `pr-posthog-js-reviewer.yml` for org-team operations).
- Pass the resulting app token to each `actions/github-script` step that performs a team membership check.
- One token step in `handle_comment`, one shared by both team checks in `build_and_enable`.
- Update the misleading error messages so future failures point at the app's permissions rather than `GITHUB_TOKEN`.

## How did you test this code?

I'm an agent. I have not run this workflow end-to-end — that requires merging to master since `issue_comment` workflows only run from the default branch.

Verified locally:
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The token step pattern matches `auto-assign-reviewers.yml`, which already uses `GH_APP_POSTHOG_ASSIGN_REVIEWERS` for `members:read`-scoped operations and works in production.
- Confirmed via `gh api orgs/PostHog/teams/team-flags-platform/memberships/haacked` that the test user IS an active member, ruling out a stale-membership cause.

After merge, smoke test by commenting `/pr-canary help` on a follow-up PR — should react with eyes and post the help message instead of failing the membership check.

**Caveat:** if the `GH_APP_POSTHOG_ASSIGN_REVIEWERS` app does not have **Organization > Members > Read** permission, the same error will recur. In that case the fix is either to grant the permission or to point at a different app that has it.

## Publish to changelog?

no
