### PR TITLE
fix(batch-exports): handle `TOO_MANY_BYTES` error in backfill query

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -172,6 +172,13 @@ class ClickHouseMemoryLimitExceededError(ClickHouseError):
         super().__init__(error_message, query, query_id)
 
 
+class ClickHouseTooManyBytesError(ClickHouseError):
+    """Exception raised when a query exceeds the limit on bytes read."""
+
+    def __init__(self, error_message, query: str | None = None, query_id: str | None = None):
+        super().__init__(error_message, query, query_id)
+
+
 class ClickHouseTooManySimultaneousQueriesError(ClickHouseError):
     """Exception raised when ClickHouse has too many simultaneous queries running."""
 
@@ -363,6 +370,7 @@ class ClickHouseClient:
         ERROR_CODE_TO_EXCEPTION: dict[str, type[ClickHouseError]] = {
             "ALL_REPLICAS_ARE_STALE": ClickHouseAllReplicasAreStaleError,
             "MEMORY_LIMIT_EXCEEDED": ClickHouseMemoryLimitExceededError,
+            "TOO_MANY_BYTES": ClickHouseTooManyBytesError,
             "TOO_MANY_SIMULTANEOUS_QUERIES": ClickHouseTooManySimultaneousQueriesError,
         }
         for error_code, exc_class in ERROR_CODE_TO_EXCEPTION.items():

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -14,6 +14,7 @@ from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
     ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
+    ClickHouseTooManyBytesError,
     ClickHouseTooManySimultaneousQueriesError,
     add_log_comment_param,
     encode_clickhouse_data,
@@ -161,6 +162,17 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
     )
     with _mock_internal_session_post(mock_response):
         with pytest.raises(ClickHouseMemoryLimitExceededError):
+            with clickhouse_client.post_query("SELECT 1", query_parameters={}, query_id=None):
+                pass
+
+
+def test_clickhouse_too_many_bytes_error(clickhouse_client):
+    mock_response = MagicMock(
+        status_code=500,
+        text="Code: 307. DB::Exception: Limit for rows or bytes to read exceeded, max bytes: 50.00 TiB, current bytes: 50.00 TiB: While executing MergeTreeSelect(pool: ReadPool, algorithm: Thread). (TOO_MANY_BYTES) (version x.x.x.x (official build))",
+    )
+    with _mock_internal_session_post(mock_response):
+        with pytest.raises(ClickHouseTooManyBytesError):
             with clickhouse_client.post_query("SELECT 1", query_parameters={}, query_id=None):
                 pass
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -24,7 +24,11 @@ from posthog.clickhouse import query_tagging
 from posthog.clickhouse.query_tagging import Product
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.clickhouse import ClickHouseMemoryLimitExceededError, get_client
+from posthog.temporal.common.clickhouse import (
+    ClickHouseMemoryLimitExceededError,
+    ClickHouseTooManyBytesError,
+    get_client,
+)
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -531,9 +535,9 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
                 total_records_count=None,
                 interval_seconds=interval_seconds,
             )
-    except ClickHouseMemoryLimitExceededError:
+    except (ClickHouseMemoryLimitExceededError, ClickHouseTooManyBytesError):
         logger.warning(
-            "Backfill estimation query exceeded memory limit, proceeding without estimate",
+            "Backfill estimation query exceeded resource limits, proceeding without estimate",
             model=model,
         )
         return GetBackfillInfoOutputs(


### PR DESCRIPTION
## Problem

Sometimes backfill info queries can attempt to consume too many bytes. We already check for queries that fail due to exceeding ClickHouse memory limits, but not `TOO_MANY_BYTES`.

## Changes

- Add a new `ClickHouseTooManyBytesError` exception
- In the `get_backfill_info` activity, catch this and skip ahead, as we already do for `ClickHouseMemoryLimitExceededError`

## How did you test this code?

- Relying on automated tests
- Added a new unit test

## Publish to changelog?

No.


## 🤖 Agent context

Co-authored with PostHog Code.
