### PR TITLE
fix(phai): prevent Tooltip from clobbering TaxonomicPopover onChange args

### DIFF
--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -351,20 +351,26 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
             <div className="flex flex-wrap items-start gap-1 w-full">
                 <ModeSelector />
                 <Tooltip title={contextDisabledReason ?? 'Add context to help PostHog AI answer your question'}>
-                    <TaxonomicPopover
-                        size="xxsmall"
-                        type="tertiary"
-                        className="flex-shrink-0 border"
-                        groupType={mainTaxonomicGroupType}
-                        groupTypes={taxonomicGroupTypes}
-                        onChange={handleTaxonomicFilterChange}
-                        icon={<IconAtSign className="text-secondary" />}
-                        placeholder={!hasData && !hasToolContext ? 'Add context' : null}
-                        placeholderClass="text-secondary"
-                        maxContextOptions={contextOptions}
-                        width={450}
-                        disabledReason={contextDisabledReason}
-                    />
+                    {/* Wrapper span prevents Base UI's Tooltip.Trigger from merging
+                        props into TaxonomicPopover. Without it, mergeProps treats
+                        onChange as a DOM event handler and wraps it in a single-arg
+                        callback, dropping the groupType and item arguments. */}
+                    <span>
+                        <TaxonomicPopover
+                            size="xxsmall"
+                            type="tertiary"
+                            className="flex-shrink-0 border"
+                            groupType={mainTaxonomicGroupType}
+                            groupTypes={taxonomicGroupTypes}
+                            onChange={handleTaxonomicFilterChange}
+                            icon={<IconAtSign className="text-secondary" />}
+                            placeholder={!hasData && !hasToolContext ? 'Add context' : null}
+                            placeholderClass="text-secondary"
+                            maxContextOptions={contextOptions}
+                            width={450}
+                            disabledReason={contextDisabledReason}
+                        />
+                    </span>
                 </Tooltip>
                 <ContextToolInfoTags size={size} />
                 <ContextTags size={size} />


### PR DESCRIPTION
## Problem

The "Add context" button in PostHog AI chat was broken — selecting any item (event, insight, dashboard, etc.) from the dropdown closed it but no context tag appeared. Reported via [support ticket](https://posthoghelp.zendesk.com/agent/tickets/57157).

## Changes

Base UI's `Tooltip.Trigger` merges props into its child element via `mergeProps`, which treats any prop matching `on` + uppercase letter as a DOM event handler and wraps it in a single-arg `(event) => {}` callback. This silently dropped the `groupType` and `item` arguments from `onChange`, so `handleTaxonomicFilterChange` always received `undefined` for both.

Wrapping `TaxonomicPopover` in a `<span>` inside the `<Tooltip>` isolates it from the prop merge.

## How did you test this code?

Manually verified in local dev: added events, actions, insights, and dashboards as context — all now produce the expected context tags.

## Showcase


https://github.com/user-attachments/assets/9ca6c8f6-badc-417a-abad-216f71057bdd


## 🤖 Agent context

Co-authored with Claude Code. Root cause was identified via diagnostic logging — the bug was an interaction between Base UI's prop merging and our multi-arg `onChange` callback, not visible through static analysis alone.