### PR TITLE
fix(sql): fix folder selection and dialog logic keying issues

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
-import { ReactNode, forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { ReactNode, forwardRef, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Root, createRoot } from 'react-dom/client'
 
 import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
@@ -169,7 +169,9 @@ export const LemonFormDialog = ({
     primaryButtonProps,
     ...props
 }: LemonFormDialogProps): JSX.Element => {
-    const logic = lemonDialogLogic({ errors })
+    const dialogId = useId()
+    const logicProps = { dialogId, errors }
+    const logic = lemonDialogLogic(logicProps)
     const { form, isFormValid, formValidationErrors } = useValues(logic)
     const { setFormValues } = useActions(logic)
     const [isLoading, setIsLoading] = useState(false)
@@ -206,6 +208,7 @@ export const LemonFormDialog = ({
     return (
         <Form
             logic={lemonDialogLogic}
+            props={logicProps}
             formKey="form"
             onKeyDown={
                 props.shouldAwaitSubmit

--- a/frontend/src/lib/lemon-ui/LemonDialog/lemonDialogLogic.ts
+++ b/frontend/src/lib/lemon-ui/LemonDialog/lemonDialogLogic.ts
@@ -1,14 +1,16 @@
-import { kea, path, props } from 'kea'
+import { kea, key, path, props } from 'kea'
 import { forms } from 'kea-forms'
 
 import type { lemonDialogLogicType } from './lemonDialogLogicType'
 
 export type LemonDialogFormPropsType = {
+    dialogId?: string
     errors?: Record<string, (value: string) => string | undefined>
 }
 
 export const lemonDialogLogic = kea<lemonDialogLogicType>([
-    path(['components', 'lemon-dialog', 'lemonDialogLogic']),
+    path((key) => ['components', 'lemon-dialog', 'lemonDialogLogic', key]),
+    key((props) => props.dialogId || 'default'),
     props({} as LemonDialogFormPropsType),
     forms(({ props }) => ({
         form: {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1369,21 +1369,18 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                                         {({ value, onChange }) => (
                                             <LemonSelect<string | null>
                                                 value={value}
-                                                onChange={onChange}
+                                                onChange={(newValue) => {
+                                                    if (newValue === '__add_new_folder__') {
+                                                        void createFolderAndSelect(onChange)
+                                                    } else {
+                                                        onChange(newValue)
+                                                    }
+                                                }}
                                                 options={[
                                                     ...folderOptions,
                                                     {
                                                         value: '__add_new_folder__',
                                                         label: '+ Add new folder',
-                                                        labelInMenu: () => (
-                                                            <button
-                                                                type="button"
-                                                                className="w-full text-left text-primary px-2 py-1.5"
-                                                                onClick={() => createFolderAndSelect(onChange)}
-                                                            >
-                                                                + Add new folder
-                                                            </button>
-                                                        ),
                                                     },
                                                 ]}
                                                 disabled={isLoading}


### PR DESCRIPTION
## Problem

The "Add new folder" option in the SQL editor was using a custom button render that didn't properly integrate with the LemonSelect component's onChange handler. Additionally, the LemonFormDialog logic was not properly keyed, which could cause state conflicts when multiple dialogs were used on the same page.

## Changes

### SQL Editor Folder Selection
- Moved the "Add new folder" logic from a custom `labelInMenu` button render into the `onChange` handler
- Now checks if the selected value is `'__add_new_folder__'` and calls `createFolderAndSelect` accordingly
- Removed the custom button rendering, simplifying the option definition

### LemonFormDialog Logic Keying
- Added `useId()` hook to generate unique dialog IDs
- Updated `lemonDialogLogic` to accept `dialogId` as a prop and use it as the logic key
- Modified the logic path to include the key for proper isolation
- Ensured the Form component receives the correct props for logic instantiation

These changes ensure that:
1. The folder creation flow works correctly within the select component's lifecycle
2. Multiple form dialogs on the same page maintain independent state

## How did you test this code?

The changes are straightforward refactors that improve component integration:
- The folder selection logic now properly integrates with LemonSelect's onChange pattern
- The dialog logic keying follows Kea best practices for component isolation
- Existing tests should continue to pass as the external behavior remains the same

## Publish to changelog?

No

https://claude.ai/code/session_0183sb3oNsUnG143JsiLRbBp