### PR TITLE
fix(llm-analytics): surface BYOK admin restriction before clicking add key

### DIFF
--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -908,7 +908,6 @@ export function LLMProviderKeysSettings(): JSX.Element {
                                         type="primary"
                                         icon={<IconPlus />}
                                         onClick={() => setNewKeyModalOpen(true)}
-                                        disabledReason={restrictionReason}
                                     >
                                         Add API key
                                     </LemonButton>

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { IconPlus, IconRefresh, IconTrash } from '@posthog/icons'
 import {
+    LemonBanner,
     LemonButton,
     LemonInput,
     LemonModal,
@@ -862,6 +863,12 @@ export function LLMProviderKeysSettings(): JSX.Element {
                     <LemonSkeleton className="w-full h-64" />
                 ) : (
                     <>
+                        {restrictionReason && (
+                            <LemonBanner type="info">
+                                {restrictionReason} Ask a project admin to add or manage API keys on your behalf.
+                            </LemonBanner>
+                        )}
+
                         <div className="flex justify-between items-start">
                             <LemonButton
                                 type="primary"
@@ -882,18 +889,30 @@ export function LLMProviderKeysSettings(): JSX.Element {
                                 <IconKey className="text-muted text-4xl mb-4" />
                                 <h3 className="font-semibold mb-2">No API keys configured</h3>
                                 <p className="text-muted mb-4 text-center">
-                                    Add your API key for LLM analytics features with your own account.
-                                    <br />
-                                    Used for evaluations and the playground.
+                                    {restrictionReason ? (
+                                        <>
+                                            Only project admins can add API keys for LLM analytics.
+                                            <br />
+                                            Ask a project admin to add a key for evaluations and the playground.
+                                        </>
+                                    ) : (
+                                        <>
+                                            Add your API key for LLM analytics features with your own account.
+                                            <br />
+                                            Used for evaluations and the playground.
+                                        </>
+                                    )}
                                 </p>
-                                <LemonButton
-                                    type="primary"
-                                    icon={<IconPlus />}
-                                    onClick={() => setNewKeyModalOpen(true)}
-                                    disabledReason={restrictionReason}
-                                >
-                                    Add API key
-                                </LemonButton>
+                                {!restrictionReason && (
+                                    <LemonButton
+                                        type="primary"
+                                        icon={<IconPlus />}
+                                        onClick={() => setNewKeyModalOpen(true)}
+                                        disabledReason={restrictionReason}
+                                    >
+                                        Add API key
+                                    </LemonButton>
+                                )}
                             </div>
                         ) : (
                             <LemonTable


### PR DESCRIPTION
## Problem

Users following the 'Add your own API key' deep links from the LLM analytics Playground (`LLMAnalyticsPlaygroundScene.tsx`) and `ModelPicker` land on the BYOK settings page where the 'Add API key' button is silently disabled for non-admins. `LemonButton` with a `disabledReason` only renders a tooltip on hover and swallows clicks, so non-admins reaching this page are stuck with no visible explanation. A `blocking_exception` problem flagged on a session replay confirmed users abandoning the task at this button.

The Admin-only gate was introduced when LLM analytics settings were migrated to project access control, but the UI surface didn't communicate the restriction.

## Changes

- Render a `LemonBanner` at the top of `LLMProviderKeysSettings` when `restrictionReason` is set, quoting the restriction message and directing the user to a project admin.
- Replace the empty-state primary CTA with explanatory copy for restricted users instead of a non-functional disabled button. Admins see the original copy and CTA unchanged.
- The toolbar 'Add API key' button keeps its `disabledReason` tooltip as a backstop.

## How did you test this code?

I'm an agent. I ran:
- `tsc --noEmit` against `frontend/tsconfig.json` — no new errors (only the two pre-existing TS deprecation warnings on `baseUrl` / `moduleResolution` that exist on master).

No manual UI verification was performed — please verify the banner copy and empty-state behavior render correctly for both restricted (non-admin) and unrestricted (admin) users before merging.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code agent based on a signal report tying a `blocking_exception` session replay to the disabled 'Add API key' button introduced when LLM analytics settings moved to project access control.
- Implementation chose option 1 from the report (banner + empty-state copy) over also gating the upstream Playground / ModelPicker links, since one centralized check covers every entry point and avoids duplicating access-level logic.
- Task-Id: 6f712e6e-88dd-4a87-bfb4-2a6009f8e8cd