### PR TITLE
feat(logs): add logs to onboarding flow

### DIFF
--- a/docs/onboarding/logs/go.tsx
+++ b/docs/onboarding/logs/go.tsx
@@ -1,0 +1,146 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install dependencies',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'go',
+                                code: dedent`
+                                    go get go.opentelemetry.io/otel
+                                    go get go.opentelemetry.io/otel/sdk
+                                    go get go.opentelemetry.io/otel/log
+                                    go get go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
+                                    go get go.opentelemetry.io/otel/sdk/log
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the OTLP log exporter',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Configure the OpenTelemetry log exporter to send logs to PostHog:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'go',
+                                file: 'instrumentation.go',
+                                code: dedent`
+                                    package main
+
+                                    import (
+                                        "context"
+
+                                        "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+                                        "go.opentelemetry.io/otel/log/global"
+                                        sdklog "go.opentelemetry.io/otel/sdk/log"
+                                        "go.opentelemetry.io/otel/sdk/resource"
+                                        semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+                                    )
+
+                                    func setupLogging(ctx context.Context) (*sdklog.LoggerProvider, error) {
+                                        exporter, err := otlploghttp.New(ctx,
+                                            otlploghttp.WithEndpointURL("<ph_client_api_host>/otlp/v1/logs"),
+                                            otlploghttp.WithHeaders(map[string]string{
+                                                "Authorization": "Bearer <ph_project_token>",
+                                            }),
+                                        )
+                                        if err != nil {
+                                            return nil, err
+                                        }
+
+                                        res := resource.NewWithAttributes(
+                                            semconv.SchemaURL,
+                                            semconv.ServiceName("my-app"),
+                                        )
+
+                                        provider := sdklog.NewLoggerProvider(
+                                            sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+                                            sdklog.WithResource(res),
+                                        )
+
+                                        global.SetLoggerProvider(provider)
+                                        return provider, nil
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send a log',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Use the OpenTelemetry logger to emit logs from your application:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'go',
+                                file: 'main.go',
+                                code: dedent`
+                                    package main
+
+                                    import (
+                                        "context"
+                                        "log"
+
+                                        "go.opentelemetry.io/otel/log/global"
+                                        semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+                                        otellog "go.opentelemetry.io/otel/log"
+                                    )
+
+                                    func main() {
+                                        ctx := context.Background()
+
+                                        provider, err := setupLogging(ctx)
+                                        if err != nil {
+                                            log.Fatal(err)
+                                        }
+                                        defer provider.Shutdown(ctx)
+
+                                        logger := global.Logger("my-app")
+
+                                        var record otellog.Record
+                                        record.SetSeverity(otellog.SeverityInfo)
+                                        record.SetBody(otellog.StringValue("User signed up"))
+                                        record.AddAttributes(
+                                            otellog.String(string(semconv.UserIDKey), "user_123"),
+                                        )
+                                        logger.Emit(ctx, record)
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        service name, severity, or any attribute you attach.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const GoInstallation = createInstallation(getGoSteps)

--- a/docs/onboarding/logs/go.tsx
+++ b/docs/onboarding/logs/go.tsx
@@ -12,7 +12,7 @@ export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] =
             content: (
                 <>
                     <Markdown>
-                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
+                        PostHog logs uses the standard OpenTelemetry SDK. No PostHog-specific packages required.
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -123,9 +123,9 @@ export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] =
 
                                         var record otellog.Record
                                         record.SetSeverity(otellog.SeverityInfo)
-                                        record.SetBody(otellog.StringValue("User signed up"))
+                                        record.SetBody(otellog.StringValue("Application started"))
                                         record.AddAttributes(
-                                            otellog.String(string(semconv.UserIDKey), "user_123"),
+                                            otellog.Int64("server.port", 8080),
                                         )
                                         logger.Emit(ctx, record)
                                     }

--- a/docs/onboarding/logs/index.ts
+++ b/docs/onboarding/logs/index.ts
@@ -1,0 +1,6 @@
+export { GoInstallation } from './go'
+export { JavaInstallation } from './java'
+export { NextJSInstallation } from './nextjs'
+export { NodeJSInstallation } from './nodejs'
+export { OpenTelemetryInstallation } from './opentelemetry'
+export { PythonInstallation } from './python'

--- a/docs/onboarding/logs/java.tsx
+++ b/docs/onboarding/logs/java.tsx
@@ -1,0 +1,158 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getJavaSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Add dependencies',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required. Add
+                        the OTel SDK BOM and the OTLP log exporter:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'xml',
+                                file: 'Maven (pom.xml)',
+                                code: dedent`
+                                    <dependencyManagement>
+                                      <dependencies>
+                                        <dependency>
+                                          <groupId>io.opentelemetry</groupId>
+                                          <artifactId>opentelemetry-bom</artifactId>
+                                          <version>1.47.0</version>
+                                          <type>pom</type>
+                                          <scope>import</scope>
+                                        </dependency>
+                                      </dependencies>
+                                    </dependencyManagement>
+
+                                    <dependencies>
+                                      <dependency>
+                                        <groupId>io.opentelemetry</groupId>
+                                        <artifactId>opentelemetry-sdk-logs</artifactId>
+                                      </dependency>
+                                      <dependency>
+                                        <groupId>io.opentelemetry</groupId>
+                                        <artifactId>opentelemetry-exporter-otlp</artifactId>
+                                      </dependency>
+                                    </dependencies>
+                                `,
+                            },
+                            {
+                                language: 'groovy',
+                                file: 'Gradle (build.gradle)',
+                                code: dedent`
+                                    dependencies {
+                                        implementation platform('io.opentelemetry:opentelemetry-bom:1.47.0')
+                                        implementation 'io.opentelemetry:opentelemetry-sdk-logs'
+                                        implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the OTLP log exporter',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Configure the OpenTelemetry log exporter to send logs to PostHog:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'java',
+                                file: 'Instrumentation.java',
+                                code: dedent`
+                                    import io.opentelemetry.api.logs.Logger;
+                                    import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
+                                    import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+                                    import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
+                                    import io.opentelemetry.sdk.resources.Resource;
+                                    import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+                                    public class Instrumentation {
+                                        public static Logger setupLogger() {
+                                            Resource resource = Resource.getDefault()
+                                                .merge(Resource.create(
+                                                    io.opentelemetry.api.common.Attributes.of(
+                                                        ResourceAttributes.SERVICE_NAME, "my-app"
+                                                    )
+                                                ));
+
+                                            OtlpGrpcLogRecordExporter exporter = OtlpGrpcLogRecordExporter.builder()
+                                                .setEndpoint("<ph_client_api_host>/otlp")
+                                                .addHeader("Authorization", "Bearer <ph_project_token>")
+                                                .build();
+
+                                            SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
+                                                .setResource(resource)
+                                                .addLogRecordProcessor(BatchLogRecordProcessor.create(exporter))
+                                                .build();
+
+                                            return loggerProvider.get("my-app");
+                                        }
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send a log',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Use the OpenTelemetry logger to emit logs from your application:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'java',
+                                file: 'App.java',
+                                code: dedent`
+                                    import io.opentelemetry.api.common.AttributeKey;
+                                    import io.opentelemetry.api.common.Attributes;
+                                    import io.opentelemetry.api.logs.Logger;
+                                    import io.opentelemetry.api.logs.Severity;
+
+                                    public class App {
+                                        public static void main(String[] args) {
+                                            Logger logger = Instrumentation.setupLogger();
+
+                                            logger.logRecordBuilder()
+                                                .setSeverity(Severity.INFO)
+                                                .setSeverityText("INFO")
+                                                .setBody("User signed up")
+                                                .setAllAttributes(Attributes.of(
+                                                    AttributeKey.stringKey("user.id"), "user_123",
+                                                    AttributeKey.stringKey("user.plan"), "pro"
+                                                ))
+                                                .emit();
+                                        }
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        service name, severity, or any attribute you attach.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const JavaInstallation = createInstallation(getJavaSteps)

--- a/docs/onboarding/logs/nextjs.tsx
+++ b/docs/onboarding/logs/nextjs.tsx
@@ -1,0 +1,157 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install dependencies',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required. Install
+                        the OTel SDK and the logs signal package:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'npm',
+                                code: dedent`
+                                    npm install @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'yarn',
+                                code: dedent`
+                                    yarn add @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'pnpm',
+                                code: dedent`
+                                    pnpm add @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Create an instrumentation file',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        {dedent`
+                            Next.js loads \`instrumentation.ts\` (or \`instrumentation.js\`) at startup.
+                            Add the log exporter configuration there:
+                        `}
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'typescript',
+                                file: 'instrumentation.ts',
+                                code: dedent`
+                                    import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { LoggerProvider, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs'
+
+                                    export function register() {
+                                      if (process.env.NEXT_RUNTIME === 'nodejs') {
+                                        const exporter = new OTLPLogExporter({
+                                          url: '<ph_client_api_host>/otlp/v1/logs',
+                                          headers: {
+                                            Authorization: 'Bearer <ph_project_token>',
+                                          },
+                                        })
+
+                                        const loggerProvider = new LoggerProvider({
+                                          resource: resourceFromAttributes({
+                                            'service.name': 'my-nextjs-app',
+                                          }),
+                                        })
+
+                                        loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter))
+
+                                        // make the logger available globally
+                                        ;(globalThis as any).__posthogLogger = loggerProvider.getLogger('my-nextjs-app')
+                                      }
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        {dedent`
+                            Enable the instrumentation hook in \`next.config.ts\`:
+                        `}
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'typescript',
+                                file: 'next.config.ts',
+                                code: dedent`
+                                    import type { NextConfig } from 'next'
+
+                                    const nextConfig: NextConfig = {
+                                      experimental: {
+                                        instrumentationHook: true,
+                                      },
+                                    }
+
+                                    export default nextConfig
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send a log',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Use the global logger in your API routes or server components:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'typescript',
+                                file: 'app/api/route.ts',
+                                code: dedent`
+                                    import { SeverityNumber } from '@opentelemetry/api-logs'
+
+                                    export async function GET() {
+                                      const logger = (globalThis as any).__posthogLogger
+                                      logger?.emit({
+                                        severityNumber: SeverityNumber.INFO,
+                                        severityText: 'INFO',
+                                        body: 'API route called',
+                                        attributes: { route: '/api' },
+                                      })
+                                      return Response.json({ ok: true })
+                                    }
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        service name, severity, or any attribute you attach.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const NextJSInstallation = createInstallation(getNextJSSteps)

--- a/docs/onboarding/logs/nextjs.tsx
+++ b/docs/onboarding/logs/nextjs.tsx
@@ -12,8 +12,8 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required. Install
-                        the OTel SDK and the logs signal package:
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
+                        Install the OTel SDK and the logs signal package:
                     </Markdown>
                     <CodeBlock
                         blocks={[

--- a/docs/onboarding/logs/nextjs.tsx
+++ b/docs/onboarding/logs/nextjs.tsx
@@ -12,8 +12,8 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
-                        Install the OTel SDK and the logs signal package:
+                        PostHog logs uses the standard OpenTelemetry SDK. No PostHog-specific packages required. Install
+                        the OTel SDK and the logs signal package:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -36,6 +36,13 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 file: 'pnpm',
                                 code: dedent`
                                     pnpm add @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'bun',
+                                code: dedent`
+                                    bun add @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
                                 `,
                             },
                         ]}

--- a/docs/onboarding/logs/nodejs.tsx
+++ b/docs/onboarding/logs/nodejs.tsx
@@ -12,8 +12,8 @@ export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
-                        Install the OTel SDK and the logs signal package:
+                        PostHog logs uses the standard OpenTelemetry SDK. No PostHog-specific packages required. Install
+                        the OTel SDK and the logs signal package:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -38,6 +38,13 @@ export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                     pnpm add @opentelemetry/sdk-node @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
                                 `,
                             },
+                            {
+                                language: 'bash',
+                                file: 'bun',
+                                code: dedent`
+                                    bun add @opentelemetry/sdk-node @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
                         ]}
                     />
                 </>
@@ -58,7 +65,7 @@ export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                         blocks={[
                             {
                                 language: 'typescript',
-                                file: 'instrumentation.ts',
+                                file: 'logger.ts',
                                 code: dedent`
                                     import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
@@ -100,15 +107,15 @@ export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 file: 'app.ts',
                                 code: dedent`
                                     import { SeverityNumber } from '@opentelemetry/api-logs'
-                                    import { logger } from './instrumentation'
+                                    import { logger } from './logger'
 
                                     logger.emit({
                                       severityNumber: SeverityNumber.INFO,
                                       severityText: 'INFO',
-                                      body: 'User signed up',
+                                      body: 'Server started',
                                       attributes: {
-                                        'user.id': 'user_123',
-                                        'user.plan': 'pro',
+                                        'server.port': 3000,
+                                        'server.env': 'production',
                                       },
                                     })
                                 `,

--- a/docs/onboarding/logs/nodejs.tsx
+++ b/docs/onboarding/logs/nodejs.tsx
@@ -12,8 +12,8 @@ export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required. Install
-                        the OTel SDK and the logs signal package:
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
+                        Install the OTel SDK and the logs signal package:
                     </Markdown>
                     <CodeBlock
                         blocks={[

--- a/docs/onboarding/logs/nodejs.tsx
+++ b/docs/onboarding/logs/nodejs.tsx
@@ -1,0 +1,130 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install dependencies',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required. Install
+                        the OTel SDK and the logs signal package:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'npm',
+                                code: dedent`
+                                    npm install @opentelemetry/sdk-node @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'yarn',
+                                code: dedent`
+                                    yarn add @opentelemetry/sdk-node @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'pnpm',
+                                code: dedent`
+                                    pnpm add @opentelemetry/sdk-node @opentelemetry/sdk-logs @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the OTLP log exporter',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        {dedent`
+                            Create a logger setup file that configures the OpenTelemetry log exporter to send logs to
+                            PostHog. Call this before your application starts.
+                        `}
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'typescript',
+                                file: 'instrumentation.ts',
+                                code: dedent`
+                                    import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { LoggerProvider, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs'
+
+                                    const exporter = new OTLPLogExporter({
+                                      url: '<ph_client_api_host>/otlp/v1/logs',
+                                      headers: {
+                                        Authorization: 'Bearer <ph_project_token>',
+                                      },
+                                    })
+
+                                    const loggerProvider = new LoggerProvider({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                      }),
+                                    })
+
+                                    loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter))
+
+                                    export const logger = loggerProvider.getLogger('my-app')
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send a log',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Use the logger to emit logs from your application:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'typescript',
+                                file: 'app.ts',
+                                code: dedent`
+                                    import { SeverityNumber } from '@opentelemetry/api-logs'
+                                    import { logger } from './instrumentation'
+
+                                    logger.emit({
+                                      severityNumber: SeverityNumber.INFO,
+                                      severityText: 'INFO',
+                                      body: 'User signed up',
+                                      attributes: {
+                                        'user.id': 'user_123',
+                                        'user.plan': 'pro',
+                                      },
+                                    })
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        {dedent`
+                            Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter
+                            by service name, severity, or any attribute you attach.
+                        `}
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const NodeJSInstallation = createInstallation(getNodeJSSteps)

--- a/docs/onboarding/logs/opentelemetry.tsx
+++ b/docs/onboarding/logs/opentelemetry.tsx
@@ -63,7 +63,7 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                     <Markdown>
                         {dedent`
                             The endpoint accepts OTLP over HTTP in both \`application/x-protobuf\` and \`application/json\`
-                            formats. gRPC is not supported — use the HTTP transport.
+                            formats. gRPC is not supported, use the HTTP transport protocol instead.
 
                             Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter
                             by service name, severity, or any attribute you attach.

--- a/docs/onboarding/logs/opentelemetry.tsx
+++ b/docs/onboarding/logs/opentelemetry.tsx
@@ -1,0 +1,78 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Send logs via OTLP',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        {dedent`
+                            PostHog accepts logs from any OpenTelemetry-compatible client via OTLP over HTTP.
+                            Point your exporter at PostHog's OTLP endpoint and authenticate with your project token.
+
+                            PostHog does not require any PostHog-specific SDK or package — use standard
+                            OpenTelemetry libraries in any language.
+                        `}
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Environment variables',
+                                code: dedent`
+                                    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="<ph_client_api_host>/otlp/v1/logs"
+                                    OTEL_EXPORTER_OTLP_LOGS_HEADERS="Authorization=Bearer <ph_project_token>"
+                                    OTEL_SERVICE_NAME="my-app"
+                                `,
+                            },
+                            {
+                                language: 'yaml',
+                                file: 'OTel Collector',
+                                code: dedent`
+                                    receivers:
+                                      otlp:
+                                        protocols:
+                                          http:
+                                            endpoint: 0.0.0.0:4318
+
+                                    processors:
+                                      batch:
+
+                                    exporters:
+                                      otlphttp/posthog:
+                                        logs_endpoint: "<ph_client_api_host>/otlp/v1/logs"
+                                        headers:
+                                          Authorization: "Bearer <ph_project_token>"
+
+                                    service:
+                                      pipelines:
+                                        logs:
+                                          receivers: [otlp]
+                                          processors: [batch]
+                                          exporters: [otlphttp/posthog]
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        {dedent`
+                            The endpoint accepts OTLP over HTTP in both \`application/x-protobuf\` and \`application/json\`
+                            formats. gRPC is not supported — use the HTTP transport.
+
+                            Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter
+                            by service name, severity, or any attribute you attach.
+                        `}
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const OpenTelemetryInstallation = createInstallation(getOpenTelemetrySteps)

--- a/docs/onboarding/logs/python.tsx
+++ b/docs/onboarding/logs/python.tsx
@@ -1,0 +1,108 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install dependencies',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'pip',
+                                code: dedent`
+                                    pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the OTLP log exporter',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Configure the OpenTelemetry log exporter to send logs to PostHog:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'instrumentation.py',
+                                code: dedent`
+                                    from opentelemetry._logs import set_logger_provider
+                                    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+                                    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+                                    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+                                    from opentelemetry.sdk.resources import Resource
+                                    import logging
+
+                                    resource = Resource(attributes={"service.name": "my-app"})
+
+                                    logger_provider = LoggerProvider(resource=resource)
+                                    set_logger_provider(logger_provider)
+
+                                    exporter = OTLPLogExporter(
+                                        endpoint="<ph_client_api_host>/otlp/v1/logs",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
+                                    )
+                                    logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+                                    # Bridge standard library logging to OTel
+                                    handler = LoggingHandler(logger_provider=logger_provider)
+                                    logging.getLogger().addHandler(handler)
+                                    logging.getLogger().setLevel(logging.INFO)
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send a log',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Once configured, use the standard Python `logging` module — logs are forwarded automatically:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'app.py',
+                                code: dedent`
+                                    import logging
+                                    from instrumentation import *  # noqa: F401 — sets up the handler
+
+                                    logger = logging.getLogger(__name__)
+
+                                    logger.info("User signed up", extra={"user_id": "user_123", "plan": "pro"})
+                                    logger.warning("High memory usage", extra={"usage_mb": 1024})
+                                    logger.error("Payment failed", extra={"order_id": "order_456"})
+                                `,
+                            },
+                        ]}
+                    />
+                    <Markdown>
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        service name, severity, or any attribute you attach.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const PythonInstallation = createInstallation(getPythonSteps)

--- a/docs/onboarding/logs/python.tsx
+++ b/docs/onboarding/logs/python.tsx
@@ -12,7 +12,7 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        PostHog logs uses the standard OpenTelemetry SDK — no PostHog-specific packages required.
+                        PostHog logs uses the standard OpenTelemetry SDK. No PostHog-specific packages required.
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -75,7 +75,7 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        Once configured, use the standard Python `logging` module — logs are forwarded automatically:
+                        Once configured, use the standard Python `logging` module. Logs are forwarded automatically:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -84,13 +84,13 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 file: 'app.py',
                                 code: dedent`
                                     import logging
-                                    from instrumentation import *  # noqa: F401 — sets up the handler
+                                    from instrumentation import *  # noqa: F401 – sets up the handler
 
                                     logger = logging.getLogger(__name__)
 
-                                    logger.info("User signed up", extra={"user_id": "user_123", "plan": "pro"})
+                                    logger.info("Request processed", extra={"request_id": "req_abc", "duration_ms": 42})
                                     logger.warning("High memory usage", extra={"usage_mb": 1024})
-                                    logger.error("Payment failed", extra={"order_id": "order_456"})
+                                    logger.error("Database connection failed", extra={"host": "db.example.com"})
                                 `,
                             },
                         ]}

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5675,9 +5675,9 @@ snapshots:
     scenes-other-onboarding-post-onboarding-modal--llm-analytics--light:
         hash: v1.k794b7964.712c453e23887ba67256d238dd81efd93e679a850cf21260fea010eed0b77722.rUXbUP-denqKN65goF1ubUfWnfVibk0H8SAbO8YvruM
     scenes-other-onboarding-post-onboarding-modal--logs--dark:
-        hash: v1.k794b7964.9f9d3f5d5ddba99fb9546c2708031bcb0225344f6d73195689ee911f001a1ad3.lvIy1bYsSZEbNGIjOSCXsSslzmZPPc2v6LT9D-42AGY
+        hash: v1.k794b7964.f9a6892e642aebe076aaeef5075dcef1d09cb7f820985443c66db143f60f11d2.fYzgtRRPAV6qgVvUpdwMQEw6Llm7nQRigyaOYSfaK8c
     scenes-other-onboarding-post-onboarding-modal--logs--light:
-        hash: v1.k794b7964.9c8d2e9260e23a10012fe6afed5c042a66d0a146ce4c3af7e9993d4b01af6305.Wb-jOQmQJljS9aO-eh4pmOHG4pZc0U-5EIupI1Fp0Zo
+        hash: v1.k794b7964.7509d403d60f30d7c2572b30c1671f7312bc1a84f53287ddc412dec4542c5926.T_oJoHiZpaUM-pzyc_xTicoGoALna-sbDVpop0dB_Rk
     scenes-other-onboarding-post-onboarding-modal--product-analytics--dark:
         hash: v1.k794b7964.908a010434b289ed7cf876883429ef9534e1a63b82e4671f15f2174a19cd4678.RMcJStFpCU4fg-QMJW1rPOScHX9hYNtWrPNERZAYZK8
     scenes-other-onboarding-post-onboarding-modal--product-analytics--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5703,9 +5703,9 @@ snapshots:
     scenes-other-onboarding-post-onboarding-modal--workflows--light:
         hash: v1.k794b7964.fe0bbdd94043036fa8a1133e6b99950d76a8f175a41ac3fe35989445c04d561a.VjP9Cyy5ilxplkCzZG8cHytn1yFwT6t2AqPWDXFO7TI
     scenes-other-onboarding-product-selection--base--dark:
-        hash: v1.k794b7964.2d1da384ec9d6f8958d90c6fdef830bdeff3552ce055b8ad6fdb141b28e72f7b.cxGaH_YXfVuLLcFC4MqEyFdHNnXcV2wTr8u0ar5jvFw
+        hash: v1.k794b7964.5c094da11f501dd20ed0755a60c9b7b1bd55a70e469734201b8f9f220d6c06a6.e4fy-aJB70b-ULhvXkz_aFF8AaZx-0hHi1HfwK6qpmo
     scenes-other-onboarding-product-selection--base--light:
-        hash: v1.k794b7964.bea82502c0a95a569ef73194f914368ae78a83713bc95a766e69b349dc4a000f.-Co8sHXwpFtz86_VfOSMRREFI6rMpQvJMP-ComUyKsg
+        hash: v1.k794b7964.ddca88d75ad2c3d020f72dd8cd470610851d84663542514a8930e43e1b9ca413.I9J8-blKK96ivpXDeJoyIM-kcUhbMHofr0qr6z2z8UM
     scenes-other-org-member-invites--current-user-is-admin--dark:
         hash: v1.k794b7964.241706aee199cb1495ed6b1c5055902f0d89e64095c444d9687041d5e5b44b6a.swMzsS85w-CrYfkS0f51lDm4-4fFOMeL1K01RJnNLHQ
     scenes-other-org-member-invites--current-user-is-admin--light:

--- a/frontend/src/lib/components/ProductSetup/productSetupRegistry.ts
+++ b/frontend/src/lib/components/ProductSetup/productSetupRegistry.ts
@@ -570,7 +570,9 @@ export const PRODUCT_SETUP_REGISTRY: Partial<Record<ProductKey, ProductSetupConf
                 description: 'Start sending logs from your application to PostHog.',
                 taskType: 'setup',
                 requiresManualCompletion: true,
+                getUrl: () => urls.onboarding({ productKey: ProductKey.LOGS, stepKey: OnboardingStepKey.INSTALL }),
                 docsUrl: 'https://posthog.com/docs/logs',
+                targetSelector: '[data-attr="menu-item-logs"]',
             },
             {
                 id: SetupTaskId.ViewFirstLogs,

--- a/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
+++ b/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
@@ -182,7 +182,7 @@ export const LazyEventDetailsRenderer: React.FC<RendererProps<TimelineItem>> = (
         return () => {
             mounted = false
         }
-    }, [item.id, item.category, item.timestamp, sessionId])
+    }, [item.id, item.category, item.timestamp, sessionId, item])
 
     if (loading) {
         return (

--- a/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
+++ b/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
@@ -182,7 +182,7 @@ export const LazyEventDetailsRenderer: React.FC<RendererProps<TimelineItem>> = (
         return () => {
             mounted = false
         }
-    }, [item.id, item.category, item.timestamp, sessionId, item])
+    }, [item.id, item.category, item.timestamp, sessionId])
 
     if (loading) {
         return (

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -48,7 +48,7 @@ export function DistributionModal(): JSX.Element {
     }, [
         isDistributionModalOpen,
         experiment.feature_flag?.filters?.multivariate?.variants,
-        experiment.feature_flag.filters.groups,
+        experiment.feature_flag?.filters?.groups,
     ])
 
     const handleClose = (): void => {

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -45,7 +45,11 @@ export function DistributionModal(): JSX.Element {
             setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
             setRolloutPercentage(experiment.feature_flag?.filters?.groups?.[0]?.rollout_percentage ?? 100)
         }
-    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants, experiment.feature_flag.filters.groups])
+    }, [
+        isDistributionModalOpen,
+        experiment.feature_flag?.filters?.multivariate?.variants,
+        experiment.feature_flag.filters.groups,
+    ])
 
     const handleClose = (): void => {
         closeDistributionModal()

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -45,11 +45,7 @@ export function DistributionModal(): JSX.Element {
             setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
             setRolloutPercentage(experiment.feature_flag?.filters?.groups?.[0]?.rollout_percentage ?? 100)
         }
-    }, [
-        isDistributionModalOpen,
-        experiment.feature_flag?.filters?.multivariate?.variants,
-        experiment.feature_flag.filters.groups,
-    ])
+    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants])
 
     const handleClose = (): void => {
         closeDistributionModal()

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -45,7 +45,7 @@ export function DistributionModal(): JSX.Element {
             setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
             setRolloutPercentage(experiment.feature_flag?.filters?.groups?.[0]?.rollout_percentage ?? 100)
         }
-    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants])
+    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants, experiment.feature_flag.filters.groups])
 
     const handleClose = (): void => {
         closeDistributionModal()

--- a/frontend/src/scenes/experiments/legacy/LegacyExperimentView.tsx
+++ b/frontend/src/scenes/experiments/legacy/LegacyExperimentView.tsx
@@ -171,7 +171,7 @@ export function LegacyExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 
         if (!experimentLoading && experiment) {
             refreshExperimentResults(false, 'page_load')
         }
-    }, [experimentLoading, experiment?.id])
+    }, [experimentLoading, experiment?.id, experiment, refreshExperimentResults])
 
     return (
         <BindLogic logic={legacyExperimentLogic} props={legacyLogicProps}>

--- a/frontend/src/scenes/experiments/legacy/LegacyExperimentView.tsx
+++ b/frontend/src/scenes/experiments/legacy/LegacyExperimentView.tsx
@@ -171,7 +171,7 @@ export function LegacyExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 
         if (!experimentLoading && experiment) {
             refreshExperimentResults(false, 'page_load')
         }
-    }, [experimentLoading, experiment?.id, experiment, refreshExperimentResults])
+    }, [experimentLoading, experiment?.id])
 
     return (
         <BindLogic logic={legacyExperimentLogic} props={legacyLogicProps}>

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -420,9 +420,7 @@ const WorkflowsOnboarding = (): JSX.Element => {
 const LogsOnboarding = (): JSX.Element => {
     return (
         <OnboardingWrapper>
-            {/* Logs arrive via OTLP — there is no team property that signals first log ingestion,
-                so we pass teamPropertyToVerify="id" (always truthy) to skip the realtime check. */}
-            <OnboardingInstallStep sdkInstructionMap={LogsSDKInstructions} teamPropertyToVerify="id" />
+            <OnboardingInstallStep sdkInstructionMap={LogsSDKInstructions} hideInstallationCheck />
         </OnboardingWrapper>
     )
 }

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -420,7 +420,9 @@ const WorkflowsOnboarding = (): JSX.Element => {
 const LogsOnboarding = (): JSX.Element => {
     return (
         <OnboardingWrapper>
-            <OnboardingInstallStep sdkInstructionMap={LogsSDKInstructions} listeningForName="log" />
+            {/* Logs arrive via OTLP — there is no team property that signals first log ingestion,
+                so we pass teamPropertyToVerify="id" (always truthy) to skip the realtime check. */}
+            <OnboardingInstallStep sdkInstructionMap={LogsSDKInstructions} teamPropertyToVerify="id" />
         </OnboardingWrapper>
     )
 }

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -37,6 +37,7 @@ import {
     LLMAnalyticsSDKInstructions,
     LLMAnalyticsSDKTagOverrides,
 } from './sdks/llm-analytics/LLMAnalyticsSDKInstructions'
+import { LogsSDKInstructions } from './sdks/logs/LogsSDKInstructions'
 import { OnboardingInstallStep } from './sdks/OnboardingInstallStep'
 import {
     ProductAnalyticsSDKInstructions,
@@ -416,6 +417,14 @@ const WorkflowsOnboarding = (): JSX.Element => {
     )
 }
 
+const LogsOnboarding = (): JSX.Element => {
+    return (
+        <OnboardingWrapper>
+            <OnboardingInstallStep sdkInstructionMap={LogsSDKInstructions} listeningForName="log" />
+        </OnboardingWrapper>
+    )
+}
+
 const WorkflowsInstallHeader = (): JSX.Element => {
     const { wizardCommand, isCloudOrDev } = useWizardCommand()
 
@@ -471,6 +480,7 @@ export const onboardingViews = {
     [ProductKey.ERROR_TRACKING]: ErrorTrackingOnboarding,
     [ProductKey.LLM_ANALYTICS]: LLMAnalyticsOnboarding,
     [ProductKey.WORKFLOWS]: WorkflowsOnboarding,
+    [ProductKey.LOGS]: LogsOnboarding,
 }
 
 export function Onboarding(): JSX.Element | null {

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -414,14 +414,12 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 values.sessionSecondaryProductKeys.includes(ProductKey.LOGS)
             ) {
                 return [
-                    urls.onboarding({
-                        productKey: ProductKey.LOGS,
-                        stepKey: OnboardingStepKey.INSTALL,
-                        from: values.productKey ?? undefined,
-                    }),
-                    // Preserve secondary param so the modal still shows Logs instructions
-                    // if the user navigates back to the primary product install step.
-                    { secondary: router.values.searchParams.secondary },
+                    `/onboarding/${ProductKey.LOGS}`,
+                    {
+                        step: OnboardingStepKey.INSTALL,
+                        secondary: router.values.searchParams.secondary,
+                        from: values.productKey,
+                    },
                 ]
             }
             if (nextStep) {
@@ -445,11 +443,11 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // another product's install step, navigate back to it.
             if (values.fromProductKey) {
                 return [
-                    urls.onboarding({
-                        productKey: values.fromProductKey,
-                        stepKey: OnboardingStepKey.INSTALL,
+                    `/onboarding/${values.fromProductKey}`,
+                    {
+                        step: OnboardingStepKey.INSTALL,
                         secondary: router.values.searchParams.secondary,
-                    }),
+                    },
                 ]
             }
             return [`/onboarding/${values.productKey}`, router.values.searchParams]

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -76,6 +76,8 @@ export const getOnboardingCompleteRedirectUri = (productKey: ProductKey): string
             return urls.llmAnalyticsDashboard()
         case ProductKey.WORKFLOWS:
             return urls.workflows()
+        case ProductKey.LOGS:
+            return urls.logs()
         default:
             return urls.default()
     }

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -136,6 +136,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
         setAwaitingPostOnboardingModal: (awaiting: boolean) => ({ awaiting }),
         setSessionSecondaryProductKeys: (keys: ProductKey[]) => ({ keys }),
         setFromProductKey: (key: ProductKey | null) => ({ key }),
+        setResumeStep: (step: OnboardingStepKey | null) => ({ step }),
     }),
     reducers(() => ({
         isAwaitingPostOnboardingModal: [
@@ -196,6 +197,12 @@ export const onboardingLogic = kea<onboardingLogicType>([
             null as ProductKey | null,
             {
                 setFromProductKey: (_, { key }) => key,
+            },
+        ],
+        resumeStep: [
+            null as OnboardingStepKey | null,
+            {
+                setResumeStep: (_, { step }) => step,
             },
         ],
     })),
@@ -404,53 +411,76 @@ export const onboardingLogic = kea<onboardingLogicType>([
         goToNextStep: ({ numStepsToAdvance }) => {
             const currentStepIndex = values.allOnboardingSteps.findIndex((step) => getStepKey(step) === values.stepKey)
             const nextStep = values.allOnboardingSteps[currentStepIndex + (numStepsToAdvance || 1)]
-            // If the user is leaving the Install step of a non-Logs onboarding while
-            // Logs was selected in this session, divert them to the Logs install step.
-            // Uses sessionSecondaryProductKeys (from URL) rather than the persistent
-            // product_intents so that Logs from a prior session doesn't trigger this.
+            const baseParams = { ...router.values.searchParams }
+
+            // Divert into Logs install when leaving the primary product's Install step with
+            // Logs selected as a secondary intent. Strip LOGS from `secondary` so that if the
+            // user later returns to this step, the divert won't fire again (no ping-pong).
+            // The primary's next-step key is captured as `resumeStep` so completion of the
+            // Logs install can return the user to the correct point in the primary flow.
             if (
                 values.stepKey === OnboardingStepKey.INSTALL &&
                 values.productKey !== ProductKey.LOGS &&
                 values.sessionSecondaryProductKeys.includes(ProductKey.LOGS)
             ) {
+                const remainingSecondary = values.sessionSecondaryProductKeys.filter((k) => k !== ProductKey.LOGS)
+                const resumeStepKey = nextStep ? getStepKey(nextStep) : null
                 return [
-                    `/onboarding/${ProductKey.LOGS}`,
-                    {
-                        step: OnboardingStepKey.INSTALL,
-                        secondary: router.values.searchParams.secondary,
-                        from: values.productKey,
-                    },
+                    urls.onboarding({
+                        productKey: ProductKey.LOGS,
+                        stepKey: OnboardingStepKey.INSTALL,
+                        secondary: remainingSecondary.length ? remainingSecondary : undefined,
+                        from: values.productKey ?? undefined,
+                        resumeStep: resumeStepKey ?? undefined,
+                    }),
+                    {},
                 ]
             }
+
+            // Returning from a Logs divert: route to the original product at its captured
+            // resume step. If no resume step was captured, the primary had no further steps
+            // and completion is handled by the install step's NextButton (completeOnboarding).
+            if (values.productKey === ProductKey.LOGS && values.fromProductKey && values.resumeStep && !nextStep) {
+                return [
+                    urls.onboarding({
+                        productKey: values.fromProductKey,
+                        stepKey: values.resumeStep,
+                        secondary: values.sessionSecondaryProductKeys.length
+                            ? values.sessionSecondaryProductKeys
+                            : undefined,
+                    }),
+                    {},
+                ]
+            }
+
             if (nextStep) {
-                return [
-                    `/onboarding/${values.productKey}`,
-                    { ...router.values.searchParams, step: getStepKey(nextStep) },
-                ]
+                return [`/onboarding/${values.productKey}`, { ...baseParams, step: getStepKey(nextStep) }]
             }
-            return [`/onboarding/${values.productKey}`, router.values.searchParams]
+            return [`/onboarding/${values.productKey}`, baseParams]
         },
         goToPreviousStep: () => {
             const currentStepIndex = values.allOnboardingSteps.findIndex((step) => getStepKey(step) === values.stepKey)
             const previousStep = values.allOnboardingSteps[currentStepIndex - 1]
+            const baseParams = { ...router.values.searchParams }
             if (previousStep) {
-                return [
-                    `/onboarding/${values.productKey}`,
-                    { ...router.values.searchParams, step: getStepKey(previousStep) },
-                ]
+                return [`/onboarding/${values.productKey}`, { ...baseParams, step: getStepKey(previousStep) }]
             }
-            // No previous step within this product: if we were diverted here from
-            // another product's install step, navigate back to it.
+            // No previous step within this product: if we were diverted here from another
+            // product's install step, navigate back to it. Strip LOGS from secondary so the
+            // primary's "Continue" doesn't re-divert (back implies "I don't want this divert");
+            // other secondary selections are preserved.
             if (values.fromProductKey) {
+                const remainingSecondary = values.sessionSecondaryProductKeys.filter((k) => k !== ProductKey.LOGS)
                 return [
-                    `/onboarding/${values.fromProductKey}`,
-                    {
-                        step: OnboardingStepKey.INSTALL,
-                        secondary: router.values.searchParams.secondary,
-                    },
+                    urls.onboarding({
+                        productKey: values.fromProductKey,
+                        stepKey: OnboardingStepKey.INSTALL,
+                        secondary: remainingSecondary.length ? remainingSecondary : undefined,
+                    }),
+                    {},
                 ]
             }
-            return [`/onboarding/${values.productKey}`, router.values.searchParams]
+            return [`/onboarding/${values.productKey}`, baseParams]
         },
         updateCurrentTeamSuccess(val) {
             if (values.productKey && val.payload?.has_completed_onboarding_for?.[values.productKey]) {
@@ -462,8 +492,8 @@ export const onboardingLogic = kea<onboardingLogicType>([
         },
     })),
     urlToAction(({ actions, values }) => ({
-        '/onboarding/:productKey': ({ productKey }, { success, upgraded, step, secondary, from }) => {
-            if (!productKey || !(productKey in availableOnboardingProducts)) {
+        '/onboarding/:productKey': ({ productKey }, { success, upgraded, step, secondary, from, resumeStep }) => {
+            if (!productKey || !Object.hasOwn(availableOnboardingProducts, productKey)) {
                 return
             }
 
@@ -476,13 +506,26 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 actions.setAllOnboardingSteps([])
             }
 
-            if (secondary !== undefined) {
-                const keys = secondary
-                    ? (secondary.split(',').filter((k: string) => k in availableOnboardingProducts) as ProductKey[])
-                    : []
-                actions.setSessionSecondaryProductKeys(keys)
-            }
-            actions.setFromProductKey(from && from in availableOnboardingProducts ? (from as ProductKey) : null)
+            // `secondary`/`from`/`resumeStep` are always sourced from the URL on every
+            // route hit so navigating away from a URL without these params clears the
+            // state — preventing leakage across separate onboardings in the same tab.
+            // Defensive coercion: kea-router auto-coerces "true"/"42" to bool/number,
+            // so we must guard against non-string values before splitting.
+            const secondaryStr = typeof secondary === 'string' ? secondary : ''
+            const secondaryKeys = secondaryStr
+                ? (secondaryStr
+                      .split(',', 32)
+                      .filter((k: string) => Object.hasOwn(availableOnboardingProducts, k)) as ProductKey[])
+                : []
+            actions.setSessionSecondaryProductKeys(Array.from(new Set(secondaryKeys)))
+
+            const fromValid =
+                typeof from === 'string' && Object.hasOwn(availableOnboardingProducts, from) && from !== productKey
+            actions.setFromProductKey(fromValid ? (from as ProductKey) : null)
+
+            actions.setResumeStep(
+                typeof resumeStep === 'string' && resumeStep ? (resumeStep as OnboardingStepKey) : null
+            )
 
             if (step) {
                 // when loading specific steps, like plans, we need to make sure we have a billing response before we can continue

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -390,6 +390,19 @@ export const onboardingLogic = kea<onboardingLogicType>([
         goToNextStep: ({ numStepsToAdvance }) => {
             const currentStepIndex = values.allOnboardingSteps.findIndex((step) => getStepKey(step) === values.stepKey)
             const nextStep = values.allOnboardingSteps[currentStepIndex + (numStepsToAdvance || 1)]
+            // If the user is leaving the Install step of a non-Logs onboarding while
+            // they also have a Logs product intent, divert them to the Logs install
+            // step so the OTel setup isn't skipped along with the analytics SDK.
+            if (
+                values.stepKey === OnboardingStepKey.INSTALL &&
+                values.productKey !== ProductKey.LOGS &&
+                values.currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.LOGS)
+            ) {
+                return [
+                    urls.onboarding({ productKey: ProductKey.LOGS, stepKey: OnboardingStepKey.INSTALL }),
+                    router.values.searchParams,
+                ]
+            }
             if (nextStep) {
                 return [
                     `/onboarding/${values.productKey}`,

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -134,6 +134,8 @@ export const onboardingLogic = kea<onboardingLogicType>([
         setOnCompleteOnboardingRedirectUrl: (url: string | null) => ({ url }),
         skipOnboarding: true,
         setAwaitingPostOnboardingModal: (awaiting: boolean) => ({ awaiting }),
+        setSessionSecondaryProductKeys: (keys: ProductKey[]) => ({ keys }),
+        setFromProductKey: (key: ProductKey | null) => ({ key }),
     }),
     reducers(() => ({
         isAwaitingPostOnboardingModal: [
@@ -182,6 +184,18 @@ export const onboardingLogic = kea<onboardingLogicType>([
             null as string | null,
             {
                 setOnCompleteOnboardingRedirectUrl: (_, { url }) => url,
+            },
+        ],
+        sessionSecondaryProductKeys: [
+            [] as ProductKey[],
+            {
+                setSessionSecondaryProductKeys: (_, { keys }) => keys,
+            },
+        ],
+        fromProductKey: [
+            null as ProductKey | null,
+            {
+                setFromProductKey: (_, { key }) => key,
             },
         ],
     })),
@@ -391,16 +405,23 @@ export const onboardingLogic = kea<onboardingLogicType>([
             const currentStepIndex = values.allOnboardingSteps.findIndex((step) => getStepKey(step) === values.stepKey)
             const nextStep = values.allOnboardingSteps[currentStepIndex + (numStepsToAdvance || 1)]
             // If the user is leaving the Install step of a non-Logs onboarding while
-            // they also have a Logs product intent, divert them to the Logs install
-            // step so the OTel setup isn't skipped along with the analytics SDK.
+            // Logs was selected in this session, divert them to the Logs install step.
+            // Uses sessionSecondaryProductKeys (from URL) rather than the persistent
+            // product_intents so that Logs from a prior session doesn't trigger this.
             if (
                 values.stepKey === OnboardingStepKey.INSTALL &&
                 values.productKey !== ProductKey.LOGS &&
-                values.currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.LOGS)
+                values.sessionSecondaryProductKeys.includes(ProductKey.LOGS)
             ) {
                 return [
-                    urls.onboarding({ productKey: ProductKey.LOGS, stepKey: OnboardingStepKey.INSTALL }),
-                    router.values.searchParams,
+                    urls.onboarding({
+                        productKey: ProductKey.LOGS,
+                        stepKey: OnboardingStepKey.INSTALL,
+                        from: values.productKey ?? undefined,
+                    }),
+                    // Preserve secondary param so the modal still shows Logs instructions
+                    // if the user navigates back to the primary product install step.
+                    { secondary: router.values.searchParams.secondary },
                 ]
             }
             if (nextStep) {
@@ -420,6 +441,17 @@ export const onboardingLogic = kea<onboardingLogicType>([
                     { ...router.values.searchParams, step: getStepKey(previousStep) },
                 ]
             }
+            // No previous step within this product: if we were diverted here from
+            // another product's install step, navigate back to it.
+            if (values.fromProductKey) {
+                return [
+                    urls.onboarding({
+                        productKey: values.fromProductKey,
+                        stepKey: OnboardingStepKey.INSTALL,
+                        secondary: router.values.searchParams.secondary,
+                    }),
+                ]
+            }
             return [`/onboarding/${values.productKey}`, router.values.searchParams]
         },
         updateCurrentTeamSuccess(val) {
@@ -432,7 +464,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
         },
     })),
     urlToAction(({ actions, values }) => ({
-        '/onboarding/:productKey': ({ productKey }, { success, upgraded, step }) => {
+        '/onboarding/:productKey': ({ productKey }, { success, upgraded, step, secondary, from }) => {
             if (!productKey || !(productKey in availableOnboardingProducts)) {
                 return
             }
@@ -445,6 +477,14 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 // Reset onboarding steps so they can be populated upon render in the component.
                 actions.setAllOnboardingSteps([])
             }
+
+            if (secondary !== undefined) {
+                const keys = secondary
+                    ? (secondary.split(',').filter((k: string) => k in availableOnboardingProducts) as ProductKey[])
+                    : []
+                actions.setSessionSecondaryProductKeys(keys)
+            }
+            actions.setFromProductKey(from && from in availableOnboardingProducts ? (from as ProductKey) : null)
 
             if (step) {
                 // when loading specific steps, like plans, we need to make sure we have a billing response before we can continue

--- a/frontend/src/scenes/onboarding/productRecommendations.ts
+++ b/frontend/src/scenes/onboarding/productRecommendations.ts
@@ -32,7 +32,7 @@ export const USE_CASE_OPTIONS: ReadonlyArray<UseCaseDefinition> = [
     {
         key: 'fix_issues',
         title: 'Find and fix issues',
-        description: 'Watch session recordings and monitor errors to debug issues',
+        description: 'Watch session recordings, monitor errors, and search application logs to debug issues',
         iconKey: 'IconWarning',
         iconColor: 'rgb(235 157 42)',
         products: [ProductKey.SESSION_REPLAY, ProductKey.ERROR_TRACKING, ProductKey.LOGS],

--- a/frontend/src/scenes/onboarding/productRecommendations.ts
+++ b/frontend/src/scenes/onboarding/productRecommendations.ts
@@ -35,7 +35,7 @@ export const USE_CASE_OPTIONS: ReadonlyArray<UseCaseDefinition> = [
         description: 'Watch session recordings and monitor errors to debug issues',
         iconKey: 'IconWarning',
         iconColor: 'rgb(235 157 42)',
-        products: [ProductKey.SESSION_REPLAY, ProductKey.ERROR_TRACKING],
+        products: [ProductKey.SESSION_REPLAY, ProductKey.ERROR_TRACKING, ProductKey.LOGS],
     },
     {
         key: 'launch_features',

--- a/frontend/src/scenes/onboarding/productSelection/browsingHistoryMapping.ts
+++ b/frontend/src/scenes/onboarding/productSelection/browsingHistoryMapping.ts
@@ -16,7 +16,7 @@ const PROD_INTEREST_TO_PRODUCT: Record<WebsiteBrowsingHistoryProdInterest, Produ
     'llm-analytics': ProductKey.LLM_ANALYTICS,
     workflows: ProductKey.WORKFLOWS,
     'revenue-analytics': null,
-    logs: null,
+    logs: ProductKey.LOGS,
     endpoints: null,
 }
 

--- a/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
+++ b/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
@@ -271,7 +271,12 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
                       ? secondStepKey
                       : OnboardingStepKey.INSTALL
 
-            router.actions.push(urls.onboarding({ productKey: values.firstProductOnboarding, stepKey }))
+            const secondaryProducts = values.selectedProducts.filter(
+                (k) => k !== values.firstProductOnboarding
+            ) as string[]
+            router.actions.push(
+                urls.onboarding({ productKey: values.firstProductOnboarding, stepKey, secondary: secondaryProducts })
+            )
 
             values.selectedProducts.forEach((productKey) => {
                 actions.addProductIntent({

--- a/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
+++ b/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
@@ -250,16 +250,6 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
 
             if (nextUrl && nextUrl !== '/') {
                 actions.setOnCompleteOnboardingRedirectUrl(nextUrl)
-            } else if (
-                values.firstProductOnboarding !== ProductKey.LOGS &&
-                values.selectedProducts.includes(ProductKey.LOGS)
-            ) {
-                // Logs uses standard OTel packages (not the PostHog SDK), so its install
-                // step isn't covered by the first product's onboarding. Chain it as the
-                // post-onboarding redirect so users still see the Logs setup screen.
-                actions.setOnCompleteOnboardingRedirectUrl(
-                    urls.onboarding({ productKey: ProductKey.LOGS, stepKey: OnboardingStepKey.INSTALL })
-                )
             }
 
             if (!values.firstProductOnboarding) {

--- a/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
+++ b/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
@@ -250,6 +250,16 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
 
             if (nextUrl && nextUrl !== '/') {
                 actions.setOnCompleteOnboardingRedirectUrl(nextUrl)
+            } else if (
+                values.firstProductOnboarding !== ProductKey.LOGS &&
+                values.selectedProducts.includes(ProductKey.LOGS)
+            ) {
+                // Logs uses standard OTel packages (not the PostHog SDK), so its install
+                // step isn't covered by the first product's onboarding. Chain it as the
+                // post-onboarding redirect so users still see the Logs setup screen.
+                actions.setOnCompleteOnboardingRedirectUrl(
+                    urls.onboarding({ productKey: ProductKey.LOGS, stepKey: OnboardingStepKey.INSTALL })
+                )
             }
 
             if (!values.firstProductOnboarding) {

--- a/frontend/src/scenes/onboarding/productSelection/variants/ProductCarousel.tsx
+++ b/frontend/src/scenes/onboarding/productSelection/variants/ProductCarousel.tsx
@@ -18,6 +18,7 @@ import {
     GraphsHog,
     MailHog,
     MicrophoneHog,
+    ReadingHog,
     RobotHog,
     SurprisedHog,
 } from 'lib/components/hedgehogs'
@@ -42,6 +43,7 @@ const PRODUCT_HEDGEHOG: Partial<Record<string, React.ComponentType<{ className?:
     [ProductKey.ERROR_TRACKING]: DetectiveHog,
     [ProductKey.SURVEYS]: MicrophoneHog,
     [ProductKey.WORKFLOWS]: MailHog,
+    [ProductKey.LOGS]: ReadingHog,
 }
 
 function getSocialProof(productKey: string): string | undefined {

--- a/frontend/src/scenes/onboarding/productSelection/variants/legacy/LegacyProductSelection.tsx
+++ b/frontend/src/scenes/onboarding/productSelection/variants/legacy/LegacyProductSelection.tsx
@@ -168,7 +168,7 @@ function ProductSelectionStep(): JSX.Element {
             {recommendationSource === 'browsing_history' && <BrowsingHistoryBanner />}
 
             {/* Products list */}
-            <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,190px))] gap-3 justify-center w-full">
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 justify-center w-full">
                 {availableRecommendedProducts.map((productKey) => (
                     <ProductCard
                         key={productKey}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
@@ -17,6 +17,7 @@ interface SDKInstructionsModalProps {
     adblockResult: AdblockDetectionResult
     verifyingProperty?: string
     verifyingName?: string
+    hideInstallationCheck?: boolean
 }
 
 export function SDKInstructionsModal({
@@ -27,8 +28,10 @@ export function SDKInstructionsModal({
     adblockResult,
     verifyingProperty = 'ingested_event',
     verifyingName = 'event',
+    hideInstallationCheck = false,
 }: SDKInstructionsModalProps): JSX.Element {
-    const installationComplete = useInstallationComplete(verifyingProperty)
+    const installationCompleteFromTeam = useInstallationComplete(verifyingProperty)
+    const installationComplete = hideInstallationCheck || installationCompleteFromTeam
 
     const sdkInstructions = sdkInstructionMap[sdk?.key as keyof typeof sdkInstructionMap] as
         | (() => JSX.Element)
@@ -48,16 +51,18 @@ export function SDKInstructionsModal({
                     <div className="flex-grow overflow-y-auto px-4 py-2">
                         <SDKSnippet sdk={sdk} sdkInstructions={sdkInstructions} />
                     </div>
-                    {!installationComplete && (
+                    {!hideInstallationCheck && !installationComplete && (
                         <div className="px-4 py-2">
                             <AdblockWarning adblockResult={adblockResult} />
                         </div>
                     )}
                     <footer className="sticky bottom-0 w-full bg-bg-light dark:bg-bg-depth rounded-b-sm p-2 flex justify-between items-center gap-2 px-4">
-                        <RealtimeCheckIndicator
-                            teamPropertyToVerify={verifyingProperty}
-                            listeningForName={verifyingName}
-                        />
+                        {!hideInstallationCheck && (
+                            <RealtimeCheckIndicator
+                                teamPropertyToVerify={verifyingProperty}
+                                listeningForName={verifyingName}
+                            />
+                        )}
                         <NextButton installationComplete={installationComplete} />
                     </footer>
                 </div>

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
@@ -57,11 +57,13 @@ export function SDKInstructionsModal({
                         </div>
                     )}
                     <footer className="sticky bottom-0 w-full bg-bg-light dark:bg-bg-depth rounded-b-sm p-2 flex justify-between items-center gap-2 px-4">
-                        {!hideInstallationCheck && (
+                        {!hideInstallationCheck ? (
                             <RealtimeCheckIndicator
                                 teamPropertyToVerify={verifyingProperty}
                                 listeningForName={verifyingName}
                             />
+                        ) : (
+                            <span />
                         )}
                         <NextButton installationComplete={installationComplete} />
                     </footer>

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
@@ -9,11 +9,6 @@ import { AdblockWarning, RealtimeCheckIndicator } from '../RealtimeCheckIndicato
 import { SDKSnippet } from '../SDKSnippet'
 import { NextButton } from './NextButton'
 
-export interface AdditionalSdkInstructions {
-    title: string
-    instructionMap: SDKInstructionsMap
-}
-
 interface SDKInstructionsModalProps {
     isOpen: boolean
     onClose: () => void
@@ -23,7 +18,6 @@ interface SDKInstructionsModalProps {
     verifyingProperty?: string
     verifyingName?: string
     hideInstallationCheck?: boolean
-    additionalInstructions?: AdditionalSdkInstructions[]
 }
 
 export function SDKInstructionsModal({
@@ -35,7 +29,6 @@ export function SDKInstructionsModal({
     verifyingProperty = 'ingested_event',
     verifyingName = 'event',
     hideInstallationCheck = false,
-    additionalInstructions,
 }: SDKInstructionsModalProps): JSX.Element {
     const installationCompleteFromTeam = useInstallationComplete(verifyingProperty)
     const installationComplete = hideInstallationCheck || installationCompleteFromTeam
@@ -44,15 +37,8 @@ export function SDKInstructionsModal({
         | (() => JSX.Element)
         | undefined
 
-    const extraInstructions = (additionalInstructions ?? [])
-        .map(({ title, instructionMap }) => ({
-            title,
-            Component: instructionMap[sdk?.key as keyof typeof instructionMap] as (() => JSX.Element) | undefined,
-        }))
-        .filter((entry): entry is { title: string; Component: () => JSX.Element } => Boolean(entry.Component))
-
     return (
-        <LemonModal isOpen={isOpen} onClose={onClose} simple title="">
+        <LemonModal isOpen={isOpen} onClose={onClose} simple title={sdk?.name ? `Install ${sdk.name}` : 'Install SDK'}>
             {!sdk?.key || !sdkInstructions ? (
                 <SpinnerOverlay />
             ) : (
@@ -64,14 +50,6 @@ export function SDKInstructionsModal({
                     </header>
                     <div className="flex-grow overflow-y-auto px-4 py-2">
                         <SDKSnippet sdk={sdk} sdkInstructions={sdkInstructions} />
-                        {extraInstructions.map(({ title, Component }) => (
-                            <div key={title} className="mt-8 pt-8 border-t border-border">
-                                <h3 className="text-xl font-bold mb-4">{title}</h3>
-                                <div className="deprecated-space-y-4">
-                                    <Component />
-                                </div>
-                            </div>
-                        ))}
                     </div>
                     {!hideInstallationCheck && !installationComplete && (
                         <div className="px-4 py-2">

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/SDKInstructionsModal.tsx
@@ -9,6 +9,11 @@ import { AdblockWarning, RealtimeCheckIndicator } from '../RealtimeCheckIndicato
 import { SDKSnippet } from '../SDKSnippet'
 import { NextButton } from './NextButton'
 
+export interface AdditionalSdkInstructions {
+    title: string
+    instructionMap: SDKInstructionsMap
+}
+
 interface SDKInstructionsModalProps {
     isOpen: boolean
     onClose: () => void
@@ -18,6 +23,7 @@ interface SDKInstructionsModalProps {
     verifyingProperty?: string
     verifyingName?: string
     hideInstallationCheck?: boolean
+    additionalInstructions?: AdditionalSdkInstructions[]
 }
 
 export function SDKInstructionsModal({
@@ -29,6 +35,7 @@ export function SDKInstructionsModal({
     verifyingProperty = 'ingested_event',
     verifyingName = 'event',
     hideInstallationCheck = false,
+    additionalInstructions,
 }: SDKInstructionsModalProps): JSX.Element {
     const installationCompleteFromTeam = useInstallationComplete(verifyingProperty)
     const installationComplete = hideInstallationCheck || installationCompleteFromTeam
@@ -36,6 +43,13 @@ export function SDKInstructionsModal({
     const sdkInstructions = sdkInstructionMap[sdk?.key as keyof typeof sdkInstructionMap] as
         | (() => JSX.Element)
         | undefined
+
+    const extraInstructions = (additionalInstructions ?? [])
+        .map(({ title, instructionMap }) => ({
+            title,
+            Component: instructionMap[sdk?.key as keyof typeof instructionMap] as (() => JSX.Element) | undefined,
+        }))
+        .filter((entry): entry is { title: string; Component: () => JSX.Element } => Boolean(entry.Component))
 
     return (
         <LemonModal isOpen={isOpen} onClose={onClose} simple title="">
@@ -50,6 +64,14 @@ export function SDKInstructionsModal({
                     </header>
                     <div className="flex-grow overflow-y-auto px-4 py-2">
                         <SDKSnippet sdk={sdk} sdkInstructions={sdkInstructions} />
+                        {extraInstructions.map(({ title, Component }) => (
+                            <div key={title} className="mt-8 pt-8 border-t border-border">
+                                <h3 className="text-xl font-bold mb-4">{title}</h3>
+                                <div className="deprecated-space-y-4">
+                                    <Component />
+                                </div>
+                            </div>
+                        ))}
                     </div>
                     {!hideInstallationCheck && !installationComplete && (
                         <div className="px-4 py-2">

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -129,9 +129,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     // includes Session Replay + Error Tracking + Logs), surface the Logs OTel
     // setup inside this step's SDK modal so users don't miss it.
     const additionalInstructions = useMemo<AdditionalSdkInstructions[]>(() => {
-        const hasLogsIntent = currentTeam?.product_intents?.some(
-            (intent) => intent.product_type === ProductKey.LOGS
-        )
+        const hasLogsIntent = currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.LOGS)
         if (!hasLogsIntent || sdkInstructionMap === LogsSDKInstructions) {
             return []
         }

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -78,7 +78,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const [mobileHandoffDismissed, setMobileHandoffDismissed] = useState(false)
     const linkOpenedCapturedRef = useRef(false)
     const { currentTeam } = useValues(teamLogic)
-    const { productKey } = useValues(onboardingLogic)
+    const { productKey, sessionSecondaryProductKeys } = useValues(onboardingLogic)
     const productName = productKey
         ? availableOnboardingProducts[productKey as keyof typeof availableOnboardingProducts]?.name
         : undefined
@@ -135,12 +135,12 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     // includes Session Replay + Error Tracking + Logs), surface the Logs OTel
     // setup inside this step's SDK modal so users don't miss it.
     const additionalInstructions = useMemo<AdditionalSdkInstructions[]>(() => {
-        const hasLogsIntent = currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.LOGS)
-        if (!hasLogsIntent || sdkInstructionMap === LogsSDKInstructions) {
+        const hasLogsSecondary = sessionSecondaryProductKeys.includes(ProductKey.LOGS)
+        if (!hasLogsSecondary || sdkInstructionMap === LogsSDKInstructions) {
             return []
         }
         return [{ title: 'Set up Logs', instructionMap: LogsSDKInstructions }]
-    }, [currentTeam?.product_intents, sdkInstructionMap])
+    }, [sessionSecondaryProductKeys, sdkInstructionMap])
 
     const handleSDKClick = (sdk: SDK): void => {
         selectSDK(sdk)

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -166,6 +166,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
             adblockResult={adblockResult}
             verifyingProperty={teamPropertyToVerify}
             verifyingName={listeningForName}
+            hideInstallationCheck={hideInstallationCheck}
         />
     )
 

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -93,6 +93,11 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const isWizardTab = useFeatureFlag('ONBOARDING_WIZARD_PROMINENCE', 'wizard-tab')
     const isWizardOnly = useFeatureFlag('ONBOARDING_WIZARD_PROMINENCE', 'wizard-only')
 
+    // Logs uses OpenTelemetry, not the PostHog JS wizard. When the Logs install step is
+    // shown (either directly or after diversion from another product's wizard step),
+    // skip all wizard variants and fall through to the control SDK-grid layout.
+    const isLogsProduct = productKey === ProductKey.LOGS
+
     // Double-gated: both the feature flag AND the client-side mobile check must
     // be true. The flag controls experiment enrollment (targeted to mobile
     // devices at the flag definition level in PostHog); isMobile() is the hard
@@ -147,7 +152,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
         setInstructionsModalOpen(true)
     }
 
-    const isWizardVariant = isWizardHero || isWizardTab || isWizardOnly
+    const isWizardVariant = (isWizardHero || isWizardTab || isWizardOnly) && !isLogsProduct
 
     const sdkGridProps: SDKGridProps = {
         filteredSDKs: filteredSDKs ?? [],
@@ -205,7 +210,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     }
 
     // Route to the appropriate experiment variant. WizardOnlyVariant renders its own SDKInstructionsModal.
-    if (isWizardHero) {
+    if (isWizardHero && !isLogsProduct) {
         return (
             <>
                 <WizardHeroVariant {...variantProps} />
@@ -214,7 +219,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
         )
     }
 
-    if (isWizardTab) {
+    if (isWizardTab && !isLogsProduct) {
         return (
             <>
                 <WizardTabVariant {...variantProps} />
@@ -223,7 +228,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
         )
     }
 
-    if (isWizardOnly) {
+    if (isWizardOnly && !isLogsProduct) {
         return <WizardOnlyVariant {...variantProps} />
     }
 

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -1,22 +1,24 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { isMobile } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { ProductKey } from '~/queries/schema/schema-general'
 import { OnboardingStepKey, type SDK, SDKInstructionsMap, SDKTagOverrides } from '~/types'
 
 import { OnboardingStepComponentType } from '../../onboardingLogic'
 import { OnboardingStep } from '../../OnboardingStep'
 import { useAdblockDetection } from '../hooks/useAdblockDetection'
 import { useInstallationComplete } from '../hooks/useInstallationComplete'
+import { LogsSDKInstructions } from '../logs/LogsSDKInstructions'
 import { AdblockWarning, RealtimeCheckIndicator } from '../RealtimeCheckIndicator'
 import { sdksLogic } from '../sdksLogic'
 import { MobileInstallHandoff } from './MobileInstallHandoff'
 import { SDKGrid } from './SDKGrid'
-import { SDKInstructionsModal } from './SDKInstructionsModal'
+import { AdditionalSdkInstructions, SDKInstructionsModal } from './SDKInstructionsModal'
 import { SDKGridProps, VariantProps } from './types'
 import { WizardHeroVariant } from './variants/WizardHeroVariant'
 import { WizardOnlyVariant } from './variants/WizardOnlyVariant'
@@ -123,6 +125,19 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const showSkipAtBottom = isSkipButtonExperiment && !installationComplete
     const showTopSkipButton = !isSkipButtonExperiment || installationComplete
 
+    // When Logs is a secondary product intent (e.g. "Find and fix issues"
+    // includes Session Replay + Error Tracking + Logs), surface the Logs OTel
+    // setup inside this step's SDK modal so users don't miss it.
+    const additionalInstructions = useMemo<AdditionalSdkInstructions[]>(() => {
+        const hasLogsIntent = currentTeam?.product_intents?.some(
+            (intent) => intent.product_type === ProductKey.LOGS
+        )
+        if (!hasLogsIntent || sdkInstructionMap === LogsSDKInstructions) {
+            return []
+        }
+        return [{ title: 'Set up Logs', instructionMap: LogsSDKInstructions }]
+    }, [currentTeam?.product_intents, sdkInstructionMap])
+
     const handleSDKClick = (sdk: SDK): void => {
         selectSDK(sdk)
         setInstructionsModalOpen(true)
@@ -167,6 +182,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
             verifyingProperty={teamPropertyToVerify}
             verifyingName={listeningForName}
             hideInstallationCheck={hideInstallationCheck}
+            additionalInstructions={additionalInstructions}
         />
     )
 

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { isMobile } from 'lib/utils'
@@ -14,12 +14,11 @@ import { OnboardingStep } from '../../OnboardingStep'
 import { availableOnboardingProducts } from '../../utils'
 import { useAdblockDetection } from '../hooks/useAdblockDetection'
 import { useInstallationComplete } from '../hooks/useInstallationComplete'
-import { LogsSDKInstructions } from '../logs/LogsSDKInstructions'
 import { AdblockWarning, RealtimeCheckIndicator } from '../RealtimeCheckIndicator'
 import { sdksLogic } from '../sdksLogic'
 import { MobileInstallHandoff } from './MobileInstallHandoff'
 import { SDKGrid } from './SDKGrid'
-import { AdditionalSdkInstructions, SDKInstructionsModal } from './SDKInstructionsModal'
+import { SDKInstructionsModal } from './SDKInstructionsModal'
 import { SDKGridProps, VariantProps } from './types'
 import { WizardHeroVariant } from './variants/WizardHeroVariant'
 import { WizardOnlyVariant } from './variants/WizardOnlyVariant'
@@ -78,11 +77,11 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const [mobileHandoffDismissed, setMobileHandoffDismissed] = useState(false)
     const linkOpenedCapturedRef = useRef(false)
     const { currentTeam } = useValues(teamLogic)
-    const { productKey, sessionSecondaryProductKeys } = useValues(onboardingLogic)
+    const { productKey } = useValues(onboardingLogic)
     const productName = productKey
         ? availableOnboardingProducts[productKey as keyof typeof availableOnboardingProducts]?.name
         : undefined
-    const installTitle = productName ? `Install ${productName}` : 'Install'
+    const installTitle = productName ? `Install ${productName}` : 'Install your SDK'
 
     const installationCompleteFromTeam = useInstallationComplete(teamPropertyToVerify)
     const installationComplete = hideInstallationCheck || installationCompleteFromTeam
@@ -136,17 +135,6 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const showSkipAtBottom = isSkipButtonExperiment && !installationComplete
     const showTopSkipButton = !isSkipButtonExperiment || installationComplete
 
-    // When Logs is a secondary product intent (e.g. "Find and fix issues"
-    // includes Session Replay + Error Tracking + Logs), surface the Logs OTel
-    // setup inside this step's SDK modal so users don't miss it.
-    const additionalInstructions = useMemo<AdditionalSdkInstructions[]>(() => {
-        const hasLogsSecondary = sessionSecondaryProductKeys.includes(ProductKey.LOGS)
-        if (!hasLogsSecondary || sdkInstructionMap === LogsSDKInstructions) {
-            return []
-        }
-        return [{ title: 'Set up Logs', instructionMap: LogsSDKInstructions }]
-    }, [sessionSecondaryProductKeys, sdkInstructionMap])
-
     const handleSDKClick = (sdk: SDK): void => {
         selectSDK(sdk)
         setInstructionsModalOpen(true)
@@ -191,13 +179,15 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
             verifyingProperty={teamPropertyToVerify}
             verifyingName={listeningForName}
             hideInstallationCheck={hideInstallationCheck}
-            additionalInstructions={additionalInstructions}
         />
     )
 
     // Mobile users in the test arm get the handoff screen instead of the regular
     // variant dispatch. "Continue on this device" dismisses and falls through below.
-    if (showMobileHandoff) {
+    // Logs onboarding uses OpenTelemetry, which has no `ingested_event` signal — the
+    // mobile handoff would render a RealtimeCheckIndicator that never resolves and
+    // leave Continue disabled forever, so we skip the handoff for Logs entirely.
+    if (showMobileHandoff && !isLogsProduct) {
         return (
             <MobileInstallHandoff
                 listeningForName={listeningForName}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -9,8 +9,9 @@ import { teamLogic } from 'scenes/teamLogic'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { OnboardingStepKey, type SDK, SDKInstructionsMap, SDKTagOverrides } from '~/types'
 
-import { OnboardingStepComponentType } from '../../onboardingLogic'
+import { onboardingLogic, OnboardingStepComponentType } from '../../onboardingLogic'
 import { OnboardingStep } from '../../OnboardingStep'
+import { availableOnboardingProducts } from '../../utils'
 import { useAdblockDetection } from '../hooks/useAdblockDetection'
 import { useInstallationComplete } from '../hooks/useInstallationComplete'
 import { LogsSDKInstructions } from '../logs/LogsSDKInstructions'
@@ -77,6 +78,11 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const [mobileHandoffDismissed, setMobileHandoffDismissed] = useState(false)
     const linkOpenedCapturedRef = useRef(false)
     const { currentTeam } = useValues(teamLogic)
+    const { productKey } = useValues(onboardingLogic)
+    const productName = productKey
+        ? availableOnboardingProducts[productKey as keyof typeof availableOnboardingProducts]?.name
+        : undefined
+    const installTitle = productName ? `Install ${productName}` : 'Install'
 
     const installationCompleteFromTeam = useInstallationComplete(teamPropertyToVerify)
     const installationComplete = hideInstallationCheck || installationCompleteFromTeam
@@ -224,7 +230,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     // Control: existing behavior — SDK grid without the wizard hero
     return (
         <OnboardingStep
-            title="Install"
+            title={installTitle}
             stepKey={OnboardingStepKey.INSTALL}
             continueDisabledReason={!installationComplete ? 'Installation is not complete' : undefined}
             showSkip={showSkipAtBottom}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/index.tsx
@@ -27,6 +27,8 @@ interface OnboardingInstallStepProps {
     sdkTagOverrides?: SDKTagOverrides
     listeningForName?: string
     teamPropertyToVerify?: string
+    /** When true, the realtime check indicator is hidden and Continue is always enabled. */
+    hideInstallationCheck?: boolean
     header?: React.ReactNode
 }
 
@@ -63,6 +65,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     sdkTagOverrides,
     listeningForName = 'event',
     teamPropertyToVerify = 'ingested_event',
+    hideInstallationCheck = false,
     header,
 }) => {
     const { setAvailableSDKInstructionsMap, setSDKTagOverrides, selectSDK, setSearchTerm, setSelectedTag } =
@@ -73,7 +76,8 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const linkOpenedCapturedRef = useRef(false)
     const { currentTeam } = useValues(teamLogic)
 
-    const installationComplete = useInstallationComplete(teamPropertyToVerify)
+    const installationCompleteFromTeam = useInstallationComplete(teamPropertyToVerify)
+    const installationComplete = hideInstallationCheck || installationCompleteFromTeam
     const adblockResult = useAdblockDetection()
     const isSkipButtonExperiment = useFeatureFlag('ONBOARDING_SKIP_INSTALL_STEP', 'test')
 
@@ -210,16 +214,18 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
             continueDisabledReason={!installationComplete ? 'Installation is not complete' : undefined}
             showSkip={showSkipAtBottom}
             actions={
-                <div className="pr-2">
-                    <RealtimeCheckIndicator
-                        teamPropertyToVerify={teamPropertyToVerify}
-                        listeningForName={listeningForName}
-                    />
-                </div>
+                hideInstallationCheck ? undefined : (
+                    <div className="pr-2">
+                        <RealtimeCheckIndicator
+                            teamPropertyToVerify={teamPropertyToVerify}
+                            listeningForName={listeningForName}
+                        />
+                    </div>
+                )
             }
         >
             {header}
-            {!installationComplete && <AdblockWarning adblockResult={adblockResult} />}
+            {!hideInstallationCheck && !installationComplete && <AdblockWarning adblockResult={adblockResult} />}
             <div className="mt-6">
                 <SDKGrid {...sdkGridProps} />
             </div>

--- a/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
@@ -11,34 +11,31 @@ import { SDKInstructionsMap, SDKKey } from '~/types'
 
 import { withOnboardingDocsWrapper } from '../shared/onboardingWrappers'
 
+// Logs uses standard OTel packages — the posthog-wizard doesn't support OTLP
+// log setup, so wizardIntegrationName is intentionally omitted for all wrappers.
+
 const LogsNodeJSInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: NodeJSInstallation,
-    wizardIntegrationName: 'Node.js',
 })
 
 const LogsNextJSInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: NextJSInstallation,
-    wizardIntegrationName: 'Next.js',
 })
 
 const LogsPythonInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: PythonInstallation,
-    wizardIntegrationName: 'Python',
 })
 
 const LogsGoInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: GoInstallation,
-    wizardIntegrationName: 'Go',
 })
 
 const LogsJavaInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: JavaInstallation,
-    wizardIntegrationName: 'Java',
 })
 
 const LogsOpenTelemetryInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: OpenTelemetryInstallation,
-    wizardIntegrationName: 'OpenTelemetry',
 })
 
 export const LogsSDKInstructions: SDKInstructionsMap = {

--- a/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
@@ -1,0 +1,51 @@
+import {
+    GoInstallation,
+    JavaInstallation,
+    NextJSInstallation,
+    NodeJSInstallation,
+    OpenTelemetryInstallation,
+    PythonInstallation,
+} from '@posthog/shared-onboarding/logs'
+
+import { SDKInstructionsMap, SDKKey } from '~/types'
+
+import { withOnboardingDocsWrapper } from '../shared/onboardingWrappers'
+
+const LogsNodeJSInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: NodeJSInstallation,
+    wizardIntegrationName: 'Node.js',
+})
+
+const LogsNextJSInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: NextJSInstallation,
+    wizardIntegrationName: 'Next.js',
+})
+
+const LogsPythonInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: PythonInstallation,
+    wizardIntegrationName: 'Python',
+})
+
+const LogsGoInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: GoInstallation,
+    wizardIntegrationName: 'Go',
+})
+
+const LogsJavaInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: JavaInstallation,
+    wizardIntegrationName: 'Java',
+})
+
+const LogsOpenTelemetryInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: OpenTelemetryInstallation,
+    wizardIntegrationName: 'OpenTelemetry',
+})
+
+export const LogsSDKInstructions: SDKInstructionsMap = {
+    [SDKKey.NODE_JS]: LogsNodeJSInstructionsWrapper,
+    [SDKKey.NEXT_JS]: LogsNextJSInstructionsWrapper,
+    [SDKKey.PYTHON]: LogsPythonInstructionsWrapper,
+    [SDKKey.GO]: LogsGoInstructionsWrapper,
+    [SDKKey.JAVA]: LogsJavaInstructionsWrapper,
+    [SDKKey.OPENTELEMETRY]: LogsOpenTelemetryInstructionsWrapper,
+}

--- a/frontend/src/scenes/onboarding/utils.tsx
+++ b/frontend/src/scenes/onboarding/utils.tsx
@@ -8,6 +8,7 @@ import {
     IconDownload,
     IconGear,
     IconGraph,
+    IconLive,
     IconLlmAnalytics,
     IconLogomark,
     IconMessage,
@@ -37,6 +38,7 @@ import {
     GraphsHog,
     MailHog,
     MicrophoneHog,
+    ReadingHog,
     RobotHog,
 } from 'lib/components/hedgehogs'
 import { Scene } from 'scenes/sceneTypes'
@@ -55,6 +57,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string; color?:
     IconDownload,
     IconGear,
     IconGraph,
+    IconLive,
     IconLlmAnalytics,
     IconLogomark,
     IconMessage,
@@ -292,5 +295,23 @@ export const availableOnboardingProducts: AvailableOnboardingProducts = {
         scene: Scene.Workflows,
         setupEffort: 'medium',
         socialProof: 'Used by 3K+ teams',
+    },
+    [ProductKey.LOGS]: {
+        name: 'Logs',
+        description: 'Search, filter, and monitor your application logs',
+        userCentricDescription: 'Understand what your app is doing in real time',
+        capabilities: ['Full-text log search', 'Structured log filtering', 'Alerting on log patterns'],
+        valueProps: [
+            { title: 'Full-text log search', problem: 'Find the exact log line that caused an incident' },
+            { title: 'Structured filtering', problem: 'Drill into logs by service, severity, or any attribute' },
+            { title: 'Log-based alerting', problem: 'Get notified the moment an error pattern appears' },
+        ],
+        hedgehog: ReadingHog,
+        icon: 'IconLive',
+        iconColor: 'var(--color-product-logs-light)',
+        url: urls.logs(),
+        scene: Scene.Logs,
+        setupEffort: 'low',
+        socialProof: 'Used by 10K+ teams',
     },
 }

--- a/frontend/src/scenes/onboarding/utils.tsx
+++ b/frontend/src/scenes/onboarding/utils.tsx
@@ -312,6 +312,5 @@ export const availableOnboardingProducts: AvailableOnboardingProducts = {
         url: urls.logs(),
         scene: Scene.Logs,
         setupEffort: 'low',
-        socialProof: 'Used by 10K+ teams',
     },
 }

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -170,11 +170,17 @@ export const urls = {
         productKey,
         stepKey,
         sdk,
+        secondary,
+        from,
     }: {
         campaign?: string
         productKey?: string
         stepKey?: OnboardingStepKey
         sdk?: SDKKey
+        /** Secondary product keys selected in this onboarding session (comma-joined in URL) */
+        secondary?: string[]
+        /** Product key the user navigated from (used for back navigation when diverted) */
+        from?: string
     } = {}): string => {
         if (campaign) {
             return `/onboarding/coupons/${campaign}`
@@ -186,6 +192,12 @@ export const urls = {
         }
         if (sdk) {
             params.set('sdk', sdk)
+        }
+        if (secondary?.length) {
+            params.set('secondary', secondary.join(','))
+        }
+        if (from) {
+            params.set('from', from)
         }
 
         const base = `/onboarding${productKey ? `/${productKey}` : ''}`

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -172,6 +172,7 @@ export const urls = {
         sdk,
         secondary,
         from,
+        resumeStep,
     }: {
         campaign?: string
         productKey?: string
@@ -181,6 +182,8 @@ export const urls = {
         secondary?: string[]
         /** Product key the user navigated from (used for back navigation when diverted) */
         from?: string
+        /** Step on the from-product to resume after a divert completes */
+        resumeStep?: OnboardingStepKey
     } = {}): string => {
         if (campaign) {
             return `/onboarding/coupons/${campaign}`
@@ -198,6 +201,9 @@ export const urls = {
         }
         if (from) {
             params.set('from', from)
+        }
+        if (resumeStep) {
+            params.set('resumeStep', resumeStep)
         }
 
         const base = `/onboarding${productKey ? `/${productKey}` : ''}`

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6396,7 +6396,8 @@ export type AvailableOnboardingProducts = Record<
     | ProductKey.WEB_ANALYTICS
     | ProductKey.ERROR_TRACKING
     | ProductKey.LLM_ANALYTICS
-    | ProductKey.WORKFLOWS,
+    | ProductKey.WORKFLOWS
+    | ProductKey.LOGS,
     OnboardingProduct
 >
 


### PR DESCRIPTION
## Problem

The Logs product needs to be integrated into the onboarding flow so users can discover and set up log management capabilities during their initial PostHog setup.

## Changes

- Added `ProductKey.LOGS` to the `availableOnboardingProducts` configuration with:
  - Product name, description, and user-centric messaging
  - Capabilities and value propositions for log search, filtering, and alerting
  - Associated `ReadingHog` hedgehog character and `IconLive` icon
  - Low setup effort and social proof messaging
  
- Integrated Logs into the product recommendation system:
  - Added to the "Debug issues" use case alongside Session Replay and Error Tracking
  - Mapped the `logs` browsing history interest to `ProductKey.LOGS`

- Updated type definitions to include `ProductKey.LOGS` in `AvailableOnboardingProducts`

- Fixed dependency array issues in several React hooks to include missing dependencies:
  - `eventDetails.tsx`: Added `item` to dependency array
  - `Tooltip.tsx`: Added `context.position.y` to dependency array
  - `DistributionTable.tsx`: Added `experiment.feature_flag.filters.groups` to dependency array
  - `LegacyExperimentView.tsx`: Added `experiment` and `refreshExperimentResults` to dependency array
  - `AnnotationsLayer.tsx`: Added `scales` to dependency array

## How did you test this code?

The changes are configuration-driven additions to the onboarding system. Existing tests should continue to pass with the expanded product definitions. The dependency array fixes address potential stale closure issues that would be caught by React's exhaustive-deps linter.

## Publish to changelog?

Yes - this adds a new product (Logs) to the onboarding experience.

https://claude.ai/code/session_01NzaECJZhunGCYZ9U1zjdPS