### PR TITLE
fix(ci): rebuild canary on synchronize when handle_comment is skipped

### DIFF
--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -679,7 +679,16 @@ jobs:
     build_and_enable:
         name: Build feature-flags image and enable canary
         needs: [preflight]
-        if: needs.preflight.outputs.should_proceed == 'true'
+        # `!cancelled()` disables the implicit success() chain check, which
+        # otherwise inherits handle_comment's `skipped` result on a
+        # `pull_request: synchronize` event (handle_comment is gated to
+        # issue_comment) and skips this job before should_proceed is even
+        # evaluated. We then re-assert success on the direct dependency
+        # only and gate on the actual `should_proceed` output.
+        if: |
+            !cancelled() &&
+            needs.preflight.result == 'success' &&
+            needs.preflight.outputs.should_proceed == 'true'
         runs-on: depot-ubuntu-22.04
         timeout-minutes: 30
         permissions:


### PR DESCRIPTION
## Problem

PR #56920 split the workflow into a lightweight `preflight` job and the heavy `build_and_enable` job, with the goal that pushing a new commit to a PR with an active canary would automatically rebuild and redeploy.

It didn't work on `pull_request: synchronize`. On run https://github.com/PostHog/posthog/actions/runs/25119028929 (PR #56298), `preflight` succeeded with `should_proceed='true'` but `build_and_enable` was skipped at queue time, so the canary never rebuilt.

The cause is a GitHub Actions quirk. Every job has an implicit `success()` requirement layered onto whatever `if:` you write, and that implicit check requires every job in the `needs` chain (transitive, not just direct parents) to have succeeded. The implicit default is only added when your `if:` does not already mention a status function (`always()`, `success()`, `failure()`, `cancelled()`). The presence of any status function tells GitHub "I'm taking responsibility for the success check," and the implicit default is dropped.

On synchronize, `handle_comment` is `skipped` because its `if:` is gated to `issue_comment`. `preflight` runs anyway because its own `if:` starts with `!cancelled()`, which is a status function and so opts out of the implicit chain check. `build_and_enable` had a plain `if: needs.preflight.outputs.should_proceed == 'true'` with no status function, so the implicit chain check stayed on, inherited the `handle_comment` skip, and never evaluated `should_proceed`.

This matches the run history. Every prior synchronize on PR #56298 was skipped or failed at preflight. The only successful redeploy (`sha-5883e05`) came from a `/pr-canary` comment, where `handle_comment` succeeds and the chain has no skipped node.

## Changes

Change `build_and_enable`'s gate from a bare `should_proceed` check to:

```yaml
if: |
    !cancelled() &&
    needs.preflight.result == 'success' &&
    needs.preflight.outputs.should_proceed == 'true'
```

This looks more restrictive (one clause grew to three) but it is actually less restrictive. The previous condition implicitly required every ancestor in the `needs` chain to have succeeded, including `handle_comment`. The new condition drops that requirement and only asks that `preflight` succeeded.

How each clause works:

- `!cancelled()` is a status function, and its presence is what disables the implicit chain check. The literal meaning is also enforced.
- `needs.preflight.result == 'success'` reasserts success on the direct parent only, since the implicit check is no longer doing it.
- `needs.preflight.outputs.should_proceed == 'true'` is the original business gate, unchanged.

The `Report failure on PR` step at the bottom of `build_and_enable` uses step-scoped `failure()` and is unaffected. There are no other downstream jobs.

## How did you test this code?

Verification requires landing the change first, since the synchronize path only fires when the workflow file is on master. After merge, push a no-op commit to a canary'd PR (#56298) and confirm `build_and_enable` runs and dispatches the rebuild.

The pre-commit YAML formatter ran clean.

## Publish to changelog?

no

## Docs update

n/a, internal CI workflow.