### PR TITLE
feat(signals): replace per-tick cap with cityHash64 sample rate

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -121,6 +121,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         hogql_query_modifiers: HogQLQueryModifiers | None = None,
         allow_event_property_expansion: bool = False,
         max_execution_time: int | None = None,
+        extra_having_predicates: list[ast.Expr] | None = None,
         **_,
     ):
         # TRICKY: we need to make sure we init test account filters only once,
@@ -181,6 +182,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         self._hogql_query_modifiers = hogql_query_modifiers
         self._allow_event_property_expansion = allow_event_property_expansion
         self._max_execution_time = max_execution_time
+        self._extra_having_predicates = extra_having_predicates or []
 
     @tracer.start_as_current_span("SessionRecordingListFromQuery.run")
     def run(self) -> SessionRecordingQueryResult:
@@ -465,5 +467,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
 
         if self._query.having_predicates:
             exprs.append(property_to_expr(self._query.having_predicates, team=self._team, scope="replay"))
+
+        exprs.extend(self._extra_having_predicates)
 
         return ast.And(exprs=exprs)

--- a/posthog/temporal/session_replay/summarization_sweep/activities.py
+++ b/posthog/temporal/session_replay/summarization_sweep/activities.py
@@ -1,5 +1,5 @@
-import re
 from collections import Counter
+from datetime import UTC, datetime
 
 import structlog
 from temporalio import activity
@@ -8,11 +8,12 @@ from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.sync import database_sync_to_async, database_sync_to_async_pool
 from posthog.temporal.common.client import async_connect
-from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY
+from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.summarization_sweep.constants import (
     CH_QUERY_MAX_EXECUTION_SECONDS,
     SCHEDULE_ID_PREFIX,
     SCHEDULE_TYPE,
+    STUCK_RASTERIZE_LOOKBACK,
     STUCK_RASTERIZE_THRESHOLD,
     WORKFLOW_NAME,
 )
@@ -22,7 +23,10 @@ from posthog.temporal.session_replay.summarization_sweep.models import (
     FindSessionsResult,
     UpsertTeamScheduleInput,
 )
-from posthog.temporal.session_replay.summarization_sweep.session_candidates import fetch_recent_session_ids
+from posthog.temporal.session_replay.summarization_sweep.session_candidates import (
+    coerce_sample_rate,
+    fetch_recent_session_ids,
+)
 
 from products.signals.backend.models import SignalSourceConfig
 
@@ -41,17 +45,8 @@ def _is_team_summarization_allowed(team_id: int) -> bool:
     ).exists()
 
 
-def _select_summarization_user(team: Team) -> User | None:
+def _select_summarization_user(team: Team, config: SignalSourceConfig | None) -> User | None:
     # Stability matters: the chosen user is embedded in the child's `redis_key_base`.
-    config = (
-        SignalSourceConfig.objects.filter(
-            team_id=team.id,
-            source_product=SignalSourceConfig.SourceProduct.SESSION_REPLAY,
-            source_type=SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER,
-        )
-        .select_related("created_by")
-        .first()
-    )
     if config is not None and config.created_by_id is not None:
         return config.created_by
     return team.all_users_with_access().order_by("id").first()
@@ -59,45 +54,52 @@ def _select_summarization_user(team: Team) -> User | None:
 
 def _load_team_user_and_sessions(team_id: int, lookback_minutes: int) -> tuple[Team, list[str], User | None]:
     team = Team.objects.get(id=team_id)
+    config = (
+        SignalSourceConfig.objects.filter(
+            team_id=team_id,
+            source_product=SignalSourceConfig.SourceProduct.SESSION_REPLAY,
+            source_type=SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER,
+            enabled=True,
+        )
+        .select_related("created_by")
+        .first()
+    )
+    # Race: was enabled at `_is_team_summarization_allowed`, now disabled. No-op cycle.
+    if config is None:
+        return team, [], None
+    raw_filters = config.config.get("recording_filters")
     session_ids = fetch_recent_session_ids(
         team=team,
         lookback_minutes=lookback_minutes,
+        sample_rate=coerce_sample_rate(config.config.get("sample_rate")),
+        recording_filters=raw_filters if isinstance(raw_filters, dict) else None,
         max_execution_time_seconds=CH_QUERY_MAX_EXECUTION_SECONDS,
     )
     if not session_ids:
         return team, [], None
-    return team, session_ids, _select_summarization_user(team)
+    return team, session_ids, _select_summarization_user(team, config)
 
 
-# Session ids land here from ClickHouse and originate at SDK clients. Rejecting anything
-# outside this shape keeps untrusted input out of the Temporal visibility query string.
-_SAFE_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,100}$")
-
-
-async def _stuck_session_ids(session_ids: list[str]) -> set[str]:
+async def _stuck_session_ids(team_id: int, session_ids: list[str]) -> set[str]:
     if not session_ids:
         return set()
-    safe_ids = [sid for sid in session_ids if _SAFE_SESSION_ID_RE.match(sid)]
-    if len(safe_ids) < len(session_ids):
-        logger.warning(
-            "summarization_sweep.unsafe_session_id_dropped",
-            count=len(session_ids) - len(safe_ids),
-        )
-    if not safe_ids:
-        return set()
+    candidate_set = set(session_ids)
     try:
         client = await async_connect()
-        ids_clause = ",".join(f'"{sid}"' for sid in safe_ids)
+        cutoff = (datetime.now(UTC) - STUCK_RASTERIZE_LOOKBACK).strftime("%Y-%m-%dT%H:%M:%S.000Z")
         query = (
             f'WorkflowType = "rasterize-recording" '
             f'AND ExecutionStatus IN ("Failed", "TimedOut") '
-            f"AND {POSTHOG_SESSION_RECORDING_ID_KEY.name} IN ({ids_clause})"
+            f"AND {POSTHOG_TEAM_ID_KEY.name} = {team_id} "
+            f'AND CloseTime > "{cutoff}"'
         )
         failures: Counter[str] = Counter()
         async for wf in client.list_workflows(query=query):
             for pair in wf.typed_search_attributes:
                 if pair.key.name == POSTHOG_SESSION_RECORDING_ID_KEY.name:
-                    failures[pair.value] += 1
+                    sid = pair.value
+                    if sid in candidate_set:
+                        failures[sid] += 1
                     break
         return {sid for sid, n in failures.items() if n >= STUCK_RASTERIZE_THRESHOLD}
     except Exception as exc:
@@ -127,8 +129,8 @@ async def find_sessions_for_team_activity(inputs: FindSessionsInput) -> FindSess
         session_ids=session_ids,
         extra_summary_context=None,
     )
-    sessions_to_summarize = [sid for sid in session_ids if not existing_summaries.get(sid)][: inputs.max_sessions]
-    stuck = await _stuck_session_ids(sessions_to_summarize)
+    sessions_to_summarize = [sid for sid in session_ids if not existing_summaries.get(sid)]
+    stuck = await _stuck_session_ids(inputs.team_id, sessions_to_summarize)
     sessions_to_summarize = [sid for sid in sessions_to_summarize if sid not in stuck]
 
     return FindSessionsResult(

--- a/posthog/temporal/session_replay/summarization_sweep/constants.py
+++ b/posthog/temporal/session_replay/summarization_sweep/constants.py
@@ -16,6 +16,11 @@ SESSION_LOOKBACK_MINUTES = 30
 SAMPLE_RATE_PRECISION = 10_000
 DEFAULT_SAMPLE_RATE = 1.0
 
+# Cap on concurrent `start_child_workflow` calls per tick. Bounds the parent's
+# task-queue pressure and the elapsed time of the dispatch loop within the
+# WORKFLOW_EXECUTION_TIMEOUT budget. Higher = more in-flight starts per batch.
+CHILD_DISPATCH_BATCH_SIZE = 100
+
 # Stops the redispatch loop on recordings the rasterizer can't process.
 STUCK_RASTERIZE_THRESHOLD = 3
 STUCK_RASTERIZE_LOOKBACK = timedelta(hours=2)

--- a/posthog/temporal/session_replay/summarization_sweep/constants.py
+++ b/posthog/temporal/session_replay/summarization_sweep/constants.py
@@ -14,7 +14,7 @@ SCHEDULE_INTERVAL = timedelta(minutes=5)
 SESSION_LOOKBACK_MINUTES = 30
 
 SAMPLE_RATE_PRECISION = 10_000
-DEFAULT_SAMPLE_RATE = 1.0
+DEFAULT_SAMPLE_RATE = 0.1
 
 # Cap on concurrent `start_child_workflow` calls per tick. Bounds the parent's
 # task-queue pressure and the elapsed time of the dispatch loop within the

--- a/posthog/temporal/session_replay/summarization_sweep/constants.py
+++ b/posthog/temporal/session_replay/summarization_sweep/constants.py
@@ -13,10 +13,12 @@ SCHEDULE_INTERVAL = timedelta(minutes=5)
 # up on the next one.
 SESSION_LOOKBACK_MINUTES = 30
 
-MAX_SESSIONS_PER_TEAM = 10
+SAMPLE_RATE_PRECISION = 10_000
+DEFAULT_SAMPLE_RATE = 1.0
 
 # Stops the redispatch loop on recordings the rasterizer can't process.
 STUCK_RASTERIZE_THRESHOLD = 3
+STUCK_RASTERIZE_LOOKBACK = timedelta(hours=2)
 
 CH_QUERY_MAX_EXECUTION_SECONDS = 180
 

--- a/posthog/temporal/session_replay/summarization_sweep/models.py
+++ b/posthog/temporal/session_replay/summarization_sweep/models.py
@@ -11,7 +11,6 @@ class SummarizeTeamSessionsInputs:
 class FindSessionsInput:
     team_id: int
     lookback_minutes: int
-    max_sessions: int
 
 
 @dataclass

--- a/posthog/temporal/session_replay/summarization_sweep/session_candidates.py
+++ b/posthog/temporal/session_replay/summarization_sweep/session_candidates.py
@@ -62,7 +62,8 @@ def _build_user_defined_query(recording_filters: dict | None) -> RecordingsQuery
 
 
 def coerce_sample_rate(value: object) -> float:
-    if value is None:
+    # `isinstance(True, int)` is True — reject bools so `float(True)` doesn't slip through as 1.0.
+    if value is None or isinstance(value, bool):
         return DEFAULT_SAMPLE_RATE
     try:
         rate = float(value)  # type: ignore[arg-type]

--- a/posthog/temporal/session_replay/summarization_sweep/session_candidates.py
+++ b/posthog/temporal/session_replay/summarization_sweep/session_candidates.py
@@ -6,14 +6,15 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.schema import PropertyOperator, RecordingPropertyFilter, RecordingsQuery
 
+from posthog.hogql import ast
+
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.exceptions_capture import capture_exception
 from posthog.models.team import Team
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.temporal.session_replay.count_playlist_items import convert_filters_to_recordings_query
-
-from products.signals.backend.models import SignalSourceConfig
+from posthog.temporal.session_replay.summarization_sweep.constants import DEFAULT_SAMPLE_RATE, SAMPLE_RATE_PRECISION
 
 from ee.hogai.session_summaries.constants import (
     MAX_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S,
@@ -49,45 +50,59 @@ if not settings.DEBUG:
 _DEFAULT_FILTER_TEST_ACCOUNTS = False  # Summarize all sessions (it's also faster to skip this filter)
 
 
-class _SourceNotEnabled(Exception):
-    pass
-
-
-def _load_user_defined_recordings_query(team_id: int) -> RecordingsQuery | None:
-    try:
-        config = SignalSourceConfig.objects.get(
-            team_id=team_id,
-            source_product=SignalSourceConfig.SourceProduct.SESSION_REPLAY,
-            source_type=SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER,
-            enabled=True,
-        )
-    except SignalSourceConfig.DoesNotExist:
-        # Config disabled mid-cycle — distinguish from the "enabled but no filters" case below.
-        raise _SourceNotEnabled() from None
-
-    try:
-        recording_filters = config.config.get("recording_filters")
-        if recording_filters and isinstance(recording_filters, dict):
-            return convert_filters_to_recordings_query(recording_filters)
+def _build_user_defined_query(recording_filters: dict | None) -> RecordingsQuery | None:
+    if not recording_filters or not isinstance(recording_filters, dict):
         return None
+    try:
+        return convert_filters_to_recordings_query(recording_filters)
     except Exception as e:
         capture_exception(e)
         # Include type so distinct bugs don't collapse into one Sentry group.
         raise ApplicationError(f"Error loading user defined recordings query: {type(e).__name__}: {e}") from e
 
 
+def coerce_sample_rate(value: object) -> float:
+    if value is None:
+        return DEFAULT_SAMPLE_RATE
+    try:
+        rate = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return DEFAULT_SAMPLE_RATE
+    if rate != rate:  # NaN
+        return DEFAULT_SAMPLE_RATE
+    return max(0.0, min(1.0, rate))
+
+
+def _sampling_having_predicate(sample_rate: float) -> ast.Expr | None:
+    if sample_rate >= 1.0:
+        return None
+    threshold = max(0, int(sample_rate * SAMPLE_RATE_PRECISION))
+    if threshold <= 0:
+        return ast.Constant(value=False)
+    return ast.CompareOperation(
+        op=ast.CompareOperationOp.Lt,
+        left=ast.Call(
+            name="modulo",
+            args=[
+                ast.Call(name="cityHash64", args=[ast.Field(chain=["session_id"])]),
+                ast.Constant(value=SAMPLE_RATE_PRECISION),
+            ],
+        ),
+        right=ast.Constant(value=threshold),
+    )
+
+
 def fetch_recent_session_ids(
     team: Team,
     lookback_minutes: int,
     *,
+    sample_rate: float = DEFAULT_SAMPLE_RATE,
+    recording_filters: dict | None = None,
     limit: int = MAX_CANDIDATE_SESSIONS,
     max_execution_time_seconds: int = HOGQL_INCREASED_MAX_EXECUTION_TIME,
 ) -> list[str]:
     """Fetch session IDs of recordings that ended within the lookback period."""
-    try:
-        user_defined_query = _load_user_defined_recordings_query(team.id)
-    except _SourceNotEnabled:
-        return []
+    user_defined_query = _build_user_defined_query(recording_filters)
     if user_defined_query:
         # Running a RecordingsQuery for consistency with the session recordings API
         query = RecordingsQuery(
@@ -111,11 +126,13 @@ def fetch_recent_session_ids(
             having_predicates=_BASELINE_HAVING_PREDICATES,
         )
 
+    sampling_predicate = _sampling_having_predicate(sample_rate)
     with tags_context(product=Product.SESSION_SUMMARY, feature=Feature.ENRICHMENT):
         result = SessionRecordingListFromQuery(
             team=team,
             query=query,
             max_execution_time=max_execution_time_seconds,
+            extra_having_predicates=[sampling_predicate] if sampling_predicate is not None else None,
         ).run()
 
     return [recording["session_id"] for recording in result.results]

--- a/posthog/temporal/session_replay/summarization_sweep/workflow.py
+++ b/posthog/temporal/session_replay/summarization_sweep/workflow.py
@@ -17,6 +17,7 @@ from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.summarization_sweep.constants import (
+    CHILD_DISPATCH_BATCH_SIZE,
     FIND_ACTIVITY_TIMEOUT,
     SESSION_LOOKBACK_MINUTES,
     WORKFLOW_NAME,
@@ -104,27 +105,29 @@ class SummarizeTeamSessionsWorkflow(PostHogWorkflow):
                 "dry_run": True,
             }
 
-        start_results = await asyncio.gather(
-            *(
-                self._start_child(inputs.team_id, sid, result.user_id, result.user_distinct_id)
-                for sid in result.session_ids
-            ),
-            return_exceptions=True,
-        )
+        # Batched fan-out so that even at high sample rates / large candidate sets we don't blow
+        # past the workflow execution timeout with thousands of concurrent `start_child_workflow`
+        # calls in flight. Each batch awaits before starting the next.
         started = 0
         skipped = 0
         failed = 0
-        for r in start_results:
-            if isinstance(r, BaseException):
-                failed += 1
-                workflow.logger.warning(
-                    "summarization_sweep.start_child_failed",
-                    extra={"team_id": inputs.team_id, "error": str(r)},
-                )
-            elif r:
-                started += 1
-            else:
-                skipped += 1
+        for batch_start in range(0, len(result.session_ids), CHILD_DISPATCH_BATCH_SIZE):
+            batch = result.session_ids[batch_start : batch_start + CHILD_DISPATCH_BATCH_SIZE]
+            batch_results = await asyncio.gather(
+                *(self._start_child(inputs.team_id, sid, result.user_id, result.user_distinct_id) for sid in batch),
+                return_exceptions=True,
+            )
+            for r in batch_results:
+                if isinstance(r, BaseException):
+                    failed += 1
+                    workflow.logger.warning(
+                        "summarization_sweep.start_child_failed",
+                        extra={"team_id": inputs.team_id, "error": str(r)},
+                    )
+                elif r:
+                    started += 1
+                else:
+                    skipped += 1
 
         # All-fail is systemic (queue config, permissions, Temporal outage) — surface it.
         if failed > 0 and started == 0 and skipped == 0:

--- a/posthog/temporal/session_replay/summarization_sweep/workflow.py
+++ b/posthog/temporal/session_replay/summarization_sweep/workflow.py
@@ -18,7 +18,6 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.session_replay.summarization_sweep.constants import (
     FIND_ACTIVITY_TIMEOUT,
-    MAX_SESSIONS_PER_TEAM,
     SESSION_LOOKBACK_MINUTES,
     WORKFLOW_NAME,
 )
@@ -56,7 +55,6 @@ class SummarizeTeamSessionsWorkflow(PostHogWorkflow):
                 FindSessionsInput(
                     team_id=inputs.team_id,
                     lookback_minutes=SESSION_LOOKBACK_MINUTES,
-                    max_sessions=MAX_SESSIONS_PER_TEAM,
                 )
             ],
             start_to_close_timeout=FIND_ACTIVITY_TIMEOUT,

--- a/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
@@ -395,9 +395,11 @@ async def test_stuck_session_ids_thresholds_failures():
 @pytest.mark.asyncio
 async def test_stuck_session_ids_filters_by_team_and_close_time():
     """The visibility query must scope to the calling team and a bounded `CloseTime` window."""
+    from freezegun import freeze_time
     from unittest.mock import AsyncMock, MagicMock
 
     from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+    from posthog.temporal.session_replay.summarization_sweep.constants import STUCK_RASTERIZE_LOOKBACK
 
     client = MagicMock()
     captured: list[str] = []
@@ -407,9 +409,15 @@ async def test_stuck_session_ids_filters_by_team_and_close_time():
         return _AsyncIter([])
 
     client.list_workflows = _list_workflows
-    with patch(
-        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
-        AsyncMock(return_value=client),
+    frozen = "2026-05-02T12:00:00"
+    expected_cutoff = '"2026-05-02T10:00:00.000Z"'  # frozen - STUCK_RASTERIZE_LOOKBACK
+    assert STUCK_RASTERIZE_LOOKBACK.total_seconds() == 2 * 3600  # guard against constant drift
+    with (
+        freeze_time(frozen),
+        patch(
+            "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
+            AsyncMock(return_value=client),
+        ),
     ):
         await _stuck_session_ids(team_id=4242, session_ids=["s1", "s2"])
     assert len(captured) == 1
@@ -417,7 +425,7 @@ async def test_stuck_session_ids_filters_by_team_and_close_time():
     assert 'WorkflowType = "rasterize-recording"' in q
     assert 'ExecutionStatus IN ("Failed", "TimedOut")' in q
     assert "PostHogTeamId = 4242" in q
-    assert "CloseTime >" in q
+    assert f"CloseTime > {expected_cutoff}" in q
     # No candidate IDs are interpolated — that's the whole point of the inversion.
     assert "s1" not in q
     assert "s2" not in q

--- a/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
@@ -19,7 +19,7 @@ async def test_find_sessions_returns_team_disabled_when_no_config(activity_envir
     """No config row at all → treat as disabled so the workflow tears down its schedule."""
     result = await activity_environment.run(
         find_sessions_for_team_activity,
-        FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+        FindSessionsInput(team_id=team.id, lookback_minutes=30),
     )
     assert result.team_disabled is True
     assert result.session_ids == []
@@ -31,7 +31,7 @@ async def test_find_sessions_returns_team_disabled_when_config_disabled(activity
     await sync_to_async(enable_signal_source)(team, enabled=False)
     result = await activity_environment.run(
         find_sessions_for_team_activity,
-        FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+        FindSessionsInput(team_id=team.id, lookback_minutes=30),
     )
     assert result.team_disabled is True
 
@@ -46,7 +46,7 @@ async def test_find_sessions_no_recent_sessions(activity_environment, team):
     ):
         result = await activity_environment.run(
             find_sessions_for_team_activity,
-            FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+            FindSessionsInput(team_id=team.id, lookback_minutes=30),
         )
     assert result.team_disabled is False
     assert result.team_id == team.id
@@ -76,7 +76,7 @@ async def test_find_sessions_filters_summarized(activity_environment, organizati
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
-                FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
             )
         assert result.session_ids == ["s2"]
         assert result.user_id == user.id
@@ -87,15 +87,15 @@ async def test_find_sessions_filters_summarized(activity_environment, organizati
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_find_sessions_applies_max_sessions_after_dedup(activity_environment, organization, team):
-    """Older unsummarized sessions must survive when the newest ones are already summarized."""
+async def test_find_sessions_dispatches_all_unsummarized_candidates(activity_environment, organization, team):
+    """Sampling replaces the per-tick cap — every unsummarized candidate is dispatched."""
     from posthog.models.user import User
 
     await sync_to_async(enable_signal_source)(team)
     user = await sync_to_async(User.objects.create_and_join)(organization, "sweep-user2@posthog.com", "pw", "Sweep")
     try:
         raw_ids = [f"s{i}" for i in range(8)]
-        # First three (newest) already summarized; cap is 3 → would starve s3-s5 without post-dedup slice.
+        # Newest three already summarized — the rest must survive.
         existing = {sid: (i < 3) for i, sid in enumerate(raw_ids)}
         with (
             patch(
@@ -109,9 +109,45 @@ async def test_find_sessions_applies_max_sessions_after_dedup(activity_environme
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
-                FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=3),
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
             )
-        assert result.session_ids == ["s3", "s4", "s5"]
+        assert result.session_ids == ["s3", "s4", "s5", "s6", "s7"]
+    finally:
+        await sync_to_async(user.delete)()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_find_sessions_passes_sample_rate_to_fetch(activity_environment, organization, team):
+    """`sample_rate` from `SignalSourceConfig.config` is forwarded to `fetch_recent_session_ids`."""
+    from posthog.models.user import User
+
+    await sync_to_async(enable_signal_source)(team)
+    user = await sync_to_async(User.objects.create_and_join)(organization, "sample@posthog.com", "pw", "Sample")
+    await sync_to_async(SignalSourceConfig.objects.filter(team=team).update)(config={"sample_rate": 0.25})
+    try:
+        captured: dict[str, float] = {}
+
+        def _fake_fetch(*, team, lookback_minutes, sample_rate, recording_filters, max_execution_time_seconds):
+            captured["sample_rate"] = sample_rate
+            return ["only-1"]
+
+        with (
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.fetch_recent_session_ids",
+                side_effect=_fake_fetch,
+            ),
+            patch(
+                "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
+                return_value={"only-1": False},
+            ),
+        ):
+            result = await activity_environment.run(
+                find_sessions_for_team_activity,
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
+            )
+        assert captured["sample_rate"] == 0.25
+        assert result.session_ids == ["only-1"]
     finally:
         await sync_to_async(user.delete)()
 
@@ -130,7 +166,7 @@ async def test_find_sessions_returns_empty_when_team_has_no_user(activity_enviro
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
-                FindSessionsInput(team_id=lonely_team.id, lookback_minutes=30, max_sessions=5),
+                FindSessionsInput(team_id=lonely_team.id, lookback_minutes=30),
             )
         assert result.session_ids == []
         assert result.user_id is None
@@ -141,53 +177,25 @@ async def test_find_sessions_returns_empty_when_team_has_no_user(activity_enviro
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_fetch_recent_session_ids_returns_empty_when_no_config(team):
-    # No SignalSourceConfig created for this team → the helper should take the
-    # `_SourceNotEnabled` path and return an empty list rather than raising.
-    from posthog.temporal.session_replay.summarization_sweep.session_candidates import fetch_recent_session_ids
-
-    session_ids = await sync_to_async(fetch_recent_session_ids)(team=team, lookback_minutes=30)
-    assert session_ids == []
-
-
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.asyncio
 async def test_find_sessions_handles_config_disabled_between_check_and_ch_query(activity_environment, team):
-    """Race: _is_team_enabled returns True, then the config is disabled before
-    _load_team_user_and_sessions hits ClickHouse. The helper should return an
-    empty-ish `FindSessionsResult` (not team_disabled=True), which the workflow
-    treats as a no-op cycle rather than firing the self-delete path.
+    """Race: _is_team_enabled returns True, then the config is disabled by the time
+    _load_team_user_and_sessions reads it. The single config read inside the helper
+    filters by enabled=True, so it returns no row → empty session_ids → no-op cycle
+    (not team_disabled=True; we don't tear down the schedule for a transient race).
     """
-    # Pass the enabled check, then race: flip the config to disabled just as the
-    # CH-bound helper starts. `fetch_recent_session_ids` re-reads the config and
-    # should raise `_SourceNotEnabled` → return [] → find activity returns an
-    # empty session_ids list.
-    await sync_to_async(enable_signal_source)(team, enabled=True)
+    await sync_to_async(enable_signal_source)(team, enabled=False)
+    team.organization.is_ai_data_processing_approved = True
+    await sync_to_async(team.organization.save)(update_fields=["is_ai_data_processing_approved"])
 
-    def _disable_config() -> None:
-        SignalSourceConfig.objects.filter(
-            team_id=team.id,
-            source_product=SignalSourceConfig.SourceProduct.SESSION_REPLAY,
-            source_type=SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER,
-        ).update(enabled=False)
-
-    def _fake_load(team_id, lookback_minutes):
-        # Runs inside the helper right after the enabled check passed — flip
-        # the config mid-cycle and let the real `fetch_recent_session_ids`
-        # observe a disabled config.
-        from posthog.temporal.session_replay.summarization_sweep.session_candidates import fetch_recent_session_ids
-
-        _disable_config()
-        t = Team.objects.get(id=team_id)
-        return t, fetch_recent_session_ids(team=t, lookback_minutes=lookback_minutes), None
-
+    # Force `_is_team_summarization_allowed` to True even though the config is disabled,
+    # simulating the disable having happened between the check and the CH query.
     with patch(
-        "posthog.temporal.session_replay.summarization_sweep.activities._load_team_user_and_sessions",
-        side_effect=_fake_load,
+        "posthog.temporal.session_replay.summarization_sweep.activities._is_team_summarization_allowed",
+        return_value=True,
     ):
         result = await activity_environment.run(
             find_sessions_for_team_activity,
-            FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+            FindSessionsInput(team_id=team.id, lookback_minutes=30),
         )
 
     assert result.team_disabled is False
@@ -206,7 +214,7 @@ async def test_find_sessions_returns_team_disabled_when_ai_consent_revoked(activ
     await sync_to_async(_revoke)()
     result = await activity_environment.run(
         find_sessions_for_team_activity,
-        FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+        FindSessionsInput(team_id=team.id, lookback_minutes=30),
     )
     assert result.team_disabled is True
 
@@ -234,7 +242,7 @@ async def test_find_sessions_prefers_created_by_user(activity_environment, organ
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
-                FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
             )
         assert result.user_id == second_user.id
     finally:
@@ -262,7 +270,7 @@ async def test_find_sessions_falls_back_when_created_by_is_null(activity_environ
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
-                FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
             )
         assert result.user_id == user.id
     finally:
@@ -317,18 +325,46 @@ async def test_find_sessions_skips_recordings_with_too_many_failures(activity_en
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
-                FindSessionsInput(team_id=team.id, lookback_minutes=30, max_sessions=5),
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
             )
         assert sorted(result.session_ids) == ["good-1", "good-3"]
     finally:
         await sync_to_async(user.delete)()
 
 
+def _make_workflow_with_session(session_id: str):
+    from unittest.mock import MagicMock
+
+    attr_key = MagicMock()
+    attr_key.name = "PostHogSessionRecordingId"
+    pair = MagicMock()
+    pair.key = attr_key
+    pair.value = session_id
+    wf = MagicMock()
+    wf.typed_search_attributes = [pair]
+    return wf
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = items
+
+    def __aiter__(self):
+        self._iter = iter(self._items)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
 @pytest.mark.asyncio
 async def test_stuck_session_ids_returns_empty_for_empty_input():
     from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
 
-    result = await _stuck_session_ids([])
+    result = await _stuck_session_ids(team_id=42, session_ids=[])
     assert result == set()
 
 
@@ -339,40 +375,52 @@ async def test_stuck_session_ids_thresholds_failures():
     from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
     from posthog.temporal.session_replay.summarization_sweep.constants import STUCK_RASTERIZE_THRESHOLD
 
-    def _make_wf(session_id: str):
-        attr_key = MagicMock()
-        attr_key.name = "PostHogSessionRecordingId"
-        pair = MagicMock()
-        pair.key = attr_key
-        pair.value = session_id
-        wf = MagicMock()
-        wf.typed_search_attributes = [pair]
-        return wf
-
-    class _AsyncIter:
-        def __init__(self, items):
-            self._items = items
-
-        def __aiter__(self):
-            self._iter = iter(self._items)
-            return self
-
-        async def __anext__(self):
-            try:
-                return next(self._iter)
-            except StopIteration:
-                raise StopAsyncIteration
-
-    # Three failures for "stuck", one for "transient", none for "fresh"
-    workflows = [_make_wf("stuck")] * STUCK_RASTERIZE_THRESHOLD + [_make_wf("transient")]
+    # Three failures for "stuck", one for "transient", none for "fresh".
+    # The query also returns "other-recording" which isn't a candidate — must be ignored.
+    workflows = (
+        [_make_workflow_with_session("stuck")] * STUCK_RASTERIZE_THRESHOLD
+        + [_make_workflow_with_session("transient")]
+        + [_make_workflow_with_session("other-recording")] * STUCK_RASTERIZE_THRESHOLD
+    )
     client = MagicMock()
     client.list_workflows = MagicMock(return_value=_AsyncIter(workflows))
     with patch(
         "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
         AsyncMock(return_value=client),
     ):
-        result = await _stuck_session_ids(["stuck", "transient", "fresh"])
+        result = await _stuck_session_ids(team_id=42, session_ids=["stuck", "transient", "fresh"])
     assert result == {"stuck"}
+
+
+@pytest.mark.asyncio
+async def test_stuck_session_ids_filters_by_team_and_close_time():
+    """The visibility query must scope to the calling team and a bounded `CloseTime` window."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
+
+    client = MagicMock()
+    captured: list[str] = []
+
+    def _list_workflows(query: str):
+        captured.append(query)
+        return _AsyncIter([])
+
+    client.list_workflows = _list_workflows
+    with patch(
+        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
+        AsyncMock(return_value=client),
+    ):
+        await _stuck_session_ids(team_id=4242, session_ids=["s1", "s2"])
+    assert len(captured) == 1
+    q = captured[0]
+    assert 'WorkflowType = "rasterize-recording"' in q
+    assert 'ExecutionStatus IN ("Failed", "TimedOut")' in q
+    assert "PostHogTeamId = 4242" in q
+    assert "CloseTime >" in q
+    # No candidate IDs are interpolated — that's the whole point of the inversion.
+    assert "s1" not in q
+    assert "s2" not in q
 
 
 @pytest.mark.asyncio
@@ -385,56 +433,6 @@ async def test_stuck_session_ids_swallows_temporal_errors():
         "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
         AsyncMock(side_effect=RuntimeError("temporal unavailable")),
     ):
-        result = await _stuck_session_ids(["a", "b"])
+        result = await _stuck_session_ids(team_id=1, session_ids=["a", "b"])
     # Degrade gracefully — better to dispatch and risk a retry than block summarization.
-    assert result == set()
-
-
-@pytest.mark.asyncio
-async def test_stuck_session_ids_rejects_unsafe_session_ids():
-    from unittest.mock import AsyncMock, MagicMock
-
-    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
-
-    client = MagicMock()
-    captured_query: list[str] = []
-
-    class _AsyncIter:
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            raise StopAsyncIteration
-
-    def _list_workflows(query: str):
-        captured_query.append(query)
-        return _AsyncIter()
-
-    client.list_workflows = _list_workflows
-    unsafe_ids = ['evil") OR (true', "back\\slash", "with space", "with;semi"]
-    safe_id = "019dbfc3-27b0-74fb-8ee3-5b500a7b9074"
-    with patch(
-        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
-        AsyncMock(return_value=client),
-    ):
-        await _stuck_session_ids([*unsafe_ids, safe_id])
-    assert len(captured_query) == 1
-    for bad in unsafe_ids:
-        assert bad not in captured_query[0]
-    assert safe_id in captured_query[0]
-
-
-@pytest.mark.asyncio
-async def test_stuck_session_ids_skips_query_when_all_unsafe():
-    from unittest.mock import AsyncMock, MagicMock
-
-    from posthog.temporal.session_replay.summarization_sweep.activities import _stuck_session_ids
-
-    client = MagicMock()
-    client.list_workflows = MagicMock(side_effect=AssertionError("must not query Temporal"))
-    with patch(
-        "posthog.temporal.session_replay.summarization_sweep.activities.async_connect",
-        AsyncMock(return_value=client),
-    ):
-        result = await _stuck_session_ids(['"', "x y"])
     assert result == set()

--- a/posthog/temporal/tests/session_replay/summarization_sweep/test_session_candidates.py
+++ b/posthog/temporal/tests/session_replay/summarization_sweep/test_session_candidates.py
@@ -30,6 +30,8 @@ from products.signals.backend.models import SignalSourceConfig
         ("nope", DEFAULT_SAMPLE_RATE),
         (float("nan"), DEFAULT_SAMPLE_RATE),
         ([], DEFAULT_SAMPLE_RATE),
+        (True, DEFAULT_SAMPLE_RATE),  # bool subclasses int; `float(True) == 1.0` would slip through.
+        (False, DEFAULT_SAMPLE_RATE),
     ],
 )
 def test_coerce_sample_rate(raw, expected):

--- a/posthog/temporal/tests/session_replay/summarization_sweep/test_session_candidates.py
+++ b/posthog/temporal/tests/session_replay/summarization_sweep/test_session_candidates.py
@@ -1,0 +1,116 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from posthog.test.base import ClickhouseTestMixin
+
+from posthog.hogql import ast
+
+from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+from posthog.temporal.session_replay.summarization_sweep.constants import DEFAULT_SAMPLE_RATE, SAMPLE_RATE_PRECISION
+from posthog.temporal.session_replay.summarization_sweep.session_candidates import (
+    _build_user_defined_query,
+    _sampling_having_predicate,
+    coerce_sample_rate,
+    fetch_recent_session_ids,
+)
+
+from products.signals.backend.models import SignalSourceConfig
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, DEFAULT_SAMPLE_RATE),
+        (1.0, 1.0),
+        (0.0, 0.0),
+        (0.25, 0.25),
+        ("0.5", 0.5),
+        (2, 1.0),  # clamped
+        (-0.1, 0.0),  # clamped
+        ("nope", DEFAULT_SAMPLE_RATE),
+        (float("nan"), DEFAULT_SAMPLE_RATE),
+        ([], DEFAULT_SAMPLE_RATE),
+    ],
+)
+def test_coerce_sample_rate(raw, expected):
+    assert coerce_sample_rate(raw) == expected
+
+
+def test_sampling_having_predicate_passthrough_at_full_rate():
+    assert _sampling_having_predicate(1.0) is None
+
+
+def test_sampling_having_predicate_short_circuits_at_zero():
+    expr = _sampling_having_predicate(0.0)
+    assert isinstance(expr, ast.Constant) and expr.value is False
+
+
+def test_build_user_defined_query_returns_none_for_empty():
+    assert _build_user_defined_query(None) is None
+    assert _build_user_defined_query({}) is None
+    assert _build_user_defined_query("not a dict") is None  # type: ignore[arg-type]
+
+
+def test_sampling_having_predicate_builds_modulo_compare():
+    expr = _sampling_having_predicate(0.25)
+    assert isinstance(expr, ast.CompareOperation)
+    assert expr.op == ast.CompareOperationOp.Lt
+    assert isinstance(expr.right, ast.Constant)
+    assert expr.right.value == int(0.25 * SAMPLE_RATE_PRECISION)
+    assert isinstance(expr.left, ast.Call) and expr.left.name == "modulo"
+    inner = expr.left.args[0]
+    assert isinstance(inner, ast.Call) and inner.name == "cityHash64"
+
+
+def _enable_source(team) -> None:
+    team.organization.is_ai_data_processing_approved = True
+    team.organization.save(update_fields=["is_ai_data_processing_approved"])
+    SignalSourceConfig.objects.create(
+        team=team,
+        source_product=SignalSourceConfig.SourceProduct.SESSION_REPLAY,
+        source_type=SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER,
+        enabled=True,
+    )
+
+
+class TestSamplingPushdown(ClickhouseTestMixin):
+    @pytest.mark.django_db(transaction=True)
+    def test_full_rate_returns_all(self, team) -> None:
+        _enable_source(team)
+        sessions = self._produce_sessions(team.id, count=10)
+
+        ids = fetch_recent_session_ids(team=team, lookback_minutes=30, sample_rate=1.0)
+        assert sorted(ids) == sorted(sessions)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_zero_rate_returns_none(self, team) -> None:
+        _enable_source(team)
+        self._produce_sessions(team.id, count=10)
+
+        ids = fetch_recent_session_ids(team=team, lookback_minutes=30, sample_rate=0.0)
+        assert ids == []
+
+    @pytest.mark.django_db(transaction=True)
+    def test_partial_rate_is_stable_across_calls(self, team) -> None:
+        _enable_source(team)
+        self._produce_sessions(team.id, count=40)
+
+        first = fetch_recent_session_ids(team=team, lookback_minutes=30, sample_rate=0.5)
+        second = fetch_recent_session_ids(team=team, lookback_minutes=30, sample_rate=0.5)
+        assert first == second
+        assert 0 < len(first) < 40
+
+    @staticmethod
+    def _produce_sessions(team_id: int, *, count: int) -> list[str]:
+        base = datetime.now(UTC) - timedelta(minutes=20)
+        session_ids = [f"sweep-test-{team_id}-{i:04x}" for i in range(count)]
+        for i, sid in enumerate(session_ids):
+            first = base + timedelta(seconds=i)
+            produce_replay_summary(
+                team_id=team_id,
+                session_id=sid,
+                first_timestamp=first.isoformat(),
+                last_timestamp=(first + timedelta(seconds=120)).isoformat(),
+                active_milliseconds=60_000,
+            )
+        return session_ids

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -20,6 +20,9 @@ from .report_generation.resolve_reviewers import enrich_reviewer_dicts_with_org_
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SESSION_ANALYSIS_SAMPLE_RATE = 0.1
+
+
 # Maps (source_product, source_type) → (ExternalDataSourceType value, schema name)
 _DATA_IMPORT_SOURCE_MAP: dict[tuple[str, str], tuple[str, str]] = {
     (SignalSourceConfig.SourceProduct.GITHUB, SignalSourceConfig.SourceType.ISSUE): ("Github", "issues"),
@@ -125,6 +128,16 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
                     }
                 )
         return attrs
+
+    def create(self, validated_data: dict) -> SignalSourceConfig:
+        if (
+            validated_data.get("source_product") == SignalSourceConfig.SourceProduct.SESSION_REPLAY
+            and validated_data.get("source_type") == SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER
+        ):
+            config = dict(validated_data.get("config") or {})
+            config.setdefault("sample_rate", DEFAULT_SESSION_ANALYSIS_SAMPLE_RATE)
+            validated_data["config"] = config
+        return super().create(validated_data)
 
 
 class SignalTeamConfigSerializer(serializers.ModelSerializer):

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -108,6 +108,13 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
             recording_filters = config.get("recording_filters")
             if recording_filters is not None and not isinstance(recording_filters, dict):
                 raise serializers.ValidationError({"config": "recording_filters must be a JSON object"})
+            sample_rate = config.get("sample_rate")
+            if sample_rate is not None:
+                # `isinstance(True, int)` is True in Python — reject bools explicitly.
+                if isinstance(sample_rate, bool) or not isinstance(sample_rate, int | float):
+                    raise serializers.ValidationError({"config": "sample_rate must be a number between 0 and 1"})
+                if not (0 <= sample_rate <= 1):
+                    raise serializers.ValidationError({"config": "sample_rate must be between 0 and 1"})
         if enabled and source_type == SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER:
             get_team = self.context.get("get_team")
             team = get_team() if get_team else None

--- a/products/signals/backend/test/test_signal_source_config_api.py
+++ b/products/signals/backend/test/test_signal_source_config_api.py
@@ -39,7 +39,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         assert data["source_product"] == "session_replay"
         assert data["source_type"] == "session_analysis_cluster"
         assert data["enabled"] is True
-        assert data["config"] == {"recording_filters": {"duration_min": 5}}
+        # `sample_rate` is auto-set to the default for newly created session-analysis configs.
+        assert data["config"] == {"recording_filters": {"duration_min": 5}, "sample_rate": 0.1}
         assert SignalSourceConfig.objects.filter(id=data["id"], team=self.team).exists()
 
     def test_create_source_config_sets_created_by(self):
@@ -61,6 +62,31 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         data = response.json()
         assert response.status_code == status.HTTP_201_CREATED, data
         assert data["enabled"] is True
+        assert data["config"] == {"sample_rate": 0.1}
+
+    def test_create_source_config_preserves_user_provided_sample_rate(self):
+        response = self.client.post(
+            self._url(),
+            data={
+                "source_product": "session_replay",
+                "source_type": "session_analysis_cluster",
+                "config": {"sample_rate": 0.5},
+            },
+            format="json",
+        )
+        data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, data
+        assert data["config"] == {"sample_rate": 0.5}
+
+    def test_create_source_config_no_default_for_other_source_types(self):
+        # Defaulting only applies to session_replay/session_analysis_cluster.
+        response = self.client.post(
+            self._url(),
+            data={"source_product": "github", "source_type": "issue", "enabled": False},
+            format="json",
+        )
+        data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, data
         assert data["config"] == {}
 
     def test_create_source_config_invalid_source_type(self):


### PR DESCRIPTION
## Problem

The summarization sweep is capped at 10 sessions per team per 5-minute tick. Higher-volume teams lose older eligible sessions to the 30-minute lookback before they're picked up.

## Changes

- New `sample_rate` (`[0, 1]`) on `SignalSourceConfig.config` replaces `MAX_SESSIONS_PER_TEAM` as the per-team throttle.
- Sampling is pushed into the recordings query's `HAVING` via `cityHash64(session_id) % 10000 < int(rate * 10000)` — single CH round trip, stable across ticks.
- Stuck-rasterize visibility query is inverted (scope by `PostHogTeamId` + a 2h `CloseTime` window) so the candidate IDs aren't embedded in the query string. Without the cap, the old `IN (...)` could exceed Temporal's query length limit.
- Newly created session-analysis `SignalSourceConfig` rows get `sample_rate=0.1` injected by the serializer when the caller doesn't provide one. The runtime `coerce_sample_rate` fallback is `1.0` but is now belt-and-suspenders.
- Existing `SignalSourceConfig` rows have already been backfilled to `sample_rate=0.1` in both prod-us (86 rows) and prod-eu (40 rows), so no row in production hits the runtime `1.0` default.

## How did you test this code?

I'm an agent. I ran `hogli test posthog/temporal/tests/session_replay/summarization_sweep/` (49 passed) and `hogli test products/signals/backend/test/test_signal_source_config_api.py` (26 passed). New tests cover `coerce_sample_rate`, the sampling AST, a CH-backed integration test, the inverted visibility query, the create-time `sample_rate` default, and that the default doesn't apply to other source-product/source-type combinations. No manual testing.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7), @tue driving. Sampling lives in `HAVING` rather than as a second query — explicit user steer. The stuck-query inversion is the follow-on of removing the cap. The serializer-level default lands in this PR rather than as a follow-up because the prod backfill exposed a small race window where new configs would inherit the runtime `1.0` default before being manually retuned.