### PR TITLE
fix(llma): surface feedback when create-evaluation button is inert

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -155,7 +155,6 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         (c) => c.rollout_percentage > 100 || c.rollout_percentage < 0
     )
     const hasConditions = evaluation.conditions.length > 0
-    const saveButtonDisabled = !basicFieldsValid
     const saveButtonDisabledReason = !hasName
         ? 'Add a name for this evaluation'
         : !configValid
@@ -259,7 +258,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                             <LemonButton
                                 type="primary"
                                 onClick={handleSave}
-                                disabledReason={saveButtonDisabled ? saveButtonDisabledReason : undefined}
+                                disabledReason={saveButtonDisabledReason}
                                 loading={evaluationFormSubmitting}
                             >
                                 {isNewEvaluation ? 'Create evaluation' : 'Save changes'}

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -21,6 +21,7 @@ import {
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
@@ -147,24 +148,49 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
     const configValid = isHog
         ? evaluation.evaluation_config.source.trim().length > 0
         : evaluation.evaluation_config.prompt.trim().length > 0
-    const basicFieldsValid = evaluation.name.length > 0 && configValid
+    const hasName = evaluation.name.length > 0
+    const basicFieldsValid = hasName && configValid
     const percentageUnset = evaluation.conditions.some((c) => c.rollout_percentage === 0)
+    const percentageOutOfRange = evaluation.conditions.some(
+        (c) => c.rollout_percentage > 100 || c.rollout_percentage < 0
+    )
+    const hasConditions = evaluation.conditions.length > 0
     const saveButtonDisabled = !basicFieldsValid
+    const saveButtonDisabledReason = !hasName
+        ? 'Add a name for this evaluation'
+        : !configValid
+          ? isHog
+              ? 'Add evaluation code before saving'
+              : 'Add an evaluation prompt before saving'
+          : undefined
+
+    const focusTriggers = (): void => {
+        setActiveTab('configuration')
+        requestAnimationFrame(() => {
+            triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        })
+    }
 
     const handleSave = (): void => {
-        // If percentage is unset but other fields are valid, switch to settings and scroll to triggers
         if (basicFieldsValid && percentageUnset) {
-            setActiveTab('configuration')
-            requestAnimationFrame(() => {
-                triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-            })
+            focusTriggers()
+            lemonToast.warning('Set a sampling percentage between 0.1% and 100% for every condition set before saving.')
             return
         }
 
-        // Otherwise proceed with save if form is valid
-        if (formValid) {
-            saveEvaluation()
+        if (!formValid) {
+            if (!hasConditions) {
+                lemonToast.error('Add at least one condition set before saving.')
+            } else if (percentageOutOfRange) {
+                lemonToast.error('Sampling percentage must be between 0.1% and 100%.')
+            } else {
+                lemonToast.error('Some required fields are missing. Please review the configuration.')
+            }
+            focusTriggers()
+            return
         }
+
+        saveEvaluation()
     }
 
     const handleCancel = (): void => {
@@ -233,7 +259,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                             <LemonButton
                                 type="primary"
                                 onClick={handleSave}
-                                disabled={saveButtonDisabled}
+                                disabledReason={saveButtonDisabled ? saveButtonDisabledReason : undefined}
                                 loading={evaluationFormSubmitting}
                             >
                                 {isNewEvaluation ? 'Create evaluation' : 'Save changes'}

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -268,6 +268,27 @@ describe('llmEvaluationLogic', () => {
                 await expectLogic(logic).toMatchValues({ formValid: false })
             })
 
+            it('returns false when conditions array is empty', async () => {
+                await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
+                logic.actions.setEvaluationName('Valid Name')
+                logic.actions.setEvaluationPrompt('Valid prompt')
+                logic.actions.setTriggerConditions([])
+
+                await expectLogic(logic).toMatchValues({ formValid: false })
+            })
+
+            it.each([
+                ['rollout_percentage of 0', 0],
+                ['rollout_percentage above 100', 150],
+            ])('returns false when %s', async (_label, percentage) => {
+                await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
+                logic.actions.setEvaluationName('Valid Name')
+                logic.actions.setEvaluationPrompt('Valid prompt')
+                logic.actions.setTriggerConditions([{ id: 'c1', rollout_percentage: percentage, properties: [] }])
+
+                await expectLogic(logic).toMatchValues({ formValid: false })
+            })
+
             it('returns true when all fields valid', async () => {
                 await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
                 logic.actions.setEvaluationName('Valid Name')


### PR DESCRIPTION
## Problem

A signal report (session replay `019dc5ee-f23f-78e4-862e-145bf0a1d9e4`) showed a user repeatedly clicking the **Create evaluation** button on a new LLM-judge evaluation form and getting nothing back — no toast, no inline error, no navigation. The user eventually figured it out, but the form felt broken.

Root cause is in `LLMAnalyticsEvaluation.tsx`'s `handleSave`: the button is only `disabled` when name + prompt/source are missing, so once those are filled it stays clickable. But `formValid` (in `llmEvaluationLogic.ts`) also requires `conditions.length > 0` and `0 < rollout_percentage <= 100`. When those fail, `handleSave` either silently switched tabs (zero percentage) or did nothing at all (empty conditions / out-of-range percentage). The default rollout for a new condition is `0`, so the silent-tab-switch case is the common path.

## Changes

`products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx`
- Replaced the silent no-op branches in \`handleSave\` with \`lemonToast\` feedback that names the missing field — warning for the percentage-unset case (paired with the existing tab-switch + scroll), and a targeted error toast for empty conditions / out-of-range percentage / generic invalidity.
- Switched the primary button from bare \`disabled\` to \`disabledReason\`, so the disabled-state tooltip explains what to fill in (name, prompt, or Hog code).

\`products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts\`
- Added regression tests for \`formValid\` covering the empty-conditions case and the rollout \`0\` / \`>100\` cases (parameterized).

## How did you test this code?

I'm an agent. I only ran the automated test suite for the evaluation logic — \`pnpm jest products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts\` (54 tests pass, including the 3 new ones). No manual UI testing was performed; a human reviewer should verify the toast and tooltip behavior in the browser before merging.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Task \`ad59d8b9-7c0f-43ba-a772-c3b8cb7ba958\`) in response to a signal report describing inert **Create evaluation** clicks on a 'Helpfulness' LLM-judge evaluation. Key decisions:
- Kept the button enabled once basic fields are filled (rather than tightening \`saveButtonDisabled\` to also require \`formValid\`) so users discover the percentage requirement via toast + tab-switch instead of a silently-disabled button.
- Used \`disabledReason\` instead of \`disabled\` so the existing disabled state (missing name / prompt / code) now explains itself via tooltip.
- Did not touch \`formValid\` itself — only added tests around its existing semantics.