### PR TITLE
fix(insights): avoid call-stack overflow in hog-charts y-domain

### DIFF
--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -11,7 +11,7 @@ import { ChartErrorBoundary } from './ChartErrorBoundary'
 import { useChartCanvas } from './hooks/useChartCanvas'
 import { useChartDraw } from './hooks/useChartDraw'
 import { useChartInteraction } from './hooks/useChartInteraction'
-import { autoFormatYTick } from './scales'
+import { autoFormatYTick, seriesValueRange } from './scales'
 import { DEFAULT_Y_AXIS_ID } from './types'
 import type {
     ChartConfig,
@@ -98,26 +98,17 @@ export function Chart<Meta = unknown>({
         if (hideYAxis) {
             return 0
         }
-        const allValues = series
-            .filter((s) => !s.visibility?.excluded)
-            .flatMap((s) => s.data)
-            .filter((v) => v != null && isFinite(v))
-        if (allValues.length === 0) {
+        const range = seriesValueRange(series)
+        if (range.count === 0) {
             return 0
         }
-        let min = Math.min(...allValues)
-        let max = Math.max(...allValues)
-        if (min > 0) {
-            min = 0
-        }
-        if (max < 0) {
-            max = 0
-        }
+        const min = range.min > 0 ? 0 : range.min
+        const max = range.max < 0 ? 0 : range.max
         const ticks = d3.scaleLinear().domain([min, max]).nice(6).ticks(6)
         if (ticks.length === 0) {
             return 0
         }
-        const domainMax = Math.abs(Math.max(...ticks))
+        const domainMax = Math.max(...ticks.map((t) => Math.abs(t)))
         const formatter = yTickFormatter ?? ((v: number) => autoFormatYTick(v, domainMax))
         let widest = 0
         for (const t of ticks) {

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -12,6 +12,51 @@ export interface ScaleSet {
     yAxes?: Record<string, { scale: D3YScale; position: 'left' | 'right' }>
 }
 
+export interface SeriesValueRange {
+    /** Smallest finite value across all visible series, or `Infinity` if none. */
+    min: number
+    /** Largest finite value across all visible series, or `-Infinity` if none. */
+    max: number
+    /** Smallest strictly-positive finite value, or `Infinity` if none. Used by log scales. */
+    minPositive: number
+    /** Number of finite values seen. `0` means the result is empty — `min`/`max` are sentinel. */
+    count: number
+}
+
+/**
+ * Single-pass min/max over visible series, skipping excluded series and
+ * non-finite values. Equivalent to `d3.min`/`d3.max` over a flatMap+filter
+ * but avoids the intermediate arrays — the spread form (`Math.min(...arr)`)
+ * also overflows the call stack at ~100k+ values.
+ */
+export function seriesValueRange(series: Series[]): SeriesValueRange {
+    let min = Infinity
+    let max = -Infinity
+    let minPositive = Infinity
+    let count = 0
+    for (const s of series) {
+        if (s.visibility?.excluded) {
+            continue
+        }
+        for (const v of s.data) {
+            if (v == null || !isFinite(v)) {
+                continue
+            }
+            count++
+            if (v < min) {
+                min = v
+            }
+            if (v > max) {
+                max = v
+            }
+            if (v > 0 && v < minPositive) {
+                minPositive = v
+            }
+        }
+    }
+    return { min, max, minPositive, count }
+}
+
 export function createXScale(labels: string[], dimensions: ChartDimensions): d3.ScalePoint<string> {
     return d3
         .scalePoint<string>()
@@ -43,30 +88,26 @@ export function createYScale(
             .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
     }
 
-    const filteredSeries = series.filter((s) => !s.visibility?.excluded)
-    const allValues = filteredSeries.flatMap((s) => s.data).filter((v) => v != null && isFinite(v))
+    const range = seriesValueRange(series)
 
-    if (allValues.length === 0) {
+    if (range.count === 0) {
         return d3
             .scaleLinear()
             .domain([0, 1])
             .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
     }
 
-    let min = d3.min(allValues) ?? 0
-    let max = d3.max(allValues) ?? 1
+    let { min, max } = range
 
     if (scaleType === 'log') {
-        const positives = allValues.filter((v) => v > 0)
-        if (positives.length === 0) {
+        if (!isFinite(range.minPositive)) {
             return d3
                 .scaleLinear()
                 .domain([min, max])
                 .nice(tickCount)
                 .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
         }
-        const minPositive = Math.min(...positives)
-        const niceMin = Math.pow(10, Math.ceil(Math.log10(minPositive)) - 1)
+        const niceMin = Math.pow(10, Math.ceil(Math.log10(range.minPositive)) - 1)
         const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
         const niceMax = Math.ceil(max / maxDecade) * maxDecade
         return d3


### PR DESCRIPTION
## Problem

Typing a large number into the points box in the chart-bench scene blew up Chart.tsx with `RangeError: Maximum call stack size exceeded`. Root cause: `Math.min(...allValues)` / `Math.max(...allValues)` in the y-domain computation passes every data value as a separate function argument, which overflows the JS engine's argument-count limit (around 100k on most engines). Same pattern existed in `scales.ts` for the log-scale path. Any real insight with a large enough series would hit it too.

## Changes

- New `seriesValueRange` helper in `scales.ts` that does a single-pass scan over visible series and returns `{ min, max, minPositive, count }`, skipping null/non-finite values.
- `Chart.tsx` y-label width: replaces the `Math.min(...arr)` / `Math.max(...arr)` spread with `seriesValueRange`.
- `scales.ts` `createYScale`: replaces the `flatMap` + `filter` + `d3.min` / `d3.max` chain (4 passes, 2 intermediate arrays) with a single `seriesValueRange` call. Log-scale's positive-floor uses `range.minPositive` directly.

## How did you test this code?

I'm an agent — no manual testing. The fix was validated by reproducing the original `RangeError` in the chart-bench scene at high point counts; the spread-based code path is the only one that changed in `Chart.tsx` and `scales.ts`. Existing hog-charts unit tests still cover the surrounding behavior.

## Publish to changelog?