### PR TITLE
feat(logs): add pagination to LogsAlertList component

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -255,6 +255,8 @@ export function LogsAlertList(): JSX.Element {
                 loading={alertsLoading}
                 emptyState="No alerts configured yet."
                 size="small"
+                pagination={{ pageSize: 30 }}
+                nouns={['alert', 'alerts']}
             />
         </div>
     )


### PR DESCRIPTION
## Problem

The logs alert list had no pagination, which could make the list unwieldy when many alerts are configured. Additionally, the list lacked proper noun labels, making count/empty state messaging less descriptive.

## Changes

Added pagination to the logs alert list with a page size of 30, and added `alert`/`alerts` nouns for improved display context.

## How did you test this code?

Verified by navigating to the logs alerting page and confirming pagination controls appear and noun labels display correctly in the list component.

## Publish to changelog?

No