### PR TITLE
chore(cloud): resume from checkpoint rather than snapshot

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -54,9 +54,7 @@ TASKS_USE_MODAL_RESUME_SNAPSHOTS: bool = get_from_env(
 # Override the process_task workflow's inactivity timeout (default 5 min). Set
 # this to e.g. 30 for local testing of the shutdown / resume flow. When set,
 # the CI-follow-up floor is also bypassed so the timer actually fires fast.
-TASKS_INACTIVITY_TIMEOUT_SECONDS: int = get_from_env(
-    "TASKS_INACTIVITY_TIMEOUT_SECONDS", 0, type_cast=int
-)
+TASKS_INACTIVITY_TIMEOUT_SECONDS: int = get_from_env("TASKS_INACTIVITY_TIMEOUT_SECONDS", 0, type_cast=int)
 
 TEMPORAL_LOG_LEVEL_PRODUCE: str = os.getenv("TEMPORAL_LOG_LEVEL_PRODUCE", "DEBUG")
 TEMPORAL_EXTERNAL_LOGS_QUEUE_SIZE: int = get_from_env("TEMPORAL_EXTERNAL_LOGS_QUEUE_SIZE", 0, type_cast=int)

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -1,6 +1,6 @@
 import os
 
-from posthog.settings.base_variables import DEBUG
+from posthog.settings.base_variables import CLOUD_DEPLOYMENT, DEBUG
 from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
 TEMPORAL_NAMESPACE: str = os.getenv("TEMPORAL_NAMESPACE", "default")
@@ -40,6 +40,23 @@ SANDBOX_PROVIDER: str | None = get_from_env(
 SANDBOX_API_URL: str | None = get_from_env("SANDBOX_API_URL", None, optional=True)
 SANDBOX_LLM_GATEWAY_URL: str | None = get_from_env("SANDBOX_LLM_GATEWAY_URL", None, optional=True)
 SANDBOX_MCP_URL: str | None = get_from_env("SANDBOX_MCP_URL", None, optional=True)
+
+# When True, cloud-to-cloud resume boots from a Modal filesystem snapshot taken at
+# end-of-run. When False, no Modal snapshot is taken and resume relies on the
+# git-checkpoint mechanism in the agent server (same path as local-to-cloud handoff).
+# Modal image storage is not EU-compliant, so this is forced off in EU.
+TASKS_USE_MODAL_RESUME_SNAPSHOTS: bool = get_from_env(
+    "TASKS_USE_MODAL_RESUME_SNAPSHOTS",
+    CLOUD_DEPLOYMENT != "EU",
+    type_cast=str_to_bool,
+)
+
+# Override the process_task workflow's inactivity timeout (default 5 min). Set
+# this to e.g. 30 for local testing of the shutdown / resume flow. When set,
+# the CI-follow-up floor is also bypassed so the timer actually fires fast.
+TASKS_INACTIVITY_TIMEOUT_SECONDS: int = get_from_env(
+    "TASKS_INACTIVITY_TIMEOUT_SECONDS", 0, type_cast=int
+)
 
 TEMPORAL_LOG_LEVEL_PRODUCE: str = os.getenv("TEMPORAL_LOG_LEVEL_PRODUCE", "DEBUG")
 TEMPORAL_EXTERNAL_LOGS_QUEUE_SIZE: int = get_from_env("TEMPORAL_EXTERNAL_LOGS_QUEUE_SIZE", 0, type_cast=int)

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -619,7 +619,7 @@ export const pluginConfigsLogsList = async (
 }
 
 /**
- * Fetch the logs for a task run. Returns JSONL formatted log entries.
+ * Fetch the logs for a task run as JSONL. If the run resumes from another (state.resume_from_run_id), each ancestor's log is concatenated first (oldest ancestor → ... → this run) so resume consumers see a single continuous history and can find the most recent git_checkpoint event regardless of which run emitted it.
  * @summary Get task run logs
  */
 export const getTasksRunsLogsRetrieveUrl = (projectId: string, taskId: string, id: string) => {

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -6,7 +6,7 @@ import logging
 import builtins
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Any, List, cast
+from typing import Any, cast
 
 from django.conf import settings
 from django.core.cache import cache

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -6,7 +6,7 @@ import logging
 import builtins
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, List, cast
 
 from django.conf import settings
 from django.core.cache import cache
@@ -1157,6 +1157,47 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return safe_name, f"{prefix}/{artifact_id[:8]}_{safe_name}"
 
     @staticmethod
+    def _walk_resume_chain(task_run: TaskRun, max_depth: int = 10) -> List[TaskRun]:
+        """Walk `state.resume_from_run_id` from this run upward.
+
+        Returns a list ordered oldest-ancestor → ... → parent → this. Bounded
+        depth and a seen-set guard against cycles. Same-task scope means no
+        extra authz surface — the caller already proved access to the task
+        by passing get_object() on the starting run.
+        """
+        chain: list[TaskRun] = [task_run]
+        seen: set[str] = {str(task_run.id)}
+        current: TaskRun | None = task_run
+        depth = 0
+        while current is not None and depth < max_depth:
+            prior_id = parse_run_state(current.state).resume_from_run_id
+            if not prior_id or prior_id in seen:
+                break
+            seen.add(prior_id)
+            current = task_run.task.runs.filter(id=prior_id).first()
+            if current is None:
+                break
+            chain.append(current)
+            depth += 1
+        chain.reverse()
+        return chain
+
+    @staticmethod
+    def _find_artifact_in_resume_chain(task_run: TaskRun, storage_path: str) -> dict | None:
+        """Look up an artifact on this run, then walk back along resume_from_run_id.
+
+        Cloud→cloud resume creates a new TaskRun whose state.resume_from_run_id
+        points to the prior run; the prior run owns the git checkpoint pack/index
+        artifacts the agent needs on resume.
+        """
+        # Iterate newest-first since artifact is more likely to be on this run.
+        for run in reversed(TaskRunViewSet._walk_resume_chain(task_run)):
+            for entry in run.artifacts or []:
+                if entry.get("storage_path") == storage_path:
+                    return entry
+        return None
+
+    @staticmethod
     def _tag_artifact_object(task_run: TaskRun, storage_path: str) -> None:
         try:
             object_storage.tag(
@@ -1642,10 +1683,11 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def artifacts_download(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
         storage_path = request.validated_data["storage_path"]
-        artifact = next(
-            (entry for entry in task_run.artifacts or [] if entry.get("storage_path") == storage_path),
-            None,
-        )
+
+        # Walk the resume chain so cloud→cloud resume runs can fetch the
+        # git checkpoint pack/index that lives on the prior run they were
+        # forked from.
+        artifact = self._find_artifact_in_resume_chain(task_run, storage_path)
 
         if artifact is None:
             return Response(
@@ -1690,15 +1732,29 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             404: OpenApiResponse(description="Task run not found"),
         },
         summary="Get task run logs",
-        description="Fetch the logs for a task run. Returns JSONL formatted log entries.",
+        description=(
+            "Fetch the logs for a task run as JSONL. If the run resumes from "
+            "another (state.resume_from_run_id), each ancestor's log is "
+            "concatenated first (oldest ancestor → ... → this run) so resume "
+            "consumers see a single continuous history and can find the most "
+            "recent git_checkpoint event regardless of which run emitted it."
+        ),
     )
     @action(detail=True, methods=["get"], url_path="logs", required_scopes=["task:read"])
     def logs(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
         timer = ServerTimingsGathered()
 
+        chain = self._walk_resume_chain(task_run)
         with timer("s3_read"):
-            log_content = object_storage.read(task_run.log_url, missing_ok=True) or ""
+            parts: list[str] = []
+            for run in chain:
+                chunk = object_storage.read(run.log_url, missing_ok=True) or ""
+                if chunk:
+                    if not chunk.endswith("\n"):
+                        chunk = chunk + "\n"
+                    parts.append(chunk)
+            log_content = "".join(parts)
 
         response = HttpResponse(log_content, content_type="application/jsonl")
         response["Cache-Control"] = "no-cache"
@@ -2025,6 +2081,19 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     )
     def resume_in_cloud(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
+
+        logger.info(
+            "resume_in_cloud_called",
+            extra={
+                "task_run_id": str(task_run.id),
+                "task_id": str(task_run.task_id),
+                "prior_status": task_run.status,
+                "prior_environment": task_run.environment,
+                "prior_state_keys": sorted((task_run.state or {}).keys()),
+                "prior_snapshot_external_id": (task_run.state or {}).get("snapshot_external_id"),
+                "use_modal_resume_snapshots": settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
+            },
+        )
 
         with transaction.atomic():
             task_run = TaskRun.objects.select_for_update().get(pk=task_run.pk)

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -1156,7 +1156,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         prefix = task_run.get_artifact_s3_prefix()
         return safe_name, f"{prefix}/{artifact_id[:8]}_{safe_name}"
 
-
     @staticmethod
     def _tag_artifact_object(task_run: TaskRun, storage_path: str) -> None:
         try:

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -1156,46 +1156,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         prefix = task_run.get_artifact_s3_prefix()
         return safe_name, f"{prefix}/{artifact_id[:8]}_{safe_name}"
 
-    @staticmethod
-    def _walk_resume_chain(task_run: TaskRun, max_depth: int = 10) -> List[TaskRun]:
-        """Walk `state.resume_from_run_id` from this run upward.
-
-        Returns a list ordered oldest-ancestor → ... → parent → this. Bounded
-        depth and a seen-set guard against cycles. Same-task scope means no
-        extra authz surface — the caller already proved access to the task
-        by passing get_object() on the starting run.
-        """
-        chain: list[TaskRun] = [task_run]
-        seen: set[str] = {str(task_run.id)}
-        current: TaskRun | None = task_run
-        depth = 0
-        while current is not None and depth < max_depth:
-            prior_id = parse_run_state(current.state).resume_from_run_id
-            if not prior_id or prior_id in seen:
-                break
-            seen.add(prior_id)
-            current = task_run.task.runs.filter(id=prior_id).first()
-            if current is None:
-                break
-            chain.append(current)
-            depth += 1
-        chain.reverse()
-        return chain
-
-    @staticmethod
-    def _find_artifact_in_resume_chain(task_run: TaskRun, storage_path: str) -> dict | None:
-        """Look up an artifact on this run, then walk back along resume_from_run_id.
-
-        Cloud→cloud resume creates a new TaskRun whose state.resume_from_run_id
-        points to the prior run; the prior run owns the git checkpoint pack/index
-        artifacts the agent needs on resume.
-        """
-        # Iterate newest-first since artifact is more likely to be on this run.
-        for run in reversed(TaskRunViewSet._walk_resume_chain(task_run)):
-            for entry in run.artifacts or []:
-                if entry.get("storage_path") == storage_path:
-                    return entry
-        return None
 
     @staticmethod
     def _tag_artifact_object(task_run: TaskRun, storage_path: str) -> None:
@@ -1687,7 +1647,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # Walk the resume chain so cloud→cloud resume runs can fetch the
         # git checkpoint pack/index that lives on the prior run they were
         # forked from.
-        artifact = self._find_artifact_in_resume_chain(task_run, storage_path)
+        artifact = task_run.find_artifact_in_resume_chain(storage_path)
 
         if artifact is None:
             return Response(
@@ -1745,7 +1705,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         task_run = cast(TaskRun, self.get_object())
         timer = ServerTimingsGathered()
 
-        chain = self._walk_resume_chain(task_run)
+        chain = task_run.get_resume_chain()
         with timer("s3_read"):
             parts: list[str] = []
             for run in chain:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -674,17 +674,30 @@ class TaskRun(models.Model):
         Returns runs ordered oldest-ancestor → ... → parent → this. Bounded
         depth and a seen-set guard against cycles. The walk is scoped to this
         task — a stale cross-task `resume_from_run_id` is silently dropped.
+
+        Loads sibling runs in a single query and walks in-memory so chain depth
+        doesn't translate to per-hop database round trips.
         """
         chain: list[TaskRun] = [self]
+        if max_depth <= 0:
+            return chain
+
+        siblings_by_id: dict[str, TaskRun] = {str(run.id): run for run in self.task.runs.all()}
         seen: set[str] = {str(self.id)}
         current: TaskRun | None = self
         depth = 0
         while current is not None and depth < max_depth:
-            prior_id = (current.state or {}).get("resume_from_run_id")
-            if not prior_id or prior_id in seen:
+            prior_id_raw = (current.state or {}).get("resume_from_run_id")
+            if not prior_id_raw:
+                break
+            try:
+                prior_id = str(uuid.UUID(str(prior_id_raw)))
+            except (ValueError, TypeError):
+                break
+            if prior_id in seen:
                 break
             seen.add(prior_id)
-            current = self.task.runs.filter(id=prior_id).first()
+            current = siblings_by_id.get(prior_id)
             if current is None:
                 break
             chain.append(current)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -568,8 +568,7 @@ class TaskRun(models.Model):
             use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
             prior_snapshot_external_id=prior_snapshot_external_id,
             stripped_snapshot_external_id=(
-                prior_snapshot_external_id is not None
-                and not settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS
+                prior_snapshot_external_id is not None and not settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS
             ),
         )
 

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -552,11 +552,26 @@ class TaskRun(models.Model):
         self.error_message = None
 
         state = self.state or {}
+        prior_snapshot_external_id = state.get("snapshot_external_id")
         state["handoff_resumed"] = True
         state["mode"] = "interactive"
         state.pop("pending_user_message", None)
         state.pop("pending_user_message_ts", None)
+        if not settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS:
+            state.pop("snapshot_external_id", None)
         self.state = state
+
+        logger.info(
+            "prepare_for_cloud_handoff",
+            run_id=str(self.id),
+            task_id=str(self.task_id),
+            use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
+            prior_snapshot_external_id=prior_snapshot_external_id,
+            stripped_snapshot_external_id=(
+                prior_snapshot_external_id is not None
+                and not settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS
+            ),
+        )
 
         self.save(
             update_fields=[

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -682,7 +682,11 @@ class TaskRun(models.Model):
         if max_depth <= 0:
             return chain
 
-        siblings_by_id: dict[str, TaskRun] = {str(run.id): run for run in self.task.runs.all()}
+        # Walking the chain only needs id/state/artifacts and the bits that
+        # `log_url` derives from (team_id, task_id). Fetching the full row would
+        # pull every column for every historical run on the task.
+        siblings_qs = self.task.runs.only("id", "team_id", "task_id", "state", "artifacts")
+        siblings_by_id: dict[str, TaskRun] = {str(run.id): run for run in siblings_qs}
         seen: set[str] = {str(self.id)}
         current: TaskRun | None = self
         depth = 0

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -668,6 +668,39 @@ class TaskRun(models.Model):
         tasks_folder = settings.OBJECT_STORAGE_TASKS_FOLDER
         return f"{tasks_folder}/artifacts/team_{self.team_id}/task_{self.task_id}/run_{self.id}"
 
+    def get_resume_chain(self, max_depth: int = 10) -> list["TaskRun"]:
+        """Walk `state.resume_from_run_id` from this run upward.
+
+        Returns runs ordered oldest-ancestor → ... → parent → this. Bounded
+        depth and a seen-set guard against cycles. The walk is scoped to this
+        task — a stale cross-task `resume_from_run_id` is silently dropped.
+        """
+        chain: list[TaskRun] = [self]
+        seen: set[str] = {str(self.id)}
+        current: TaskRun | None = self
+        depth = 0
+        while current is not None and depth < max_depth:
+            prior_id = (current.state or {}).get("resume_from_run_id")
+            if not prior_id or prior_id in seen:
+                break
+            seen.add(prior_id)
+            current = self.task.runs.filter(id=prior_id).first()
+            if current is None:
+                break
+            chain.append(current)
+            depth += 1
+        chain.reverse()
+        return chain
+
+    def find_artifact_in_resume_chain(self, storage_path: str) -> dict | None:
+        """Find an artifact by storage_path on this run or any ancestor in the resume chain."""
+        # Iterate newest-first since artifact is more likely to be on this run.
+        for run in reversed(self.get_resume_chain()):
+            for entry in run.artifacts or []:
+                if entry.get("storage_path") == storage_path:
+                    return entry
+        return None
+
     @staticmethod
     def _is_agent_message_chunk(entry: dict) -> bool:
         """Check if an entry is an agent_message_chunk event."""

--- a/products/tasks/backend/temporal/process_task/activities/create_resume_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_resume_snapshot.py
@@ -33,6 +33,8 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
     """
     SandboxClass = get_sandbox_class()
 
+    logger.info("create_resume_snapshot_started", sandbox_id=input.sandbox_id, run_id=input.run_id)
+
     try:
         sandbox = SandboxClass.get_by_id(input.sandbox_id)
     except Exception as e:

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -53,6 +53,9 @@ class TaskProcessingContext:
     allowed_domains: list[str] | None = None
     json_schema: dict | None = None
     ci_prompt: str | None = None
+    # Captured at workflow start so a flag flip mid-run can't introduce
+    # nondeterminism (the workflow consults this in its finally block).
+    use_modal_resume_snapshots: bool = True
 
     @property
     def mode(self) -> str:
@@ -235,4 +238,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         allowed_domains=allowed_domains,
         json_schema=task.json_schema,
         ci_prompt=task.ci_prompt,
+        use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
     )

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -268,22 +268,17 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
 
         activity.logger.info(
             "resume_decision",
-            run_id=ctx.run_id,
-            use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
-            state_snapshot_external_id=run_state.snapshot_external_id,
-            effective_snapshot_external_id=resume_snapshot_external_id,
-            handoff_resumed=run_state.handoff_resumed,
-            resume_from_run_id=run_state.resume_from_run_id,
-            posthog_resume_run_id_set="POSTHOG_RESUME_RUN_ID" in environment_variables,
-            used_snapshot=used_snapshot,
+            extra={
+                "run_id": ctx.run_id,
+                "use_modal_resume_snapshots": settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
+                "state_snapshot_external_id": run_state.snapshot_external_id,
+                "effective_snapshot_external_id": resume_snapshot_external_id,
+                "handoff_resumed": run_state.handoff_resumed,
+                "resume_from_run_id": run_state.resume_from_run_id,
+                "posthog_resume_run_id_set": "POSTHOG_RESUME_RUN_ID" in environment_variables,
+                "used_snapshot": used_snapshot,
+            },
         )
-        if run_state.snapshot_external_id and not settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS:
-            emit_agent_log(
-                ctx.run_id,
-                "debug",
-                f"Ignoring snapshot_external_id={run_state.snapshot_external_id} (TASKS_USE_MODAL_RESUME_SNAPSHOTS=false); "
-                "resume will use git-checkpoint flow",
-            )
         if run_state.handoff_resumed or run_state.resume_from_run_id:
             emit_agent_log(
                 ctx.run_id,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -257,9 +257,41 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         environment_variables = _build_environment_variables(ctx, task, github_token, access_token)
 
         run_state = parse_run_state(ctx.state)
-        resume_snapshot_external_id = run_state.snapshot_external_id
+        # When Modal resume snapshots are disabled, ignore any snapshot_external_id
+        # baked into TaskRun state — resume falls back to the agent server's
+        # git-checkpoint flow (POSTHOG_RESUME_RUN_ID continues to be set above).
+        resume_snapshot_external_id = (
+            run_state.snapshot_external_id if settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS else None
+        )
         if resume_snapshot_external_id:
             used_snapshot = True
+
+        activity.logger.info(
+            "resume_decision",
+            run_id=ctx.run_id,
+            use_modal_resume_snapshots=settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS,
+            state_snapshot_external_id=run_state.snapshot_external_id,
+            effective_snapshot_external_id=resume_snapshot_external_id,
+            handoff_resumed=run_state.handoff_resumed,
+            resume_from_run_id=run_state.resume_from_run_id,
+            posthog_resume_run_id_set="POSTHOG_RESUME_RUN_ID" in environment_variables,
+            used_snapshot=used_snapshot,
+        )
+        if run_state.snapshot_external_id and not settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS:
+            emit_agent_log(
+                ctx.run_id,
+                "debug",
+                f"Ignoring snapshot_external_id={run_state.snapshot_external_id} (TASKS_USE_MODAL_RESUME_SNAPSHOTS=false); "
+                "resume will use git-checkpoint flow",
+            )
+        if run_state.handoff_resumed or run_state.resume_from_run_id:
+            emit_agent_log(
+                ctx.run_id,
+                "debug",
+                f"Resume mode: handoff_resumed={run_state.handoff_resumed}, "
+                f"resume_from_run_id={run_state.resume_from_run_id}, "
+                f"using_modal_snapshot={resume_snapshot_external_id is not None}",
+            )
 
         provider = getattr(settings, "SANDBOX_PROVIDER", None)
         image_source, image_source_label = _get_image_source_label(

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -569,7 +569,12 @@ class TestProcessTaskWorkflowUnit:
         ],
     )
     async def test_get_sandbox_respects_modal_resume_flag(
-        self, monkeypatch, use_modal_resume_snapshots, prior_snapshot_external_id, expect_used_snapshot, expect_inject_tokens
+        self,
+        monkeypatch,
+        use_modal_resume_snapshots,
+        prior_snapshot_external_id,
+        expect_used_snapshot,
+        expect_inject_tokens,
     ):
         """`_get_sandbox_for_repository` honors TASKS_USE_MODAL_RESUME_SNAPSHOTS.
 

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -495,3 +495,134 @@ class TestProcessTaskWorkflowUnit:
         await workflow._get_sandbox_for_repository()
 
         assert inject_fresh_tokens_on_resume not in activity_calls
+
+    @pytest.mark.parametrize(
+        "use_modal_resume_snapshots, mode, expect_resume_snapshot_call",
+        [
+            (True, "interactive", True),
+            (False, "interactive", False),
+            (True, "background", False),
+            (False, "background", False),
+        ],
+    )
+    async def test_finally_block_resume_snapshot_gating(
+        self, monkeypatch, use_modal_resume_snapshots, mode, expect_resume_snapshot_call
+    ):
+        """`_create_resume_snapshot` runs only when interactive AND flag is on.
+
+        Disabling the Modal-snapshot flag (e.g. for EU compliance) must skip the
+        snapshot creation activity in the workflow's finally block, regardless of
+        mode.
+        """
+        monkeypatch.setattr(settings, "TASKS_USE_MODAL_RESUME_SNAPSHOTS", use_modal_resume_snapshots)
+
+        workflow = ProcessTaskWorkflow()
+        get_task_processing_context_mock = AsyncMock(
+            return_value=_build_context(github_integration_id=123, state={"mode": mode})
+        )
+        update_task_run_status_mock = AsyncMock()
+        track_workflow_event_mock = AsyncMock()
+        post_slack_update_mock = AsyncMock()
+        read_sandbox_logs_mock = AsyncMock()
+        cleanup_sandbox_mock = AsyncMock()
+        create_resume_snapshot_mock = AsyncMock()
+
+        monkeypatch.setattr(workflow, "_get_task_processing_context", get_task_processing_context_mock)
+        monkeypatch.setattr(workflow, "_update_task_run_status", update_task_run_status_mock)
+        monkeypatch.setattr(workflow, "_track_workflow_event", track_workflow_event_mock)
+        monkeypatch.setattr(workflow, "_post_slack_update", post_slack_update_mock)
+        monkeypatch.setattr(workflow, "_read_sandbox_logs", read_sandbox_logs_mock)
+        monkeypatch.setattr(workflow, "_cleanup_sandbox", cleanup_sandbox_mock)
+        monkeypatch.setattr(workflow, "_create_resume_snapshot", create_resume_snapshot_mock)
+        monkeypatch.setattr(workflow, "_emit_progress", AsyncMock())
+
+        # Force the workflow into the finally block with a sandbox to clean up.
+        async def fail_after_sandbox_creation() -> GetSandboxForRepositoryOutput:
+            workflow._sandbox_id_for_cleanup = "sandbox-123"
+            raise RuntimeError("forced failure to reach finally block")
+
+        monkeypatch.setattr(workflow, "_get_sandbox_for_repository", fail_after_sandbox_creation)
+
+        await workflow.run(ProcessTaskInput(run_id="run-id"))
+
+        cleanup_sandbox_mock.assert_awaited_once_with("sandbox-123")
+        if expect_resume_snapshot_call:
+            create_resume_snapshot_mock.assert_awaited_once_with("sandbox-123")
+        else:
+            create_resume_snapshot_mock.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "use_modal_resume_snapshots, prior_snapshot_external_id, expect_used_snapshot, expect_inject_tokens",
+        [
+            # Flag on: a stale snapshot id propagated via state still gets used,
+            # and the post-resume token-injection activity runs to refresh the
+            # snapshotted .git/config.
+            (True, "im-abc123", True, True),
+            # Flag off: snapshot id is ignored even if state still carries it,
+            # and the token-injection activity is skipped (no snapshotted creds).
+            (False, "im-abc123", False, False),
+        ],
+    )
+    async def test_get_sandbox_respects_modal_resume_flag(
+        self, monkeypatch, use_modal_resume_snapshots, prior_snapshot_external_id, expect_used_snapshot, expect_inject_tokens
+    ):
+        """`_get_sandbox_for_repository` honors TASKS_USE_MODAL_RESUME_SNAPSHOTS.
+
+        Verified via the prepared-output the workflow receives: when the flag is
+        off, the workflow doesn't see a `snapshot_external_id` and therefore
+        doesn't schedule the `inject_fresh_tokens_on_resume` activity.
+        """
+        monkeypatch.setattr(settings, "TASKS_USE_MODAL_RESUME_SNAPSHOTS", use_modal_resume_snapshots)
+
+        workflow = ProcessTaskWorkflow()
+        workflow._context = _build_context(
+            github_integration_id=123,
+            state={"snapshot_external_id": prior_snapshot_external_id, "resume_from_run_id": "previous-run-id"},
+        )
+
+        # Mirror what `prepare_sandbox_for_repository` would produce given the flag.
+        prepared = PrepareSandboxForRepositoryOutput(
+            sandbox_name="sandbox-name",
+            repository="posthog/posthog-js",
+            github_token="ghs_fresh",
+            branch=None,
+            environment_variables={},
+            snapshot_id=None,
+            snapshot_external_id=prior_snapshot_external_id if expect_used_snapshot else None,
+            used_snapshot=expect_used_snapshot,
+            should_create_snapshot=not expect_used_snapshot,
+            shallow_clone=True,
+            image_source="resume_snapshot" if expect_used_snapshot else "base_image",
+            image_source_label="resume snapshot" if expect_used_snapshot else "published sandbox base image",
+        )
+        created = CreateSandboxForRepositoryOutput(
+            sandbox_id="sandbox-123",
+            sandbox_url="https://sandbox.example",
+            connect_token="connect-token",
+        )
+        activity_calls: list[object] = []
+
+        async def fake_execute_activity(activity_fn, *args, **kwargs):
+            activity_calls.append(activity_fn)
+            if activity_fn is prepare_sandbox_for_repository:
+                return prepared
+            if activity_fn is create_sandbox_for_repository:
+                return created
+            if activity_fn is inject_fresh_tokens_on_resume:
+                return None
+            if activity_fn is emit_progress_activity:
+                return None
+            if activity_fn is clone_repository_in_sandbox:
+                return None
+            if activity_fn is checkout_branch_in_sandbox:
+                return None
+            raise AssertionError(f"Unexpected activity call: {activity_fn}")
+
+        monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+        await workflow._get_sandbox_for_repository()
+
+        if expect_inject_tokens:
+            assert inject_fresh_tokens_on_resume in activity_calls
+        else:
+            assert inject_fresh_tokens_on_resume not in activity_calls

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -50,6 +50,7 @@ def _build_context(
     github_integration_id: int | None,
     repository: str | None = "posthog/posthog-js",
     state: dict | None = None,
+    use_modal_resume_snapshots: bool = True,
 ) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
@@ -63,6 +64,7 @@ def _build_context(
         create_pr=True,
         state=state or {},
         _branch="feature-branch",
+        use_modal_resume_snapshots=use_modal_resume_snapshots,
     )
 
 
@@ -512,13 +514,16 @@ class TestProcessTaskWorkflowUnit:
 
         Disabling the Modal-snapshot flag (e.g. for EU compliance) must skip the
         snapshot creation activity in the workflow's finally block, regardless of
-        mode.
+        mode. The flag value is set on the context (captured at workflow start)
+        so a mid-run flip can't introduce replay nondeterminism.
         """
-        monkeypatch.setattr(settings, "TASKS_USE_MODAL_RESUME_SNAPSHOTS", use_modal_resume_snapshots)
-
         workflow = ProcessTaskWorkflow()
         get_task_processing_context_mock = AsyncMock(
-            return_value=_build_context(github_integration_id=123, state={"mode": mode})
+            return_value=_build_context(
+                github_integration_id=123,
+                state={"mode": mode},
+                use_modal_resume_snapshots=use_modal_resume_snapshots,
+            )
         )
         update_task_run_status_mock = AsyncMock()
         track_workflow_event_mock = AsyncMock()

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -73,6 +73,7 @@ class TaskEvent(StrEnum):
     CI_FOLLOW_UP = "ci_follow_up"
 
 
+<<<<<<< New base: resume from last checkpoint
 class CIFollowUpDecision(StrEnum):
     FIRE = "fire"
     SKIP = "skip"
@@ -80,6 +81,15 @@ class CIFollowUpDecision(StrEnum):
 
 
 INACTIVITY_TIMEOUT = timedelta(minutes=5)
+||||||| Common ancestor
+INACTIVITY_TIMEOUT = timedelta(minutes=5)
+=======
+# Default 5 min in production. Override via TASKS_INACTIVITY_TIMEOUT_SECONDS
+# for local testing (e.g. `TASKS_INACTIVITY_TIMEOUT_SECONDS=30` to force a fast
+# shutdown for resume-flow testing). When overridden, the CI follow-up floor
+# below is bypassed so the timer actually fires that fast.
+INACTIVITY_TIMEOUT = timedelta(seconds=int(getattr(settings, "TASKS_INACTIVITY_TIMEOUT_SECONDS", 0) or 300))
+>>>>>>> Current commit: resume from last checkpoint
 CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
 RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT = timedelta(hours=24)
 PENDING_MESSAGE_FORWARD_TIMEOUT_SECONDS = 180
@@ -227,10 +237,13 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         )
         # When a CI follow-up is scheduled, ensure the inactivity timer can't
         # race ahead of it — otherwise the short inactivity window would always
-        # fire first and CI fixes would be silently skipped.
+        # fire first and CI fixes would be silently skipped. The
+        # TASKS_INACTIVITY_TIMEOUT_SECONDS override bypasses this floor so
+        # local testing of the shutdown/resume flow is fast.
+        inactivity_override_active = bool(getattr(settings, "TASKS_INACTIVITY_TIMEOUT_SECONDS", 0))
         inactivity_timeout = (
             max(INACTIVITY_TIMEOUT, CI_FOLLOW_UP_DELAY + timedelta(minutes=1))
-            if ci_follow_up_scheduled
+            if ci_follow_up_scheduled and not inactivity_override_active
             else INACTIVITY_TIMEOUT
         )
         possible_events: list[asyncio.Task[TaskEvent]] = [
@@ -541,8 +554,14 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         finally:
             cleanup_sandbox_id = sandbox_id or self._sandbox_id_for_cleanup
             if cleanup_sandbox_id:
-                # Create a resume snapshot for interactive sandboxes before cleanup
-                if self._context and self._context.mode == "interactive":
+                # Create a resume snapshot for interactive sandboxes before cleanup.
+                # Skipped when TASKS_USE_MODAL_RESUME_SNAPSHOTS is off — resume then
+                # relies on the agent server's git-checkpoint mechanism instead.
+                if (
+                    self._context
+                    and self._context.mode == "interactive"
+                    and settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS
+                ):
                     await self._create_resume_snapshot(cleanup_sandbox_id)
 
                 await self._read_sandbox_logs(cleanup_sandbox_id)

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -554,11 +554,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 # agent server's git-checkpoint mechanism instead. Read from
                 # context (captured at workflow start) so replay is deterministic
                 # against env-var flips.
-                if (
-                    self._context
-                    and self._context.mode == "interactive"
-                    and self._context.use_modal_resume_snapshots
-                ):
+                if self._context and self._context.mode == "interactive" and self._context.use_modal_resume_snapshots:
                     await self._create_resume_snapshot(cleanup_sandbox_id)
 
                 await self._read_sandbox_logs(cleanup_sandbox_id)

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -235,13 +235,10 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             and self._context.pr_loop_enabled
             and self._ci_repetitions < MAX_CI_REPETITIONS
         )
-        # When a CI follow-up is scheduled, ensure the inactivity timer can't
-        # race ahead of it — otherwise the short inactivity window would always
-        # fire first and CI fixes would be silently skipped. A short
-        # TASKS_INACTIVITY_TIMEOUT_SECONDS override (used for local testing of
-        # the shutdown/resume flow) is allowed to bypass this floor; the
-        # default (no override set) and any sufficiently large override still
-        # respect it, so a misconfigured env var can't fire before CI.
+        # When CI follow-up is scheduled, the inactivity timer must outlive
+        # CI_FOLLOW_UP_DELAY. The testing-only `TASKS_INACTIVITY_TIMEOUT_SECONDS`
+        # env var bypasses the floor, but only when explicitly set AND short —
+        # so a misconfigured large value still respects the CI floor.
         ci_follow_up_floor = CI_FOLLOW_UP_DELAY + timedelta(minutes=1)
         testing_override_active = bool(settings.TASKS_INACTIVITY_TIMEOUT_SECONDS) and (
             INACTIVITY_TIMEOUT < ci_follow_up_floor
@@ -559,12 +556,10 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         finally:
             cleanup_sandbox_id = sandbox_id or self._sandbox_id_for_cleanup
             if cleanup_sandbox_id:
-                # Create a resume snapshot for interactive sandboxes before cleanup.
-                # Skipped when TASKS_USE_MODAL_RESUME_SNAPSHOTS is off — resume then
-                # relies on the agent server's git-checkpoint mechanism instead.
-                # The flag is read from the context (captured at workflow start)
-                # rather than from settings directly so a mid-run flip doesn't
-                # cause replay nondeterminism.
+                # When `use_modal_resume_snapshots` is off, resume relies on the
+                # agent server's git-checkpoint mechanism instead. Read from
+                # context (captured at workflow start) so replay is deterministic
+                # against env-var flips.
                 if (
                     self._context
                     and self._context.mode == "interactive"

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -73,23 +73,17 @@ class TaskEvent(StrEnum):
     CI_FOLLOW_UP = "ci_follow_up"
 
 
-<<<<<<< New base: resume from last checkpoint
 class CIFollowUpDecision(StrEnum):
     FIRE = "fire"
     SKIP = "skip"
     NO_PR = "no_pr"
 
 
-INACTIVITY_TIMEOUT = timedelta(minutes=5)
-||||||| Common ancestor
-INACTIVITY_TIMEOUT = timedelta(minutes=5)
-=======
 # Default 5 min in production. Override via TASKS_INACTIVITY_TIMEOUT_SECONDS
 # for local testing (e.g. `TASKS_INACTIVITY_TIMEOUT_SECONDS=30` to force a fast
 # shutdown for resume-flow testing). When overridden, the CI follow-up floor
 # below is bypassed so the timer actually fires that fast.
 INACTIVITY_TIMEOUT = timedelta(seconds=settings.TASKS_INACTIVITY_TIMEOUT_SECONDS or 300)
->>>>>>> Current commit: resume from last checkpoint
 CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
 RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT = timedelta(hours=24)
 PENDING_MESSAGE_FORWARD_TIMEOUT_SECONDS = 180

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -88,7 +88,7 @@ INACTIVITY_TIMEOUT = timedelta(minutes=5)
 # for local testing (e.g. `TASKS_INACTIVITY_TIMEOUT_SECONDS=30` to force a fast
 # shutdown for resume-flow testing). When overridden, the CI follow-up floor
 # below is bypassed so the timer actually fires that fast.
-INACTIVITY_TIMEOUT = timedelta(seconds=int(getattr(settings, "TASKS_INACTIVITY_TIMEOUT_SECONDS", 0) or 300))
+INACTIVITY_TIMEOUT = timedelta(seconds=settings.TASKS_INACTIVITY_TIMEOUT_SECONDS or 300)
 >>>>>>> Current commit: resume from last checkpoint
 CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
 RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT = timedelta(hours=24)
@@ -237,13 +237,18 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         )
         # When a CI follow-up is scheduled, ensure the inactivity timer can't
         # race ahead of it — otherwise the short inactivity window would always
-        # fire first and CI fixes would be silently skipped. The
-        # TASKS_INACTIVITY_TIMEOUT_SECONDS override bypasses this floor so
-        # local testing of the shutdown/resume flow is fast.
-        inactivity_override_active = bool(getattr(settings, "TASKS_INACTIVITY_TIMEOUT_SECONDS", 0))
+        # fire first and CI fixes would be silently skipped. A short
+        # TASKS_INACTIVITY_TIMEOUT_SECONDS override (used for local testing of
+        # the shutdown/resume flow) is allowed to bypass this floor; the
+        # default (no override set) and any sufficiently large override still
+        # respect it, so a misconfigured env var can't fire before CI.
+        ci_follow_up_floor = CI_FOLLOW_UP_DELAY + timedelta(minutes=1)
+        testing_override_active = bool(settings.TASKS_INACTIVITY_TIMEOUT_SECONDS) and (
+            INACTIVITY_TIMEOUT < ci_follow_up_floor
+        )
         inactivity_timeout = (
-            max(INACTIVITY_TIMEOUT, CI_FOLLOW_UP_DELAY + timedelta(minutes=1))
-            if ci_follow_up_scheduled and not inactivity_override_active
+            max(INACTIVITY_TIMEOUT, ci_follow_up_floor)
+            if ci_follow_up_scheduled and not testing_override_active
             else INACTIVITY_TIMEOUT
         )
         possible_events: list[asyncio.Task[TaskEvent]] = [
@@ -557,10 +562,13 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 # Create a resume snapshot for interactive sandboxes before cleanup.
                 # Skipped when TASKS_USE_MODAL_RESUME_SNAPSHOTS is off — resume then
                 # relies on the agent server's git-checkpoint mechanism instead.
+                # The flag is read from the context (captured at workflow start)
+                # rather than from settings directly so a mid-run flip doesn't
+                # cause replay nondeterminism.
                 if (
                     self._context
                     and self._context.mode == "interactive"
-                    and settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS
+                    and self._context.use_modal_resume_snapshots
                 ):
                     await self._create_resume_snapshot(cleanup_sandbox_id)
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3277,7 +3277,6 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
     def test_find_artifact_in_resume_chain_direct_hit(self):
         """Finds artifact on the run itself without walking the chain."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         storage_path = "tasks/artifacts/team_1/task_x/run_a/artifact.pack"
@@ -3288,19 +3287,17 @@ class TestTaskRunAPI(BaseTaskAPITest):
             artifacts=[{"id": "a", "name": "artifact.pack", "storage_path": storage_path}],
         )
 
-        artifact = TaskRunViewSet._find_artifact_in_resume_chain(run, storage_path)
+        artifact = run.find_artifact_in_resume_chain(storage_path)
         self.assertIsNotNone(artifact)
         self.assertEqual(artifact["storage_path"], storage_path)  # type: ignore
 
     def test_find_artifact_in_resume_chain_miss(self):
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, artifacts=[])
-        self.assertIsNone(TaskRunViewSet._find_artifact_in_resume_chain(run, "tasks/missing.pack"))
+        self.assertIsNone(run.find_artifact_in_resume_chain("tasks/missing.pack"))
 
     def test_find_artifact_in_resume_chain_walks_one_hop(self):
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         storage_path = "tasks/artifacts/team_1/task_x/run_prior/artifact.pack"
@@ -3316,12 +3313,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
             state={"resume_from_run_id": str(prior_run.id)},
         )
 
-        artifact = TaskRunViewSet._find_artifact_in_resume_chain(new_run, storage_path)
+        artifact = new_run.find_artifact_in_resume_chain(storage_path)
         self.assertIsNotNone(artifact)
 
     def test_find_artifact_in_resume_chain_walks_multiple_hops(self):
         """Resumed-from-resumed-from chain still resolves."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         storage_path = "tasks/artifacts/team_1/task_x/run_root/artifact.pack"
@@ -3343,12 +3339,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
             state={"resume_from_run_id": str(middle_run.id)},
         )
 
-        artifact = TaskRunViewSet._find_artifact_in_resume_chain(new_run, storage_path)
+        artifact = new_run.find_artifact_in_resume_chain(storage_path)
         self.assertIsNotNone(artifact)
 
     def test_find_artifact_in_resume_chain_handles_cycle(self):
         """A self-referencing or circular resume chain doesn't loop forever."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         run_a = TaskRun.objects.create(task=task, team=self.team, artifacts=[])
@@ -3362,12 +3357,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
         run_a.state = {"resume_from_run_id": str(run_b.id)}
         run_a.save(update_fields=["state"])
 
-        result = TaskRunViewSet._find_artifact_in_resume_chain(run_b, "tasks/missing.pack")
+        result = run_b.find_artifact_in_resume_chain("tasks/missing.pack")
         self.assertIsNone(result)
 
     def test_find_artifact_in_resume_chain_does_not_cross_tasks(self):
         """Resume chain lookup is scoped to the same task — sibling tasks are invisible."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task_a = self.create_task(title="A")
         task_b = self.create_task(title="B")
@@ -3386,21 +3380,19 @@ class TestTaskRunAPI(BaseTaskAPITest):
             state={"resume_from_run_id": str(prior_run_on_a.id)},
         )
 
-        self.assertIsNone(TaskRunViewSet._find_artifact_in_resume_chain(run_on_b, storage_path))
+        self.assertIsNone(run_on_b.find_artifact_in_resume_chain(storage_path))
 
     def test_walk_resume_chain_single_run(self):
         """A run with no resume_from_run_id resolves to a 1-element chain."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team)
 
-        chain = TaskRunViewSet._walk_resume_chain(run)
+        chain = run.get_resume_chain()
         self.assertEqual([r.id for r in chain], [run.id])
 
     def test_walk_resume_chain_multi_hop_ordered_oldest_first(self):
         """Chain returns oldest-ancestor → ... → parent → this in order."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         root = TaskRun.objects.create(task=task, team=self.team)
@@ -3411,12 +3403,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
             task=task, team=self.team, state={"resume_from_run_id": str(middle.id)}
         )
 
-        chain = TaskRunViewSet._walk_resume_chain(leaf)
+        chain = leaf.get_resume_chain()
         self.assertEqual([r.id for r in chain], [root.id, middle.id, leaf.id])
 
     def test_walk_resume_chain_handles_cycle(self):
         """A circular `resume_from_run_id` chain doesn't loop forever."""
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         run_a = TaskRun.objects.create(task=task, team=self.team)
@@ -3426,11 +3417,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
         run_a.state = {"resume_from_run_id": str(run_b.id)}
         run_a.save(update_fields=["state"])
 
-        chain = TaskRunViewSet._walk_resume_chain(run_b)
+        chain = run_b.get_resume_chain()
         self.assertEqual({r.id for r in chain}, {run_a.id, run_b.id})
 
     def test_walk_resume_chain_respects_max_depth(self):
-        from products.tasks.backend.api import TaskRunViewSet
 
         task = self.create_task()
         prior: TaskRun | None = None
@@ -3444,13 +3434,12 @@ class TestTaskRunAPI(BaseTaskAPITest):
             runs.append(current)
             prior = current
 
-        chain = TaskRunViewSet._walk_resume_chain(runs[-1], max_depth=2)
+        chain = runs[-1].get_resume_chain(max_depth=2)
         # max_depth=2 means we walk at most 2 hops back from the leaf, so the
         # chain should contain exactly 3 entries (leaf + 2 ancestors).
         self.assertEqual(len(chain), 3)
 
     def test_walk_resume_chain_does_not_cross_tasks(self):
-        from products.tasks.backend.api import TaskRunViewSet
 
         task_a = self.create_task(title="A")
         task_b = self.create_task(title="B")
@@ -3460,7 +3449,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
             task=task_b, team=self.team, state={"resume_from_run_id": str(run_on_a.id)}
         )
 
-        chain = TaskRunViewSet._walk_resume_chain(run_on_b)
+        chain = run_on_b.get_resume_chain()
         # Walker is scoped via `task_run.task.runs.filter(...)` so a stale
         # cross-task `resume_from_run_id` is silently dropped.
         self.assertEqual([r.id for r in chain], [run_on_b.id])

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3232,6 +3232,302 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @patch("posthog.storage.object_storage.read_bytes")
+    def test_download_artifact_walks_resume_chain(self, mock_read_bytes):
+        """A resumed run can download an artifact owned by the run it was forked from.
+
+        Cloud→cloud resume creates a new TaskRun with state.resume_from_run_id pointing
+        to the prior run; the prior run owns the git checkpoint pack/index artifacts.
+        """
+        mock_read_bytes.return_value = b"prior run pack bytes"
+        task = self.create_task()
+        prior_storage_path = "tasks/artifacts/team_1/task_x/run_prior/abc_pack.pack"
+
+        prior_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            artifacts=[
+                {
+                    "id": uuid.uuid4().hex,
+                    "name": "checkpoint.pack",
+                    "type": "artifact",
+                    "content_type": "application/x-git-packed-objects",
+                    "storage_path": prior_storage_path,
+                }
+            ],
+        )
+        new_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            artifacts=[],
+            state={"resume_from_run_id": str(prior_run.id)},
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{new_run.id}/artifacts/download/",
+            {"storage_path": prior_storage_path},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content, b"prior run pack bytes")
+        mock_read_bytes.assert_called_once_with(prior_storage_path, missing_ok=True)
+
+    def test_find_artifact_in_resume_chain_direct_hit(self):
+        """Finds artifact on the run itself without walking the chain."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        storage_path = "tasks/artifacts/team_1/task_x/run_a/artifact.pack"
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            artifacts=[{"id": "a", "name": "artifact.pack", "storage_path": storage_path}],
+        )
+
+        artifact = TaskRunViewSet._find_artifact_in_resume_chain(run, storage_path)
+        self.assertIsNotNone(artifact)
+        self.assertEqual(artifact["storage_path"], storage_path)  # type: ignore
+
+    def test_find_artifact_in_resume_chain_miss(self):
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        run = TaskRun.objects.create(task=task, team=self.team, artifacts=[])
+        self.assertIsNone(TaskRunViewSet._find_artifact_in_resume_chain(run, "tasks/missing.pack"))
+
+    def test_find_artifact_in_resume_chain_walks_one_hop(self):
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        storage_path = "tasks/artifacts/team_1/task_x/run_prior/artifact.pack"
+        prior_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            artifacts=[{"id": "a", "name": "artifact.pack", "storage_path": storage_path}],
+        )
+        new_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            artifacts=[],
+            state={"resume_from_run_id": str(prior_run.id)},
+        )
+
+        artifact = TaskRunViewSet._find_artifact_in_resume_chain(new_run, storage_path)
+        self.assertIsNotNone(artifact)
+
+    def test_find_artifact_in_resume_chain_walks_multiple_hops(self):
+        """Resumed-from-resumed-from chain still resolves."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        storage_path = "tasks/artifacts/team_1/task_x/run_root/artifact.pack"
+        root_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            artifacts=[{"id": "a", "name": "artifact.pack", "storage_path": storage_path}],
+        )
+        middle_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            artifacts=[],
+            state={"resume_from_run_id": str(root_run.id)},
+        )
+        new_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            artifacts=[],
+            state={"resume_from_run_id": str(middle_run.id)},
+        )
+
+        artifact = TaskRunViewSet._find_artifact_in_resume_chain(new_run, storage_path)
+        self.assertIsNotNone(artifact)
+
+    def test_find_artifact_in_resume_chain_handles_cycle(self):
+        """A self-referencing or circular resume chain doesn't loop forever."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        run_a = TaskRun.objects.create(task=task, team=self.team, artifacts=[])
+        run_b = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            artifacts=[],
+            state={"resume_from_run_id": str(run_a.id)},
+        )
+        # Patch run_a to point back at run_b — circular.
+        run_a.state = {"resume_from_run_id": str(run_b.id)}
+        run_a.save(update_fields=["state"])
+
+        result = TaskRunViewSet._find_artifact_in_resume_chain(run_b, "tasks/missing.pack")
+        self.assertIsNone(result)
+
+    def test_find_artifact_in_resume_chain_does_not_cross_tasks(self):
+        """Resume chain lookup is scoped to the same task — sibling tasks are invisible."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task_a = self.create_task(title="A")
+        task_b = self.create_task(title="B")
+        storage_path = "tasks/artifacts/team_1/task_a/run/artifact.pack"
+
+        prior_run_on_a = TaskRun.objects.create(
+            task=task_a,
+            team=self.team,
+            artifacts=[{"id": "a", "name": "artifact.pack", "storage_path": storage_path}],
+        )
+        # Run on task B references a run from task A — should not resolve.
+        run_on_b = TaskRun.objects.create(
+            task=task_b,
+            team=self.team,
+            artifacts=[],
+            state={"resume_from_run_id": str(prior_run_on_a.id)},
+        )
+
+        self.assertIsNone(TaskRunViewSet._find_artifact_in_resume_chain(run_on_b, storage_path))
+
+    def test_walk_resume_chain_single_run(self):
+        """A run with no resume_from_run_id resolves to a 1-element chain."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        run = TaskRun.objects.create(task=task, team=self.team)
+
+        chain = TaskRunViewSet._walk_resume_chain(run)
+        self.assertEqual([r.id for r in chain], [run.id])
+
+    def test_walk_resume_chain_multi_hop_ordered_oldest_first(self):
+        """Chain returns oldest-ancestor → ... → parent → this in order."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        root = TaskRun.objects.create(task=task, team=self.team)
+        middle = TaskRun.objects.create(
+            task=task, team=self.team, state={"resume_from_run_id": str(root.id)}
+        )
+        leaf = TaskRun.objects.create(
+            task=task, team=self.team, state={"resume_from_run_id": str(middle.id)}
+        )
+
+        chain = TaskRunViewSet._walk_resume_chain(leaf)
+        self.assertEqual([r.id for r in chain], [root.id, middle.id, leaf.id])
+
+    def test_walk_resume_chain_handles_cycle(self):
+        """A circular `resume_from_run_id` chain doesn't loop forever."""
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        run_a = TaskRun.objects.create(task=task, team=self.team)
+        run_b = TaskRun.objects.create(
+            task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)}
+        )
+        run_a.state = {"resume_from_run_id": str(run_b.id)}
+        run_a.save(update_fields=["state"])
+
+        chain = TaskRunViewSet._walk_resume_chain(run_b)
+        self.assertEqual({r.id for r in chain}, {run_a.id, run_b.id})
+
+    def test_walk_resume_chain_respects_max_depth(self):
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task = self.create_task()
+        prior: TaskRun | None = None
+        runs: list[TaskRun] = []
+        for _ in range(5):
+            current = TaskRun.objects.create(
+                task=task,
+                team=self.team,
+                state={"resume_from_run_id": str(prior.id)} if prior else {},
+            )
+            runs.append(current)
+            prior = current
+
+        chain = TaskRunViewSet._walk_resume_chain(runs[-1], max_depth=2)
+        # max_depth=2 means we walk at most 2 hops back from the leaf, so the
+        # chain should contain exactly 3 entries (leaf + 2 ancestors).
+        self.assertEqual(len(chain), 3)
+
+    def test_walk_resume_chain_does_not_cross_tasks(self):
+        from products.tasks.backend.api import TaskRunViewSet
+
+        task_a = self.create_task(title="A")
+        task_b = self.create_task(title="B")
+
+        run_on_a = TaskRun.objects.create(task=task_a, team=self.team)
+        run_on_b = TaskRun.objects.create(
+            task=task_b, team=self.team, state={"resume_from_run_id": str(run_on_a.id)}
+        )
+
+        chain = TaskRunViewSet._walk_resume_chain(run_on_b)
+        # Walker is scoped via `task_run.task.runs.filter(...)` so a stale
+        # cross-task `resume_from_run_id` is silently dropped.
+        self.assertEqual([r.id for r in chain], [run_on_b.id])
+
+    @patch("posthog.storage.object_storage.read")
+    def test_logs_endpoint_returns_chain_concatenated_oldest_first(self, mock_read):
+        """When a run is part of a resume chain, /logs returns ancestors first.
+
+        This means a checkpoint event emitted on Run A is still discoverable by
+        the agent resuming Run B even if B never wrote a file (and so never
+        emitted its own checkpoint).
+        """
+        task = self.create_task()
+        run_a = TaskRun.objects.create(task=task, team=self.team)
+        run_b = TaskRun.objects.create(
+            task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)}
+        )
+
+        a_line = '{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}'
+        b_line = '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}'
+
+        def fake_read(path: str, missing_ok: bool = False) -> str | None:
+            if path == run_a.log_url:
+                return a_line + "\n"
+            if path == run_b.log_url:
+                return b_line + "\n"
+            return None
+
+        mock_read.side_effect = fake_read
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run_b.id}/logs/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        body = response.content.decode("utf-8").splitlines()
+        self.assertEqual(body, [a_line, b_line])
+
+    @patch("posthog.storage.object_storage.read")
+    def test_logs_endpoint_unchained_returns_only_own_log(self, mock_read):
+        task = self.create_task()
+        run = TaskRun.objects.create(task=task, team=self.team)
+        mock_read.return_value = '{"hello":"world"}\n'
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/logs/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content.decode("utf-8").strip(), '{"hello":"world"}')
+        mock_read.assert_called_once_with(run.log_url, missing_ok=True)
+
+    @patch("posthog.storage.object_storage.read")
+    def test_logs_endpoint_skips_missing_ancestor_logs(self, mock_read):
+        """An ancestor with no log file (e.g. never started) is silently skipped."""
+        task = self.create_task()
+        run_a = TaskRun.objects.create(task=task, team=self.team)
+        run_b = TaskRun.objects.create(
+            task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)}
+        )
+
+        def fake_read(path: str, missing_ok: bool = False) -> str | None:
+            if path == run_b.log_url:
+                return '{"only":"b"}\n'
+            return None  # ancestor missing
+
+        mock_read.side_effect = fake_read
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run_b.id}/logs/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content.decode("utf-8").strip(), '{"only":"b"}')
+
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_connection_token_returns_jwt(self):
         get_sandbox_jwt_public_key.cache_clear()

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3454,68 +3454,59 @@ class TestTaskRunAPI(BaseTaskAPITest):
         # cross-task `resume_from_run_id` is silently dropped.
         self.assertEqual([r.id for r in chain], [run_on_b.id])
 
+    @parameterized.expand(
+        [
+            (
+                "chained_returns_ancestors_first",
+                True,  # has_ancestor
+                {"a": '{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}\n'},
+                '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}\n',
+                ['{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}',
+                 '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}'],
+            ),
+            (
+                "unchained_returns_only_own_log",
+                False,
+                {},
+                '{"hello":"world"}\n',
+                ['{"hello":"world"}'],
+            ),
+            (
+                "skips_missing_ancestor_logs",
+                True,
+                {"a": None},
+                '{"only":"b"}\n',
+                ['{"only":"b"}'],
+            ),
+        ]
+    )
     @patch("posthog.storage.object_storage.read")
-    def test_logs_endpoint_returns_chain_concatenated_oldest_first(self, mock_read):
-        """When a run is part of a resume chain, /logs returns ancestors first.
-
-        This means a checkpoint event emitted on Run A is still discoverable by
-        the agent resuming Run B even if B never wrote a file (and so never
-        emitted its own checkpoint).
-        """
+    def test_logs_endpoint_walks_resume_chain(
+        self,
+        _name: str,
+        has_ancestor: bool,
+        ancestor_logs: dict[str, str | None],
+        own_log: str,
+        expected_lines: list[str],
+        mock_read,
+    ):
         task = self.create_task()
-        run_a = TaskRun.objects.create(task=task, team=self.team)
-        run_b = TaskRun.objects.create(
-            task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)}
-        )
-
-        a_line = '{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}'
-        b_line = '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}'
+        ancestor = TaskRun.objects.create(task=task, team=self.team) if has_ancestor else None
+        target_state = {"resume_from_run_id": str(ancestor.id)} if ancestor else {}
+        target = TaskRun.objects.create(task=task, team=self.team, state=target_state)
 
         def fake_read(path: str, missing_ok: bool = False) -> str | None:
-            if path == run_a.log_url:
-                return a_line + "\n"
-            if path == run_b.log_url:
-                return b_line + "\n"
+            if ancestor and path == ancestor.log_url:
+                return ancestor_logs.get("a")
+            if path == target.log_url:
+                return own_log
             return None
 
         mock_read.side_effect = fake_read
 
-        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run_b.id}/logs/")
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{target.id}/logs/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        body = response.content.decode("utf-8").splitlines()
-        self.assertEqual(body, [a_line, b_line])
-
-    @patch("posthog.storage.object_storage.read")
-    def test_logs_endpoint_unchained_returns_only_own_log(self, mock_read):
-        task = self.create_task()
-        run = TaskRun.objects.create(task=task, team=self.team)
-        mock_read.return_value = '{"hello":"world"}\n'
-
-        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/logs/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.content.decode("utf-8").strip(), '{"hello":"world"}')
-        mock_read.assert_called_once_with(run.log_url, missing_ok=True)
-
-    @patch("posthog.storage.object_storage.read")
-    def test_logs_endpoint_skips_missing_ancestor_logs(self, mock_read):
-        """An ancestor with no log file (e.g. never started) is silently skipped."""
-        task = self.create_task()
-        run_a = TaskRun.objects.create(task=task, team=self.team)
-        run_b = TaskRun.objects.create(
-            task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)}
-        )
-
-        def fake_read(path: str, missing_ok: bool = False) -> str | None:
-            if path == run_b.log_url:
-                return '{"only":"b"}\n'
-            return None  # ancestor missing
-
-        mock_read.side_effect = fake_read
-
-        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run_b.id}/logs/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.content.decode("utf-8").strip(), '{"only":"b"}')
+        self.assertEqual(response.content.decode("utf-8").splitlines(), expected_lines)
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_connection_token_returns_jwt(self):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3292,13 +3292,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(artifact["storage_path"], storage_path)  # type: ignore
 
     def test_find_artifact_in_resume_chain_miss(self):
-
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, artifacts=[])
         self.assertIsNone(run.find_artifact_in_resume_chain("tasks/missing.pack"))
 
     def test_find_artifact_in_resume_chain_walks_one_hop(self):
-
         task = self.create_task()
         storage_path = "tasks/artifacts/team_1/task_x/run_prior/artifact.pack"
         prior_run = TaskRun.objects.create(
@@ -3396,12 +3394,8 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         root = TaskRun.objects.create(task=task, team=self.team)
-        middle = TaskRun.objects.create(
-            task=task, team=self.team, state={"resume_from_run_id": str(root.id)}
-        )
-        leaf = TaskRun.objects.create(
-            task=task, team=self.team, state={"resume_from_run_id": str(middle.id)}
-        )
+        middle = TaskRun.objects.create(task=task, team=self.team, state={"resume_from_run_id": str(root.id)})
+        leaf = TaskRun.objects.create(task=task, team=self.team, state={"resume_from_run_id": str(middle.id)})
 
         chain = leaf.get_resume_chain()
         self.assertEqual([r.id for r in chain], [root.id, middle.id, leaf.id])
@@ -3411,9 +3405,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         task = self.create_task()
         run_a = TaskRun.objects.create(task=task, team=self.team)
-        run_b = TaskRun.objects.create(
-            task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)}
-        )
+        run_b = TaskRun.objects.create(task=task, team=self.team, state={"resume_from_run_id": str(run_a.id)})
         run_a.state = {"resume_from_run_id": str(run_b.id)}
         run_a.save(update_fields=["state"])
 
@@ -3421,7 +3413,6 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual({r.id for r in chain}, {run_a.id, run_b.id})
 
     def test_walk_resume_chain_respects_max_depth(self):
-
         task = self.create_task()
         prior: TaskRun | None = None
         runs: list[TaskRun] = []
@@ -3440,14 +3431,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(len(chain), 3)
 
     def test_walk_resume_chain_does_not_cross_tasks(self):
-
         task_a = self.create_task(title="A")
         task_b = self.create_task(title="B")
 
         run_on_a = TaskRun.objects.create(task=task_a, team=self.team)
-        run_on_b = TaskRun.objects.create(
-            task=task_b, team=self.team, state={"resume_from_run_id": str(run_on_a.id)}
-        )
+        run_on_b = TaskRun.objects.create(task=task_b, team=self.team, state={"resume_from_run_id": str(run_on_a.id)})
 
         chain = run_on_b.get_resume_chain()
         # Walker is scoped via `task_run.task.runs.filter(...)` so a stale
@@ -3461,8 +3449,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
                 True,  # has_ancestor
                 {"a": '{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}\n'},
                 '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}\n',
-                ['{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}',
-                 '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}'],
+                [
+                    '{"notification":{"method":"_posthog/git_checkpoint","params":{"checkpointId":"ckpt-A"}}}',
+                    '{"notification":{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message"}}}}',
+                ],
             ),
             (
                 "unchained_returns_only_own_log",


### PR DESCRIPTION
Since Modal snapshots are not supported in the EU region, we need to have a way of resuming cloud runs from the last checkpoint.

This adds support for that behind an env var, because of the way we’re resuming cloud runs, this walks the chain of previous cloud runs to pull the logs for the current run, so that the last saved checkpoint is always included.

It also adds some logs for debugging cloud run resuming.