### PR TITLE
fix(ci): unbreak canary preflight (gh api flag, missing app token)

### DIFF
--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -329,7 +329,7 @@ jobs:
                   # network/auth/parse failure — that is the bug being fixed.
                   set -euo pipefail
                   tmp=$(mktemp)
-                  gh api --retry-count 3 \
+                  gh api \
                       -H 'Accept: application/vnd.github.raw' \
                       repos/PostHog/charts/contents/state.yaml > "$tmp"
                   enabled=$(yq '.state["feature-flags"].canary.enabled // false' "$tmp")

--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -561,6 +561,7 @@ jobs:
               env:
                   PR_AUTHOR: ${{ steps.pr_info.outputs.pr_author }}
               with:
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       // pr_author is set by pr_info: from the API for workflow_dispatch,
                       // from the event payload for pull_request.


### PR DESCRIPTION
## Problem

Two bugs in `canary-flags-enable.yml` keep the preflight gate shut on `pull_request: synchronize` and `workflow_dispatch`:

1. Line 332 calls `gh api --retry-count 3`. That flag does not exist; `gh api` has no retry mechanism. Failing run: https://github.com/PostHog/posthog/actions/runs/25116658722.
2. Line 558 ("Verify PR author is org member") calls `github.rest.orgs.getMembershipForUser` with no `github-token:`, so it falls back to the default `GITHUB_TOKEN`. That token has no `read:org` scope, the call returns `404`, and the catch block reports the user as a non-member.

Bug 1 masks bug 2 today.

## Changes

- Drop `--retry-count 3` from the `gh api` call. `set -euo pipefail` above the call still aborts on non-zero exit, preserving the no-silent-default guarantee.
- Pass `${{ steps.app-token.outputs.token }}` to the org-membership step, matching the pattern at the team-membership step (line 596).

The token fix assumes `GH_APP_POSTHOG_ASSIGN_REVIEWERS` has Organization > Members > Read. The team-membership step uses the same token but against a different endpoint (`getMembershipForUserInOrg`), so its success doesn't fully prove the org-level permission. If the App lacks it, the catch block needs to be reworded to point at the App permissions instead of the user.

## How did you test this code?

Verified by inspection: `gh api --help` lists no `--retry-count` flag, and the token wiring matches the canary-label step (line 502) and team-membership step (line 596) in the same file. The next canary run on a `pull_request: synchronize` event will tell us whether the App's permissions are sufficient.