### PR TITLE
fix: email verification does not bypass 2fa

### DIFF
--- a/frontend/src/scenes/authentication/signup/verify-email/verifyEmailLogic.ts
+++ b/frontend/src/scenes/authentication/signup/verify-email/verifyEmailLogic.ts
@@ -1,10 +1,11 @@
 import { actions, connect, kea, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
-import { urlToAction } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getRelativeNextPath } from 'lib/utils'
+import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import type { verifyEmailLogicType } from './verifyEmailLogicType'
@@ -38,11 +39,21 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
             {
                 validateEmailToken: async ({ uuid, token }: { uuid: string; token: string }, breakpoint) => {
                     try {
-                        await api.create(`api/users/verify_email/`, { token, uuid })
+                        const response = await api.create<{ success: boolean; token?: string; requires_2fa?: boolean }>(
+                            `api/users/verify_email/`,
+                            { token, uuid }
+                        )
                         actions.setView('success')
                         await breakpoint(VERIFY_EMAIL_REDIRECT_DELAY_MS)
 
                         const nextUrl = getRelativeNextPath(new URLSearchParams(location.search).get('next'), location)
+                        if (response.requires_2fa) {
+                            lemonToast.success(
+                                'Email verified! Please log in with your password to complete two-factor authentication.'
+                            )
+                            router.actions.push(urls.login(), nextUrl ? { next: nextUrl } : {})
+                            return { success: true, token, uuid }
+                        }
 
                         // this url is validated in getRelativeNextPath as either being relative or on the same origin
                         // this url is also secret and so we can trust it's not attacker controlled

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1993,6 +1993,57 @@ class TestEmailVerificationAPI(APIBaseTest):
         assert self.user.email == "new@posthog.com"
         assert self.user.pending_email is None
 
+    def test_email_verification_does_not_log_in_user_with_2fa_totp(self):
+        # If the user has a TOTP device configured, verifying their email must
+        # NOT silently establish an authenticated session — otherwise an
+        # attacker with access to the email inbox could bypass 2FA entirely.
+        TOTPDevice.objects.create(user=self.user, name="default", confirmed=True)
+
+        token = email_verification_token_generator.make_token(self.user)
+        self.client.logout()
+        assert self.client.session.get("_auth_user_id") is None
+
+        response = self.client.post(f"/api/users/verify_email/", {"uuid": self.user.uuid, "token": token})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"success": True, "token": token, "requires_2fa": True}
+
+        # Email should still be marked verified, but the session must remain unauthenticated.
+        self.user.refresh_from_db()
+        assert self.user.is_email_verified
+        assert self.client.session.get("_auth_user_id") is None
+
+    def test_cant_request_verification_for_already_verified_email(self):
+        self.user.is_email_verified = True
+        self.user.save()
+
+        with self.settings(CELERY_TASK_ALWAYS_EAGER=True):
+            response = self.client.post(f"/api/users/request_email_verification/", {"uuid": self.user.uuid})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "already_verified",
+                "detail": "Email is already verified.",
+                "attr": None,
+            },
+        )
+        # No email should have been sent for an already-verified address.
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_can_request_verification_for_pending_email_change(self):
+        # An already-verified user who initiated an email change still needs to
+        # verify the new address — re-requesting the verification link must work.
+        self.user.is_email_verified = True
+        self.user.pending_email = "new-address@posthog.com"
+        self.user.save()
+
+        with self.settings(CELERY_TASK_ALWAYS_EAGER=True, SITE_URL="https://my.posthog.net"):
+            response = self.client.post(f"/api/users/request_email_verification/", {"uuid": self.user.uuid})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["new-address@posthog.com"])
+
 
 class TestUserTwoFactor(APIBaseTest):
     def setUp(self):

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -70,7 +70,7 @@ from posthog.event_usage import (
 )
 from posthog.helpers.email_utils import validate_display_name
 from posthog.helpers.session_cache import SessionCache
-from posthog.helpers.two_factor_session import set_two_factor_verified_in_session
+from posthog.helpers.two_factor_session import has_passkeys, set_two_factor_verified_in_session
 from posthog.middleware import get_impersonated_session_expires_at, is_read_only_impersonation
 from posthog.models import Team, User, UserScenePersonalisation
 from posthog.models.organization import Organization
@@ -724,7 +724,13 @@ class UserViewSet(
         user.save()
         report_user_verified_email(user)
 
+        user_has_passkeys = has_passkeys(user)
+        passkeys_enabled_for_2fa = user_has_passkeys and user.passkeys_enabled_for_2fa
+        if default_device(user) or passkeys_enabled_for_2fa:
+            return Response({"success": True, "token": token, "requires_2fa": True})
+
         login(self.request, user, backend="django.contrib.auth.backends.ModelBackend")
+        set_two_factor_verified_in_session(self.request)
         report_user_logged_in(user)
         return Response({"success": True, "token": token})
 
@@ -746,6 +752,13 @@ class UserViewSet(
         except User.DoesNotExist:
             user = None
         if user:
+            # Allow re-requests when there's a pending email change that still
+            # needs to be verified, even though the current address is verified.
+            if user.is_email_verified and not user.pending_email:
+                raise serializers.ValidationError(
+                    "Email is already verified.",
+                    code="already_verified",
+                )
             EmailVerifier.create_token_and_send_email_verification(user)
 
         return Response({"success": True})


### PR DESCRIPTION
## Problem

When a user has 2fa enabled, but still has to verify their email then verifying their email bypasses the 2fa requirements. This shouldn't be possible under normal circumstances since it would somehow require the user to setup 2fa between the time they create their account and are shown the email verification screen (not possible unless there is a manual intervention from a django admin), but we should fix nonetheless.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Do not login the user during email verification flow when they have 2fa enabled
- Allow user to rerequest email verification when there is a pending email change

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
