### PR TITLE
fix(replay): get rid of autocapture-required for session summary

### DIFF
--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -188,10 +188,6 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         summaryDisabledReason: [
             (s) => [s.allItemsByMiniFilterKey],
             (allItemsByMiniFilterKey): string | undefined => {
-                const hasAutocapture = !!allItemsByMiniFilterKey['events-autocapture']?.length
-                if (hasAutocapture) {
-                    return undefined
-                }
                 const hasAnyEvents = [
                     'events-posthog',
                     'events-custom',
@@ -199,9 +195,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                     'events-autocapture',
                     'events-exceptions',
                 ].some((key) => allItemsByMiniFilterKey[key]?.length > 0)
-                return hasAnyEvents
-                    ? 'This session has no autocapture events. Enable autocapture in your project settings to use AI summaries.'
-                    : 'Session events are not available yet. Try again in a few minutes.'
+                return hasAnyEvents ? undefined : 'Session events are not available yet. Try again in a few minutes.'
             },
         ],
         loading: [


### PR DESCRIPTION
## Problem

this wasnt right / was a leftover gate



![Screenshot 2026-04-28 at 1.47.55 PM.png](https://app.graphite.com/user-attachments/assets/e8a94748-d7a5-4756-bb62-376ec11e1ffc.png)



<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

remove requirement for autocapture

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

i can now click the button below the player 

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->