### PR TITLE
fix(cymbal): make resolve_failure round-trip through PG

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    error::{FrameError, UnhandledError},
+    error::UnhandledError,
     fingerprinting::{FingerprintBuilder, FingerprintComponent, FingerprintRecordPart},
     langs::{
         apple::{AppleDebugImage, RawAppleFrame},
@@ -25,6 +25,26 @@ use crate::{
     sanitize_source_line,
     symbol_store::Catalog,
 };
+
+/// Records the metric and tracing line for a single failed-frame construction. Each
+/// language-specific `From<(&RawFrame, Err, ...)> for Frame` impl calls this with the
+/// typed error in scope, so we don't have to round-trip the typed error through the
+/// `Frame` struct just to recover the metric reason later.
+pub(crate) fn record_frame_resolution_failure(
+    lang: &'static str,
+    reason: &'static str,
+    err: &dyn std::fmt::Display,
+) {
+    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang, "reason" => reason).increment(1);
+    match reason {
+        "network_error" | "invalid_data" | "symbol_not_found" => {
+            tracing::warn!(lang = lang, reason = reason, error = %err, "frame resolution failed");
+        }
+        _ => {
+            tracing::debug!(lang = lang, reason = reason, error = %err, "frame resolution failed");
+        }
+    }
+}
 
 pub mod records;
 pub mod releases;
@@ -115,22 +135,13 @@ impl RawFrame {
             for frame in frames {
                 if frame.resolved {
                     metrics::counter!(FRAME_RESOLVED, "lang" => lang_tag).increment(1);
-                } else if let Some(err) = &frame.resolve_failure {
-                    let reason = err.metric_reason();
-                    match reason {
-                        "network_error" | "invalid_data" | "symbol_not_found" => {
-                            tracing::warn!(lang = lang_tag, reason = reason, error = %err, "frame resolution failed");
-                        }
-                        _ => {
-                            tracing::debug!(lang = lang_tag, reason = reason, error = %err, "frame resolution failed");
-                        }
-                    }
-                    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => reason)
-                        .increment(1);
-                } else {
-                    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => "unknown")
-                        .increment(1);
                 }
+                // Failure metrics are emitted by the language-specific `From` impls in
+                // `langs/*.rs` at the moment of frame construction, where the typed error
+                // is in scope (so we can call `metric_reason()` directly). This avoids
+                // having to carry the typed error on the `Frame` struct just to recover
+                // the metric label, which previously required a custom serializer plus
+                // `skip_deserializing` and silently dropped failure reasons on PG round-trip.
             }
         }
 
@@ -204,13 +215,8 @@ pub struct Frame {
     pub resolved_name: Option<String>, // The name of the function, after symbolification
     pub lang: String, // The language of the frame. Always known (I guess?)
     pub resolved: bool, // Did we manage to resolve the frame?
-    #[serde(
-        serialize_with = "frame_error_serde::serialize",
-        skip_deserializing,
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
-    pub resolve_failure: Option<FrameError>, // If we failed to resolve the frame, why?
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub resolve_failure: Option<String>, // If we failed to resolve the frame, why? Plain string so it round-trips cleanly through PG/JSON; the typed metric label is emitted at construction time via `record_frame_resolution_failure`.
 
     #[serde(default)] // Defaults to false
     pub synthetic: bool, // Some SDKs construct stack traces, or partially reconstruct them. This flag indicates whether the frame is synthetic or not.
@@ -380,11 +386,7 @@ impl std::fmt::Display for Frame {
         writeln!(
             f,
             "  resolve_failure: {}",
-            self.resolve_failure
-                .as_ref()
-                .map(|e| e.to_string())
-                .as_deref()
-                .unwrap_or("no failure")
+            self.resolve_failure.as_deref().unwrap_or("no failure")
         )?;
 
         // Context
@@ -433,25 +435,6 @@ impl From<Frame> for FrameData {
             column: frame.column,
             lang: frame.lang,
             code_variables: frame.code_variables,
-        }
-    }
-}
-
-mod frame_error_serde {
-    use super::FrameError;
-    use serde::Serializer;
-
-    pub fn serialize<S>(value: &Option<FrameError>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // skip_serializing_if = "Option::is_none" guarantees value is Some here,
-        // but we match exhaustively to satisfy the type checker.
-        match value {
-            Some(err) => serializer.serialize_str(&err.to_string()),
-            None => {
-                unreachable!("skip_serializing_if = Option::is_none prevents None reaching here")
-            }
         }
     }
 }

--- a/rust/cymbal/src/langs/apple.rs
+++ b/rust/cymbal/src/langs/apple.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::Ordering;
 use crate::{
     config::FRAME_CONTEXT_LINES,
     error::{AppleError, FrameError, ResolveError, UnhandledError},
-    frames::Frame,
+    frames::{record_frame_resolution_failure, Frame},
     langs::utils::{add_raw_to_junk, get_context_lines},
     langs::CommonFrameMetadata,
     symbol_store::{
@@ -340,6 +340,8 @@ impl RawAppleFrame {
     }
 
     fn handle_resolution_error(&self, err: AppleError) -> Frame {
+        record_frame_resolution_failure("apple", err.metric_reason(), &err);
+
         // Demangle the raw function name if present
         let mangled = self.function.clone().unwrap_or_default();
         let resolved_name = if !mangled.is_empty() {
@@ -391,7 +393,7 @@ impl RawAppleFrame {
             resolved_name,
             lang: lang_from_filename(self.filename.as_deref()).to_string(),
             resolved: false,
-            resolve_failure: Some(FrameError::from(err)),
+            resolve_failure: Some(err.to_string()),
             junk_drawer: None,
             release: None,
             synthetic: self.meta.synthetic,

--- a/rust/cymbal/src/langs/hermes.rs
+++ b/rust/cymbal/src/langs/hermes.rs
@@ -7,7 +7,7 @@ use sourcemap::Token;
 
 use crate::{
     error::{FrameError, HermesError, ResolveError, UnhandledError},
-    frames::Frame,
+    frames::{record_frame_resolution_failure, Frame},
     langs::{
         utils::{add_raw_to_junk, get_token_context},
         CommonFrameMetadata,
@@ -123,6 +123,10 @@ impl Display for HermesRef {
 
 impl From<(&RawHermesFrame, HermesError)> for Frame {
     fn from((frame, err): (&RawHermesFrame, HermesError)) -> Self {
+        record_frame_resolution_failure("hermes", err.metric_reason(), &err);
+
+        let resolve_failure = Some(err.to_string());
+
         let mut res = Self {
             frame_id: FrameId::placeholder(),
             mangled_name: frame.fn_name.clone(),
@@ -133,7 +137,7 @@ impl From<(&RawHermesFrame, HermesError)> for Frame {
             resolved_name: None,
             lang: "javascript".to_string(),
             resolved: false,
-            resolve_failure: Some(FrameError::from(err)),
+            resolve_failure,
             synthetic: frame.meta.synthetic,
             junk_drawer: None,
             code_variables: None,

--- a/rust/cymbal/src/langs/java.rs
+++ b/rust/cymbal/src/langs/java.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 
 use crate::{
     error::{FrameError, ProguardError, ResolveError, UnhandledError},
-    frames::Frame,
+    frames::{record_frame_resolution_failure, Frame},
     langs::{utils::add_raw_to_junk, CommonFrameMetadata},
     symbol_store::{
         chunk_id::OrChunkId,
@@ -175,6 +175,10 @@ impl<'a> From<(&'a RawJavaFrame, StackFrame<'a>)> for Frame {
 
 impl From<(&RawJavaFrame, ProguardError)> for Frame {
     fn from((raw, error): (&RawJavaFrame, ProguardError)) -> Self {
+        record_frame_resolution_failure("java", error.metric_reason(), &error);
+
+        let resolve_failure = Some(error.to_string());
+
         let mut f = Frame {
             frame_id: FrameId::placeholder(),
             mangled_name: raw.function.clone(),
@@ -185,7 +189,7 @@ impl From<(&RawJavaFrame, ProguardError)> for Frame {
             resolved_name: None,
             lang: "java".to_string(),
             resolved: false,
-            resolve_failure: Some(FrameError::from(error)),
+            resolve_failure,
             junk_drawer: None,
             code_variables: None,
             release: None,

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -6,7 +6,7 @@ use symbolic::sourcemapcache::{ScopeLookupResult, SourceLocation, SourcePosition
 
 use crate::{
     error::{FrameError, JsResolveErr, ResolveError, UnhandledError},
-    frames::Frame,
+    frames::{record_frame_resolution_failure, Frame},
     langs::CommonFrameMetadata,
     sanitize_string,
     symbol_store::{chunk_id::OrChunkId, sourcemap::OwnedSourceMapCache, SymbolCatalog},
@@ -239,6 +239,8 @@ impl From<(&RawJSFrame, SourceLocation<'_>)> for Frame {
 // mark it as a failed resolve and emit an "unresolved" frame
 impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
     fn from((raw_frame, err, location): (&RawJSFrame, JsResolveErr, &FrameLocation)) -> Self {
+        record_frame_resolution_failure("javascript", err.metric_reason(), &err);
+
         // TODO - extremely rough
         let was_minified = match err {
             JsResolveErr::NoSourceUrl | JsResolveErr::NoUrlOrChunkId => false, // This frame's `source` didn't exist
@@ -253,6 +255,8 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
             Some(raw_frame.fn_name.clone())
         };
 
+        let resolve_failure = Some(err.to_string());
+
         let mut res = Self {
             frame_id: FrameId::placeholder(),
             mangled_name: raw_frame.fn_name.clone(),
@@ -266,7 +270,7 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
             // Regardless of whather we think this was a minified frame or not, we still put
             // the error message in resolve_failure, so if a user comes along and want to know
             // why we thought a frame wasn't minified, they can see the error message
-            resolve_failure: Some(FrameError::from(err)),
+            resolve_failure,
             junk_drawer: None,
             code_variables: None,
             context: None,

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -239,8 +239,6 @@ impl From<(&RawJSFrame, SourceLocation<'_>)> for Frame {
 // mark it as a failed resolve and emit an "unresolved" frame
 impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
     fn from((raw_frame, err, location): (&RawJSFrame, JsResolveErr, &FrameLocation)) -> Self {
-        record_frame_resolution_failure("javascript", err.metric_reason(), &err);
-
         // TODO - extremely rough
         let was_minified = match err {
             JsResolveErr::NoSourceUrl | JsResolveErr::NoUrlOrChunkId => false, // This frame's `source` didn't exist
@@ -248,6 +246,16 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
             JsResolveErr::NoSourcemap(_) => location.column > 300,
             _ => true,
         };
+
+        let resolved = !was_minified;
+
+        // Only record a frame-resolution-failure when the frame is actually unresolved —
+        // for `NoUrlOrChunkId` / `NoSourceUrl` (and short-line `NoSourcemap`) the heuristic
+        // above keeps the original function name and marks the frame `resolved: true`, so the
+        // dispatcher will already emit `FRAME_RESOLVED`. Firing here too would double-count.
+        if !resolved {
+            record_frame_resolution_failure("javascript", err.metric_reason(), &err);
+        }
 
         let resolved_name = if was_minified {
             None
@@ -266,7 +274,7 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
             in_app: raw_frame.meta.in_app,
             resolved_name,
             lang: "javascript".to_string(),
-            resolved: !was_minified,
+            resolved,
             // Regardless of whather we think this was a minified frame or not, we still put
             // the error message in resolve_failure, so if a user comes along and want to know
             // why we thought a frame wasn't minified, they can see the error message

--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{FrameError, JsResolveErr, ResolveError, UnhandledError},
-    frames::{Context, ContextLine, Frame},
+    frames::{record_frame_resolution_failure, Context, ContextLine, Frame},
     langs::CommonFrameMetadata,
     sanitize_string,
     symbol_store::{chunk_id::OrChunkId, sourcemap::OwnedSourceMapCache, SymbolCatalog},
@@ -221,6 +221,8 @@ impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
 
 impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
     fn from((raw_frame, resolve_err): (&RawNodeFrame, JsResolveErr)) -> Self {
+        record_frame_resolution_failure("javascript", resolve_err.metric_reason(), &resolve_err);
+
         let was_minified = raw_frame
             .get_context()
             .as_ref()
@@ -232,6 +234,8 @@ impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
         } else {
             Some(raw_frame.function.clone())
         };
+
+        let resolve_failure = Some(resolve_err.to_string());
 
         let mut res = Self {
             frame_id: FrameId::placeholder(),
@@ -246,7 +250,7 @@ impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
             // Regardless of whather we think this was a minified frame or not, we still put
             // the error message in resolve_failure, so if a user comes along and want to know
             // why we thought a frame wasn't minified, they can see the error message
-            resolve_failure: Some(FrameError::from(resolve_err)),
+            resolve_failure,
             junk_drawer: None,
             code_variables: None,
             context: raw_frame.get_context(),

--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -221,13 +221,24 @@ impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
 
 impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
     fn from((raw_frame, resolve_err): (&RawNodeFrame, JsResolveErr)) -> Self {
-        record_frame_resolution_failure("javascript", resolve_err.metric_reason(), &resolve_err);
-
         let was_minified = raw_frame
             .get_context()
             .as_ref()
             .map(context_likely_minified)
             .unwrap_or_default();
+
+        let resolved = !was_minified;
+
+        // Only record a frame-resolution-failure when the frame is actually unresolved —
+        // when context heuristics say "not minified", the dispatcher emits `FRAME_RESOLVED`
+        // and firing here too would double-count.
+        if !resolved {
+            record_frame_resolution_failure(
+                "javascript",
+                resolve_err.metric_reason(),
+                &resolve_err,
+            );
+        }
 
         let resolved_name = if was_minified {
             None
@@ -246,7 +257,7 @@ impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
             in_app: raw_frame.meta.in_app,
             resolved_name,
             lang: "javascript".to_string(),
-            resolved: !was_minified,
+            resolved,
             // Regardless of whather we think this was a minified frame or not, we still put
             // the error message in resolve_failure, so if a user comes along and want to know
             // why we thought a frame wasn't minified, they can see the error message

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -301,12 +301,6 @@ fn extract_exception_list(response: &SuccessResponse) -> ExceptionList {
     props.exception_list
 }
 
-fn extract_exception_list_raw(response: &SuccessResponse) -> serde_json::Value {
-    let event = response.first_event();
-    let props = event.as_ref().unwrap().properties.clone();
-    props["$exception_list"].clone()
-}
-
 // Tests
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -553,10 +547,8 @@ async fn handles_missing_sourcemap(db: PgPool) {
     let (status, body): (_, SuccessResponse) = harness.post_event(&event).await;
 
     assert!(status.is_success());
-    // Use raw JSON extraction to avoid losing resolve_failure during
-    // typed deserialization (Frame's resolve_failure is skip_deserializing).
-    let exception_list = extract_exception_list_raw(&body);
-    assert_json_snapshot!(exception_list, {
+    let exception_list = extract_exception_list(&body);
+    assert_json_snapshot!(exception_list.0, {
         "[].id" => "REDACTED",
     });
 }

--- a/rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap
+++ b/rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap
@@ -1,15 +1,26 @@
 ---
 source: cymbal/tests/event.rs
-expression: exception_list
+expression: exception_list.0
 ---
 [
   {
     "id": "REDACTED",
+    "type": "CustomError",
+    "value": "Custom error message",
     "stacktrace": {
+      "type": "resolved",
       "frames": [
         {
+          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
+          "mangled_name": "onClok",
+          "line": 123,
           "column": 45,
           "in_app": true,
+          "lang": "javascript",
+          "resolved": false,
+          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
+          "synthetic": false,
+          "suspicious": false,
           "junk_drawer": {
             "raw_frame": {
               "chunk_id": "124",
@@ -20,19 +31,19 @@ expression: exception_list
               "lineno": 123,
               "synthetic": false
             }
-          },
-          "lang": "javascript",
-          "line": 123,
-          "mangled_name": "onClok",
-          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
-          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
-          "resolved": false,
-          "suspicious": false,
-          "synthetic": false
+          }
         },
         {
+          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
+          "mangled_name": "onClok",
+          "line": 123,
           "column": 45,
           "in_app": true,
+          "lang": "javascript",
+          "resolved": false,
+          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
+          "synthetic": false,
+          "suspicious": false,
           "junk_drawer": {
             "raw_frame": {
               "chunk_id": "124",
@@ -43,19 +54,19 @@ expression: exception_list
               "lineno": 123,
               "synthetic": false
             }
-          },
-          "lang": "javascript",
-          "line": 123,
-          "mangled_name": "onClok",
-          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
-          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
-          "resolved": false,
-          "suspicious": false,
-          "synthetic": false
+          }
         },
         {
+          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
+          "mangled_name": "onClok",
+          "line": 123,
           "column": 45,
           "in_app": true,
+          "lang": "javascript",
+          "resolved": false,
+          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
+          "synthetic": false,
+          "suspicious": false,
           "junk_drawer": {
             "raw_frame": {
               "chunk_id": "124",
@@ -66,20 +77,9 @@ expression: exception_list
               "lineno": 123,
               "synthetic": false
             }
-          },
-          "lang": "javascript",
-          "line": 123,
-          "mangled_name": "onClok",
-          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
-          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
-          "resolved": false,
-          "suspicious": false,
-          "synthetic": false
+          }
         }
-      ],
-      "type": "resolved"
-    },
-    "type": "CustomError",
-    "value": "Custom error message"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Problem

Frame `resolve_failure` was silently dropped on every PG round-trip in cymbal, so any frame served from the `posthog_errortrackingstackframe` cache came back as if it had no failure reason. Concretely, this manifested as JS frames with non-`http(s)://` URLs (e.g. Capacitor / Ionic frames where `filename` is `capacitor://localhost/...`) appearing as `resolved: true` with the original mangled name and **no `resolve_failure`** — so neither the user nor the metric label could see the frame had actually skipped sourcemap resolution. The PG cache also caused the failure-reason metric counter to mis-bucket into `reason: "unknown"` on cache hits.

Root cause was the `Option<FrameError>` field on `Frame` using a custom `serialize_with` plus `skip_deserializing` (introduced in #52057): the typed enum was written out as a flat string, but never read back, so `Option::is_none` then stripped it from the next serialization. The typed value only existed to power one consumer — `metric_reason()` for the `FRAME_NOT_RESOLVED` counter label — and storing it on the transport struct just to read it back two lines later was the design mistake.

## Changes

- Reverted `Frame.resolve_failure` to `Option<String>` with default symmetric serde — round-trips through PG/JSON without information loss.
- Added `record_frame_resolution_failure(lang, reason, err)` helper in `frames/mod.rs`. Each language-specific failure `From` impl (`js`, `node`, `hermes`, `apple`, `java`) calls it once at construction with the typed error in scope, so `metric_reason()` is read where it's available without needing to round-trip the typed value.
- Removed the `frame_error_serde` custom-serializer module.
- Simplified the dispatcher loop in `RawFrame::resolve` — only emits the `FRAME_RESOLVED` counter; failure metrics are now emitted at construction.
- Cleaned up the `tests/event.rs` workaround that existed specifically because of `skip_deserializing`: switched `handles_missing_sourcemap` back to the typed `extract_exception_list` path and removed the now-dead `extract_exception_list_raw` helper. Existing snapshot is unchanged because `err.to_string()` produces the same string as the previous custom serializer (`FrameError::JavaScript` is `#[error(transparent)]`).

## How did you test this code?

Agent-authored PR. Verified locally:

- \`cargo check -p cymbal --tests\` — clean
- \`cargo build -p cymbal\` — clean
- \`cargo clippy -p cymbal --tests --no-deps\` — clean
- \`cargo test -p cymbal --lib\` — 59 passed; 11 failed, all due to local PG \`PoolTimedOut\` (pre-existing, unrelated to this change)
- Existing \`handles_missing_sourcemap\` snapshot at \`rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap\` is unchanged; it expects \`"resolve_failure": "No sourcemap uploaded for chunk id: 124"\` which is what the new \`Option<String>\` path produces.

No manual testing performed. PG-dependent integration tests should be run in CI.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) under direction of @hpouillot. Investigation flow: traced a real-world Capacitor frame showing \`resolved: true\` with no \`resolve_failure\`, identified that PG cache load via \`ErrorTrackingStackFrame::load_all\` deserialized through \`Frame\` and silently dropped the field, traced the regression to #52057 (Mar 24, same author). Discussed alternatives (custom deserializer, two-field split, typed-on-Frame retention) before settling on the move-emission-to-construction approach.