### PR TITLE
ci(codeql): only run go/c-cpp/actions extractors when paths change

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,41 +46,39 @@ jobs:
                         - '**/*.hh'
                         - '**/*.hxx'
 
+            # Keep a CodeQL PR check present while only adding low-volume extractors
+            # when the PR touches their inputs. Pushes and schedules still run all languages.
             - name: Select languages
               id: matrix
-              shell: bash
+              shell: python3 {0}
               env:
+                  EVENT_NAME: ${{ github.event_name }}
                   ACTIONS_CHANGED: ${{ steps.filter.outputs.actions || 'false' }}
                   GO_CHANGED: ${{ steps.filter.outputs.go || 'false' }}
                   C_CPP_CHANGED: ${{ steps.filter.outputs.c_cpp || 'false' }}
               run: |
-                  # Keep a CodeQL PR check present while only adding low-volume extractors
-                  # when the PR touches their inputs. Pushes and schedules still run all languages.
-                  full_matrix='{"include":[{"language":"actions","build-mode":"none"},{"language":"c-cpp","build-mode":"none"},{"language":"go","build-mode":"autobuild"},{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"}]}'
+                  import json, os
 
-                  if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
-                      echo "matrix=$full_matrix" >> "$GITHUB_OUTPUT"
-                      echo "Selected CodeQL matrix: $full_matrix"
-                      exit 0
-                  fi
+                  always = [
+                      {"language": "javascript-typescript", "build-mode": "none"},
+                      {"language": "python", "build-mode": "none"},
+                  ]
+                  conditional = [
+                      ("ACTIONS_CHANGED", {"language": "actions", "build-mode": "none"}),
+                      ("GO_CHANGED", {"language": "go", "build-mode": "autobuild"}),
+                      ("C_CPP_CHANGED", {"language": "c-cpp", "build-mode": "none"}),
+                  ]
 
-                  matrix='{"include":[{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"}'
+                  is_pr = os.environ["EVENT_NAME"] == "pull_request"
+                  include = list(always)
+                  for env_key, entry in conditional:
+                      if not is_pr or os.environ[env_key] == "true":
+                          include.append(entry)
 
-                  if [[ "$ACTIONS_CHANGED" == "true" ]]; then
-                      matrix="${matrix}"',{"language":"actions","build-mode":"none"}'
-                  fi
-
-                  if [[ "$GO_CHANGED" == "true" ]]; then
-                      matrix="${matrix}"',{"language":"go","build-mode":"autobuild"}'
-                  fi
-
-                  if [[ "$C_CPP_CHANGED" == "true" ]]; then
-                      matrix="${matrix}"',{"language":"c-cpp","build-mode":"none"}'
-                  fi
-
-                  matrix="${matrix}"']}'
-                  echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-                  echo "Selected CodeQL matrix: $matrix"
+                  matrix = {"include": include}
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                      f.write(f"matrix={json.dumps(matrix)}\n")
+                  print(f"Selected CodeQL matrix: {json.dumps(matrix)}")
 
     analyze:
         name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,8 @@ jobs:
               shell: python3 {0}
               env:
                   EVENT_NAME: ${{ github.event_name }}
+                  # The filter step is PR-only; on push/schedule its outputs are empty,
+                  # so default to 'false' and let the Python step handle the run-everything case.
                   ACTIONS_CHANGED: ${{ steps.filter.outputs.actions || 'false' }}
                   GO_CHANGED: ${{ steps.filter.outputs.go || 'false' }}
                   C_CPP_CHANGED: ${{ steps.filter.outputs.c_cpp || 'false' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,66 @@ concurrency:
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+    select-languages:
+        name: Select CodeQL languages
+        runs-on: 'ubuntu-latest'
+        timeout-minutes: 5
+        permissions:
+            contents: read
+        outputs:
+            matrix: ${{ steps.matrix.outputs.matrix }}
+        steps:
+            - name: Checkout pull request
+              if: github.event_name == 'pull_request'
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 2
+
+            - name: Select languages
+              id: matrix
+              shell: bash
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+              run: |
+                  full_matrix='{"include":[{"language":"actions","build-mode":"none"},{"language":"c-cpp","build-mode":"none"},{"language":"go","build-mode":"autobuild"},{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"}]}'
+
+                  if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+                      echo "matrix=$full_matrix" >> "$GITHUB_OUTPUT"
+                      echo "Selected CodeQL matrix: $full_matrix"
+                      exit 0
+                  fi
+
+                  changed_files="$(mktemp)"
+                  if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+                      git diff --name-only HEAD^1 HEAD^2 > "$changed_files"
+                  else
+                      git fetch --no-tags --depth=1 origin "$BASE_SHA"
+                      git diff --name-only "$BASE_SHA" HEAD > "$changed_files"
+                  fi
+
+                  # Keep a CodeQL PR check present while only adding low-volume extractors
+                  # when the PR touches their inputs. Pushes and schedules still run all languages.
+                  matrix='{"include":[{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"}'
+
+                  if grep -Eq '^\.github/(workflows|actions)/' "$changed_files"; then
+                      matrix="${matrix}"',{"language":"actions","build-mode":"none"}'
+                  fi
+
+                  if grep -Eq '(\.go$|(^|/)go\.(mod|sum)$)' "$changed_files"; then
+                      matrix="${matrix}"',{"language":"go","build-mode":"autobuild"}'
+                  fi
+
+                  if grep -Eq '\.(c|cc|cpp|cxx|h|hpp|hh|hxx)$' "$changed_files"; then
+                      matrix="${matrix}"',{"language":"c-cpp","build-mode":"none"}'
+                  fi
+
+                  matrix="${matrix}"']}'
+                  echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+                  echo "Selected CodeQL matrix: $matrix"
+
     analyze:
         name: Analyze (${{ matrix.language }})
+        needs: select-languages
         # Runner size impacts CodeQL analysis time. To learn more, please see:
         #   - https://gh.io/recommended-hardware-resources-for-running-codeql
         #   - https://gh.io/supported-runners-and-hardware-resources
@@ -36,26 +94,15 @@ jobs:
         strategy:
             fail-fast: false
             max-parallel: 2
-            matrix:
-                include:
-                    - language: actions
-                      build-mode: none
-                    - language: c-cpp
-                      build-mode: none
-                    - language: go
-                      build-mode: autobuild
-                    - language: javascript-typescript
-                      build-mode: none
-                    - language: python
-                      build-mode: none
-                # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-                # Use `c-cpp` to analyze code written in C, C++ or both
-                # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-                # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-                # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-                # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-                # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-                # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+            # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+            # Use `c-cpp` to analyze code written in C, C++ or both
+            # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+            # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+            # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+            # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+            # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+            # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+            matrix: ${{ fromJSON(needs.select-languages.outputs.matrix) }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,21 +20,42 @@ jobs:
         timeout-minutes: 5
         permissions:
             contents: read
+            pull-requests: read
         outputs:
             matrix: ${{ steps.matrix.outputs.matrix }}
         steps:
-            - name: Checkout pull request
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: filter
               if: github.event_name == 'pull_request'
-              uses: actions/checkout@v6
               with:
-                  fetch-depth: 2
+                  filters: |
+                      actions:
+                        - '.github/workflows/**'
+                        - '.github/actions/**'
+                      go:
+                        - '**/*.go'
+                        - '**/go.mod'
+                        - '**/go.sum'
+                      c_cpp:
+                        - '**/*.c'
+                        - '**/*.cc'
+                        - '**/*.cpp'
+                        - '**/*.cxx'
+                        - '**/*.h'
+                        - '**/*.hpp'
+                        - '**/*.hh'
+                        - '**/*.hxx'
 
             - name: Select languages
               id: matrix
               shell: bash
               env:
-                  BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+                  ACTIONS_CHANGED: ${{ steps.filter.outputs.actions || 'false' }}
+                  GO_CHANGED: ${{ steps.filter.outputs.go || 'false' }}
+                  C_CPP_CHANGED: ${{ steps.filter.outputs.c_cpp || 'false' }}
               run: |
+                  # Keep a CodeQL PR check present while only adding low-volume extractors
+                  # when the PR touches their inputs. Pushes and schedules still run all languages.
                   full_matrix='{"include":[{"language":"actions","build-mode":"none"},{"language":"c-cpp","build-mode":"none"},{"language":"go","build-mode":"autobuild"},{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"}]}'
 
                   if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
@@ -43,27 +64,17 @@ jobs:
                       exit 0
                   fi
 
-                  changed_files="$(mktemp)"
-                  if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
-                      git diff --name-only HEAD^1 HEAD^2 > "$changed_files"
-                  else
-                      git fetch --no-tags --depth=1 origin "$BASE_SHA"
-                      git diff --name-only "$BASE_SHA" HEAD > "$changed_files"
-                  fi
-
-                  # Keep a CodeQL PR check present while only adding low-volume extractors
-                  # when the PR touches their inputs. Pushes and schedules still run all languages.
                   matrix='{"include":[{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"}'
 
-                  if grep -Eq '^\.github/(workflows|actions)/' "$changed_files"; then
+                  if [[ "$ACTIONS_CHANGED" == "true" ]]; then
                       matrix="${matrix}"',{"language":"actions","build-mode":"none"}'
                   fi
 
-                  if grep -Eq '(\.go$|(^|/)go\.(mod|sum)$)' "$changed_files"; then
+                  if [[ "$GO_CHANGED" == "true" ]]; then
                       matrix="${matrix}"',{"language":"go","build-mode":"autobuild"}'
                   fi
 
-                  if grep -Eq '\.(c|cc|cpp|cxx|h|hpp|hh|hxx)$' "$changed_files"; then
+                  if [[ "$C_CPP_CHANGED" == "true" ]]; then
                       matrix="${matrix}"',{"language":"c-cpp","build-mode":"none"}'
                   fi
 


### PR DESCRIPTION
## Problem

CodeQL was running its full 5-language matrix on every PR (`actions`, `c-cpp`, `go`, `javascript-typescript`, `python`), even when a PR didn't touch the inputs for the low-volume extractors. Pushes to `master` and the weekly schedule already ran a full scan, so re-running everything per PR was wasted CI time and contributed to GitHub API rate-limit pressure.

## Changes

- Added a `select-languages` setup job that uses `dorny/paths-filter` to detect changes to Go, C/C++, and workflow/action files.
- The setup job emits a dynamic matrix that the `analyze` job consumes via `fromJSON`.
- For PRs: always include `javascript-typescript` and `python` (so a CodeQL check is always present); add `actions`, `go`, or `c-cpp` only when the PR touches their inputs.
- For pushes and the weekly schedule: still run the full 5-language matrix unchanged.
- Matrix construction uses `shell: python3 {0}` with `json.dumps`, mirroring the convention already used by `.github/workflows/ci-rust.yml`.

## How did you test this code?

Agent-assisted change. I'm an agent.

- Validated the YAML parses with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Ran a local Python harness covering all 7 selection cases (push / schedule / PR-no-changes / PR-go-only / PR-actions-only / PR-cpp-only / PR-all). Behavior matches expectations.
- Real verification happens when this PR's CodeQL check runs.

## Publish to changelog?

no

## 🤖 Agent context

- Tools: Claude Code (Opus 4.7, 1M context).
- Author wrote the original PR; agent refactored the bash JSON-concatenation into a `python3 {0}` block to match the in-repo convention from `ci-rust.yml`. No behavior change vs. the previous PR head, only the matrix-construction style.