### PR TITLE
fix(logs): increase alert list fetch limit to 500

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -76,7 +76,7 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
             {
                 loadAlerts: async () => {
                     const projectId = String(values.currentTeamId)
-                    const response = await logsAlertsList(projectId)
+                    const response = await logsAlertsList(projectId, { limit: 500 })
                     return response.results
                 },
             },


### PR DESCRIPTION
## Problem

When a project has more than the default number of alerts, the logs alerting list would be truncated, causing some alerts to not appear in the UI.

## Changes

Increased the fetch limit to 500 when loading alerts in `logsAlertingLogic`, ensuring a much larger set of alerts can be retrieved in a single request.

## How did you test this code?

Verified that the `logsAlertsList` call now passes `{ limit: 500 }` as a query parameter, allowing up to 500 alerts to be returned instead of the default page size.

## Publish to changelog?

No