### PR TITLE
fix(insights): unwrap length-1 breakdown value before boolean conversion

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1690,6 +1690,31 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.results[0]["count"] == 7
         assert response.results[1]["count"] == 3
 
+    def test_trends_breakdowns_boolean_via_multi_breakdown_shape(self):
+        # Regression test for the TypeError introduced by #56520. When a Boolean property is passed
+        # via the modern `breakdowns: [Breakdown(...)]` shape (length 1),
+        # `_is_breakdown_filter_field_boolean` returns True and `_convert_boolean` was called with
+        # a list (`[True]` / `[False]`) which raised `TypeError: unhashable type: 'list'`.
+        self._create_test_events()
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [EventsNode(event="$pageview")],
+            None,
+            BreakdownFilter(breakdowns=[Breakdown(property="bool_field", type=MultipleBreakdownType.EVENT)]),
+        )
+
+        breakdown_labels = [result["breakdown_value"] for result in response.results]
+
+        assert len(response.results) == 2
+        assert sorted(breakdown_labels) == ["false", "true"]
+
+        labels_to_count = {r["breakdown_value"]: r["count"] for r in response.results}
+        assert labels_to_count["true"] == 7
+        assert labels_to_count["false"] == 3
+
     def test_trends_breakdowns_histogram(self):
         self._create_test_events()
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -623,7 +623,13 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                 remapped_label = None
 
                 if self._is_breakdown_filter_field_boolean():
-                    remapped_label = self._convert_boolean(get_value("breakdown_value", val))
+                    breakdown_value_for_boolean = get_value("breakdown_value", val)
+                    # `_is_breakdown_filter_field_boolean` accepts both legacy single-breakdown (scalar
+                    # value) and length-1 `breakdowns` (list-of-1). Unwrap so `_convert_boolean` always
+                    # receives a hashable scalar.
+                    if isinstance(breakdown_value_for_boolean, list) and len(breakdown_value_for_boolean) == 1:
+                        breakdown_value_for_boolean = breakdown_value_for_boolean[0]
+                    remapped_label = self._convert_boolean(breakdown_value_for_boolean)
 
                     if remapped_label == "" or remapped_label is None:
                         # Skip the "none" series if it doesn't have any data


### PR DESCRIPTION
## Problem

After [#56520](https://github.com/PostHog/posthog/pull/56520), `/api/environments/*/query/` started returning 500 for any trends insight using the modern `breakdowns: [Breakdown(...)]` shape with a Boolean property. The exception is `TypeError: unhashable type: 'list'`, raised in `TrendsQueryRunner._convert_boolean`.

Production telemetry (PostHog cloud project 2):

| Hour (PDT) | `unhashable type: 'list'` count |
|---|---|
| 2026-04-28 00:00 | 0 |
| 2026-04-28 01:00 | 94 (first appearance) |
| 2026-04-28 02:00 - 23:00 | 38 - 212 / hr (sustained) |

`unhashable type: 'list'` was unobserved before the PR shipped; the spike start (2026-04-28 ~08:00 UTC) lines up with the merge of #56520 (06:14 UTC) plus deploy lag. Affected ~50+ teams across both regions; trends insights with a `breakdowns: [Breakdown(property=<bool>, type=<...>)]` filter (which most modern frontend clients now emit, including dashboards refreshing automatically) all 500.

#### Root cause

#56520 widened `_is_breakdown_filter_field_boolean` to also return `True` for the modern length-1 `breakdowns` shape (previously it required the legacy `breakdownFilter.breakdown` to be set, which the new shape doesn't populate). That widened the gate at `trends_query_runner.py` line 626:

```python
if self._is_breakdown_filter_field_boolean():
    remapped_label = self._convert_boolean(get_value("breakdown_value", val))
```

`get_value("breakdown_value", val)` on a row from the new shape returns `[True]` (a list-of-1). `_convert_boolean` does `dict.get(value)` which raises on unhashable keys. Within #56520 the data-warehouse branch already handles this with an `isinstance(..., list)` unwrap on line 1093 — the boolean call site was just missed.

PR #56764 widened validation rules but does **not** touch the runtime path; the bleeding was still observable into 2026-04-29.

## Changes

`posthog/hogql_queries/insights/trends/trends_query_runner.py`: unwrap a length-1 list before calling `_convert_boolean`, mirroring the existing unwrap on the data-warehouse path.

`posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py`: regression test `test_trends_breakdowns_boolean_via_multi_breakdown_shape` exercising the exact failing path (`breakdowns=[Breakdown(property="bool_field", type=MultipleBreakdownType.EVENT)]`).

## How did you test this code?

I'm an agent; I have **not** manually run any tests. The cloud sandbox lacks Docker / ClickHouse / Kafka so the new integration test can't be run locally. CI will execute it.

What I did verify locally:
- `ruff check` + `ruff format --check` clean on both files.
- `python -m ast.parse` on both files (syntax OK).

The new test asserts the same `breakdown_value` / `label` shape (`"true"` / `"false"` scalars, counts 7 / 3) as the existing `test_trends_breakdowns_boolean` legacy-single-breakdown test, so the post-fix output is consistent with prior behavior.

## Publish to changelog?

No — bug fix, no user-facing changelog entry.

## Docs update

`skip-inkeep-docs` label — bug fix, no docs.

## 🤖 Agent context

PostHog Code agent (Opus 4.7). Investigation followed `/investigate-metric` after I initially missed it; rolled up via the Grafana TypeError signal the user surfaced. Root cause was traced via:

1. Hourly counts of distinct `$exception_values` matching `TypeError` in project 2 — found `unhashable type: 'list'` was a brand-new exception class as of 2026-04-28 01:00 PDT.
2. Stack trace extraction from `properties.$exception_list` — `posthog.hogql_queries.insights.trends.trends_query_runner._convert_boolean:1139`.
3. `gh api` to identify the regression PR (#56520) by listing commits to that file in the 24h before the spike.
4. Diff inspection of #56520 to confirm the widened helper + missed unwrap.

Key decision: fix at the call site rather than in `_convert_boolean` itself. The helper documents in its branching that it accepts both legacy single-breakdown and length-1 multi-breakdown; the call site is the right layer to bridge the value-shape difference, and it mirrors the unwrap pattern #56520 already added on the data warehouse path one helper above. Keeping `_convert_boolean` as a pure scalar-in / scalar-out function preserves its contract.

Requires human review and CI run before merge.