### PR TITLE
feat(llma): percentage rollout for ai_events ingestion split

### DIFF
--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -92,7 +92,12 @@ function buildPipeline(configOverrides: Partial<AiEventSubpipelineConfig> = {}) 
             updatePersonWithPropertiesDiffForUpdate: jest.fn().mockResolvedValue([existingPerson, [], false]),
         } as any,
         groupStore: {} as any,
-        splitAiEventsConfig: { enabled: false, enabledTeams: '*', stripHeavyTeams: [] },
+        splitAiEventsConfig: {
+            enabled: false,
+            enabledTeams: '*',
+            enabledPercentage: 0,
+            stripHeavyTeams: [],
+        },
         groupId: 'test-group',
         topHog: (step) => step,
         ...configOverrides,

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -158,8 +158,13 @@ export type IngestionConsumerConfig = {
 
     // AI event splitting config
     INGESTION_AI_EVENT_SPLITTING_ENABLED: boolean
-    /** '*' for all teams, or comma-separated team IDs */
+    /** '*' for all teams, or comma-separated team IDs always routed to ai_events */
     INGESTION_AI_EVENT_SPLITTING_TEAMS: string
+    /**
+     * Sticky percentage rollout (0-100), unioned with INGESTION_AI_EVENT_SPLITTING_TEAMS.
+     * Bucketed deterministically on team_id so increases are monotonic and per-team writes don't flap.
+     */
+    INGESTION_AI_EVENT_SPLITTING_PERCENTAGE: number
     /**
      * Teams whose events copy should have heavy AI properties stripped — i.e. the post-migration final state
      * where heavy columns live only in the AI events table. '*' for all teams, or comma-separated team IDs.
@@ -264,6 +269,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         // AI event splitting config
         INGESTION_AI_EVENT_SPLITTING_ENABLED: false,
         INGESTION_AI_EVENT_SPLITTING_TEAMS: '*',
+        INGESTION_AI_EVENT_SPLITTING_PERCENTAGE: 0,
         INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS: '',
 
         // Clickhouse topics

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
@@ -601,5 +601,31 @@ describe('split-ai-events-step', () => {
             expect(await runForTeam(config, 1)).toBe(2)
             expect(await runForTeam(config, 999_999)).toBe(2)
         })
+
+        it('bucketing stays stable for team ids past the f64-precision threshold (~3.4M)', async () => {
+            // Without Math.imul, `teamId * 2654435761` loses precision past 2^53, shifting
+            // the bucket by ±1 for teamIds ≳ 3.4M. teamId 3_393_265 lands in bucket 77
+            // under the corrected implementation; the naive multiplication would produce 76.
+            const noRollout: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [],
+                enabledPercentage: 77,
+                stripHeavyTeams: [],
+            }
+            const fullRollout: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [],
+                enabledPercentage: 78,
+                stripHeavyTeams: [],
+            }
+            // bucket 77, threshold 77 → not routed; threshold 78 → routed.
+            expect(await runForTeam(noRollout, 3_393_265)).toBe(1)
+            expect(await runForTeam(fullRollout, 3_393_265)).toBe(2)
+            // High teamIds still respect 0% and 100% boundaries.
+            for (const teamId of [10_000_000, 50_000_000, 99_999_999]) {
+                expect(await runForTeam({ ...noRollout, enabledPercentage: 0 }, teamId)).toBe(1)
+                expect(await runForTeam({ ...noRollout, enabledPercentage: 100 }, teamId)).toBe(2)
+            }
+        })
     })
 })

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.test.ts
@@ -26,10 +26,16 @@ function createProcessedEvent(
     }
 }
 
-const ENABLED_FOR_ALL: SplitAiEventsStepConfig = { enabled: true, enabledTeams: '*', stripHeavyTeams: '*' }
+const ENABLED_FOR_ALL: SplitAiEventsStepConfig = {
+    enabled: true,
+    enabledTeams: '*',
+    enabledPercentage: 0,
+    stripHeavyTeams: '*',
+}
 const ENABLED_NO_STRIP: SplitAiEventsStepConfig = {
     enabled: true,
     enabledTeams: '*',
+    enabledPercentage: 0,
     stripHeavyTeams: [],
 }
 
@@ -40,37 +46,37 @@ describe('split-ai-events-step', () => {
                 enabled: true,
                 teams: '*',
                 stripTeams: '',
-                expected: { enabled: true, enabledTeams: '*', stripHeavyTeams: [] },
+                expected: { enabled: true, enabledTeams: '*', enabledPercentage: 0, stripHeavyTeams: [] },
             },
             {
                 enabled: false,
                 teams: '*',
                 stripTeams: '',
-                expected: { enabled: false, enabledTeams: '*', stripHeavyTeams: [] },
+                expected: { enabled: false, enabledTeams: '*', enabledPercentage: 0, stripHeavyTeams: [] },
             },
             {
                 enabled: true,
                 teams: '1,2,3',
                 stripTeams: '*',
-                expected: { enabled: true, enabledTeams: [1, 2, 3], stripHeavyTeams: '*' },
+                expected: { enabled: true, enabledTeams: [1, 2, 3], enabledPercentage: 0, stripHeavyTeams: '*' },
             },
             {
                 enabled: true,
                 teams: ' 1 , 2 ',
                 stripTeams: '2',
-                expected: { enabled: true, enabledTeams: [1, 2], stripHeavyTeams: [2] },
+                expected: { enabled: true, enabledTeams: [1, 2], enabledPercentage: 0, stripHeavyTeams: [2] },
             },
             {
                 enabled: true,
                 teams: '',
                 stripTeams: '',
-                expected: { enabled: true, enabledTeams: [], stripHeavyTeams: [] },
+                expected: { enabled: true, enabledTeams: [], enabledPercentage: 0, stripHeavyTeams: [] },
             },
             {
                 enabled: true,
                 teams: 'abc,1',
                 stripTeams: 'abc,2',
-                expected: { enabled: true, enabledTeams: [1], stripHeavyTeams: [2] },
+                expected: { enabled: true, enabledTeams: [1], enabledPercentage: 0, stripHeavyTeams: [2] },
             },
         ])(
             'should parse enabled=$enabled teams=$teams stripTeams=$stripTeams',
@@ -78,6 +84,18 @@ describe('split-ai-events-step', () => {
                 expect(parseSplitAiEventsConfig(enabled, teams, stripTeams)).toEqual(expected)
             }
         )
+
+        it.each([
+            { input: 25, expected: 25 },
+            { input: 0, expected: 0 },
+            { input: 100, expected: 100 },
+            { input: 150, expected: 100 },
+            { input: -5, expected: 0 },
+            { input: NaN, expected: 0 },
+            { input: Infinity, expected: 100 },
+        ])('should clamp percentage $input -> $expected', ({ input, expected }) => {
+            expect(parseSplitAiEventsConfig(true, '', '', input).enabledPercentage).toBe(expected)
+        })
     })
 
     describe('feature flag behavior', () => {
@@ -85,6 +103,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: false,
                 enabledTeams: '*',
+                enabledPercentage: 0,
                 stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
@@ -103,6 +122,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
                 enabledTeams: [99, 100],
+                enabledPercentage: 0,
                 stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input' })
@@ -120,6 +140,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
                 enabledTeams: [1, 2],
+                enabledPercentage: 0,
                 stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
@@ -137,6 +158,7 @@ describe('split-ai-events-step', () => {
             const step = createSplitAiEventsStep({
                 enabled: true,
                 enabledTeams: '*',
+                enabledPercentage: 0,
                 stripHeavyTeams: '*',
             })
             const event = createProcessedEvent({ $ai_input: 'large input', $ai_model: 'gpt-4' })
@@ -420,6 +442,7 @@ describe('split-ai-events-step', () => {
         const step = createSplitAiEventsStep({
             enabled: true,
             enabledTeams: '*',
+            enabledPercentage: 0,
             stripHeavyTeams: [2],
         })
 
@@ -455,6 +478,128 @@ describe('split-ai-events-step', () => {
             expect(eventsToEmit[0].event.properties).toHaveProperty('$ai_input', 'large input')
             expect(eventsToEmit[1].event).toBe(event)
             expect(eventsToEmit[1].event.properties).toHaveProperty('$ai_input', 'large input')
+        })
+    })
+
+    describe('percentage rollout', () => {
+        async function runForTeam(config: SplitAiEventsStepConfig, teamId: number): Promise<number> {
+            const step = createSplitAiEventsStep(config)
+            const event = createProcessedEvent({ $ai_input: 'x', $ai_model: 'gpt-4' })
+            const result = await step({ eventsToEmit: [{ event, output: EVENTS_OUTPUT }], teamId })
+            if (!isOkResult(result)) {
+                throw new Error('expected ok result')
+            }
+            return result.value.eventsToEmit.length
+        }
+
+        it('routes no team when percentage is 0 and team list is empty', async () => {
+            const config: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [],
+                enabledPercentage: 0,
+                stripHeavyTeams: [],
+            }
+            for (const teamId of [1, 2, 3, 99, 1234]) {
+                expect(await runForTeam(config, teamId)).toBe(1)
+            }
+        })
+
+        it('routes every team when percentage is 100', async () => {
+            const config: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [],
+                enabledPercentage: 100,
+                stripHeavyTeams: [],
+            }
+            for (const teamId of [1, 2, 3, 99, 1234]) {
+                expect(await runForTeam(config, teamId)).toBe(2)
+            }
+        })
+
+        it('rollout is monotonic — every team in at X% stays in at any Y% > X%', async () => {
+            const teamIds = Array.from({ length: 1000 }, (_, i) => i + 1)
+            const inAt: Record<number, Set<number>> = {}
+            for (const pct of [10, 25, 50, 75, 90, 100]) {
+                const config: SplitAiEventsStepConfig = {
+                    enabled: true,
+                    enabledTeams: [],
+                    enabledPercentage: pct,
+                    stripHeavyTeams: [],
+                }
+                inAt[pct] = new Set()
+                for (const teamId of teamIds) {
+                    if ((await runForTeam(config, teamId)) === 2) {
+                        inAt[pct].add(teamId)
+                    }
+                }
+            }
+            for (const [lo, hi] of [
+                [10, 25],
+                [25, 50],
+                [50, 75],
+                [75, 90],
+                [90, 100],
+            ]) {
+                for (const teamId of inAt[lo]) {
+                    expect(inAt[hi].has(teamId)).toBe(true)
+                }
+            }
+        })
+
+        it('rollout bucket distribution stays close to the configured percentage', async () => {
+            const teamIds = Array.from({ length: 10_000 }, (_, i) => i + 1)
+            const config: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [],
+                enabledPercentage: 25,
+                stripHeavyTeams: [],
+            }
+            let routed = 0
+            for (const teamId of teamIds) {
+                if ((await runForTeam(config, teamId)) === 2) {
+                    routed++
+                }
+            }
+            const ratio = routed / teamIds.length
+            expect(ratio).toBeGreaterThan(0.22)
+            expect(ratio).toBeLessThan(0.28)
+        })
+
+        it('union: explicit team is always routed, even when its bucket falls outside the percentage', async () => {
+            // Team 2's bucket is 26 — at percentage 10 it would be excluded by hash alone.
+            const config: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [2],
+                enabledPercentage: 10,
+                stripHeavyTeams: [],
+            }
+            expect(await runForTeam(config, 2)).toBe(2)
+        })
+
+        it('union: percentage routes additional teams beyond the explicit list', async () => {
+            const config: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: [2],
+                enabledPercentage: 50,
+                stripHeavyTeams: [],
+            }
+            // teamId 5 → bucket 17 (under 50%); not in the explicit list
+            expect(await runForTeam(config, 5)).toBe(2)
+            // teamId 2 → in the explicit list
+            expect(await runForTeam(config, 2)).toBe(2)
+            // teamId 3 → bucket 87 (above 50%); not in the explicit list
+            expect(await runForTeam(config, 3)).toBe(1)
+        })
+
+        it("'*' routes everything regardless of percentage", async () => {
+            const config: SplitAiEventsStepConfig = {
+                enabled: true,
+                enabledTeams: '*',
+                enabledPercentage: 0,
+                stripHeavyTeams: [],
+            }
+            expect(await runForTeam(config, 1)).toBe(2)
+            expect(await runForTeam(config, 999_999)).toBe(2)
         })
     })
 })

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
@@ -17,10 +17,16 @@ const LARGE_AI_PROPERTIES = new Set([
 export interface SplitAiEventsStepConfig {
     enabled: boolean
     /**
-     * '*' for all teams, or a small array of enabled team IDs.
+     * '*' for all teams, or a small array of always-routed team IDs.
      * Hot-path lookup uses Array.includes; expected size is ~3–10, which beats Set in V8.
      */
     enabledTeams: number[] | '*'
+    /**
+     * Sticky percentage rollout (0-100), unioned with enabledTeams. A team is routed if it's
+     * in the allowlist OR its bucket falls under the percentage. Bucketing is deterministic on
+     * team_id, so the rollout is monotonic — every team in at X% stays in at any Y% > X%.
+     */
+    enabledPercentage: number
     /**
      * Teams whose events copy should have heavy AI properties stripped — i.e. the post-migration final state
      * where heavy columns live only in the AI events table. '*' for all teams, or a small array of team IDs.
@@ -89,14 +95,47 @@ function parseTeamsList(teamsStr: string): number[] | '*' {
         .filter((n) => !isNaN(n))
 }
 
+function clampPercentage(pct: number): number {
+    if (Number.isNaN(pct) || pct <= 0) {
+        return 0
+    }
+    if (pct >= 100) {
+        return 100
+    }
+    return pct
+}
+
+/**
+ * Stable bucket [0, 99] for a team id. Knuth's multiplicative hash so consecutive
+ * team ids don't cluster into the same bucket.
+ */
+function teamRolloutBucket(teamId: number): number {
+    return ((teamId * 2654435761) >>> 0) % 100
+}
+
+function isTeamRouted(teams: number[] | '*', percentage: number, teamId: number): boolean {
+    if (teams === '*' || percentage >= 100) {
+        return true
+    }
+    if (teams.includes(teamId)) {
+        return true
+    }
+    if (percentage <= 0) {
+        return false
+    }
+    return teamRolloutBucket(teamId) < percentage
+}
+
 export function parseSplitAiEventsConfig(
     enabled: boolean,
     teamsStr: string,
-    stripHeavyTeamsStr: string
+    stripHeavyTeamsStr: string,
+    percentage: number = 0
 ): SplitAiEventsStepConfig {
     return {
         enabled,
         enabledTeams: parseTeamsList(teamsStr),
+        enabledPercentage: clampPercentage(percentage),
         stripHeavyTeams: parseTeamsList(stripHeavyTeamsStr),
     }
 }
@@ -105,7 +144,7 @@ export function createSplitAiEventsStep<T extends SplitAiEventsStepInput>(
     config: SplitAiEventsStepConfig
 ): ProcessingStep<T, T & SplitAiEventsStepOutput> {
     return function splitAiEventsStep(input) {
-        if (!config.enabled || (config.enabledTeams !== '*' && !config.enabledTeams.includes(input.teamId))) {
+        if (!config.enabled || !isTeamRouted(config.enabledTeams, config.enabledPercentage, input.teamId)) {
             return Promise.resolve(ok(input))
         }
 

--- a/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
+++ b/nodejs/src/ingestion/event-processing/split-ai-events-step.ts
@@ -110,7 +110,7 @@ function clampPercentage(pct: number): number {
  * team ids don't cluster into the same bucket.
  */
 function teamRolloutBucket(teamId: number): number {
-    return ((teamId * 2654435761) >>> 0) % 100
+    return (Math.imul(teamId, 2654435761) >>> 0) % 100
 }
 
 function isTeamRouted(teams: number[] | '*', percentage: number, teamId: number): boolean {

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -261,7 +261,8 @@ export class IngestionConsumer {
             splitAiEventsConfig: parseSplitAiEventsConfig(
                 this.config.INGESTION_AI_EVENT_SPLITTING_ENABLED,
                 this.config.INGESTION_AI_EVENT_SPLITTING_TEAMS,
-                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS
+                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS,
+                this.config.INGESTION_AI_EVENT_SPLITTING_PERCENTAGE
             ),
             perDistinctIdOptions: {
                 SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: this.config.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -329,7 +329,8 @@ export class IngestionApiServer implements NodeServer {
             splitAiEventsConfig: parseSplitAiEventsConfig(
                 this.config.INGESTION_AI_EVENT_SPLITTING_ENABLED,
                 this.config.INGESTION_AI_EVENT_SPLITTING_TEAMS,
-                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS
+                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS,
+                this.config.INGESTION_AI_EVENT_SPLITTING_PERCENTAGE
             ),
             perDistinctIdOptions: {
                 SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: this.config.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,

--- a/products/llm_analytics/docs/ai-events-table-rollout.md
+++ b/products/llm_analytics/docs/ai-events-table-rollout.md
@@ -14,11 +14,16 @@ Dedicated ClickHouse table for AI events with extracted columns
 
 ## Env vars
 
-| Var                                        | Default | Purpose                                 |
-| ------------------------------------------ | ------- | --------------------------------------- |
-| `INGESTION_AI_EVENT_SPLITTING_ENABLED`     | `false` | Master switch for dual-writing          |
-| `INGESTION_AI_EVENT_SPLITTING_TEAMS`       | `*`     | Team allowlist (`*` or comma-separated) |
-| `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY` | `false` | Strip heavy props from `events` copy    |
+| Var                                              | Default | Purpose                                                             |
+| ------------------------------------------------ | ------- | ------------------------------------------------------------------- |
+| `INGESTION_AI_EVENT_SPLITTING_ENABLED`           | `false` | Master switch for dual-writing                                      |
+| `INGESTION_AI_EVENT_SPLITTING_TEAMS`             | `*`     | Always-routed teams (`*` or comma-separated). Unioned with the pct. |
+| `INGESTION_AI_EVENT_SPLITTING_PERCENTAGE`        | `0`     | Sticky % rollout, deterministic per team_id and monotonic           |
+| `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS` | ``      | Team allowlist for strip-heavy phase (`*` or comma-separated)       |
+
+A team is routed to `ai_events` if it's in `_TEAMS` **or** its team_id bucket falls under `_PERCENTAGE`.
+Buckets are stable (Knuth multiplicative hash of `team_id`), so every team in at X% stays in at any
+Y% > X%. `_TEAMS=*` and `_PERCENTAGE=100` are both ways to route everyone.
 
 ## Feature flag
 
@@ -58,10 +63,13 @@ INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY=false   # keep heavy props in events
 
 ### Phase 5: Expand and flip reads for everyone
 
-- Expand env var teams + feature flag to more teams, then all
-- Monitor query latency and data completeness
-- Once stable: set `STRIP_HEAVY=true` -> events stops getting heavy props
-- CH team is free to rewrite `events` history to drop heavy columns
+- Expand `_PERCENTAGE` 10 → 25 → 50 → 100 to widen the write rollout.
+  Each step is a one-line charts PR. Bucketing is sticky per team, so increases only add
+  teams, never remove them. Test teams pinned in `_TEAMS` stay routed regardless of the percentage.
+- Expand the read-side feature flag to match.
+- Monitor query latency and data completeness.
+- Once stable: set `_STRIP_HEAVY_TEAMS=*` so events stops getting heavy props.
+- CH team is free to rewrite `events` history to drop heavy columns.
 
 ### Phase 6: Cleanup (see section below)
 
@@ -113,9 +121,9 @@ After stable GA and CH team has rewritten events history:
 
 ### Node.js write side
 
-- [ ] Remove `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY` env var
+- [ ] Remove `INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY_TEAMS` env var
       (stripping becomes unconditional, or unnecessary if CH MV strips)
-- [ ] Remove `INGESTION_AI_EVENT_SPLITTING_TEAMS` env var
+- [ ] Remove `INGESTION_AI_EVENT_SPLITTING_TEAMS` and `INGESTION_AI_EVENT_SPLITTING_PERCENTAGE` env vars
       (splitting applies to all teams)
 - [ ] Simplify `SplitAiEventsStepConfig` to just `enabled: boolean`
 - [ ] If CH team changes events MV to exclude heavy props at the table level,


### PR DESCRIPTION
## Problem

The `ai_events` write-side rollout is currently gated by `INGESTION_AI_EVENT_SPLITTING_TEAMS` (CSV of team IDs). To go beyond a fixed allowlist we need a knob that lets us widen the rollout to a sample of all teams without enumerating them, while keeping the existing pinned test teams routed throughout.

## Changes

- Add `INGESTION_AI_EVENT_SPLITTING_PERCENTAGE` (default `0`). A team is routed to `ai_events` if it's in `_TEAMS` **or** its team_id bucket falls under `_PERCENTAGE` — union semantics, not mutually exclusive.
- Bucketing is a Knuth multiplicative hash of `team_id` modulo 100, so the rollout is **monotonic**: every team in at X% stays in at any Y% > X%, and percentage steps don't flap individual teams in and out (which would leave `ai_events` partially populated for that team).
- Strip-heavy stays allowlist-only — the strip phase happens once per cohort, no need for a percentage there.
- Doc and tests updated; no behavior change at default config.

## How did you test this code?

I'm an agent. Automated checks I ran:

- `pnpm jest src/ingestion/event-processing/split-ai-events-step.test.ts` — 51 cases pass, including new tests for 0%/100%, monotonicity across 10/25/50/75/90/100 over 1k teams, distribution sanity at 25% over 10k teams, and the union semantics (pinned team always routed even when its bucket is outside the percentage; bucket routes additional teams beyond the explicit list; `*` wins).
- `pnpm tsc --noEmit` clean.
- `pnpm exec eslint --fix` clean on the touched files.

No manual / production testing performed.

## Publish to changelog?

do not publish to changelog

## Docs update

`products/llm_analytics/docs/ai-events-table-rollout.md` updated to document the new knob and the percentage-based rollout phase. Add `skip-inkeep-docs` if the bot picks this up — internal rollout doc only.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Key decisions:

- **Union, not list-overrides-pct.** PersonHog's precedent (`shouldUseGrpcForTeam` in `nodejs/src/ingestion/personhog/client.ts`) treats the team list as overriding the percentage. For a double-write rollout that's a footgun: switching from allowlist to percentage can drop your pinned test teams unless their bucket happens to fall under the percentage. Union semantics keep pinned teams routed regardless.
- **Sticky bucketing, not `Math.random()`.** PersonHog uses per-call `Math.random()` for its percentage. That's wrong for a double-write to a separate table — half a team's events would land in `ai_events` and half wouldn't, leaving `ai_events` partially populated for that team. Hashing on `team_id` makes routing per-team-stable and rollout bumps monotonic.
- **No percentage on strip-heavy.** Initial draft had a separate `_STRIP_HEAVY_PERCENTAGE`; trimmed to keep the PR lean — strip-heavy is a single forward step, allowlist + `*` cover what we need.
- **Charts impact:** each rollout bump is a one-line edit to `argocd/ingestion/config/ingestion.{prod-us,prod-eu}.yaml`. No code changes needed for incremental expansion once this lands.
