### PR TITLE
fix(flags): use correct --retry-count flag for gh api

### DIFF
--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -329,7 +329,7 @@ jobs:
                   # network/auth/parse failure — that is the bug being fixed.
                   set -euo pipefail
                   tmp=$(mktemp)
-                  gh api --retry 3 \
+                  gh api --retry-count 3 \
                       -H 'Accept: application/vnd.github.raw' \
                       repos/PostHog/charts/contents/state.yaml > "$tmp"
                   enabled=$(yq '.state["feature-flags"].canary.enabled // false' "$tmp")


### PR DESCRIPTION
## Problem

Hwhoops!

PR #56920 introduced `gh api --retry 3` in the canary flags workflow, but `gh api` has no `--retry` flag. The workflow would fail on every PR synchronize event when it tries to read `state.yaml` from PostHog/charts.

## Changes

Change `--retry 3` to `--retry-count 3`, the actual flag name (added in gh CLI 2.55.0). GitHub-hosted runners currently ship gh 2.89.0, well above the minimum.

`--retry-count` retries on transient HTTP 5xx and network errors, not on 4xx responses, so real failures (bad token, missing file) still surface immediately. The `set -euo pipefail` and explicit failure handling from #56920 remain intact.

## How did you test this code?

The line only runs on PR synchronize against the canary workflow, so CI on this PR won't exercise it. Verified `--retry-count` is the supported flag (added in gh CLI 2.55.0) and that GitHub-hosted runners ship gh 2.89.0.