### PR TITLE
fix(mcp): default product tag for queries from MCP

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -219,7 +219,17 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
             # QueryRunner.run or QueryRunner.calculate before sync_execute fires. Scenes not
             # registered in `_infer_query_tags` stay untagged — they surface as
             # UntaggedQueryError in DEBUG, which is the signal to add them.
-            if inferred_tags := _infer_query_tags(query):
+            inferred_tags = dict(_infer_query_tags(query))
+
+            # MCP clients (e.g. services/mcp/src/api/client.ts) don't attach
+            # `query.tags.scene`/`query.tags.productKey` to their payloads, which would
+            # leave `product` unset and trip UntaggedQueryError in DEBUG. Default the
+            # product to Product.MCP whenever the request advertises itself as MCP via
+            # the `X-PostHog-Client` header.
+            if "product" not in inferred_tags and request.headers.get("x-posthog-client") == "mcp":
+                inferred_tags["product"] = Product.MCP
+
+            if inferred_tags:
                 tag_queries(**inferred_tags)
             self._tag_client_query_id(client_query_id)
             analytics_props = get_request_analytics_properties(request)

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -39,6 +39,7 @@ class Product(StrEnum):
     LLM_ANALYTICS = "llm_analytics"
     LOGS = "logs"
     MAX_AI = "max_ai"
+    MCP = "mcp"
     MESSAGING = "messaging"
     MOBILE_REPLAY = "mobile_replay"
     PIPELINE_DESTINATIONS = "pipeline_destinations"


### PR DESCRIPTION
## Summary

MCP's `services/mcp/src/api/client.ts` posts to `/api/environments/:id/query/` without `query.tags.scene` or `query.tags.productKey`, so the `product` query tag was being left unset. With the enforcement added in #55901 that's an `UntaggedQueryError` in DEBUG (and will start failing on team 2 US soon), which MCP unfortunately swallows into the very misleading "you must pass your PostHog project's api key" surface that agents see.

This adds a backend-side fallback: when a request is identified as MCP via the `X-PostHog-Client: mcp` header (already attached by the MCP client on every request) and no other product tag has been inferred from the payload, default `product=Product.MCP`.

A new `Product.MCP = "mcp"` enum value is introduced for this. `source=mcp` and the `mcp_*` columns are already populated independently by the `CHQueries` middleware, so this PR only fills the missing `product` dimension.

### Why backend-side and not MCP-side

The MCP client constructs query payloads in many places (`client.ts` lines 575, 675, 705, 844, 905, 918, 951 — `experiments().getMetricResults`, `experiments().getExposures`, `insights().query`, `query().runQuery`, `query().trendsActors`, etc.). A single backend-side guard covers all of them and works for any future call site.

### Precedence preserved

- Frontend-supplied `query.tags.scene` / `tags.productKey` still wins via `_infer_query_tags` and the runner-level override at `posthog/hogql_queries/query_runner.py:1318`.
- Per-product `QueryRunner` subclasses that hardcode their product (e.g. `experiment_query_runner.py`, `experiment_exposures_query_runner.py`) still override via `tags_context(product=Product.EXPERIMENTS, …)` later in the runner's `with` block, so MCP experiment queries continue to be tagged `experiments` rather than `mcp`.
- Only purely-untagged MCP queries (today: trends/funnels/retention/lifecycle/paths/stickiness/llm-traces/error-tracking-issues/recordings-list/insight-query/query-run) end up with `product=mcp` instead of `product=null`.

### Follow-up worth doing in a separate PR

The cleaner long-term shape is per-tool `productKey` attribution on the MCP side — e.g. `query-wrapper-factory.ts` setting `productKey` based on its `kind` (`TrendsQuery` → `product_analytics`, `ErrorTrackingQuery` → `error_tracking`, `LLMTracesQuery` → `llm_analytics`, `RecordingsQuery` → `replay`), and `experiments/getResults.ts` setting `experiments`, etc. With that done, the `Product.MCP` fallback would only catch the genuinely product-less `query-run` (raw HogQL via the agent), which is the right semantic.

## Test plan

- [ ] Local DEBUG: hit `/api/environments/:id/query/` from an MCP client (e.g. `query-run` with a HogQLQuery via Claude Desktop / inspector) and confirm it no longer raises `UntaggedQueryError` and returns results.
- [ ] Hit the same endpoint from the web UI and confirm `product` still resolves to the scene-mapped product (e.g. `product_analytics` for an Insights query) — i.e. MCP fallback doesn't shadow the web tagging.
- [ ] Hit `experiment-getResults` from MCP and confirm queries are tagged `product=experiments` (runner override wins over the MCP fallback).


Made with [Cursor](https://cursor.com)