### PR TITLE
fix(llma): memoize dashboardLogic in reload action to avoid stale store path

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx
@@ -7,6 +7,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
@@ -39,6 +40,7 @@ export function LLMAnalyticsReloadAction(): JSX.Element {
         []
     )
     const boundLogic = dashboardLogicInstance || fallbackLogicInstance
+    useAttachedLogic(boundLogic, llmAnalyticsSharedLogic)
 
     const {
         itemsLoading: dashboardLoading,

--- a/products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import React from 'react'
 
 import { IconRefresh } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -21,18 +22,31 @@ export function LLMAnalyticsReloadAction(): JSX.Element {
     const { activeTab } = useValues(llmAnalyticsSharedLogic)
     const { selectedDashboardId } = useValues(llmAnalyticsDashboardLogic)
 
-    const shouldUseDashboardLogic = selectedDashboardId && activeTab === 'dashboard'
-    const dashboardLogicInstance = dashboardLogic({
-        id: selectedDashboardId || 0,
-        placement: DashboardPlacement.Builtin,
-    })
+    const shouldUseDashboardLogic = !!(selectedDashboardId && activeTab === 'dashboard')
+
+    // Memoize per-id so the previous dashboardLogic.<id> store path is released cleanly
+    // before the next one mounts; an unmemoized call on every render leaves selectors/
+    // listeners reading from an unmounted store and Kea throws "Can not find path".
+    const dashboardLogicInstance = React.useMemo(
+        () =>
+            selectedDashboardId
+                ? dashboardLogic({ id: selectedDashboardId, placement: DashboardPlacement.Builtin })
+                : null,
+        [selectedDashboardId]
+    )
+    const fallbackLogicInstance = React.useMemo(
+        () => dashboardLogic({ id: 0, placement: DashboardPlacement.Builtin }),
+        []
+    )
+    const boundLogic = dashboardLogicInstance || fallbackLogicInstance
+
     const {
         itemsLoading: dashboardLoading,
         effectiveLastRefresh,
         refreshMetrics,
         dashboardLoadData,
-    } = useValues(dashboardLogicInstance)
-    const { triggerDashboardRefresh } = useActions(dashboardLogicInstance)
+    } = useValues(boundLogic)
+    const { triggerDashboardRefresh } = useActions(boundLogic)
 
     const { reloadAll } = useActions(dataNodeCollectionLogic({ key: LLM_ANALYTICS_DATA_COLLECTION_NODE_ID }))
     const { reloadAll: reloadEvaluationMetrics } = useActions(


### PR DESCRIPTION
## Problem

Users loading the LLM analytics dashboard tab were hitting `[KEA] Can not find path "scenes.dashboard.dashboardLogic.1" in the store.` (issue `019da6d7-0220-7722-827a-e8dd06cf67a4`, first seen 2026-04-22). The error breaks the refresh interaction on the dashboard tab whenever `selectedDashboardId` changes.

`LLMAnalyticsReloadAction.tsx` called `dashboardLogic({ id: selectedDashboardId || 0, placement: Builtin })` unmemoized on every render and unconditionally bound `useValues` / `useActions` to it. When `selectedDashboardId` changed (tab switch, dashboard selection change, or deletion via the `selectedDashboardId` reducer in `llmAnalyticsDashboardLogic`), the previous `dashboardLogic.<id>` instance was unmounted while pending selectors/listeners (the `refreshAllDashboardItems` flow visible in the stack frame) still tried to `get()` from the old store path — Kea then threw.

The sister component `LLMAnalyticsScene.tsx:120-131` already used a `React.useMemo` + `fallbackLogicInstance` pattern (introduced in `3add019`, widened by `ac63f98` and `64060e8`); the reload action was simply never updated to match.

## Changes

In `products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx`:

- Wrap `dashboardLogicInstance` in `React.useMemo` keyed on `selectedDashboardId` so the store mount/unmount lifecycle stays in sync with React's render lifecycle.
- Add a stable memoized `fallbackLogicInstance` (`id: 0`) so `useValues` / `useActions` always bind to a stable reference, even when no dashboard is selected.
- Coerce `shouldUseDashboardLogic` to a real `boolean`.

`refreshAllDashboardItems` in `llmAnalyticsDashboardLogic.ts:153-180` already guards on `insightDataLogic.findMounted(insightProps)` before calling `loadData`, so no change is required there.

## How did you test this code?

I'm an agent — I did not perform manual testing in a browser.

- Confirmed the change compiles cleanly (`pnpm --filter=@posthog/frontend typescript:check` produced only pre-existing TS deprecation warnings unrelated to this file).
- Visually diffed against the analogous memoization pattern in `LLMAnalyticsScene.tsx:120-131` to confirm the fix matches the established convention.

A reviewer should manually verify by switching tabs / changing the selected LLM analytics dashboard while the reload control is mounted and confirming no Kea "Can not find path" exception fires.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) acting on a signal report linking the Kea exception to `LLMAnalyticsReloadAction.tsx`.
- Key decision: mirror the existing `useMemo` + fallback pattern from `LLMAnalyticsScene.tsx` rather than introduce a new abstraction, to keep the two consumers of `dashboardLogic` consistent.
- No automated tests added — the bug surfaces only via Kea runtime behavior across component remounts and is not currently covered by a Jest harness for this component.