### PR TITLE
fix(replay): hide the summarize button while the summary is loading

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -78,7 +78,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
         >
             {isOpen && <Resizer {...resizerProps} />}
             <div className="flex items-center justify-between h-11 px-3 shrink-0">
-                {hasSummary ? (
+                {hasSummary || sessionSummaryLoading ? (
                     <div className="flex items-center gap-2 font-semibold">
                         <IconMagicWand className="text-primary" />
                         AI summary
@@ -88,12 +88,9 @@ export function PlayerSummaryDock(): JSX.Element | null {
                         size="small"
                         type="primary"
                         icon={<IconMagicWand />}
-                        loading={sessionSummaryLoading}
                         disabledReason={summaryDisabledReason}
                         onClick={() => {
-                            if (!sessionSummaryLoading) {
-                                summarizeSession()
-                            }
+                            summarizeSession()
                             setIsOpen(true)
                         }}
                         data-attr="load-session-summary"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
there's too many loading states UI when single session summary is loading

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- do not show the summarize button while the summary is loading.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
