### PR TITLE
fix(insights): use WRAPPER_NODE_KINDS for type filtering consistency

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1411,7 +1411,7 @@ class InsightViewSet(
                     queryset = queryset.filter(
                         legacy_filter
                         | Q(query__isnull=False)
-                        & Q(query__kind=schema.NodeKind.INSIGHT_VIZ_NODE)
+                        & Q(query__kind__in=WRAPPER_NODE_KINDS)
                         & Q(query__source__kind=legacy_to_hogql_mapping[insight])
                     )
                 else:


### PR DESCRIPTION
Fixes #25941

The type filter in the saved insights list was using a hardcoded `INSIGHT_VIZ_NODE` check, while every other filter in the same block uses `WRAPPER_NODE_KINDS`. This caused insights wrapped in other node kinds to be excluded from filtered results.

One-line fix: `Q(query__kind=schema.NodeKind.INSIGHT_VIZ_NODE)` -> `Q(query__kind__in=WRAPPER_NODE_KINDS)`

This aligns with lines 1403, 1405, and 1409 in the same file which already use `WRAPPER_NODE_KINDS`.