### PR TITLE
fix(web-analytics): use video_3_sec_watched_actions for Meta ads source

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/schemas.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/schemas.py
@@ -112,7 +112,7 @@ RESOURCE_SCHEMAS: dict[MetaAdsResource, dict[str, Any]] = {
             "conversion_values",
             "cost_per_action_type",
             "action_values",
-            "video_30_sec_watched_actions",
+            "video_3_sec_watched_actions",
             "video_p25_watched_actions",
             "video_p50_watched_actions",
             "video_p75_watched_actions",


### PR DESCRIPTION
https://developers.facebook.com/ads/blog/post/v2/2018/07/31/mapi-video-metrics/

`video_30_sec_watched_actions` is deprecated.

[User](https://posthoghelp.zendesk.com/agent/tickets/57209) requests `video_3_sec_watched_actions` instead. 

## Changes

- Swap video_30_sec_watched_actions for video_3_sec_watched_actions

## How did you test this code?

untested

## Publish to changelog?

Removed video_30_sec_watched_actions and added video_3_sec_watched_actions from Meta Ads source

## Docs update



## 🤖 Agent context


