### PR TITLE
fix(insights): hog-charts annotation and tooltip fixes in dashboards

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -42,6 +42,13 @@
         padding: 0.5rem;
     }
 
+    // Hog-charts doesn't need the legacy padding compensation — its canvas is
+    // absolutely positioned, so the inherited overlay padding pushes badges
+    // below the x-axis instead of aligning them.
+    .HogChartsAnnotationsLayer .AnnotationsOverlay {
+        padding: 0;
+    }
+
     .LemonTable {
         background: none;
         border: none;

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -101,6 +101,33 @@ export function useChartInteraction<Meta = unknown>({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [series, labels, scales, dimensions])
 
+    // Dismiss the tooltip on scroll — pinned or not — since the anchor moves
+    // with the page and a stale tooltip is worse than no tooltip.
+    const tooltipShown = tooltipCtx !== null
+    useEffect(() => {
+        if (!tooltipShown) {
+            return
+        }
+        const handleScroll = (e: Event): void => {
+            // Allow scrolling inside the tooltip itself (long pinned content)
+            // or the chart wrapper (a nested legend) without dismissing.
+            const target = e.target
+            if (target instanceof Element) {
+                if (target.closest('[data-hog-charts-tooltip]')) {
+                    return
+                }
+                if (wrapperRef.current?.contains(target)) {
+                    return
+                }
+            }
+            clearTooltip()
+        }
+        window.addEventListener('scroll', handleScroll, { passive: true, capture: true })
+        return () => {
+            window.removeEventListener('scroll', handleScroll, true)
+        }
+    }, [tooltipShown, wrapperRef, clearTooltip])
+
     // Dismiss listeners for pinned tooltip
     useEffect(() => {
         if (!isPinned) {
@@ -124,34 +151,16 @@ export function useChartInteraction<Meta = unknown>({
             }
         }
 
-        const handleScroll = (e: Event): void => {
-            // Ignore scrolls that originate inside the tooltip itself or inside
-            // the chart wrapper — users should be able to scroll long pinned
-            // content (or a nested legend) without dismissing the tooltip.
-            const target = e.target
-            if (target instanceof Element) {
-                if (target.closest('[data-hog-charts-tooltip]')) {
-                    return
-                }
-                if (wrapperRef.current?.contains(target)) {
-                    return
-                }
-            }
-            clearTooltip()
-        }
-
         // Delay click listener so the pinning click doesn't immediately unpin
         const timer = setTimeout(() => {
             document.addEventListener('click', handleClickOutside, { passive: true })
         }, 0)
         document.addEventListener('keydown', handleKeyDown, { passive: true })
-        window.addEventListener('scroll', handleScroll, { passive: true, capture: true })
 
         return () => {
             clearTimeout(timer)
             document.removeEventListener('click', handleClickOutside)
             document.removeEventListener('keydown', handleKeyDown)
-            window.removeEventListener('scroll', handleScroll, true)
         }
     }, [isPinned, wrapperRef, clearTooltip])
 

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -57,7 +57,8 @@ export function Tooltip<Meta = unknown>({
                     ...floatingStyles,
                     pointerEvents: context.isPinned ? 'auto' : 'none',
                     width: 'max-content',
-                    zIndex: 'var(--z-tooltip)',
+                    // Below --z-modal (1100) so opening a modal cleanly covers the tooltip.
+                    zIndex: 1050,
                 }}
             >
                 {renderTooltip(context)}

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -57,8 +57,7 @@ export function Tooltip<Meta = unknown>({
                     ...floatingStyles,
                     pointerEvents: context.isPinned ? 'auto' : 'none',
                     width: 'max-content',
-                    // Below --z-modal (1100) so opening a modal cleanly covers the tooltip.
-                    zIndex: 1050,
+                    zIndex: 'var(--z-chart-tooltip)',
                 }}
             >
                 {renderTooltip(context)}

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useRef } from 'react'
+import React, { useMemo } from 'react'
 
 import { Chart } from 'lib/Chart'
 import { AnnotationsOverlay } from 'lib/components/AnnotationsOverlay'
@@ -32,18 +32,6 @@ export function AnnotationsLayer({
     xTickFormatter,
 }: AnnotationsLayerProps): React.ReactElement | null {
     const { scales, dimensions, labels } = useChart()
-    const wrapperRef = useRef<HTMLDivElement | null>(null)
-
-    // The shared `.AnnotationsOverlay` picks up `padding: 0.5rem` inside `.InsightCard__viz`
-    // (a legacy alignment hack for chart.js). Hog-charts doesn't need it — the canvas is
-    // absolutely positioned, so the padding only shifts the badges off the x-axis.
-    // Null out padding inline to avoid touching the shared scss rule.
-    useLayoutEffect(() => {
-        const overlay = wrapperRef.current?.querySelector<HTMLDivElement>('.AnnotationsOverlay')
-        if (overlay) {
-            overlay.style.padding = '0'
-        }
-    })
 
     const chartLike = useMemo(() => {
         const visibleXLabels = computeVisibleXLabels(labels, scales.x, xTickFormatter)
@@ -66,7 +54,7 @@ export function AnnotationsLayer({
     }
 
     return (
-        <div ref={wrapperRef} style={WRAPPER_STYLE} onClick={stopClickPropagation}>
+        <div className="HogChartsAnnotationsLayer" style={WRAPPER_STYLE} onClick={stopClickPropagation}>
             <AnnotationsOverlay
                 chart={chartLike as unknown as Chart}
                 dates={dates}

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -20,6 +20,12 @@ const WRAPPER_STYLE: React.CSSProperties = {
     pointerEvents: 'auto',
 }
 
+// Stop badge clicks from bubbling to the chart wrapper, which would otherwise
+// fire the chart's onPointClick (e.g. opening the persons modal).
+const stopClickPropagation = (e: React.MouseEvent<HTMLDivElement>): void => {
+    e.stopPropagation()
+}
+
 export function AnnotationsLayer({
     insightNumericId,
     dates,
@@ -48,7 +54,11 @@ export function AnnotationsLayer({
     }
 
     return (
-        <div style={WRAPPER_STYLE}>
+        <div
+            className="HogChartsAnnotationsLayer [&_.AnnotationsOverlay]:!p-0"
+            style={WRAPPER_STYLE}
+            onClick={stopClickPropagation}
+        >
             <AnnotationsOverlay
                 chart={chartLike as unknown as Chart}
                 dates={dates}

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useLayoutEffect, useMemo, useRef } from 'react'
 
 import { Chart } from 'lib/Chart'
 import { AnnotationsOverlay } from 'lib/components/AnnotationsOverlay'
@@ -32,6 +32,18 @@ export function AnnotationsLayer({
     xTickFormatter,
 }: AnnotationsLayerProps): React.ReactElement | null {
     const { scales, dimensions, labels } = useChart()
+    const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+    // The shared `.AnnotationsOverlay` picks up `padding: 0.5rem` inside `.InsightCard__viz`
+    // (a legacy alignment hack for chart.js). Hog-charts doesn't need it — the canvas is
+    // absolutely positioned, so the padding only shifts the badges off the x-axis.
+    // Null out padding inline to avoid touching the shared scss rule.
+    useLayoutEffect(() => {
+        const overlay = wrapperRef.current?.querySelector<HTMLDivElement>('.AnnotationsOverlay')
+        if (overlay) {
+            overlay.style.padding = '0'
+        }
+    })
 
     const chartLike = useMemo(() => {
         const visibleXLabels = computeVisibleXLabels(labels, scales.x, xTickFormatter)
@@ -54,11 +66,7 @@ export function AnnotationsLayer({
     }
 
     return (
-        <div
-            className="HogChartsAnnotationsLayer [&_.AnnotationsOverlay]:!p-0"
-            style={WRAPPER_STYLE}
-            onClick={stopClickPropagation}
-        >
+        <div ref={wrapperRef} style={WRAPPER_STYLE} onClick={stopClickPropagation}>
             <AnnotationsOverlay
                 chart={chartLike as unknown as Chart}
                 dates={dates}

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -650,6 +650,7 @@
     --z-definition-popover: 1250;
     --z-popover: 1200;
     --z-graph-tooltip: 1150;
+    --z-chart-tooltip: calc(var(--z-modal) - 50);
 
     // 1161 and 1162 are reserved to be set from code
     // 1166 through 1169 are reserved to be set from code


### PR DESCRIPTION
## Problem

A few bugs surfaced in the new hog-charts library when used inside dashboard insight cards:

- Annotation badges sat ~8px below the x-axis, overlapping the date labels.
- Clicking the annotation `+` badge also triggered the chart's `onPointClick`, opening the persons modal alongside the annotation popover.
- The chart tooltip stayed visible when an annotation modal opened on top.
- The chart tooltip didn't dismiss on scroll unless it was pinned.

## Changes

- `AnnotationsLayer.tsx`: zero out the inherited `.AnnotationsOverlay` padding via a Tailwind arbitrary variant — the legacy padding hack compensated for a canvas shift that no longer exists in hog-charts (canvas is `position: absolute`).
- `AnnotationsLayer.tsx`: stop clicks on annotation badges/popover from bubbling to the chart wrapper's `onClick`.
- `Tooltip.tsx`: lower hog-charts tooltip `z-index` to `1050` (below `--z-modal: 1100`) so modals cleanly cover it.
- `useChartInteraction.ts`: split the scroll-dismiss listener out of the pinned-only effect so unpinned tooltips also dismiss on scroll.

## How did you test this code?

I'm an agent — no manual testing. No automated tests added/run for this change. Visual verification of the tooltip and annotation behavior should happen in dashboard cards before merge.

## Publish to changelog?