### PR TITLE
feat: show default price for discounted addons

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5283,9 +5283,9 @@ snapshots:
     scenes-app-web-analytics--web-analytics-dashboard--light:
         hash: v1.k794b7964.0d336797602434aaaf6364ba4030ee4bd93762ae2df7223e1151bc6002ea2a60.oy7VmDHh6XEZi9xvVObmMtvWqO11BZY46XPgOc36mPQ
     scenes-other-billing--billing--dark:
-        hash: v1.k794b7964.293821301d395841fddf30d5a2d70375834d4d3f29141d074ff21a90dbdf5ef8.JaF-miXSOzjj_pNc9GxBZJGdQ5JYJXLlVy0XyLqMtrs
+        hash: v1.k794b7964.1de93d7fb5ef5bf55972cfc3638f35de1f935a21d3f83733f9034f2a6447adfe.U1-p3yB5bpclrzWdqZAL-uhieEDSDVtVwYiVSI7oyQc
     scenes-other-billing--billing--light:
-        hash: v1.k794b7964.573a3dc0219bdf219f6944d263fc538f68bc833ebede8991daffa4f176931aa5._F2k-ncUT6lLNJ7if18v9SZY4SbCRot-8hnw5-ddOfk
+        hash: v1.k794b7964.0dfb0e733cc5858f068ffce50bd81e887a3c59de06c32bb569654ab0e99ade60.9lzRtW7O7FiKhrTX9ZG3QnLx2K3m8f14C3bNGkxral0
     scenes-other-billing--billing-purchase-credits-modal--dark:
         hash: v1.k794b7964.dc9b77730db0685138240858a0c550db9765c172321e54304e9f297d0bd00adc.v7awXXbWH1-_a9mzHgVKs99YvwpmU6dHZQgLI_OW9k4
     scenes-other-billing--billing-purchase-credits-modal--light:
@@ -5295,9 +5295,9 @@ snapshots:
     scenes-other-billing--billing-unsubscribe-modal--light:
         hash: v1.k794b7964.b676dda14727516b10f340ebb626babaee98152329868ac8aa8c5a3a90ee26d1.MxyCnRf692V5gtPnmOsCTnxMCAAt__URa4rJQJENBZw
     scenes-other-billing--billing-with-credit-cta--dark:
-        hash: v1.k794b7964.671be717d51d66645b9501351aea0ded703a0042db6934ccdaa1c7ebc85a188a.gH2hqDf7PqGFGSMfwrtwjRn5hRxZXgaZXUuucCTi7_U
+        hash: v1.k794b7964.b3d4639e966f47b6c847684db6a12398a110cf27233a8db91d043c082f18b47f.4UWLNcoKKtBl26HMvWUmrYrZ-OI6Fd7ILWvOpjCz4uE
     scenes-other-billing--billing-with-credit-cta--light:
-        hash: v1.k794b7964.6b92dd93d7304fd3ab221aeeca0d1341fc957263e3e8c34177ad32a5f5b94ab6.p9ZPmKv_YIBruugVavTLIiljAJHUYolSuFUJlxKBvB0
+        hash: v1.k794b7964.10a3e79404d48788838946dc9705e2db59b92ee90253aebac7d77dd2779abe85.7GfH6fz0lX-mJyWUZH4jp5Fb7CggVKeERqI0MQ-h0tU
     scenes-other-billing--billing-with-credits--dark:
         hash: v1.k794b7964.457257072f4ee70056be2e1a4551fc098644ce363246c8ce4727a636d6231a06.RvIsfP2a2yPEOYspq28VMp3DZx-mY_nAbnb5OsRGHVU
     scenes-other-billing--billing-with-credits--light:
@@ -5311,25 +5311,25 @@ snapshots:
     scenes-other-billing--billing-with-limit-and-100-percent-discount--light:
         hash: v1.k794b7964.c60133947fb5ef34eaf37fa21bb0390bccff77b1b5fe49e01e9f5a7b239a7c04.oIDvDkc41HCJUBwamg0ahQQYn3NNsIX7cLFMOTjk4VE
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--dark:
-        hash: v1.k794b7964.c0df0df2ebf71de4d5ea223d0649976aa6670a23a4ddfee7d20e60f840e1e083.64wd-og8WBouyV-eDgDEX1u9K3b7Oepbdqimfw3Ea5U
+        hash: v1.k794b7964.dc4fccf8ebca69c3f2467f79943ee07128e51d1ff1b4dcd867d2f7aabb2d8b42.QUs_q6oZ3HOkpxGZqUvXvavbgRaHNijyC8SErUlJYiw
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--light:
-        hash: v1.k794b7964.6f1a8b014c5a0103eb96839b35e406aaad89e66035d5d4c752f237416bfd63c0.kJRLM6LkW9Jj5VjPiGLDNgoNQrrV-eKmbLcEstL5o4o
+        hash: v1.k794b7964.cc182b410da64a9fa2290ea2b1811c1be10ce76bcf1de5f1206644b68777f5aa.NfR3IjRbxMdhWQy5pKt1klGG4nbIGvmseTG2XBxXmI0
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--dark:
-        hash: v1.k794b7964.76efcb921ce3995c044cbed643c9b215edc81fd6b19548db7e7ba60e9d033507.ok0wpOfrsmFZ6cewWrsZxb5F4fw8rQAucpHfQj45SoA
+        hash: v1.k794b7964.fd85f9088df0262a16e3c866995eec5b8b8c284318e46f2d8d1f88b79673c301.dh4lRmGm06j7zlQw8trCZivY2GBlmFYblx2lt_Y8Z8s
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--light:
-        hash: v1.k794b7964.93da26b28c7b22106752f77c7fa66fdb3691593995ac51e36373167841209d6c.AZaWbrbcyl89Sei0KshVxEM-nLNjn4y1BjJeFNtmE2A
+        hash: v1.k794b7964.29d4fd65ebc3699ad2af50c3248f5decc8118e39466c811fbe83f3b583f2f409.g9ky4uyz8pPEn2GjiBFEKjMeUjtcxweeLoa50nW_XCc
     scenes-other-billing-product--billing-product-platform-addons-on-scale--dark:
-        hash: v1.k794b7964.2fb9da9c8a5b77c47805a836c2bd15779022240ae29a9482516a735f0849297f._dDRjMEuE9SOQMNJUkibocFE2UePxysMjRlxiJ_auvE
+        hash: v1.k794b7964.513b1f701eba8bc569c9882d6512341ea60281c0c83aaf7e1e2975f07c8ccd18.YZ7cYR_vY7pq0uYPc0eLW9nYGIPTKZdVRgq0PpfFeKw
     scenes-other-billing-product--billing-product-platform-addons-on-scale--light:
-        hash: v1.k794b7964.26dc01d44e329c65f0206a120e798fdacd674c69f24e67dac4a9af213641e0f0.8-j4rC8H1XwJv75m35p6xMUsn-JuhvgL1CgwUcutQ2Q
+        hash: v1.k794b7964.1bd527498bd7a876cbd014a265924c26250bcb2026c02cbd7d5776536433c444.XjuGFEchLG9Lhy4VDkYKE4P6Xu9a4dv1JvRyK85MgMU
     scenes-other-billing-product--billing-product-platform-addons-trial-available--dark:
-        hash: v1.k794b7964.c0df0df2ebf71de4d5ea223d0649976aa6670a23a4ddfee7d20e60f840e1e083.ltV5JkvSQ-guDC1Vk2d2GaU9xZW5V3_hEwS8SwfrfeA
+        hash: v1.k794b7964.dc4fccf8ebca69c3f2467f79943ee07128e51d1ff1b4dcd867d2f7aabb2d8b42.xg4P1RWPlWR_8r2XqnDZuO9RIcMcluXF_Jy-N3dOwGQ
     scenes-other-billing-product--billing-product-platform-addons-trial-available--light:
-        hash: v1.k794b7964.6f1a8b014c5a0103eb96839b35e406aaad89e66035d5d4c752f237416bfd63c0.oSN7D68SHmdfgBi-9MS8XSj5XMq-bpRVeXCYDGbf0es
+        hash: v1.k794b7964.cc182b410da64a9fa2290ea2b1811c1be10ce76bcf1de5f1206644b68777f5aa.3nZiAgpq3rSoU2EpmG7ltoGZZ5kLizL8Z5AfwqxCCxk
     scenes-other-billing-product--billing-product-platform-addons-trial-used--dark:
-        hash: v1.k794b7964.be30f5ff9b522df35203fd554d92c0c6a4022039882db0e2af65930d80ab7292.a2_bn2aR3YTlF3tqEsmGKHjEGDBCJFdvhaV70-3HhtA
+        hash: v1.k794b7964.976383cc81b17b5cbf9944853deac7b612184afa07032d8d649304f97b1b76e5.jXxBT5Jie-qx7APMERRBw4Z7KQYfE4gMGP5sYkF-38Y
     scenes-other-billing-product--billing-product-platform-addons-trial-used--light:
-        hash: v1.k794b7964.fae056f1e4a2b94a43d50655387e077efc56392c8feb6e243aab6c449bf0a8be.AnijTyvza_alSThGXRA7oymYdNnFir6nhuQkEH_AFcE
+        hash: v1.k794b7964.5cfdd7dd009495b1a8c13296498702708806458eef6aa84a5e52cb164392b560.WOuIC4IAhXljk-9rjGZQguZU5lWBsT6u8T0HpaSL9Lg
     scenes-other-billing-product--billing-product-temporarily-free--dark:
         hash: v1.k794b7964.793c583d893543c9f4ccd111450b803d1966cf2f2d89b9e5e4d34144c41fde7e.7u2bxJwsxrwUWutogyzX9FtdlGxd7mPZkYgglNhgsSs
     scenes-other-billing-product--billing-product-temporarily-free--light:

--- a/frontend/src/scenes/billing/PlatformAddonComparison.tsx
+++ b/frontend/src/scenes/billing/PlatformAddonComparison.tsx
@@ -68,6 +68,33 @@ type ComparisonFeature = {
     includedIn: Map<string, BillingFeatureType>
 }
 
+const PlanPrice = ({
+    addon,
+    unit_amount_usd,
+    unit_label,
+}: {
+    addon: BillingProductV2AddonType
+    unit_amount_usd: string | null
+    unit_label: string | null
+}): JSX.Element => {
+    // When the customer is subscribed to a price lower than the product's default price,
+    // show the default price as a strikethrough
+    const showDiscount = addon.subscribed && addon.default_unit_amount_usd != null && addon.unit_amount_usd != null
+    const mainPrice = showDiscount ? addon.unit_amount_usd : unit_amount_usd
+
+    return (
+        <div className="flex items-start gap-x-1 mt-1">
+            <span className="font-bold text-3xl leading-none">{humanFriendlyCurrency(Number(mainPrice), 0)}</span>
+            {showDiscount && (
+                <span className="text-secondary line-through self-baseline">
+                    {humanFriendlyCurrency(Number(addon.default_unit_amount_usd), 0)}
+                </span>
+            )}
+            {unit_label && <span className="text-secondary self-baseline">/ {unit_label}</span>}
+        </div>
+    )
+}
+
 const PlanCard = ({
     addon,
     onExpandCompare,
@@ -125,12 +152,7 @@ const PlanCard = ({
                 </div>
             )}
             {pricedPlan?.flat_rate && (
-                <div className="flex items-baseline gap-x-1 mt-1">
-                    <span className="font-bold text-3xl leading-none">
-                        {humanFriendlyCurrency(Number(pricedPlan.unit_amount_usd), 0)}
-                    </span>
-                    {pricedPlan.unit && <span className="text-secondary">/ {pricedPlan.unit}</span>}
-                </div>
+                <PlanPrice addon={addon} unit_amount_usd={pricedPlan.unit_amount_usd} unit_label={pricedPlan.unit} />
             )}
             <div className="-mt-2">
                 <BillingProductAddonActions addon={addon} buttonSize="small" align="left" hidePricingNote />
@@ -159,12 +181,11 @@ const LegacyPlanHero = ({ addon }: { addon: BillingProductV2AddonType }): JSX.El
                 </div>
                 <div className="flex items-center gap-2 shrink-0 self-center">
                     {pricedPlan?.flat_rate && (
-                        <div className="flex items-baseline gap-x-1">
-                            <span className="font-bold text-3xl leading-none">
-                                {humanFriendlyCurrency(Number(pricedPlan.unit_amount_usd), 0)}
-                            </span>
-                            {pricedPlan.unit && <span className="text-secondary">/ {pricedPlan.unit}</span>}
-                        </div>
+                        <PlanPrice
+                            addon={addon}
+                            unit_amount_usd={pricedPlan.unit_amount_usd}
+                            unit_label={pricedPlan.unit}
+                        />
                     )}
                     <More
                         overlay={

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -19,6 +19,7 @@ import {
 import { HeartHog } from 'lib/components/hedgehogs'
 import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
 import { supportLogic } from 'lib/components/Support/supportLogic'
+import { humanFriendlyCurrency } from 'lib/utils'
 
 import { BillingProductV2AddonType, BillingProductV2Type } from '~/types'
 
@@ -58,6 +59,7 @@ export const UnsubscribeSurveyModal = ({
     )
 
     const textAreaNotEmpty = surveyResponse[SurveyEventProperties.SURVEY_RESPONSE]?.length > 0
+    const isOnDiscountedPrice = isAddonProduct && (product as BillingProductV2AddonType).default_unit_amount_usd != null
 
     let action = 'Unsubscribe'
     let actionVerb = 'unsubscribing'
@@ -173,10 +175,22 @@ export const UnsubscribeSurveyModal = ({
                             </LemonBanner>
                         )}
                         {isAddonProduct ? (
-                            <p className="mb-0">
-                                We're sorry to see you go! Please note, you'll lose access to the addon features
-                                immediately.
-                            </p>
+                            isOnDiscountedPrice ? (
+                                <p className="mb-0">
+                                    We're sorry to see you go! You're on a special discounted price of{' '}
+                                    <strong>
+                                        {humanFriendlyCurrency(Number(product.unit_amount_usd), 0)} /{' '}
+                                        {product.unit ?? 'month'}
+                                    </strong>{' '}
+                                    - removing this add-on will end the discount and you'll lose access to the features
+                                    immediately.
+                                </p>
+                            ) : (
+                                <p className="mb-0">
+                                    We're sorry to see you go! Please note, you'll lose access to the addon features
+                                    immediately.
+                                </p>
+                            )
                         ) : (
                             <p className="mb-0">
                                 We're sorry to see you go! Please note, you'll lose access to platform features and

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -182,7 +182,7 @@ export const UnsubscribeSurveyModal = ({
                                         {humanFriendlyCurrency(Number(product.unit_amount_usd), 0)} /{' '}
                                         {product.unit ?? 'month'}
                                     </strong>{' '}
-                                    - removing this add-on will end the discount and you'll lose access to the features
+                                    — removing this add-on will end the discount and you'll lose access to the features
                                     immediately.
                                 </p>
                             ) : (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2101,6 +2101,7 @@ export interface BillingProductV2AddonType {
     display_decimals: number | null // Decimal places in display (e.g., 2 for "27.65 GB")
     display_divisor: number | null // Divide raw value by this for display (e.g., 1000 for MB->GB)
     unit_amount_usd: string | null
+    default_unit_amount_usd: string | null // Product's default (undiscounted) unit price
     current_amount_usd: string | null
     current_usage: number
     projected_usage: number | null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2101,7 +2101,7 @@ export interface BillingProductV2AddonType {
     display_decimals: number | null // Decimal places in display (e.g., 2 for "27.65 GB")
     display_divisor: number | null // Divide raw value by this for display (e.g., 1000 for MB->GB)
     unit_amount_usd: string | null
-    default_unit_amount_usd: string | null // Product's default (undiscounted) unit price
+    default_unit_amount_usd?: string | null // Product's default (undiscounted) unit price
     current_amount_usd: string | null
     current_usage: number
     projected_usage: number | null


### PR DESCRIPTION
## Problem

Follow-up to: https://github.com/PostHog/billing/pull/1884  
that exposes `default_unit_amount_usd` on the addon API. This is the frontend side. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- Render the customer's price as the main number with the default price as a strikethrough next to it on the billing comparison cards
- Copy in the unsubscribe modal warning that discount will be lost

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

## ![2026-04-29 15.57.55.gif](https://app.graphite.com/user-attachments/assets/c8e8da31-3e2d-4ee5-b57c-401b351e0f79.gif)



## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->