### PR TITLE
feat(logs): add metrics for alert processing durations and pending alerts

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -43,10 +43,14 @@ from products.logs.backend.temporal.metrics import (
     increment_checks_total,
     increment_notification_failures,
     increment_state_transition,
+    record_alert_save_duration,
     record_alerts_active,
     record_check_duration,
     record_checkpoint_lag,
+    record_clickhouse_duration,
+    record_pending_alerts,
     record_scheduler_lag,
+    record_semaphore_wait,
 )
 
 logger = structlog.get_logger(__name__)
@@ -102,8 +106,10 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
     eval_async = database_sync_to_async_pool(_evaluate_single_alert)
 
     async def _bounded_eval(alert: LogsAlertConfiguration) -> dict[str, int]:
+        wait_start = time.perf_counter()
+        local_stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         async with semaphore:
-            local_stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+            wait_ms = int((time.perf_counter() - wait_start) * 1000)
             try:
                 await eval_async(alert, now, local_stats, checkpoint=checkpoint)
             except Exception:
@@ -114,7 +120,11 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
                     team_id=alert.team_id,
                 )
                 local_stats["errored"] += 1
-            return local_stats
+        try:
+            record_semaphore_wait(wait_ms)
+        except Exception:
+            logger.exception("Failed to record semaphore_wait histogram")
+        return local_stats
 
     tasks: list[asyncio.Task[dict[str, int]]] = []
     async with asyncio.TaskGroup() as tg:
@@ -129,6 +139,12 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
     if aggregated["checked"] > 0:
         logger.info("Alert check cycle complete", **aggregated)
 
+    try:
+        pending = await database_sync_to_async_pool(_count_pending_alerts)()
+        record_pending_alerts(pending)
+    except Exception:
+        logger.exception("Failed to record pending_alerts gauge")
+
     return CheckAlertsOutput(
         alerts_checked=aggregated["checked"],
         alerts_fired=aggregated["fired"],
@@ -137,19 +153,26 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
     )
 
 
-def _load_alerts_and_checkpoint() -> tuple[datetime, list[LogsAlertConfiguration], datetime | None]:
-    """Sync setup: pin `now`, load due alerts, fetch ingestion checkpoint, emit cycle metrics."""
-    now = datetime.now(UTC)
-
-    all_alerts = list(
+def _due_alerts_qs(now: datetime):
+    return (
         LogsAlertConfiguration.objects.filter(
             Q(enabled=True),
             Q(next_check_at__lte=now) | Q(next_check_at__isnull=True),
         )
-        .select_related("team")
         .exclude(state=LogsAlertConfiguration.State.SNOOZED, snooze_until__gt=now)
         .exclude(state=LogsAlertConfiguration.State.BROKEN)
     )
+
+
+def _count_pending_alerts() -> int:
+    return _due_alerts_qs(datetime.now(UTC)).count()
+
+
+def _load_alerts_and_checkpoint() -> tuple[datetime, list[LogsAlertConfiguration], datetime | None]:
+    """Sync setup: pin `now`, load due alerts, fetch ingestion checkpoint, emit cycle metrics."""
+    now = datetime.now(UTC)
+
+    all_alerts = list(_due_alerts_qs(now).select_related("team"))
 
     try:
         record_alerts_active(len(all_alerts))
@@ -338,6 +361,7 @@ def _evaluate_single_alert(
     state_before = alert.state
     state_changed = state_before != committed_state.value
     is_error = outcome.error_message is not None
+    save_start = time.perf_counter()
     with transaction.atomic():
         # Stateless eval: write a CHECK row only on state transition or eval error.
         # Steady-state same-state evals don't write — the N-of-M evaluator gets its
@@ -369,6 +393,7 @@ def _evaluate_single_alert(
             update_fields.append("last_notified_at")
 
         alert.save(update_fields=update_fields)
+    save_ms = int((time.perf_counter() - save_start) * 1000)
 
     stats["checked"] += 1
 
@@ -379,6 +404,9 @@ def _evaluate_single_alert(
     try:
         elapsed_ms = int((time.perf_counter() - start_time) * 1000)
         record_check_duration(elapsed_ms)
+        record_alert_save_duration(save_ms)
+        if check_result.query_duration_ms is not None:
+            record_clickhouse_duration(check_result.query_duration_ms)
         if original_next_check_at is not None:
             lag_ms = int((now - original_next_check_at).total_seconds() * 1000)
             if lag_ms > 0:

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -35,6 +35,9 @@ LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS = (
     "logs_alerting_cycle_duration_ms",
     "logs_alerting_scheduler_lag_ms",
     "logs_alerting_schedule_to_start_ms",
+    "logs_alerting_clickhouse_duration_ms",
+    "logs_alerting_semaphore_wait_ms",
+    "logs_alerting_alert_save_ms",
 )
 
 LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS = [
@@ -47,6 +50,8 @@ LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS = [
     60_000.0,
     120_000.0,
     300_000.0,
+    600_000.0,
+    1_800_000.0,
 ]
 
 
@@ -118,6 +123,15 @@ def record_alerts_active(count: int) -> None:
     gauge.set(count)
 
 
+def record_pending_alerts(count: int) -> None:
+    meter = get_metric_meter()
+    gauge = meter.create_gauge(
+        "logs_alerting_pending_alerts",
+        "Number of due alerts still waiting to be evaluated at end of cycle (backlog)",
+    )
+    gauge.set(count)
+
+
 def record_checkpoint_lag(now: dt.datetime, checkpoint: dt.datetime) -> None:
     meter = get_metric_meter()
     gauge = meter.create_gauge(
@@ -139,6 +153,30 @@ def increment_checkpoint_unavailable() -> None:
 
 def record_check_duration(duration_ms: int) -> None:
     _record_histogram("logs_alerting_check_duration_ms", "Per-alert evaluation duration", duration_ms)
+
+
+def record_clickhouse_duration(duration_ms: int) -> None:
+    _record_histogram(
+        "logs_alerting_clickhouse_duration_ms",
+        "ClickHouse query wall time for a single alert evaluation",
+        duration_ms,
+    )
+
+
+def record_semaphore_wait(wait_ms: int) -> None:
+    _record_histogram(
+        "logs_alerting_semaphore_wait_ms",
+        "Time an alert spent waiting on the per-cycle concurrency semaphore",
+        wait_ms,
+    )
+
+
+def record_alert_save_duration(duration_ms: int) -> None:
+    _record_histogram(
+        "logs_alerting_alert_save_ms",
+        "Postgres write time for the per-eval alert state update",
+        duration_ms,
+    )
 
 
 def record_scheduler_lag(lag_ms: int) -> None:

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -350,6 +350,8 @@ class TestEvaluateSingleAlert(APIBaseTest):
         for target in (
             "products.logs.backend.temporal.activities.record_check_duration",
             "products.logs.backend.temporal.activities.record_scheduler_lag",
+            "products.logs.backend.temporal.activities.record_clickhouse_duration",
+            "products.logs.backend.temporal.activities.record_alert_save_duration",
             "products.logs.backend.temporal.activities.increment_checks_total",
             "products.logs.backend.temporal.activities.increment_check_errors",
         ):

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -16,11 +16,15 @@ from products.logs.backend.temporal.metrics import (
     increment_checks_total,
     increment_notification_failures,
     increment_state_transition,
+    record_alert_save_duration,
     record_alerts_active,
     record_check_duration,
     record_checkpoint_lag,
+    record_clickhouse_duration,
+    record_pending_alerts,
     record_schedule_to_start_latency,
     record_scheduler_lag,
+    record_semaphore_wait,
 )
 
 
@@ -172,6 +176,55 @@ class TestRecordCheckDuration:
     def test_records_histogram_with_duration(self, mock_record: MagicMock):
         record_check_duration(150)
         mock_record.assert_called_once_with("logs_alerting_check_duration_ms", "Per-alert evaluation duration", 150)
+
+
+class TestRecordClickhouseDuration:
+    @patch("products.logs.backend.temporal.metrics._record_histogram")
+    def test_records_histogram_with_duration(self, mock_record: MagicMock):
+        record_clickhouse_duration(2_500)
+        mock_record.assert_called_once_with(
+            "logs_alerting_clickhouse_duration_ms",
+            "ClickHouse query wall time for a single alert evaluation",
+            2_500,
+        )
+
+
+class TestRecordSemaphoreWait:
+    @patch("products.logs.backend.temporal.metrics._record_histogram")
+    def test_records_histogram_with_wait(self, mock_record: MagicMock):
+        record_semaphore_wait(800)
+        mock_record.assert_called_once_with(
+            "logs_alerting_semaphore_wait_ms",
+            "Time an alert spent waiting on the per-cycle concurrency semaphore",
+            800,
+        )
+
+
+class TestRecordAlertSaveDuration:
+    @patch("products.logs.backend.temporal.metrics._record_histogram")
+    def test_records_histogram_with_duration(self, mock_record: MagicMock):
+        record_alert_save_duration(45)
+        mock_record.assert_called_once_with(
+            "logs_alerting_alert_save_ms",
+            "Postgres write time for the per-eval alert state update",
+            45,
+        )
+
+
+class TestRecordPendingAlerts:
+    @pytest.mark.parametrize("count", [42, 0])
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_sets_gauge_value(self, mock_get_meter: MagicMock, count: int):
+        mock_meter = MagicMock()
+        mock_gauge = MagicMock()
+        mock_meter.create_gauge.return_value = mock_gauge
+        mock_get_meter.return_value = mock_meter
+
+        record_pending_alerts(count)
+
+        (name, _description), _ = mock_meter.create_gauge.call_args
+        assert name == "logs_alerting_pending_alerts"
+        mock_gauge.set.assert_called_once_with(count)
 
 
 class TestRecordScheduleToStartLatency:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8267,9 +8267,9 @@ export namespace Schemas {
       _create_static_person_ids?: string[];
     }
 
-    export type CohortPersonResultProperties = {[key: string]: unknown};
+    export type CohortPersonResultProperties = { [key: string]: unknown };
 
-    export type CohortPersonResultMatchedRecordingsItem = {[key: string]: unknown};
+    export type CohortPersonResultMatchedRecordingsItem = { [key: string]: unknown };
 
     /**
      * * `person` - person


### PR DESCRIPTION
## Problem

Observability gaps in the logs alerting pipeline made it difficult to diagnose latency and backlog issues. Specifically, there was no visibility into how long alerts waited on the concurrency semaphore, how long ClickHouse queries took per evaluation, how long Postgres writes took when saving alert state, or how many due alerts remained pending at the end of a cycle.

## Changes

Four new metrics have been added to the logs alerting pipeline:

- **`logs_alerting_semaphore_wait_ms`** (histogram) — time each alert spends waiting to acquire the per-cycle concurrency semaphore before evaluation begins.
- **`logs_alerting_clickhouse_duration_ms`** (histogram) — ClickHouse query wall time for a single alert evaluation, recorded when `query_duration_ms` is available on the check result.
- **`logs_alerting_alert_save_ms`** (histogram) — Postgres write time for the per-eval alert state update (the `transaction.atomic()` block).
- **`logs_alerting_pending_alerts`** (gauge) — count of due alerts still waiting to be evaluated at the end of each cycle, providing a backlog signal.

The histogram bucket range has also been extended to cover 600 s and 1,800 s to accommodate slower outliers.

The due-alerts query has been extracted into a shared `_due_alerts_qs` helper, which is reused by both the existing alert loader and the new `_count_pending_alerts` function.

## How did you test this code?

Unit tests were added for all four new metric functions (`TestRecordClickhouseDuration`, `TestRecordSemaphoreWait`, `TestRecordAlertSaveDuration`, `TestRecordPendingAlerts`) and the two new histogram recorders were added to the existing activity-level mock patches to prevent test interference.

## Publish to changelog?

No