### PR TITLE
fix(signals): mark task runs as internal

### DIFF
--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -533,6 +533,7 @@ async def run_multi_turn_research(
         output_fn=output_fn,
         origin_product="signal_report",
         signal_report_id=signal_report_id,
+        internal=True,
     )
 
     # Record the research task relationship immediately after task creation

--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -496,6 +496,7 @@ async def run_multi_turn_research(
     signal_report_id: str | None = None,
 ) -> ReportResearchOutput:
     """Orchestrate a multi-turn sandbox session that investigates each signal individually."""
+    from products.tasks.backend.models import Task
     from products.tasks.backend.services.custom_prompt_multi_turn_runner import MultiTurnSession
 
     total = len(signals)
@@ -531,7 +532,7 @@ async def run_multi_turn_research(
         step_name="report_research",
         verbose=verbose,
         output_fn=output_fn,
-        origin_product="signal_report",
+        origin_product=Task.OriginProduct.SIGNAL_REPORT,
         signal_report_id=signal_report_id,
         internal=True,
     )

--- a/products/signals/backend/report_generation/select_repo.py
+++ b/products/signals/backend/report_generation/select_repo.py
@@ -10,6 +10,7 @@ from posthog.models.integration import GitHubIntegration, Integration
 from posthog.sync import database_sync_to_async
 
 from products.signals.backend.temporal.types import SignalData, render_signals_to_text
+from products.tasks.backend.models import Task
 from products.tasks.backend.services.custom_prompt_executor import run_sandbox_agent_get_structured_output
 from products.tasks.backend.services.custom_prompt_runner import CustomPromptSandboxContext
 
@@ -129,6 +130,7 @@ async def select_repository_for_report(
         step_name="repo_selection",
         verbose=verbose,
         output_fn=output_fn,
+        origin_product=Task.OriginProduct.SIGNAL_REPORT,
         internal=True,
     )
     # Validate that the selected repo is actually in the candidate list

--- a/products/signals/backend/report_generation/select_repo.py
+++ b/products/signals/backend/report_generation/select_repo.py
@@ -129,6 +129,7 @@ async def select_repository_for_report(
         step_name="repo_selection",
         verbose=verbose,
         output_fn=output_fn,
+        internal=True,
     )
     # Validate that the selected repo is actually in the candidate list
     if result.repository is not None:

--- a/products/tasks/backend/services/custom_prompt_executor.py
+++ b/products/tasks/backend/services/custom_prompt_executor.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
+from products.tasks.backend.models import Task
 from products.tasks.backend.services.custom_prompt_runner import CustomPromptSandboxContext, OutputFn, run_prompt
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ async def run_sandbox_agent_get_structured_output(
     step_name: str = "",
     verbose: bool = False,
     output_fn: OutputFn = None,
+    origin_product: Task.OriginProduct | None = None,
     internal: bool = False,
 ) -> _ModelT:
     """Run an agent with a custom prompt in a sandbox and return validated Pydantic output."""
@@ -32,6 +34,7 @@ async def run_sandbox_agent_get_structured_output(
             step_name=step_name,
             verbose=verbose,
             output_fn=output_fn,
+            origin_product=origin_product,
             internal=internal,
         )
     except Exception:

--- a/products/tasks/backend/services/custom_prompt_executor.py
+++ b/products/tasks/backend/services/custom_prompt_executor.py
@@ -21,6 +21,7 @@ async def run_sandbox_agent_get_structured_output(
     step_name: str = "",
     verbose: bool = False,
     output_fn: OutputFn = None,
+    internal: bool = False,
 ) -> _ModelT:
     """Run an agent with a custom prompt in a sandbox and return validated Pydantic output."""
     try:
@@ -31,6 +32,7 @@ async def run_sandbox_agent_get_structured_output(
             step_name=step_name,
             verbose=verbose,
             output_fn=output_fn,
+            internal=internal,
         )
     except Exception:
         logger.exception("Sandbox execution failed")

--- a/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
+++ b/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
@@ -55,6 +55,7 @@ class MultiTurnSession:
         output_fn: OutputFn = None,
         origin_product: str | None = None,
         signal_report_id: str | None = None,
+        internal: bool = False,
     ) -> tuple[MultiTurnSession, _ModelT]:
         """Start a multi-turn sandbox session and wait for the first response."""
         task, task_run = await _create_task_and_trigger(
@@ -64,6 +65,7 @@ class MultiTurnSession:
             step_name,
             origin_product=origin_product,
             signal_report_id=signal_report_id,
+            internal=internal,
         )
         logger.info("multi_turn: started task=%s run=%s step=%s", task.id, task_run.id, step_name or "unknown")
         # Get session's parent workflow to send heartbeats to keep the agent alive while waiting for turns

--- a/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
+++ b/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
@@ -53,7 +53,7 @@ class MultiTurnSession:
         step_name: str = "",
         verbose: bool = False,
         output_fn: OutputFn = None,
-        origin_product: str | None = None,
+        origin_product: Task.OriginProduct | None = None,
         signal_report_id: str | None = None,
         internal: bool = False,
     ) -> tuple[MultiTurnSession, _ModelT]:

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -62,9 +62,10 @@ async def run_prompt(
     step_name: str = "",
     verbose: bool = False,
     output_fn: OutputFn = None,
+    internal: bool = False,
 ) -> tuple[str, str]:
     """Spawn a sandbox agent with the given prompt and return (last_message, full_log)."""
-    task, task_run = await _create_task_and_trigger(prompt, context, branch, step_name)
+    task, task_run = await _create_task_and_trigger(prompt, context, branch, step_name, internal=internal)
     logger.info("custom_prompt: started task=%s run=%s step=%s", task.id, task_run.id, step_name or "unknown")
     # No try/catch, propagating to the caller, if it fails,
     # to turn into a clear failure instead of JSON parse error
@@ -80,6 +81,7 @@ async def _create_task_and_trigger(
     step_name: str = "",
     origin_product: str | None = None,
     signal_report_id: str | None = None,
+    internal: bool = False,
 ):
     title = f"[sandbox_prompt:{step_name}] {description[:80]}" if step_name else description[:100]
     team = await sync_to_async(Team.objects.get)(id=context.team_id)
@@ -94,7 +96,12 @@ async def _create_task_and_trigger(
         mode="background",
         branch=branch,
         signal_report_id=signal_report_id,
+<<<<<<< New base: mark signals tasks as internal
         model=context.model,
+||||||| Common ancestor
+=======
+        internal=internal,
+>>>>>>> Current commit: mark signals tasks as internal
     )
     # lambda wrap: task.latest_run is a lazy ORM property; sync_to_async needs a callable
     task_run = await sync_to_async(lambda: task.latest_run)()

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -62,10 +62,13 @@ async def run_prompt(
     step_name: str = "",
     verbose: bool = False,
     output_fn: OutputFn = None,
+    origin_product: Task.OriginProduct | None = None,
     internal: bool = False,
 ) -> tuple[str, str]:
     """Spawn a sandbox agent with the given prompt and return (last_message, full_log)."""
-    task, task_run = await _create_task_and_trigger(prompt, context, branch, step_name, internal=internal)
+    task, task_run = await _create_task_and_trigger(
+        prompt, context, branch, step_name, origin_product=origin_product, internal=internal
+    )
     logger.info("custom_prompt: started task=%s run=%s step=%s", task.id, task_run.id, step_name or "unknown")
     # No try/catch, propagating to the caller, if it fails,
     # to turn into a clear failure instead of JSON parse error
@@ -79,7 +82,7 @@ async def _create_task_and_trigger(
     context: CustomPromptSandboxContext,
     branch: str | None = None,
     step_name: str = "",
-    origin_product: str | None = None,
+    origin_product: Task.OriginProduct | None = None,
     signal_report_id: str | None = None,
     internal: bool = False,
 ):
@@ -89,7 +92,7 @@ async def _create_task_and_trigger(
         team=team,
         title=title,
         description=description,
-        origin_product=Task.OriginProduct(origin_product) if origin_product else Task.OriginProduct.USER_CREATED,
+        origin_product=origin_product or Task.OriginProduct.USER_CREATED,
         user_id=context.user_id,
         repository=context.repository,
         create_pr=False,

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -99,12 +99,8 @@ async def _create_task_and_trigger(
         mode="background",
         branch=branch,
         signal_report_id=signal_report_id,
-<<<<<<< New base: mark signals tasks as internal
         model=context.model,
-||||||| Common ancestor
-=======
         internal=internal,
->>>>>>> Current commit: mark signals tasks as internal
     )
     # lambda wrap: task.latest_run is a lazy ORM property; sync_to_async needs a callable
     task_run = await sync_to_async(lambda: task.latest_run)()


### PR DESCRIPTION
These should be marked as internal, and not externally available for PH code users to view, we also want to exclude them from billing