### PR TITLE
fix(messaging): parameterize cohort backfill property keys

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -30,6 +30,27 @@ if TYPE_CHECKING:
     pass
 
 LOGGER = get_logger(__name__)
+MAX_OPTIMIZED_PROPERTIES = 100  # Safety limit to avoid query complexity issues
+
+
+def build_person_properties_select_clause(person_properties: list[str]) -> tuple[str, dict[str, str], dict[str, str]]:
+    """Build ClickHouse SELECT expressions for the requested person properties.
+
+    Property names come from cohort filters, so they must stay out of the SQL string.
+    The returned clause contains only generated aliases and query parameter placeholders.
+    """
+    property_selects: list[str] = []
+    property_alias_mapping: dict[str, str] = {}
+    property_query_params: dict[str, str] = {}
+
+    for i, prop in enumerate(person_properties):
+        safe_alias = f"prop_{i}"
+        property_key_param = f"property_key_{i}"
+        property_selects.append(f"JSONExtract(properties, %({property_key_param})s, 'String') as `{safe_alias}`")
+        property_alias_mapping[safe_alias] = prop
+        property_query_params[property_key_param] = prop
+
+    return ",\n                ".join(property_selects), property_alias_mapping, property_query_params
 
 
 def format_cohort_ids_for_logging(cohort_ids: list[int]) -> str:
@@ -456,40 +477,16 @@ async def backfill_precalculated_person_properties_activity(
             pass
 
         # Build optimized query to only fetch needed person properties
-        MAX_OPTIMIZED_PROPERTIES = 100  # Safety limit to avoid query complexity issues
-        property_alias_mapping = {}
+        property_alias_mapping: dict[str, str] = {}
+        property_query_params: dict[str, str] = {}
 
         if person_properties and len(person_properties) <= MAX_OPTIMIZED_PROPERTIES:
-            # Build a single JSONExtract with tuple structure for all properties
-            escaped_properties = []
-            for prop in person_properties:
-                # Use backtick escaping for identifier names in tuple definition
-                escaped_prop = prop.replace("`", "``")
-                escaped_properties.append(f"`{escaped_prop}` String")
-
-            tuple_definition = ",\n        ".join(escaped_properties)
-
-            # Build the select statements for tupleElement extractions
-            property_selects = []
-            for i, prop in enumerate(person_properties):
-                safe_alias = f"prop_{i}"  # Use safe numeric aliases
-                # Escape single quotes for string literal in tupleElement
-                string_escaped_prop = prop.replace("'", "''")
-                property_selects.append(f"tupleElement(p, '{string_escaped_prop}') as `{safe_alias}`")
-                property_alias_mapping[safe_alias] = prop
-
-            tuple_selects = ",\n                ".join(property_selects)
-
-            properties_clause = f"""JSONExtract(
-                properties,
-                'Tuple(
-        {tuple_definition}
-                )'
-            ) AS p,
-                {tuple_selects}"""
+            properties_clause, property_alias_mapping, property_query_params = build_person_properties_select_clause(
+                person_properties
+            )
 
             logger.info(
-                f"Optimized query: using single JSONExtract with tuple structure for {len(person_properties)} properties"
+                f"Optimized query: fetching {len(person_properties)} specific properties with parameterized keys"
             )
         else:
             # Fallback to all properties if we have too many properties or can't determine which ones are needed
@@ -522,6 +519,7 @@ async def backfill_precalculated_person_properties_activity(
             "team_id": inputs.team_id,
             "start_person_id": inputs.start_person_id,
             "end_person_id": inputs.end_person_id,
+            **property_query_params,
         }
         if inputs.person_id is not None:
             query_params["person_id"] = inputs.person_id

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -1,3 +1,5 @@
+from types import TracebackType
+
 import pytest
 from unittest.mock import Mock, patch
 
@@ -7,6 +9,7 @@ from parameterized import parameterized
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
     backfill_precalculated_person_properties_activity,
+    build_person_properties_select_clause,
     evaluate_combined_filters_sync,
     flush_kafka_batch_async,
 )
@@ -15,6 +18,40 @@ from posthog.temporal.messaging.types import PersonPropertyFilter
 
 from common.hogvm.python.execute import execute_bytecode
 from common.hogvm.python.operation import Operation
+
+
+class _NoopHeartbeater:
+    details: tuple[str, ...]
+
+    def __init__(self, details: tuple[str, ...] = (), factor: int = 120) -> None:
+        self.details = details
+
+    async def __aenter__(self) -> "_NoopHeartbeater":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+
+class _AsyncClientContextManager:
+    def __init__(self, client: Mock) -> None:
+        self.client = client
+
+    async def __aenter__(self) -> Mock:
+        return self.client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
 
 
 class TestFlushKafkaBatchAsync:
@@ -185,6 +222,83 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
 
         # Basic verification that the filter was stored correctly
         assert inputs.filter_storage_key == storage_key
+
+    def test_build_person_properties_select_clause_parameterizes_property_keys(self):
+        malicious_property = "email') FROM person WHERE team_id != %(team_id)s UNION ALL SELECT sleep(3) --"
+
+        properties_clause, property_alias_mapping, property_query_params = build_person_properties_select_clause(
+            [malicious_property]
+        )
+
+        assert malicious_property not in properties_clause
+        assert "team_id !=" not in properties_clause
+        assert "%(property_key_0)s" in properties_clause
+        assert property_alias_mapping == {"prop_0": malicious_property}
+        assert property_query_params == {"property_key_0": malicious_property}
+
+    @pytest.mark.asyncio
+    async def test_activity_parameterizes_property_keys_in_clickhouse_query(self):
+        malicious_property = "email') FROM person WHERE team_id != %(team_id)s UNION ALL SELECT sleep(3) --"
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="injection_condition",
+                bytecode=["_H", 1, 29],
+                cohort_ids=[10],
+                property_key=malicious_property,
+            ),
+        ]
+        captured_query: dict[str, object] = {}
+
+        async def stream_query_as_jsonl(query: str, query_parameters: dict[str, object] | None = None):
+            captured_query["query"] = query
+            captured_query["query_parameters"] = query_parameters
+            if False:
+                yield {}
+
+        mock_client = Mock()
+        mock_client.stream_query_as_jsonl = stream_query_as_jsonl
+
+        inputs = BackfillPrecalculatedPersonPropertiesInputs(
+            team_id=1,
+            filter_storage_key="storage_key",
+            cohort_ids=[10],
+            batch_size=10,
+            start_person_id="00000000-0000-0000-0000-000000000000",
+            end_person_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        )
+
+        with (
+            patch(
+                "posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.get_filters_and_properties",
+                return_value=(filters, [malicious_property], combine_filter_bytecodes(filters)),
+            ),
+            patch(
+                "posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.get_client",
+                return_value=_AsyncClientContextManager(mock_client),
+            ),
+            patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.get_producer"),
+            patch(
+                "posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.Heartbeater",
+                _NoopHeartbeater,
+            ),
+            patch(
+                "posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.get_person_properties_backfill_success_metric",
+                return_value=Mock(),
+            ),
+        ):
+            result = await backfill_precalculated_person_properties_activity(inputs)
+
+        assert result.persons_processed == 0
+
+        query = captured_query["query"]
+        assert isinstance(query, str)
+        assert malicious_property not in query
+        assert "team_id !=" not in query
+        assert "%(property_key_0)s" in query
+
+        query_parameters = captured_query["query_parameters"]
+        assert isinstance(query_parameters, dict)
+        assert query_parameters["property_key_0"] == malicious_property
 
 
 class TestCombineFilterBytecodes:


### PR DESCRIPTION
## Problem

There's a less than optimal temporal workflow.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
