### PR TITLE
fix(auth): clear local credentials on SSO merge

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -837,9 +837,13 @@ def social_create_user(
         # on the organization domain or if JIT provisioning is enabled, we'll provision them.
         logger.info(f"social_create_user_is_not_new")
 
-        if not user.is_email_verified and user.password is not None:
-            logger.info(f"social_create_user_is_not_new_unverified_has_password")
+        if not user.is_email_verified:
+            # Email isn't verified yet — anyone could have set these local credentials.
+            # Wipe them before linking the SSO identity.
+            logger.info(f"social_create_user_is_not_new_unverified_clearing_local_credentials")
             user.set_unusable_password()
+            WebauthnCredential.objects.filter(user=user).delete()
+            user.passkeys_enabled_for_2fa = False
             user.is_email_verified = True
             WebauthnCredential.objects.filter(user=user).delete()
             user.save()

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -845,7 +845,6 @@ def social_create_user(
             WebauthnCredential.objects.filter(user=user).delete()
             user.passkeys_enabled_for_2fa = False
             user.is_email_verified = True
-            WebauthnCredential.objects.filter(user=user).delete()
             user.save()
 
         if invite_id:

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1063,6 +1063,103 @@ class TestSignupAPI(APIBaseTest):
             self.assertEqual(existing_user.organization_memberships.count(), 1)
             self.assertEqual(existing_user.organization, new_org)
 
+    def _setup_jit_domain_for_email(self, email: str) -> Organization:
+        org = Organization.objects.create(name="Test org")
+        OrganizationDomain.objects.create(
+            domain=email.split("@")[1],
+            verified_at=timezone.now(),
+            jit_provisioning_enabled=True,
+            organization=org,
+        )
+        Team.objects.create(organization=org, name="Test Project")
+        return org
+
+    def _complete_sso_for_email(self, mock_request, mock_sso_providers, email: str):
+        mock_sso_providers.return_value = {"google-oauth2": True}
+        response = self.client.get(reverse("social:begin", kwargs={"backend": "google-oauth2"}))
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        url = reverse("social:complete", kwargs={"backend": "google-oauth2"})
+        url += f"?code=2&state={response.client.session['google-oauth2_state']}"
+        mock_request.return_value.json.return_value = {"access_token": "123", "email": email, "sub": "123"}
+        return self.client.get(url, follow=True)
+
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_merge_into_unverified_passkey_account_clears_passkey(self, mock_sso_providers, mock_request):
+        # An attacker pre-registered the email with a passkey-only signup. SSO must wipe
+        # the dangling passkey before merging the SSO identity into the existing row.
+        with self.is_cloud(True):
+            email = "victim@posthog.net"
+            squatter = User.objects.create(email=email, distinct_id=str(uuid.uuid4()))
+            squatter.set_unusable_password()
+            squatter.is_email_verified = False
+            squatter.passkeys_enabled_for_2fa = True
+            squatter.save()
+            WebauthnCredential.objects.create(
+                user=squatter,
+                credential_id=b"squatter-credential",
+                label="Squatter passkey",
+                public_key=b"squatter-public-key",
+                algorithm=-7,
+                verified=True,
+            )
+            self._setup_jit_domain_for_email(email)
+
+            response = self._complete_sso_for_email(mock_request, mock_sso_providers, email)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            squatter.refresh_from_db()
+            self.assertTrue(squatter.is_email_verified)
+            self.assertFalse(squatter.passkeys_enabled_for_2fa)
+            self.assertFalse(WebauthnCredential.objects.filter(user=squatter).exists())
+
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_merge_into_unverified_password_account_clears_password(self, mock_sso_providers, mock_request):
+        with self.is_cloud(True):
+            email = "victim@posthog.net"
+            squatter = User.objects.create(email=email, distinct_id=str(uuid.uuid4()))
+            squatter.set_password(VALID_TEST_PASSWORD)
+            squatter.is_email_verified = False
+            squatter.save()
+            self._setup_jit_domain_for_email(email)
+
+            response = self._complete_sso_for_email(mock_request, mock_sso_providers, email)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            squatter.refresh_from_db()
+            self.assertTrue(squatter.is_email_verified)
+            self.assertFalse(squatter.has_usable_password())
+
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_merge_into_verified_account_preserves_credentials(self, mock_sso_providers, mock_request):
+        with self.is_cloud(True):
+            email = "legit@posthog.net"
+            existing = User.objects.create(email=email, distinct_id=str(uuid.uuid4()))
+            existing.set_password(VALID_TEST_PASSWORD)
+            existing.is_email_verified = True
+            existing.save()
+            WebauthnCredential.objects.create(
+                user=existing,
+                credential_id=b"legit-credential",
+                label="Legit passkey",
+                public_key=b"legit-public-key",
+                algorithm=-7,
+                verified=True,
+            )
+            self._setup_jit_domain_for_email(email)
+
+            response = self._complete_sso_for_email(mock_request, mock_sso_providers, email)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            existing.refresh_from_db()
+            self.assertTrue(existing.has_usable_password())
+            self.assertTrue(WebauthnCredential.objects.filter(user=existing).exists())
+
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8267,9 +8267,9 @@ export namespace Schemas {
       _create_static_person_ids?: string[];
     }
 
-    export type CohortPersonResultProperties = {[key: string]: unknown};
+    export type CohortPersonResultProperties = { [key: string]: unknown };
 
-    export type CohortPersonResultMatchedRecordingsItem = {[key: string]: unknown};
+    export type CohortPersonResultMatchedRecordingsItem = { [key: string]: unknown };
 
     /**
      * * `person` - person


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

When SSO merges into an existing-but-unverified local user, we only wipe the local password if one was set - passkey-only accounts keep their pre-existing `WebauthnCredential` and `passkeys_enabled_for_2fa`

Security report: https://posthog.slack.com/archives/C0AB8JMD93P/p1777146555484749

## Changes

Drop the `password is not None` guard so the cleanup runs for every unverified merge, and clear `passkeys_enabled_for_2fa` alongside the password and `WebauthnCredential` rows.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

Tests

## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->