### PR TITLE
chore(llm-gateway): increase cost limit for django

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -29,7 +29,7 @@ DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "wizard": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),
     "posthog_code": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
     "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
-    "django": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),
+    "django": ProductCostLimit(limit_usd=5000.0, window_seconds=86400),
 }
 
 DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {


### PR DESCRIPTION
## Problem

Django is hitting a cost limit because we routed more traffic from PHAI to the LLM Gateway.

## Changes

Increased default limit

## How did you test this code?

n/a

## Publish to changelog?

no

## Docs update

n/a