### PR TITLE
fix(trends): handle legacy warehouse column metadata

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
@@ -353,6 +353,45 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
         # The series label is the "::"-joined string form, mirroring the frontend.
         assert [r["label"] for r in breakdown_results] == ["false", "true"]
 
+    @parameterized.expand(
+        [
+            ("legacy_bool", "Bool", True),
+            ("legacy_nullable_bool", "Nullable(Bool)", True),
+            ("legacy_string", "String", False),
+            ("introspected_bool", {"clickhouse": "Bool", "hogql": "BooleanDatabaseField"}, True),
+        ]
+    )
+    def test_data_warehouse_breakdown_field_boolean_detection_supports_column_metadata_shapes(
+        self, _name: str, column_metadata: str | dict[str, str], expected: bool
+    ) -> None:
+        DataWarehouseTable.objects.create(
+            name="test_table_bool_metadata",
+            format=DataWarehouseTable.TableFormat.CSVWithNames,
+            team=self.team,
+            url_pattern="https://bucket.s3/data/*",
+            columns={"bool_prop": column_metadata},
+        )
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            dateRange=DateRange(date_from="2023-01-01"),
+            series=[
+                DataWarehouseNode(
+                    id="test_table_bool_metadata",
+                    table_name="test_table_bool_metadata",
+                    id_field="id",
+                    distinct_id_field="id",
+                    timestamp_field="created",
+                )
+            ],
+            breakdownFilter=BreakdownFilter(
+                breakdown="bool_prop",
+                breakdown_type=BreakdownType.DATA_WAREHOUSE,
+            ),
+        )
+
+        assert TrendsQueryRunner(team=self.team, query=trends_query)._is_breakdown_filter_field_boolean() is expected
+
     def test_trends_breakdown_with_event_property(self):
         table_name = self.setup_data_warehouse()
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -1100,11 +1100,16 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
 
             breakdown_key = breakdown_value[0] if isinstance(breakdown_value, list) else breakdown_value
 
-            columns = dict(table_or_view.columns)
+            columns = table_or_view.columns
+            if not isinstance(columns, dict):
+                return False
+
             if breakdown_key not in columns:
                 return False
 
-            field_type = columns[breakdown_key]["clickhouse"]
+            field_type = self._data_warehouse_column_clickhouse_type(columns[breakdown_key])
+            if field_type is None:
+                return False
 
             if field_type.startswith("Nullable("):
                 field_type = field_type.replace("Nullable(", "")[:-1]
@@ -1117,6 +1122,17 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             breakdown_type,
             breakdown_group_type_index,
         )
+
+    def _data_warehouse_column_clickhouse_type(self, column: object) -> str | None:
+        if isinstance(column, str):
+            return column
+
+        if isinstance(column, dict):
+            clickhouse_type = column.get("clickhouse")
+            if isinstance(clickhouse_type, str):
+                return clickhouse_type
+
+        return None
 
     def _is_breakdown_field_boolean(
         self,


### PR DESCRIPTION
## Problem

Trends insights with data warehouse breakdowns can fail when the warehouse table stores column metadata in the legacy plain-string shape, for example `"plan": "String"`.

The boolean breakdown detection path assumed the newer introspected shape, for example `"plan": {"clickhouse": "String", ...}`, and raised `TypeError: string indices must be integers, not 'str'`.

## Changes

- Updated trends data warehouse breakdown boolean detection to read ClickHouse column types from both supported metadata shapes:
  - legacy string values
  - newer dict values with a `clickhouse` field
- Added regression coverage for legacy bool, nullable bool, non-bool, and introspected bool column metadata.
- Left demo data generation unchanged.

## How did you test this code?

I’m an agent. I ran:

```bash
ruff check posthog/hogql_queries/insights/trends/trends_query_runner.py posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
.flox/cache/venv/bin/pytest posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py -k "single_item_multi_breakdown_boolean_field or data_warehouse_breakdown_field_boolean_detection_supports_column_metadata_shapes"
