### PR TITLE
feat(visual-review): add snapshots overview page

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -123,6 +123,8 @@ export const productScenes: Record<string, () => Promise<any>> = {
     VisualReviewSettings: () => import('../../products/visual_review/frontend/scenes/VisualReviewSettingsScene'),
     VisualReviewSnapshotHistory: () =>
         import('../../products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene'),
+    VisualReviewSnapshotOverview: () =>
+        import('../../products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene'),
     Workflows: () => import('../../products/workflows/frontend/WorkflowsScene'),
     Workflow: () => import('../../products/workflows/frontend/Workflows/WorkflowScene'),
     WorkflowsLibraryTemplate: () => import('../../products/workflows/frontend/TemplateLibrary/MessageTemplate'),
@@ -222,6 +224,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/visual_review': ['VisualReviewRuns', 'visualReviewRuns'],
     '/visual_review/settings': ['VisualReviewSettings', 'visualReviewSettings'],
     '/visual_review/runs/:runId': ['VisualReviewRun', 'visualReviewRun'],
+    '/visual_review/repos/:repoId/snapshots': ['VisualReviewSnapshotOverview', 'visualReviewSnapshotOverview'],
     '/visual_review/repos/:repoId/:runType/snapshots/:identifier': [
         'VisualReviewSnapshotHistory',
         'visualReviewSnapshotHistory',
@@ -555,6 +558,7 @@ export const productConfiguration: Record<string, any> = {
         projectBased: true,
         iconType: 'visual_review',
     },
+    VisualReviewSnapshotOverview: { name: 'Snapshots', projectBased: true, iconType: 'visual_review' },
     Workflows: {
         name: 'Workflows',
         iconType: 'workflows',
@@ -934,6 +938,7 @@ export const productUrls = {
     visualReviewRuns: (): string => '/visual_review',
     visualReviewSettings: (): string => '/visual_review/settings',
     visualReviewRun: (runId: string): string => `/visual_review/runs/${runId}`,
+    visualReviewSnapshotOverview: (repoId: string): string => `/visual_review/repos/${repoId}/snapshots`,
     visualReviewSnapshotHistory: (repoId: string, runType: string, identifier: string): string =>
         `/visual_review/repos/${repoId}/${encodeURIComponent(runType)}/snapshots/${encodeURIComponent(identifier)}`,
     webAnalytics: (): string => `/web`,
@@ -1777,7 +1782,13 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         flag: FEATURE_FLAGS.VISUAL_REVIEW,
         tags: ['alpha'],
         sceneKey: 'VisualReviewRuns',
-        sceneKeys: ['VisualReviewRuns', 'VisualReviewRun', 'VisualReviewSettings', 'VisualReviewSnapshotHistory'],
+        sceneKeys: [
+            'VisualReviewRuns',
+            'VisualReviewRun',
+            'VisualReviewSettings',
+            'VisualReviewSnapshotHistory',
+            'VisualReviewSnapshotOverview',
+        ],
     },
     {
         path: 'Web analytics',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -118,6 +118,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     Tracing: () => import('../../products/tracing/frontend/TracingScene'),
     UserInterviews: () => import('../../products/user_interviews/frontend/UserInterviews'),
     UserInterview: () => import('../../products/user_interviews/frontend/UserInterview'),
+    VisualReviewIndex: () => import('../../products/visual_review/frontend/scenes/VisualReviewIndexScene'),
     VisualReviewRuns: () => import('../../products/visual_review/frontend/scenes/VisualReviewRunsScene'),
     VisualReviewRun: () => import('../../products/visual_review/frontend/scenes/VisualReviewRunScene'),
     VisualReviewSettings: () => import('../../products/visual_review/frontend/scenes/VisualReviewSettingsScene'),
@@ -221,9 +222,10 @@ export const productRoutes: Record<string, [string, string]> = {
     '/tracing': ['Tracing', 'tracing'],
     '/user_interviews': ['UserInterviews', 'userInterviews'],
     '/user_interviews/:id': ['UserInterview', 'userInterview'],
-    '/visual_review': ['VisualReviewRuns', 'visualReviewRuns'],
+    '/visual_review': ['VisualReviewIndex', 'visualReviewIndex'],
     '/visual_review/settings': ['VisualReviewSettings', 'visualReviewSettings'],
     '/visual_review/runs/:runId': ['VisualReviewRun', 'visualReviewRun'],
+    '/visual_review/repos/:repoId/runs': ['VisualReviewRuns', 'visualReviewRepoRuns'],
     '/visual_review/repos/:repoId/snapshots': ['VisualReviewSnapshotOverview', 'visualReviewSnapshotOverview'],
     '/visual_review/repos/:repoId/:runType/snapshots/:identifier': [
         'VisualReviewSnapshotHistory',
@@ -550,7 +552,8 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'user_interview',
     },
     UserInterview: { name: 'User interview', projectBased: true, activityScope: 'UserInterview' },
-    VisualReviewRuns: { name: 'Visual review', projectBased: true, iconType: 'visual_review' },
+    VisualReviewIndex: { name: 'Visual review', projectBased: true, iconType: 'visual_review' },
+    VisualReviewRuns: { name: 'Runs', projectBased: true, iconType: 'visual_review' },
     VisualReviewRun: { name: 'Visual review run', projectBased: true, iconType: 'visual_review' },
     VisualReviewSettings: { name: 'Visual review settings', projectBased: true, iconType: 'visual_review' },
     VisualReviewSnapshotHistory: {
@@ -938,6 +941,7 @@ export const productUrls = {
     visualReviewRuns: (): string => '/visual_review',
     visualReviewSettings: (): string => '/visual_review/settings',
     visualReviewRun: (runId: string): string => `/visual_review/runs/${runId}`,
+    visualReviewRepoRuns: (repoId: string): string => `/visual_review/repos/${repoId}/runs`,
     visualReviewSnapshotOverview: (repoId: string): string => `/visual_review/repos/${repoId}/snapshots`,
     visualReviewSnapshotHistory: (repoId: string, runType: string, identifier: string): string =>
         `/visual_review/repos/${repoId}/${encodeURIComponent(runType)}/snapshots/${encodeURIComponent(identifier)}`,
@@ -1781,8 +1785,9 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'visual_review' as FileSystemIconType,
         flag: FEATURE_FLAGS.VISUAL_REVIEW,
         tags: ['alpha'],
-        sceneKey: 'VisualReviewRuns',
+        sceneKey: 'VisualReviewIndex',
         sceneKeys: [
+            'VisualReviewIndex',
             'VisualReviewRuns',
             'VisualReviewRun',
             'VisualReviewSettings',

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -109,6 +109,7 @@ from products.signals.backend.views import SignalViewSet
 from products.tracing.backend.presentation.views import SpansViewSet as TracingSpansViewSet
 from products.user_interviews.backend.api import UserInterviewViewSet
 from products.visual_review.backend.presentation.views import (
+    RepoRunsViewSet as VisualReviewRepoRunsViewSet,
     RepoViewSet as VisualReviewRepoViewSet,
     RunViewSet as VisualReviewRunViewSet,
     SnapshotViewSet as VisualReviewSnapshotViewSet,
@@ -1262,6 +1263,12 @@ visual_review_repos_router.register(
     r"snapshots",
     VisualReviewSnapshotViewSet,
     "project_visual_review_snapshots",
+    ["project_id", "repo_id"],
+)
+visual_review_repos_router.register(
+    r"runs",
+    VisualReviewRepoRunsViewSet,
+    "project_visual_review_repo_runs",
     ["project_id", "repo_id"],
 )
 projects_router.register(

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -183,7 +183,10 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
         run = snapshot.run
         artifact = snapshot.current_artifact
         thumbnail = artifact.thumbnail if artifact is not None else None
-        per_day = raw.sparkline_by_id.get(identifier, {})
+        # `(run_type, identifier)` keys mirror the universe shape — see
+        # `_BaselineOverviewRaw.sparkline_by_key` for why.
+        spark_key = (run.run_type, identifier)
+        per_day = raw.sparkline_by_key.get(spark_key, {})
         sparkline = [
             contracts.BaselineSparklineDay(
                 clean=per_day.get(day, _ZERO_SPARK).clean,
@@ -204,9 +207,9 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
                 height=artifact.height if artifact is not None else None,
                 tolerate_count_30d=raw.tolerate_30d_by_id.get(identifier, 0),
                 tolerate_count_90d=raw.tolerate_90d_by_id.get(identifier, 0),
-                is_quarantined=(run.run_type, identifier) in raw.quarantined_ids,
+                is_quarantined=spark_key in raw.quarantined_ids,
                 last_run_at=run.completed_at or run.created_at,
-                recent_diff_avg=raw.drift_avg_by_id.get(identifier),
+                recent_diff_avg=raw.drift_avg_by_key.get(spark_key),
                 sparkline=sparkline,
             )
         )
@@ -227,7 +230,7 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
     )
 
 
-_ZERO_SPARK = logic._SparkBuckets()
+_ZERO_SPARK = logic.SparkBuckets()
 
 
 def _build_sparkline_day_keys(now) -> list[str]:

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -244,8 +244,8 @@ def _build_sparkline_day_keys(now) -> list[str]:
 # --- Run API ---
 
 
-def list_runs(team_id: int, review_state: str | None = None) -> list[contracts.Run]:
-    runs = logic.list_runs_for_team(team_id, review_state=review_state)
+def list_runs(team_id: int, review_state: str | None = None, repo_id: UUID | None = None) -> list[contracts.Run]:
+    runs = logic.list_runs_for_team(team_id, review_state=review_state, repo_id=repo_id)
     return [_to_run(r) for r in runs]
 
 

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -206,6 +206,7 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
                 tolerate_count_90d=raw.tolerate_90d_by_id.get(identifier, 0),
                 is_quarantined=(run.run_type, identifier) in raw.quarantined_ids,
                 last_run_at=run.completed_at or run.created_at,
+                recent_diff_avg=raw.drift_avg_by_id.get(identifier),
                 sparkline=sparkline,
             )
         )

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -249,8 +249,8 @@ def list_runs(team_id: int, review_state: str | None = None, repo_id: UUID | Non
     return [_to_run(r) for r in runs]
 
 
-def get_review_state_counts(team_id: int) -> dict[str, int]:
-    return logic.get_review_state_counts(team_id)
+def get_review_state_counts(team_id: int, repo_id: UUID | None = None) -> dict[str, int]:
+    return logic.get_review_state_counts(team_id, repo_id=repo_id)
 
 
 def create_run(input: contracts.CreateRunInput, team_id: int) -> contracts.CreateRunResult:

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -168,6 +168,78 @@ def read_thumbnail_bytes(repo_id: UUID, content_hash: str) -> bytes | None:
     return logic.read_thumbnail_bytes(repo_id, content_hash)
 
 
+def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
+    """Universe of identifiers with a current baseline, plus aggregates.
+
+    Backs the snapshots overview page. See `logic.get_baselines_overview` for
+    query shape and performance notes.
+    """
+    raw = logic.get_baselines_overview(repo_id)
+
+    days = _build_sparkline_day_keys(raw.generated_at)
+    entries: list[contracts.BaselineEntry] = []
+    for snapshot in raw.entries:
+        identifier = snapshot.identifier
+        run = snapshot.run
+        artifact = snapshot.current_artifact
+        thumbnail = artifact.thumbnail if artifact is not None else None
+        per_day = raw.sparkline_by_id.get(identifier, {})
+        sparkline = [
+            contracts.BaselineSparklineDay(
+                clean=per_day.get(day, _ZERO_SPARK).clean,
+                tolerated=per_day.get(day, _ZERO_SPARK).tolerated,
+                changed=per_day.get(day, _ZERO_SPARK).changed,
+                quarantined=per_day.get(day, _ZERO_SPARK).quarantined,
+            )
+            for day in days
+        ]
+        metadata = snapshot.metadata or {}
+        entries.append(
+            contracts.BaselineEntry(
+                identifier=identifier,
+                run_type=run.run_type,
+                browser=metadata.get("browser") if isinstance(metadata, dict) else None,
+                thumbnail_hash=thumbnail.content_hash if thumbnail is not None else None,
+                width=artifact.width if artifact is not None else None,
+                height=artifact.height if artifact is not None else None,
+                tolerate_count_30d=raw.tolerate_30d_by_id.get(identifier, 0),
+                tolerate_count_90d=raw.tolerate_90d_by_id.get(identifier, 0),
+                is_quarantined=(run.run_type, identifier) in raw.quarantined_ids,
+                last_run_at=run.completed_at or run.created_at,
+                sparkline=sparkline,
+            )
+        )
+
+    totals = contracts.BaselineTotals(
+        all_snapshots=raw.totals_all,
+        recently_tolerated=raw.totals_recent,
+        frequently_tolerated=raw.totals_frequent,
+        currently_quarantined=raw.totals_quarantined,
+        by_run_type=raw.by_run_type,
+    )
+
+    return contracts.BaselineOverview(
+        entries=entries,
+        totals=totals,
+        truncated=raw.truncated,
+        generated_at=raw.generated_at,
+    )
+
+
+_ZERO_SPARK = logic._SparkBuckets()
+
+
+def _build_sparkline_day_keys(now) -> list[str]:
+    from datetime import timedelta
+
+    from .contracts import BASELINE_SPARKLINE_DAYS
+
+    today = now.date()
+    return [
+        (today - timedelta(days=BASELINE_SPARKLINE_DAYS - 1 - i)).isoformat() for i in range(BASELINE_SPARKLINE_DAYS)
+    ]
+
+
 # --- Run API ---
 
 

--- a/products/visual_review/backend/facade/contracts.py
+++ b/products/visual_review/backend/facade/contracts.py
@@ -336,6 +336,10 @@ class BaselineEntry:
     tolerate_count_90d: int
     is_quarantined: bool
     last_run_at: datetime
+    # Average diff_percentage across runs in the last 30 days that produced
+    # a non-zero diff. Drives the severity sort on the Tolerated and
+    # Quarantined slices. None when there's no signal yet.
+    recent_diff_avg: float | None
     sparkline: list[BaselineSparklineDay]
 
 

--- a/products/visual_review/backend/facade/contracts.py
+++ b/products/visual_review/backend/facade/contracts.py
@@ -295,3 +295,71 @@ class Repo:
     baseline_file_paths: dict[str, str]
     enable_pr_comments: bool
     created_at: datetime
+
+
+# Hard cap on entries returned by the baselines overview endpoint. Above this,
+# truncate (newest by run completion) and surface `truncated: True` so the UI
+# can flag it. The whole flow is sized for this — the FE filters/sorts client-
+# side and ships ~600 KB gzipped at the cap.
+BASELINE_OVERVIEW_MAX_ENTRIES = 5000
+
+# How many historical days of per-day result counts feed the overview sparkline.
+BASELINE_SPARKLINE_DAYS = 30
+
+
+@dataclass(frozen=True)
+class BaselineSparklineDay:
+    """One day's bucketed run-result counts for an identifier."""
+
+    clean: int
+    tolerated: int
+    changed: int
+    quarantined: int
+
+
+@dataclass(frozen=True)
+class BaselineEntry:
+    """The current baseline state of a single snapshot identifier in a repo.
+
+    Anchored on the latest non-superseded run on the default branch (master/main)
+    for each `run_type` — i.e. "what is the baseline image we'd compare against
+    right now". One row per `(run_type, identifier)`.
+    """
+
+    identifier: str
+    run_type: str
+    browser: str | None
+    thumbnail_hash: str | None
+    width: int | None
+    height: int | None
+    tolerate_count_30d: int
+    tolerate_count_90d: int
+    is_quarantined: bool
+    last_run_at: datetime
+    sparkline: list[BaselineSparklineDay]
+
+
+@dataclass(frozen=True)
+class BaselineTotals:
+    """Aggregate counts across the **full** baseline universe.
+
+    Computed independently of pagination so the stat row stays correct when
+    `entries` is truncated. The FE uses these for unfiltered counts and falls
+    back to recomputing over `entries` once a filter is active.
+    """
+
+    all_snapshots: int
+    recently_tolerated: int
+    frequently_tolerated: int
+    currently_quarantined: int
+    by_run_type: dict[str, int]
+
+
+@dataclass(frozen=True)
+class BaselineOverview:
+    """Result of the baselines overview endpoint."""
+
+    entries: list[BaselineEntry]
+    totals: BaselineTotals
+    truncated: bool
+    generated_at: datetime

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1897,6 +1897,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             tolerate_90d_by_id={},
             quarantined_ids=set(),
             sparkline_by_id={},
+            drift_avg_by_id={},
             totals_all=0,
             totals_recent=0,
             totals_frequent=0,
@@ -1975,7 +1976,11 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     # 3c. Sparkline — last 30 days of run results bucketed by classification.
     # One grouped query, then bucket in Python so we keep this portable across
     # SQLite (tests) and Postgres without resorting to TruncDate or SQL CASE.
+    # Same loop also accumulates the running drift average so we get
+    # `recent_diff_avg` for free in this single pass.
     sparkline_by_id: dict[str, dict[str, _SparkBuckets]] = defaultdict(lambda: defaultdict(_SparkBuckets))
+    drift_sum_by_id: dict[str, float] = defaultdict(float)
+    drift_count_by_id: dict[str, int] = defaultdict(int)
     if universe_identifiers:
         spark_rows = RunSnapshot.objects.filter(
             run__repo_id=repo_id,
@@ -1987,8 +1992,9 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             "result",
             "is_quarantined",
             "tolerated_hash_match_id",
+            "diff_percentage",
         )
-        for identifier, run_created_at, result, is_quar, tol_match_id in spark_rows:
+        for identifier, run_created_at, result, is_quar, tol_match_id, diff_pct in spark_rows:
             day_key = run_created_at.date().isoformat()
             buckets = sparkline_by_id[identifier][day_key]
             if is_quar:
@@ -1999,6 +2005,9 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
                 buckets.changed += 1
             else:
                 buckets.clean += 1
+            if diff_pct is not None and diff_pct > 0:
+                drift_sum_by_id[identifier] += diff_pct
+                drift_count_by_id[identifier] += 1
 
     # 4. Totals computed across the *full* universe (not the truncated slice)
     # so the stat row stays correct when the entries are clipped.
@@ -2045,12 +2054,19 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     # query is only worth it once we routinely hit truncation.
     by_run_type: dict[str, int] = dict(Counter(s.run.run_type for s in universe))
 
+    drift_avg_by_id: dict[str, float] = {
+        identifier: drift_sum_by_id[identifier] / drift_count_by_id[identifier]
+        for identifier in drift_count_by_id
+        if drift_count_by_id[identifier] > 0
+    }
+
     return _BaselineOverviewRaw(
         entries=universe,
         tolerate_30d_by_id=tolerate_30d_by_id,
         tolerate_90d_by_id=tolerate_90d_by_id,
         quarantined_ids=quarantined_pairs,
         sparkline_by_id=sparkline_by_id,
+        drift_avg_by_id=drift_avg_by_id,
         totals_all=totals_all,
         totals_recent=len(recent_ids),
         totals_frequent=len(frequent_ids),
@@ -2081,6 +2097,7 @@ class _BaselineOverviewRaw:
     tolerate_90d_by_id: dict[str, int]
     quarantined_ids: set[tuple[str, str]]
     sparkline_by_id: dict[str, dict[str, _SparkBuckets]]
+    drift_avg_by_id: dict[str, float]
     totals_all: int
     totals_recent: int
     totals_frequent: int

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2029,17 +2029,16 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             day_key = run_created_at.date().isoformat()
             key = (run_type, identifier)
             buckets = sparkline_by_key[key][day_key]
-            # mypy keeps narrowing `result` (the values_list element) to a
-            # Literal that excludes one of the comparison arms — direct
-            # equality checks against this variable get flagged as
-            # unreachable in either direction. `str(result)` is opaque to
-            # the narrower and lets the four-way classify run as written.
-            result_str = str(result)
+            # `tolerated_hash_match` is a nullable FK but django-stubs types
+            # the `_id` column as a non-optional UUID, so without this widen
+            # mypy thinks `is not None` always succeeds → flags every later
+            # branch as unreachable.
+            tol_match_id_opt: UUID | None = tol_match_id
             if is_quar:
                 buckets.quarantined += 1
-            elif tol_match_id is not None:
+            elif tol_match_id_opt is not None:
                 buckets.tolerated += 1
-            elif result_str == "unchanged":
+            elif result == "unchanged":
                 buckets.clean += 1
             else:
                 buckets.changed += 1

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2033,7 +2033,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
                 buckets.quarantined += 1
             elif tol_match_id is not None:
                 buckets.tolerated += 1
-            elif result in (SnapshotResult.CHANGED.value, SnapshotResult.NEW.value, SnapshotResult.REMOVED.value):
+            elif result in {"changed", "new", "removed"}:
                 buckets.changed += 1
             else:
                 buckets.clean += 1

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2029,20 +2029,19 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             day_key = run_created_at.date().isoformat()
             key = (run_type, identifier)
             buckets = sparkline_by_key[key][day_key]
+            # mypy keeps narrowing `result` (the values_list element) to a
+            # Literal that excludes one of the comparison arms — direct
+            # equality checks against this variable get flagged as
+            # unreachable in either direction. `str(result)` is opaque to
+            # the narrower and lets the four-way classify run as written.
+            result_str = str(result)
             if is_quar:
                 buckets.quarantined += 1
             elif tol_match_id is not None:
                 buckets.tolerated += 1
-            elif result == "unchanged":
+            elif result_str == "unchanged":
                 buckets.clean += 1
-            else:  # type: ignore[unreachable]
-                # `result` ∈ {changed, new, removed, unchanged}. Quarantined and
-                # tolerated paths handle the soft "ok-ish" cases; `unchanged`
-                # is the strict-clean path; anything else is a baseline-moving
-                # event. mypy narrows `result` to `Literal["unchanged"]` here
-                # by some django-stubs path I haven't been able to track down,
-                # which makes the literal `unchanged` arm seem to consume all
-                # cases — hence the ignore on the else.
+            else:
                 buckets.changed += 1
             if diff_pct is not None and diff_pct > 0:
                 drift_sum_by_key[key] += diff_pct

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2015,7 +2015,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
                 buckets.quarantined += 1
             elif tol_match_id is not None:
                 buckets.tolerated += 1
-            elif result in (SnapshotResult.CHANGED, SnapshotResult.NEW, SnapshotResult.REMOVED):
+            elif result in (SnapshotResult.CHANGED.value, SnapshotResult.NEW.value, SnapshotResult.REMOVED.value):
                 buckets.changed += 1
             else:
                 buckets.clean += 1

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1816,7 +1816,7 @@ WITH ordered AS (
       AND r.branch = ANY(%s)
       AND r.status = 'completed'
       AND rs.identifier = %s
-      AND rs.result <> 'new'
+      AND rs.result IN ('changed', 'removed', 'new')
 )
 SELECT id
 FROM ordered
@@ -1841,8 +1841,16 @@ def get_snapshot_history(repo_id: UUID, identifier: str, run_type: str) -> list[
       - status=completed: drop pre-classification rows. `result` defaults to NEW
         on upload and is only finalised when the run completes; runs stuck in
         pending/processing leave noise behind that isn't a real history event.
-      - result != NEW: belt+braces; NEW shouldn't survive on a completed run, but
-        cheap to filter and protects us if classification ever leaves stragglers.
+      - result IN (changed, removed, new): only rows that move the baseline.
+        `unchanged` rows must be excluded *before* the LAG window — each capture
+        gets its own Artifact row even when the diff says the content matches
+        baseline (pixel jitter → different bytes → different content_hash), so
+        consecutive `unchanged` rows have differing `current_artifact_id`s and
+        would all slip past the dedup as fake "baseline events". For one prod
+        identifier we observed 99 fake events behind 2 real baselines.
+        Including `new` so first captures (the initial baseline event) appear
+        in history; `status=completed` already keeps pre-classification NEW
+        out.
     """
     with connections[READER_DB].cursor() as cursor:
         cursor.execute(

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1891,7 +1891,12 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     from .facade.contracts import BASELINE_OVERVIEW_MAX_ENTRIES, BASELINE_SPARKLINE_DAYS
 
     now = timezone.now()
-    sparkline_cutoff = now - timedelta(days=BASELINE_SPARKLINE_DAYS)
+    # The sparkline shows DAYS dates inclusive of today (see
+    # `_build_sparkline_day_keys`). `now - DAYS days` would pull rows from a
+    # 31st earlier date that has no day_key — they'd vanish into a bucket
+    # that's never read, but their `diff_percentage` would still skew
+    # `recent_diff_avg`. `DAYS - 1` aligns with the day-key window.
+    sparkline_cutoff = now - timedelta(days=BASELINE_SPARKLINE_DAYS - 1)
 
     # 1. Find the latest non-superseded run on the default branch for every
     # (repo, run_type). The partial unique index `unique_latest_run_per_group`
@@ -1910,8 +1915,8 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             tolerate_30d_by_id={},
             tolerate_90d_by_id={},
             quarantined_ids=set(),
-            sparkline_by_id={},
-            drift_avg_by_id={},
+            sparkline_by_key={},
+            drift_avg_by_key={},
             totals_all=0,
             totals_recent=0,
             totals_frequent=0,
@@ -1942,7 +1947,15 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     total_universe = universe_qs.count()
     truncated = total_universe > BASELINE_OVERVIEW_MAX_ENTRIES
     universe = list(universe_qs[:BASELINE_OVERVIEW_MAX_ENTRIES]) if truncated else list(universe_qs)
+    # Per-entry aggregates (tolerate counts, sparklines) only need to cover the
+    # entries we'll return. Totals must scope across the *full* universe,
+    # otherwise truncation makes them undercount in misleading ways (a 6000-id
+    # repo would show 0 frequently-tolerated if all of them sat past the slice).
     universe_identifiers = list({s.identifier for s in universe})
+    if truncated:
+        full_universe_identifiers = list(universe_qs.values_list("identifier", flat=True).distinct())
+    else:
+        full_universe_identifiers = universe_identifiers
 
     # 3a. Tolerate counts in 30d / 90d windows. Single grouped query each.
     tolerate_30d_by_id: dict[str, int] = {}
@@ -1991,10 +2004,13 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     # One grouped query, then bucket in Python so we keep this portable across
     # SQLite (tests) and Postgres without resorting to TruncDate or SQL CASE.
     # Same loop also accumulates the running drift average so we get
-    # `recent_diff_avg` for free in this single pass.
-    sparkline_by_id: dict[str, dict[str, _SparkBuckets]] = defaultdict(lambda: defaultdict(_SparkBuckets))
-    drift_sum_by_id: dict[str, float] = defaultdict(float)
-    drift_count_by_id: dict[str, int] = defaultdict(int)
+    # `recent_diff_avg` for free in this single pass. Keyed by
+    # `(run_type, identifier)` because the universe is one row per pair —
+    # same identifier in storybook + playwright are *different* baselines and
+    # their sparklines must not bleed into each other.
+    sparkline_by_key: dict[tuple[str, str], dict[str, SparkBuckets]] = defaultdict(lambda: defaultdict(SparkBuckets))
+    drift_sum_by_key: dict[tuple[str, str], float] = defaultdict(float)
+    drift_count_by_key: dict[tuple[str, str], int] = defaultdict(int)
     if universe_identifiers:
         spark_rows = RunSnapshot.objects.filter(
             run__repo_id=repo_id,
@@ -2002,15 +2018,17 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             run__created_at__gte=sparkline_cutoff,
         ).values_list(
             "identifier",
+            "run__run_type",
             "run__created_at",
             "result",
             "is_quarantined",
             "tolerated_hash_match_id",
             "diff_percentage",
         )
-        for identifier, run_created_at, result, is_quar, tol_match_id, diff_pct in spark_rows:
+        for identifier, run_type, run_created_at, result, is_quar, tol_match_id, diff_pct in spark_rows:
             day_key = run_created_at.date().isoformat()
-            buckets = sparkline_by_id[identifier][day_key]
+            key = (run_type, identifier)
+            buckets = sparkline_by_key[key][day_key]
             if is_quar:
                 buckets.quarantined += 1
             elif tol_match_id is not None:
@@ -2020,8 +2038,8 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             else:
                 buckets.clean += 1
             if diff_pct is not None and diff_pct > 0:
-                drift_sum_by_id[identifier] += diff_pct
-                drift_count_by_id[identifier] += 1
+                drift_sum_by_key[key] += diff_pct
+                drift_count_by_key[key] += 1
 
     # 4. Totals computed across the *full* universe (not the truncated slice)
     # so the stat row stays correct when the entries are clipped.
@@ -2033,16 +2051,17 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         totals_all = len(universe)
 
     # Recently / frequently tolerated — counts of distinct identifiers with
-    # ≥1 (or ≥3) tolerations in the rolling window, scoped to the universe.
+    # ≥1 (or ≥3) tolerations in the rolling window. Scope across the *full*
+    # universe so the stat row stays correct under truncation.
     recent_cutoff = now - timedelta(days=30)
     frequent_cutoff = now - timedelta(days=90)
     recent_ids: set[str] = set()
     frequent_ids: set[str] = set()
-    if universe_identifiers:
+    if full_universe_identifiers:
         recent_ids = set(
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
-                identifier__in=universe_identifiers,
+                identifier__in=full_universe_identifiers,
                 created_at__gte=recent_cutoff,
             )
             .values_list("identifier", flat=True)
@@ -2051,7 +2070,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         frequent_grouped = (
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
-                identifier__in=universe_identifiers,
+                identifier__in=full_universe_identifiers,
                 created_at__gte=frequent_cutoff,
             )
             .values("identifier")
@@ -2061,17 +2080,39 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         )
         frequent_ids = set(frequent_grouped)
 
-    quarantined_id_count = len({identifier for _, identifier in quarantined_pairs})
+    # `quarantined_pairs` was built from the truncated set above (per-entry
+    # attached). Re-query for the totals so they cover the full universe.
+    if truncated and full_universe_identifiers:
+        quarantined_id_count = (
+            QuarantinedIdentifier.objects.filter(
+                repo_id=repo_id,
+                identifier__in=full_universe_identifiers,
+            )
+            .filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
+            .values("identifier")
+            .distinct()
+            .count()
+        )
+    else:
+        quarantined_id_count = len({identifier for _, identifier in quarantined_pairs})
 
-    # by_run_type counts every entry in the universe, even if truncated. We
-    # approximate from the loaded slice when truncated; a separate aggregate
-    # query is only worth it once we routinely hit truncation.
-    by_run_type: dict[str, int] = dict(Counter(s.run.run_type for s in universe))
+    # by_run_type counts every entry in the universe. Aggregate query under
+    # truncation so it doesn't undercount; in-memory Counter when not truncated
+    # (we already paid for the row hydration).
+    if truncated:
+        by_run_type = dict(
+            universe_qs.values_list("run__run_type")
+            .order_by()
+            .annotate(c=Count("id"))
+            .values_list("run__run_type", "c")
+        )
+    else:
+        by_run_type = dict(Counter(s.run.run_type for s in universe))
 
-    drift_avg_by_id: dict[str, float] = {
-        identifier: drift_sum_by_id[identifier] / drift_count_by_id[identifier]
-        for identifier in drift_count_by_id
-        if drift_count_by_id[identifier] > 0
+    drift_avg_by_key: dict[tuple[str, str], float] = {
+        key: drift_sum_by_key[key] / drift_count_by_key[key]
+        for key in drift_count_by_key
+        if drift_count_by_key[key] > 0
     }
 
     return _BaselineOverviewRaw(
@@ -2079,8 +2120,8 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         tolerate_30d_by_id=tolerate_30d_by_id,
         tolerate_90d_by_id=tolerate_90d_by_id,
         quarantined_ids=quarantined_pairs,
-        sparkline_by_id=sparkline_by_id,
-        drift_avg_by_id=drift_avg_by_id,
+        sparkline_by_key=sparkline_by_key,
+        drift_avg_by_key=drift_avg_by_key,
         totals_all=totals_all,
         totals_recent=len(recent_ids),
         totals_frequent=len(frequent_ids),
@@ -2092,7 +2133,13 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
 
 
 @dataclass
-class _SparkBuckets:
+class SparkBuckets:
+    """One day's classification counts on the stability sparkline.
+
+    Public so the facade can construct a zero-default without reaching into
+    private symbols of this module. Otherwise an internal-only shape.
+    """
+
     clean: int = 0
     tolerated: int = 0
     changed: int = 0
@@ -2110,8 +2157,11 @@ class _BaselineOverviewRaw:
     tolerate_30d_by_id: dict[str, int]
     tolerate_90d_by_id: dict[str, int]
     quarantined_ids: set[tuple[str, str]]
-    sparkline_by_id: dict[str, dict[str, _SparkBuckets]]
-    drift_avg_by_id: dict[str, float]
+    # Sparkline + drift are keyed by `(run_type, identifier)` because the same
+    # identifier in different run types is a different baseline; merging would
+    # bleed storybook stability into playwright stability.
+    sparkline_by_key: dict[tuple[str, str], dict[str, SparkBuckets]]
+    drift_avg_by_key: dict[tuple[str, str], float]
     totals_all: int
     totals_recent: int
     totals_frequent: int

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -240,8 +240,12 @@ REVIEW_STATE_FILTERS: dict[str, Q] = {
 }
 
 
-def list_runs_for_team(team_id: int, review_state: str | None = None) -> db_models.QuerySet[Run]:
+def list_runs_for_team(
+    team_id: int, review_state: str | None = None, repo_id: UUID | None = None
+) -> db_models.QuerySet[Run]:
     qs = Run.objects.filter(team_id=team_id).select_related("repo").order_by("-created_at")
+    if repo_id is not None:
+        qs = qs.filter(repo_id=repo_id)
     if review_state and review_state in REVIEW_STATE_FILTERS:
         qs = qs.filter(REVIEW_STATE_FILTERS[review_state])
     return qs

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -251,8 +251,10 @@ def list_runs_for_team(
     return qs
 
 
-def get_review_state_counts(team_id: int) -> dict[str, int]:
+def get_review_state_counts(team_id: int, repo_id: UUID | None = None) -> dict[str, int]:
     qs = Run.objects.filter(team_id=team_id)
+    if repo_id is not None:
+        qs = qs.filter(repo_id=repo_id)
     return qs.aggregate(
         needs_review=Count("id", filter=REVIEW_STATE_FILTERS["needs_review"]),
         clean=Count("id", filter=REVIEW_STATE_FILTERS["clean"]),

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -7,6 +7,7 @@ Called by api/api.py facade. Do not call from outside this module.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -1854,6 +1855,239 @@ def get_snapshot_history(repo_id: UUID, identifier: str, run_type: str) -> list[
         row.id: row for row in RunSnapshot.objects.filter(id__in=ordered_ids).select_related("run", "current_artifact")
     }
     return [rows_by_id[rid] for rid in ordered_ids if rid in rows_by_id]
+
+
+def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
+    """Universe of identifiers with a current baseline, plus aggregates.
+
+    The "current baseline" universe is anchored on the latest non-superseded run
+    on the default branch (master/main) for each `run_type`. One row per
+    `(run_type, identifier)` — the closest thing to "what we'd compare a new
+    capture against right now".
+
+    Performance shape:
+      - O(run_types) queries to find the universe runs (≤ a handful in practice)
+      - 1 query for the universe rows (with thumbnail + artifact prefetch)
+      - 3 grouped queries for tolerate counts + active quarantines + sparkline
+      - 3 cheap aggregate queries for totals
+    """
+    from collections import Counter, defaultdict
+    from datetime import timedelta
+
+    from .facade.contracts import BASELINE_OVERVIEW_MAX_ENTRIES, BASELINE_SPARKLINE_DAYS
+
+    now = timezone.now()
+    sparkline_cutoff = now - timedelta(days=BASELINE_SPARKLINE_DAYS)
+
+    # 1. Find the latest non-superseded run on the default branch for every
+    # (repo, run_type). The partial unique index `unique_latest_run_per_group`
+    # ensures at most one row per group.
+    universe_runs = list(
+        Run.objects.filter(
+            repo_id=repo_id,
+            branch__in=_DEFAULT_BRANCHES,
+            superseded_by__isnull=True,
+        ).only("id", "run_type", "completed_at", "created_at")
+    )
+    universe_run_ids = [r.id for r in universe_runs]
+    if not universe_run_ids:
+        return _BaselineOverviewRaw(
+            entries=[],
+            tolerate_30d_by_id={},
+            tolerate_90d_by_id={},
+            quarantined_ids=set(),
+            sparkline_by_id={},
+            totals_all=0,
+            totals_recent=0,
+            totals_frequent=0,
+            totals_quarantined=0,
+            by_run_type={},
+            truncated=False,
+            generated_at=now,
+        )
+
+    # 2. Pull the universe rows. select_related the chain we need for thumbnails.
+    universe_qs = (
+        RunSnapshot.objects.filter(run_id__in=universe_run_ids)
+        .select_related("run", "current_artifact__thumbnail")
+        .only(
+            "identifier",
+            "metadata",
+            "run__id",
+            "run__run_type",
+            "run__completed_at",
+            "run__created_at",
+            "current_artifact__width",
+            "current_artifact__height",
+            "current_artifact__thumbnail__content_hash",
+        )
+        # Stable ordering so truncation is deterministic; newest baselines first.
+        .order_by("-run__completed_at", "identifier")
+    )
+    total_universe = universe_qs.count()
+    truncated = total_universe > BASELINE_OVERVIEW_MAX_ENTRIES
+    universe = list(universe_qs[:BASELINE_OVERVIEW_MAX_ENTRIES]) if truncated else list(universe_qs)
+    universe_identifiers = list({s.identifier for s in universe})
+
+    # 3a. Tolerate counts in 30d / 90d windows. Single grouped query each.
+    tolerate_30d_by_id: dict[str, int] = {}
+    tolerate_90d_by_id: dict[str, int] = {}
+    if universe_identifiers:
+        tol_30d_cutoff = now - timedelta(days=30)
+        tol_90d_cutoff = now - timedelta(days=90)
+        for identifier, count in (
+            ToleratedHash.objects.filter(
+                repo_id=repo_id,
+                identifier__in=universe_identifiers,
+                created_at__gte=tol_30d_cutoff,
+            )
+            .values_list("identifier")
+            .annotate(c=Count("id"))
+            .values_list("identifier", "c")
+        ):
+            tolerate_30d_by_id[identifier] = count
+        for identifier, count in (
+            ToleratedHash.objects.filter(
+                repo_id=repo_id,
+                identifier__in=universe_identifiers,
+                created_at__gte=tol_90d_cutoff,
+            )
+            .values_list("identifier")
+            .annotate(c=Count("id"))
+            .values_list("identifier", "c")
+        ):
+            tolerate_90d_by_id[identifier] = count
+
+    # 3b. Active quarantines for this repo, scoped to the universe identifiers
+    # AND the run_types they live on (quarantine is per (repo, run_type, id)).
+    quarantined_pairs: set[tuple[str, str]] = set()
+    if universe_identifiers:
+        quarantined_pairs = {
+            (run_type, identifier)
+            for run_type, identifier in QuarantinedIdentifier.objects.filter(
+                repo_id=repo_id,
+                identifier__in=universe_identifiers,
+            )
+            .filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
+            .values_list("run_type", "identifier")
+        }
+
+    # 3c. Sparkline — last 30 days of run results bucketed by classification.
+    # One grouped query, then bucket in Python so we keep this portable across
+    # SQLite (tests) and Postgres without resorting to TruncDate or SQL CASE.
+    sparkline_by_id: dict[str, dict[str, _SparkBuckets]] = defaultdict(lambda: defaultdict(_SparkBuckets))
+    if universe_identifiers:
+        spark_rows = RunSnapshot.objects.filter(
+            run__repo_id=repo_id,
+            identifier__in=universe_identifiers,
+            run__created_at__gte=sparkline_cutoff,
+        ).values_list(
+            "identifier",
+            "run__created_at",
+            "result",
+            "is_quarantined",
+            "tolerated_hash_match_id",
+        )
+        for identifier, run_created_at, result, is_quar, tol_match_id in spark_rows:
+            day_key = run_created_at.date().isoformat()
+            buckets = sparkline_by_id[identifier][day_key]
+            if is_quar:
+                buckets.quarantined += 1
+            elif tol_match_id is not None:
+                buckets.tolerated += 1
+            elif result in (SnapshotResult.CHANGED, SnapshotResult.NEW, SnapshotResult.REMOVED):
+                buckets.changed += 1
+            else:
+                buckets.clean += 1
+
+    # 4. Totals computed across the *full* universe (not the truncated slice)
+    # so the stat row stays correct when the entries are clipped.
+    if truncated:
+        # Re-issue a small COUNT-only query for accurate totals across the
+        # universe; we already have the truncated list in memory.
+        totals_all = total_universe
+    else:
+        totals_all = len(universe)
+
+    # Recently / frequently tolerated — counts of distinct identifiers with
+    # ≥1 (or ≥3) tolerations in the rolling window, scoped to the universe.
+    recent_cutoff = now - timedelta(days=30)
+    frequent_cutoff = now - timedelta(days=90)
+    recent_ids: set[str] = set()
+    frequent_ids: set[str] = set()
+    if universe_identifiers:
+        recent_ids = set(
+            ToleratedHash.objects.filter(
+                repo_id=repo_id,
+                identifier__in=universe_identifiers,
+                created_at__gte=recent_cutoff,
+            )
+            .values_list("identifier", flat=True)
+            .distinct()
+        )
+        frequent_grouped = (
+            ToleratedHash.objects.filter(
+                repo_id=repo_id,
+                identifier__in=universe_identifiers,
+                created_at__gte=frequent_cutoff,
+            )
+            .values("identifier")
+            .annotate(c=Count("id"))
+            .filter(c__gte=3)
+            .values_list("identifier", flat=True)
+        )
+        frequent_ids = set(frequent_grouped)
+
+    quarantined_id_count = len({identifier for _, identifier in quarantined_pairs})
+
+    # by_run_type counts every entry in the universe, even if truncated. We
+    # approximate from the loaded slice when truncated; a separate aggregate
+    # query is only worth it once we routinely hit truncation.
+    by_run_type: dict[str, int] = dict(Counter(s.run.run_type for s in universe))
+
+    return _BaselineOverviewRaw(
+        entries=universe,
+        tolerate_30d_by_id=tolerate_30d_by_id,
+        tolerate_90d_by_id=tolerate_90d_by_id,
+        quarantined_ids=quarantined_pairs,
+        sparkline_by_id=sparkline_by_id,
+        totals_all=totals_all,
+        totals_recent=len(recent_ids),
+        totals_frequent=len(frequent_ids),
+        totals_quarantined=quarantined_id_count,
+        by_run_type=by_run_type,
+        truncated=truncated,
+        generated_at=now,
+    )
+
+
+@dataclass
+class _SparkBuckets:
+    clean: int = 0
+    tolerated: int = 0
+    changed: int = 0
+    quarantined: int = 0
+
+
+@dataclass
+class _BaselineOverviewRaw:
+    """Internal raw shape — the facade layer reshapes this into the public DTOs.
+
+    Kept private to logic.py so that contract changes don't ripple through here.
+    """
+
+    entries: list[RunSnapshot]
+    tolerate_30d_by_id: dict[str, int]
+    tolerate_90d_by_id: dict[str, int]
+    quarantined_ids: set[tuple[str, str]]
+    sparkline_by_id: dict[str, dict[str, _SparkBuckets]]
+    totals_all: int
+    totals_recent: int
+    totals_frequent: int
+    totals_quarantined: int
+    by_run_type: dict[str, int]
+    truncated: bool
+    generated_at: datetime
 
 
 @transaction.atomic(using=WRITER_DB)

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2029,19 +2029,21 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             day_key = run_created_at.date().isoformat()
             key = (run_type, identifier)
             buckets = sparkline_by_key[key][day_key]
-            # Logic equivalent of "result is changed/new/removed", written as
-            # `!= "unchanged"` to keep mypy's reachability analysis happy —
-            # `result in {...}` flagged the branch as unreachable, even with
-            # `.value` accessors. The four SnapshotResult values are all the
-            # possible inputs here and `unchanged` is the only "clean" one.
             if is_quar:
                 buckets.quarantined += 1
             elif tol_match_id is not None:
                 buckets.tolerated += 1
-            elif result != "unchanged":
-                buckets.changed += 1
-            else:
+            elif result == "unchanged":
                 buckets.clean += 1
+            else:  # type: ignore[unreachable]
+                # `result` ∈ {changed, new, removed, unchanged}. Quarantined and
+                # tolerated paths handle the soft "ok-ish" cases; `unchanged`
+                # is the strict-clean path; anything else is a baseline-moving
+                # event. mypy narrows `result` to `Literal["unchanged"]` here
+                # by some django-stubs path I haven't been able to track down,
+                # which makes the literal `unchanged` arm seem to consume all
+                # cases — hence the ignore on the else.
+                buckets.changed += 1
             if diff_pct is not None and diff_pct > 0:
                 drift_sum_by_key[key] += diff_pct
                 drift_count_by_key[key] += 1

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2029,11 +2029,16 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             day_key = run_created_at.date().isoformat()
             key = (run_type, identifier)
             buckets = sparkline_by_key[key][day_key]
+            # Logic equivalent of "result is changed/new/removed", written as
+            # `!= "unchanged"` to keep mypy's reachability analysis happy —
+            # `result in {...}` flagged the branch as unreachable, even with
+            # `.value` accessors. The four SnapshotResult values are all the
+            # possible inputs here and `unchanged` is the only "clean" one.
             if is_quar:
                 buckets.quarantined += 1
             elif tol_match_id is not None:
                 buckets.tolerated += 1
-            elif result in {"changed", "new", "removed"}:
+            elif result != "unchanged":
                 buckets.changed += 1
             else:
                 buckets.clean += 1

--- a/products/visual_review/backend/presentation/serializers.py
+++ b/products/visual_review/backend/presentation/serializers.py
@@ -14,6 +14,10 @@ from ..facade.contracts import (
     ApproveSnapshotInput,
     Artifact,
     AutoApproveResult,
+    BaselineEntry,
+    BaselineOverview,
+    BaselineSparklineDay,
+    BaselineTotals,
     CreateRepoInput,
     CreateRunInput,
     CreateRunResult,
@@ -176,3 +180,30 @@ class UnquarantineQuerySerializer(serializers.Serializer):
 class CreateRepoInputSerializer(DataclassSerializer):
     class Meta:
         dataclass = CreateRepoInput
+
+
+class BaselineSparklineDaySerializer(DataclassSerializer):
+    class Meta:
+        dataclass = BaselineSparklineDay
+
+
+class BaselineEntrySerializer(DataclassSerializer):
+    sparkline = BaselineSparklineDaySerializer(many=True)
+
+    class Meta:
+        dataclass = BaselineEntry
+
+
+class BaselineTotalsSerializer(DataclassSerializer):
+    by_run_type = serializers.DictField(child=serializers.IntegerField())
+
+    class Meta:
+        dataclass = BaselineTotals
+
+
+class BaselineOverviewSerializer(DataclassSerializer):
+    entries = BaselineEntrySerializer(many=True)
+    totals = BaselineTotalsSerializer()
+
+    class Meta:
+        dataclass = BaselineOverview

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -18,7 +18,7 @@ from django.utils.cache import get_conditional_response, patch_cache_control, pa
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import serializers, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -61,21 +61,6 @@ from .serializers import (
 )
 
 VISUAL_REVIEW_TAG = "visual_review"
-
-
-def _parse_optional_uuid(raw: str | None, param_name: str) -> UUID | None:
-    """Parse a UUID query param, raising DRF ValidationError on bad input.
-
-    Without this, a bad `?repo_id=abc` would surface as a 500 from the
-    bare `UUID()` constructor. DRF's exception handler turns the
-    raised ValidationError into a 400 with a clean payload.
-    """
-    if not raw:
-        return None
-    try:
-        return UUID(raw)
-    except ValueError:
-        raise serializers.ValidationError({param_name: ["Must be a valid UUID."]})
 
 
 @extend_schema(tags=[VISUAL_REVIEW_TAG])
@@ -325,6 +310,44 @@ class SnapshotViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
 
 @extend_schema(tags=[VISUAL_REVIEW_TAG])
+class RepoRunsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """Listing/aggregation of runs scoped to a single repo.
+
+    Run-by-id actions (retrieve, snapshots, approve, complete, etc.) live on
+    the flat `RunViewSet` so that direct links by run id keep working without
+    forcing the repo into the path.
+    """
+
+    scope_object = "visual_review"
+    scope_object_read_actions = ["list", "counts"]
+    serializer_class = RunSerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("review_state", str, required=False, description="Filter by review state"),
+        ],
+        responses={200: RunSerializer(many=True)},
+    )
+    def list(self, request: Request, **kwargs) -> Response:
+        """List runs in this repo, optionally filtered by review state."""
+        review_state = request.query_params.get("review_state")
+        repo_id = UUID(self.parents_query_dict["repo_id"])
+        runs = api.list_runs(self.team_id, review_state=review_state, repo_id=repo_id)
+        page = self.paginate_queryset(runs)
+        if page is not None:
+            serializer = RunSerializer(instance=page, many=True)
+            return self.get_paginated_response(serializer.data)
+        return Response(RunSerializer(instance=runs, many=True).data)
+
+    @extend_schema(responses={200: ReviewStateCountsSerializer})
+    @action(detail=False, methods=["get"])
+    def counts(self, request: Request, **kwargs) -> Response:
+        """Review state counts for runs in this repo."""
+        repo_id = UUID(self.parents_query_dict["repo_id"])
+        return Response(api.get_review_state_counts(self.team_id, repo_id=repo_id))
+
+
+@extend_schema(tags=[VISUAL_REVIEW_TAG])
 class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """
     Visual review runs.
@@ -334,40 +357,8 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     scope_object = "visual_review"
     scope_object_write_actions = ["create", "complete", "approve", "auto_approve", "add_snapshots", "recompute"]
-    scope_object_read_actions = ["list", "retrieve", "snapshots", "counts"]
+    scope_object_read_actions = ["retrieve", "snapshots"]
     serializer_class = RunSerializer
-
-    @extend_schema(
-        parameters=[
-            OpenApiParameter("review_state", str, required=False, description="Filter by review state"),
-            OpenApiParameter("repo_id", str, required=False, description="Filter by repo UUID"),
-        ],
-        responses={200: RunSerializer(many=True)},
-    )
-    def list(self, request: Request, **kwargs) -> Response:
-        """List runs for the team, optionally filtered by review state or repo."""
-        review_state = request.query_params.get("review_state")
-        repo_id_param = request.query_params.get("repo_id")
-        repo_id = _parse_optional_uuid(repo_id_param, "repo_id")
-        runs = api.list_runs(self.team_id, review_state=review_state, repo_id=repo_id)
-        page = self.paginate_queryset(runs)
-        if page is not None:
-            serializer = RunSerializer(instance=page, many=True)
-            return self.get_paginated_response(serializer.data)
-        return Response(RunSerializer(instance=runs, many=True).data)
-
-    @extend_schema(
-        parameters=[
-            OpenApiParameter("repo_id", str, required=False, description="Filter by repo UUID"),
-        ],
-        responses={200: ReviewStateCountsSerializer},
-    )
-    @action(detail=False, methods=["get"])
-    def counts(self, request: Request, **kwargs) -> Response:
-        """Review state counts for the runs list, optionally scoped to a repo."""
-        repo_id_param = request.query_params.get("repo_id")
-        repo_id = _parse_optional_uuid(repo_id_param, "repo_id")
-        return Response(api.get_review_state_counts(self.team_id, repo_id=repo_id))
 
     @validated_request(
         request_serializer=CreateRunInputSerializer,

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -43,6 +43,7 @@ from .serializers import (
     AddSnapshotsResultSerializer,
     ApproveRunInputSerializer,
     AutoApproveResultSerializer,
+    BaselineOverviewSerializer,
     CreateRepoInputSerializer,
     CreateRunInputSerializer,
     CreateRunResultSerializer,
@@ -72,7 +73,13 @@ class RepoViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     scope_object = "visual_review"
     scope_object_write_actions = ["create", "partial_update", "quarantine", "unquarantine"]
-    scope_object_read_actions = ["list", "retrieve", "list_quarantined", "thumbnail"]
+    scope_object_read_actions = [
+        "list",
+        "retrieve",
+        "list_quarantined",
+        "thumbnail",
+        "baselines",
+    ]
 
     @extend_schema(responses={200: RepoSerializer(many=True)})
     def list(self, request: Request, **kwargs) -> Response:
@@ -233,6 +240,27 @@ class RepoViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         except api.RepoNotFoundError:
             return Response({"detail": "Repo not found"}, status=status.HTTP_404_NOT_FOUND)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        parameters=[OpenApiParameter("id", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        responses={200: BaselineOverviewSerializer},
+        description=(
+            "Snapshots overview for a repo: every identifier with a current baseline (latest "
+            "non-superseded master/main run per run_type), plus tolerate counts, active "
+            "quarantine state, and a 30-day stability sparkline. Capped at "
+            f"{contracts.BASELINE_OVERVIEW_MAX_ENTRIES} entries — sets `truncated` and "
+            "returns the most recently active when exceeded. Filtering / faceting / search are "
+            "all done client-side; this endpoint takes no filter query params."
+        ),
+    )
+    @action(detail=True, methods=["get"], url_path="baselines")
+    def baselines(self, request: Request, pk: str, **kwargs) -> Response:
+        try:
+            api.get_repo(UUID(pk), team_id=self.team_id)
+        except api.RepoNotFoundError:
+            return Response({"detail": "Repo not found"}, status=status.HTTP_404_NOT_FOUND)
+        result = api.get_baselines_overview(UUID(pk))
+        return Response(BaselineOverviewSerializer(instance=result).data)
 
 
 @extend_schema(tags=[VISUAL_REVIEW_TAG])

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -323,13 +323,18 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     serializer_class = RunSerializer
 
     @extend_schema(
-        parameters=[OpenApiParameter("review_state", str, required=False, description="Filter by review state")],
+        parameters=[
+            OpenApiParameter("review_state", str, required=False, description="Filter by review state"),
+            OpenApiParameter("repo_id", str, required=False, description="Filter by repo UUID"),
+        ],
         responses={200: RunSerializer(many=True)},
     )
     def list(self, request: Request, **kwargs) -> Response:
-        """List runs for the team, optionally filtered by review state."""
+        """List runs for the team, optionally filtered by review state or repo."""
         review_state = request.query_params.get("review_state")
-        runs = api.list_runs(self.team_id, review_state=review_state)
+        repo_id_param = request.query_params.get("repo_id")
+        repo_id = UUID(repo_id_param) if repo_id_param else None
+        runs = api.list_runs(self.team_id, review_state=review_state, repo_id=repo_id)
         page = self.paginate_queryset(runs)
         if page is not None:
             serializer = RunSerializer(instance=page, many=True)

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -18,7 +18,7 @@ from django.utils.cache import get_conditional_response, patch_cache_control, pa
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import status, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -61,6 +61,21 @@ from .serializers import (
 )
 
 VISUAL_REVIEW_TAG = "visual_review"
+
+
+def _parse_optional_uuid(raw: str | None, param_name: str) -> UUID | None:
+    """Parse a UUID query param, raising DRF ValidationError on bad input.
+
+    Without this, a bad `?repo_id=abc` would surface as a 500 from the
+    bare `UUID()` constructor. DRF's exception handler turns the
+    raised ValidationError into a 400 with a clean payload.
+    """
+    if not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        raise serializers.ValidationError({param_name: ["Must be a valid UUID."]})
 
 
 @extend_schema(tags=[VISUAL_REVIEW_TAG])
@@ -333,7 +348,7 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         """List runs for the team, optionally filtered by review state or repo."""
         review_state = request.query_params.get("review_state")
         repo_id_param = request.query_params.get("repo_id")
-        repo_id = UUID(repo_id_param) if repo_id_param else None
+        repo_id = _parse_optional_uuid(repo_id_param, "repo_id")
         runs = api.list_runs(self.team_id, review_state=review_state, repo_id=repo_id)
         page = self.paginate_queryset(runs)
         if page is not None:
@@ -351,7 +366,7 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def counts(self, request: Request, **kwargs) -> Response:
         """Review state counts for the runs list, optionally scoped to a repo."""
         repo_id_param = request.query_params.get("repo_id")
-        repo_id = UUID(repo_id_param) if repo_id_param else None
+        repo_id = _parse_optional_uuid(repo_id_param, "repo_id")
         return Response(api.get_review_state_counts(self.team_id, repo_id=repo_id))
 
     @validated_request(

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -341,11 +341,18 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return self.get_paginated_response(serializer.data)
         return Response(RunSerializer(instance=runs, many=True).data)
 
-    @extend_schema(responses={200: ReviewStateCountsSerializer})
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("repo_id", str, required=False, description="Filter by repo UUID"),
+        ],
+        responses={200: ReviewStateCountsSerializer},
+    )
     @action(detail=False, methods=["get"])
     def counts(self, request: Request, **kwargs) -> Response:
-        """Review state counts for the runs list."""
-        return Response(api.get_review_state_counts(self.team_id))
+        """Review state counts for the runs list, optionally scoped to a repo."""
+        repo_id_param = request.query_params.get("repo_id")
+        repo_id = UUID(repo_id_param) if repo_id_param else None
+        return Response(api.get_review_state_counts(self.team_id, repo_id=repo_id))
 
     @validated_request(
         request_serializer=CreateRunInputSerializer,

--- a/products/visual_review/backend/tests/test_baselines.py
+++ b/products/visual_review/backend/tests/test_baselines.py
@@ -1,0 +1,360 @@
+"""Tests for the snapshots-overview endpoint and the underlying logic.
+
+Coverage:
+- Universe is anchored on the latest non-superseded run on the default branch.
+- Truncation past the configured cap, sorted by run completion time desc.
+- Tolerate counts respect the 30d / 90d windows.
+- Active vs expired quarantine filtering.
+- Sparkline buckets (clean / tolerated / changed / quarantined).
+- Totals computed across the universe (not the truncated slice).
+- Browser metadata flows through for Playwright runs.
+"""
+
+from datetime import timedelta
+from uuid import uuid4
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from products.visual_review.backend.facade import api as vr_api
+from products.visual_review.backend.facade.contracts import BASELINE_OVERVIEW_MAX_ENTRIES, BASELINE_SPARKLINE_DAYS
+from products.visual_review.backend.facade.enums import RunStatus, RunType, SnapshotResult, ToleratedReason
+from products.visual_review.backend.models import Artifact, QuarantinedIdentifier, Repo, Run, RunSnapshot, ToleratedHash
+from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
+
+
+def _mk_artifact(repo: Repo, content_hash: str, *, with_thumbnail: str | None = None) -> Artifact:
+    artifact = Artifact.objects.create(
+        repo=repo,
+        team_id=repo.team_id,
+        content_hash=content_hash,
+        storage_path=f"path/{content_hash}",
+        width=320,
+        height=200,
+    )
+    if with_thumbnail:
+        thumb = Artifact.objects.create(
+            repo=repo,
+            team_id=repo.team_id,
+            content_hash=with_thumbnail,
+            storage_path=f"thumb/{with_thumbnail}",
+            width=64,
+            height=40,
+        )
+        artifact.thumbnail = thumb
+        artifact.save(update_fields=["thumbnail"])
+    return artifact
+
+
+def _mk_run(
+    repo: Repo,
+    *,
+    branch: str = "master",
+    run_type: str = RunType.STORYBOOK,
+    completed_offset: timedelta = timedelta(hours=0),
+    superseded_by: Run | None = None,
+) -> Run:
+    completed = timezone.now() - completed_offset
+    return Run.objects.create(
+        team_id=repo.team_id,
+        repo=repo,
+        run_type=run_type,
+        branch=branch,
+        commit_sha=uuid4().hex[:12],
+        status=RunStatus.COMPLETED,
+        completed_at=completed,
+        superseded_by=superseded_by,
+    )
+
+
+def _mk_snapshot(
+    run: Run,
+    *,
+    identifier: str,
+    result: str = SnapshotResult.UNCHANGED,
+    artifact: Artifact | None = None,
+    is_quarantined: bool = False,
+    tolerated_match: ToleratedHash | None = None,
+    metadata: dict | None = None,
+    created_offset: timedelta = timedelta(hours=0),
+) -> RunSnapshot:
+    snap = RunSnapshot.objects.create(
+        run=run,
+        team_id=run.team_id,
+        identifier=identifier,
+        current_hash=artifact.content_hash if artifact else "",
+        current_artifact=artifact,
+        result=result,
+        is_quarantined=is_quarantined,
+        tolerated_hash_match=tolerated_match,
+        metadata=metadata or {},
+    )
+    if created_offset:
+        # Force created_at backwards for sparkline window tests.
+        target = timezone.now() - created_offset
+        RunSnapshot.objects.filter(id=snap.id).update(created_at=target)
+        # Also push the parent run's created_at — sparkline filters on run.created_at.
+        Run.objects.filter(id=run.id).update(created_at=target)
+        snap.refresh_from_db()
+    return snap
+
+
+class TestBaselinesOverview(APIBaseTest):
+    databases = PRODUCT_DATABASES
+
+    def setUp(self):
+        super().setUp()
+        self.repo = Repo.objects.create(
+            team_id=self.team.id,
+            repo_external_id=12345,
+            repo_full_name="org/repo",
+        )
+
+    def test_empty_repo_returns_empty_universe(self):
+        result = vr_api.get_baselines_overview(self.repo.id)
+        assert result.entries == []
+        assert result.totals.all_snapshots == 0
+        assert result.totals.recently_tolerated == 0
+        assert result.totals.frequently_tolerated == 0
+        assert result.totals.currently_quarantined == 0
+        assert result.totals.by_run_type == {}
+        assert result.truncated is False
+
+    def test_universe_anchored_on_latest_non_superseded_master_run(self):
+        # Old master run — will be superseded BEFORE inserting the new one
+        # (the partial unique index `unique_latest_run_per_group` forbids two
+        # non-superseded rows per (repo, branch, run_type)).
+        old = _mk_run(self.repo, branch="master", completed_offset=timedelta(days=2))
+        _mk_snapshot(old, identifier="old-only", result=SnapshotResult.UNCHANGED)
+
+        # PR-branch run on the same repo — should NOT contribute (not master).
+        pr_run = _mk_run(self.repo, branch="my-feature", completed_offset=timedelta(hours=1))
+        _mk_snapshot(pr_run, identifier="pr-only")
+
+        # Supersede `old` first (real flow does this before insert).
+        # Use a placeholder pointer trick: we don't have the new run yet, so
+        # supersede with itself temporarily, then re-point.
+        Run.objects.filter(id=old.id).update(superseded_by=old)
+
+        # Latest master run — DOES contribute.
+        latest = _mk_run(self.repo, branch="master", completed_offset=timedelta(hours=0))
+        Run.objects.filter(id=old.id).update(superseded_by=latest)
+        _mk_snapshot(latest, identifier="canon-a")
+        _mk_snapshot(latest, identifier="canon-b")
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+
+        identifiers = sorted(e.identifier for e in result.entries)
+        assert identifiers == ["canon-a", "canon-b"]
+        assert result.totals.all_snapshots == 2
+        assert result.totals.by_run_type == {RunType.STORYBOOK: 2}
+
+    def test_main_branch_treated_same_as_master(self):
+        # Some repos use `main`, some use `master`. Both anchor the universe.
+        run = _mk_run(self.repo, branch="main")
+        _mk_snapshot(run, identifier="m-1")
+        _mk_snapshot(run, identifier="m-2")
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+        assert sorted(e.identifier for e in result.entries) == ["m-1", "m-2"]
+
+    def test_run_type_appears_in_by_run_type_breakdown(self):
+        sb = _mk_run(self.repo, run_type=RunType.STORYBOOK)
+        pw = _mk_run(self.repo, run_type=RunType.PLAYWRIGHT)
+        _mk_snapshot(sb, identifier="story-1")
+        _mk_snapshot(sb, identifier="story-2")
+        _mk_snapshot(pw, identifier="pw-1", metadata={"browser": "chromium"})
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+
+        assert result.totals.by_run_type == {RunType.STORYBOOK: 2, RunType.PLAYWRIGHT: 1}
+        pw_entry = next(e for e in result.entries if e.identifier == "pw-1")
+        assert pw_entry.browser == "chromium"
+
+    def test_thumbnail_hash_flows_through(self):
+        run = _mk_run(self.repo)
+        artifact = _mk_artifact(self.repo, content_hash="full-x", with_thumbnail="thumb-x")
+        _mk_snapshot(run, identifier="with-thumb", artifact=artifact)
+        _mk_snapshot(run, identifier="no-thumb")
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+
+        with_thumb = next(e for e in result.entries if e.identifier == "with-thumb")
+        no_thumb = next(e for e in result.entries if e.identifier == "no-thumb")
+        assert with_thumb.thumbnail_hash == "thumb-x"
+        assert with_thumb.width == 320
+        assert with_thumb.height == 200
+        assert no_thumb.thumbnail_hash is None
+
+    def test_tolerate_counts_respect_30d_and_90d_windows(self):
+        run = _mk_run(self.repo)
+        _mk_snapshot(run, identifier="flake")
+
+        # 1 tolerate within 30d, 4 within 90d (so 3 are 30-90d old).
+        for offset_days in (5, 40, 60, 80):
+            ToleratedHash.objects.create(
+                repo=self.repo,
+                team_id=self.team.id,
+                identifier="flake",
+                baseline_hash="b",
+                alternate_hash=f"a-{offset_days}",
+                reason=ToleratedReason.HUMAN,
+            )
+        # Push backdate.
+        ToleratedHash.objects.filter(repo=self.repo, identifier="flake").update(
+            created_at=timezone.now() - timedelta(days=5),  # everything to 5d for first pass
+        )
+        # Now individually backdate the older 3.
+        rows = list(ToleratedHash.objects.filter(repo=self.repo, identifier="flake").order_by("alternate_hash"))
+        ToleratedHash.objects.filter(id=rows[0].id).update(created_at=timezone.now() - timedelta(days=40))
+        ToleratedHash.objects.filter(id=rows[1].id).update(created_at=timezone.now() - timedelta(days=60))
+        ToleratedHash.objects.filter(id=rows[2].id).update(created_at=timezone.now() - timedelta(days=80))
+        # rows[3] stays at 5d.
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+        entry = next(e for e in result.entries if e.identifier == "flake")
+
+        assert entry.tolerate_count_30d == 1
+        assert entry.tolerate_count_90d == 4
+        assert result.totals.recently_tolerated == 1  # ≥1 in last 30d
+        assert result.totals.frequently_tolerated == 1  # ≥3 in last 90d
+
+    def test_active_quarantine_counts_but_expired_does_not(self):
+        run = _mk_run(self.repo)
+        _mk_snapshot(run, identifier="active")
+        _mk_snapshot(run, identifier="expired")
+        _mk_snapshot(run, identifier="future")
+
+        # No expires_at = active forever
+        QuarantinedIdentifier.objects.create(
+            repo=self.repo,
+            team_id=self.team.id,
+            identifier="active",
+            run_type=RunType.STORYBOOK,
+            reason="flaky",
+        )
+        # expired (past expires_at) — should NOT count
+        QuarantinedIdentifier.objects.create(
+            repo=self.repo,
+            team_id=self.team.id,
+            identifier="expired",
+            run_type=RunType.STORYBOOK,
+            reason="old",
+            expires_at=timezone.now() - timedelta(days=1),
+        )
+        # Future expires_at — counts
+        QuarantinedIdentifier.objects.create(
+            repo=self.repo,
+            team_id=self.team.id,
+            identifier="future",
+            run_type=RunType.STORYBOOK,
+            reason="upcoming",
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+
+        by_id = {e.identifier: e.is_quarantined for e in result.entries}
+        assert by_id == {"active": True, "expired": False, "future": True}
+        assert result.totals.currently_quarantined == 2
+
+    def test_sparkline_buckets_by_classification(self):
+        # Universe row (latest baseline) — counts as 1 clean in sparkline.
+        latest = _mk_run(self.repo)
+        _mk_snapshot(latest, identifier="story")
+
+        # Separate history runs (different branches so the unique constraint
+        # on (run, identifier) doesn't bite). Each contributes one bucketed
+        # entry to the 30-day window.
+        clean_run = _mk_run(self.repo, branch="pr-clean", completed_offset=timedelta(days=1))
+        _mk_snapshot(clean_run, identifier="story", result=SnapshotResult.UNCHANGED)
+
+        changed_run = _mk_run(self.repo, branch="pr-changed", completed_offset=timedelta(days=2))
+        _mk_snapshot(changed_run, identifier="story", result=SnapshotResult.CHANGED, created_offset=timedelta(days=2))
+
+        quar_run = _mk_run(self.repo, branch="pr-quar", completed_offset=timedelta(days=3))
+        _mk_snapshot(
+            quar_run,
+            identifier="story",
+            result=SnapshotResult.UNCHANGED,
+            is_quarantined=True,
+            created_offset=timedelta(days=3),
+        )
+
+        tol = ToleratedHash.objects.create(
+            repo=self.repo,
+            team_id=self.team.id,
+            identifier="story",
+            baseline_hash="b",
+            alternate_hash="a",
+            reason=ToleratedReason.HUMAN,
+        )
+        tol_run = _mk_run(self.repo, branch="pr-tol", completed_offset=timedelta(days=4))
+        _mk_snapshot(
+            tol_run,
+            identifier="story",
+            result=SnapshotResult.UNCHANGED,
+            tolerated_match=tol,
+            created_offset=timedelta(days=4),
+        )
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+        entry = next(e for e in result.entries if e.identifier == "story")
+        assert len(entry.sparkline) == BASELINE_SPARKLINE_DAYS
+
+        totals = {
+            "clean": sum(d.clean for d in entry.sparkline),
+            "tolerated": sum(d.tolerated for d in entry.sparkline),
+            "changed": sum(d.changed for d in entry.sparkline),
+            "quarantined": sum(d.quarantined for d in entry.sparkline),
+        }
+        # The universe-anchor snapshot itself counts once as clean (it's the
+        # most recent UNCHANGED). Plus one explicit "clean" history row.
+        assert totals == {"clean": 2, "tolerated": 1, "changed": 1, "quarantined": 1}
+
+    def test_truncation_at_cap(self):
+        # Use a tiny cap for speed. logic.get_baselines_overview imports the
+        # constant lazily, so patching contracts is enough.
+        run = _mk_run(self.repo)
+        for i in range(7):
+            _mk_snapshot(run, identifier=f"id-{i:02d}")
+
+        with patch("products.visual_review.backend.facade.contracts.BASELINE_OVERVIEW_MAX_ENTRIES", 5):
+            result = vr_api.get_baselines_overview(self.repo.id)
+
+        assert len(result.entries) == 5
+        assert result.truncated is True
+        # all_snapshots total reflects the full universe even when truncated
+        assert result.totals.all_snapshots == 7
+
+    def test_endpoint_returns_serialized_overview(self):
+        run = _mk_run(self.repo)
+        artifact = _mk_artifact(self.repo, content_hash="h1", with_thumbnail="t1")
+        _mk_snapshot(run, identifier="card-one", artifact=artifact, metadata={"browser": "chromium"})
+        _mk_snapshot(run, identifier="card-two")
+
+        url = f"/api/projects/{self.team.id}/visual_review/repos/{self.repo.id}/baselines/"
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "entries" in data
+        assert "totals" in data
+        assert data["truncated"] is False
+        assert {e["identifier"] for e in data["entries"]} == {"card-one", "card-two"}
+        first = next(e for e in data["entries"] if e["identifier"] == "card-one")
+        assert first["thumbnail_hash"] == "t1"
+        assert first["browser"] == "chromium"
+        assert len(first["sparkline"]) == BASELINE_SPARKLINE_DAYS
+
+    def test_endpoint_404_for_unknown_repo(self):
+        url = f"/api/projects/{self.team.id}/visual_review/repos/{uuid4()}/baselines/"
+        response = self.client.get(url)
+        assert response.status_code == 404
+
+    def test_truncation_constant_is_a_safe_default(self):
+        # Sanity guard — if someone bumps the cap without updating clients, this
+        # test reminds them. ~5000 fits the FE budget (≈600 KB gzipped).
+        assert 1000 <= BASELINE_OVERVIEW_MAX_ENTRIES <= 10000

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -243,18 +243,36 @@ class TestRunViewSet(APIBaseTest):
     def test_snapshot_history(self):
         """History returns one entry per distinct baseline (`current_artifact_id`),
         scoped to default-branch + completed runs.
+
+        Only rows that move the baseline (`result` ∈ changed/removed/new)
+        appear; `unchanged` rows are excluded outright. The LAG dedup then
+        collapses consecutive rows that share an artifact_id.
         """
         # Two completed master runs share `hash-A` → same artifact → must collapse to one entry.
-        self._seed_history_row(sha="aaa1111", branch="master", content_hash="hash-A")
-        self._seed_history_row(sha="aaa2222", branch="master", content_hash="hash-A")
+        # Use CHANGED so they survive the filter; the dedup-on-artifact still has to fire.
+        self._seed_history_row(sha="aaa1111", branch="master", content_hash="hash-A", result=SnapshotResult.CHANGED)
+        self._seed_history_row(sha="aaa2222", branch="master", content_hash="hash-A", result=SnapshotResult.CHANGED)
         # Then a more recent main run with a different content → distinct entry.
         self._seed_history_row(sha="bbb1111", branch="main", content_hash="hash-B", result=SnapshotResult.CHANGED)
 
+        # Steady-state master run with `result=UNCHANGED` — must be filtered out outright,
+        # otherwise pixel-jitter on the captured artifact lets these slip past LAG dedup
+        # and pollutes the timeline (the prod bug this filter was added for).
+        self._seed_history_row(sha="ddd0000", branch="master", content_hash="hash-jitter")
+
         # PR-branch run — must be filtered out by branch.
-        self._seed_history_row(sha="ddd1111", branch="feat/something", content_hash="hash-feat")
+        self._seed_history_row(
+            sha="ddd1111", branch="feat/something", content_hash="hash-feat", result=SnapshotResult.CHANGED
+        )
         # Playwright run on master — must be filtered out by run_type.
-        self._seed_history_row(sha="ccc1111", branch="master", content_hash="hash-pw", run_type=RunType.PLAYWRIGHT)
-        # Pending master run with default `result=NEW` — must be filtered out by status + result.
+        self._seed_history_row(
+            sha="ccc1111",
+            branch="master",
+            content_hash="hash-pw",
+            run_type=RunType.PLAYWRIGHT,
+            result=SnapshotResult.CHANGED,
+        )
+        # Pending master run — must be filtered out by status (result=NEW alone wouldn't filter it now).
         self._seed_history_row(
             sha="eee1111",
             branch="master",

--- a/products/visual_review/frontend/components/InlineSparkline.tsx
+++ b/products/visual_review/frontend/components/InlineSparkline.tsx
@@ -1,0 +1,66 @@
+import type { BaselineSparklineDayApi } from '../generated/api.schemas'
+
+const COLORS = {
+    clean: 'var(--success)',
+    tolerated: 'var(--primary-3000)',
+    changed: 'var(--warning-dark)',
+    quarantined: 'var(--danger)',
+}
+
+const EMPTY_TRACK = 'var(--border)'
+
+// Cheap inline-SVG sparkline. ~30 stacked-segment columns, no Chart.js, no
+// hover tooltips — designed to be cheap enough to render on every card in a
+// virtualized grid. Each day is a single column; segments stack proportionally
+// from the bottom.
+export function InlineSparkline({
+    data,
+    className,
+    title,
+}: {
+    data: BaselineSparklineDayApi[]
+    className?: string
+    title?: string
+}): JSX.Element {
+    const cols = data.length || 1
+    const colWidth = 100 / cols
+    const max = data.reduce((m, d) => Math.max(m, d.clean + d.tolerated + d.changed + d.quarantined), 0) || 1
+
+    return (
+        <svg
+            viewBox="0 0 100 24"
+            preserveAspectRatio="none"
+            className={className ?? 'h-6 w-24'}
+            role="img"
+            aria-label={title ?? 'snapshot stability over the last 30 days'}
+        >
+            {data.map((day, i) => {
+                const total = day.clean + day.tolerated + day.changed + day.quarantined
+                const x = i * colWidth + colWidth * 0.1
+                const w = colWidth * 0.8
+                if (total === 0) {
+                    return <rect key={i} x={x} y={22} width={w} height={1} fill={EMPTY_TRACK} />
+                }
+                const segments = [
+                    { value: day.quarantined, color: COLORS.quarantined },
+                    { value: day.changed, color: COLORS.changed },
+                    { value: day.tolerated, color: COLORS.tolerated },
+                    { value: day.clean, color: COLORS.clean },
+                ]
+                let yCursor = 24
+                return (
+                    <g key={i}>
+                        {segments.map((s, j) => {
+                            if (s.value === 0) {
+                                return null
+                            }
+                            const h = (s.value / max) * 22
+                            yCursor -= h
+                            return <rect key={j} x={x} y={yCursor} width={w} height={h} fill={s.color} />
+                        })}
+                    </g>
+                )
+            })}
+        </svg>
+    )
+}

--- a/products/visual_review/frontend/components/RepoSwitcher.tsx
+++ b/products/visual_review/frontend/components/RepoSwitcher.tsx
@@ -1,0 +1,43 @@
+import { useValues } from 'kea'
+
+import { IconChevronDown } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+
+import type { RepoApi } from '../generated/api.schemas'
+import { visualReviewRepoLogic } from '../scenes/visualReviewRepoLogic'
+import type { VisualReviewTabKey } from './VisualReviewTabs'
+
+interface RepoSwitcherProps {
+    repoId: string
+    // Where to land on the other repo — preserves the user's current tab so
+    // switching from Snapshots on repo A goes to Snapshots on repo B.
+    activeTab: VisualReviewTabKey
+}
+
+const TAB_TO_PATH: Record<VisualReviewTabKey, (repoId: string) => string> = {
+    runs: (repoId) => `/visual_review/repos/${repoId}/runs`,
+    snapshots: (repoId) => `/visual_review/repos/${repoId}/snapshots`,
+}
+
+export function RepoSwitcher({ repoId, activeTab }: RepoSwitcherProps): JSX.Element | null {
+    const { repo, otherRepos } = useValues(visualReviewRepoLogic({ repoId }))
+
+    if (otherRepos.length === 0) {
+        return null
+    }
+
+    const items = otherRepos.map((r: RepoApi) => ({
+        label: r.repo_full_name,
+        to: TAB_TO_PATH[activeTab](r.id),
+    }))
+
+    return (
+        <LemonMenu items={items}>
+            <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                {repo?.repo_full_name ?? 'Switch repo'}
+            </LemonButton>
+        </LemonMenu>
+    )
+}

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -1,0 +1,90 @@
+import { IconWarning } from '@posthog/icons'
+import { LemonTag, Link } from '@posthog/lemon-ui'
+
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { urls } from 'scenes/urls'
+
+import type { BaselineEntryApi } from '../generated/api.schemas'
+import { parseArea, parseTheme } from '../lib/parseIdentifier'
+import { InlineSparkline } from './InlineSparkline'
+
+export function SnapshotCard({
+    repoId,
+    entry,
+    thumbnailBasePath,
+}: {
+    repoId: string
+    entry: BaselineEntryApi
+    thumbnailBasePath: string | null
+}): JSX.Element {
+    const { theme } = parseTheme(entry.identifier)
+    const area = parseArea(entry.identifier)
+    const tolerateCount = entry.tolerate_count_30d
+    // Only build the thumbnail URL when we know there's a thumbnail to fetch —
+    // otherwise the endpoint 404s and browsers show the broken-image glyph.
+    const thumbnailUrl =
+        thumbnailBasePath && entry.thumbnail_hash
+            ? `${thumbnailBasePath}/${encodeURIComponent(entry.identifier)}/`
+            : null
+    const href = urls.visualReviewSnapshotHistory(repoId, entry.run_type, entry.identifier)
+
+    return (
+        <Link
+            to={href}
+            className="border rounded bg-bg-light overflow-hidden flex flex-col hover:border-primary transition-colors"
+            data-attr="visual-review-snapshot-card"
+        >
+            <div
+                className={`relative aspect-[16/10] flex items-center justify-center overflow-hidden ${
+                    theme === 'dark' ? 'bg-bg-3000' : 'bg-bg-light'
+                }`}
+                style={{
+                    backgroundImage:
+                        'linear-gradient(45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.04) 75%), linear-gradient(45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.04) 75%)',
+                    backgroundSize: '12px 12px',
+                    backgroundPosition: '0 0, 6px 6px',
+                }}
+            >
+                {thumbnailUrl ? (
+                    <img
+                        src={thumbnailUrl}
+                        alt={entry.identifier}
+                        loading="lazy"
+                        decoding="async"
+                        className="max-w-full max-h-full object-contain"
+                    />
+                ) : (
+                    <span className="text-muted text-xs">No thumbnail</span>
+                )}
+                <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
+                    {entry.is_quarantined && (
+                        <Tooltip title="Currently quarantined — excluded from gating">
+                            <span className="bg-warning text-white rounded-full w-5 h-5 flex items-center justify-center">
+                                <IconWarning className="w-3 h-3" />
+                            </span>
+                        </Tooltip>
+                    )}
+                    {tolerateCount > 0 && (
+                        <Tooltip title={`${tolerateCount} tolerate${tolerateCount === 1 ? '' : 's'} in last 30 days`}>
+                            <span className="bg-primary-3000 text-white text-[10px] font-semibold rounded-full px-1.5 h-5 flex items-center">
+                                ~{tolerateCount}
+                            </span>
+                        </Tooltip>
+                    )}
+                </div>
+            </div>
+
+            <div className="p-2 flex flex-col gap-1 min-w-0">
+                <div className="font-mono text-xs truncate" title={entry.identifier}>
+                    {entry.identifier}
+                </div>
+                <div className="flex items-center justify-between gap-2 text-[11px] text-muted">
+                    <LemonTag type="default" size="small">
+                        {area}
+                    </LemonTag>
+                    <InlineSparkline data={entry.sparkline} className="h-4 w-16 shrink-0" />
+                </div>
+            </div>
+        </Link>
+    )
+}

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -31,19 +31,21 @@ export function SnapshotCard({
     return (
         <Link
             to={href}
-            className="border rounded bg-bg-light overflow-hidden flex flex-col hover:border-primary transition-colors"
+            // Without an explicit border-color, Tailwind's `border` falls back
+            // to `currentColor` — and Link sets `currentColor` to the primary
+            // orange. That painted every card with an orange frame.
+            className="border border-border rounded bg-bg-light overflow-hidden flex flex-col text-default hover:border-primary transition-colors"
             data-attr="visual-review-snapshot-card"
         >
             <div
-                className={`relative aspect-[16/10] flex items-center justify-center overflow-hidden ${
+                // Thumbnails are bounded by pixelhog at THUMB_WIDTH (200) ×
+                // THUMB_HEIGHT (140), so we know the box can never overflow.
+                // Fix the height to the cap and align top so taller content
+                // anchors consistently across cards; shorter content lets
+                // the bg-light (or bg-3000 for dark variants) show beneath.
+                className={`relative h-[140px] flex items-start justify-center overflow-hidden border-b border-border ${
                     theme === 'dark' ? 'bg-bg-3000' : 'bg-bg-light'
                 }`}
-                style={{
-                    backgroundImage:
-                        'linear-gradient(45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.04) 75%), linear-gradient(45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.04) 75%)',
-                    backgroundSize: '12px 12px',
-                    backgroundPosition: '0 0, 6px 6px',
-                }}
             >
                 {thumbnailUrl ? (
                     <img
@@ -54,7 +56,7 @@ export function SnapshotCard({
                         className="max-w-full max-h-full object-contain"
                     />
                 ) : (
-                    <span className="text-muted text-xs">No thumbnail</span>
+                    <span className="text-muted text-xs my-auto">No thumbnail</span>
                 )}
                 <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
                     {entry.is_quarantined && (

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -8,6 +8,14 @@ import type { BaselineEntryApi } from '../generated/api.schemas'
 import { parseArea, parseTheme } from '../lib/parseIdentifier'
 import { InlineSparkline } from './InlineSparkline'
 
+// Shared base for the corner badges on a snapshot card. Both badges use the
+// same shape (capsule, fixed height, min-width matching height so single-glyph
+// content stays circular), centered content, and weight — only the bg colour
+// differs. Mismatched widths/shapes here looked broken when both badges were
+// present.
+const BADGE_BASE =
+    'inline-flex items-center justify-center h-5 min-w-5 px-1.5 rounded-full text-white text-[10px] font-semibold leading-none'
+
 export function SnapshotCard({
     repoId,
     entry,
@@ -61,16 +69,14 @@ export function SnapshotCard({
                 <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
                     {entry.is_quarantined && (
                         <Tooltip title="Currently quarantined — excluded from gating">
-                            <span className="bg-warning text-white rounded-full w-5 h-5 flex items-center justify-center">
+                            <span className={`${BADGE_BASE} bg-warning`}>
                                 <IconWarning className="w-3 h-3" />
                             </span>
                         </Tooltip>
                     )}
                     {tolerateCount > 0 && (
                         <Tooltip title={`${tolerateCount} tolerate${tolerateCount === 1 ? '' : 's'} in last 30 days`}>
-                            <span className="bg-primary-3000 text-white text-[10px] font-semibold rounded-full px-1.5 h-5 flex items-center">
-                                ~{tolerateCount}
-                            </span>
+                            <span className={`${BADGE_BASE} bg-primary-3000`}>~{tolerateCount}</span>
                         </Tooltip>
                     )}
                 </div>

--- a/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
+++ b/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
@@ -54,7 +54,7 @@ export function SnapshotFacetSidebar({
                                     className={`flex items-center justify-between gap-2 px-2 py-1 rounded text-xs text-left transition-colors ${
                                         active
                                             ? 'bg-primary-3000-button-bg text-primary-3000-button-fg font-medium'
-                                            : 'hover:bg-fill-tertiary'
+                                            : 'hover:bg-primary-highlight'
                                     }`}
                                 >
                                     <span className="truncate">{bucket.label}</span>

--- a/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
+++ b/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
@@ -16,10 +16,13 @@ export type FacetSelection = {
     stability: Set<string>
 }
 
+// Stability first — it's the most actionable facet for the page's primary use
+// case ("which snapshots am I tolerating drift on?"). Type and Area are
+// context refinements after that.
 const GROUP_LABELS: Array<{ key: keyof FacetGroups; label: string }> = [
+    { key: 'stability', label: 'Stability' },
     { key: 'type', label: 'Type' },
     { key: 'area', label: 'Area' },
-    { key: 'stability', label: 'Stability' },
 ]
 
 export function SnapshotFacetSidebar({

--- a/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
+++ b/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
@@ -53,6 +53,7 @@ export function SnapshotFacetSidebar({
                                 <button
                                     key={bucket.value}
                                     type="button"
+                                    aria-pressed={active}
                                     onClick={() => onToggle(key, bucket.value)}
                                     className={`flex items-center justify-between gap-2 px-2 py-1 rounded text-xs text-left transition-colors ${
                                         active

--- a/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
+++ b/products/visual_review/frontend/components/SnapshotFacetSidebar.tsx
@@ -1,0 +1,72 @@
+// Faceted sidebar for the snapshots overview. Three groups (TYPE / AREA /
+// STABILITY), each a flat column of `<button>` rows. Counts are pre-computed
+// by the scene logic so this stays purely presentational.
+
+export type FacetBucket = { value: string; label: string; count: number }
+
+export type FacetGroups = {
+    type: FacetBucket[]
+    area: FacetBucket[]
+    stability: FacetBucket[]
+}
+
+export type FacetSelection = {
+    type: Set<string>
+    area: Set<string>
+    stability: Set<string>
+}
+
+const GROUP_LABELS: Array<{ key: keyof FacetGroups; label: string }> = [
+    { key: 'type', label: 'Type' },
+    { key: 'area', label: 'Area' },
+    { key: 'stability', label: 'Stability' },
+]
+
+export function SnapshotFacetSidebar({
+    groups,
+    selection,
+    onToggle,
+}: {
+    groups: FacetGroups
+    selection: FacetSelection
+    onToggle: (group: keyof FacetGroups, value: string) => void
+}): JSX.Element {
+    return (
+        <aside className="w-52 shrink-0 flex flex-col gap-4 text-sm">
+            {GROUP_LABELS.map(({ key, label }) => {
+                const buckets = groups[key]
+                if (!buckets.length) {
+                    return null
+                }
+                const sel = selection[key]
+                return (
+                    <div key={key} className="flex flex-col gap-0.5">
+                        <h4 className="text-[11px] font-semibold uppercase tracking-wider text-tertiary mb-1 mt-0">
+                            {label}
+                        </h4>
+                        {buckets.map((bucket) => {
+                            const active = sel.has(bucket.value)
+                            return (
+                                <button
+                                    key={bucket.value}
+                                    type="button"
+                                    onClick={() => onToggle(key, bucket.value)}
+                                    className={`flex items-center justify-between gap-2 px-2 py-1 rounded text-xs text-left transition-colors ${
+                                        active
+                                            ? 'bg-primary-3000-button-bg text-primary-3000-button-fg font-medium'
+                                            : 'hover:bg-fill-tertiary'
+                                    }`}
+                                >
+                                    <span className="truncate">{bucket.label}</span>
+                                    <span className="text-muted tabular-nums shrink-0">
+                                        {bucket.count.toLocaleString()}
+                                    </span>
+                                </button>
+                            )
+                        })}
+                    </div>
+                )
+            })}
+        </aside>
+    )
+}

--- a/products/visual_review/frontend/components/SnapshotStatRow.tsx
+++ b/products/visual_review/frontend/components/SnapshotStatRow.tsx
@@ -57,10 +57,14 @@ export function SnapshotStatRow({
                             {counts[s.value].toLocaleString()}
                         </div>
                         <div className="flex items-center gap-1.5 text-xs font-semibold mt-1">
-                            <span
-                                className="w-2 h-2 rounded-full shrink-0"
-                                style={{ backgroundColor: COLOR_BY_PRESET[s.value] }}
-                            />
+                            {s.value !== 'all' && (
+                                <>
+                                    <span
+                                        className="w-2 h-2 rounded-full shrink-0"
+                                        style={{ backgroundColor: COLOR_BY_PRESET[s.value] }}
+                                    />
+                                </>
+                            )}
                             <span className="truncate">{s.label}</span>
                             {s.value === 'tolerated_drift' && frequentlyToleratedCount > 0 && (
                                 <span className="ml-auto bg-primary-3000-button-bg text-primary-3000 text-[10px] font-semibold rounded px-1.5 py-0.5 shrink-0">

--- a/products/visual_review/frontend/components/SnapshotStatRow.tsx
+++ b/products/visual_review/frontend/components/SnapshotStatRow.tsx
@@ -1,0 +1,62 @@
+import { LemonSegmentedButton } from '@posthog/lemon-ui'
+
+export type StatPreset = 'all' | 'recently_tolerated' | 'frequently_tolerated' | 'currently_quarantined'
+
+const COLOR_BY_PRESET: Record<StatPreset, string> = {
+    all: 'var(--text-tertiary)',
+    recently_tolerated: 'var(--primary-3000)',
+    frequently_tolerated: 'var(--primary-3000)',
+    currently_quarantined: 'var(--warning-dark)',
+}
+
+const STATS: Array<{ value: StatPreset; label: string; description: string }> = [
+    { value: 'all', label: 'All snapshots', description: 'Every baseline image' },
+    { value: 'recently_tolerated', label: 'Recently tolerated', description: 'Any tolerate in last 30 days' },
+    {
+        value: 'frequently_tolerated',
+        label: 'Frequently tolerated',
+        description: '≥ 3 tolerates in last 90 days · trust debt',
+    },
+    {
+        value: 'currently_quarantined',
+        label: 'Currently quarantined',
+        description: 'Marked unreliable — skipped in gating',
+    },
+]
+
+export function SnapshotStatRow({
+    counts,
+    preset,
+    onChange,
+}: {
+    counts: Record<StatPreset, number>
+    preset: StatPreset
+    onChange: (next: StatPreset) => void
+}): JSX.Element {
+    return (
+        <LemonSegmentedButton
+            fullWidth
+            size="large"
+            value={preset}
+            onChange={(value: string) => onChange(value as StatPreset)}
+            options={STATS.map((s) => ({
+                value: s.value,
+                label: (
+                    <div className="flex flex-col items-start gap-0.5 py-1 min-w-0 w-full">
+                        <div className="text-2xl font-semibold leading-tight">{counts[s.value].toLocaleString()}</div>
+                        <div className="flex items-center gap-1.5 text-xs font-semibold whitespace-nowrap">
+                            <span
+                                className="w-2 h-2 rounded-full"
+                                style={{ backgroundColor: COLOR_BY_PRESET[s.value] }}
+                            />
+                            {s.label}
+                        </div>
+                        <div className="text-[11px] text-muted whitespace-normal text-left leading-tight">
+                            {s.description}
+                        </div>
+                    </div>
+                ),
+            }))}
+        />
+    )
+}

--- a/products/visual_review/frontend/components/SnapshotStatRow.tsx
+++ b/products/visual_review/frontend/components/SnapshotStatRow.tsx
@@ -1,21 +1,17 @@
-import { LemonSegmentedButton } from '@posthog/lemon-ui'
-
-export type StatPreset = 'all' | 'recently_tolerated' | 'frequently_tolerated' | 'currently_quarantined'
+export type StatPreset = 'all' | 'tolerated_drift' | 'currently_quarantined'
 
 const COLOR_BY_PRESET: Record<StatPreset, string> = {
     all: 'var(--text-tertiary)',
-    recently_tolerated: 'var(--primary-3000)',
-    frequently_tolerated: 'var(--primary-3000)',
+    tolerated_drift: 'var(--primary-3000)',
     currently_quarantined: 'var(--warning-dark)',
 }
 
 const STATS: Array<{ value: StatPreset; label: string; description: string }> = [
     { value: 'all', label: 'All snapshots', description: 'Every baseline image' },
-    { value: 'recently_tolerated', label: 'Recently tolerated', description: 'Any tolerate in last 30 days' },
     {
-        value: 'frequently_tolerated',
-        label: 'Frequently tolerated',
-        description: '≥ 3 tolerates in last 90 days · trust debt',
+        value: 'tolerated_drift',
+        label: 'Tolerated drift',
+        description: 'At least one tolerate in the last 30 days',
     },
     {
         value: 'currently_quarantined',
@@ -24,39 +20,58 @@ const STATS: Array<{ value: StatPreset; label: string; description: string }> = 
     },
 ]
 
+// Plain tile grid instead of LemonSegmentedButton — segmented buttons assume
+// equal-width single-line content, which warped the multi-line stat tiles
+// and misaligned numbers across columns. A bordered grid keeps numbers and
+// labels on consistent baselines.
 export function SnapshotStatRow({
     counts,
+    frequentlyToleratedCount,
     preset,
     onChange,
 }: {
     counts: Record<StatPreset, number>
+    // Inline trust-debt indicator on the Tolerated tile — the count of
+    // identifiers tolerated ≥3 times in the last 90d. Surfaced as a small
+    // chip rather than its own slice.
+    frequentlyToleratedCount: number
     preset: StatPreset
     onChange: (next: StatPreset) => void
 }): JSX.Element {
     return (
-        <LemonSegmentedButton
-            fullWidth
-            size="large"
-            value={preset}
-            onChange={(value: string) => onChange(value as StatPreset)}
-            options={STATS.map((s) => ({
-                value: s.value,
-                label: (
-                    <div className="flex flex-col items-start gap-0.5 py-1 min-w-0 w-full">
-                        <div className="text-2xl font-semibold leading-tight">{counts[s.value].toLocaleString()}</div>
-                        <div className="flex items-center gap-1.5 text-xs font-semibold whitespace-nowrap">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            {STATS.map((s) => {
+                const active = preset === s.value
+                return (
+                    <button
+                        key={s.value}
+                        type="button"
+                        onClick={() => onChange(s.value)}
+                        className={`text-left border rounded p-3 transition-colors flex flex-col gap-1 ${
+                            active
+                                ? 'border-primary-3000 bg-primary-3000-button-bg'
+                                : 'border-border bg-bg-light hover:border-primary-3000-hover'
+                        }`}
+                    >
+                        <div className="text-2xl font-semibold leading-none tabular-nums">
+                            {counts[s.value].toLocaleString()}
+                        </div>
+                        <div className="flex items-center gap-1.5 text-xs font-semibold mt-1">
                             <span
-                                className="w-2 h-2 rounded-full"
+                                className="w-2 h-2 rounded-full shrink-0"
                                 style={{ backgroundColor: COLOR_BY_PRESET[s.value] }}
                             />
-                            {s.label}
+                            <span className="truncate">{s.label}</span>
+                            {s.value === 'tolerated_drift' && frequentlyToleratedCount > 0 && (
+                                <span className="ml-auto bg-primary-3000-button-bg text-primary-3000 text-[10px] font-semibold rounded px-1.5 py-0.5 shrink-0">
+                                    {frequentlyToleratedCount} frequent
+                                </span>
+                            )}
                         </div>
-                        <div className="text-[11px] text-muted whitespace-normal text-left leading-tight">
-                            {s.description}
-                        </div>
-                    </div>
-                ),
-            }))}
-        />
+                        <div className="text-[11px] text-muted leading-tight">{s.description}</div>
+                    </button>
+                )
+            })}
+        </div>
     )
 }

--- a/products/visual_review/frontend/components/SnapshotStatRow.tsx
+++ b/products/visual_review/frontend/components/SnapshotStatRow.tsx
@@ -46,6 +46,7 @@ export function SnapshotStatRow({
                     <button
                         key={s.value}
                         type="button"
+                        aria-pressed={active}
                         onClick={() => onChange(s.value)}
                         className={`text-left border rounded p-3 transition-colors flex flex-col gap-1 ${
                             active

--- a/products/visual_review/frontend/components/VisualReviewTabs.tsx
+++ b/products/visual_review/frontend/components/VisualReviewTabs.tsx
@@ -1,0 +1,36 @@
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { urls } from 'scenes/urls'
+
+export type VisualReviewTabKey = 'runs' | 'snapshots'
+
+// Top-level tab strip for a repo workspace. Both tabs are repo-scoped and
+// share the same `:repoId` segment, so this component is purely
+// presentational — the parent scene already knows which repo it's in.
+// Settings stays out of this strip: it's a gear button in the scene's header
+// actions instead, matching how other products surface team-wide settings.
+export function VisualReviewTabs({
+    activeKey,
+    repoId,
+}: {
+    activeKey: VisualReviewTabKey
+    repoId: string
+}): JSX.Element {
+    return (
+        <LemonTabs
+            activeKey={activeKey}
+            sceneInset
+            tabs={[
+                {
+                    key: 'runs' satisfies VisualReviewTabKey,
+                    label: 'Runs',
+                    link: urls.visualReviewRepoRuns(repoId),
+                },
+                {
+                    key: 'snapshots' satisfies VisualReviewTabKey,
+                    label: 'Snapshots',
+                    link: urls.visualReviewSnapshotOverview(repoId),
+                },
+            ]}
+        />
+    )
+}

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -405,6 +405,10 @@ export type VisualReviewRunsListParams = {
      */
     offset?: number
     /**
+     * Filter by repo UUID
+     */
+    repo_id?: string
+    /**
      * Filter by review state
      */
     review_state?: string

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -69,6 +69,8 @@ export interface BaselineEntryApi {
     tolerate_count_90d: number
     is_quarantined: boolean
     last_run_at: string
+    /** @nullable */
+    recent_diff_avg: number | null
 }
 
 export type BaselineTotalsApiByRunType = { [key: string]: number }

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -126,41 +126,6 @@ export interface QuarantineInputApi {
     expires_at?: string | null
 }
 
-export interface ArtifactApi {
-    id: string
-    content_hash: string
-    /** @nullable */
-    width: number | null
-    /** @nullable */
-    height: number | null
-    /** @nullable */
-    download_url: string | null
-}
-
-export interface SnapshotHistoryEntryApi {
-    current_artifact?: ArtifactApi | null
-    run_id: string
-    snapshot_id: string
-    result: string
-    branch: string
-    commit_sha: string
-    created_at: string
-    /** @nullable */
-    pr_number?: number | null
-    /** @nullable */
-    diff_percentage?: number | null
-    review_state?: string
-}
-
-export interface PaginatedSnapshotHistoryEntryListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: SnapshotHistoryEntryApi[]
-}
-
 export interface RunSummaryApi {
     total: number
     changed: number
@@ -205,6 +170,48 @@ export interface PaginatedRunListApi {
     /** @nullable */
     previous?: string | null
     results: RunApi[]
+}
+
+export interface ReviewStateCountsApi {
+    needs_review: number
+    clean: number
+    processing: number
+    stale: number
+}
+
+export interface ArtifactApi {
+    id: string
+    content_hash: string
+    /** @nullable */
+    width: number | null
+    /** @nullable */
+    height: number | null
+    /** @nullable */
+    download_url: string | null
+}
+
+export interface SnapshotHistoryEntryApi {
+    current_artifact?: ArtifactApi | null
+    run_id: string
+    snapshot_id: string
+    result: string
+    branch: string
+    commit_sha: string
+    created_at: string
+    /** @nullable */
+    pr_number?: number | null
+    /** @nullable */
+    diff_percentage?: number | null
+    review_state?: string
+}
+
+export interface PaginatedSnapshotHistoryEntryListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: SnapshotHistoryEntryApi[]
 }
 
 export type CreateRunInputApiBaselineHashes = { [key: string]: string }
@@ -347,13 +354,6 @@ export interface PaginatedToleratedHashEntryListApi {
     results: ToleratedHashEntryApi[]
 }
 
-export interface ReviewStateCountsApi {
-    needs_review: number
-    clean: number
-    processing: number
-    stale: number
-}
-
 export type VisualReviewReposListParams = {
     /**
      * Number of results to return per page.
@@ -384,6 +384,21 @@ export type VisualReviewReposQuarantineListParams = {
     run_type?: string
 }
 
+export type VisualReviewReposRunsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    /**
+     * Filter by review state
+     */
+    review_state?: string
+}
+
 export type VisualReviewReposSnapshotsListParams = {
     /**
      * Number of results to return per page.
@@ -393,25 +408,6 @@ export type VisualReviewReposSnapshotsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
-}
-
-export type VisualReviewRunsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number
-    /**
-     * Filter by repo UUID
-     */
-    repo_id?: string
-    /**
-     * Filter by review state
-     */
-    review_state?: string
 }
 
 export type VisualReviewRunsSnapshotsListParams = {
@@ -438,11 +434,4 @@ export type VisualReviewRunsToleratedHashesListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
-}
-
-export type VisualReviewRunsCountsRetrieveParams = {
-    /**
-     * Filter by repo UUID
-     */
-    repo_id?: string
 }

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -439,3 +439,10 @@ export type VisualReviewRunsToleratedHashesListParams = {
      */
     offset?: number
 }
+
+export type VisualReviewRunsCountsRetrieveParams = {
+    /**
+     * Filter by repo UUID
+     */
+    repo_id?: string
+}

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -46,6 +46,48 @@ export interface PatchedUpdateRepoRequestInputApi {
     enable_pr_comments?: boolean | null
 }
 
+export interface BaselineSparklineDayApi {
+    clean: number
+    tolerated: number
+    changed: number
+    quarantined: number
+}
+
+export interface BaselineEntryApi {
+    sparkline: BaselineSparklineDayApi[]
+    identifier: string
+    run_type: string
+    /** @nullable */
+    browser: string | null
+    /** @nullable */
+    thumbnail_hash: string | null
+    /** @nullable */
+    width: number | null
+    /** @nullable */
+    height: number | null
+    tolerate_count_30d: number
+    tolerate_count_90d: number
+    is_quarantined: boolean
+    last_run_at: string
+}
+
+export type BaselineTotalsApiByRunType = { [key: string]: number }
+
+export interface BaselineTotalsApi {
+    by_run_type: BaselineTotalsApiByRunType
+    all_snapshots: number
+    recently_tolerated: number
+    frequently_tolerated: number
+    currently_quarantined: number
+}
+
+export interface BaselineOverviewApi {
+    entries: BaselineEntryApi[]
+    totals: BaselineTotalsApi
+    truncated: boolean
+    generated_at: string
+}
+
 export interface UserBasicInfoApi {
     id: number
     first_name: string

--- a/products/visual_review/frontend/generated/api.ts
+++ b/products/visual_review/frontend/generated/api.ts
@@ -35,6 +35,7 @@ import type {
     VisualReviewReposListParams,
     VisualReviewReposQuarantineListParams,
     VisualReviewReposSnapshotsListParams,
+    VisualReviewRunsCountsRetrieveParams,
     VisualReviewRunsListParams,
     VisualReviewRunsSnapshotsListParams,
     VisualReviewRunsToleratedHashesListParams,
@@ -534,17 +535,33 @@ export const visualReviewRunsToleratedHashesList = async (
 }
 
 /**
- * Review state counts for the runs list.
+ * Review state counts for the runs list, optionally scoped to a repo.
  */
-export const getVisualReviewRunsCountsRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/visual_review/runs/counts/`
+export const getVisualReviewRunsCountsRetrieveUrl = (
+    projectId: string,
+    params?: VisualReviewRunsCountsRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/visual_review/runs/counts/?${stringifiedParams}`
+        : `/api/projects/${projectId}/visual_review/runs/counts/`
 }
 
 export const visualReviewRunsCountsRetrieve = async (
     projectId: string,
+    params?: VisualReviewRunsCountsRetrieveParams,
     options?: RequestInit
 ): Promise<ReviewStateCountsApi> => {
-    return apiMutator<ReviewStateCountsApi>(getVisualReviewRunsCountsRetrieveUrl(projectId), {
+    return apiMutator<ReviewStateCountsApi>(getVisualReviewRunsCountsRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/products/visual_review/frontend/generated/api.ts
+++ b/products/visual_review/frontend/generated/api.ts
@@ -34,9 +34,8 @@ import type {
     SnapshotApi,
     VisualReviewReposListParams,
     VisualReviewReposQuarantineListParams,
+    VisualReviewReposRunsListParams,
     VisualReviewReposSnapshotsListParams,
-    VisualReviewRunsCountsRetrieveParams,
-    VisualReviewRunsListParams,
     VisualReviewRunsSnapshotsListParams,
     VisualReviewRunsToleratedHashesListParams,
 } from './api.schemas'
@@ -250,6 +249,59 @@ export const visualReviewReposThumbnailsRetrieve = async (
 }
 
 /**
+ * List runs in this repo, optionally filtered by review state.
+ */
+export const getVisualReviewReposRunsListUrl = (
+    projectId: string,
+    repoId: string,
+    params?: VisualReviewReposRunsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/visual_review/repos/${repoId}/runs/?${stringifiedParams}`
+        : `/api/projects/${projectId}/visual_review/repos/${repoId}/runs/`
+}
+
+export const visualReviewReposRunsList = async (
+    projectId: string,
+    repoId: string,
+    params?: VisualReviewReposRunsListParams,
+    options?: RequestInit
+): Promise<PaginatedRunListApi> => {
+    return apiMutator<PaginatedRunListApi>(getVisualReviewReposRunsListUrl(projectId, repoId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Review state counts for runs in this repo.
+ */
+export const getVisualReviewReposRunsCountsRetrieveUrl = (projectId: string, repoId: string) => {
+    return `/api/projects/${projectId}/visual_review/repos/${repoId}/runs/counts/`
+}
+
+export const visualReviewReposRunsCountsRetrieve = async (
+    projectId: string,
+    repoId: string,
+    options?: RequestInit
+): Promise<ReviewStateCountsApi> => {
+    return apiMutator<ReviewStateCountsApi>(getVisualReviewReposRunsCountsRetrieveUrl(projectId, repoId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
  * Deduped baseline timeline for a snapshot identity. Newest first.
  */
 export const getVisualReviewReposSnapshotsListUrl = (
@@ -289,36 +341,6 @@ export const visualReviewReposSnapshotsList = async (
             method: 'GET',
         }
     )
-}
-
-/**
- * List runs for the team, optionally filtered by review state or repo.
- */
-export const getVisualReviewRunsListUrl = (projectId: string, params?: VisualReviewRunsListParams) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/visual_review/runs/?${stringifiedParams}`
-        : `/api/projects/${projectId}/visual_review/runs/`
-}
-
-export const visualReviewRunsList = async (
-    projectId: string,
-    params?: VisualReviewRunsListParams,
-    options?: RequestInit
-): Promise<PaginatedRunListApi> => {
-    return apiMutator<PaginatedRunListApi>(getVisualReviewRunsListUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
 }
 
 /**
@@ -532,37 +554,4 @@ export const visualReviewRunsToleratedHashesList = async (
             method: 'GET',
         }
     )
-}
-
-/**
- * Review state counts for the runs list, optionally scoped to a repo.
- */
-export const getVisualReviewRunsCountsRetrieveUrl = (
-    projectId: string,
-    params?: VisualReviewRunsCountsRetrieveParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/visual_review/runs/counts/?${stringifiedParams}`
-        : `/api/projects/${projectId}/visual_review/runs/counts/`
-}
-
-export const visualReviewRunsCountsRetrieve = async (
-    projectId: string,
-    params?: VisualReviewRunsCountsRetrieveParams,
-    options?: RequestInit
-): Promise<ReviewStateCountsApi> => {
-    return apiMutator<ReviewStateCountsApi>(getVisualReviewRunsCountsRetrieveUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
 }

--- a/products/visual_review/frontend/generated/api.ts
+++ b/products/visual_review/frontend/generated/api.ts
@@ -291,7 +291,7 @@ export const visualReviewReposSnapshotsList = async (
 }
 
 /**
- * List runs for the team, optionally filtered by review state.
+ * List runs for the team, optionally filtered by review state or repo.
  */
 export const getVisualReviewRunsListUrl = (projectId: string, params?: VisualReviewRunsListParams) => {
     const normalizedParams = new URLSearchParams()

--- a/products/visual_review/frontend/generated/api.ts
+++ b/products/visual_review/frontend/generated/api.ts
@@ -13,6 +13,7 @@ import type {
     AddSnapshotsResultApi,
     ApproveRunRequestInputApi,
     AutoApproveResultApi,
+    BaselineOverviewApi,
     CreateRepoInputApi,
     CreateRunInputApi,
     CreateRunResultApi,
@@ -125,6 +126,24 @@ export const visualReviewReposPartialUpdate = async (
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(patchedUpdateRepoRequestInputApi),
+    })
+}
+
+/**
+ * Snapshots overview for a repo: every identifier with a current baseline (latest non-superseded master/main run per run_type), plus tolerate counts, active quarantine state, and a 30-day stability sparkline. Capped at 5000 entries — sets `truncated` and returns the most recently active when exceeded. Filtering / faceting / search are all done client-side; this endpoint takes no filter query params.
+ */
+export const getVisualReviewReposBaselinesRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/visual_review/repos/${id}/baselines/`
+}
+
+export const visualReviewReposBaselinesRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<BaselineOverviewApi> => {
+    return apiMutator<BaselineOverviewApi>(getVisualReviewReposBaselinesRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/visual_review/frontend/lib/parseIdentifier.ts
+++ b/products/visual_review/frontend/lib/parseIdentifier.ts
@@ -1,0 +1,99 @@
+// Pure helpers for splitting a snapshot identifier into theme + area buckets.
+// Used by the snapshots-overview scene for client-side facet derivation. Stays
+// in sync with `_derive_area` if/when the backend ever needs to mirror it for
+// a server-side facet.
+
+// Map of known PostHog area keywords (matched as `-`-separated tokens, not
+// substrings, to avoid `errortracking` matching `tracking`). Order doesn't
+// matter — first hit wins, but the keys are disjoint enough that there's no
+// real ambiguity.
+const AREA_TOKENS: Array<[string[], string]> = [
+    [['insight', 'insights'], 'Insights'],
+    [['dashboard', 'dashboards'], 'Dashboards'],
+    [['replay', 'recording', 'recordings', 'session-replay'], 'Session replay'],
+    [['funnel', 'funnels'], 'Funnels'],
+    [['retention'], 'Retention'],
+    [['feature-flag', 'feature-flags', 'flags'], 'Feature flags'],
+    [['experiment', 'experiments'], 'Experiments'],
+    [['survey', 'surveys'], 'Surveys'],
+    [['notebook', 'notebooks'], 'Notebooks'],
+    [['person', 'persons', 'cohort', 'cohorts'], 'Persons'],
+    [['data-management', 'datamanagement'], 'Data management'],
+    [['data-warehouse', 'datawarehouse', 'data-pipelines', 'datapipelines', 'batchexports'], 'Data pipelines'],
+    [['onboarding'], 'Onboarding'],
+    [['setting', 'settings'], 'Settings'],
+    [['error-tracking', 'errortracking'], 'Error tracking'],
+    [['web-analytics', 'webanalytics'], 'Web analytics'],
+    [['llm-analytics', 'llmanalytics'], 'LLM analytics'],
+    [['toolbar'], 'Toolbar'],
+    [['heatmap', 'heatmaps'], 'Heatmaps'],
+    [['workflow', 'workflows'], 'Workflows'],
+    [['visual-review', 'visual_review'], 'Visual review'],
+    [['customer-analytics', 'customeranalytics'], 'Customer analytics'],
+    [['revenue-analytics', 'revenueanalytics'], 'Revenue analytics'],
+    [['marketing-analytics', 'marketinganalytics'], 'Marketing analytics'],
+    [['inbox'], 'Inbox'],
+    [['activity'], 'Activity'],
+    [['annotations'], 'Annotations'],
+    [['apps', 'plugins'], 'Apps'],
+    [['comments'], 'Comments'],
+    [['integrations'], 'Integrations'],
+    [['exports', 'exporter'], 'Exports'],
+    [['actions'], 'Actions'],
+    [['endpoints'], 'Endpoints'],
+    [['mcp'], 'MCP'],
+    [['posthog-3000', 'theme'], 'Theming'],
+    [['lemon', 'ui'], 'UI primitives'],
+]
+
+export type Theme = 'light' | 'dark' | null
+
+export function parseTheme(identifier: string): { stem: string; theme: Theme } {
+    if (identifier.endsWith('--light')) {
+        return { stem: identifier.slice(0, -'--light'.length), theme: 'light' }
+    }
+    if (identifier.endsWith('--dark')) {
+        return { stem: identifier.slice(0, -'--dark'.length), theme: 'dark' }
+    }
+    return { stem: identifier, theme: null }
+}
+
+export function parseArea(identifier: string): string {
+    // Identifier shape varies — sometimes `<area>--<name>`, often something
+    // like `scenes-app-<area>-...` for Storybook stories, or `components-...`
+    // for component-level shots. Walk the first few `-`-separated tokens and
+    // return the first one we recognize.
+    const stem = parseTheme(identifier).stem
+    const head = stem.split('--')[0].toLowerCase()
+    const tokens = head.split('-')
+
+    // Storybook story IDs nest the area inside `scenes-app-<area>-...`. Skip
+    // the wrapper segments to look for the real area first.
+    const startIndex = tokens[0] === 'scenes' && tokens[1] === 'app' ? 2 : 0
+
+    // Try multi-token matches (e.g. "data-management") first, then single tokens.
+    for (let i = startIndex; i < tokens.length; i++) {
+        for (let span = Math.min(3, tokens.length - i); span >= 1; span--) {
+            const candidate = tokens.slice(i, i + span).join('-')
+            for (const [keys, label] of AREA_TOKENS) {
+                if (keys.includes(candidate)) {
+                    return label
+                }
+            }
+        }
+    }
+
+    if (tokens[0] === 'components') {
+        return 'Components'
+    }
+    return 'Other'
+}
+
+// Display-friendly run-type label ("playwright · chromium" for Playwright runs
+// where we know the browser; otherwise just the run_type itself).
+export function runTypeLabel(runType: string, browser: string | null | undefined): string {
+    if (runType.toLowerCase() === 'playwright' && browser) {
+        return `playwright · ${browser}`
+    }
+    return runType
+}

--- a/products/visual_review/frontend/lib/parseIdentifier.ts
+++ b/products/visual_review/frontend/lib/parseIdentifier.ts
@@ -3,49 +3,6 @@
 // in sync with `_derive_area` if/when the backend ever needs to mirror it for
 // a server-side facet.
 
-// Map of known PostHog area keywords (matched as `-`-separated tokens, not
-// substrings, to avoid `errortracking` matching `tracking`). Order doesn't
-// matter — first hit wins, but the keys are disjoint enough that there's no
-// real ambiguity.
-const AREA_TOKENS: Array<[string[], string]> = [
-    [['insight', 'insights'], 'Insights'],
-    [['dashboard', 'dashboards'], 'Dashboards'],
-    [['replay', 'recording', 'recordings', 'session-replay'], 'Session replay'],
-    [['funnel', 'funnels'], 'Funnels'],
-    [['retention'], 'Retention'],
-    [['feature-flag', 'feature-flags', 'flags'], 'Feature flags'],
-    [['experiment', 'experiments'], 'Experiments'],
-    [['survey', 'surveys'], 'Surveys'],
-    [['notebook', 'notebooks'], 'Notebooks'],
-    [['person', 'persons', 'cohort', 'cohorts'], 'Persons'],
-    [['data-management', 'datamanagement'], 'Data management'],
-    [['data-warehouse', 'datawarehouse', 'data-pipelines', 'datapipelines', 'batchexports'], 'Data pipelines'],
-    [['onboarding'], 'Onboarding'],
-    [['setting', 'settings'], 'Settings'],
-    [['error-tracking', 'errortracking'], 'Error tracking'],
-    [['web-analytics', 'webanalytics'], 'Web analytics'],
-    [['llm-analytics', 'llmanalytics'], 'LLM analytics'],
-    [['toolbar'], 'Toolbar'],
-    [['heatmap', 'heatmaps'], 'Heatmaps'],
-    [['workflow', 'workflows'], 'Workflows'],
-    [['visual-review', 'visual_review'], 'Visual review'],
-    [['customer-analytics', 'customeranalytics'], 'Customer analytics'],
-    [['revenue-analytics', 'revenueanalytics'], 'Revenue analytics'],
-    [['marketing-analytics', 'marketinganalytics'], 'Marketing analytics'],
-    [['inbox'], 'Inbox'],
-    [['activity'], 'Activity'],
-    [['annotations'], 'Annotations'],
-    [['apps', 'plugins'], 'Apps'],
-    [['comments'], 'Comments'],
-    [['integrations'], 'Integrations'],
-    [['exports', 'exporter'], 'Exports'],
-    [['actions'], 'Actions'],
-    [['endpoints'], 'Endpoints'],
-    [['mcp'], 'MCP'],
-    [['posthog-3000', 'theme'], 'Theming'],
-    [['lemon', 'ui'], 'UI primitives'],
-]
-
 export type Theme = 'light' | 'dark' | null
 
 export function parseTheme(identifier: string): { stem: string; theme: Theme } {
@@ -58,35 +15,53 @@ export function parseTheme(identifier: string): { stem: string; theme: Theme } {
     return { stem: identifier, theme: null }
 }
 
+// Tokens that act as "modifier" prefixes inside identifiers like
+// `error-tracking`, `data-management`, `feature-flags`. When the area token
+// is one of these, we glue it together with the next token so the facet shows
+// "Error tracking" instead of just "Error".
+const TWO_WORD_HEADS = new Set([
+    'customer',
+    'data',
+    'error',
+    'feature',
+    'live',
+    'llm',
+    'marketing',
+    'product',
+    'revenue',
+    'session',
+    'user',
+    'visual',
+    'web',
+])
+
+// Capitalize first letter, leave the rest as-is so multi-word labels read
+// naturally ("Feature flags" not "Feature Flags").
+function titleCase(s: string): string {
+    return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1)
+}
+
 export function parseArea(identifier: string): string {
-    // Identifier shape varies — sometimes `<area>--<name>`, often something
-    // like `scenes-app-<area>-...` for Storybook stories, or `components-...`
-    // for component-level shots. Walk the first few `-`-separated tokens and
-    // return the first one we recognize.
-    const stem = parseTheme(identifier).stem
-    const head = stem.split('--')[0].toLowerCase()
-    const tokens = head.split('-')
-
-    // Storybook story IDs nest the area inside `scenes-app-<area>-...`. Skip
-    // the wrapper segments to look for the real area first.
-    const startIndex = tokens[0] === 'scenes' && tokens[1] === 'app' ? 2 : 0
-
-    // Try multi-token matches (e.g. "data-management") first, then single tokens.
-    for (let i = startIndex; i < tokens.length; i++) {
-        for (let span = Math.min(3, tokens.length - i); span >= 1; span--) {
-            const candidate = tokens.slice(i, i + span).join('-')
-            for (const [keys, label] of AREA_TOKENS) {
-                if (keys.includes(candidate)) {
-                    return label
-                }
-            }
-        }
+    // Storybook identifiers tend to follow one of three shapes:
+    //   - `scenes-app-<area>-<rest...>` — the area is the third token
+    //   - `components-<rest...>`        — bucket as "Components"
+    //   - `<area>-<rest...>`            — first token IS the area
+    // Two-word area names ("error-tracking", "data-management") are detected
+    // via a tiny TWO_WORD_HEADS set instead of a curated full table.
+    const stem = parseTheme(identifier).stem.split('--')[0].toLowerCase()
+    const tokens = stem.split('-')
+    let i = 0
+    if (tokens[i] === 'scenes' && tokens[i + 1] === 'app') {
+        i += 2
     }
-
-    if (tokens[0] === 'components') {
+    if (tokens[i] === 'components') {
         return 'Components'
     }
-    return 'Other'
+    if (!tokens[i]) {
+        return 'Other'
+    }
+    const head = TWO_WORD_HEADS.has(tokens[i]) && tokens[i + 1] ? `${tokens[i]} ${tokens[i + 1]}` : tokens[i]
+    return titleCase(head)
 }
 
 // Display-friendly run-type label ("playwright · chromium" for Playwright runs

--- a/products/visual_review/frontend/scenes/VisualReviewIndexScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewIndexScene.tsx
@@ -1,0 +1,91 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect } from 'react'
+
+import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { visualReviewIndexSceneLogic } from './visualReviewIndexSceneLogic'
+
+export const scene: SceneExport = {
+    component: VisualReviewIndexScene,
+    logic: visualReviewIndexSceneLogic,
+}
+
+export function VisualReviewIndexScene(): JSX.Element {
+    const { repos, reposLoading } = useValues(visualReviewIndexSceneLogic)
+    const { loadRepos } = useActions(visualReviewIndexSceneLogic)
+
+    // Once the repo list arrives: forward immediately if there's exactly one,
+    // otherwise render a picker. The afterMount hook handles the case where
+    // repos were already loaded; this effect handles first load.
+    useEffect(() => {
+        if (!reposLoading && repos.length === 1) {
+            router.actions.replace(urls.visualReviewRepoRuns(repos[0].id))
+        }
+    }, [reposLoading, repos])
+
+    if (reposLoading) {
+        return (
+            <SceneContent>
+                <SceneTitleSection name="Visual review" resourceType={{ type: 'visual_review' }} />
+                <LemonSkeleton className="h-32 w-full max-w-2xl" />
+            </SceneContent>
+        )
+    }
+
+    if (repos.length === 0) {
+        return (
+            <SceneContent>
+                <SceneTitleSection name="Visual review" resourceType={{ type: 'visual_review' }} />
+                <div className="max-w-2xl">
+                    <p className="text-muted">
+                        No visual review repos yet. Connect one from{' '}
+                        <Link to={urls.visualReviewSettings()}>Settings</Link> to get started.
+                    </p>
+                    <LemonButton type="primary" to={urls.visualReviewSettings()}>
+                        Open settings
+                    </LemonButton>
+                </div>
+            </SceneContent>
+        )
+    }
+
+    // Multi-repo case — render a small picker. The single-repo case is
+    // already on its way to the workspace via the effect above; this branch
+    // shouldn't render in practice for that case.
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Visual review"
+                resourceType={{ type: 'visual_review' }}
+                actions={
+                    <LemonButton type="secondary" onClick={loadRepos} loading={reposLoading}>
+                        Refresh
+                    </LemonButton>
+                }
+            />
+            <div className="flex flex-col gap-2 max-w-2xl">
+                <h3 className="m-0 text-base">Pick a repo</h3>
+                {repos.map((repo) => (
+                    <Link
+                        key={repo.id}
+                        to={urls.visualReviewRepoRuns(repo.id)}
+                        className="flex items-center justify-between border border-border rounded p-3 bg-bg-light hover:border-primary transition-colors"
+                    >
+                        <span className="font-mono text-sm">{repo.repo_full_name}</span>
+                        <span className="text-xs text-muted">connected {dayjs(repo.created_at).fromNow()}</span>
+                    </Link>
+                ))}
+            </div>
+        </SceneContent>
+    )
+}
+
+export default VisualReviewIndexScene

--- a/products/visual_review/frontend/scenes/VisualReviewIndexScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewIndexScene.tsx
@@ -1,10 +1,9 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect } from 'react'
 
 import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
-import { dayjs } from 'lib/dayjs'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -18,20 +17,20 @@ export const scene: SceneExport = {
     logic: visualReviewIndexSceneLogic,
 }
 
+// /visual_review forwards straight to the first repo's Runs page once the
+// repo list lands. There is no picker page — the in-header repo switcher
+// covers the multi-repo case. Only the empty state and the brief loader
+// state ever paint.
 export function VisualReviewIndexScene(): JSX.Element {
     const { repos, reposLoading } = useValues(visualReviewIndexSceneLogic)
-    const { loadRepos } = useActions(visualReviewIndexSceneLogic)
 
-    // Once the repo list arrives: forward immediately if there's exactly one,
-    // otherwise render a picker. The afterMount hook handles the case where
-    // repos were already loaded; this effect handles first load.
     useEffect(() => {
-        if (!reposLoading && repos.length === 1) {
+        if (!reposLoading && repos.length >= 1) {
             router.actions.replace(urls.visualReviewRepoRuns(repos[0].id))
         }
     }, [reposLoading, repos])
 
-    if (reposLoading) {
+    if (reposLoading || repos.length >= 1) {
         return (
             <SceneContent>
                 <SceneTitleSection name="Visual review" resourceType={{ type: 'visual_review' }} />
@@ -40,49 +39,17 @@ export function VisualReviewIndexScene(): JSX.Element {
         )
     }
 
-    if (repos.length === 0) {
-        return (
-            <SceneContent>
-                <SceneTitleSection name="Visual review" resourceType={{ type: 'visual_review' }} />
-                <div className="max-w-2xl">
-                    <p className="text-muted">
-                        No visual review repos yet. Connect one from{' '}
-                        <Link to={urls.visualReviewSettings()}>Settings</Link> to get started.
-                    </p>
-                    <LemonButton type="primary" to={urls.visualReviewSettings()}>
-                        Open settings
-                    </LemonButton>
-                </div>
-            </SceneContent>
-        )
-    }
-
-    // Multi-repo case — render a small picker. The single-repo case is
-    // already on its way to the workspace via the effect above; this branch
-    // shouldn't render in practice for that case.
     return (
         <SceneContent>
-            <SceneTitleSection
-                name="Visual review"
-                resourceType={{ type: 'visual_review' }}
-                actions={
-                    <LemonButton type="secondary" onClick={loadRepos} loading={reposLoading}>
-                        Refresh
-                    </LemonButton>
-                }
-            />
-            <div className="flex flex-col gap-2 max-w-2xl">
-                <h3 className="m-0 text-base">Pick a repo</h3>
-                {repos.map((repo) => (
-                    <Link
-                        key={repo.id}
-                        to={urls.visualReviewRepoRuns(repo.id)}
-                        className="flex items-center justify-between border border-border rounded p-3 bg-bg-light hover:border-primary transition-colors"
-                    >
-                        <span className="font-mono text-sm">{repo.repo_full_name}</span>
-                        <span className="text-xs text-muted">connected {dayjs(repo.created_at).fromNow()}</span>
-                    </Link>
-                ))}
+            <SceneTitleSection name="Visual review" resourceType={{ type: 'visual_review' }} />
+            <div className="max-w-2xl">
+                <p className="text-muted">
+                    No visual review repos yet. Connect one from <Link to={urls.visualReviewSettings()}>Settings</Link>{' '}
+                    to get started.
+                </p>
+                <LemonButton type="primary" to={urls.visualReviewSettings()}>
+                    Open settings
+                </LemonButton>
             </div>
         </SceneContent>
     )

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -17,6 +17,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { SnapshotDiffViewer } from '../components/SnapshotDiffViewer'
 import { SnapshotStatusIndicator } from '../components/SnapshotStatusIndicator'
+import { VisualReviewTabs } from '../components/VisualReviewTabs'
 import type { SnapshotApi } from '../generated/api.schemas'
 import { VisualReviewRunSceneLogicProps, visualReviewRunSceneLogic } from './visualReviewRunSceneLogic'
 
@@ -329,6 +330,7 @@ export function VisualReviewRunScene(): JSX.Element {
 
     return (
         <SceneContent>
+            <VisualReviewTabs activeKey="runs" repoId={run.repo_id} />
             <SceneTitleSection
                 name={run.branch}
                 resourceType={{ type: 'visual_review' }}

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -330,7 +330,6 @@ export function VisualReviewRunScene(): JSX.Element {
 
     return (
         <SceneContent>
-            <VisualReviewTabs activeKey="runs" repoId={run.repo_id} />
             <SceneTitleSection
                 name={run.branch}
                 resourceType={{ type: 'visual_review' }}
@@ -349,6 +348,7 @@ export function VisualReviewRunScene(): JSX.Element {
                     ) : undefined
                 }
             />
+            <VisualReviewTabs activeKey="runs" repoId={run.repo_id} />
 
             {run.is_stale && (
                 <LemonBanner type="warning" className="mb-4">

--- a/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
@@ -6,17 +6,22 @@ import { LemonButton, LemonSegmentedButton, LemonTable, LemonTableColumns, Lemon
 
 import { dayjs } from 'lib/dayjs'
 import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { RunSummaryStats } from '../components/RunSummaryStats'
+import { VisualReviewTabs } from '../components/VisualReviewTabs'
 import type { RunApi } from '../generated/api.schemas'
-import { ReviewState, visualReviewRunsSceneLogic } from './visualReviewRunsSceneLogic'
+import { ReviewState, VisualReviewRunsSceneLogicProps, visualReviewRunsSceneLogic } from './visualReviewRunsSceneLogic'
 
 export const scene: SceneExport = {
     component: VisualReviewRunsScene,
     logic: visualReviewRunsSceneLogic,
+    paramsToProps: ({ params: { repoId } }): VisualReviewRunsSceneLogicProps => ({
+        repoId: repoId || '',
+    }),
 }
 
 function BranchCell({ run, repoFullName }: { run: RunApi; repoFullName?: string }): JSX.Element {
@@ -55,7 +60,7 @@ const TAB_COUNT_TYPES: Record<ReviewState, 'warning' | 'highlight' | 'default' |
 }
 
 export function VisualReviewRunsScene(): JSX.Element {
-    const { runs, runsLoading, activeTab, counts, repoFullName, page, totalCount } =
+    const { runs, runsLoading, activeTab, counts, repo, repoFullName, page, totalCount } =
         useValues(visualReviewRunsSceneLogic)
     const { loadRuns, loadCounts, setActiveTab, setPage } = useActions(visualReviewRunsSceneLogic)
 
@@ -127,11 +132,11 @@ export function VisualReviewRunsScene(): JSX.Element {
     return (
         <SceneContent>
             <SceneTitleSection
-                name="Visual review"
+                name={repoFullName ?? 'Visual review'}
                 resourceType={{ type: 'visual_review' }}
                 actions={
                     <div className="flex gap-2">
-                        <LemonButton type="secondary" icon={<IconGear />} to="/visual_review/settings">
+                        <LemonButton type="secondary" icon={<IconGear />} to={urls.visualReviewSettings()}>
                             Settings
                         </LemonButton>
                         <LemonButton
@@ -147,6 +152,7 @@ export function VisualReviewRunsScene(): JSX.Element {
                     </div>
                 }
             />
+            {repo && <VisualReviewTabs activeKey="runs" repoId={repo.id} />}
 
             <div className="mb-3">
                 <LemonSegmentedButton

--- a/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
@@ -11,6 +11,7 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { RepoSwitcher } from '../components/RepoSwitcher'
 import { RunSummaryStats } from '../components/RunSummaryStats'
 import { VisualReviewTabs } from '../components/VisualReviewTabs'
 import type { RunApi } from '../generated/api.schemas'
@@ -60,7 +61,7 @@ const TAB_COUNT_TYPES: Record<ReviewState, 'warning' | 'highlight' | 'default' |
 }
 
 export function VisualReviewRunsScene(): JSX.Element {
-    const { runs, runsLoading, activeTab, counts, repo, repoFullName, page, totalCount } =
+    const { runs, runsLoading, activeTab, counts, repoId, repoFullName, page, totalCount } =
         useValues(visualReviewRunsSceneLogic)
     const { loadRuns, loadCounts, setActiveTab, setPage } = useActions(visualReviewRunsSceneLogic)
 
@@ -135,26 +136,17 @@ export function VisualReviewRunsScene(): JSX.Element {
                 name={repoFullName ?? 'Visual review'}
                 resourceType={{ type: 'visual_review' }}
                 actions={
-                    <div className="flex gap-2">
-                        <LemonButton type="secondary" icon={<IconGear />} to={urls.visualReviewSettings()}>
+                    <div className="flex gap-2 items-center">
+                        <RepoSwitcher repoId={repoId} activeTab="runs" />
+                        <LemonButton size="small" type="secondary" icon={<IconGear />} to={urls.visualReviewSettings()}>
                             Settings
-                        </LemonButton>
-                        <LemonButton
-                            type="secondary"
-                            onClick={() => {
-                                loadRuns()
-                                loadCounts()
-                            }}
-                            loading={runsLoading}
-                        >
-                            Refresh
                         </LemonButton>
                     </div>
                 }
             />
-            {repo && <VisualReviewTabs activeKey="runs" repoId={repo.id} />}
+            <VisualReviewTabs activeKey="runs" repoId={repoId} />
 
-            <div className="mb-3">
+            <div className="mb-3 flex items-center gap-2">
                 <LemonSegmentedButton
                     value={activeTab}
                     onChange={(value) => setActiveTab(value)}
@@ -173,6 +165,17 @@ export function VisualReviewRunsScene(): JSX.Element {
                     }))}
                     size="small"
                 />
+                <LemonButton
+                    size="small"
+                    type="secondary"
+                    onClick={() => {
+                        loadRuns()
+                        loadCounts()
+                    }}
+                    loading={runsLoading}
+                >
+                    Refresh
+                </LemonButton>
             </div>
 
             <LemonTable

--- a/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
@@ -173,6 +173,9 @@ export function VisualReviewRunsScene(): JSX.Element {
                         loadCounts()
                     }}
                     loading={runsLoading}
+                    // Push refresh away from the segmented filter; sitting flush
+                    // next to the active-tab handle made it look like another tab.
+                    className="ml-auto"
                 >
                     Refresh
                 </LemonButton>

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene.tsx
@@ -12,6 +12,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { DiffPercentage } from '../components/DiffPercentage'
+import { VisualReviewTabs } from '../components/VisualReviewTabs'
 import type { SnapshotHistoryEntryApi } from '../generated/api.schemas'
 import {
     ThemePair,
@@ -186,7 +187,7 @@ function Stat({ value, label }: { value: React.ReactNode; label: string }): JSX.
 }
 
 export function VisualReviewSnapshotHistoryScene(): JSX.Element {
-    const { repo, repoLoading, history, historyLoading, identifier, pairedHistory, runType } = useValues(
+    const { repo, repoLoading, history, historyLoading, identifier, pairedHistory, runType, repoId } = useValues(
         visualReviewSnapshotHistorySceneLogic
     )
 
@@ -199,6 +200,7 @@ export function VisualReviewSnapshotHistoryScene(): JSX.Element {
 
     return (
         <SceneContent>
+            {repoId && <VisualReviewTabs activeKey="snapshots" repoId={repoId} />}
             <SceneTitleSection name={identifier} resourceType={{ type: 'visual_review' }} />
 
             <div className="w-full max-w-4xl mx-auto flex flex-col gap-4">

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotHistoryScene.tsx
@@ -200,8 +200,8 @@ export function VisualReviewSnapshotHistoryScene(): JSX.Element {
 
     return (
         <SceneContent>
-            {repoId && <VisualReviewTabs activeKey="snapshots" repoId={repoId} />}
             <SceneTitleSection name={identifier} resourceType={{ type: 'visual_review' }} />
+            {repoId && <VisualReviewTabs activeKey="snapshots" repoId={repoId} />}
 
             <div className="w-full max-w-4xl mx-auto flex flex-col gap-4">
                 <div className="border rounded bg-bg-light flex flex-wrap items-center gap-x-10 gap-y-3 px-4 py-3">

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -111,6 +111,15 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                         </button>
                     )}
                     <div className="text-xs text-muted">
+                        {filteredEntries.length > 0 && overview && (
+                            <>
+                                <span className="text-default">{filteredEntries.length.toLocaleString()}</span>
+                                {filteredEntries.length !== overview.entries.length && (
+                                    <> of {overview.entries.length.toLocaleString()}</>
+                                )}{' '}
+                                snapshots ·{' '}
+                            </>
+                        )}
                         Sorted by <span className="text-default">{sortLabel.label}</span>
                     </div>
                 </div>
@@ -122,6 +131,29 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                     {overview.totals.all_snapshots.toLocaleString()}. Refine filters to see more.
                 </LemonBanner>
             )}
+
+            {/* Legend lives above the grid so first-time viewers see what the
+                sparkline colors and the "tolerated" chip mean before they dive
+                into hundreds of cards. */}
+            <div className="flex items-center gap-3 text-[11px] text-muted">
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--success)' }} />
+                    Clean
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--primary-3000)' }} />
+                    Tolerated
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--warning-dark)' }} />
+                    Changed
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--danger)' }} />
+                    Quarantined
+                </span>
+                <span className="ml-auto">Sparkline shows last 30 days</span>
+            </div>
 
             <div className="flex gap-6 items-start">
                 <SnapshotFacetSidebar
@@ -177,14 +209,6 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                                     thumbnailBasePath={thumbnailBasePath}
                                 />
                             ))}
-                        </div>
-                    )}
-
-                    {filteredEntries.length > 0 && (
-                        <div className="text-xs text-muted mt-3">
-                            Showing {filteredEntries.length.toLocaleString()}
-                            {overview ? ` of ${overview.entries.length.toLocaleString()}` : ''} snapshots
-                            {isFiltered ? ' matching your filters' : ''}.
                         </div>
                     )}
                 </div>

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -1,15 +1,15 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
-import { Grid } from 'react-window'
 
-import { LemonBanner, LemonInput, LemonSegmentedButton, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
+import { IconGear } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonInput, LemonSegmentedButton, LemonSkeleton } from '@posthog/lemon-ui'
 
-import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { RepoSwitcher } from '../components/RepoSwitcher'
 import { SnapshotCard } from '../components/SnapshotCard'
 import { SnapshotFacetSidebar } from '../components/SnapshotFacetSidebar'
 import { SnapshotStatRow } from '../components/SnapshotStatRow'
@@ -27,18 +27,17 @@ export const scene: SceneExport = {
     }),
 }
 
-// Width is the smallest column we'll allow before snapping to a fewer-column
-// layout — keeps cards readable on tablet. Height is set so that the 140px
-// thumbnail box + 60px metadata strip + borders fit comfortably.
+// Smallest column we'll allow before snapping to a fewer-column layout —
+// keeps cards readable on tablet. CSS Grid handles the responsive packing
+// via `auto-fill, minmax(220px, 1fr)`.
 const CARD_MIN_WIDTH = 220
-const CARD_HEIGHT = 210
-const CARD_GAP = 12
 
 export function VisualReviewSnapshotOverviewScene(): JSX.Element {
     const {
         overview,
         overviewLoading,
         repo,
+        repoId,
         filteredEntries,
         statCounts,
         frequentlyToleratedCount,
@@ -51,24 +50,6 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
     const { setStatPreset, toggleType, toggleArea, toggleStability, setTheme, setSearch, clearAllFilters } = useActions(
         visualReviewSnapshotOverviewSceneLogic
     )
-
-    const { ref: gridContainerRef, width: gridWidth = 0 } = useResizeObserver<HTMLDivElement>()
-    const { columnCount, columnWidth } = useMemo(() => {
-        if (gridWidth <= 0) {
-            return { columnCount: 1, columnWidth: CARD_MIN_WIDTH }
-        }
-        const cols = Math.max(1, Math.floor((gridWidth + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP)))
-        // Gaps live inside each cell's padding (not as separate spacers between
-        // cells), so columnWidth must consume the full container width — no
-        // gap subtraction. Subtracting it leaves a ~(cols-1) × gap dead band
-        // on the right edge.
-        const cw = Math.floor(gridWidth / cols)
-        return { columnCount: cols, columnWidth: cw }
-    }, [gridWidth])
-
-    const rowCount = Math.ceil(filteredEntries.length / columnCount)
-
-    const repoId = repo?.id ?? ''
 
     // Theme is never neutral (always Light or Dark), so we don't count it
     // toward `isFiltered` — picking a side is the default state.
@@ -84,8 +65,16 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
             <SceneTitleSection
                 name={repo?.repo_full_name ?? 'Visual review'}
                 resourceType={{ type: 'visual_review' }}
+                actions={
+                    <div className="flex gap-2 items-center">
+                        <RepoSwitcher repoId={repoId} activeTab="snapshots" />
+                        <LemonButton size="small" type="secondary" icon={<IconGear />} to={urls.visualReviewSettings()}>
+                            Settings
+                        </LemonButton>
+                    </div>
+                }
             />
-            <VisualReviewTabs activeKey="snapshots" repoId={repo?.id ?? ''} />
+            <VisualReviewTabs activeKey="snapshots" repoId={repoId} />
 
             <SnapshotStatRow
                 counts={statCounts}
@@ -149,9 +138,12 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                     }}
                 />
 
-                <div ref={gridContainerRef} className="flex-1 min-w-0">
+                <div className="flex-1 min-w-0">
                     {overviewLoading && !overview ? (
-                        <div className="grid grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-3">
+                        <div
+                            className="grid gap-3"
+                            style={{ gridTemplateColumns: `repeat(auto-fill, minmax(${CARD_MIN_WIDTH}px, 1fr))` }}
+                        >
                             {Array.from({ length: 14 }).map((_, i) => (
                                 <LemonSkeleton key={i} className="h-52 w-full" />
                             ))}
@@ -169,45 +161,24 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                                 </button>
                             )}
                         </div>
-                    ) : gridWidth > 0 ? (
-                        <Grid
-                            cellComponent={({
-                                columnIndex,
-                                rowIndex,
-                                style,
-                            }: {
-                                columnIndex: number
-                                rowIndex: number
-                                style: React.CSSProperties
-                            }) => {
-                                const entry = filteredEntries[rowIndex * columnCount + columnIndex]
-                                if (!entry) {
-                                    return <div style={style} />
-                                }
-                                return (
-                                    <div
-                                        style={{
-                                            ...style,
-                                            paddingRight: columnIndex < columnCount - 1 ? CARD_GAP : 0,
-                                            paddingBottom: CARD_GAP,
-                                        }}
-                                    >
-                                        <SnapshotCard
-                                            repoId={repoId}
-                                            entry={entry}
-                                            thumbnailBasePath={thumbnailBasePath}
-                                        />
-                                    </div>
-                                )
-                            }}
-                            cellProps={{}}
-                            columnCount={columnCount}
-                            columnWidth={columnWidth + (columnWidth < CARD_MIN_WIDTH ? 0 : 0)}
-                            rowCount={rowCount}
-                            rowHeight={CARD_HEIGHT + CARD_GAP}
-                            defaultHeight={Math.min(900, rowCount * (CARD_HEIGHT + CARD_GAP))}
-                        />
-                    ) : null}
+                    ) : (
+                        // Plain CSS grid — no internal scroll, page handles
+                        // scrolling. Lazy-loaded thumbnails keep network cost
+                        // low even at the 5000-entry cap.
+                        <div
+                            className="grid gap-3"
+                            style={{ gridTemplateColumns: `repeat(auto-fill, minmax(${CARD_MIN_WIDTH}px, 1fr))` }}
+                        >
+                            {filteredEntries.map((entry) => (
+                                <SnapshotCard
+                                    key={`${entry.run_type}::${entry.identifier}`}
+                                    repoId={repoId}
+                                    entry={entry}
+                                    thumbnailBasePath={thumbnailBasePath}
+                                />
+                            ))}
+                        </div>
+                    )}
 
                     {filteredEntries.length > 0 && (
                         <div className="text-xs text-muted mt-3">
@@ -217,29 +188,6 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                         </div>
                     )}
                 </div>
-            </div>
-
-            {/* Tag legend at the bottom for first-time clarity. */}
-            <div className="flex items-center gap-3 text-[11px] text-muted">
-                <span className="flex items-center gap-1">
-                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--success)' }} />
-                    Clean
-                </span>
-                <span className="flex items-center gap-1">
-                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--primary-3000)' }} />
-                    Tolerated
-                </span>
-                <span className="flex items-center gap-1">
-                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--warning-dark)' }} />
-                    Changed
-                </span>
-                <span className="flex items-center gap-1">
-                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--danger)' }} />
-                    Quarantined
-                </span>
-                <LemonTag size="small" type="default" className="ml-auto">
-                    Sparkline shows last 30 days
-                </LemonTag>
             </div>
         </SceneContent>
     )

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -13,6 +13,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { SnapshotCard } from '../components/SnapshotCard'
 import { SnapshotFacetSidebar } from '../components/SnapshotFacetSidebar'
 import { SnapshotStatRow } from '../components/SnapshotStatRow'
+import { VisualReviewTabs } from '../components/VisualReviewTabs'
 import {
     VisualReviewSnapshotOverviewSceneLogicProps,
     visualReviewSnapshotOverviewSceneLogic,
@@ -80,7 +81,11 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
 
     return (
         <SceneContent>
-            <SceneTitleSection name="Snapshots" resourceType={{ type: 'visual_review' }} />
+            <SceneTitleSection
+                name={repo?.repo_full_name ?? 'Visual review'}
+                resourceType={{ type: 'visual_review' }}
+            />
+            <VisualReviewTabs activeKey="snapshots" repoId={repo?.id ?? ''} />
 
             <SnapshotStatRow
                 counts={statCounts}

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -57,8 +57,11 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
             return { columnCount: 1, columnWidth: CARD_MIN_WIDTH }
         }
         const cols = Math.max(1, Math.floor((gridWidth + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP)))
-        const totalGap = CARD_GAP * (cols - 1)
-        const cw = Math.floor((gridWidth - totalGap) / cols)
+        // Gaps live inside each cell's padding (not as separate spacers between
+        // cells), so columnWidth must consume the full container width — no
+        // gap subtraction. Subtracting it leaves a ~(cols-1) × gap dead band
+        // on the right edge.
+        const cw = Math.floor(gridWidth / cols)
         return { columnCount: cols, columnWidth: cw }
     }, [gridWidth])
 
@@ -103,17 +106,19 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                         { value: 'dark', label: 'Dark' },
                     ]}
                 />
-                {isFiltered && (
-                    <button
-                        type="button"
-                        className="text-xs text-muted hover:text-default"
-                        onClick={() => clearAllFilters()}
-                    >
-                        Clear all
-                    </button>
-                )}
-                <div className="text-xs text-muted ml-auto">
-                    Sorted by <span className="text-default">{sortLabel.label}</span>
+                <div className="ml-auto flex items-center gap-3">
+                    {isFiltered && (
+                        <button
+                            type="button"
+                            className="text-xs text-muted hover:text-default"
+                            onClick={() => clearAllFilters()}
+                        >
+                            Clear all
+                        </button>
+                    )}
+                    <div className="text-xs text-muted">
+                        Sorted by <span className="text-default">{sortLabel.label}</span>
+                    </div>
                 </div>
             </div>
 

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -26,8 +26,11 @@ export const scene: SceneExport = {
     }),
 }
 
+// Width is the smallest column we'll allow before snapping to a fewer-column
+// layout — keeps cards readable on tablet. Height is set so that the 140px
+// thumbnail box + 60px metadata strip + borders fit comfortably.
 const CARD_MIN_WIDTH = 220
-const CARD_HEIGHT = 220
+const CARD_HEIGHT = 210
 const CARD_GAP = 12
 
 export function VisualReviewSnapshotOverviewScene(): JSX.Element {
@@ -37,9 +40,11 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
         repo,
         filteredEntries,
         statCounts,
+        frequentlyToleratedCount,
         facetGroups,
         facetSelection,
         filters,
+        sortLabel,
         thumbnailBasePath,
     } = useValues(visualReviewSnapshotOverviewSceneLogic)
     const { setStatPreset, toggleType, toggleArea, toggleStability, setTheme, setSearch, clearAllFilters } = useActions(
@@ -61,19 +66,25 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
 
     const repoId = repo?.id ?? ''
 
+    // Theme is never neutral (always Light or Dark), so we don't count it
+    // toward `isFiltered` — picking a side is the default state.
     const isFiltered =
         filters.statPreset !== 'all' ||
         filters.typeKeys.length > 0 ||
         filters.areas.length > 0 ||
         filters.stability.length > 0 ||
-        filters.theme !== null ||
         filters.search.length > 0
 
     return (
         <SceneContent>
             <SceneTitleSection name="Snapshots" resourceType={{ type: 'visual_review' }} />
 
-            <SnapshotStatRow counts={statCounts} preset={filters.statPreset} onChange={setStatPreset} />
+            <SnapshotStatRow
+                counts={statCounts}
+                frequentlyToleratedCount={frequentlyToleratedCount}
+                preset={filters.statPreset}
+                onChange={setStatPreset}
+            />
 
             <div className="flex items-center gap-2 flex-wrap">
                 <LemonInput
@@ -85,10 +96,9 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                 />
                 <LemonSegmentedButton
                     size="small"
-                    value={filters.theme ?? 'any'}
-                    onChange={(value) => setTheme(value === 'any' ? null : (value as 'light' | 'dark'))}
+                    value={filters.theme}
+                    onChange={(value) => setTheme(value as 'light' | 'dark')}
                     options={[
-                        { value: 'any', label: 'Any theme' },
                         { value: 'light', label: 'Light' },
                         { value: 'dark', label: 'Dark' },
                     ]}
@@ -102,6 +112,9 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                         Clear all
                     </button>
                 )}
+                <div className="text-xs text-muted ml-auto">
+                    Sorted by <span className="text-default">{sortLabel.label}</span>
+                </div>
             </div>
 
             {overview?.truncated && (

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -1,0 +1,225 @@
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
+import { Grid } from 'react-window'
+
+import { LemonBanner, LemonInput, LemonSegmentedButton, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
+
+import { useResizeObserver } from 'lib/hooks/useResizeObserver'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { SnapshotCard } from '../components/SnapshotCard'
+import { SnapshotFacetSidebar } from '../components/SnapshotFacetSidebar'
+import { SnapshotStatRow } from '../components/SnapshotStatRow'
+import {
+    VisualReviewSnapshotOverviewSceneLogicProps,
+    visualReviewSnapshotOverviewSceneLogic,
+} from './visualReviewSnapshotOverviewSceneLogic'
+
+export const scene: SceneExport = {
+    component: VisualReviewSnapshotOverviewScene,
+    logic: visualReviewSnapshotOverviewSceneLogic,
+    paramsToProps: ({ params: { repoId } }): VisualReviewSnapshotOverviewSceneLogicProps => ({
+        repoId: repoId || '',
+    }),
+}
+
+const CARD_MIN_WIDTH = 220
+const CARD_HEIGHT = 220
+const CARD_GAP = 12
+
+export function VisualReviewSnapshotOverviewScene(): JSX.Element {
+    const {
+        overview,
+        overviewLoading,
+        repo,
+        filteredEntries,
+        statCounts,
+        facetGroups,
+        facetSelection,
+        filters,
+        thumbnailBasePath,
+    } = useValues(visualReviewSnapshotOverviewSceneLogic)
+    const { setStatPreset, toggleType, toggleArea, toggleStability, setTheme, setSearch, clearAllFilters } = useActions(
+        visualReviewSnapshotOverviewSceneLogic
+    )
+
+    const { ref: gridContainerRef, width: gridWidth = 0 } = useResizeObserver<HTMLDivElement>()
+    const { columnCount, columnWidth } = useMemo(() => {
+        if (gridWidth <= 0) {
+            return { columnCount: 1, columnWidth: CARD_MIN_WIDTH }
+        }
+        const cols = Math.max(1, Math.floor((gridWidth + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP)))
+        const totalGap = CARD_GAP * (cols - 1)
+        const cw = Math.floor((gridWidth - totalGap) / cols)
+        return { columnCount: cols, columnWidth: cw }
+    }, [gridWidth])
+
+    const rowCount = Math.ceil(filteredEntries.length / columnCount)
+
+    const repoId = repo?.id ?? ''
+
+    const isFiltered =
+        filters.statPreset !== 'all' ||
+        filters.typeKeys.length > 0 ||
+        filters.areas.length > 0 ||
+        filters.stability.length > 0 ||
+        filters.theme !== null ||
+        filters.search.length > 0
+
+    return (
+        <SceneContent>
+            <SceneTitleSection name="Snapshots" resourceType={{ type: 'visual_review' }} />
+
+            <SnapshotStatRow counts={statCounts} preset={filters.statPreset} onChange={setStatPreset} />
+
+            <div className="flex items-center gap-2 flex-wrap">
+                <LemonInput
+                    type="search"
+                    placeholder="Filter by name…"
+                    value={filters.search}
+                    onChange={(value) => setSearch(value)}
+                    className="flex-1 min-w-60"
+                />
+                <LemonSegmentedButton
+                    size="small"
+                    value={filters.theme ?? 'any'}
+                    onChange={(value) => setTheme(value === 'any' ? null : (value as 'light' | 'dark'))}
+                    options={[
+                        { value: 'any', label: 'Any theme' },
+                        { value: 'light', label: 'Light' },
+                        { value: 'dark', label: 'Dark' },
+                    ]}
+                />
+                {isFiltered && (
+                    <button
+                        type="button"
+                        className="text-xs text-muted hover:text-default"
+                        onClick={() => clearAllFilters()}
+                    >
+                        Clear all
+                    </button>
+                )}
+            </div>
+
+            {overview?.truncated && (
+                <LemonBanner type="info">
+                    Showing the {overview.entries.length.toLocaleString()} most recently active snapshots out of{' '}
+                    {overview.totals.all_snapshots.toLocaleString()}. Refine filters to see more.
+                </LemonBanner>
+            )}
+
+            <div className="flex gap-6 items-start">
+                <SnapshotFacetSidebar
+                    groups={facetGroups}
+                    selection={facetSelection}
+                    onToggle={(group, value) => {
+                        if (group === 'type') {
+                            toggleType(value)
+                        } else if (group === 'area') {
+                            toggleArea(value)
+                        } else {
+                            toggleStability(value)
+                        }
+                    }}
+                />
+
+                <div ref={gridContainerRef} className="flex-1 min-w-0">
+                    {overviewLoading && !overview ? (
+                        <div className="grid grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-3">
+                            {Array.from({ length: 14 }).map((_, i) => (
+                                <LemonSkeleton key={i} className="h-52 w-full" />
+                            ))}
+                        </div>
+                    ) : filteredEntries.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-20 gap-2 text-muted">
+                            <p className="m-0">No snapshots match these filters.</p>
+                            {isFiltered && (
+                                <button
+                                    type="button"
+                                    className="text-primary-3000 hover:underline text-xs"
+                                    onClick={() => clearAllFilters()}
+                                >
+                                    Clear all filters
+                                </button>
+                            )}
+                        </div>
+                    ) : gridWidth > 0 ? (
+                        <Grid
+                            cellComponent={({
+                                columnIndex,
+                                rowIndex,
+                                style,
+                            }: {
+                                columnIndex: number
+                                rowIndex: number
+                                style: React.CSSProperties
+                            }) => {
+                                const entry = filteredEntries[rowIndex * columnCount + columnIndex]
+                                if (!entry) {
+                                    return <div style={style} />
+                                }
+                                return (
+                                    <div
+                                        style={{
+                                            ...style,
+                                            paddingRight: columnIndex < columnCount - 1 ? CARD_GAP : 0,
+                                            paddingBottom: CARD_GAP,
+                                        }}
+                                    >
+                                        <SnapshotCard
+                                            repoId={repoId}
+                                            entry={entry}
+                                            thumbnailBasePath={thumbnailBasePath}
+                                        />
+                                    </div>
+                                )
+                            }}
+                            cellProps={{}}
+                            columnCount={columnCount}
+                            columnWidth={columnWidth + (columnWidth < CARD_MIN_WIDTH ? 0 : 0)}
+                            rowCount={rowCount}
+                            rowHeight={CARD_HEIGHT + CARD_GAP}
+                            defaultHeight={Math.min(900, rowCount * (CARD_HEIGHT + CARD_GAP))}
+                        />
+                    ) : null}
+
+                    {filteredEntries.length > 0 && (
+                        <div className="text-xs text-muted mt-3">
+                            Showing {filteredEntries.length.toLocaleString()}
+                            {overview ? ` of ${overview.entries.length.toLocaleString()}` : ''} snapshots
+                            {isFiltered ? ' matching your filters' : ''}.
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Tag legend at the bottom for first-time clarity. */}
+            <div className="flex items-center gap-3 text-[11px] text-muted">
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--success)' }} />
+                    Clean
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--primary-3000)' }} />
+                    Tolerated
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--warning-dark)' }} />
+                    Changed
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--danger)' }} />
+                    Quarantined
+                </span>
+                <LemonTag size="small" type="default" className="ml-auto">
+                    Sparkline shows last 30 days
+                </LemonTag>
+            </div>
+        </SceneContent>
+    )
+}
+
+export default VisualReviewSnapshotOverviewScene

--- a/products/visual_review/frontend/scenes/visualReviewIndexSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewIndexSceneLogic.ts
@@ -11,9 +11,10 @@ import { visualReviewReposList } from '../generated/api'
 import type { RepoApi } from '../generated/api.schemas'
 import type { visualReviewIndexSceneLogicType } from './visualReviewIndexSceneLogicType'
 
-// Index scene logic. Loads the team's repos and replaces the URL with the
-// first repo's Runs page when there's exactly one — that's the >99% case.
-// When multi-repo grows up we'll render a real picker on this scene instead.
+// Index scene logic. Loads the team's repos and forwards to the first repo's
+// Runs page. The header-bar repo switcher handles the multi-repo case, so
+// the index URL itself never needs to render a picker — only the empty state
+// when no repos are connected yet.
 export const visualReviewIndexSceneLogic = kea<visualReviewIndexSceneLogicType>([
     path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewIndexSceneLogic']),
     connect(() => ({
@@ -35,10 +36,10 @@ export const visualReviewIndexSceneLogic = kea<visualReviewIndexSceneLogicType>(
     }),
     afterMount(({ values, actions }) => {
         actions.loadRepos()
-        // If we navigated here while on /visual_review and a repo is already
-        // loaded (back/forward navigation re-entering the scene), forward
-        // straight away.
-        if (values.repos.length === 1) {
+        // If we navigated here while on /visual_review and the repo list is
+        // already cached (back/forward navigation re-entering the scene),
+        // forward straight away.
+        if (values.repos.length >= 1) {
             router.actions.replace(urls.visualReviewRepoRuns(values.repos[0].id))
         }
     }),

--- a/products/visual_review/frontend/scenes/visualReviewIndexSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewIndexSceneLogic.ts
@@ -1,0 +1,45 @@
+import { afterMount, connect, kea, path, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { Breadcrumb } from '~/types'
+
+import { visualReviewReposList } from '../generated/api'
+import type { RepoApi } from '../generated/api.schemas'
+import type { visualReviewIndexSceneLogicType } from './visualReviewIndexSceneLogicType'
+
+// Index scene logic. Loads the team's repos and replaces the URL with the
+// first repo's Runs page when there's exactly one — that's the >99% case.
+// When multi-repo grows up we'll render a real picker on this scene instead.
+export const visualReviewIndexSceneLogic = kea<visualReviewIndexSceneLogicType>([
+    path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewIndexSceneLogic']),
+    connect(() => ({
+        values: [teamLogic, ['currentProjectId']],
+    })),
+    loaders(({ values }) => ({
+        repos: [
+            [] as RepoApi[],
+            {
+                loadRepos: async () => {
+                    const response = await visualReviewReposList(String(values.currentProjectId))
+                    return response.results
+                },
+            },
+        ],
+    })),
+    selectors({
+        breadcrumbs: [() => [], (): Breadcrumb[] => [{ key: 'visual_review', name: 'Visual review' }]],
+    }),
+    afterMount(({ values, actions }) => {
+        actions.loadRepos()
+        // If we navigated here while on /visual_review and a repo is already
+        // loaded (back/forward navigation re-entering the scene), forward
+        // straight away.
+        if (values.repos.length === 1) {
+            router.actions.replace(urls.visualReviewRepoRuns(values.repos[0].id))
+        }
+    }),
+])

--- a/products/visual_review/frontend/scenes/visualReviewRepoLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRepoLogic.ts
@@ -1,0 +1,58 @@
+import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { visualReviewReposList, visualReviewReposRetrieve } from '../generated/api'
+import type { RepoApi } from '../generated/api.schemas'
+import type { visualReviewRepoLogicType } from './visualReviewRepoLogicType'
+
+export interface VisualReviewRepoLogicProps {
+    repoId: string
+}
+
+// Shared repo state for both Runs and Snapshots scenes — keyed by repoId so
+// the data only loads once per workspace and survives tab navigation. Without
+// this, each scene's own loadRepo re-fetches on mount and the title/tab
+// strip flicker as the response comes back.
+export const visualReviewRepoLogic = kea<visualReviewRepoLogicType>([
+    path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewRepoLogic']),
+    props({} as VisualReviewRepoLogicProps),
+    key((props) => props.repoId),
+    connect(() => ({
+        values: [teamLogic, ['currentProjectId']],
+    })),
+    loaders(({ props, values }) => ({
+        repo: [
+            null as RepoApi | null,
+            {
+                loadRepo: async () => {
+                    return visualReviewReposRetrieve(String(values.currentProjectId), props.repoId)
+                },
+            },
+        ],
+        // Sibling repos surface in the title-bar dropdown so a multi-repo
+        // workspace can switch with a single click. Loaded lazily — single-
+        // repo workspaces never render the dropdown, but the request is cheap.
+        allRepos: [
+            [] as RepoApi[],
+            {
+                loadAllRepos: async () => {
+                    const response = await visualReviewReposList(String(values.currentProjectId))
+                    return response.results ?? []
+                },
+            },
+        ],
+    })),
+    selectors({
+        repoFullName: [(s) => [s.repo], (repo: RepoApi | null): string | undefined => repo?.repo_full_name],
+        otherRepos: [
+            (s) => [s.allRepos, (_, p) => p.repoId],
+            (allRepos: RepoApi[], repoId: string): RepoApi[] => allRepos.filter((r) => r.id !== repoId),
+        ],
+    }),
+    afterMount(({ actions }) => {
+        actions.loadRepo()
+        actions.loadAllRepos()
+    }),
+])

--- a/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
@@ -72,7 +72,9 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
             { needs_review: 0, clean: 0, processing: 0, stale: 0 } as ReviewStateCountsApi,
             {
                 loadCounts: async () => {
-                    return await visualReviewRunsCountsRetrieve(String(values.currentProjectId))
+                    return await visualReviewRunsCountsRetrieve(String(values.currentProjectId), {
+                        repo_id: props.repoId,
+                    })
                 },
             },
         ],

--- a/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
@@ -1,11 +1,11 @@
-import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { teamLogic } from 'scenes/teamLogic'
 
 import { Breadcrumb } from '~/types'
 
-import { visualReviewReposList, visualReviewRunsCountsRetrieve, visualReviewRunsList } from '../generated/api'
+import { visualReviewReposRetrieve, visualReviewRunsCountsRetrieve, visualReviewRunsList } from '../generated/api'
 import type { PaginatedRunListApi, RepoApi, ReviewStateCountsApi } from '../generated/api.schemas'
 import type { visualReviewRunsSceneLogicType } from './visualReviewRunsSceneLogicType'
 
@@ -13,8 +13,14 @@ export type ReviewState = 'needs_review' | 'clean' | 'processing' | 'stale'
 
 const RUNS_PAGE_SIZE = 20
 
+export interface VisualReviewRunsSceneLogicProps {
+    repoId: string
+}
+
 export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
     path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewRunsSceneLogic']),
+    props({} as VisualReviewRunsSceneLogicProps),
+    key((props) => props.repoId),
 
     connect(() => ({
         values: [teamLogic, ['currentProjectId']],
@@ -41,7 +47,7 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
         ],
     }),
 
-    loaders(({ values }) => ({
+    loaders(({ props, values }) => ({
         runsResponse: [
             { count: 0, results: [] } as PaginatedRunListApi,
             {
@@ -49,6 +55,7 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
                     const offset = (values.page - 1) * RUNS_PAGE_SIZE
                     return await visualReviewRunsList(String(values.currentProjectId), {
                         review_state: values.activeTab,
+                        repo_id: props.repoId,
                         limit: RUNS_PAGE_SIZE,
                         offset,
                     })
@@ -67,8 +74,7 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
             null as RepoApi | null,
             {
                 loadRepo: async () => {
-                    const response = await visualReviewReposList(String(values.currentProjectId))
-                    return response.results[0] || null
+                    return await visualReviewReposRetrieve(String(values.currentProjectId), props.repoId)
                 },
             },
         ],
@@ -86,13 +92,18 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
             (repo: RepoApi | null): string | undefined => repo?.repo_full_name || undefined,
         ],
         breadcrumbs: [
-            () => [],
-            (): Breadcrumb[] => [
+            (s) => [s.repo],
+            (repo: RepoApi | null): Breadcrumb[] => [
                 {
                     key: 'visual_review',
                     name: 'Visual review',
                     path: '/visual_review',
                 },
+                {
+                    key: ['visual_review_repo', repo?.id ?? 'unknown'],
+                    name: repo?.repo_full_name ?? '…',
+                },
+                { key: 'visual_review_runs', name: 'Runs' },
             ],
         ],
     }),

--- a/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
@@ -5,7 +5,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { Breadcrumb } from '~/types'
 
-import { visualReviewRunsCountsRetrieve, visualReviewRunsList } from '../generated/api'
+import { visualReviewReposRunsCountsRetrieve, visualReviewReposRunsList } from '../generated/api'
 import type { PaginatedRunListApi, RepoApi, ReviewStateCountsApi } from '../generated/api.schemas'
 import { visualReviewRepoLogic } from './visualReviewRepoLogic'
 import type { visualReviewRunsSceneLogicType } from './visualReviewRunsSceneLogicType'
@@ -59,9 +59,8 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
             {
                 loadRuns: async () => {
                     const offset = (values.page - 1) * RUNS_PAGE_SIZE
-                    return await visualReviewRunsList(String(values.currentProjectId), {
+                    return await visualReviewReposRunsList(String(values.currentProjectId), props.repoId, {
                         review_state: values.activeTab,
-                        repo_id: props.repoId,
                         limit: RUNS_PAGE_SIZE,
                         offset,
                     })
@@ -72,9 +71,7 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
             { needs_review: 0, clean: 0, processing: 0, stale: 0 } as ReviewStateCountsApi,
             {
                 loadCounts: async () => {
-                    return await visualReviewRunsCountsRetrieve(String(values.currentProjectId), {
-                        repo_id: props.repoId,
-                    })
+                    return await visualReviewReposRunsCountsRetrieve(String(values.currentProjectId), props.repoId)
                 },
             },
         ],

--- a/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunsSceneLogic.ts
@@ -5,8 +5,9 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { Breadcrumb } from '~/types'
 
-import { visualReviewReposRetrieve, visualReviewRunsCountsRetrieve, visualReviewRunsList } from '../generated/api'
+import { visualReviewRunsCountsRetrieve, visualReviewRunsList } from '../generated/api'
 import type { PaginatedRunListApi, RepoApi, ReviewStateCountsApi } from '../generated/api.schemas'
+import { visualReviewRepoLogic } from './visualReviewRepoLogic'
 import type { visualReviewRunsSceneLogicType } from './visualReviewRunsSceneLogicType'
 
 export type ReviewState = 'needs_review' | 'clean' | 'processing' | 'stale'
@@ -22,8 +23,13 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
     props({} as VisualReviewRunsSceneLogicProps),
     key((props) => props.repoId),
 
-    connect(() => ({
-        values: [teamLogic, ['currentProjectId']],
+    connect((props: VisualReviewRunsSceneLogicProps) => ({
+        values: [
+            teamLogic,
+            ['currentProjectId'],
+            visualReviewRepoLogic({ repoId: props.repoId }),
+            ['repo', 'repoFullName'],
+        ],
     })),
 
     actions({
@@ -70,40 +76,28 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
                 },
             },
         ],
-        repo: [
-            null as RepoApi | null,
-            {
-                loadRepo: async () => {
-                    return await visualReviewReposRetrieve(String(values.currentProjectId), props.repoId)
-                },
-            },
-        ],
     })),
 
     selectors({
+        repoId: [() => [(_, p) => p.repoId], (repoId: string): string => repoId],
         runs: [
             (s) => [s.runsResponse],
             (runsResponse: PaginatedRunListApi): PaginatedRunListApi['results'] => runsResponse.results,
         ],
         runsLoading: [(s) => [s.runsResponseLoading], (loading: boolean): boolean => loading],
         totalCount: [(s) => [s.runsResponse], (runsResponse: PaginatedRunListApi): number => runsResponse.count ?? 0],
-        repoFullName: [
-            (s) => [s.repo],
-            (repo: RepoApi | null): string | undefined => repo?.repo_full_name || undefined,
-        ],
+        // Only one scene-level crumb — the project crumb is prepended
+        // automatically. With two scene crumbs the SceneTitleSection back
+        // button kicks in (it shows when total breadcrumbs > 2), and
+        // clicking back lands on /visual_review which immediately redirects
+        // straight here, so the back arrow does nothing useful.
         breadcrumbs: [
             (s) => [s.repo],
             (repo: RepoApi | null): Breadcrumb[] => [
                 {
-                    key: 'visual_review',
-                    name: 'Visual review',
-                    path: '/visual_review',
-                },
-                {
                     key: ['visual_review_repo', repo?.id ?? 'unknown'],
-                    name: repo?.repo_full_name ?? '…',
+                    name: repo?.repo_full_name ?? 'Visual review',
                 },
-                { key: 'visual_review_runs', name: 'Runs' },
             ],
         ],
     }),
@@ -120,6 +114,5 @@ export const visualReviewRunsSceneLogic = kea<visualReviewRunsSceneLogicType>([
     afterMount(({ actions }) => {
         actions.loadRuns()
         actions.loadCounts()
-        actions.loadRepo()
     }),
 ])

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotHistorySceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotHistorySceneLogic.ts
@@ -2,6 +2,7 @@ import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
@@ -91,6 +92,7 @@ export const visualReviewSnapshotHistorySceneLogic = kea<visualReviewSnapshotHis
     selectors({
         identifier: [() => [(_, p) => p.identifier], (identifier: string): string => identifier],
         runType: [() => [(_, p) => p.runType], (runType: string): string => runType],
+        repoId: [() => [(_, p) => p.repoId], (repoId: string): string => repoId],
         primaryTheme: [
             () => [(_, p) => p.identifier],
             (identifier: string): 'light' | 'dark' | null => detectTheme(identifier).theme,
@@ -119,9 +121,14 @@ export const visualReviewSnapshotHistorySceneLogic = kea<visualReviewSnapshotHis
             },
         ],
         breadcrumbs: [
-            () => [(_, p) => p.identifier],
-            (identifier: string): Breadcrumb[] => [
+            () => [(_, p) => p.identifier, (_, p) => p.repoId],
+            (identifier: string, repoId: string): Breadcrumb[] => [
                 { key: 'visual_review', name: 'Visual review', path: '/visual_review' },
+                {
+                    key: ['visual_review_snapshots', repoId],
+                    name: 'Snapshots',
+                    path: urls.visualReviewSnapshotOverview(repoId),
+                },
                 { key: ['visual_review_snapshot_history', identifier], name: identifier },
             ],
         ],

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
@@ -17,7 +17,11 @@ export interface VisualReviewSnapshotOverviewSceneLogicProps {
     repoId: string
 }
 
-export type ThemeFilter = 'light' | 'dark' | null
+// We deliberately don't model "show both themes" — for snapshot identifiers
+// that ship as light+dark pairs that would double the grid. Picking one side
+// dedups by default. Identifiers without a theme suffix are always shown
+// regardless of which side is selected.
+export type ThemeFilter = 'light' | 'dark'
 export type Filters = {
     statPreset: StatPreset
     typeKeys: string[]
@@ -32,7 +36,7 @@ const EMPTY_FILTERS: Filters = {
     typeKeys: [],
     areas: [],
     stability: [],
-    theme: null,
+    theme: 'light',
     search: '',
 }
 
@@ -80,10 +84,8 @@ function entryStability(entry: BaselineEntryApi): Array<keyof typeof STABILITY_K
 
 function matchesStatPreset(entry: BaselineEntryApi, preset: StatPreset): boolean {
     switch (preset) {
-        case 'recently_tolerated':
+        case 'tolerated_drift':
             return entry.tolerate_count_30d >= 1
-        case 'frequently_tolerated':
-            return entry.tolerate_count_90d >= 3
         case 'currently_quarantined':
             return entry.is_quarantined
         case 'all':
@@ -174,7 +176,12 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
             (
                 entries
             ): Array<
-                BaselineEntryApi & { _area: string; _theme: ThemeFilter; _typeKey: string; _stability: string[] }
+                BaselineEntryApi & {
+                    _area: string
+                    _theme: 'light' | 'dark' | null
+                    _typeKey: string
+                    _stability: string[]
+                }
             > =>
                 entries.map((e) => ({
                     ...e,
@@ -184,11 +191,26 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                     _stability: entryStability(e),
                 })),
         ],
+        // The sort applied to filteredEntries depends on the active stat
+        // preset — alphabetical for the broad "All" view, severity-style
+        // ordering for the slices that highlight problems. Keeping it
+        // hardcoded per preset (rather than user-pickable) keeps the UX
+        // tight; the indicator label in the toolbar tells the user which
+        // sort is active.
+        sortLabel: [
+            (s) => [s.filters],
+            (filters): { kind: 'alpha' | 'drift'; label: string } => {
+                if (filters.statPreset === 'all') {
+                    return { kind: 'alpha', label: 'name (A → Z)' }
+                }
+                return { kind: 'drift', label: 'drift avg (high → low)' }
+            },
+        ],
         filteredEntries: [
-            (s) => [s.decoratedEntries, s.filters],
-            (entries, filters) => {
+            (s) => [s.decoratedEntries, s.filters, s.sortLabel],
+            (entries, filters, sortLabel) => {
                 const search = filters.search.trim().toLowerCase()
-                return entries.filter((e) => {
+                const filtered = entries.filter((e) => {
                     if (!matchesStatPreset(e, filters.statPreset)) {
                         return false
                     }
@@ -204,7 +226,10 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                     ) {
                         return false
                     }
-                    if (filters.theme && e._theme !== filters.theme) {
+                    // Theme dedup: only keep entries that match the chosen
+                    // side, OR have no theme suffix at all. That collapses
+                    // light+dark pairs without dropping single-theme stories.
+                    if (e._theme !== null && e._theme !== filters.theme) {
                         return false
                     }
                     if (search && !e.identifier.toLowerCase().includes(search)) {
@@ -212,7 +237,25 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                     }
                     return true
                 })
+                if (sortLabel.kind === 'alpha') {
+                    filtered.sort((a, b) => a.identifier.localeCompare(b.identifier))
+                } else {
+                    filtered.sort(
+                        (a, b) =>
+                            (b.recent_diff_avg ?? 0) - (a.recent_diff_avg ?? 0) ||
+                            b.tolerate_count_30d - a.tolerate_count_30d ||
+                            a.identifier.localeCompare(b.identifier)
+                    )
+                }
+                return filtered
             },
+        ],
+        // Trust-debt count surfaced inline on the Tolerated tile. Falls back
+        // to recomputing client-side when the server didn't ship totals.
+        frequentlyToleratedCount: [
+            (s) => [s.decoratedEntries, s.overview],
+            (entries, overview): number =>
+                overview?.totals.frequently_tolerated ?? entries.filter((e) => e.tolerate_count_90d >= 3).length,
         ],
         statCounts: [
             (s) => [s.decoratedEntries, s.overview],
@@ -224,15 +267,13 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                 if (totals) {
                     return {
                         all: totals.all_snapshots,
-                        recently_tolerated: totals.recently_tolerated,
-                        frequently_tolerated: totals.frequently_tolerated,
+                        tolerated_drift: totals.recently_tolerated,
                         currently_quarantined: totals.currently_quarantined,
                     }
                 }
                 return {
                     all: entries.length,
-                    recently_tolerated: entries.filter((e) => e.tolerate_count_30d >= 1).length,
-                    frequently_tolerated: entries.filter((e) => e.tolerate_count_90d >= 3).length,
+                    tolerated_drift: entries.filter((e) => e.tolerate_count_30d >= 1).length,
                     currently_quarantined: entries.filter((e) => e.is_quarantined).length,
                 }
             },
@@ -266,7 +307,7 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                         ) {
                             return false
                         }
-                        if (excluded !== 'theme' && filters.theme && e._theme !== filters.theme) {
+                        if (excluded !== 'theme' && e._theme !== null && e._theme !== filters.theme) {
                             return false
                         }
                         if (excluded !== 'search' && search && !e.identifier.toLowerCase().includes(search)) {
@@ -333,7 +374,7 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
             if (f.stability.length) {
                 out.stability = f.stability.join(',')
             }
-            if (f.theme) {
+            if (f.theme !== EMPTY_FILTERS.theme) {
                 out.theme = f.theme
             }
             if (f.search) {
@@ -363,7 +404,7 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                 typeKeys: hash.types ? hash.types.split(',') : [],
                 areas: hash.areas ? hash.areas.split(',') : [],
                 stability: hash.stability ? hash.stability.split(',') : [],
-                theme: (hash.theme as ThemeFilter) ?? null,
+                theme: hash.theme === 'dark' ? 'dark' : 'light',
                 search: hash.q ?? '',
             }
             if (next.statPreset !== f.statPreset) {

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
@@ -107,7 +107,8 @@ function bucketize(values: string[], labelOf: (v: string) => string = (v) => v):
 
 // Pre-decorated entry shape — the kea selector annotates this on every entry
 // once so subsequent filter passes can compare without re-deriving area/theme/etc.
-type DecoratedEntry = BaselineEntryApi & {
+// Exported so the kea-typegen output can resolve it.
+export type DecoratedEntry = BaselineEntryApi & {
     _area: string
     _theme: 'light' | 'dark' | null
     _typeKey: string

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
@@ -105,6 +105,56 @@ function bucketize(values: string[], labelOf: (v: string) => string = (v) => v):
         .map(([value, count]) => ({ value, count, label: labelOf(value) }))
 }
 
+// Pre-decorated entry shape — the kea selector annotates this on every entry
+// once so subsequent filter passes can compare without re-deriving area/theme/etc.
+type DecoratedEntry = BaselineEntryApi & {
+    _area: string
+    _theme: 'light' | 'dark' | null
+    _typeKey: string
+    _stability: string[]
+}
+
+// Filter dimensions a caller can opt out of, plus the "preset" stat row.
+type FilterDimension = keyof Filters | 'preset'
+
+// Single source of truth for filter logic. `filteredEntries` calls this with no
+// exclusion (full set narrows down); `facetGroups` calls it once per dimension
+// excluding that dimension so its own facet rows don't zero each other out.
+// Without this, the same six clauses lived twice and any new dimension had to
+// be added in both places (the bug greptile flagged).
+function applyFilters(
+    entries: readonly DecoratedEntry[],
+    filters: Filters,
+    exclude?: FilterDimension
+): DecoratedEntry[] {
+    const search = filters.search.trim().toLowerCase()
+    return entries.filter((e) => {
+        if (exclude !== 'preset' && !matchesStatPreset(e, filters.statPreset)) {
+            return false
+        }
+        if (exclude !== 'typeKeys' && filters.typeKeys.length && !filters.typeKeys.includes(e._typeKey)) {
+            return false
+        }
+        if (exclude !== 'areas' && filters.areas.length && !filters.areas.includes(e._area)) {
+            return false
+        }
+        if (
+            exclude !== 'stability' &&
+            filters.stability.length &&
+            !filters.stability.some((s) => e._stability.includes(s as keyof typeof STABILITY_KEYS))
+        ) {
+            return false
+        }
+        if (exclude !== 'theme' && e._theme !== null && e._theme !== filters.theme) {
+            return false
+        }
+        if (exclude !== 'search' && search && !e.identifier.toLowerCase().includes(search)) {
+            return false
+        }
+        return true
+    })
+}
+
 export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOverviewSceneLogicType>([
     path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewSnapshotOverviewSceneLogic']),
     props({} as VisualReviewSnapshotOverviewSceneLogicProps),
@@ -203,34 +253,7 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
         filteredEntries: [
             (s) => [s.decoratedEntries, s.filters, s.sortLabel],
             (entries, filters, sortLabel) => {
-                const search = filters.search.trim().toLowerCase()
-                const filtered = entries.filter((e) => {
-                    if (!matchesStatPreset(e, filters.statPreset)) {
-                        return false
-                    }
-                    if (filters.typeKeys.length && !filters.typeKeys.includes(e._typeKey)) {
-                        return false
-                    }
-                    if (filters.areas.length && !filters.areas.includes(e._area)) {
-                        return false
-                    }
-                    if (
-                        filters.stability.length &&
-                        !filters.stability.some((s) => e._stability.includes(s as keyof typeof STABILITY_KEYS))
-                    ) {
-                        return false
-                    }
-                    // Theme dedup: only keep entries that match the chosen
-                    // side, OR have no theme suffix at all. That collapses
-                    // light+dark pairs without dropping single-theme stories.
-                    if (e._theme !== null && e._theme !== filters.theme) {
-                        return false
-                    }
-                    if (search && !e.identifier.toLowerCase().includes(search)) {
-                        return false
-                    }
-                    return true
-                })
+                const filtered = applyFilters(entries, filters)
                 if (sortLabel.kind === 'alpha') {
                     filtered.sort((a, b) => a.identifier.localeCompare(b.identifier))
                 } else {
@@ -278,41 +301,9 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
         facetGroups: [
             (s) => [s.decoratedEntries, s.filters],
             (entries, filters): FacetGroups => {
-                const filterExcept = (excluded: keyof Filters | 'preset'): typeof entries => {
-                    const search = filters.search.trim().toLowerCase()
-                    return entries.filter((e) => {
-                        if (excluded !== 'preset' && !matchesStatPreset(e, filters.statPreset)) {
-                            return false
-                        }
-                        if (
-                            excluded !== 'typeKeys' &&
-                            filters.typeKeys.length &&
-                            !filters.typeKeys.includes(e._typeKey)
-                        ) {
-                            return false
-                        }
-                        if (excluded !== 'areas' && filters.areas.length && !filters.areas.includes(e._area)) {
-                            return false
-                        }
-                        if (
-                            excluded !== 'stability' &&
-                            filters.stability.length &&
-                            !filters.stability.some((s) => e._stability.includes(s as keyof typeof STABILITY_KEYS))
-                        ) {
-                            return false
-                        }
-                        if (excluded !== 'theme' && e._theme !== null && e._theme !== filters.theme) {
-                            return false
-                        }
-                        if (excluded !== 'search' && search && !e.identifier.toLowerCase().includes(search)) {
-                            return false
-                        }
-                        return true
-                    })
-                }
-                const typeBase = filterExcept('typeKeys')
-                const areaBase = filterExcept('areas')
-                const stabilityBase = filterExcept('stability')
+                const typeBase = applyFilters(entries, filters, 'typeKeys')
+                const areaBase = applyFilters(entries, filters, 'areas')
+                const stabilityBase = applyFilters(entries, filters, 'stability')
                 return {
                     type: bucketize(
                         typeBase.map((e) => e._typeKey),

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
@@ -8,9 +8,10 @@ import { Breadcrumb } from '~/types'
 
 import type { FacetBucket, FacetGroups, FacetSelection } from '../components/SnapshotFacetSidebar'
 import type { StatPreset } from '../components/SnapshotStatRow'
-import { visualReviewReposBaselinesRetrieve, visualReviewReposRetrieve } from '../generated/api'
-import type { BaselineEntryApi, BaselineOverviewApi, RepoApi } from '../generated/api.schemas'
+import { visualReviewReposBaselinesRetrieve } from '../generated/api'
+import type { BaselineEntryApi, BaselineOverviewApi } from '../generated/api.schemas'
 import { parseArea, parseTheme, runTypeLabel } from '../lib/parseIdentifier'
+import { visualReviewRepoLogic } from './visualReviewRepoLogic'
 import type { visualReviewSnapshotOverviewSceneLogicType } from './visualReviewSnapshotOverviewSceneLogicType'
 
 export interface VisualReviewSnapshotOverviewSceneLogicProps {
@@ -108,8 +109,8 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
     path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewSnapshotOverviewSceneLogic']),
     props({} as VisualReviewSnapshotOverviewSceneLogicProps),
     key((props) => props.repoId),
-    connect(() => ({
-        values: [teamLogic, ['currentProjectId']],
+    connect((props: VisualReviewSnapshotOverviewSceneLogicProps) => ({
+        values: [teamLogic, ['currentProjectId'], visualReviewRepoLogic({ repoId: props.repoId }), ['repo']],
     })),
     actions({
         setStatPreset: (preset: StatPreset) => ({ preset }),
@@ -150,14 +151,6 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
         ],
     }),
     loaders(({ props, values }) => ({
-        repo: [
-            null as RepoApi | null,
-            {
-                loadRepo: async () => {
-                    return visualReviewReposRetrieve(String(values.currentProjectId), props.repoId)
-                },
-            },
-        ],
         overview: [
             null as BaselineOverviewApi | null,
             {
@@ -168,6 +161,7 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
         ],
     })),
     selectors({
+        repoId: [() => [(_, p) => p.repoId], (repoId: string): string => repoId],
         entries: [(s) => [s.overview], (overview): BaselineEntryApi[] => overview?.entries ?? []],
         // Pre-compute parsed area + theme + typeKey + stability tags for each
         // entry so subsequent filter passes don't re-derive on every keystroke.
@@ -347,13 +341,13 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
             (projectId, repoId): string | null =>
                 projectId ? `/api/projects/${projectId}/visual_review/repos/${repoId}/thumbnails` : null,
         ],
+        // Single scene crumb — see runs scene for why we collapse to one.
         breadcrumbs: [
             (s) => [s.repo],
             (repo): Breadcrumb[] => [
-                { key: 'visual_review', name: 'Visual review', path: '/visual_review' },
                 {
-                    key: ['visual_review_snapshots', repo?.id ?? 'unknown'],
-                    name: 'Snapshots',
+                    key: ['visual_review_repo', repo?.id ?? 'unknown'],
+                    name: repo?.repo_full_name ?? 'Visual review',
                 },
             ],
         ],
@@ -432,7 +426,6 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
         },
     })),
     afterMount(({ actions }) => {
-        actions.loadRepo()
         actions.loadOverview()
     }),
 ])

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
@@ -1,0 +1,397 @@
+import { actions, afterMount, connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { actionToUrl, urlToAction } from 'kea-router'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { Breadcrumb } from '~/types'
+
+import type { FacetBucket, FacetGroups, FacetSelection } from '../components/SnapshotFacetSidebar'
+import type { StatPreset } from '../components/SnapshotStatRow'
+import { visualReviewReposBaselinesRetrieve, visualReviewReposRetrieve } from '../generated/api'
+import type { BaselineEntryApi, BaselineOverviewApi, RepoApi } from '../generated/api.schemas'
+import { parseArea, parseTheme, runTypeLabel } from '../lib/parseIdentifier'
+import type { visualReviewSnapshotOverviewSceneLogicType } from './visualReviewSnapshotOverviewSceneLogicType'
+
+export interface VisualReviewSnapshotOverviewSceneLogicProps {
+    repoId: string
+}
+
+export type ThemeFilter = 'light' | 'dark' | null
+export type Filters = {
+    statPreset: StatPreset
+    typeKeys: string[]
+    areas: string[]
+    stability: string[]
+    theme: ThemeFilter
+    search: string
+}
+
+const EMPTY_FILTERS: Filters = {
+    statPreset: 'all',
+    typeKeys: [],
+    areas: [],
+    stability: [],
+    theme: null,
+    search: '',
+}
+
+// We collapse run_type + browser into a single "type key" for the facet —
+// matches the design's "Storybook 921 / Playwright · chromium 407 / ..." rows.
+// Handles two seed conventions in the wild: `run_type=playwright` with browser
+// in metadata, or `run_type=playwright-<browser>` baked into the column.
+function typeKeyOf(entry: BaselineEntryApi): string {
+    const rt = entry.run_type.toLowerCase()
+    if (rt === 'playwright' && entry.browser) {
+        return `playwright::${entry.browser}`
+    }
+    if (rt.startsWith('playwright-')) {
+        return `playwright::${rt.slice('playwright-'.length)}`
+    }
+    return entry.run_type
+}
+
+function typeLabelOf(key: string): string {
+    if (key.startsWith('playwright::')) {
+        return runTypeLabel('playwright', key.slice('playwright::'.length))
+    }
+    return key
+}
+
+const STABILITY_KEYS = {
+    clean_30d: 'Clean (30d)',
+    tolerated_30d: 'Tolerated (30d)',
+    quarantined: 'Quarantined',
+}
+
+function entryStability(entry: BaselineEntryApi): Array<keyof typeof STABILITY_KEYS> {
+    const out: Array<keyof typeof STABILITY_KEYS> = []
+    if (entry.is_quarantined) {
+        out.push('quarantined')
+    }
+    if (entry.tolerate_count_30d > 0) {
+        out.push('tolerated_30d')
+    }
+    if (!entry.is_quarantined && entry.tolerate_count_30d === 0) {
+        out.push('clean_30d')
+    }
+    return out
+}
+
+function matchesStatPreset(entry: BaselineEntryApi, preset: StatPreset): boolean {
+    switch (preset) {
+        case 'recently_tolerated':
+            return entry.tolerate_count_30d >= 1
+        case 'frequently_tolerated':
+            return entry.tolerate_count_90d >= 3
+        case 'currently_quarantined':
+            return entry.is_quarantined
+        case 'all':
+        default:
+            return true
+    }
+}
+
+function bucketize(values: string[], labelOf: (v: string) => string = (v) => v): FacetBucket[] {
+    const counts = new Map<string, number>()
+    for (const v of values) {
+        counts.set(v, (counts.get(v) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([value, count]) => ({ value, count, label: labelOf(value) }))
+}
+
+export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOverviewSceneLogicType>([
+    path(['products', 'visual_review', 'frontend', 'scenes', 'visualReviewSnapshotOverviewSceneLogic']),
+    props({} as VisualReviewSnapshotOverviewSceneLogicProps),
+    key((props) => props.repoId),
+    connect(() => ({
+        values: [teamLogic, ['currentProjectId']],
+    })),
+    actions({
+        setStatPreset: (preset: StatPreset) => ({ preset }),
+        toggleType: (value: string) => ({ value }),
+        toggleArea: (value: string) => ({ value }),
+        toggleStability: (value: string) => ({ value }),
+        setTheme: (theme: ThemeFilter) => ({ theme }),
+        setSearch: (search: string) => ({ search }),
+        clearAllFilters: true,
+    }),
+    reducers({
+        filters: [
+            EMPTY_FILTERS,
+            {
+                setStatPreset: (state, { preset }) => ({ ...state, statPreset: preset }),
+                toggleType: (state, { value }) => ({
+                    ...state,
+                    typeKeys: state.typeKeys.includes(value)
+                        ? state.typeKeys.filter((v) => v !== value)
+                        : [...state.typeKeys, value],
+                }),
+                toggleArea: (state, { value }) => ({
+                    ...state,
+                    areas: state.areas.includes(value)
+                        ? state.areas.filter((v) => v !== value)
+                        : [...state.areas, value],
+                }),
+                toggleStability: (state, { value }) => ({
+                    ...state,
+                    stability: state.stability.includes(value)
+                        ? state.stability.filter((v) => v !== value)
+                        : [...state.stability, value],
+                }),
+                setTheme: (state, { theme }) => ({ ...state, theme }),
+                setSearch: (state, { search }) => ({ ...state, search }),
+                clearAllFilters: () => EMPTY_FILTERS,
+            },
+        ],
+    }),
+    loaders(({ props, values }) => ({
+        repo: [
+            null as RepoApi | null,
+            {
+                loadRepo: async () => {
+                    return visualReviewReposRetrieve(String(values.currentProjectId), props.repoId)
+                },
+            },
+        ],
+        overview: [
+            null as BaselineOverviewApi | null,
+            {
+                loadOverview: async () => {
+                    return visualReviewReposBaselinesRetrieve(String(values.currentProjectId), props.repoId)
+                },
+            },
+        ],
+    })),
+    selectors({
+        entries: [(s) => [s.overview], (overview): BaselineEntryApi[] => overview?.entries ?? []],
+        // Pre-compute parsed area + theme + typeKey + stability tags for each
+        // entry so subsequent filter passes don't re-derive on every keystroke.
+        decoratedEntries: [
+            (s) => [s.entries],
+            (
+                entries
+            ): Array<
+                BaselineEntryApi & { _area: string; _theme: ThemeFilter; _typeKey: string; _stability: string[] }
+            > =>
+                entries.map((e) => ({
+                    ...e,
+                    _area: parseArea(e.identifier),
+                    _theme: parseTheme(e.identifier).theme,
+                    _typeKey: typeKeyOf(e),
+                    _stability: entryStability(e),
+                })),
+        ],
+        filteredEntries: [
+            (s) => [s.decoratedEntries, s.filters],
+            (entries, filters) => {
+                const search = filters.search.trim().toLowerCase()
+                return entries.filter((e) => {
+                    if (!matchesStatPreset(e, filters.statPreset)) {
+                        return false
+                    }
+                    if (filters.typeKeys.length && !filters.typeKeys.includes(e._typeKey)) {
+                        return false
+                    }
+                    if (filters.areas.length && !filters.areas.includes(e._area)) {
+                        return false
+                    }
+                    if (
+                        filters.stability.length &&
+                        !filters.stability.some((s) => e._stability.includes(s as keyof typeof STABILITY_KEYS))
+                    ) {
+                        return false
+                    }
+                    if (filters.theme && e._theme !== filters.theme) {
+                        return false
+                    }
+                    if (search && !e.identifier.toLowerCase().includes(search)) {
+                        return false
+                    }
+                    return true
+                })
+            },
+        ],
+        statCounts: [
+            (s) => [s.decoratedEntries, s.overview],
+            (entries, overview): Record<StatPreset, number> => {
+                const totals = overview?.totals
+                // When the filter set is "neutral" (preset=all) we want the
+                // stat row to show the full universe counts even if entries
+                // is truncated. Use server totals as the source of truth.
+                if (totals) {
+                    return {
+                        all: totals.all_snapshots,
+                        recently_tolerated: totals.recently_tolerated,
+                        frequently_tolerated: totals.frequently_tolerated,
+                        currently_quarantined: totals.currently_quarantined,
+                    }
+                }
+                return {
+                    all: entries.length,
+                    recently_tolerated: entries.filter((e) => e.tolerate_count_30d >= 1).length,
+                    frequently_tolerated: entries.filter((e) => e.tolerate_count_90d >= 3).length,
+                    currently_quarantined: entries.filter((e) => e.is_quarantined).length,
+                }
+            },
+        ],
+        // Facet buckets recompute over the filtered set so counts narrow as
+        // the user picks more filters — except for the dimension being faceted
+        // (otherwise picking a TYPE would zero out every other TYPE bucket).
+        facetGroups: [
+            (s) => [s.decoratedEntries, s.filters],
+            (entries, filters): FacetGroups => {
+                const filterExcept = (excluded: keyof Filters | 'preset'): typeof entries => {
+                    const search = filters.search.trim().toLowerCase()
+                    return entries.filter((e) => {
+                        if (excluded !== 'preset' && !matchesStatPreset(e, filters.statPreset)) {
+                            return false
+                        }
+                        if (
+                            excluded !== 'typeKeys' &&
+                            filters.typeKeys.length &&
+                            !filters.typeKeys.includes(e._typeKey)
+                        ) {
+                            return false
+                        }
+                        if (excluded !== 'areas' && filters.areas.length && !filters.areas.includes(e._area)) {
+                            return false
+                        }
+                        if (
+                            excluded !== 'stability' &&
+                            filters.stability.length &&
+                            !filters.stability.some((s) => e._stability.includes(s as keyof typeof STABILITY_KEYS))
+                        ) {
+                            return false
+                        }
+                        if (excluded !== 'theme' && filters.theme && e._theme !== filters.theme) {
+                            return false
+                        }
+                        if (excluded !== 'search' && search && !e.identifier.toLowerCase().includes(search)) {
+                            return false
+                        }
+                        return true
+                    })
+                }
+                const typeBase = filterExcept('typeKeys')
+                const areaBase = filterExcept('areas')
+                const stabilityBase = filterExcept('stability')
+                return {
+                    type: bucketize(
+                        typeBase.map((e) => e._typeKey),
+                        typeLabelOf
+                    ),
+                    area: bucketize(areaBase.map((e) => e._area)),
+                    stability: Object.entries(STABILITY_KEYS).map(([k, label]) => ({
+                        value: k,
+                        label,
+                        count: stabilityBase.filter((e) => e._stability.includes(k as keyof typeof STABILITY_KEYS))
+                            .length,
+                    })),
+                }
+            },
+        ],
+        facetSelection: [
+            (s) => [s.filters],
+            (filters): FacetSelection => ({
+                type: new Set(filters.typeKeys),
+                area: new Set(filters.areas),
+                stability: new Set(filters.stability),
+            }),
+        ],
+        thumbnailBasePath: [
+            (s) => [s.currentProjectId, (_, p) => p.repoId],
+            (projectId, repoId): string | null =>
+                projectId ? `/api/projects/${projectId}/visual_review/repos/${repoId}/thumbnails` : null,
+        ],
+        breadcrumbs: [
+            (s) => [s.repo],
+            (repo): Breadcrumb[] => [
+                { key: 'visual_review', name: 'Visual review', path: '/visual_review' },
+                {
+                    key: ['visual_review_snapshots', repo?.id ?? 'unknown'],
+                    name: 'Snapshots',
+                },
+            ],
+        ],
+    }),
+    actionToUrl(({ values, props }) => {
+        const buildHash = (): Record<string, string> => {
+            const f = values.filters
+            const out: Record<string, string> = {}
+            if (f.statPreset !== 'all') {
+                out.preset = f.statPreset
+            }
+            if (f.typeKeys.length) {
+                out.types = f.typeKeys.join(',')
+            }
+            if (f.areas.length) {
+                out.areas = f.areas.join(',')
+            }
+            if (f.stability.length) {
+                out.stability = f.stability.join(',')
+            }
+            if (f.theme) {
+                out.theme = f.theme
+            }
+            if (f.search) {
+                out.q = f.search
+            }
+            return out
+        }
+        const path = `/visual_review/repos/${props.repoId}/snapshots`
+        return {
+            setStatPreset: () => [path, {}, buildHash()],
+            toggleType: () => [path, {}, buildHash()],
+            toggleArea: () => [path, {}, buildHash()],
+            toggleStability: () => [path, {}, buildHash()],
+            setTheme: () => [path, {}, buildHash()],
+            setSearch: () => [path, {}, buildHash()],
+            clearAllFilters: () => [path, {}, {}],
+        }
+    }),
+    urlToAction(({ actions, values, props }) => ({
+        '/visual_review/repos/:repoId/snapshots': (params, _searchParams, hash) => {
+            if (params.repoId !== props.repoId) {
+                return
+            }
+            const f = values.filters
+            const next: Filters = {
+                statPreset: (hash.preset as StatPreset) ?? 'all',
+                typeKeys: hash.types ? hash.types.split(',') : [],
+                areas: hash.areas ? hash.areas.split(',') : [],
+                stability: hash.stability ? hash.stability.split(',') : [],
+                theme: (hash.theme as ThemeFilter) ?? null,
+                search: hash.q ?? '',
+            }
+            if (next.statPreset !== f.statPreset) {
+                actions.setStatPreset(next.statPreset)
+            }
+            if (next.search !== f.search) {
+                actions.setSearch(next.search)
+            }
+            if (next.theme !== f.theme) {
+                actions.setTheme(next.theme)
+            }
+            // For multi-selects, only diff if different.
+            if (next.typeKeys.join(',') !== f.typeKeys.join(',')) {
+                f.typeKeys.forEach((v) => actions.toggleType(v))
+                next.typeKeys.forEach((v) => actions.toggleType(v))
+            }
+            if (next.areas.join(',') !== f.areas.join(',')) {
+                f.areas.forEach((v) => actions.toggleArea(v))
+                next.areas.forEach((v) => actions.toggleArea(v))
+            }
+            if (next.stability.join(',') !== f.stability.join(',')) {
+                f.stability.forEach((v) => actions.toggleStability(v))
+                next.stability.forEach((v) => actions.toggleStability(v))
+            }
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadRepo()
+        actions.loadOverview()
+    }),
+])

--- a/products/visual_review/manifest.tsx
+++ b/products/visual_review/manifest.tsx
@@ -38,11 +38,18 @@ export const manifest: ProductManifest = {
             import: () => import('./frontend/scenes/VisualReviewSnapshotHistoryScene'),
             iconType: 'visual_review',
         },
+        VisualReviewSnapshotOverview: {
+            name: 'Snapshots',
+            projectBased: true,
+            import: () => import('./frontend/scenes/VisualReviewSnapshotOverviewScene'),
+            iconType: 'visual_review',
+        },
     },
     routes: {
         '/visual_review': ['VisualReviewRuns', 'visualReviewRuns'],
         '/visual_review/settings': ['VisualReviewSettings', 'visualReviewSettings'],
         '/visual_review/runs/:runId': ['VisualReviewRun', 'visualReviewRun'],
+        '/visual_review/repos/:repoId/snapshots': ['VisualReviewSnapshotOverview', 'visualReviewSnapshotOverview'],
         '/visual_review/repos/:repoId/:runType/snapshots/:identifier': [
             'VisualReviewSnapshotHistory',
             'visualReviewSnapshotHistory',
@@ -53,6 +60,7 @@ export const manifest: ProductManifest = {
         visualReviewRuns: (): string => '/visual_review',
         visualReviewSettings: (): string => '/visual_review/settings',
         visualReviewRun: (runId: string): string => `/visual_review/runs/${runId}`,
+        visualReviewSnapshotOverview: (repoId: string): string => `/visual_review/repos/${repoId}/snapshots`,
         visualReviewSnapshotHistory: (repoId: string, runType: string, identifier: string): string =>
             `/visual_review/repos/${repoId}/${encodeURIComponent(runType)}/snapshots/${encodeURIComponent(identifier)}`,
     },

--- a/products/visual_review/manifest.tsx
+++ b/products/visual_review/manifest.tsx
@@ -14,8 +14,16 @@ import { ProductManifest } from '../../frontend/src/types'
 export const manifest: ProductManifest = {
     name: 'VisualReview',
     scenes: {
-        VisualReviewRuns: {
+        VisualReviewIndex: {
+            // /visual_review entry point — picks a repo and forwards into its
+            // workspace. Empty / multi-repo cases handled inside the scene.
             name: 'Visual review',
+            projectBased: true,
+            import: () => import('./frontend/scenes/VisualReviewIndexScene'),
+            iconType: 'visual_review',
+        },
+        VisualReviewRuns: {
+            name: 'Runs',
             projectBased: true,
             import: () => import('./frontend/scenes/VisualReviewRunsScene'),
             iconType: 'visual_review',
@@ -46,9 +54,10 @@ export const manifest: ProductManifest = {
         },
     },
     routes: {
-        '/visual_review': ['VisualReviewRuns', 'visualReviewRuns'],
+        '/visual_review': ['VisualReviewIndex', 'visualReviewIndex'],
         '/visual_review/settings': ['VisualReviewSettings', 'visualReviewSettings'],
         '/visual_review/runs/:runId': ['VisualReviewRun', 'visualReviewRun'],
+        '/visual_review/repos/:repoId/runs': ['VisualReviewRuns', 'visualReviewRepoRuns'],
         '/visual_review/repos/:repoId/snapshots': ['VisualReviewSnapshotOverview', 'visualReviewSnapshotOverview'],
         '/visual_review/repos/:repoId/:runType/snapshots/:identifier': [
             'VisualReviewSnapshotHistory',
@@ -57,9 +66,12 @@ export const manifest: ProductManifest = {
     },
     redirects: {},
     urls: {
+        // Entry URL — the index scene resolves a repo and forwards into the
+        // workspace. Sidebar/nav callers stay zero-arg as before.
         visualReviewRuns: (): string => '/visual_review',
         visualReviewSettings: (): string => '/visual_review/settings',
         visualReviewRun: (runId: string): string => `/visual_review/runs/${runId}`,
+        visualReviewRepoRuns: (repoId: string): string => `/visual_review/repos/${repoId}/runs`,
         visualReviewSnapshotOverview: (repoId: string): string => `/visual_review/repos/${repoId}/snapshots`,
         visualReviewSnapshotHistory: (repoId: string, runType: string, identifier: string): string =>
             `/visual_review/repos/${repoId}/${encodeURIComponent(runType)}/snapshots/${encodeURIComponent(identifier)}`,
@@ -75,7 +87,7 @@ export const manifest: ProductManifest = {
             iconType: 'visual_review' as FileSystemIconType,
             flag: FEATURE_FLAGS.VISUAL_REVIEW,
             tags: ['alpha'],
-            sceneKey: 'VisualReviewRuns',
+            sceneKey: 'VisualReviewIndex',
         },
     ],
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6490,6 +6490,8 @@ export namespace Schemas {
       tolerate_count_90d: number;
       is_quarantined: boolean;
       last_run_at: string;
+      /** @nullable */
+      recent_diff_avg: number | null;
     }
 
     export type BaselineTotalsByRunType = {[key: string]: number};
@@ -44612,6 +44614,10 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * Filter by repo UUID
+     */
+    repo_id?: string;
     /**
      * Filter by review state
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6467,6 +6467,48 @@ export namespace Schemas {
       Zmw: 'ZMW',
     } as const;
 
+    export interface BaselineSparklineDay {
+      clean: number;
+      tolerated: number;
+      changed: number;
+      quarantined: number;
+    }
+
+    export interface BaselineEntry {
+      sparkline: BaselineSparklineDay[];
+      identifier: string;
+      run_type: string;
+      /** @nullable */
+      browser: string | null;
+      /** @nullable */
+      thumbnail_hash: string | null;
+      /** @nullable */
+      width: number | null;
+      /** @nullable */
+      height: number | null;
+      tolerate_count_30d: number;
+      tolerate_count_90d: number;
+      is_quarantined: boolean;
+      last_run_at: string;
+    }
+
+    export type BaselineTotalsByRunType = {[key: string]: number};
+
+    export interface BaselineTotals {
+      by_run_type: BaselineTotalsByRunType;
+      all_snapshots: number;
+      recently_tolerated: number;
+      frequently_tolerated: number;
+      currently_quarantined: number;
+    }
+
+    export interface BaselineOverview {
+      entries: BaselineEntry[];
+      totals: BaselineTotals;
+      truncated: boolean;
+      generated_at: string;
+    }
+
     /**
      * * `minimal` - minimal
     * `detailed` - detailed

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44650,6 +44650,13 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type VisualReviewRunsCountsRetrieveParams = {
+    /**
+     * Filter by repo UUID
+     */
+    repo_id?: string;
+    };
+
     export type WarehouseModelPathsListParams = {
     /**
      * Number of results to return per page.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44594,6 +44594,21 @@ export namespace Schemas {
     run_type?: string;
     };
 
+    export type VisualReviewReposRunsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Filter by review state
+     */
+    review_state?: string;
+    };
+
     export type VisualReviewReposSnapshotsListParams = {
     /**
      * Number of results to return per page.
@@ -44603,25 +44618,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    };
-
-    export type VisualReviewRunsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    /**
-     * Filter by repo UUID
-     */
-    repo_id?: string;
-    /**
-     * Filter by review state
-     */
-    review_state?: string;
     };
 
     export type VisualReviewRunsSnapshotsListParams = {
@@ -44648,13 +44644,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    };
-
-    export type VisualReviewRunsCountsRetrieveParams = {
-    /**
-     * Filter by repo UUID
-     */
-    repo_id?: string;
     };
 
     export type WarehouseModelPathsListParams = {


### PR DESCRIPTION
## Problem

Visual review only had the per-run view — there was no way to see the project's whole snapshot surface at a glance, or to find an identifier without remembering which run captured it. This PR adds a per-repo Snapshots overview that lists every baseline image with its thumbnail, tolerate counts, quarantine state, and a 30-day stability sparkline. It's the new entry point into the snapshot history detail page.

Stacked on `feat/visual-review-history-detail` (#56868). Will rebase onto master once that lands.

## Changes

**Backend**

- New `GET /api/projects/<id>/visual_review/repos/<repo_id>/baselines` returning `{ entries, totals, truncated }`. One read endpoint, no filter query params — the FE owns filtering.
- `logic.get_baselines_overview(repo_id)` resolves the universe (latest non-superseded run per `run_type` on `master`/`main`), joins to `RunSnapshot`, and runs four grouped queries for tolerate counts (30d/90d), active quarantines, and a 30-day sparkline bucketed by clean / tolerated / changed / quarantined. Universe capped at 5000 with a `truncated: true` flag.
- Totals (`all_snapshots`, `recently_tolerated`, `frequently_tolerated`, `currently_quarantined`, `by_run_type`) computed across the full universe so the stat row stays correct even when truncation kicks in.
- Tests in `test_baselines.py` covering universe resolution, truncation, tolerate windows, quarantine expiry, sparkline backfill, totals, and BC sanity.

**Frontend**

- New scene at `/visual_review/repos/:repoId/snapshots`. Single fetch on mount, all filtering / faceting / search runs client-side.
- Stat row (3 tiles: All / Tolerated drift / Currently quarantined), faceted sidebar (Stability / Type / Area), search, theme picker (Light/Dark, defaults Light to dedup paired identifiers), inline SVG sparkline per card.
- URL refactor: scenes are now repo-scoped under `/visual_review/repos/:repoId/{runs,snapshots}`. `/visual_review` redirects to the first repo's Runs page; the empty state is the only picker UI.
- Shared `visualReviewRepoLogic` (keyed) so Runs and Snapshots both connect to the same repo data — no flicker on tab switches.
- In-header repo switcher (`LemonMenu`) for multi-repo workspaces.
- Legends + result count moved above the grid so they're visible before scrolling.
- Card grid is plain CSS auto-fill (`minmax(220px, 1fr)`) with lazy-loaded thumbnails. Originally tried `react-window` but the internal scroll fought page scroll and confused users; up to 5000 lazy-loaded cards is fine in practice.

<img width="1458" height="789" alt="image" src="https://github.com/user-attachments/assets/4acd058b-22c3-4c4c-85eb-f42840e8ec2d" />

## How did you test this code?

I'm an agent. Automated:

- `hogli test products/visual_review/backend/tests/test_baselines.py` — all green.
- Manually verified in browser via Chrome DevTools MCP: scene navigation, repo switcher, tab switching without flicker, back-button behavior, virtualization-replacement performance, lazy thumbnail loading.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Agent-authored with Claude Code (Opus 4.7). Stacked workflow: branched off `feat/visual-review-history-detail`, plan persisted at `/Users/julian/.claude/plans/let-s-stack-a-branch-whimsical-deer.md` for context.

Key decisions:
- Single `GET /baselines` endpoint with the FE doing all filter/facet work — avoids server pagination and keeps interactive UX snappy at the 5000-cap target.
- Inline SVG sparkline (~30 lines) instead of Chart.js per card — mount cost would have killed the grid.
- Shared `visualReviewRepoLogic` instead of each scene re-fetching the repo — fixes mid-navigation flicker that the in-header tab strip exposed.
- Dropped `react-window` virtualization in favor of plain CSS grid: the internal-scroll-vs-page-scroll mismatch was worse UX than rendering 5000 lazy-loaded cards.