### PR TITLE
chore(replay): add data attrs for trigger group buttons

### DIFF
--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/CreateFromLegacyModal.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/CreateFromLegacyModal.tsx
@@ -130,7 +130,12 @@ export function CreateFromLegacyModal({
                     <LemonButton type="secondary" onClick={onClose} disabled={isCreating}>
                         Cancel
                     </LemonButton>
-                    <LemonButton type="primary" onClick={onConfirm} loading={isCreating}>
+                    <LemonButton
+                        type="primary"
+                        onClick={onConfirm}
+                        loading={isCreating}
+                        data-attr="trigger-group-create-from-legacy-confirm"
+                    >
                         Create {pluralize(previewGroups.length, 'group')}
                     </LemonButton>
                 </div>

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupCard.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupCard.tsx
@@ -153,7 +153,7 @@ export function TriggerGroupCard({ group, onEdit, onDelete }: TriggerGroupCardPr
                 </div>
                 <div className="flex items-center gap-4">
                     <div className="flex gap-2">
-                        <LemonButton size="small" icon={<IconPencil />} onClick={onEdit}>
+                        <LemonButton size="small" icon={<IconPencil />} onClick={onEdit} data-attr="trigger-group-edit">
                             Edit
                         </LemonButton>
                         <LemonButton
@@ -162,6 +162,7 @@ export function TriggerGroupCard({ group, onEdit, onDelete }: TriggerGroupCardPr
                             status="danger"
                             onClick={onDelete ? () => onDelete(id) : undefined}
                             disabledReason={!onDelete ? 'Delete not yet implemented' : undefined}
+                            data-attr="trigger-group-delete"
                         >
                             Delete
                         </LemonButton>

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -130,7 +130,12 @@ export function TriggerGroupsEditor(): JSX.Element {
                 {!isAddingGroup && !editingGroupId && (
                     <div className="flex gap-2">
                         {triggerGroups.length === 0 && (
-                            <LemonButton type="secondary" size="small" onClick={showCreateFromLegacyModal}>
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                onClick={showCreateFromLegacyModal}
+                                data-attr="trigger-group-migrate-from-legacy"
+                            >
                                 Migrate from legacy recording conditions
                             </LemonButton>
                         )}
@@ -139,6 +144,7 @@ export function TriggerGroupsEditor(): JSX.Element {
                             icon={<IconPlus />}
                             size="small"
                             onClick={() => setIsAddingGroup(true)}
+                            data-attr="trigger-group-add"
                         >
                             Add
                         </LemonButton>
@@ -497,7 +503,7 @@ function GroupForm({ group, onSave, onCancel }: GroupFormProps): JSX.Element {
                 </div>
 
                 <div className="flex justify-end gap-2 pt-2 border-t">
-                    <LemonButton type="secondary" onClick={onCancel}>
+                    <LemonButton type="secondary" onClick={onCancel} data-attr="trigger-group-cancel">
                         Cancel
                     </LemonButton>
                     <LemonButton
@@ -505,6 +511,7 @@ function GroupForm({ group, onSave, onCancel }: GroupFormProps): JSX.Element {
                         htmlType="submit"
                         loading={isTriggerGroupSubmitting}
                         disabledReason={!triggerGroup.name.trim() ? 'Group name is required' : undefined}
+                        data-attr="trigger-group-save"
                     >
                         Save
                     </LemonButton>
@@ -600,7 +607,12 @@ function DeleteLastGroupModal({ isOpen, onClose, onConfirm, groupName }: DeleteL
                     <LemonButton type="secondary" onClick={onClose}>
                         Cancel
                     </LemonButton>
-                    <LemonButton type="primary" status="danger" onClick={onConfirm}>
+                    <LemonButton
+                        type="primary"
+                        status="danger"
+                        onClick={onConfirm}
+                        data-attr="trigger-group-delete-last-confirm"
+                    >
                         Delete and use legacy trigger settings
                     </LemonButton>
                 </div>


### PR DESCRIPTION
## Problem

oops

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->