### PR TITLE
fix: tag MCP requests and poll_query_performance HogQL queries

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -39,6 +39,7 @@ class Product(StrEnum):
     LLM_ANALYTICS = "llm_analytics"
     LOGS = "logs"
     MAX_AI = "max_ai"
+    MCP = "mcp"
     MESSAGING = "messaging"
     MOBILE_REPLAY = "mobile_replay"
     PIPELINE_DESTINATIONS = "pipeline_destinations"

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -31,10 +31,10 @@ from statshog.defaults.django import statsd
 
 from posthog.api.shared import UserBasicSerializer
 from posthog.clickhouse.client.execute import clickhouse_query_counter
-from posthog.clickhouse.query_tagging import QueryCounter, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, QueryCounter, reset_query_tags, tag_queries
 from posthog.cloud_utils import is_cloud, is_dev_mode
 from posthog.constants import AUTH_BACKEND_KEYS
-from posthog.event_usage import get_event_source, get_mcp_properties
+from posthog.event_usage import EventSource, get_event_source, get_mcp_properties
 from posthog.geoip import get_geoip_properties
 from posthog.helpers.user_devices import set_known_device_cookie
 from posthog.models import Action, Cohort, FeatureFlag, Insight, Team, User
@@ -381,6 +381,11 @@ class CHQueries:
             if request_id := structlog.get_context(self.logger).get("request_id"):
                 tag_queries(http_request_id=uuid.UUID(request_id))
 
+        source = get_event_source(request)
+        # MCP-originated requests can't tag queries themselves (no `tags.scene` or
+        # per-tool product/feature plumbing yet), so default both here. View-level
+        # `@monitor` decorators still override `feature` per endpoint.
+        mcp_defaults: dict = {"product": Product.MCP, "feature": Feature.QUERY} if source == EventSource.MCP else {}
         tag_queries(
             user_id=user.pk,
             kind="request",
@@ -391,7 +396,8 @@ class CHQueries:
             session_id=self._get_param(request, "session_id"),
             http_referer=request.headers.get("referer"),
             http_user_agent=request.headers.get("user-agent"),
-            source=get_event_source(request),
+            source=source,
+            **mcp_defaults,
             **get_mcp_properties(request),
         )
 

--- a/posthog/tasks/poll_query_performance.py
+++ b/posthog/tasks/poll_query_performance.py
@@ -8,6 +8,7 @@ from structlog import get_logger
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute_async import QueryStatusManager
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.settings import CLICKHOUSE_CLUSTER
 from posthog.utils import UUID_REGEX
 
@@ -25,6 +26,7 @@ def query_manager_from_initial_query_id(initial_query_id: str) -> Optional[Query
 
 
 def get_query_results() -> list[Any]:
+    tag_queries(product=Product.INTERNAL, feature=Feature.HEALTH_CHECK, name="poll_query_performance")
     SYSTEM_PROCESSES_SQL = r"""
         SELECT
             initial_query_id,

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1604,3 +1604,37 @@ def test_oauth_coop_middleware(path, query_string, expected_coop):
     middleware = OAuthCoopMiddleware(get_response)
     response = middleware(request)
     assert response["Cross-Origin-Opener-Policy"] == expected_coop
+
+
+@parameterized.expand(
+    [
+        ("mcp_user_agent_sets_defaults", "posthog/mcp-server v1", "mcp", "mcp", "query"),
+        ("api_user_agent_no_defaults", "Mozilla/5.0", "api", None, None),
+        ("posthog_code_no_defaults", "posthog/code", "posthog_code", None, None),
+    ]
+)
+def test_chqueries_middleware_mcp_defaults(name, user_agent, expected_source, expected_product, expected_feature):
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    from posthog.clickhouse.query_tagging import get_query_tags
+    from posthog.middleware import CHQueries
+
+    captured: dict = {}
+
+    def get_response(req):
+        tags = get_query_tags()
+        captured["source"] = tags.source
+        captured["product"] = tags.product
+        captured["feature"] = tags.feature
+        return HttpResponse("ok")
+
+    factory = RequestFactory()
+    request = factory.get("/api/projects/@current/query/", HTTP_USER_AGENT=user_agent)
+    request.user = MagicMock(pk=1, is_authenticated=False)
+
+    CHQueries(get_response)(request)
+
+    assert captured["source"] == expected_source
+    assert captured["product"] == expected_product
+    assert captured["feature"] == expected_feature

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1608,12 +1608,12 @@ def test_oauth_coop_middleware(path, query_string, expected_coop):
 
 @parameterized.expand(
     [
-        ("mcp_user_agent_sets_defaults", "posthog/mcp-server v1", "mcp", "mcp", "query"),
-        ("api_user_agent_no_defaults", "Mozilla/5.0", "api", None, None),
-        ("posthog_code_no_defaults", "posthog/code", "posthog_code", None, None),
+        ("posthog/mcp-server v1", "mcp", "mcp", "query"),
+        ("Mozilla/5.0", "web", None, None),
+        ("posthog/code", "posthog_code", None, None),
     ]
 )
-def test_chqueries_middleware_mcp_defaults(name, user_agent, expected_source, expected_product, expected_feature):
+def test_chqueries_middleware_mcp_defaults(user_agent, expected_source, expected_product, expected_feature):
     from django.http import HttpResponse
     from django.test import RequestFactory
 
@@ -1632,6 +1632,7 @@ def test_chqueries_middleware_mcp_defaults(name, user_agent, expected_source, ex
     factory = RequestFactory()
     request = factory.get("/api/projects/@current/query/", HTTP_USER_AGENT=user_agent)
     request.user = MagicMock(pk=1, is_authenticated=False)
+    request.session = MagicMock(session_key="abc123")
 
     CHQueries(get_response)(request)
 


### PR DESCRIPTION
## Problem

When running the local dev server with `DEBUG=1`, every HogQL query executed against ClickHouse without both `tags.product` and `tags.feature` raises `UntaggedQueryError` (`posthog/clickhouse/client/execute.py`). Two distinct paths were tripping it:

1. **MCP-originated queries.** `CHQueries` middleware already tags MCP requests with `source="mcp"` and `mcp_*` metadata, but never `product` / `feature`. View-level decorators normally fill those in (`@monitor(feature=Feature.QUERY)` on `QueryViewSet.create`, `_infer_query_tags` reading the frontend's `tags.scene`), but the MCP server has no equivalent of the frontend's scene plumbing.

2. **`poll_query_performance` Celery task.** A periodic infra job polls ClickHouse `system.processes` / `system.query_log` to track in-flight async queries — never had any product/feature tagging.

Beyond fixing the local error, an explicit `product` value also gives us a clean filter (`product=mcp`) for visibility on MCP-originated queries in the ClickHouse query log — same shape as the existing `Product.MAX_AI` precedent.

> _Note: this PR previously also added a `SQLEditor` scene mapping to `_SCENE_TO_TAGS`, but master picked it up independently while the PR was in review._

## Changes

- Add `Product.MCP = "mcp"` to the `Product` enum.
- In `CHQueries` middleware, default-tag `product=Product.MCP` and `feature=Feature.QUERY` whenever `get_event_source(request) == EventSource.MCP`. View-level `@monitor` decorators still override `feature` per endpoint.
- Tag `poll_query_performance` queries with `product=Product.INTERNAL`, `feature=Feature.HEALTH_CHECK`, matching the precedent in `posthog/temporal/health_checks/activities.py`.

## How did you test this code?

I'm an agent — I only ran automated tests, no manual testing.

- `posthog/test/test_middleware.py::test_chqueries_middleware_mcp_defaults` (3 parameterized cases): MCP user-agent gets the defaults; web-session and `posthog/code` user-agents do not.
- `posthog/tasks/test/test_poll_query_performance.py` (9 existing tests) still pass after adding the tag call.
- `posthog/clickhouse/test/test_query_tagging.py` (21 existing tests) still pass after adding the new `MCP` enum value.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). Decisions worth flagging for review:

- Chose to set the MCP defaults in `CHQueries` middleware rather than in the QueryViewSet because that's the existing chokepoint where `source` and `mcp_*` are already set, and it covers any future MCP-hit endpoint without further wiring.
- Picked `Product.MCP` (new enum value) instead of reusing `Product.API` because the goal includes query-log visibility on MCP traffic, and the existing precedent (`MAX_AI`, `ENDPOINTS`) treats "this caller is special" as a product.
- For `poll_query_performance`, picked `Product.INTERNAL` + `Feature.HEALTH_CHECK` to match the polling/status-check semantics used in `temporal/health_checks/activities.py` rather than `Feature.ENRICHMENT` (also a candidate, but less direct).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*