### PR TITLE
fix(llma): clarify playground metric tags are display-only

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
@@ -40,10 +40,16 @@ export function MetadataHeader({
         <div className={clsx('flex flex-wrap gap-2', className)}>
             {isError && <LemonTag type="danger">Error</LemonTag>}
             {typeof latency === 'number' && (
-                <MetadataTag label="Latency">{`${Math.round(latency * 10e2) / 10e2}s latency`}</MetadataTag>
+                <MetadataTag
+                    label="Latency"
+                    tooltipContent="End-to-end latency from request to final response."
+                >{`${Math.round(latency * 10e2) / 10e2}s latency`}</MetadataTag>
             )}
             {typeof timeToFirstToken === 'number' && isStreaming && (
-                <MetadataTag label="Time to first token">
+                <MetadataTag
+                    label="Time to first token"
+                    tooltipContent="Time between sending the request and receiving the first streamed token."
+                >
                     {timeToFirstToken < 1
                         ? `${Math.round(timeToFirstToken * 1000)} ms`
                         : `${timeToFirstToken.toFixed(2)}s TTFT`}
@@ -51,17 +57,28 @@ export function MetadataHeader({
             )}
             {timestamp && <MetadataTag label="Timestamp">{dayjs(timestamp).format('MMM D, YYYY h:mm A')}</MetadataTag>}
             {typeof inputTokens === 'number' && typeof outputTokens === 'number' && (
-                <MetadataTag label="Token usage">
+                <MetadataTag
+                    label="Token usage"
+                    tooltipContent={`Prompt: ${inputTokens} · Completion: ${outputTokens} · Total: ${
+                        inputTokens + outputTokens
+                    }`}
+                >
                     {`${inputTokens} prompt tokens → ${outputTokens} completion tokens (∑ ${
                         inputTokens + outputTokens
                     })`}
                 </MetadataTag>
             )}
             {typeof cacheReadTokens === 'number' && cacheReadTokens > 0 && (
-                <MetadataTag label="Cache read">{`${cacheReadTokens} cache read tokens`}</MetadataTag>
+                <MetadataTag
+                    label="Cache read"
+                    tooltipContent="Prompt tokens served from the provider's cache (cheaper, faster)."
+                >{`${cacheReadTokens} cache read tokens`}</MetadataTag>
             )}
             {typeof cacheWriteTokens === 'number' && cacheWriteTokens > 0 && (
-                <MetadataTag label="Cache write">{`${cacheWriteTokens} cache write tokens`}</MetadataTag>
+                <MetadataTag
+                    label="Cache write"
+                    tooltipContent="Prompt tokens written to the provider's cache for reuse on subsequent calls."
+                >{`${cacheWriteTokens} cache write tokens`}</MetadataTag>
             )}
             {model && (
                 <MetadataTag label="Model" textToCopy={lowercaseFirstLetter(model)}>

--- a/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
@@ -59,9 +59,7 @@ export function MetadataHeader({
             {typeof inputTokens === 'number' && typeof outputTokens === 'number' && (
                 <MetadataTag
                     label="Token usage"
-                    tooltipContent={`Prompt: ${inputTokens} · Completion: ${outputTokens} · Total: ${
-                        inputTokens + outputTokens
-                    }`}
+                    tooltipContent="Input and output tokens consumed by this generation call."
                 >
                     {`${inputTokens} prompt tokens → ${outputTokens} completion tokens (∑ ${
                         inputTokens + outputTokens

--- a/products/llm_analytics/frontend/components/MetadataTag.tsx
+++ b/products/llm_analytics/frontend/components/MetadataTag.tsx
@@ -10,8 +10,9 @@ interface MetadataTagProps {
 }
 
 export function MetadataTag({ children, label, textToCopy, tooltipContent }: MetadataTagProps): JSX.Element {
+    const isCopyable = typeof textToCopy === 'string' && typeof children === 'string'
     let wrappedChildren: React.ReactNode = children
-    if (typeof textToCopy === 'string' && typeof children === 'string') {
+    if (isCopyable) {
         wrappedChildren = (
             <CopyToClipboardInline iconSize="xsmall" description={textToCopy} tooltipMessage={label}>
                 {children}
@@ -21,5 +22,6 @@ export function MetadataTag({ children, label, textToCopy, tooltipContent }: Met
         wrappedChildren = <Tooltip title={tooltipContent ?? label}>{children}</Tooltip>
     }
 
-    return <LemonTag className="bg-surface-primary cursor-default">{wrappedChildren}</LemonTag>
+    const cursorClass = isCopyable ? 'cursor-default' : 'cursor-help'
+    return <LemonTag className={`bg-surface-primary ${cursorClass}`}>{wrappedChildren}</LemonTag>
 }


### PR DESCRIPTION
## Problem

A signal report flagged that users running prompts in the LLM analytics Playground click on the latency / tokens / TTFT tags expecting a detail action and get nothing back. The tags use `LemonTag` styling that reads as clickable, but only the cost tag actually has rich tooltip content (`CostBreakdownTooltip`); every other metric falls through to a tooltip whose title is just the metric label. The `cursor-default` class also doesn't communicate "informational" — it just neutralizes the pointer.

## Changes

- `products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx` — pass meaningful `tooltipContent` to the latency, TTFT, token usage, cache read, and cache write tags so hovering surfaces what the metric means / how it's measured, instead of repeating the visible label.
- `products/llm_analytics/frontend/components/MetadataTag.tsx` — for non-copyable tags (everything except `model`), switch the cursor from `cursor-default` to `cursor-help`. Copyable tags keep their existing cursor since `CopyToClipboardInline` renders its own affordance.

This is the "add a clear affordance that these are display-only" branch of the signal's resolution suggestions, kept narrow so the change is reviewable in one pass. Wiring tags through to the underlying trace would be a larger follow-up.

## How did you test this code?

I'm an agent. I did not run a browser or the dev server. Verified only:
- Read all `MetadataTag` call sites in `products/llm_analytics/frontend/` (only `MetadataHeader.tsx` and `EvaluationDisplay.tsx`) — the new `tooltipContent` prop is already part of the existing `MetadataTagProps` interface, so existing callers are unaffected.
- The cursor branch keys off `isCopyable` which mirrors the original copy-vs-tooltip branch, so behavior for `textToCopy` callers is unchanged.

`pnpm typescript:check` was not runnable in the sandbox (no `node_modules`).

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code agent in response to a signal report on session `019dc5ee-f23f-78e4-862e-145bf0a1d9e4`. The same signal also flagged a recurring `TypeError: b is not a function` on `/llm-analytics/evaluations/new` (fingerprint `d16ce336…`, 221 occurrences across 34 sessions in 7d). That part is **not addressed here** — exceptions in the report are minified with no `\$exception_stack_trace_raw`, and reviewing the suspected regression-window commits (`486bce3e4a`, `7f0d4e5f17`, plus the follow-ups `b51476fa7c` and `7ac30dd32e`) didn't surface an obvious undefined-as-function. A separate source-mapped reproduction is needed before patching.

Task: 5bfec76d-ab9c-4fe5-b620-eb4634ba3b4c