### PR TITLE
fix(llma): resolve OTEL distinct_id per span for vercel-ai

### DIFF
--- a/rust/capture/src/otel/fan_out.rs
+++ b/rust/capture/src/otel/fan_out.rs
@@ -486,7 +486,7 @@ mod tests {
     }
 
     #[test]
-    fn span_attribute_distinct_id_overrides_resource_and_fallback() {
+    fn test_span_attribute_distinct_id_overrides_resource_and_fallback() {
         let request = ExportTraceServiceRequest {
             resource_spans: vec![ResourceSpans {
                 resource: Some(Resource {
@@ -526,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn mixed_users_in_one_batch_get_independent_distinct_ids() {
+    fn test_mixed_users_in_one_batch_get_independent_distinct_ids() {
         let request = ExportTraceServiceRequest {
             resource_spans: vec![ResourceSpans {
                 resource: None,
@@ -582,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_resource_when_span_has_no_id() {
+    fn test_falls_back_to_resource_when_span_has_no_id() {
         let request = ExportTraceServiceRequest {
             resource_spans: vec![ResourceSpans {
                 resource: Some(Resource {
@@ -616,7 +616,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_request_fallback_when_no_attrs() {
+    fn test_falls_back_to_request_fallback_when_no_attrs() {
         let request = ExportTraceServiceRequest {
             resource_spans: vec![ResourceSpans {
                 resource: None,

--- a/rust/capture/src/otel/fan_out.rs
+++ b/rust/capture/src/otel/fan_out.rs
@@ -4,6 +4,7 @@ use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value, KeyValue};
 use serde_json::Value;
 
+use super::identity::extract_distinct_id_for_span;
 use super::providers;
 
 pub struct SpanEvent {
@@ -102,9 +103,13 @@ fn nanos_to_datetime(nanos: u64) -> Option<DateTime<Utc>> {
     Utc.timestamp_opt(secs, nsecs).single()
 }
 
+/// Convert OTLP spans into [`SpanEvent`]s. `request_fallback_distinct_id` is
+/// used only when neither the span nor its enclosing resource carries a
+/// distinct_id attribute — see [`extract_distinct_id_for_span`] for the full
+/// precedence list.
 pub fn expand_into_events(
     request: &ExportTraceServiceRequest,
-    distinct_id: &str,
+    request_fallback_distinct_id: &str,
 ) -> Vec<SpanEvent> {
     let total_spans: usize = request
         .resource_spans
@@ -127,6 +132,11 @@ pub fn expand_into_events(
                     continue;
                 };
 
+                let distinct_id = extract_distinct_id_for_span(
+                    &span.attributes,
+                    rs.resource.as_ref(),
+                    request_fallback_distinct_id,
+                );
                 let span_attrs = attributes_to_map(&span.attributes);
                 let event_name = (provider.classify)(&span_attrs);
 
@@ -171,7 +181,7 @@ pub fn expand_into_events(
 
                 events.push(SpanEvent {
                     event_name: event_name.to_string(),
-                    distinct_id: distinct_id.to_string(),
+                    distinct_id,
                     properties: Value::Object(properties),
                     timestamp,
                 });
@@ -473,5 +483,163 @@ mod tests {
         };
         let events = expand_into_events(&request, "user");
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn span_attribute_distinct_id_overrides_resource_and_fallback() {
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![make_kv(
+                        "posthog.distinct_id",
+                        any_value::Value::StringValue("resource-user".to_string()),
+                    )],
+                    dropped_attributes_count: 0,
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![make_span(
+                        vec![0; 16],
+                        vec![0; 8],
+                        vec![],
+                        0,
+                        0,
+                        "",
+                        vec![
+                            make_kv(
+                                "ai.telemetry.metadata.posthog_distinct_id",
+                                any_value::Value::StringValue("span-user".to_string()),
+                            ),
+                            make_kv(
+                                "gen_ai.request.model",
+                                any_value::Value::StringValue("gpt-4".to_string()),
+                            ),
+                        ],
+                    )],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let events = expand_into_events(&request, "fallback");
+        assert_eq!(events[0].distinct_id, "span-user");
+    }
+
+    #[test]
+    fn mixed_users_in_one_batch_get_independent_distinct_ids() {
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: None,
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![
+                        make_span(
+                            vec![0; 16],
+                            vec![1; 8],
+                            vec![],
+                            0,
+                            0,
+                            "",
+                            vec![
+                                make_kv(
+                                    "ai.telemetry.metadata.posthog_distinct_id",
+                                    any_value::Value::StringValue("user-a".to_string()),
+                                ),
+                                make_kv(
+                                    "gen_ai.request.model",
+                                    any_value::Value::StringValue("gpt-4".to_string()),
+                                ),
+                            ],
+                        ),
+                        make_span(
+                            vec![0; 16],
+                            vec![2; 8],
+                            vec![],
+                            0,
+                            0,
+                            "",
+                            vec![
+                                make_kv(
+                                    "ai.telemetry.metadata.posthog_distinct_id",
+                                    any_value::Value::StringValue("user-b".to_string()),
+                                ),
+                                make_kv(
+                                    "gen_ai.request.model",
+                                    any_value::Value::StringValue("gpt-4".to_string()),
+                                ),
+                            ],
+                        ),
+                    ],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let events = expand_into_events(&request, "fallback");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].distinct_id, "user-a");
+        assert_eq!(events[1].distinct_id, "user-b");
+    }
+
+    #[test]
+    fn falls_back_to_resource_when_span_has_no_id() {
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![make_kv(
+                        "posthog.distinct_id",
+                        any_value::Value::StringValue("resource-user".to_string()),
+                    )],
+                    dropped_attributes_count: 0,
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![make_span(
+                        vec![0; 16],
+                        vec![0; 8],
+                        vec![],
+                        0,
+                        0,
+                        "",
+                        vec![make_kv(
+                            "gen_ai.request.model",
+                            any_value::Value::StringValue("gpt-4".to_string()),
+                        )],
+                    )],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let events = expand_into_events(&request, "fallback");
+        assert_eq!(events[0].distinct_id, "resource-user");
+    }
+
+    #[test]
+    fn falls_back_to_request_fallback_when_no_attrs() {
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: None,
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![make_span(
+                        vec![0; 16],
+                        vec![0; 8],
+                        vec![],
+                        0,
+                        0,
+                        "",
+                        vec![make_kv(
+                            "gen_ai.request.model",
+                            any_value::Value::StringValue("gpt-4".to_string()),
+                        )],
+                    )],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let events = expand_into_events(&request, "fallback-id");
+        assert_eq!(events[0].distinct_id, "fallback-id");
     }
 }

--- a/rust/capture/src/otel/identity.rs
+++ b/rust/capture/src/otel/identity.rs
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[test]
-    fn span_metadata_distinct_id_wins_over_resource() {
+    fn test_span_metadata_distinct_id_wins_over_resource() {
         let span_attrs = vec![string_kv(
             "ai.telemetry.metadata.posthog_distinct_id",
             "span-user",
@@ -97,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn span_posthog_distinct_id_wins_over_user_id() {
+    fn test_span_posthog_distinct_id_wins_over_user_id() {
         let span_attrs = vec![
             string_kv("user.id", "user-id-value"),
             string_kv("posthog.distinct_id", "posthog-id-value"),
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn ai_telemetry_metadata_wins_over_posthog_distinct_id() {
+    fn test_ai_telemetry_metadata_wins_over_posthog_distinct_id() {
         let span_attrs = vec![
             string_kv("posthog.distinct_id", "explicit"),
             string_kv("ai.telemetry.metadata.posthog_distinct_id", "metadata"),
@@ -121,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_resource_when_no_span_attrs() {
+    fn test_falls_back_to_resource_when_no_span_attrs() {
         let resource = resource_with(vec![string_kv("posthog.distinct_id", "resource-user")]);
         assert_eq!(
             extract_distinct_id_for_span(&[], Some(&resource), "fallback"),
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn resource_user_id_used_when_no_posthog_id() {
+    fn test_resource_user_id_used_when_no_posthog_id() {
         let resource = resource_with(vec![string_kv("user.id", "user-id-value")]);
         assert_eq!(
             extract_distinct_id_for_span(&[], Some(&resource), "fallback"),
@@ -139,7 +139,19 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_when_no_attrs_present() {
+    fn test_resource_posthog_distinct_id_wins_over_user_id() {
+        let resource = resource_with(vec![
+            string_kv("user.id", "user-id-value"),
+            string_kv("posthog.distinct_id", "posthog-id-value"),
+        ]);
+        assert_eq!(
+            extract_distinct_id_for_span(&[], Some(&resource), "fallback"),
+            "posthog-id-value"
+        );
+    }
+
+    #[test]
+    fn test_falls_back_when_no_attrs_present() {
         assert_eq!(
             extract_distinct_id_for_span(&[], None, "fallback-id"),
             "fallback-id"
@@ -147,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_span_value_falls_through_to_resource() {
+    fn test_empty_span_value_falls_through_to_resource() {
         let span_attrs = vec![string_kv("posthog.distinct_id", "")];
         let resource = resource_with(vec![string_kv("posthog.distinct_id", "resource-user")]);
         assert_eq!(
@@ -157,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_resource_value_falls_through_to_fallback() {
+    fn test_empty_resource_value_falls_through_to_fallback() {
         let resource = resource_with(vec![
             string_kv("posthog.distinct_id", ""),
             string_kv("user.id", ""),
@@ -169,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn non_string_span_value_is_ignored() {
+    fn test_non_string_span_value_is_ignored() {
         let span_attrs = vec![make_kv(
             "ai.telemetry.metadata.posthog_distinct_id",
             any_value::Value::IntValue(42),
@@ -181,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn request_fallback_distinct_id_is_uuid() {
+    fn test_request_fallback_distinct_id_is_uuid() {
         let id = request_fallback_distinct_id();
         assert!(Uuid::parse_str(&id).is_ok());
     }

--- a/rust/capture/src/otel/identity.rs
+++ b/rust/capture/src/otel/identity.rs
@@ -1,13 +1,23 @@
-use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
-use opentelemetry_proto::tonic::common::v1::any_value;
+use opentelemetry_proto::tonic::common::v1::{any_value, KeyValue};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use uuid::Uuid;
 
-const DISTINCT_ID_KEYS: &[&str] = &["posthog.distinct_id", "user.id"];
+/// Span-level keys checked in order. The Vercel AI SDK serializes
+/// `experimental_telemetry.metadata.posthog_distinct_id` as
+/// `ai.telemetry.metadata.posthog_distinct_id`, which is the canonical
+/// per-call way to attribute an event to a user.
+const SPAN_DISTINCT_ID_KEYS: &[&str] = &[
+    "ai.telemetry.metadata.posthog_distinct_id",
+    "posthog.distinct_id",
+    "user.id",
+];
 
-fn get_string_attr<'a>(resource: &'a Resource, key: &str) -> Option<&'a str> {
-    resource
-        .attributes
+/// Resource-level keys are the per-process fallback used when no per-span
+/// override is set.
+const RESOURCE_DISTINCT_ID_KEYS: &[&str] = &["posthog.distinct_id", "user.id"];
+
+fn get_string_attr<'a>(attrs: &'a [KeyValue], key: &str) -> Option<&'a str> {
+    attrs
         .iter()
         .find(|attr| attr.key == key)
         .and_then(|attr| attr.value.as_ref())
@@ -18,24 +28,42 @@ fn get_string_attr<'a>(resource: &'a Resource, key: &str) -> Option<&'a str> {
         })
 }
 
-pub fn extract_distinct_id(request: &ExportTraceServiceRequest) -> String {
-    for rs in &request.resource_spans {
-        if let Some(resource) = &rs.resource {
-            for key in DISTINCT_ID_KEYS {
-                if let Some(id) = get_string_attr(resource, key) {
-                    return id.to_string();
-                }
+/// Resolve the distinct_id for a single span, with span attributes taking
+/// precedence over resource attributes. A single OTLP request can carry spans
+/// for multiple users (typical in serverless / multi-tenant runtimes), so
+/// distinct_id must be resolved per-span rather than per-request.
+pub fn extract_distinct_id_for_span(
+    span_attrs: &[KeyValue],
+    resource: Option<&Resource>,
+    fallback: &str,
+) -> String {
+    for key in SPAN_DISTINCT_ID_KEYS {
+        if let Some(id) = get_string_attr(span_attrs, key) {
+            return id.to_string();
+        }
+    }
+    if let Some(resource) = resource {
+        for key in RESOURCE_DISTINCT_ID_KEYS {
+            if let Some(id) = get_string_attr(&resource.attributes, key) {
+                return id.to_string();
             }
         }
     }
+    fallback.to_string()
+}
+
+/// One stable UUID per OTLP request, used as the last-resort fallback when no
+/// span or resource attribute identifies the user. Sharing a single UUID
+/// across all anonymous spans in a batch keeps them grouped on a single
+/// distinct_id rather than scattering them across one-shot UUIDs.
+pub fn request_fallback_distinct_id() -> String {
     Uuid::new_v4().to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
-    use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+    use opentelemetry_proto::tonic::common::v1::AnyValue;
 
     fn make_kv(key: &str, value: any_value::Value) -> KeyValue {
         KeyValue {
@@ -44,103 +72,117 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_posthog_distinct_id_found() {
-        let request = ExportTraceServiceRequest {
-            resource_spans: vec![ResourceSpans {
-                resource: Some(Resource {
-                    attributes: vec![make_kv(
-                        "posthog.distinct_id",
-                        any_value::Value::StringValue("user-123".to_string()),
-                    )],
-                    dropped_attributes_count: 0,
-                }),
-                scope_spans: vec![],
-                schema_url: String::new(),
-            }],
-        };
-        assert_eq!(extract_distinct_id(&request), "user-123");
+    fn string_kv(key: &str, value: &str) -> KeyValue {
+        make_kv(key, any_value::Value::StringValue(value.to_string()))
+    }
+
+    fn resource_with(attrs: Vec<KeyValue>) -> Resource {
+        Resource {
+            attributes: attrs,
+            dropped_attributes_count: 0,
+        }
     }
 
     #[test]
-    fn test_user_id_fallback() {
-        let request = ExportTraceServiceRequest {
-            resource_spans: vec![ResourceSpans {
-                resource: Some(Resource {
-                    attributes: vec![make_kv(
-                        "user.id",
-                        any_value::Value::StringValue("user-456".to_string()),
-                    )],
-                    dropped_attributes_count: 0,
-                }),
-                scope_spans: vec![],
-                schema_url: String::new(),
-            }],
-        };
-        assert_eq!(extract_distinct_id(&request), "user-456");
+    fn span_metadata_distinct_id_wins_over_resource() {
+        let span_attrs = vec![string_kv(
+            "ai.telemetry.metadata.posthog_distinct_id",
+            "span-user",
+        )];
+        let resource = resource_with(vec![string_kv("posthog.distinct_id", "resource-user")]);
+        assert_eq!(
+            extract_distinct_id_for_span(&span_attrs, Some(&resource), "fallback"),
+            "span-user"
+        );
     }
 
     #[test]
-    fn test_uuid_fallback() {
-        let request = ExportTraceServiceRequest {
-            resource_spans: vec![],
-        };
-        let distinct_id = extract_distinct_id(&request);
-        assert!(Uuid::parse_str(&distinct_id).is_ok());
+    fn span_posthog_distinct_id_wins_over_user_id() {
+        let span_attrs = vec![
+            string_kv("user.id", "user-id-value"),
+            string_kv("posthog.distinct_id", "posthog-id-value"),
+        ];
+        assert_eq!(
+            extract_distinct_id_for_span(&span_attrs, None, "fallback"),
+            "posthog-id-value"
+        );
     }
 
     #[test]
-    fn test_empty_string_skipped() {
-        let request = ExportTraceServiceRequest {
-            resource_spans: vec![ResourceSpans {
-                resource: Some(Resource {
-                    attributes: vec![
-                        make_kv(
-                            "posthog.distinct_id",
-                            any_value::Value::StringValue(String::new()),
-                        ),
-                        make_kv(
-                            "user.id",
-                            any_value::Value::StringValue("fallback-user".to_string()),
-                        ),
-                    ],
-                    dropped_attributes_count: 0,
-                }),
-                scope_spans: vec![],
-                schema_url: String::new(),
-            }],
-        };
-        assert_eq!(extract_distinct_id(&request), "fallback-user");
+    fn ai_telemetry_metadata_wins_over_posthog_distinct_id() {
+        let span_attrs = vec![
+            string_kv("posthog.distinct_id", "explicit"),
+            string_kv("ai.telemetry.metadata.posthog_distinct_id", "metadata"),
+        ];
+        assert_eq!(
+            extract_distinct_id_for_span(&span_attrs, None, "fallback"),
+            "metadata"
+        );
     }
 
     #[test]
-    fn test_multiple_resource_spans_picks_first() {
-        let request = ExportTraceServiceRequest {
-            resource_spans: vec![
-                ResourceSpans {
-                    resource: Some(Resource {
-                        attributes: vec![make_kv(
-                            "posthog.distinct_id",
-                            any_value::Value::StringValue("first".to_string()),
-                        )],
-                        dropped_attributes_count: 0,
-                    }),
-                    scope_spans: vec![],
-                    schema_url: String::new(),
-                },
-                ResourceSpans {
-                    resource: Some(Resource {
-                        attributes: vec![make_kv(
-                            "posthog.distinct_id",
-                            any_value::Value::StringValue("second".to_string()),
-                        )],
-                        dropped_attributes_count: 0,
-                    }),
-                    scope_spans: vec![],
-                    schema_url: String::new(),
-                },
-            ],
-        };
-        assert_eq!(extract_distinct_id(&request), "first");
+    fn falls_back_to_resource_when_no_span_attrs() {
+        let resource = resource_with(vec![string_kv("posthog.distinct_id", "resource-user")]);
+        assert_eq!(
+            extract_distinct_id_for_span(&[], Some(&resource), "fallback"),
+            "resource-user"
+        );
+    }
+
+    #[test]
+    fn resource_user_id_used_when_no_posthog_id() {
+        let resource = resource_with(vec![string_kv("user.id", "user-id-value")]);
+        assert_eq!(
+            extract_distinct_id_for_span(&[], Some(&resource), "fallback"),
+            "user-id-value"
+        );
+    }
+
+    #[test]
+    fn falls_back_when_no_attrs_present() {
+        assert_eq!(
+            extract_distinct_id_for_span(&[], None, "fallback-id"),
+            "fallback-id"
+        );
+    }
+
+    #[test]
+    fn empty_span_value_falls_through_to_resource() {
+        let span_attrs = vec![string_kv("posthog.distinct_id", "")];
+        let resource = resource_with(vec![string_kv("posthog.distinct_id", "resource-user")]);
+        assert_eq!(
+            extract_distinct_id_for_span(&span_attrs, Some(&resource), "fallback"),
+            "resource-user"
+        );
+    }
+
+    #[test]
+    fn empty_resource_value_falls_through_to_fallback() {
+        let resource = resource_with(vec![
+            string_kv("posthog.distinct_id", ""),
+            string_kv("user.id", ""),
+        ]);
+        assert_eq!(
+            extract_distinct_id_for_span(&[], Some(&resource), "fallback-id"),
+            "fallback-id"
+        );
+    }
+
+    #[test]
+    fn non_string_span_value_is_ignored() {
+        let span_attrs = vec![make_kv(
+            "ai.telemetry.metadata.posthog_distinct_id",
+            any_value::Value::IntValue(42),
+        )];
+        assert_eq!(
+            extract_distinct_id_for_span(&span_attrs, None, "fallback"),
+            "fallback"
+        );
+    }
+
+    #[test]
+    fn request_fallback_distinct_id_is_uuid() {
+        let id = request_fallback_distinct_id();
+        assert!(Uuid::parse_str(&id).is_ok());
     }
 }

--- a/rust/capture/src/otel/mod.rs
+++ b/rust/capture/src/otel/mod.rs
@@ -146,8 +146,8 @@ pub async fn otel_handler(
     }
 
     let received_at = Utc::now();
-    let distinct_id = identity::extract_distinct_id(&request);
-    let span_events = fan_out::expand_into_events(&request, &distinct_id);
+    let request_fallback_distinct_id = identity::request_fallback_distinct_id();
+    let span_events = fan_out::expand_into_events(&request, &request_fallback_distinct_id);
     let span_count = span_events.len();
     let dropped_span_count = raw_span_count.saturating_sub(span_count);
 


### PR DESCRIPTION
## Problem

PostHog's OTEL ingestion silently drops `experimental_telemetry.metadata.posthog_distinct_id` from the Vercel AI SDK. Setting it on a per-call basis — the documented per-user attribution path for `@convex-dev/agent` and similar — has no effect, so `$ai_generation` / `$ai_trace` events arrive with a random UUID distinct_id and aren't linked to a user.

The root cause is in capture: distinct_id is assigned once per OTLP request from resource attributes only. A single batch carrying spans for many users (the typical Convex / serverless case) collapses onto one distinct_id, and span-level attributes are never inspected.

The complementary Node ingestion fix (lifting `ai.telemetry.metadata.posthog_distinct_id` onto `event.distinct_id`) already shipped in #54002 with broader scope, so this PR addresses the remaining capture-side gap.

## Changes

**Rust capture (`rust/capture/src/otel/`)**
- Replace request-level `extract_distinct_id` with `extract_distinct_id_for_span`, resolved per span with this precedence:
  1. Span attribute `ai.telemetry.metadata.posthog_distinct_id` (Vercel AI SDK convention)
  2. Span attribute `posthog.distinct_id`
  3. Span attribute `user.id`
  4. Resource attribute `posthog.distinct_id`
  5. Resource attribute `user.id`
  6. Request-level fallback UUID (one stable UUID per OTLP request, shared across anonymous spans so they stay grouped)
- `expand_into_events` now resolves distinct_id per emitted span, so a mixed-user batch produces correctly attributed events.

> ⚠️ **Semantic shift to flag for reviewers:** any span-level identity key — including `user.id` — now beats any resource-level key — including `posthog.distinct_id`. A span carrying `user.id=alice` plus a resource carrying `posthog.distinct_id=bob` previously resolved to `bob` and now resolves to `alice`. This is intentional (per-call should beat per-process), but worth a deliberate look.

**Companion PR** — PostHog/posthog-js#3501 drops the misleading resource-level `posthog.distinct_id` from the Convex example so it stops masking this bug.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual end-to-end testing.

Automated tests run locally:

- `cargo test -p capture --lib otel` — 47/47 passing, with 15 new tests in `identity.rs` and `fan_out.rs` covering precedence ordering at both span and resource level, mixed-user batches, empty-string fallthrough, non-string attribute values, and resource/request fallbacks
- `cargo clippy -p capture --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Publish to changelog?

no

## Docs update

No user-facing docs change needed — this restores the documented behavior of `experimental_telemetry.metadata.posthog_distinct_id`.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Diagnosis came from a manual end-to-end trace by the human author across `@convex-dev/agent`, `@posthog/ai`, capture, and ingestion. Key decision: the request-level UUID fallback is shared across anonymous spans in a batch rather than generated per-span, so anonymous traffic stays grouped on one distinct_id.

Originally included a Node middleware change as a safety net; that was rebased out after master picked up #54002, which implements the same lift with broader scope.

Pairs with PostHog/posthog-js#3501.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*