### PR TITLE
chore(insights): factor out hog-charts story helpers and resolve series colors

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -425,75 +425,75 @@ snapshots:
     components-hedgehogmode--static-hedgehog--light:
         hash: v1.k794b7964.43d71f5c3ad02bd9e1fa87433d34df79e0de653c4b55004188bed5de78a2c3f5.i2ATBYyqY7uq7UxwlL2Rdte6AuMyySa8Jnbeb1VouoQ
     components-hogcharts-confidenceintervals--area-chart-with-hatching--dark:
-        hash: v1.k794b7964.0eb9f320b5b581fef06635fb79b8a6a937545b83e861cbf100a340c884efadc8.Al3L-yUledHXLcoTns1l9mnWYeuG5uA5dBhSox3l0H4
+        hash: v1.k794b7964.5f857d684fe686df0679265b55a1564ef13fab08750023a99241b27648a77c69.isroL1mISOxgoYwg9v9qH_Ktbee7EdDoCzmjbdl4j-8
     components-hogcharts-confidenceintervals--area-chart-with-hatching--light:
         hash: v1.k794b7964.2531a9ed46e4b3c25f079b18363a98e1e55b11539297c5e27754ae936cd5cf1b.SVd4nhHy1M-Z5cpUMFS8TDfyFW2a9PF5t2HIicIijfA
     components-hogcharts-confidenceintervals--multi-series-with-ci--dark:
-        hash: v1.k794b7964.a9ba033b1974bbfe126f1343b402c0f1b67d02ee6b1d99f489768aeba077ff44.9-3d5yrHuEr1YCyzhl-LaigDyenW6MWdfYdAV1mftt4
+        hash: v1.k794b7964.dbee1b12833401a376a20e555e001cb21152cbbe07c7ae49ae8897b94ec6e0de.Tn5Ym7BnIC86N9QxKLPy84Jl8DMetS5x7Pxrsshzs4U
     components-hogcharts-confidenceintervals--multi-series-with-ci--light:
         hash: v1.k794b7964.c7ed1aa2b2e7adde128703393c70da1411df3b7ef2d003011c611aa8977ab24c.9xGz0-JizhacccQg60no1VJQRhUI2n_xiaHW25VCG_E
     components-hogcharts-confidenceintervals--with-confidence-interval--dark:
-        hash: v1.k794b7964.a5d1c6025fdaea66abdbe3489a2ac8ce7263a3f1d8033cfd10847814b5484909.OY9NAORVj5yyISdGnUebRQ_46GRUY6ODpyqeoOMaw7k
+        hash: v1.k794b7964.34253a704e0ca543182f4cdbdac6473077264f710794842e5ccd61debca49631.fF9yOjoQrm6f5rmumEMWDH4Gu8axooMDTEc8Xlp8nKQ
     components-hogcharts-confidenceintervals--with-confidence-interval--light:
         hash: v1.k794b7964.2c6fbb402ad80d420aee251b6c2630a980e92292424e381a3b9742e839cbc175.9XI8X-3m7ifzGKDKUETPMxIFY9anqdrQbv55LYvlDKA
     components-hogcharts-referenceline--fill-sides--dark:
-        hash: v1.k794b7964.6842b004f884e08b3cc324761f4de7a0c97c6c6d99cd42608d709d4264cb26d5.3uwtIIjAtF8_6dYGAR-mLH6CBP2KvWbWoVF-zCpRknQ
+        hash: v1.k794b7964.90f4952ddfc3e8b1645a462a24fcbde0a40584ffb0b2450fba6df79726a30033.4kZQt2UNtLSWspx7msbeULVNxN7Bm6mV9hNEZ6hZNXs
     components-hogcharts-referenceline--fill-sides--light:
         hash: v1.k794b7964.a71ab0c23a7c7222476deb4460e75c8a89ff7682f140a034421418202c4b6afc.8l3ygmUZLRyjknLjF-GH3adEfkcX1W2NrY380Dq3Sz0
     components-hogcharts-referenceline--horizontal-goal--dark:
-        hash: v1.k794b7964.83fa17c0f03b963a700ef6e6398de8fc3737efc2ef97b23b6e9b503786e024cb.pNUQwHq07K1d1WSLCCjcxq24XhWHcAg5-0SoOpVXNtg
+        hash: v1.k794b7964.c5fdf7008f2de74ccf46994fa1d1ad8fad8544eecf5e32b1ce72a2f269e25e55.9E2tPNgIObPg-huyFgvLfOWskL6u5XRRWfkRrCBOsc4
     components-hogcharts-referenceline--horizontal-goal--light:
         hash: v1.k794b7964.60564511fae1b64d2ec4bed069d247101bfa599c2c05290c06e0251dc61cc07c.csySfcl9y3wcKY5Aexk7p_oBEZM4UxtOk3uvyC0ktWk
     components-hogcharts-referenceline--horizontal-variants--dark:
-        hash: v1.k794b7964.8713696652e356b4f10d80faa70c5f18c55f8fc4b16f35e2fecf0dabed9e7ead.SFeODsf4V7sbr3_NHYTcKrFRa92rvpAhMXoPwQSt3gs
+        hash: v1.k794b7964.ce54a72d5735a1cd190f76c1827905f9e7a93c18792bd01c4ec2ccc58b9217dd.n-puhpH3Af34pPHPlJgW4r59RnPZPGxhGfJHIZ1DS2M
     components-hogcharts-referenceline--horizontal-variants--light:
         hash: v1.k794b7964.e9bd58e91c90ea3881adb25bb844bca46ccdbd14d5b67ce62d146fecf4ef49a6.W1Vbocbn01QPSDg3-UYJgymoa5ixZCosmDzSGBdbAPA
     components-hogcharts-referenceline--label-start-vs-end--dark:
-        hash: v1.k794b7964.4c48df534bb8147df03d77abf2f221cac15e32957f71af45e378702502f0604d.I1LhvB-FE09wjxMpkez1LkMvyvyrj0dp5MYTAZ0UAxo
+        hash: v1.k794b7964.4534934eac32d82ee4698dfe170bb8478b3544f7bf211ae18d2a4f68483aaf14.uz69Z-T9PlKLydMV2yZj0t9sTRtK1E0TEkmI3yrINVw
     components-hogcharts-referenceline--label-start-vs-end--light:
         hash: v1.k794b7964.f9e96a9ea2c20280604d7fb14f799da60a7021985374e4c550b64549806133cb.EjRgeSRVB5vUIW2RKCYCYs4kA9IQfqhJ9PrS4sPRByQ
     components-hogcharts-referenceline--vertical-reference-lines--dark:
-        hash: v1.k794b7964.ec1a39ae511e6a3c73dc1633d9c2f49c3805aba382131a6435de46326390ab66.8zBFF69Bl1yEv3OWi5-inUSg8BujD-P_71h1SdfUDaQ
+        hash: v1.k794b7964.8f27aa8ee4161d4041693a5549046f0e348aab5fdccc466ea461d6a0f5cf97e2.KEpUtlvBURMPzv1Vyq9Pvf8i_sDKoF3t7fZO8Ed1yPs
     components-hogcharts-referenceline--vertical-reference-lines--light:
         hash: v1.k794b7964.12ee9bdb34e0a1350d67ef73abd8621dd428d7fb565b713c61a2003db02b2091.-cD8-EsT_newJlN05zXLQ5sTZ_6RteILczqWSvQ5osE
     components-hogcharts-trendlines--multi-series-with-trend-lines--dark:
-        hash: v1.k794b7964.f7e2ebb25221124fc70bcfaf7acc13c8392ba309634bb6feec2f6a06d5821b03.X-pRpaY5rnjIt6O4iSTcPguMZWW2kQWI2aZFSq2Jy64
+        hash: v1.k794b7964.578da6198bfc384c3a1745c4fb065fb432f829c7a6b1f710f0bb80f77f61bde8.R92w8u3UUCE13JxPsgGUQKUlm_VKsYo8KmNf_Dh0dh0
     components-hogcharts-trendlines--multi-series-with-trend-lines--light:
         hash: v1.k794b7964.b5ff3b2eadc5ab0aee4ed2c38b5f41974452f429adc68e1a1c03357b1e8e9fc3.FsSXW-ULWLC9xrZJi8DMaewkru57GvY25GP2tB6BPuk
     components-hogcharts-trendlines--trend-line-with-incomplete-period--dark:
-        hash: v1.k794b7964.b77746e1a1c6606876d8d68acb1558cdef2565eb533ece8a85536f0b19d560af.toiSfjGjMRHO13FZ4IMO8s5HCRUrv4ZdR_8zdaCj6EA
+        hash: v1.k794b7964.73f36c27bc79d89db2f6fffe93ed0228fee5bfb44240b3613a84a5c3a64da65b.Po9mKppi4LsB6-nAMKjA2KgeTKQSjGWqhYxoQjUYYsg
     components-hogcharts-trendlines--trend-line-with-incomplete-period--light:
         hash: v1.k794b7964.c86f2feb2f761b56d2828fc63cf8def695a682b3784f51ecb7bae82b155f3531.SOsy4fk0TmnKWkFjSPazPJhkPUCGlqpnoJGSMqMtPxQ
     components-hogcharts-trendlines--with-trend-line--dark:
-        hash: v1.k794b7964.15b3d6602cebd061962ce0d72e14a736a9a975ea03a6f0f7fe0ac82c306b1188.bdrQKBriBnrL3jb8fZHvQ8oq8el9n4Y5ImFJ43z1HfA
+        hash: v1.k794b7964.e79d9bd628231ff272f7616daee20cdda600e3d73d3d7f7053fee2f2a26627ac.WHaEK3QdJYKz_0z-XBJHgmymwMthF3XuoaJIakRpGgQ
     components-hogcharts-trendlines--with-trend-line--light:
         hash: v1.k794b7964.031d098b111eda98755473f6d42b857a48fcfcc4d140f66ee92ea68fd6637073.I4KaJxlhrj5keiC7WykaUmlCbcBu8WoO1HL8hiaqGU4
     components-hogcharts-valuelabels--cross-series-overlap-removal--dark:
-        hash: v1.k794b7964.3d90bcc9693aee720d3f4c5cc6b3be8cf8a9e33ba1163df5585ed759e4e9e9b8.Wpss8nGjTBCUENrPpWax81SpmA_KMQFRvdZzvY549og
+        hash: v1.k794b7964.b766f038277710789aefeabc721df0c662a10aa672b24e14f7e68349f88f396a.Jef_dCFf6j8X_7hXhsuDQa6KMpkq-BS1akkcNUH46MU
     components-hogcharts-valuelabels--cross-series-overlap-removal--light:
         hash: v1.k794b7964.cff06072d78522c0c6a15e08e74dba88f3248cb14b08d572ca800dbf910be563.zIlE9_jkswGcT8QC-x1i1PsKRIU7s_HA17ZNBPh5pUc
     components-hogcharts-valuelabels--dual-y-axes--dark:
-        hash: v1.k794b7964.7bf38541b500014aee037838a4ba2e9c8940f909385d2d7abc410507edbc5195.kC6oTfF3YbyStZyWp5hZ4j9xtHJb3lQOKgOQEWth42U
+        hash: v1.k794b7964.c59fa1bc6566fc96b0cb92d025b108a40138e9a8a8496d0b3e233aae9d66ed59.QrGcG6laRMqVU7TQdp89RMBC8seb_yRx3TEwrN7vF6A
     components-hogcharts-valuelabels--dual-y-axes--light:
         hash: v1.k794b7964.4386469f5e098a7368f916b4831fc163c5ec7f7dc19761e62e3fc653b874a93e.vdXaWL7pLGhw96-xmxt4PK-XKiD3AvahstM6a_-F5rM
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--dark:
-        hash: v1.k794b7964.98227edf79690e1fd5cedc1ea411a21855025e630dba667c27fd0f6f389b5a58.LpSsqMQk6SELgqi_n4IMVVw50twcVdS291eHqo5D5RM
+        hash: v1.k794b7964.6d55aa7b02f1431eccce354fb2092f8d57f1a354930639e1eb4a550ba59540b5.0MOERS1S2FZ3gCdxsoz8PrMxurpfZq9ioaOO5X3dzWw
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--light:
         hash: v1.k794b7964.1d21d670655079b968c7a32f49af34c4c5fde6d2cb2ffb437201d4c766250aea.NYWcvSRwJFCcjBfJnp0fOpmWZpQ1CN7JWk0yn3N2u2Q
     components-hogcharts-valuelabels--multi-series-collision--dark:
-        hash: v1.k794b7964.c884d2f3bbb6c78cf62b8fcacfc03fd705be2328b98a8c5be86138e6f8a36b75.hoILWJkaC8Wt87lizo_MJT_FPodjBolDUwVwMoDYN1Q
+        hash: v1.k794b7964.3e831219695d3b2e2679faa95e4c5b70f06959c53de6dd6c71b6e375b485d514.HvUvjDgcyCdbvcY2ITeLEaS0M-A75vVU2qYSHC-O56A
     components-hogcharts-valuelabels--multi-series-collision--light:
         hash: v1.k794b7964.cbb2de65e2334b96bf752473e861e12826cd089ea8c427d404f89e3febfb719d.LF1QrV8BLIPslpRJMADQNr2gYgzyGdBBbPV-q1uKUY0
     components-hogcharts-valuelabels--negative-values--dark:
-        hash: v1.k794b7964.f0861706b533a3c4172e46584fcc977d50a97000a460014985aea8337855bfe6.ggPRuqg-llkvyGNzLTAFLPYgq-3WkSttVyu4f6Nm3Us
+        hash: v1.k794b7964.084ed1c20e236fa9ccd59c10449535e91487c01029ffb7d39c103bde8d206e73.4uYU-zN-9MIL2gu_0wtPkYPFO9iKBLlM70dUcKsRsec
     components-hogcharts-valuelabels--negative-values--light:
         hash: v1.k794b7964.4cb29caf9337c3c23ac16658ccf2df46865c440170febede1842f7a293c830ef.UjUgL5B54SbOYJYEnntavnsZZxZMP4ZcxJEhLQM-nIk
     components-hogcharts-valuelabels--single-series--dark:
-        hash: v1.k794b7964.6a609ae0671c46d3d96b8db43130691a0d144ce79b9e2c710f2ddac232b34b3a.Tm_tRi8aRB2bXskGZlBoVAo5itlJgMB4WKDMF0y3Oic
+        hash: v1.k794b7964.5f5f542bff21e42d779f36ffb063812be6426f9b978923f5a690ac4da831e23f.VnV0gDnMaQaGaTxV66nNL4lvumyI2nknOgY7tUiCi_w
     components-hogcharts-valuelabels--single-series--light:
         hash: v1.k794b7964.5b00b365741d5bd03b112455e14f735077dab9fd4f0f7b7224a7921e3da88785.Kc87s1yKUIjsG3YpBaC3yAXfJYqQvyirhH9v0e54AjY
     components-hogcharts-valuelabels--with-custom-formatter--dark:
-        hash: v1.k794b7964.b029a01d670f92b8df1a20ef42c38d73f3e417928dccf91c3e2607795cde6bf6.en2mgQBAUOGIu0q2n8RyQHMSHXN3yzvcQXR5HVvV72c
+        hash: v1.k794b7964.284c816866c7f67906abf9dd62203ab9a41dc886e7f1cca01a544d8e33316ad1.At2dmfyFhRyVBLUMETHoOy7_63K5F51s5l9N-FCP-94
     components-hogcharts-valuelabels--with-custom-formatter--light:
         hash: v1.k794b7964.818c9c01d63fc7cc299b13bfb29bcefa0e02eb6aa9732b56a73037e5f4b96a60.gFgqVn2RSJGVjYsTP_qBRlMqk8nDrboIYuJl7vPJwwU
     components-hogfetti--hogfetti--dark:
@@ -933,9 +933,9 @@ snapshots:
     components-search--default--light:
         hash: v1.k794b7964.5e4dfbdfdbb77976e939d0990052bc978becb99ec62f2de7af9119b5defe6bea.qbCAFw_u6dq-F4kGHfIMXowwPVs3t0rg8JBeN59-G0I
     components-search--searching--dark:
-        hash: v1.k794b7964.5daa29069586515e515e316df1d189beaaafea5d11933feb899c81e555d58655.khp95QojtG6ybnuZKOOju7JUg8GgGHDRTaJD5_qjEIA
+        hash: v1.k794b7964.68ab8bef374ab0313369c61df847587f087b2657f4ec43ebbcc532cce3cb3abc.uoWd0-vG62pjMtGu2nsyYEiFqI3jtQPMv_O-TI5MiTA
     components-search--searching--light:
-        hash: v1.k794b7964.1f23ccb6117831145d457b45b8939a158c179b37a23ee58897f432be66fee343.1GvRw-sWeGzAqQQomv7-oQJm2AXZunTg6qd36R3_ivk
+        hash: v1.k794b7964.2be6650cb02240a39b0f23299c69dee87714f03945033a4148806f0ee019a28c.A9vA6qIPU4HeLq9Y0466x4vAYIuyzxEObnR5JVl5XNw
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.9d72ed5224f75be3f53f1ba8edc2547978e519aa46a57cc97eef9087b403cb7d.3yHHiA7NW-p6vVSlM-2nPx7Nbk7wuTr5SA9Av2nW--g
     components-sentencelist--full-sentence--light:
@@ -5283,9 +5283,9 @@ snapshots:
     scenes-app-web-analytics--web-analytics-dashboard--light:
         hash: v1.k794b7964.0d336797602434aaaf6364ba4030ee4bd93762ae2df7223e1151bc6002ea2a60.oy7VmDHh6XEZi9xvVObmMtvWqO11BZY46XPgOc36mPQ
     scenes-other-billing--billing--dark:
-        hash: v1.k794b7964.1de93d7fb5ef5bf55972cfc3638f35de1f935a21d3f83733f9034f2a6447adfe.U1-p3yB5bpclrzWdqZAL-uhieEDSDVtVwYiVSI7oyQc
+        hash: v1.k794b7964.293821301d395841fddf30d5a2d70375834d4d3f29141d074ff21a90dbdf5ef8.JaF-miXSOzjj_pNc9GxBZJGdQ5JYJXLlVy0XyLqMtrs
     scenes-other-billing--billing--light:
-        hash: v1.k794b7964.0dfb0e733cc5858f068ffce50bd81e887a3c59de06c32bb569654ab0e99ade60.9lzRtW7O7FiKhrTX9ZG3QnLx2K3m8f14C3bNGkxral0
+        hash: v1.k794b7964.573a3dc0219bdf219f6944d263fc538f68bc833ebede8991daffa4f176931aa5._F2k-ncUT6lLNJ7if18v9SZY4SbCRot-8hnw5-ddOfk
     scenes-other-billing--billing-purchase-credits-modal--dark:
         hash: v1.k794b7964.dc9b77730db0685138240858a0c550db9765c172321e54304e9f297d0bd00adc.v7awXXbWH1-_a9mzHgVKs99YvwpmU6dHZQgLI_OW9k4
     scenes-other-billing--billing-purchase-credits-modal--light:
@@ -5295,9 +5295,9 @@ snapshots:
     scenes-other-billing--billing-unsubscribe-modal--light:
         hash: v1.k794b7964.b676dda14727516b10f340ebb626babaee98152329868ac8aa8c5a3a90ee26d1.MxyCnRf692V5gtPnmOsCTnxMCAAt__URa4rJQJENBZw
     scenes-other-billing--billing-with-credit-cta--dark:
-        hash: v1.k794b7964.b3d4639e966f47b6c847684db6a12398a110cf27233a8db91d043c082f18b47f.4UWLNcoKKtBl26HMvWUmrYrZ-OI6Fd7ILWvOpjCz4uE
+        hash: v1.k794b7964.671be717d51d66645b9501351aea0ded703a0042db6934ccdaa1c7ebc85a188a.gH2hqDf7PqGFGSMfwrtwjRn5hRxZXgaZXUuucCTi7_U
     scenes-other-billing--billing-with-credit-cta--light:
-        hash: v1.k794b7964.10a3e79404d48788838946dc9705e2db59b92ee90253aebac7d77dd2779abe85.7GfH6fz0lX-mJyWUZH4jp5Fb7CggVKeERqI0MQ-h0tU
+        hash: v1.k794b7964.6b92dd93d7304fd3ab221aeeca0d1341fc957263e3e8c34177ad32a5f5b94ab6.p9ZPmKv_YIBruugVavTLIiljAJHUYolSuFUJlxKBvB0
     scenes-other-billing--billing-with-credits--dark:
         hash: v1.k794b7964.457257072f4ee70056be2e1a4551fc098644ce363246c8ce4727a636d6231a06.RvIsfP2a2yPEOYspq28VMp3DZx-mY_nAbnb5OsRGHVU
     scenes-other-billing--billing-with-credits--light:
@@ -5311,25 +5311,25 @@ snapshots:
     scenes-other-billing--billing-with-limit-and-100-percent-discount--light:
         hash: v1.k794b7964.c60133947fb5ef34eaf37fa21bb0390bccff77b1b5fe49e01e9f5a7b239a7c04.oIDvDkc41HCJUBwamg0ahQQYn3NNsIX7cLFMOTjk4VE
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--dark:
-        hash: v1.k794b7964.dc4fccf8ebca69c3f2467f79943ee07128e51d1ff1b4dcd867d2f7aabb2d8b42.QUs_q6oZ3HOkpxGZqUvXvavbgRaHNijyC8SErUlJYiw
+        hash: v1.k794b7964.c0df0df2ebf71de4d5ea223d0649976aa6670a23a4ddfee7d20e60f840e1e083.64wd-og8WBouyV-eDgDEX1u9K3b7Oepbdqimfw3Ea5U
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--light:
-        hash: v1.k794b7964.cc182b410da64a9fa2290ea2b1811c1be10ce76bcf1de5f1206644b68777f5aa.NfR3IjRbxMdhWQy5pKt1klGG4nbIGvmseTG2XBxXmI0
+        hash: v1.k794b7964.6f1a8b014c5a0103eb96839b35e406aaad89e66035d5d4c752f237416bfd63c0.kJRLM6LkW9Jj5VjPiGLDNgoNQrrV-eKmbLcEstL5o4o
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--dark:
-        hash: v1.k794b7964.fd85f9088df0262a16e3c866995eec5b8b8c284318e46f2d8d1f88b79673c301.dh4lRmGm06j7zlQw8trCZivY2GBlmFYblx2lt_Y8Z8s
+        hash: v1.k794b7964.76efcb921ce3995c044cbed643c9b215edc81fd6b19548db7e7ba60e9d033507.ok0wpOfrsmFZ6cewWrsZxb5F4fw8rQAucpHfQj45SoA
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--light:
-        hash: v1.k794b7964.29d4fd65ebc3699ad2af50c3248f5decc8118e39466c811fbe83f3b583f2f409.g9ky4uyz8pPEn2GjiBFEKjMeUjtcxweeLoa50nW_XCc
+        hash: v1.k794b7964.93da26b28c7b22106752f77c7fa66fdb3691593995ac51e36373167841209d6c.AZaWbrbcyl89Sei0KshVxEM-nLNjn4y1BjJeFNtmE2A
     scenes-other-billing-product--billing-product-platform-addons-on-scale--dark:
-        hash: v1.k794b7964.513b1f701eba8bc569c9882d6512341ea60281c0c83aaf7e1e2975f07c8ccd18.YZ7cYR_vY7pq0uYPc0eLW9nYGIPTKZdVRgq0PpfFeKw
+        hash: v1.k794b7964.2fb9da9c8a5b77c47805a836c2bd15779022240ae29a9482516a735f0849297f._dDRjMEuE9SOQMNJUkibocFE2UePxysMjRlxiJ_auvE
     scenes-other-billing-product--billing-product-platform-addons-on-scale--light:
-        hash: v1.k794b7964.1bd527498bd7a876cbd014a265924c26250bcb2026c02cbd7d5776536433c444.XjuGFEchLG9Lhy4VDkYKE4P6Xu9a4dv1JvRyK85MgMU
+        hash: v1.k794b7964.26dc01d44e329c65f0206a120e798fdacd674c69f24e67dac4a9af213641e0f0.8-j4rC8H1XwJv75m35p6xMUsn-JuhvgL1CgwUcutQ2Q
     scenes-other-billing-product--billing-product-platform-addons-trial-available--dark:
-        hash: v1.k794b7964.dc4fccf8ebca69c3f2467f79943ee07128e51d1ff1b4dcd867d2f7aabb2d8b42.xg4P1RWPlWR_8r2XqnDZuO9RIcMcluXF_Jy-N3dOwGQ
+        hash: v1.k794b7964.c0df0df2ebf71de4d5ea223d0649976aa6670a23a4ddfee7d20e60f840e1e083.ltV5JkvSQ-guDC1Vk2d2GaU9xZW5V3_hEwS8SwfrfeA
     scenes-other-billing-product--billing-product-platform-addons-trial-available--light:
-        hash: v1.k794b7964.cc182b410da64a9fa2290ea2b1811c1be10ce76bcf1de5f1206644b68777f5aa.3nZiAgpq3rSoU2EpmG7ltoGZZ5kLizL8Z5AfwqxCCxk
+        hash: v1.k794b7964.6f1a8b014c5a0103eb96839b35e406aaad89e66035d5d4c752f237416bfd63c0.oSN7D68SHmdfgBi-9MS8XSj5XMq-bpRVeXCYDGbf0es
     scenes-other-billing-product--billing-product-platform-addons-trial-used--dark:
-        hash: v1.k794b7964.976383cc81b17b5cbf9944853deac7b612184afa07032d8d649304f97b1b76e5.jXxBT5Jie-qx7APMERRBw4Z7KQYfE4gMGP5sYkF-38Y
+        hash: v1.k794b7964.be30f5ff9b522df35203fd554d92c0c6a4022039882db0e2af65930d80ab7292.a2_bn2aR3YTlF3tqEsmGKHjEGDBCJFdvhaV70-3HhtA
     scenes-other-billing-product--billing-product-platform-addons-trial-used--light:
-        hash: v1.k794b7964.5cfdd7dd009495b1a8c13296498702708806458eef6aa84a5e52cb164392b560.WOuIC4IAhXljk-9rjGZQguZU5lWBsT6u8T0HpaSL9Lg
+        hash: v1.k794b7964.fae056f1e4a2b94a43d50655387e077efc56392c8feb6e243aab6c449bf0a8be.AnijTyvza_alSThGXRA7oymYdNnFir6nhuQkEH_AFcE
     scenes-other-billing-product--billing-product-temporarily-free--dark:
         hash: v1.k794b7964.793c583d893543c9f4ccd111450b803d1966cf2f2d89b9e5e4d34144c41fde7e.7u2bxJwsxrwUWutogyzX9FtdlGxd7mPZkYgglNhgsSs
     scenes-other-billing-product--billing-product-temporarily-free--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -425,77 +425,77 @@ snapshots:
     components-hedgehogmode--static-hedgehog--light:
         hash: v1.k794b7964.43d71f5c3ad02bd9e1fa87433d34df79e0de653c4b55004188bed5de78a2c3f5.i2ATBYyqY7uq7UxwlL2Rdte6AuMyySa8Jnbeb1VouoQ
     components-hogcharts-confidenceintervals--area-chart-with-hatching--dark:
-        hash: v1.k794b7964.5f857d684fe686df0679265b55a1564ef13fab08750023a99241b27648a77c69.isroL1mISOxgoYwg9v9qH_Ktbee7EdDoCzmjbdl4j-8
+        hash: v1.k794b7964.193e2a3711df414de90a8edacd05fc466bcd93ac38c2417eae7eb978dbc7fd99.eyDzDB5-jRnYFwlIylKlrH8ZbzwJz8xeW5W0LLMd5BQ
     components-hogcharts-confidenceintervals--area-chart-with-hatching--light:
-        hash: v1.k794b7964.2531a9ed46e4b3c25f079b18363a98e1e55b11539297c5e27754ae936cd5cf1b.SVd4nhHy1M-Z5cpUMFS8TDfyFW2a9PF5t2HIicIijfA
+        hash: v1.k794b7964.fdee91816d86bd2e29efa409a4a950976cd55392756e7d89caa41eb34bba7e26.Zu-QT4LCi5h8fqawgftOt46UjRCms1w3oBINYmylWSQ
     components-hogcharts-confidenceintervals--multi-series-with-ci--dark:
-        hash: v1.k794b7964.dbee1b12833401a376a20e555e001cb21152cbbe07c7ae49ae8897b94ec6e0de.Tn5Ym7BnIC86N9QxKLPy84Jl8DMetS5x7Pxrsshzs4U
+        hash: v1.k794b7964.76eb1c55841df26f035727adb3e1aeef03c8addc0efc3d97ffaab4d9b294cc30.j5Y76J7iZ493uuiOtFmLa5HDIgJ3amw-0U7RX0sFYgM
     components-hogcharts-confidenceintervals--multi-series-with-ci--light:
-        hash: v1.k794b7964.c7ed1aa2b2e7adde128703393c70da1411df3b7ef2d003011c611aa8977ab24c.9xGz0-JizhacccQg60no1VJQRhUI2n_xiaHW25VCG_E
+        hash: v1.k794b7964.99bf758c61e2550cf9f503c25ef812a556540db22e8bb79121d4bd7fafe82c52.M7Uu40FMy9qywNacmdRGXCxkX0ZDi1LuoYQ9zPmBqnw
     components-hogcharts-confidenceintervals--with-confidence-interval--dark:
-        hash: v1.k794b7964.34253a704e0ca543182f4cdbdac6473077264f710794842e5ccd61debca49631.fF9yOjoQrm6f5rmumEMWDH4Gu8axooMDTEc8Xlp8nKQ
+        hash: v1.k794b7964.2361a0c1dfa2cd3d505400852acf783ed1bbd387445b8a6b5db1764f3e28bafc.2OgFJ6v3t7A7Z-SFc340tRdOW6yVKOp5-2GoQxI1GHM
     components-hogcharts-confidenceintervals--with-confidence-interval--light:
-        hash: v1.k794b7964.2c6fbb402ad80d420aee251b6c2630a980e92292424e381a3b9742e839cbc175.9XI8X-3m7ifzGKDKUETPMxIFY9anqdrQbv55LYvlDKA
+        hash: v1.k794b7964.872d5390447a4e85f525f4f79bd9a6a007ee1cfa90bf1a4341ce22e857cf6918.ay7TMZRj8gV2tKRZEujR_vpiuDCMbPePuNdwxdIPGOk
     components-hogcharts-referenceline--fill-sides--dark:
         hash: v1.k794b7964.90f4952ddfc3e8b1645a462a24fcbde0a40584ffb0b2450fba6df79726a30033.4kZQt2UNtLSWspx7msbeULVNxN7Bm6mV9hNEZ6hZNXs
     components-hogcharts-referenceline--fill-sides--light:
-        hash: v1.k794b7964.a71ab0c23a7c7222476deb4460e75c8a89ff7682f140a034421418202c4b6afc.8l3ygmUZLRyjknLjF-GH3adEfkcX1W2NrY380Dq3Sz0
+        hash: v1.k794b7964.17f8a868cc4c7bfe44f68707e557ceed96ac65c3acd2a5baec7e047a5f77e4ca.byQG4cac7gaKBjoZNU6eaYIQDjA0fm1OiqhdUrkUryw
     components-hogcharts-referenceline--horizontal-goal--dark:
         hash: v1.k794b7964.c5fdf7008f2de74ccf46994fa1d1ad8fad8544eecf5e32b1ce72a2f269e25e55.9E2tPNgIObPg-huyFgvLfOWskL6u5XRRWfkRrCBOsc4
     components-hogcharts-referenceline--horizontal-goal--light:
-        hash: v1.k794b7964.60564511fae1b64d2ec4bed069d247101bfa599c2c05290c06e0251dc61cc07c.csySfcl9y3wcKY5Aexk7p_oBEZM4UxtOk3uvyC0ktWk
+        hash: v1.k794b7964.7741eb34b4f6d03446c484ded5ad8e4434f41b76655daa1e09baa11b0d1c70eb.SprwKaqpL6iBRoIADN1f5QBO_6qa828eNaVzfr2VU08
     components-hogcharts-referenceline--horizontal-variants--dark:
         hash: v1.k794b7964.ce54a72d5735a1cd190f76c1827905f9e7a93c18792bd01c4ec2ccc58b9217dd.n-puhpH3Af34pPHPlJgW4r59RnPZPGxhGfJHIZ1DS2M
     components-hogcharts-referenceline--horizontal-variants--light:
-        hash: v1.k794b7964.e9bd58e91c90ea3881adb25bb844bca46ccdbd14d5b67ce62d146fecf4ef49a6.W1Vbocbn01QPSDg3-UYJgymoa5ixZCosmDzSGBdbAPA
+        hash: v1.k794b7964.40ad007b12a16ef7ad94c25f12c2b34c78bd2ef40f73eff838cd6521eb14034d.M8yvNWxElaz-m9SW63NwWdC4wyX2COzEG-xrhXUJ7Wc
     components-hogcharts-referenceline--label-start-vs-end--dark:
         hash: v1.k794b7964.4534934eac32d82ee4698dfe170bb8478b3544f7bf211ae18d2a4f68483aaf14.uz69Z-T9PlKLydMV2yZj0t9sTRtK1E0TEkmI3yrINVw
     components-hogcharts-referenceline--label-start-vs-end--light:
-        hash: v1.k794b7964.f9e96a9ea2c20280604d7fb14f799da60a7021985374e4c550b64549806133cb.EjRgeSRVB5vUIW2RKCYCYs4kA9IQfqhJ9PrS4sPRByQ
+        hash: v1.k794b7964.2011ccda46dcd2c0c96c43184eceb695aa6479f7022f9d267825fd6cb1dbd3b0.k8sfS2GNrp8nut6UlXp8wozq-jKBygfkS7OswbOsKw0
     components-hogcharts-referenceline--vertical-reference-lines--dark:
         hash: v1.k794b7964.8f27aa8ee4161d4041693a5549046f0e348aab5fdccc466ea461d6a0f5cf97e2.KEpUtlvBURMPzv1Vyq9Pvf8i_sDKoF3t7fZO8Ed1yPs
     components-hogcharts-referenceline--vertical-reference-lines--light:
-        hash: v1.k794b7964.12ee9bdb34e0a1350d67ef73abd8621dd428d7fb565b713c61a2003db02b2091.-cD8-EsT_newJlN05zXLQ5sTZ_6RteILczqWSvQ5osE
+        hash: v1.k794b7964.c5c09ab055b1b0fde7a5d73279e6a1adba9cc4165d0883ea8c641d4cd68ebf2b.hb7hZ9GBhWL6oRE5jtOZuUEer6xZ5dTyjpH0qB4Dfpk
     components-hogcharts-trendlines--multi-series-with-trend-lines--dark:
-        hash: v1.k794b7964.578da6198bfc384c3a1745c4fb065fb432f829c7a6b1f710f0bb80f77f61bde8.R92w8u3UUCE13JxPsgGUQKUlm_VKsYo8KmNf_Dh0dh0
+        hash: v1.k794b7964.c4d1b48451ab3231999f574e32c46f09fe726674e38ceed7287a56436af6dd65.oZ76MjCQgERyreA76uIexJnztbryt_ybWv5H-mvH6K8
     components-hogcharts-trendlines--multi-series-with-trend-lines--light:
-        hash: v1.k794b7964.b5ff3b2eadc5ab0aee4ed2c38b5f41974452f429adc68e1a1c03357b1e8e9fc3.FsSXW-ULWLC9xrZJi8DMaewkru57GvY25GP2tB6BPuk
+        hash: v1.k794b7964.a8b652bba2fbd790320cbbf86634348aab1ce13d02a587c94004645908d6341f.fePjyvEHeZEikIzUN1avYMLjf5SRxYR9baBAa8Dap00
     components-hogcharts-trendlines--trend-line-with-incomplete-period--dark:
-        hash: v1.k794b7964.73f36c27bc79d89db2f6fffe93ed0228fee5bfb44240b3613a84a5c3a64da65b.Po9mKppi4LsB6-nAMKjA2KgeTKQSjGWqhYxoQjUYYsg
+        hash: v1.k794b7964.d04494a4e11636fc66822df81c633d09c0e03f8f89a04e543d0c217047fd3329.U8Y3eNsEKJDo0ATa1ZhK8Katkc-kr3eXHasN6fL8Xjs
     components-hogcharts-trendlines--trend-line-with-incomplete-period--light:
-        hash: v1.k794b7964.c86f2feb2f761b56d2828fc63cf8def695a682b3784f51ecb7bae82b155f3531.SOsy4fk0TmnKWkFjSPazPJhkPUCGlqpnoJGSMqMtPxQ
+        hash: v1.k794b7964.2d3dcb5ba740b6771510220828f93bd2c6c0d83325b556e253f3fd91a51c4b1d.cXH6b81E_M5MLlFdOZj_yQoD9i0UYIR7HGVaGZNNaAc
     components-hogcharts-trendlines--with-trend-line--dark:
-        hash: v1.k794b7964.e79d9bd628231ff272f7616daee20cdda600e3d73d3d7f7053fee2f2a26627ac.WHaEK3QdJYKz_0z-XBJHgmymwMthF3XuoaJIakRpGgQ
+        hash: v1.k794b7964.26176653b1c3c0c5793a8e27adc23c73a3afa71cba34c1693d8214fe4259857b.dgysrpHK2czRxuLWU3Yp43-PSLazXniyNEwVbx0Sk5Q
     components-hogcharts-trendlines--with-trend-line--light:
-        hash: v1.k794b7964.031d098b111eda98755473f6d42b857a48fcfcc4d140f66ee92ea68fd6637073.I4KaJxlhrj5keiC7WykaUmlCbcBu8WoO1HL8hiaqGU4
+        hash: v1.k794b7964.0398535cd2a0d52b317c4497af47bda576e2872c36fa3488e8c3705c9de70055.2kEDWY3cantl-sob_uk-yES5tny5CCbekfyq5isHa3A
     components-hogcharts-valuelabels--cross-series-overlap-removal--dark:
         hash: v1.k794b7964.b766f038277710789aefeabc721df0c662a10aa672b24e14f7e68349f88f396a.Jef_dCFf6j8X_7hXhsuDQa6KMpkq-BS1akkcNUH46MU
     components-hogcharts-valuelabels--cross-series-overlap-removal--light:
-        hash: v1.k794b7964.cff06072d78522c0c6a15e08e74dba88f3248cb14b08d572ca800dbf910be563.zIlE9_jkswGcT8QC-x1i1PsKRIU7s_HA17ZNBPh5pUc
+        hash: v1.k794b7964.738cf86744e8c623069b0424dc408121c0890856f0b238c327bf6ee80db752fa.cBXFNYsgpPGFXg8N2e2L4PNkzum6hyXTzNN6Du7efLc
     components-hogcharts-valuelabels--dual-y-axes--dark:
-        hash: v1.k794b7964.c59fa1bc6566fc96b0cb92d025b108a40138e9a8a8496d0b3e233aae9d66ed59.QrGcG6laRMqVU7TQdp89RMBC8seb_yRx3TEwrN7vF6A
+        hash: v1.k794b7964.62abb507261bb063565586a275a004a0d3b47ac353e90fbeed26c65ca1269283.ml7ENWI5BKVLuWfSWeI5dJcsxVqvOtCxce_WEvxWrHU
     components-hogcharts-valuelabels--dual-y-axes--light:
-        hash: v1.k794b7964.4386469f5e098a7368f916b4831fc163c5ec7f7dc19761e62e3fc653b874a93e.vdXaWL7pLGhw96-xmxt4PK-XKiD3AvahstM6a_-F5rM
+        hash: v1.k794b7964.9eb63ed9bdc220590b2cae0af8776b41f6ec32d74182647f3f65d114b65f14ab.EB_OqrxJ2qvitx43QmgQjmkU1UX6aieZ2UTv3ufpSdw
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--dark:
         hash: v1.k794b7964.6d55aa7b02f1431eccce354fb2092f8d57f1a354930639e1eb4a550ba59540b5.0MOERS1S2FZ3gCdxsoz8PrMxurpfZq9ioaOO5X3dzWw
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--light:
-        hash: v1.k794b7964.1d21d670655079b968c7a32f49af34c4c5fde6d2cb2ffb437201d4c766250aea.NYWcvSRwJFCcjBfJnp0fOpmWZpQ1CN7JWk0yn3N2u2Q
+        hash: v1.k794b7964.b423c91cffbc16b4fb4c94bd3bb80c75cc6f5314eeaed5ba7c44f58a4dc02c9c._fTMFjN74s3JUZ8U5pcHlxTZzTe7uO9G2hixlWWuBV0
     components-hogcharts-valuelabels--multi-series-collision--dark:
-        hash: v1.k794b7964.3e831219695d3b2e2679faa95e4c5b70f06959c53de6dd6c71b6e375b485d514.HvUvjDgcyCdbvcY2ITeLEaS0M-A75vVU2qYSHC-O56A
+        hash: v1.k794b7964.bfc6898117609b6447503f3a2a24497e526e6f37dd9225332b5d1645d5886920.SJhI4YbdThoOZSqnoyBO612qzUmm-YkzmFb-xVXmr74
     components-hogcharts-valuelabels--multi-series-collision--light:
-        hash: v1.k794b7964.cbb2de65e2334b96bf752473e861e12826cd089ea8c427d404f89e3febfb719d.LF1QrV8BLIPslpRJMADQNr2gYgzyGdBBbPV-q1uKUY0
+        hash: v1.k794b7964.083a141ca72d3e4f54a9d39cd22ea27af8365702f1d9eb50aa657d606575264f.hYJk2mifWFWHmBLZh3T_SZTvC9FgryryhzAWwGbNaaY
     components-hogcharts-valuelabels--negative-values--dark:
         hash: v1.k794b7964.084ed1c20e236fa9ccd59c10449535e91487c01029ffb7d39c103bde8d206e73.4uYU-zN-9MIL2gu_0wtPkYPFO9iKBLlM70dUcKsRsec
     components-hogcharts-valuelabels--negative-values--light:
-        hash: v1.k794b7964.4cb29caf9337c3c23ac16658ccf2df46865c440170febede1842f7a293c830ef.UjUgL5B54SbOYJYEnntavnsZZxZMP4ZcxJEhLQM-nIk
+        hash: v1.k794b7964.d0ba0d11f0168b9861a9ab51ed874f239f30c58f730b094cbc319c464d69a915.2YZ5kCzOMQRlM8wwCD0VyJLldGWLOd_3SOxysL92k84
     components-hogcharts-valuelabels--single-series--dark:
         hash: v1.k794b7964.5f5f542bff21e42d779f36ffb063812be6426f9b978923f5a690ac4da831e23f.VnV0gDnMaQaGaTxV66nNL4lvumyI2nknOgY7tUiCi_w
     components-hogcharts-valuelabels--single-series--light:
-        hash: v1.k794b7964.5b00b365741d5bd03b112455e14f735077dab9fd4f0f7b7224a7921e3da88785.Kc87s1yKUIjsG3YpBaC3yAXfJYqQvyirhH9v0e54AjY
+        hash: v1.k794b7964.c506075149be03109b832c92efaf1d12d9c57ff1679d2f5fc3cfeaad3b304971.6qLWBIFOKR77_s_qKcyxvDR0dS-RVooMQAp9JMuiRN4
     components-hogcharts-valuelabels--with-custom-formatter--dark:
         hash: v1.k794b7964.284c816866c7f67906abf9dd62203ab9a41dc886e7f1cca01a544d8e33316ad1.At2dmfyFhRyVBLUMETHoOy7_63K5F51s5l9N-FCP-94
     components-hogcharts-valuelabels--with-custom-formatter--light:
-        hash: v1.k794b7964.818c9c01d63fc7cc299b13bfb29bcefa0e02eb6aa9732b56a73037e5f4b96a60.gFgqVn2RSJGVjYsTP_qBRlMqk8nDrboIYuJl7vPJwwU
+        hash: v1.k794b7964.f75097bea54619a6b41c9b00084f09b5ab2b81eb3b3cbd1881310a09015e6380.E3Rs8YqC-5CH8xdU2x4Ri1qaLO84PEj17DrPrlJZDjE
     components-hogfetti--hogfetti--dark:
         hash: v1.k794b7964.dc6868e284e60433ae001da81ba90cf3f05eef1dae1765a849c6e9c63f1ae2ea.T9sV0zE441WqbpRr2zp64VZZfC1xlzxST-bxbW2egvI
     components-hogfetti--hogfetti--light:
@@ -5283,9 +5283,9 @@ snapshots:
     scenes-app-web-analytics--web-analytics-dashboard--light:
         hash: v1.k794b7964.0d336797602434aaaf6364ba4030ee4bd93762ae2df7223e1151bc6002ea2a60.oy7VmDHh6XEZi9xvVObmMtvWqO11BZY46XPgOc36mPQ
     scenes-other-billing--billing--dark:
-        hash: v1.k794b7964.293821301d395841fddf30d5a2d70375834d4d3f29141d074ff21a90dbdf5ef8.JaF-miXSOzjj_pNc9GxBZJGdQ5JYJXLlVy0XyLqMtrs
+        hash: v1.k794b7964.0fbd211a7ee299a4abb1afb6d3d1e0589eb349c82c59bd5997b16e434356ee18.HyWfDl8iMD41jnar9y2uxNCx2MJJ6DuHch0n18cCWBA
     scenes-other-billing--billing--light:
-        hash: v1.k794b7964.573a3dc0219bdf219f6944d263fc538f68bc833ebede8991daffa4f176931aa5._F2k-ncUT6lLNJ7if18v9SZY4SbCRot-8hnw5-ddOfk
+        hash: v1.k794b7964.ec333a1128280653920054bbfa7758909259b4ff6b80179ad465afc763a029bf.NneoMyLu4B49A0zcyNsQthEJxuswloZjIh8A-2JlKDQ
     scenes-other-billing--billing-purchase-credits-modal--dark:
         hash: v1.k794b7964.dc9b77730db0685138240858a0c550db9765c172321e54304e9f297d0bd00adc.v7awXXbWH1-_a9mzHgVKs99YvwpmU6dHZQgLI_OW9k4
     scenes-other-billing--billing-purchase-credits-modal--light:
@@ -5295,9 +5295,9 @@ snapshots:
     scenes-other-billing--billing-unsubscribe-modal--light:
         hash: v1.k794b7964.b676dda14727516b10f340ebb626babaee98152329868ac8aa8c5a3a90ee26d1.MxyCnRf692V5gtPnmOsCTnxMCAAt__URa4rJQJENBZw
     scenes-other-billing--billing-with-credit-cta--dark:
-        hash: v1.k794b7964.671be717d51d66645b9501351aea0ded703a0042db6934ccdaa1c7ebc85a188a.gH2hqDf7PqGFGSMfwrtwjRn5hRxZXgaZXUuucCTi7_U
+        hash: v1.k794b7964.53893ebd7f73563e2e83b32f6c0d819eca291be67e480af696f2d77ee71f113a.OcFNrsOVcSzBB0oBvAK-0_Yu1XeQmfQhtBNcY_s24_s
     scenes-other-billing--billing-with-credit-cta--light:
-        hash: v1.k794b7964.6b92dd93d7304fd3ab221aeeca0d1341fc957263e3e8c34177ad32a5f5b94ab6.p9ZPmKv_YIBruugVavTLIiljAJHUYolSuFUJlxKBvB0
+        hash: v1.k794b7964.f4bcaf25e2cce65f109b1dcffdd98ee7e990a8d63f4142c8b46c84485247f120.VkO7gG_OVPe8LKTqjT8PhVZUm7kpjvO5JMbV7fwqolM
     scenes-other-billing--billing-with-credits--dark:
         hash: v1.k794b7964.457257072f4ee70056be2e1a4551fc098644ce363246c8ce4727a636d6231a06.RvIsfP2a2yPEOYspq28VMp3DZx-mY_nAbnb5OsRGHVU
     scenes-other-billing--billing-with-credits--light:
@@ -5311,25 +5311,25 @@ snapshots:
     scenes-other-billing--billing-with-limit-and-100-percent-discount--light:
         hash: v1.k794b7964.c60133947fb5ef34eaf37fa21bb0390bccff77b1b5fe49e01e9f5a7b239a7c04.oIDvDkc41HCJUBwamg0ahQQYn3NNsIX7cLFMOTjk4VE
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--dark:
-        hash: v1.k794b7964.c0df0df2ebf71de4d5ea223d0649976aa6670a23a4ddfee7d20e60f840e1e083.64wd-og8WBouyV-eDgDEX1u9K3b7Oepbdqimfw3Ea5U
+        hash: v1.k794b7964.64ccfd0de013c474a9ac6fa2706aa85ae741306312d5b5b5fb3045bff60b9901.BMvWfPso4WjTHMAmPD7zddxGstkpvZEL89vmOB5hcJg
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--light:
-        hash: v1.k794b7964.6f1a8b014c5a0103eb96839b35e406aaad89e66035d5d4c752f237416bfd63c0.kJRLM6LkW9Jj5VjPiGLDNgoNQrrV-eKmbLcEstL5o4o
+        hash: v1.k794b7964.b27a399bdb0861ce79f7d2b5fb3f86343789462f6a3ba862147c79eeca5b9b5a.OJngiZnIIx8jrT-MY_eK1zE7pI-J9DHil3nC4JCsmio
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--dark:
-        hash: v1.k794b7964.76efcb921ce3995c044cbed643c9b215edc81fd6b19548db7e7ba60e9d033507.ok0wpOfrsmFZ6cewWrsZxb5F4fw8rQAucpHfQj45SoA
+        hash: v1.k794b7964.e922ba9818de410151d0b633554fd279e2711b42d03cd4f6d80ea4951127b279.qORTw7PIZtpP2bdTMZpebJ43oIi1YgKuSZfa8LQeiEY
     scenes-other-billing-product--billing-product-platform-addons-on-legacy-teams--light:
-        hash: v1.k794b7964.93da26b28c7b22106752f77c7fa66fdb3691593995ac51e36373167841209d6c.AZaWbrbcyl89Sei0KshVxEM-nLNjn4y1BjJeFNtmE2A
+        hash: v1.k794b7964.9e7da6dcb6b7703cd0b344a1b5a234bf3e094ed955fc93dc9209a5ef739f38b6.7byC6-7Q1xlUUYFaSp2WMKgOL6gFS5zCC2YvkheSFCc
     scenes-other-billing-product--billing-product-platform-addons-on-scale--dark:
-        hash: v1.k794b7964.2fb9da9c8a5b77c47805a836c2bd15779022240ae29a9482516a735f0849297f._dDRjMEuE9SOQMNJUkibocFE2UePxysMjRlxiJ_auvE
+        hash: v1.k794b7964.646170e02093f0d750a126daec494440719c9c1aa1050f02c058c6b82fc3fb6e.ue7TJgQfvgh0ca9zBQW8PJbwZvsTcC7xph-AA50mfpk
     scenes-other-billing-product--billing-product-platform-addons-on-scale--light:
-        hash: v1.k794b7964.26dc01d44e329c65f0206a120e798fdacd674c69f24e67dac4a9af213641e0f0.8-j4rC8H1XwJv75m35p6xMUsn-JuhvgL1CgwUcutQ2Q
+        hash: v1.k794b7964.dec22348aae29dc20122b9a3091df25dbeb823b43fed0b6d75b1e840ca7b04b7.Wc2SDEOixDvWeDXWIs-Fm_d8UqIZq8kbzE2W4xqgUPg
     scenes-other-billing-product--billing-product-platform-addons-trial-available--dark:
-        hash: v1.k794b7964.c0df0df2ebf71de4d5ea223d0649976aa6670a23a4ddfee7d20e60f840e1e083.ltV5JkvSQ-guDC1Vk2d2GaU9xZW5V3_hEwS8SwfrfeA
+        hash: v1.k794b7964.64ccfd0de013c474a9ac6fa2706aa85ae741306312d5b5b5fb3045bff60b9901.YjX5hkBczEhEk5yij5sJKh3OiO_XM9d0q7bnY83l1uM
     scenes-other-billing-product--billing-product-platform-addons-trial-available--light:
-        hash: v1.k794b7964.6f1a8b014c5a0103eb96839b35e406aaad89e66035d5d4c752f237416bfd63c0.oSN7D68SHmdfgBi-9MS8XSj5XMq-bpRVeXCYDGbf0es
+        hash: v1.k794b7964.b27a399bdb0861ce79f7d2b5fb3f86343789462f6a3ba862147c79eeca5b9b5a.P0gZfwTACrxR5OwIrhsiF-EafmuFW53w_l84PVU8MOo
     scenes-other-billing-product--billing-product-platform-addons-trial-used--dark:
-        hash: v1.k794b7964.be30f5ff9b522df35203fd554d92c0c6a4022039882db0e2af65930d80ab7292.a2_bn2aR3YTlF3tqEsmGKHjEGDBCJFdvhaV70-3HhtA
+        hash: v1.k794b7964.c182e6e4a167c2c0b1a0509685313e4fef9544cc72ad6b2fc8baeae386938bd6.FlNMKKoDb8d11W1V7qssIpBbQlMK5ekEy8VgFJj7_Oo
     scenes-other-billing-product--billing-product-platform-addons-trial-used--light:
-        hash: v1.k794b7964.fae056f1e4a2b94a43d50655387e077efc56392c8feb6e243aab6c449bf0a8be.AnijTyvza_alSThGXRA7oymYdNnFir6nhuQkEH_AFcE
+        hash: v1.k794b7964.ec00e43af4951307e829dc14e7f4e9e126849dc2a4ef5f4f434cbb64122e57e8.QegssiorS1CNn5gM1woV2qdWh8XjjHBPeAbdZYuGGcg
     scenes-other-billing-product--billing-product-temporarily-free--dark:
         hash: v1.k794b7964.793c583d893543c9f4ccd111450b803d1966cf2f2d89b9e5e4d34144c41fde7e.7u2bxJwsxrwUWutogyzX9FtdlGxd7mPZkYgglNhgsSs
     scenes-other-billing-product--billing-product-temporarily-free--light:

--- a/frontend/src/lib/hog-charts/ConfidenceIntervals.stories.tsx
+++ b/frontend/src/lib/hog-charts/ConfidenceIntervals.stories.tsx
@@ -1,22 +1,16 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { buildTheme } from 'lib/charts/utils/theme'
 import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import { ciRanges } from 'lib/statistics'
+
+import { Stage, useReactiveTheme } from './story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const CONFIG: LineChartConfig = {
     showGrid: true,
     showCrosshair: false,
-}
-
-function Stage({ children }: { children: React.ReactNode }): JSX.Element {
-    return (
-        // eslint-disable-next-line react/forbid-dom-props
-        <div style={{ height: 280, width: 480, display: 'flex', flexDirection: 'column' }}>{children}</div>
-    )
 }
 
 const meta: Meta = {
@@ -29,21 +23,16 @@ type Story = StoryObj<{}>
 
 export const WithConfidenceInterval: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
+        const color = theme.colors[0]
         const data = [20, 35, 28, 60, 45, 70, 52]
         const [lower, upper] = ciRanges(data, 0.95)
         const series: Series[] = [
-            {
-                key: 'visits',
-                label: 'Visits',
-                color: 'var(--brand-blue)',
-                data,
-                points: { radius: 3 },
-            },
+            { key: 'visits', label: 'Visits', color, data, points: { radius: 3 } },
             {
                 key: 'visits__ci',
                 label: 'Visits (CI)',
-                color: 'var(--brand-blue)',
+                color,
                 data: upper,
                 fill: { opacity: 0.2, lowerData: lower },
                 visibility: { fromTooltip: true },
@@ -59,12 +48,12 @@ export const WithConfidenceInterval: Story = {
 
 export const AreaChartWithHatching: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const series: Series[] = [
             {
                 key: 'visits',
                 label: 'Visits',
-                color: 'var(--brand-blue)',
+                color: '',
                 data: [20, 35, 28, 60, 45, 70, 52],
                 fill: {},
                 points: { radius: 3 },
@@ -81,38 +70,28 @@ export const AreaChartWithHatching: Story = {
 
 export const MultiSeriesWithCI: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
+        const colorA = theme.colors[0]
+        const colorB = theme.colors[1]
         const dataA = [40, 42, 44, 43, 55, 57, 66]
         const dataB = [38, 36, 30, 32, 28, 22, 18]
         const [lowerA, upperA] = ciRanges(dataA, 0.95)
         const [lowerB, upperB] = ciRanges(dataB, 0.95)
         const series: Series[] = [
-            {
-                key: 'visits',
-                label: 'Visits',
-                color: 'var(--brand-blue)',
-                data: dataA,
-                points: { radius: 3 },
-            },
+            { key: 'visits', label: 'Visits', color: colorA, data: dataA, points: { radius: 3 } },
             {
                 key: 'visits__ci',
                 label: 'Visits (CI)',
-                color: 'var(--brand-blue)',
+                color: colorA,
                 data: upperA,
                 fill: { opacity: 0.2, lowerData: lowerA },
                 visibility: { fromTooltip: true },
             },
-            {
-                key: 'signups',
-                label: 'Signups',
-                color: 'var(--brand-red)',
-                data: dataB,
-                points: { radius: 3 },
-            },
+            { key: 'signups', label: 'Signups', color: colorB, data: dataB, points: { radius: 3 } },
             {
                 key: 'signups__ci',
                 label: 'Signups (CI)',
-                color: 'var(--brand-red)',
+                color: colorB,
                 data: upperB,
                 fill: { opacity: 0.2, lowerData: lowerB },
                 visibility: { fromTooltip: true },

--- a/frontend/src/lib/hog-charts/ReferenceLine.stories.tsx
+++ b/frontend/src/lib/hog-charts/ReferenceLine.stories.tsx
@@ -1,30 +1,17 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { buildTheme } from 'lib/charts/utils/theme'
 import { LineChart, ReferenceLine } from 'lib/hog-charts'
 import type { LineChartConfig, ReferenceLineFillSide, ReferenceLineVariant, Series } from 'lib/hog-charts'
 
+import { Stage, useReactiveTheme } from './story-helpers'
+
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
-const SERIES: Series[] = [
-    {
-        key: 'visits',
-        label: 'Visits',
-        color: 'var(--brand-blue)',
-        data: [20, 35, 28, 60, 45, 70, 52],
-    },
-]
+const SERIES: Series[] = [{ key: 'visits', label: 'Visits', color: '', data: [20, 35, 28, 60, 45, 70, 52] }]
 
 const CONFIG: LineChartConfig = {
     showGrid: true,
     showCrosshair: false,
-}
-
-function Stage({ children }: { children: React.ReactNode }): JSX.Element {
-    return (
-        // eslint-disable-next-line react/forbid-dom-props
-        <div style={{ height: 280, width: 480, display: 'flex', flexDirection: 'column' }}>{children}</div>
-    )
 }
 
 const meta: Meta = {
@@ -37,7 +24,7 @@ type Story = StoryObj<{}>
 
 export const HorizontalGoal: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         return (
             <Stage>
                 <LineChart series={SERIES} labels={LABELS} config={CONFIG} theme={theme}>
@@ -50,7 +37,7 @@ export const HorizontalGoal: Story = {
 
 export const HorizontalVariants: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const variants: { variant: ReferenceLineVariant; value: number; label: string }[] = [
             { variant: 'goal', value: 30, label: 'Goal' },
             { variant: 'alert', value: 55, label: 'Alert' },
@@ -70,7 +57,7 @@ export const HorizontalVariants: Story = {
 
 export const VerticalReferenceLines: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         return (
             <Stage>
                 <LineChart series={SERIES} labels={LABELS} config={CONFIG} theme={theme}>
@@ -84,7 +71,7 @@ export const VerticalReferenceLines: Story = {
 
 export const FillSides: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const rows: { side: ReferenceLineFillSide; orientation: 'horizontal' | 'vertical'; value: number | string }[] =
             [
                 { side: 'above', orientation: 'horizontal', value: 45 },
@@ -119,7 +106,7 @@ export const FillSides: Story = {
 
 export const LabelStartVsEnd: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         return (
             // eslint-disable-next-line react/forbid-dom-props
             <div style={{ display: 'flex', gap: 24 }}>

--- a/frontend/src/lib/hog-charts/TrendLines.stories.tsx
+++ b/frontend/src/lib/hog-charts/TrendLines.stories.tsx
@@ -1,22 +1,16 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { buildTheme } from 'lib/charts/utils/theme'
 import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import { trendLine } from 'lib/statistics'
+
+import { Stage, useReactiveTheme } from './story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const CONFIG: LineChartConfig = {
     showGrid: true,
     showCrosshair: false,
-}
-
-function Stage({ children }: { children: React.ReactNode }): JSX.Element {
-    return (
-        // eslint-disable-next-line react/forbid-dom-props
-        <div style={{ height: 280, width: 480, display: 'flex', flexDirection: 'column' }}>{children}</div>
-    )
 }
 
 function trendLineOverlay(parent: Series, fitUpTo?: number): Series {
@@ -41,11 +35,11 @@ type Story = StoryObj<{}>
 
 export const WithTrendLine: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const base: Series = {
             key: 'visits',
             label: 'Visits',
-            color: 'var(--brand-blue)',
+            color: theme.colors[0],
             data: [20, 35, 28, 60, 45, 70, 52],
             points: { radius: 3 },
         }
@@ -60,18 +54,18 @@ export const WithTrendLine: Story = {
 
 export const MultiSeriesWithTrendLines: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const visits: Series = {
             key: 'visits',
             label: 'Visits',
-            color: 'var(--brand-blue)',
+            color: theme.colors[0],
             data: [40, 42, 44, 43, 55, 57, 66],
             points: { radius: 3 },
         }
         const signups: Series = {
             key: 'signups',
             label: 'Signups',
-            color: 'var(--brand-red)',
+            color: theme.colors[1],
             data: [38, 36, 30, 32, 28, 22, 18],
             points: { radius: 3 },
         }
@@ -86,7 +80,7 @@ export const MultiSeriesWithTrendLines: Story = {
 
 export const TrendLineWithIncompletePeriod: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         // First 5 buckets show a steady climb (fit target); last 2 are artificially low
         // because the period is still in progress — they'd pull the slope down if included.
         const data = [20, 25, 35, 40, 50, 15, 8]
@@ -95,7 +89,7 @@ export const TrendLineWithIncompletePeriod: Story = {
         const base: Series = {
             key: 'visits',
             label: 'Visits',
-            color: 'var(--brand-blue)',
+            color: theme.colors[0],
             data,
             points: { radius: 3 },
             stroke: { partial: { fromIndex } },

--- a/frontend/src/lib/hog-charts/ValueLabels.stories.tsx
+++ b/frontend/src/lib/hog-charts/ValueLabels.stories.tsx
@@ -1,21 +1,15 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { buildTheme } from 'lib/charts/utils/theme'
 import { LineChart, ValueLabels } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
+
+import { Stage, useReactiveTheme } from './story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const CONFIG: LineChartConfig = {
     showGrid: true,
     showCrosshair: false,
-}
-
-function Stage({ children }: { children: React.ReactNode }): JSX.Element {
-    return (
-        // eslint-disable-next-line react/forbid-dom-props
-        <div style={{ height: 280, width: 480, display: 'flex', flexDirection: 'column' }}>{children}</div>
-    )
 }
 
 const meta: Meta = {
@@ -28,15 +22,9 @@ type Story = StoryObj<{}>
 
 export const SingleSeries: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const series: Series[] = [
-            {
-                key: 'visits',
-                label: 'Visits',
-                color: 'var(--brand-blue)',
-                data: [20, 35, 28, 60, 45, 70, 52],
-                points: { radius: 3 },
-            },
+            { key: 'visits', label: 'Visits', color: '', data: [20, 35, 28, 60, 45, 70, 52], points: { radius: 3 } },
         ]
         return (
             <Stage>
@@ -50,31 +38,13 @@ export const SingleSeries: Story = {
 
 export const MultiSeriesCollision: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         // Three dense series with values close enough in places that collision
         // avoidance should visibly drop some labels.
         const series: Series[] = [
-            {
-                key: 'desktop',
-                label: 'Desktop',
-                color: 'var(--brand-blue)',
-                data: [40, 42, 44, 43, 45, 47, 46],
-                points: { radius: 3 },
-            },
-            {
-                key: 'mobile',
-                label: 'Mobile',
-                color: 'var(--brand-red)',
-                data: [38, 41, 40, 44, 46, 48, 47],
-                points: { radius: 3 },
-            },
-            {
-                key: 'tablet',
-                label: 'Tablet',
-                color: 'var(--brand-yellow)',
-                data: [36, 39, 42, 41, 43, 46, 44],
-                points: { radius: 3 },
-            },
+            { key: 'desktop', label: 'Desktop', color: '', data: [40, 42, 44, 43, 45, 47, 46], points: { radius: 3 } },
+            { key: 'mobile', label: 'Mobile', color: '', data: [38, 41, 40, 44, 46, 48, 47], points: { radius: 3 } },
+            { key: 'tablet', label: 'Tablet', color: '', data: [36, 39, 42, 41, 43, 46, 44], points: { radius: 3 } },
         ]
         return (
             <Stage>
@@ -88,15 +58,9 @@ export const MultiSeriesCollision: Story = {
 
 export const NegativeValues: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const series: Series[] = [
-            {
-                key: 'delta',
-                label: 'Delta',
-                color: 'var(--brand-blue)',
-                data: [20, -15, 30, -25, 10, -5, 25],
-                points: { radius: 3 },
-            },
+            { key: 'delta', label: 'Delta', color: '', data: [20, -15, 30, -25, 10, -5, 25], points: { radius: 3 } },
         ]
         return (
             <Stage>
@@ -110,12 +74,12 @@ export const NegativeValues: Story = {
 
 export const DualYAxes: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const series: Series[] = [
             {
                 key: 'revenue',
                 label: 'Revenue',
-                color: 'var(--brand-blue)',
+                color: '',
                 data: [1200, 1500, 1100, 1800, 1600, 2100, 1900],
                 yAxisId: 'left',
                 points: { radius: 3 },
@@ -123,7 +87,7 @@ export const DualYAxes: Story = {
             {
                 key: 'conversion',
                 label: 'Conversion %',
-                color: 'var(--brand-red)',
+                color: '',
                 data: [2.1, 2.5, 1.9, 3.2, 2.8, 3.6, 3.1],
                 yAxisId: 'right',
                 points: { radius: 3 },
@@ -141,18 +105,19 @@ export const DualYAxes: Story = {
 
 export const HiddenOnAuxiliarySeries: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
+        const color = theme.colors[0]
         const base: Series = {
             key: 'visits',
             label: 'Visits',
-            color: 'var(--brand-blue)',
+            color,
             data: [20, 35, 28, 60, 45, 70, 52],
             points: { radius: 3 },
         }
         const trendline: Series = {
             key: 'visits__trendline',
             label: 'Visits',
-            color: 'var(--brand-blue)',
+            color,
             data: [22, 30, 38, 46, 54, 62, 70],
             stroke: { pattern: [1, 3] },
             visibility: { fromTooltip: true, fromValueLabels: true },
@@ -169,19 +134,14 @@ export const HiddenOnAuxiliarySeries: Story = {
 
 export const CrossSeriesOverlapRemoval: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
+        const color = theme.colors[0]
         const series: Series[] = [
-            {
-                key: 'main',
-                label: 'Main',
-                color: 'var(--brand-blue)',
-                data: [500, 480, 460, 450, 440, 430, 420],
-                points: { radius: 3 },
-            },
+            { key: 'main', label: 'Main', color, data: [500, 480, 460, 450, 440, 430, 420], points: { radius: 3 } },
             {
                 key: 'moving-avg',
                 label: 'Moving avg',
-                color: 'var(--brand-blue)',
+                color,
                 data: [490, 475, 463, 452, 443, 435, 428],
                 stroke: { pattern: [10, 3] },
             },
@@ -198,12 +158,12 @@ export const CrossSeriesOverlapRemoval: Story = {
 
 export const WithCustomFormatter: Story = {
     render: () => {
-        const theme = buildTheme()
+        const theme = useReactiveTheme()
         const series: Series[] = [
             {
                 key: 'revenue',
                 label: 'Revenue',
-                color: 'var(--brand-blue)',
+                color: '',
                 data: [12000, 15500, 11000, 18400, 16200, 21100, 19800],
                 points: { radius: 3 },
             },

--- a/frontend/src/lib/hog-charts/story-helpers.tsx
+++ b/frontend/src/lib/hog-charts/story-helpers.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, waitFor } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+
+import { buildTheme } from 'lib/charts/utils/theme'
+
+import type { ChartTheme } from './core/types'
+
+/**
+ * `buildTheme()` reads CSS variables from `document.body` once. The Storybook
+ * test runner takes a second screenshot after flipping `body[theme="dark"]`,
+ * but stories that captured the theme at first render keep light-mode colors
+ * in the dark snapshot. This hook re-evaluates `buildTheme()` whenever the
+ * theme attribute changes so the chart's own colors actually update.
+ */
+export function useReactiveTheme(): ChartTheme {
+    const [theme, setTheme] = useState<ChartTheme>(() => buildTheme())
+    useEffect(() => {
+        const observer = new MutationObserver(() => setTheme(buildTheme()))
+        observer.observe(document.body, { attributes: true, attributeFilter: ['theme', 'class'] })
+        return () => observer.disconnect()
+    }, [])
+    return theme
+}
+
+interface StageProps {
+    children: React.ReactNode
+    width?: number | string
+    height?: number
+}
+
+/** Fixed-size chart container shared by stories so snapshots have stable geometry. */
+export function Stage({ children, width = 480, height = 280 }: StageProps): JSX.Element {
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ width, height, display: 'flex', flexDirection: 'column' }}>{children}</div>
+    )
+}
+
+/**
+ * Dispatch a `mousemove` on the chart wrapper at a fraction of its width.
+ * Used in `play` functions to make hover-driven overlays (tooltip, crosshair,
+ * highlight ring) visible in screenshots.
+ */
+export async function playHoverAtFraction(
+    canvasElement: HTMLElement,
+    fraction: number,
+    yFraction: number = 0.5
+): Promise<void> {
+    const wrapper = await waitFor(
+        () => {
+            const canvas = canvasElement.querySelector<HTMLCanvasElement>('canvas[role="img"]')
+            const parent = canvas?.parentElement
+            if (!parent) {
+                throw new Error('chart wrapper not yet rendered')
+            }
+            const rect = parent.getBoundingClientRect()
+            if (rect.width < 50 || rect.height < 50) {
+                throw new Error('chart wrapper not yet sized')
+            }
+            return parent
+        },
+        { timeout: 3000 }
+    )
+    const rect = wrapper.getBoundingClientRect()
+    fireEvent.mouseMove(wrapper, {
+        clientX: rect.left + rect.width * fraction,
+        clientY: rect.top + rect.height * yFraction,
+    })
+    await waitFor(
+        () => {
+            if (!document.querySelector('[data-hog-charts-tooltip]')) {
+                throw new Error('tooltip not yet rendered')
+            }
+        },
+        { timeout: 1000 }
+    )
+}


### PR DESCRIPTION
## Problem

The four existing hog-charts story files each duplicated the same `Stage` wrapper and called `buildTheme()` once at render time. `buildTheme()` reads CSS variables from `document.body`, but the storybook test runner takes its dark-mode screenshot after flipping `body[theme="dark"]`, so the dark snapshot reused the light-mode palette captured at first render. Charts also painted with `var(--brand-…)` series colors directly — `<canvas>` doesn't resolve CSS variables, so `ctx.strokeStyle` silently dropped them and lines came out black.

## Changes

- Add `frontend/src/lib/hog-charts/story-helpers.tsx` exporting:
  - `Stage` — fixed-size container previously inlined in each story file.
  - `useReactiveTheme()` — re-runs `buildTheme()` whenever the body's `theme` attribute or `class` changes via `MutationObserver`, so dark-mode snapshots actually pick up dark colors.
  - `playHoverAtFraction()` — waits for the chart wrapper to size, dispatches a `mousemove` at a fraction of its width, and waits for the tooltip portal. Used by hover stories in the stacked PR.
- Update `ConfidenceIntervals`, `ReferenceLine`, `TrendLines`, and `ValueLabels` story files to import these helpers and replace `var(--brand-…)` series colors with hex values from `theme.colors[i]` (already resolved via `getColorVar` → `getComputedStyle`).
- Refresh the affected snapshot hashes.

The actual chart-level snapshot coverage is in the stacked follow-up: #57009.

## How did you test this code?

I'm an agent (PostHog Code / Claude Opus 4.7). I ran:

- `oxlint` against the touched files — 0 warnings, 0 errors.
- `oxfmt` against the touched files.
- Type-check via a scoped tsconfig — no errors in changed files.

I did not run the storybook test runner. The visual baseline bot will regenerate any drifted hashes on CI.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). This PR is the first half of a split — kept here are the shared helpers and the color/theme reactivity fix; the new `LineChart.stories.tsx` (chart-level coverage) is stacked in #57009 so each branch stays under 500 lines of change.

Key decisions:
- The dark-mode fix uses a `MutationObserver` on `body`'s `theme` attribute and `class` rather than touching `buildTheme()` itself — keeps the production utility unchanged.
- Replaced `var(--…)` series colors with `theme.colors[i]` (resolved hex) because `<canvas>` can't parse CSS variables.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*