### PR TITLE
refactor(messaging): extract person properties clause builder

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -114,6 +114,51 @@ async def flush_kafka_batch_async(
     return successful_count
 
 
+def _escape_clickhouse_string_literal(value: str) -> str:
+    """Escape a value for inclusion in a single-quoted ClickHouse string literal.
+
+    ClickHouse string literals use C-style escapes, so backslashes must be
+    escaped first and single quotes after.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _build_properties_clause(person_properties: list[str]) -> tuple[str, dict[str, str]]:
+    """Build the SELECT clause that extracts the requested person properties.
+
+    Returns the clause SQL fragment and a mapping from generated alias to the
+    original property key.
+    """
+    property_alias_mapping: dict[str, str] = {}
+
+    escaped_properties: list[str] = []
+    for prop in person_properties:
+        identifier_escaped = prop.replace("`", "``")
+        literal_escaped = _escape_clickhouse_string_literal(identifier_escaped)
+        escaped_properties.append(f"`{literal_escaped}` String")
+
+    tuple_definition = ",\n        ".join(escaped_properties)
+
+    property_selects: list[str] = []
+    for i, prop in enumerate(person_properties):
+        safe_alias = f"prop_{i}"
+        string_escaped_prop = _escape_clickhouse_string_literal(prop)
+        property_selects.append(f"tupleElement(p, '{string_escaped_prop}') as `{safe_alias}`")
+        property_alias_mapping[safe_alias] = prop
+
+    tuple_selects = ",\n                ".join(property_selects)
+
+    properties_clause = f"""JSONExtract(
+                properties,
+                'Tuple(
+        {tuple_definition}
+                )'
+            ) AS p,
+                {tuple_selects}"""
+
+    return properties_clause, property_alias_mapping
+
+
 def get_person_properties_backfill_success_metric():
     """Counter for successful person properties backfills."""
     return temporalio.activity.metric_meter().create_counter(
@@ -457,37 +502,10 @@ async def backfill_precalculated_person_properties_activity(
 
         # Build optimized query to only fetch needed person properties
         MAX_OPTIMIZED_PROPERTIES = 100  # Safety limit to avoid query complexity issues
-        property_alias_mapping = {}
+        property_alias_mapping: dict[str, str] = {}
 
         if person_properties and len(person_properties) <= MAX_OPTIMIZED_PROPERTIES:
-            # Build a single JSONExtract with tuple structure for all properties
-            escaped_properties = []
-            for prop in person_properties:
-                # Use backtick escaping for identifier names in tuple definition
-                escaped_prop = prop.replace("`", "``")
-                escaped_properties.append(f"`{escaped_prop}` String")
-
-            tuple_definition = ",\n        ".join(escaped_properties)
-
-            # Build the select statements for tupleElement extractions
-            property_selects = []
-            for i, prop in enumerate(person_properties):
-                safe_alias = f"prop_{i}"  # Use safe numeric aliases
-                # Escape single quotes for string literal in tupleElement
-                string_escaped_prop = prop.replace("'", "''")
-                property_selects.append(f"tupleElement(p, '{string_escaped_prop}') as `{safe_alias}`")
-                property_alias_mapping[safe_alias] = prop
-
-            tuple_selects = ",\n                ".join(property_selects)
-
-            properties_clause = f"""JSONExtract(
-                properties,
-                'Tuple(
-        {tuple_definition}
-                )'
-            ) AS p,
-                {tuple_selects}"""
-
+            properties_clause, property_alias_mapping = _build_properties_clause(person_properties)
             logger.info(
                 f"Optimized query: using single JSONExtract with tuple structure for {len(person_properties)} properties"
             )

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
+    _build_properties_clause,
     backfill_precalculated_person_properties_activity,
     evaluate_combined_filters_sync,
     flush_kafka_batch_async,
@@ -372,3 +373,36 @@ class TestEvaluateCombinedFiltersSync:
             assert call_args[0][0] == "HogVM evaluation returned non-dict result"
         else:
             mock_logger.warning.assert_not_called()
+
+
+class TestBuildPropertiesClause:
+    """Tests for the property clause builder."""
+
+    def test_simple_property_keys(self):
+        clause, mapping = _build_properties_clause(["$browser", "email"])
+        assert mapping == {"prop_0": "$browser", "prop_1": "email"}
+        assert "`$browser` String" in clause
+        assert "`email` String" in clause
+        assert "tupleElement(p, '$browser') as `prop_0`" in clause
+        assert "tupleElement(p, 'email') as `prop_1`" in clause
+
+    def test_single_quote_in_tuple_definition_is_escaped(self):
+        clause, _ = _build_properties_clause(["prop'name"])
+        tuple_section = clause.split("'Tuple(", 1)[1].split(")'", 1)[0]
+        assert "'" not in tuple_section.replace("\\'", "")
+
+    def test_backslash_in_tupleelement_is_escaped(self):
+        clause, _ = _build_properties_clause(["trailing\\"])
+        assert "tupleElement(p, 'trailing\\\\') as `prop_0`" in clause
+
+    def test_backtick_in_property_is_doubled(self):
+        clause, mapping = _build_properties_clause(["weird`name"])
+        assert mapping == {"prop_0": "weird`name"}
+        assert "`weird``name` String" in clause
+
+    def test_combined_special_characters(self):
+        prop = "a\\b'c`d"
+        clause, mapping = _build_properties_clause([prop])
+        assert mapping == {"prop_0": prop}
+        assert "`a\\\\b\\'c``d` String" in clause
+        assert "tupleElement(p, 'a\\\\b\\'c`d') as `prop_0`" in clause


### PR DESCRIPTION
## Problem

The person properties clause for the backfill activity was built inline in the activity body, which made the escaping rules hard to follow and untested.

## Changes

Extracted the clause construction into a small module-level `_build_properties_clause` helper with unit tests

## How did you test this code?

unit tests

## Publish to changelog?

No