### PR TITLE
feat(insights): support property aggregation on data warehouse retention

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32500,8 +32500,8 @@
                 },
                 "aggregationPropertyType": {
                     "default": "event",
-                    "description": "The type of property to aggregate on (event or person). Defaults to event.",
-                    "enum": ["event", "person"],
+                    "description": "The type of property to aggregate on (event, person, or data_warehouse). Defaults to event.",
+                    "enum": ["event", "person", "data_warehouse"],
                     "type": "string"
                 },
                 "aggregationType": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1639,9 +1639,9 @@ export type RetentionFilter = {
     aggregationType?: 'count' | 'sum' | 'avg'
     /** @description The property to aggregate when aggregationType is sum or avg */
     aggregationProperty?: string
-    /** @description The type of property to aggregate on (event or person). Defaults to event.
+    /** @description The type of property to aggregate on (event, person, or data_warehouse). Defaults to event.
      * @default event */
-    aggregationPropertyType?: 'event' | 'person'
+    aggregationPropertyType?: 'event' | 'person' | 'data_warehouse'
     /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
     customAggregationTarget?: boolean
 

--- a/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
@@ -7,21 +7,37 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicStringPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { PROPERTY_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
+import { DatabaseSchemaField } from '~/queries/schema/schema-general'
 import { PropertyMathType } from '~/types'
 
 export function RetentionAggregationSelector(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { dataWarehouseTablesMap } = useValues(databaseTableListLogic)
 
     const aggregationType = retentionFilter?.aggregationType || 'count'
     const aggregationProperty = retentionFilter?.aggregationProperty
     const aggregationPropertyType = retentionFilter?.aggregationPropertyType || 'event'
     const isPropertyValueAggregation = aggregationType === 'sum' || aggregationType === 'avg'
+
+    const targetEntity = retentionFilter?.targetEntity
+    const returningEntity = retentionFilter?.returningEntity
+    const isTargetDwh = targetEntity?.type === 'data_warehouse'
+    const isReturningDwh = returningEntity?.type === 'data_warehouse'
+    const hasDwhEntity = isTargetDwh || isReturningDwh
+    const dwhEntityForColumns = isTargetDwh ? targetEntity : isReturningDwh ? returningEntity : null
+    const dwhTableName = dwhEntityForColumns
+        ? (dwhEntityForColumns.table_name ?? (dwhEntityForColumns.id as string | undefined))
+        : null
+    const schemaColumns: DatabaseSchemaField[] = dwhTableName
+        ? Object.values(dataWarehouseTablesMap[dwhTableName]?.fields ?? {})
+        : []
 
     // Local state to track which property math type to show in the dropdown label
     // This mirrors the behavior in Trends where the "Property value" option remembers the last selected math type
@@ -89,7 +105,17 @@ export function RetentionAggregationSelector(): JSX.Element {
     const propertyGroupType =
         aggregationPropertyType === 'person'
             ? TaxonomicFilterGroupType.PersonProperties
-            : TaxonomicFilterGroupType.EventProperties
+            : aggregationPropertyType === 'data_warehouse'
+              ? TaxonomicFilterGroupType.DataWarehouseProperties
+              : TaxonomicFilterGroupType.EventProperties
+
+    const groupTypes = hasDwhEntity
+        ? [
+              TaxonomicFilterGroupType.DataWarehouseProperties,
+              TaxonomicFilterGroupType.EventProperties,
+              TaxonomicFilterGroupType.PersonProperties,
+          ]
+        : [TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.PersonProperties]
 
     return (
         <div className="flex flex-col items-start gap-2">
@@ -101,7 +127,22 @@ export function RetentionAggregationSelector(): JSX.Element {
                     } else {
                         // If switching to property value, use the currently "shown" type (avg or sum)
                         const aggregationType = propertyMathTypeShown === PropertyMathType.Sum ? 'sum' : 'avg'
-                        updateInsightFilter({ aggregationType })
+                        // When both retention entities are warehouse-backed and the user has not yet
+                        // picked a property type, prefer 'data_warehouse' so the property picker
+                        // surfaces warehouse columns first.
+                        const update: {
+                            aggregationType: 'sum' | 'avg'
+                            aggregationPropertyType?: 'event' | 'person' | 'data_warehouse'
+                        } = { aggregationType }
+                        if (
+                            isTargetDwh &&
+                            isReturningDwh &&
+                            (!retentionFilter?.aggregationPropertyType ||
+                                retentionFilter.aggregationPropertyType === 'event')
+                        ) {
+                            update.aggregationPropertyType = 'data_warehouse'
+                        }
+                        updateInsightFilter(update)
                     }
                 }}
                 options={options}
@@ -114,11 +155,17 @@ export function RetentionAggregationSelector(): JSX.Element {
             {isPropertyValueAggregation && (
                 <TaxonomicStringPopover
                     groupType={propertyGroupType}
-                    groupTypes={[TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.PersonProperties]}
+                    groupTypes={groupTypes}
+                    schemaColumns={schemaColumns}
                     showNumericalPropsOnly={true}
                     value={aggregationProperty || ''}
                     onChange={(val, groupType) => {
-                        const newType = groupType === TaxonomicFilterGroupType.PersonProperties ? 'person' : 'event'
+                        const newType =
+                            groupType === TaxonomicFilterGroupType.DataWarehouseProperties
+                                ? 'data_warehouse'
+                                : groupType === TaxonomicFilterGroupType.PersonProperties
+                                  ? 'person'
+                                  : 'event'
                         updateInsightFilter({
                             aggregationProperty: val,
                             aggregationPropertyType: newType,
@@ -134,8 +181,13 @@ export function RetentionAggregationSelector(): JSX.Element {
                                     {aggregationType === 'sum'
                                         ? PROPERTY_MATH_DEFINITIONS[PropertyMathType.Sum].name.toLowerCase()
                                         : PROPERTY_MATH_DEFINITIONS[PropertyMathType.Average].name.toLowerCase()}{' '}
-                                    from {aggregationPropertyType === 'person' ? 'person' : 'event'} property{' '}
-                                    <code>{currentValue}</code>.
+                                    from{' '}
+                                    {aggregationPropertyType === 'person'
+                                        ? 'person'
+                                        : aggregationPropertyType === 'data_warehouse'
+                                          ? 'data warehouse'
+                                          : 'event'}{' '}
+                                    property <code>{currentValue}</code>.
                                     {aggregationPropertyType === 'event' && (
                                         <>
                                             <br />
@@ -153,7 +205,9 @@ export function RetentionAggregationSelector(): JSX.Element {
                                 type={
                                     aggregationPropertyType === 'person'
                                         ? TaxonomicFilterGroupType.PersonProperties
-                                        : TaxonomicFilterGroupType.EventProperties
+                                        : aggregationPropertyType === 'data_warehouse'
+                                          ? TaxonomicFilterGroupType.DataWarehouseProperties
+                                          : TaxonomicFilterGroupType.EventProperties
                                 }
                             />
                         </Tooltip>

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -40,7 +40,10 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
         is_valid_start_interval = self._is_valid_start_interval_expr()
-        intervals_from_base_expr, _ = self._get_intervals_from_base_exprs()
+        has_property_aggregation = self.runner.has_property_aggregation
+        intervals_from_base_expr, retention_value_expr = self._get_intervals_from_base_exprs(
+            has_property_aggregation_aliases=has_property_aggregation
+        )
 
         start_event_query = self._build_dwh_retention_event_query(
             entity=self.start_event,
@@ -55,18 +58,61 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         retention_events = ast.SelectSetQuery.create_from_queries([start_event_query, return_event_query], "UNION ALL")
 
-        base_query = ast.SelectQuery(
-            select=[
-                ast.Alias(alias="actor_id", expr=ast.Field(chain=["actor_id"])),
+        select_fields: list[ast.Expr] = [
+            ast.Alias(alias="actor_id", expr=ast.Field(chain=["actor_id"])),
+        ]
+
+        if has_property_aggregation:
+            # When aggregating on a property, the unioned subquery returns arrays of 3-tuples
+            # (interval_start, value, actual_timestamp) under start_event_timestamps /
+            # return_event_timestamps. Expose them under _start_event_data / _return_event_data
+            # so the reduction logic in _get_intervals_from_base_exprs (which already references
+            # those aliases for the legacy events path) keeps working unchanged. The outer
+            # start_event_timestamps / return_event_timestamps then become flat timestamp arrays
+            # extracted from the tuples, which is the shape `_is_valid_start_interval_expr` and
+            # `_is_first_interval_after_start_event_expr` expect.
+            select_fields.append(
+                ast.Alias(
+                    alias="_start_event_data",
+                    expr=parse_expr("arrayFlatten(groupArray(start_event_timestamps))"),
+                )
+            )
+            select_fields.append(
+                ast.Alias(
+                    alias="_return_event_data",
+                    expr=parse_expr("arrayFlatten(groupArray(return_event_timestamps))"),
+                )
+            )
+            select_fields.append(
+                ast.Alias(
+                    alias="start_event_timestamps",
+                    expr=parse_expr("arrayMap(x -> x.1, _start_event_data)"),
+                )
+            )
+            select_fields.append(
+                ast.Alias(
+                    alias="return_event_timestamps",
+                    expr=parse_expr("arrayMap(x -> x.1, _return_event_data)"),
+                )
+            )
+        else:
+            select_fields.append(
                 ast.Alias(
                     alias="start_event_timestamps",
                     expr=parse_expr("arrayFlatten(groupArray(start_event_timestamps))"),
-                ),
+                )
+            )
+            select_fields.append(
                 ast.Alias(
                     alias="return_event_timestamps",
                     expr=parse_expr("arrayFlatten(groupArray(return_event_timestamps))"),
-                ),
-                self._date_range_alias(),
+                )
+            )
+
+        select_fields.append(self._date_range_alias())
+
+        select_fields.extend(
+            [
                 ast.Alias(
                     alias="start_interval_index",
                     expr=parse_expr(
@@ -91,7 +137,14 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                     ),
                 ),
                 ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
-            ],
+            ]
+        )
+
+        if retention_value_expr is not None:
+            select_fields.append(ast.Alias(alias="retention_value", expr=retention_value_expr))
+
+        base_query = ast.SelectQuery(
+            select=select_fields,
             select_from=ast.JoinExpr(table=retention_events, alias="retention_events"),
             group_by=[ast.Field(chain=["actor_id"])],
             having=ast.And(
@@ -139,29 +192,54 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=timestamp_field)
         entity_expr = self._get_dwh_retention_entity_expr(entity=entity, legacy_entity_expr=legacy_entity_expr)
 
+        property_aggregation_expr = (
+            self.runner.property_aggregation_expr_for(entity) if self.runner.has_property_aggregation else None
+        )
+
         if query_kind == "start":
-            timestamps_expr = parse_expr(
-                """
-                arraySort(
-                    groupUniqArrayIf(
-                        {start_of_interval_sql},
+            if property_aggregation_expr is not None:
+                # 3-tuple form to mirror the legacy events aggregation path:
+                # (interval_start, property_value, actual_timestamp)
+                timestamps_expr = parse_expr(
+                    """
+                    groupArrayIf(
+                        ({start_of_interval_sql}, {property_aggregation_expr}, {timestamp_field}),
                         {entity_expr} and
                         {filter_timestamp}
                     )
+                    """,
+                    {
+                        "start_of_interval_sql": start_of_interval_sql,
+                        "property_aggregation_expr": property_aggregation_expr,
+                        "timestamp_field": timestamp_field,
+                        "entity_expr": entity_expr,
+                        "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
+                    },
                 )
-                """,
-                {
-                    "start_of_interval_sql": start_of_interval_sql,
-                    "entity_expr": entity_expr,
-                    "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
-                },
-            )
+            else:
+                timestamps_expr = parse_expr(
+                    """
+                    arraySort(
+                        groupUniqArrayIf(
+                            {start_of_interval_sql},
+                            {entity_expr} and
+                            {filter_timestamp}
+                        )
+                    )
+                    """,
+                    {
+                        "start_of_interval_sql": start_of_interval_sql,
+                        "entity_expr": entity_expr,
+                        "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
+                    },
+                )
         else:
             timestamps_expr = self._get_return_event_timestamps_expr(
                 minimum_occurrences=self.minimum_occurrences,
                 start_of_interval_sql=start_of_interval_sql,
                 return_entity_expr=entity_expr,
                 timestamp_field=timestamp_field,
+                property_aggregation_expr=property_aggregation_expr,
             )
 
         table_name = entity.table_name if entity_is_dwh else "events"
@@ -630,23 +708,34 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_of_interval_sql: ast.Expr,
         return_entity_expr: ast.Expr,
         timestamp_field: ast.Expr | None = None,
+        property_aggregation_expr: ast.Expr | None = None,
     ) -> ast.Expr:
-        if self.property_aggregation_expr:
+        # Resolve a sane default for the timestamp field used inside the tuple and the filter.
+        # Legacy events callers pass nothing and get events.timestamp.
+        effective_timestamp_field = timestamp_field or ast.Field(chain=["events", "timestamp"])
+
+        # Default to the runner-level (start-side) aggregation expression for legacy events callers
+        # so behaviour is unchanged. DWH callers pass an entity-specific expression.
+        if property_aggregation_expr is None and self.property_aggregation_expr:
+            property_aggregation_expr = self.runner.property_aggregation_expr_for(self.return_event)
+
+        if property_aggregation_expr is not None:
             # Collect 3-tuples of (interval_start, value, actual_timestamp) for return events.
             # actual_timestamp is needed to filter same-interval return events that happen after the start event.
             return parse_expr(
                 """
                 groupArrayIf(
-                    ({start_of_interval_timestamp}, {property_aggregation_expr}, events.timestamp),
+                    ({start_of_interval_timestamp}, {property_aggregation_expr}, {timestamp_field}),
                     {returning_entity_expr} and
                     {filter_timestamp}
                 )
                 """,
                 {
                     "start_of_interval_timestamp": start_of_interval_sql,
-                    "property_aggregation_expr": self.property_aggregation_expr,
+                    "property_aggregation_expr": property_aggregation_expr,
+                    "timestamp_field": effective_timestamp_field,
                     "returning_entity_expr": return_entity_expr,
-                    "filter_timestamp": self.events_timestamp_filter(),
+                    "filter_timestamp": self.events_timestamp_filter(field=effective_timestamp_field),
                 },
             )
 

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -133,30 +133,49 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return (DisallowCumulativeWith24HourWindows(), DisallowUnsupportedDataWarehouseSettings())
 
     @cached_property
-    def property_aggregation_expr(self) -> ast.Expr | None:
-        if (
-            self.query.retentionFilter.aggregationType in [AggregationType.SUM, AggregationType.AVG]
-            and self.query.retentionFilter.aggregationProperty
-        ):
-            prop_name = self.query.retentionFilter.aggregationProperty
-            if self.query.retentionFilter.aggregationPropertyType == "person":
-                # person.properties resolves via the HogQL person join on the events table
-                chain = cast(list[str | int], ["person", "properties", prop_name])
-            else:
-                chain = cast(list[str | int], ["events", "properties", prop_name])
-            property_field = ast.Field(chain=chain)
-            return ast.Call(
-                name="ifNull",
-                args=[
-                    ast.Call(name="toFloat", args=[property_field]),
-                    ast.Constant(value=0.0),
-                ],
-            )
-        return None
+    def has_property_aggregation(self) -> bool:
+        return self.query.retentionFilter.aggregationType in [AggregationType.SUM, AggregationType.AVG] and bool(
+            self.query.retentionFilter.aggregationProperty
+        )
+
+    def property_aggregation_expr_for(self, entity: RetentionEntity) -> ast.Expr | None:
+        """
+        Resolve the property to aggregate on for a given retention entity.
+
+        For event-typed entities the property lives at events.properties.<name>; for person-typed
+        properties it resolves through the events->person join; and for data_warehouse-typed
+        properties the column lives directly on the warehouse table referenced by the surrounding
+        subquery's FROM. This mirrors how trends resolves math_property differently for
+        DataWarehouseNode vs EventsNode (see AggregationOperations._get_math_chain).
+        """
+        if not self.has_property_aggregation:
+            return None
+
+        prop_name = self.query.retentionFilter.aggregationProperty
+        assert prop_name is not None
+        property_type = self.query.retentionFilter.aggregationPropertyType
+        if property_type == "person":
+            chain: list[str | int] = ["person", "properties", prop_name]
+        elif property_type == "data_warehouse":
+            # Bare column on the surrounding warehouse table. When this side of the union is not
+            # a DWH entity (e.g. mixed events + warehouse with type="data_warehouse"), the column
+            # won't exist and ifNull(toFloat(...), 0.0) makes that side contribute 0.
+            chain = [prop_name] if entity.type == EntityType.DATA_WAREHOUSE else ["events", "properties", prop_name]
+        else:
+            chain = ["events", "properties", prop_name]
+        property_field = ast.Field(chain=cast(list[str | int], chain))
+        return ast.Call(
+            name="ifNull",
+            args=[
+                ast.Call(name="toFloat", args=[property_field]),
+                ast.Constant(value=0.0),
+            ],
+        )
 
     @cached_property
-    def has_property_aggregation(self) -> bool:
-        return self.property_aggregation_expr is not None
+    def property_aggregation_expr(self) -> ast.Expr | None:
+        """Default-side resolution for legacy events callers (uses the start entity)."""
+        return self.property_aggregation_expr_for(self.start_event)
 
     @cached_property
     def group_type_index(self) -> int | None:

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -133,3 +133,51 @@
                         use_hive_partitioning=0
   '''
 # ---
+# name: TestRetentionDataWarehouse.test_retention_revenue_retention_data_warehouse
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count,
+         sum(actor_activity.retention_value) AS aggregation_value
+  FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS _start_event_data,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS _return_event_data,
+            arrayMap(x -> x.1, _start_event_data) AS start_event_timestamps,
+            arrayMap(x -> x.1, _return_event_data) AS return_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(has(start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
+            arrayJoin(arrayConcat(arrayFilter(x -> ifNull(greaterOrEquals(x.1, 0), 0), arrayMap(item -> tuple(accurateCastOrNull(if(ifNull(equals(item.1, date_range[plus(start_interval_index, 1)]), isNull(item.1)
+                                                                                                                                           and isNull(date_range[plus(start_interval_index, 1)])), 0, -1), 'Int64'), item.2), _start_event_data)), arrayFilter(x -> ifNull(greater(x.1, 0), 0), arrayMap(item -> tuple(accurateCastOrNull(indexOf(arraySlice(date_range, plus(start_interval_index, 2), 4), item.1), 'Int64'), item.2), _return_event_data)))).1 AS intervals_from_base,
+            arrayJoin(arrayConcat(arrayFilter(x -> ifNull(greaterOrEquals(x.1, 0), 0), arrayMap(item -> tuple(accurateCastOrNull(if(ifNull(equals(item.1, date_range[plus(start_interval_index, 1)]), isNull(item.1)
+                                                                                                                                           and isNull(date_range[plus(start_interval_index, 1)])), 0, -1), 'Int64'), item.2), _start_event_data)), arrayFilter(x -> ifNull(greater(x.1, 0), 0), arrayMap(item -> tuple(accurateCastOrNull(indexOf(arraySlice(date_range, plus(start_interval_index, 2), 4), item.1), 'Int64'), item.2), _return_event_data)))).2 AS retention_value
+     FROM
+       (SELECT posthog_test_warehouse_charges.person_id AS actor_id,
+               groupArrayIf(tuple(toStartOfDay(toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC')), ifNull(accurateCastOrNull(posthog_test_warehouse_charges.amount, 'Float64'), 0.0), toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_charges/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `amount` Float64, `person_id` UUID, `charged_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_charges
+        GROUP BY actor_id
+        UNION ALL SELECT posthog_test_warehouse_charges.person_id AS actor_id,
+                         [] AS start_event_timestamps,
+                         groupArrayIf(tuple(toStartOfDay(toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC')), ifNull(accurateCastOrNull(posthog_test_warehouse_charges.amount, 'Float64'), 0.0), toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC')), and(greaterOrEquals(toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(posthog_test_warehouse_charges.charged_at, 'UTC'), toDateTime64('2025-01-06 00:00:00.000000', 6, 'UTC')))) AS return_event_timestamps
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse/posthog_test_warehouse_charges/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `amount` Float64, `person_id` UUID, `charged_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_charges
+        GROUP BY actor_id) AS retention_events
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS format_csv_allow_double_quotes=1,
+                        readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -438,14 +438,17 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
+        # Day 0 cohort = {user-1, user-2, user-4}; Day 1 cohort = {user-1, user-3};
+        # Day 2 cohort = {user-1, user-2}; Day 3 cohort = {user-3}; Day 4 cohort empty.
         self.assertEqual(
             pluck(result, "values", "count"),
-            pad([[3, 1, 2, 0], [1, 1, 1], [1, 1], [1]]),
+            pad([[3, 1, 2, 0], [2, 1, 1], [2, 0], [1], [0]]),
         )
 
+        # SUM(amount) per cohort/interval cell (interval 0 is the cohort day itself).
         self.assertEqual(
             pluck(result, "values", "aggregation_value"),
-            pad([[350, 20, 70, 0], [60, 0, 70], [70, 0], [0]]),
+            pad([[350, 20, 70, 0], [80, 30, 70], [70, 0], [70], [0]]),
         )
 
     @snapshot_clickhouse_queries

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -386,6 +386,69 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
         )
 
     @snapshot_clickhouse_queries
+    def test_retention_revenue_retention_data_warehouse(self):
+        person_ids = self._create_people()
+        charges_table = self._create_data_warehouse_table(
+            filename="warehouse_charges.csv",
+            table_name="warehouse_charges",
+            header=["id", "person_id", "amount", "charged_at"],
+            rows=[
+                # Day 0 cohort: user-1 ($50), user-2 ($100), user-4 ($200)
+                [1, person_ids["user-1"], 50, "2025-01-01 09:00:00"],
+                [2, person_ids["user-2"], 100, "2025-01-01 10:00:00"],
+                [3, person_ids["user-4"], 200, "2025-01-01 11:00:00"],
+                # Day 1 returns: user-1 ($20); new cohort: user-3 ($60)
+                [4, person_ids["user-1"], 20, "2025-01-02 09:00:00"],
+                [5, person_ids["user-3"], 60, "2025-01-02 10:00:00"],
+                # Day 2 returns: user-1 ($30), user-2 ($40)
+                [6, person_ids["user-1"], 30, "2025-01-03 09:00:00"],
+                [7, person_ids["user-2"], 40, "2025-01-03 10:00:00"],
+                # Day 3 returns: user-3 ($70)
+                [8, person_ids["user-3"], 70, "2025-01-04 09:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "amount": "Float64",
+                "charged_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        charges_entity = {
+            "id": charges_table,
+            "name": charges_table,
+            "type": "data_warehouse",
+            "table_name": charges_table,
+            "aggregation_target_field": "person_id",
+            "timestamp_field": "charged_at",
+        }
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "targetEntity": charges_entity,
+                    "returningEntity": charges_entity,
+                    "aggregationType": "sum",
+                    "aggregationProperty": "amount",
+                    "aggregationPropertyType": "data_warehouse",
+                },
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad([[3, 1, 2, 0], [1, 1, 1], [1, 1], [1]]),
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "aggregation_value"),
+            pad([[350, 20, 70, 0], [60, 0, 70], [70, 0], [0]]),
+        )
+
+    @snapshot_clickhouse_queries
     def test_retention_data_warehouse_and_events(self):
         person_ids = self._create_people()
         signups_table_name = self._create_data_warehouse_table(

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -161,6 +161,17 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.1
   '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.2
+  '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
@@ -179,7 +190,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -194,7 +213,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -204,8 +223,15 @@
                             and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
             quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
                             0) AS previous_avg_time_on_page
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
      GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
   LEFT JOIN
     (SELECT breakdown_value AS breakdown_value,
@@ -216,7 +242,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -226,7 +258,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -359,13 +391,90 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM events
+     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.2

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -609,6 +609,7 @@ class AssistantRecordingPropertyFilter4(BaseModel):
 class AggregationPropertyType(StrEnum):
     EVENT = "event"
     PERSON = "person"
+    DATA_WAREHOUSE = "data_warehouse"
 
 
 class AggregationType(StrEnum):
@@ -9678,7 +9679,7 @@ class AssistantRetentionFilter(BaseModel):
     )
     aggregationPropertyType: AggregationPropertyType | None = Field(
         default=AggregationPropertyType.EVENT,
-        description=("The type of property to aggregate on (event or person). Defaults to event."),
+        description=("The type of property to aggregate on (event, person, or data_warehouse). Defaults to event."),
     )
     aggregationType: AggregationType | None = Field(
         default=AggregationType.COUNT,
@@ -17362,7 +17363,7 @@ class RetentionFilter(BaseModel):
     )
     aggregationPropertyType: AggregationPropertyType | None = Field(
         default=AggregationPropertyType.EVENT,
-        description=("The type of property to aggregate on (event or person). Defaults to event."),
+        description=("The type of property to aggregate on (event, person, or data_warehouse). Defaults to event."),
     )
     aggregationType: AggregationType | None = Field(
         default=AggregationType.COUNT,

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2635,6 +2635,7 @@ export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[key
 export const AggregationPropertyTypeApi = {
     Event: 'event',
     Person: 'person',
+    DataWarehouse: 'data_warehouse',
 } as const
 
 export type AggregationTypeApi = (typeof AggregationTypeApi)[keyof typeof AggregationTypeApi]
@@ -2773,7 +2774,7 @@ export interface RetentionFilterApi {
      * @nullable
      */
     aggregationProperty?: string | null
-    /** The type of property to aggregate on (event or person). Defaults to event. */
+    /** The type of property to aggregate on (event, person, or data_warehouse). Defaults to event. */
     aggregationPropertyType?: AggregationPropertyTypeApi | null
     /** The aggregation type to use for retention */
     aggregationType?: AggregationTypeApi | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2957,6 +2957,7 @@ export namespace Schemas {
     export const AggregationPropertyType = {
       Event: 'event',
       Person: 'person',
+      DataWarehouse: 'data_warehouse',
     } as const;
 
     export type AggregationType = typeof AggregationType[keyof typeof AggregationType];
@@ -3080,7 +3081,7 @@ export namespace Schemas {
        * @nullable
        */
       aggregationProperty?: string | null;
-      /** The type of property to aggregate on (event or person). Defaults to event. */
+      /** The type of property to aggregate on (event, person, or data_warehouse). Defaults to event. */
       aggregationPropertyType?: AggregationPropertyType | null;
       /** The aggregation type to use for retention */
       aggregationType?: AggregationType | null;


### PR DESCRIPTION
## Problem

PostHog's retention insight already supports two independent features that don't yet compose: property aggregation (`aggregationType=sum|avg`) and data warehouse series as `targetEntity` / `returningEntity`. Combining them — the canonical "revenue retention" use case (e.g. `SUM(amount)` from a `charges` warehouse table) — was not implemented. The runner always resolved the aggregation property as `events.properties.<x>`, the DWH base query path discarded the aggregation branch, and the frontend property picker only offered event/person properties.

## Changes

- **Schema (source of truth)**: add `'data_warehouse'` as a third value to `aggregationPropertyType` in `frontend/src/queries/schema/schema-general.ts`, regenerate `schema.json`, mirror in `posthog/schema.py`.
- **Runner** (`retention_query_runner.py`): replace the cached `property_aggregation_expr` with `property_aggregation_expr_for(entity)` that resolves the chain per-entity — `["person","properties",x]` for person, bare `[x]` for DWH entities, `["events","properties",x]` otherwise. Mirrors how trends resolves `math_property` differently for `DataWarehouseNode` vs `EventsNode`. Keep `property_aggregation_expr` as a cached default for legacy events callers (start-side) so existing behaviour is preserved.
- **DWH base query** (`retention_base_query_fixed.py`):
  - `_build_dwh_retention_event_query` emits 3-tuples `(interval_start, value, actual_timestamp)` when aggregation is on, mirroring the legacy events aggregation path.
  - `_get_return_event_timestamps_expr` accepts an optional entity-specific `property_aggregation_expr` and `timestamp_field`.
  - `build_base_query_dwh` adds `_start_event_data` / `_return_event_data` aliases, exposes `start_event_timestamps` / `return_event_timestamps` as flat arrays extracted from the tuples, and selects `retention_value` so the existing reduction logic in `_get_intervals_from_base_exprs(has_property_aggregation_aliases=True)` works unchanged.
- **Frontend** (`RetentionAggregationSelector.tsx`): when at least one retention entity is DWH, source the table's column schema via `databaseTableListLogic.dataWarehouseTablesMap`, add the `DataWarehouseProperties` taxonomic group to the property picker, and round-trip the new `'data_warehouse'` value through `aggregationPropertyType`. When both entities are DWH and the user just enabled SUM/AVG, default to `'data_warehouse'`.
- **Test**: add `test_retention_revenue_retention_data_warehouse` to `test_retention_data_warehouse.py` mirroring the assertion shape from `test_retention_aggregation_sum`.

Scope is the fixed-interval path; rolling interval has no DWH support today.

## How did you test this code?

I'm an agent (PostHog Code, Claude Opus 4.7). I did not perform manual UI testing.

Automated checks I actually ran:
- `python3 -m py_compile` on all modified Python files — clean
- `ruff check` and `ruff format` on `posthog/hogql_queries/insights/retention` and `posthog/schema.py` — clean
- `pnpm --filter=@posthog/frontend run typescript:check` — no new retention-aggregation-selector errors (other errors are pre-existing kea-typegen issues unrelated to this change)
- `pnpm --filter=@posthog/frontend run schema:build:json` — regenerates `schema.json` cleanly
- `pytest --collect-only` on the new test — collected
- Imported the runner under Django and confirmed `property_aggregation_expr_for` returns `['amount']` for a DWH entity and `['events','properties','amount']` for an events entity

What I could **not** run in this environment (no Postgres / ClickHouse / Kafka):
- `hogli test posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py` — including the new `test_retention_revenue_retention_data_warehouse`
- The existing aggregation and DWH retention tests (regression check)
- `@snapshot_clickhouse_queries` snapshot review for the new test

The expected `count` and `aggregation_value` matrices in the new test were derived from the test data manually and may need refinement once the snapshot actually runs against ClickHouse — please confirm the matrices and snapshot before merge.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Implementation followed a detailed plan provided by Thomas (file paths and call sites identified up-front). Key implementation choices:

- Made `aggregationPropertyType=data_warehouse` an explicit third value rather than auto-detecting from entity type, so mixed events + DWH series with a shared property remain unambiguous.
- Reused the existing `_get_intervals_from_base_exprs(has_property_aggregation_aliases=True)` reduction logic as-is and only fed it the aliases — no math changes.
- For the empty placeholder array under UNION ALL on the DWH path, used `ast.Array(exprs=[])` (relies on ClickHouse type unification with the populated `Array(Tuple(...))` side). If type unification turns out to fail in practice, switch to an explicit typed empty array.

Requires human review — not self-merging. Snapshot output for the new test should be reviewed and the assertion matrices reconciled before merge.