### PR TITLE
feat(duckling): route DuckLake backfill through duckgres pgwire

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -31,14 +31,13 @@ Partition Strategy:
 """
 
 import json
-import time
 import calendar
 from datetime import date, datetime, timedelta
 from typing import Any
 
 from django.utils import timezone
 
-import duckdb
+import psycopg
 import structlog
 from clickhouse_driver import Client
 from clickhouse_driver.errors import Error as ClickHouseError
@@ -68,16 +67,16 @@ from posthog.dags.events_backfill_to_ducklake import (
     EXPECTED_DUCKLAKE_COLUMNS,
     MAX_RETRY_ATTEMPTS,
 )
-from posthog.ducklake.common import attach_catalog, escape, get_ducklake_catalog_by_team_org, get_org_config
+from posthog.ducklake.client import _make_duckgres_conninfo
+from posthog.ducklake.common import escape, get_ducklake_catalog_by_team_org
 from posthog.ducklake.models import DuckLakeBackfill, DuckLakeCatalog
-from posthog.ducklake.storage import configure_cross_account_connection
 
 logger = structlog.get_logger(__name__)
 
-# DuckDB memory limit for Dagster pod operations.
-# The Dagster pod has 16Gi total; we cap DuckDB at 4Gi to leave headroom
-# for Python, Dagster framework, and ClickHouse client overhead.
-DUCKDB_MEMORY_LIMIT = "4GB"
+# Catalog alias used by every duckgres connection. Duckgres auto-attaches the
+# DuckLake catalog under this name on session start (see duckgres server.go),
+# so the DAG can hardcode it everywhere instead of threading a config value.
+DUCKLAKE_ALIAS = "ducklake"
 
 
 @retry(
@@ -96,11 +95,21 @@ def _get_cluster() -> ClickhouseCluster:
     return get_cluster()
 
 
-def _connect_duckdb() -> duckdb.DuckDBPyConnection:
-    """Create a DuckDB connection with memory limits appropriate for the Dagster pod."""
-    conn = duckdb.connect(config={"memory_limit": DUCKDB_MEMORY_LIMIT})
-    conn.execute("SET temp_directory = '/tmp/duckdb_temp'")
-    return conn
+def _connect_duckgres(catalog: DuckLakeCatalog) -> psycopg.Connection[Any]:
+    """Open a psycopg connection to the org's duckgres server.
+
+    Each org runs its own duckgres process on the duckling side; it auto-attaches
+    the DuckLake catalog as `ducklake` on connection. The Dagster image is no
+    longer responsible for choosing a duckdb/ducklake version — duckgres is.
+
+    Cross-account S3 credentials are configured server-side via IRSA on the
+    duckling, so the DAG no longer calls `configure_cross_account_connection`.
+    """
+    conninfo = _make_duckgres_conninfo(
+        catalog.team_id if catalog.team_id is not None else 0,
+        organization_id=str(catalog.organization_id),
+    )
+    return psycopg.connect(conninfo, autocommit=True)
 
 
 # Columns to export from ClickHouse events table for duckling backfill.
@@ -422,7 +431,7 @@ def _validate_identifier(identifier: str) -> None:
 
 
 def table_exists(
-    conn: duckdb.DuckDBPyConnection,
+    conn: psycopg.Connection[Any],
     catalog_alias: str,
     schema: str,
     table: str,
@@ -430,10 +439,10 @@ def table_exists(
     """Check if a table exists in the DuckLake catalog.
 
     Args:
-        conn: DuckDB connection with catalog already attached
-        catalog_alias: Catalog alias (must be alphanumeric/underscore only)
-        schema: Schema name (must be alphanumeric/underscore only)
-        table: Table name (must be alphanumeric/underscore only)
+        conn: psycopg connection to the org's duckgres server.
+        catalog_alias: Catalog alias (must be alphanumeric/underscore only).
+        schema: Schema name (must be alphanumeric/underscore only).
+        table: Table name (must be alphanumeric/underscore only).
 
     Returns:
         True if the table exists, False otherwise.
@@ -448,12 +457,12 @@ def table_exists(
     try:
         conn.execute(f"DESCRIBE {catalog_alias}.{schema}.{table}")
         return True
-    except duckdb.CatalogException:
+    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
         return False
 
 
 def _set_table_partitioning(
-    conn: duckdb.DuckDBPyConnection,
+    conn: psycopg.Connection[Any],
     alias: str,
     table: str,
     partition_expr: str,
@@ -466,7 +475,7 @@ def _set_table_partitioning(
     partition expression is safe and will succeed.
 
     Args:
-        conn: DuckDB connection with catalog attached.
+        conn: psycopg connection to the org's duckgres server.
         alias: Catalog alias.
         table: Table name (must be alphanumeric/underscore only).
         partition_expr: Partition expression (e.g., "year(timestamp), month(timestamp), day(timestamp)").
@@ -517,15 +526,10 @@ def ensure_events_table_exists(
     is idempotent and handles race conditions gracefully. Partitioning is also
     idempotent - calling SET PARTITIONED BY multiple times with the same keys succeeds.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckdb()
+    conn = _connect_duckgres(catalog)
     try:
-        configure_cross_account_connection(conn, destinations=[destination])
-        attach_catalog(conn, catalog_config, alias=alias)
-
         if table_exists(conn, alias, "posthog", "events"):
             context.log.info("Events table already exists in duckling catalog")
             # Ensure partitioning is set even on existing tables (idempotent)
@@ -546,11 +550,11 @@ def ensure_events_table_exists(
         ddl = EVENTS_TABLE_DDL.format(catalog=alias)
         try:
             conn.execute(ddl)
-        except duckdb.CatalogException as exc:
-            # Check if this was a race condition (another worker created the table)
+        except psycopg.errors.DuplicateTable as exc:
+            # Race condition: another worker created the table between our
+            # table_exists check and the CREATE. Treat as success.
             if table_exists(conn, alias, "posthog", "events"):
                 context.log.info("Events table was created by another worker")
-                # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
                     conn,
                     alias,
@@ -560,7 +564,6 @@ def ensure_events_table_exists(
                     catalog.team_id,
                 )
                 return False
-            # Real error - log and re-raise
             context.log.exception(f"Failed to create events table: {exc}")
             raise
 
@@ -601,15 +604,10 @@ def ensure_persons_table_exists(
     is idempotent and handles race conditions gracefully. Partitioning is also
     idempotent - calling SET PARTITIONED BY multiple times with the same keys succeeds.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckdb()
+    conn = _connect_duckgres(catalog)
     try:
-        configure_cross_account_connection(conn, destinations=[destination])
-        attach_catalog(conn, catalog_config, alias=alias)
-
         if table_exists(conn, alias, "posthog", "persons"):
             context.log.info("Persons table already exists in duckling catalog")
             # Ensure partitioning is set even on existing tables (idempotent)
@@ -630,11 +628,9 @@ def ensure_persons_table_exists(
         ddl = PERSONS_TABLE_DDL.format(catalog=alias)
         try:
             conn.execute(ddl)
-        except duckdb.CatalogException as exc:
-            # Check if this was a race condition (another worker created the table)
+        except psycopg.errors.DuplicateTable as exc:
             if table_exists(conn, alias, "posthog", "persons"):
                 context.log.info("Persons table was created by another worker")
-                # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
                     conn,
                     alias,
@@ -644,7 +640,6 @@ def ensure_persons_table_exists(
                     catalog.team_id,
                 )
                 return False
-            # Real error - log and re-raise
             context.log.exception(f"Failed to create persons table: {exc}")
             raise
 
@@ -681,15 +676,10 @@ def delete_events_table(
 
     Returns True if the table was deleted, False if it didn't exist.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckdb()
+    conn = _connect_duckgres(catalog)
     try:
-        configure_cross_account_connection(conn, destinations=[destination])
-        attach_catalog(conn, catalog_config, alias=alias)
-
         if not table_exists(conn, alias, "posthog", "events"):
             context.log.info("Events table does not exist, nothing to delete")
             return False
@@ -719,15 +709,10 @@ def delete_persons_table(
 
     Returns True if the table was deleted, False if it didn't exist.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckdb()
+    conn = _connect_duckgres(catalog)
     try:
-        configure_cross_account_connection(conn, destinations=[destination])
-        attach_catalog(conn, catalog_config, alias=alias)
-
         if not table_exists(conn, alias, "posthog", "persons"):
             context.log.info("Persons table does not exist, nothing to delete")
             return False
@@ -756,17 +741,13 @@ def validate_duckling_schema(
     This pre-flight check ensures we don't waste time exporting data that can't
     be registered with DuckLake due to schema mismatches.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckdb()
+    conn = _connect_duckgres(catalog)
     try:
-        configure_cross_account_connection(conn, destinations=[destination])
-        attach_catalog(conn, catalog_config, alias=alias)
-
-        result = conn.execute(f"DESCRIBE {alias}.posthog.events").fetchall()
-        ducklake_columns = {row[0] for row in result}
+        with conn.cursor() as cur:
+            cur.execute(f"DESCRIBE {alias}.posthog.events")
+            ducklake_columns = {row[0] for row in cur.fetchall()}
 
         missing_in_ducklake = EXPECTED_DUCKLAKE_COLUMNS - ducklake_columns
         if missing_in_ducklake:
@@ -805,17 +786,13 @@ def validate_duckling_persons_schema(
     catalog: DuckLakeCatalog,
 ) -> None:
     """Validate that the duckling's persons table schema matches our export columns."""
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckdb()
+    conn = _connect_duckgres(catalog)
     try:
-        configure_cross_account_connection(conn, destinations=[destination])
-        attach_catalog(conn, catalog_config, alias=alias)
-
-        result = conn.execute(f"DESCRIBE {alias}.posthog.persons").fetchall()
-        ducklake_columns = {row[0] for row in result}
+        with conn.cursor() as cur:
+            cur.execute(f"DESCRIBE {alias}.posthog.persons")
+            ducklake_columns = {row[0] for row in cur.fetchall()}
 
         missing_in_ducklake = EXPECTED_DUCKLAKE_PERSONS_COLUMNS - ducklake_columns
         if missing_in_ducklake:
@@ -874,11 +851,6 @@ def _execute_export_with_retry(
         raise
 
 
-def _is_transaction_conflict(exc: BaseException) -> bool:
-    """Check if exception is a DuckLake transaction conflict (retryable)."""
-    return isinstance(exc, duckdb.TransactionException) and "Transaction conflict" in str(exc)
-
-
 def delete_events_partition_data(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -887,17 +859,16 @@ def delete_events_partition_data(
 ) -> int:
     """Delete existing events data for a specific team_id and date from DuckLake.
 
-    This enables idempotent re-processing of partitions by removing existing data
+    Enables idempotent re-processing of partitions by removing existing data
     before registering new files.
 
-    Includes retry logic for DuckLake transaction conflicts, which can occur when
-    multiple concurrent jobs attempt to modify the same table.
+    DuckLake transaction conflicts are retried server-side by duckgres
+    (server/transient.go retryOnConflict, max 5 attempts with jitter), so this
+    function no longer needs an in-process retry loop.
 
     Returns the number of rows deleted.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
     date_str = partition_date.strftime("%Y-%m-%d")
 
     # Range predicate enables DuckLake partition pruning.
@@ -907,68 +878,40 @@ def delete_events_partition_data(
     next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
     delete_sql = f"""
     DELETE FROM {alias}.posthog.events
-    WHERE team_id = $1
-      AND timestamp >= $2
-      AND timestamp < $3
+    WHERE team_id = %s
+      AND timestamp >= %s
+      AND timestamp < %s
     """
 
-    last_exception: Exception | None = None
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        conn = _connect_duckdb()
-        try:
-            configure_cross_account_connection(conn, destinations=[destination])
-            attach_catalog(conn, catalog_config, alias=alias)
+    conn = _connect_duckgres(catalog)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(delete_sql, (team_id, date_str, next_date_str))
+            deleted_count = cur.rowcount
 
-            result = conn.execute(delete_sql, [team_id, date_str, next_date_str]).fetchone()
-            deleted_count = result[0] if result else 0
-
-            if deleted_count > 0:
-                context.log.info(f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}")
-                logger.info(
-                    "duckling_events_partition_deleted",
-                    team_id=team_id,
-                    date=date_str,
-                    deleted_count=deleted_count,
-                )
-            return deleted_count
-
-        except duckdb.CatalogException:
-            context.log.debug(
-                f"Events table doesn't exist yet, nothing to delete for team_id={team_id}, date={date_str}"
-            )
-            return 0
-
-        except Exception as e:
-            last_exception = e
-            if _is_transaction_conflict(e) and attempt < MAX_RETRY_ATTEMPTS - 1:
-                wait_time = min(4 * (2**attempt), 60)
-                context.log.warning(
-                    f"DuckLake transaction conflict on delete attempt {attempt + 1}, retrying in {wait_time}s..."
-                )
-                logger.warning(
-                    "duckling_events_delete_transaction_conflict",
-                    team_id=team_id,
-                    date=date_str,
-                    attempt=attempt + 1,
-                    wait_time=wait_time,
-                )
-                time.sleep(wait_time)
-                continue
-
-            context.log.exception(f"Failed to delete events for team_id={team_id}, date={date_str}")
-            logger.exception(
-                "duckling_events_delete_failed",
+        if deleted_count > 0:
+            context.log.info(f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}")
+            logger.info(
+                "duckling_events_partition_deleted",
                 team_id=team_id,
                 date=date_str,
+                deleted_count=deleted_count,
             )
-            raise
+        return deleted_count
 
-        finally:
-            conn.close()
-
-    if last_exception:
-        raise last_exception
-    return 0
+    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
+        context.log.debug(f"Events table doesn't exist yet, nothing to delete for team_id={team_id}, date={date_str}")
+        return 0
+    except Exception:
+        context.log.exception(f"Failed to delete events for team_id={team_id}, date={date_str}")
+        logger.exception(
+            "duckling_events_delete_failed",
+            team_id=team_id,
+            date=date_str,
+        )
+        raise
+    finally:
+        conn.close()
 
 
 def delete_persons_partition_data(
@@ -982,90 +925,63 @@ def delete_persons_partition_data(
     For full exports (partition_date=None), deletes all persons for the team.
     For daily exports, deletes persons modified on that date.
 
-    Includes retry logic for DuckLake transaction conflicts, which can occur when
-    multiple concurrent jobs attempt to modify the same table.
+    DuckLake transaction conflicts are retried server-side by duckgres, so this
+    function no longer needs an in-process retry loop.
 
     Returns the number of rows deleted.
     """
-    destination = catalog.to_cross_account_destination()
-    catalog_config = get_org_config(str(catalog.organization_id))
-    alias = "ducklake"
+    alias = DUCKLAKE_ALIAS
     date_label = partition_date.strftime("%Y-%m-%d") if partition_date else "full"
 
+    delete_params: tuple[Any, ...]
     if partition_date is None:
         delete_sql = f"""
         DELETE FROM {alias}.posthog.persons
-        WHERE team_id = $1
+        WHERE team_id = %s
         """
-        delete_params: list[Any] = [team_id]
+        delete_params = (team_id,)
     else:
         date_str = partition_date.strftime("%Y-%m-%d")
         next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
         delete_sql = f"""
         DELETE FROM {alias}.posthog.persons
-        WHERE team_id = $1
-          AND _timestamp >= $2
-          AND _timestamp < $3
+        WHERE team_id = %s
+          AND _timestamp >= %s
+          AND _timestamp < %s
         """
-        delete_params = [team_id, date_str, next_date_str]
+        delete_params = (team_id, date_str, next_date_str)
 
-    last_exception: Exception | None = None
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        conn = _connect_duckdb()
-        try:
-            configure_cross_account_connection(conn, destinations=[destination])
-            attach_catalog(conn, catalog_config, alias=alias)
+    conn = _connect_duckgres(catalog)
+    try:
+        if partition_date is None:
+            context.log.info(f"Deleting all existing persons for team_id={team_id}")
+        with conn.cursor() as cur:
+            cur.execute(delete_sql, delete_params)
+            deleted_count = cur.rowcount
 
-            if partition_date is None:
-                context.log.info(f"Deleting all existing persons for team_id={team_id}")
-            result = conn.execute(delete_sql, delete_params).fetchone()
-            deleted_count = result[0] if result else 0
-
-            if deleted_count > 0:
-                context.log.info(f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}")
-                logger.info(
-                    "duckling_persons_partition_deleted",
-                    team_id=team_id,
-                    date=date_label,
-                    deleted_count=deleted_count,
-                )
-            return deleted_count
-
-        except duckdb.CatalogException:
-            context.log.debug(f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}")
-            return 0
-
-        except Exception as e:
-            last_exception = e
-            if _is_transaction_conflict(e) and attempt < MAX_RETRY_ATTEMPTS - 1:
-                wait_time = min(4 * (2**attempt), 60)
-                context.log.warning(
-                    f"DuckLake transaction conflict on delete attempt {attempt + 1}, retrying in {wait_time}s..."
-                )
-                logger.warning(
-                    "duckling_persons_delete_transaction_conflict",
-                    team_id=team_id,
-                    date=date_label,
-                    attempt=attempt + 1,
-                    wait_time=wait_time,
-                )
-                time.sleep(wait_time)
-                continue
-
-            context.log.exception(f"Failed to delete persons for team_id={team_id}, date={date_label}")
-            logger.exception(
-                "duckling_persons_delete_failed",
+        if deleted_count > 0:
+            context.log.info(f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}")
+            logger.info(
+                "duckling_persons_partition_deleted",
                 team_id=team_id,
                 date=date_label,
+                deleted_count=deleted_count,
             )
-            raise
+        return deleted_count
 
-        finally:
-            conn.close()
-
-    if last_exception:
-        raise last_exception
-    return 0
+    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
+        context.log.debug(f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}")
+        return 0
+    except Exception:
+        context.log.exception(f"Failed to delete persons for team_id={team_id}, date={date_label}")
+        logger.exception(
+            "duckling_persons_delete_failed",
+            team_id=team_id,
+            date=date_label,
+        )
+        raise
+    finally:
+        conn.close()
 
 
 def export_events_to_duckling_s3(
@@ -1149,11 +1065,11 @@ def register_file_with_duckling(
 ) -> bool:
     """Register an exported Parquet file with the duckling's DuckLake catalog.
 
-    Uses cross-account role assumption via IRSA. The Dagster worker's IAM role
-    has permission to assume the duckling's cross-account S3 role.
+    Cross-account S3 access is configured server-side on the duckling's duckgres
+    via IRSA, so the DAG only needs a pgwire connection.
 
-    Includes retry logic for DuckLake transaction conflicts, which can occur when
-    multiple concurrent jobs attempt to register files with the same table.
+    DuckLake transaction conflicts are retried server-side by duckgres, so this
+    function no longer needs an in-process retry loop.
 
     Args:
         context: Dagster asset execution context.
@@ -1172,56 +1088,27 @@ def register_file_with_duckling(
         context.log.info(f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}")
         return False
 
-    destination = catalog.to_cross_account_destination()
-    alias = "ducklake"
-    catalog_config = get_org_config(str(catalog.organization_id))
+    alias = DUCKLAKE_ALIAS
 
-    last_exception: Exception | None = None
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        conn = _connect_duckdb()
-        try:
-            configure_cross_account_connection(conn, destinations=[destination])
-            attach_catalog(conn, catalog_config, alias=alias)
+    conn = _connect_duckgres(catalog)
+    try:
+        context.log.info(f"Registering file with DuckLake: {s3_path}")
+        conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
 
-            context.log.info(f"Registering file with DuckLake: {s3_path}")
-            conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
+        context.log.info(f"Successfully registered: {s3_path}")
+        logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
+        return True
 
-            context.log.info(f"Successfully registered: {s3_path}")
-            logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
-            return True
-
-        except Exception as e:
-            last_exception = e
-            if _is_transaction_conflict(e) and attempt < MAX_RETRY_ATTEMPTS - 1:
-                wait_time = min(4 * (2**attempt), 60)  # Exponential backoff: 4, 8, 16, ... capped at 60s
-                context.log.warning(
-                    f"DuckLake transaction conflict on attempt {attempt + 1}, retrying in {wait_time}s..."
-                )
-                logger.warning(
-                    "duckling_registration_transaction_conflict",
-                    s3_path=s3_path,
-                    team_id=catalog.team_id,
-                    attempt=attempt + 1,
-                    wait_time=wait_time,
-                )
-                time.sleep(wait_time)
-                continue
-
-            context.log.exception(f"Failed to register file {s3_path}")
-            logger.exception(
-                "duckling_file_registration_failed",
-                s3_path=s3_path,
-                team_id=catalog.team_id,
-            )
-            raise
-
-        finally:
-            conn.close()
-
-    # Should not reach here, but just in case
-    if last_exception:
-        raise last_exception
-    return False
+    except Exception:
+        context.log.exception(f"Failed to register file {s3_path}")
+        logger.exception(
+            "duckling_file_registration_failed",
+            s3_path=s3_path,
+            team_id=catalog.team_id,
+        )
+        raise
+    finally:
+        conn.close()
 
 
 def export_persons_to_duckling_s3(
@@ -1382,8 +1269,8 @@ def register_persons_file_with_duckling(
 ) -> bool:
     """Register an exported persons Parquet file with the duckling's DuckLake catalog.
 
-    Includes retry logic for DuckLake transaction conflicts, which can occur when
-    multiple concurrent jobs attempt to register files with the same table.
+    DuckLake transaction conflicts are retried server-side by duckgres, so this
+    function no longer needs an in-process retry loop.
     """
     if config.skip_ducklake_registration:
         context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
@@ -1393,61 +1280,31 @@ def register_persons_file_with_duckling(
         context.log.info(f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}")
         return False
 
-    destination = catalog.to_cross_account_destination()
-    alias = "ducklake"
-    catalog_config = get_org_config(str(catalog.organization_id))
+    alias = DUCKLAKE_ALIAS
 
-    last_exception: Exception | None = None
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        conn = _connect_duckdb()
-        try:
-            configure_cross_account_connection(conn, destinations=[destination])
-            attach_catalog(conn, catalog_config, alias=alias)
+    conn = _connect_duckgres(catalog)
+    try:
+        context.log.info(f"Registering persons file with DuckLake: {s3_path}")
+        conn.execute(f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}', schema => 'posthog')")
 
-            context.log.info(f"Registering persons file with DuckLake: {s3_path}")
-            conn.execute(
-                f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}', schema => 'posthog')"
-            )
+        context.log.info(f"Successfully registered persons: {s3_path}")
+        logger.info(
+            "duckling_persons_file_registered",
+            s3_path=s3_path,
+            team_id=catalog.team_id,
+        )
+        return True
 
-            context.log.info(f"Successfully registered persons: {s3_path}")
-            logger.info(
-                "duckling_persons_file_registered",
-                s3_path=s3_path,
-                team_id=catalog.team_id,
-            )
-            return True
-
-        except Exception as e:
-            last_exception = e
-            if _is_transaction_conflict(e) and attempt < MAX_RETRY_ATTEMPTS - 1:
-                wait_time = min(4 * (2**attempt), 60)
-                context.log.warning(
-                    f"DuckLake transaction conflict on attempt {attempt + 1}, retrying in {wait_time}s..."
-                )
-                logger.warning(
-                    "duckling_persons_registration_transaction_conflict",
-                    s3_path=s3_path,
-                    team_id=catalog.team_id,
-                    attempt=attempt + 1,
-                    wait_time=wait_time,
-                )
-                time.sleep(wait_time)
-                continue
-
-            context.log.exception(f"Failed to register persons file {s3_path}")
-            logger.exception(
-                "duckling_persons_file_registration_failed",
-                s3_path=s3_path,
-                team_id=catalog.team_id,
-            )
-            raise
-
-        finally:
-            conn.close()
-
-    if last_exception:
-        raise last_exception
-    return False
+    except Exception:
+        context.log.exception(f"Failed to register persons file {s3_path}")
+        logger.exception(
+            "duckling_persons_file_registration_failed",
+            s3_path=s3_path,
+            team_id=catalog.team_id,
+        )
+        raise
+    finally:
+        conn.close()
 
 
 @asset(

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1388,7 +1388,9 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     if server is None:
         raise ValueError(f"No DuckgresServer found for org={catalog.organization_id} — cannot proceed with backfill.")
 
-    context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
+    context.log.info(
+        f"Backfill ready for team_id={team_id}: duckgres={server.host}:{server.port}, bucket={catalog.bucket}"
+    )
 
     # Delete events table if requested (dangerous - loses all data)
     if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
@@ -1526,7 +1528,13 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
     if catalog is None:
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
 
-    context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
+    server = get_duckgres_server_for_organization(str(catalog.organization_id))
+    if server is None:
+        raise ValueError(f"No DuckgresServer found for org={catalog.organization_id} — cannot proceed with backfill.")
+
+    context.log.info(
+        f"Backfill ready for team_id={team_id}: duckgres={server.host}:{server.port}, bucket={catalog.bucket}"
+    )
 
     # Delete persons table if requested (dangerous - loses all data)
     if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -55,6 +55,7 @@ from dagster import (
     define_asset_job,
     sensor,
 )
+from psycopg import sql as psql
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
@@ -68,7 +69,7 @@ from posthog.dags.events_backfill_to_ducklake import (
     MAX_RETRY_ATTEMPTS,
 )
 from posthog.ducklake.client import _make_duckgres_conninfo
-from posthog.ducklake.common import escape, get_ducklake_catalog_by_team_org
+from posthog.ducklake.common import get_duckgres_server_for_organization, get_ducklake_catalog_by_team_org
 from posthog.ducklake.models import DuckLakeBackfill, DuckLakeCatalog
 
 logger = structlog.get_logger(__name__)
@@ -77,6 +78,21 @@ logger = structlog.get_logger(__name__)
 # DuckLake catalog under this name on session start (see duckgres server.go),
 # so the DAG can hardcode it everywhere instead of threading a config value.
 DUCKLAKE_ALIAS = "ducklake"
+
+# Duckgres connection timeouts: connect_timeout bounds the TCP+TLS handshake;
+# statement_timeout bounds query execution to prevent hung Dagster workers.
+DUCKGRES_CONNECT_TIMEOUT = 10  # seconds
+DUCKGRES_STATEMENT_TIMEOUT_MS = 300_000  # 5 minutes
+
+# Retry duckgres operations on transient connection/network failures.
+# Duckgres handles transaction conflicts server-side (retryOnConflict, max 5
+# attempts with jitter), so this decorator targets only connection-level errors.
+_retry_duckgres_connection = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    retry=retry_if_exception_type((psycopg.OperationalError, psycopg.InterfaceError)),
+    reraise=True,
+)
 
 
 @retry(
@@ -105,10 +121,18 @@ def _connect_duckgres(catalog: DuckLakeCatalog) -> psycopg.Connection[Any]:
     Cross-account S3 credentials are configured server-side via IRSA on the
     duckling, so the DAG no longer calls `configure_cross_account_connection`.
     """
+    if catalog.team_id is None:
+        raise ValueError(
+            f"DuckLakeCatalog team_id is None for org={catalog.organization_id} — "
+            "cannot route to a duckgres instance without a team identifier."
+        )
+
     conninfo = _make_duckgres_conninfo(
-        catalog.team_id if catalog.team_id is not None else 0,
+        catalog.team_id,
         organization_id=str(catalog.organization_id),
     )
+    conninfo += f" connect_timeout={DUCKGRES_CONNECT_TIMEOUT}"
+    conninfo += f" options='-c statement_timeout={DUCKGRES_STATEMENT_TIMEOUT_MS}'"
     return psycopg.connect(conninfo, autocommit=True)
 
 
@@ -457,7 +481,11 @@ def table_exists(
     try:
         conn.execute(f"DESCRIBE {catalog_alias}.{schema}.{table}")
         return True
-    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
+    except (
+        psycopg.errors.UndefinedTable,
+        psycopg.errors.InvalidSchemaName,
+        psycopg.DatabaseError,
+    ):
         return False
 
 
@@ -512,6 +540,7 @@ def _set_table_partitioning(
         return False
 
 
+@_retry_duckgres_connection
 def ensure_events_table_exists(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -547,26 +576,7 @@ def ensure_events_table_exists(
         conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
         context.log.info("Creating events table in duckling catalog...")
-        ddl = EVENTS_TABLE_DDL.format(catalog=alias)
-        try:
-            conn.execute(ddl)
-        except psycopg.errors.DuplicateTable as exc:
-            # Race condition: another worker created the table between our
-            # table_exists check and the CREATE. Treat as success.
-            if table_exists(conn, alias, "posthog", "events"):
-                context.log.info("Events table was created by another worker")
-                _set_table_partitioning(
-                    conn,
-                    alias,
-                    "events",
-                    "year(timestamp), month(timestamp), day(timestamp)",
-                    context,
-                    catalog.team_id,
-                )
-                return False
-            context.log.exception(f"Failed to create events table: {exc}")
-            raise
-
+        conn.execute(EVENTS_TABLE_DDL.format(catalog=alias))
         context.log.info("Successfully created events table")
 
         # Set partitioning by year/month/day for efficient querying
@@ -590,6 +600,7 @@ def ensure_events_table_exists(
         conn.close()
 
 
+@_retry_duckgres_connection
 def ensure_persons_table_exists(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -625,24 +636,7 @@ def ensure_persons_table_exists(
         conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
         context.log.info("Creating persons table in duckling catalog...")
-        ddl = PERSONS_TABLE_DDL.format(catalog=alias)
-        try:
-            conn.execute(ddl)
-        except psycopg.errors.DuplicateTable as exc:
-            if table_exists(conn, alias, "posthog", "persons"):
-                context.log.info("Persons table was created by another worker")
-                _set_table_partitioning(
-                    conn,
-                    alias,
-                    "persons",
-                    "year(_timestamp), month(_timestamp)",
-                    context,
-                    catalog.team_id,
-                )
-                return False
-            context.log.exception(f"Failed to create persons table: {exc}")
-            raise
-
+        conn.execute(PERSONS_TABLE_DDL.format(catalog=alias))
         context.log.info("Successfully created persons table")
 
         # Set partitioning by year/month of _timestamp for efficient querying
@@ -695,6 +689,14 @@ def delete_events_table(
         )
         return True
 
+    except Exception:
+        context.log.exception(f"Failed to delete events table for team_id={catalog.team_id}")
+        logger.exception(
+            "duckling_events_table_delete_failed",
+            team_id=catalog.team_id,
+            bucket=catalog.bucket,
+        )
+        raise
     finally:
         conn.close()
 
@@ -728,10 +730,19 @@ def delete_persons_table(
         )
         return True
 
+    except Exception:
+        context.log.exception(f"Failed to delete persons table for team_id={catalog.team_id}")
+        logger.exception(
+            "duckling_persons_table_delete_failed",
+            team_id=catalog.team_id,
+            bucket=catalog.bucket,
+        )
+        raise
     finally:
         conn.close()
 
 
+@_retry_duckgres_connection
 def validate_duckling_schema(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -781,6 +792,7 @@ def validate_duckling_schema(
         conn.close()
 
 
+@_retry_duckgres_connection
 def validate_duckling_persons_schema(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -851,6 +863,7 @@ def _execute_export_with_retry(
         raise
 
 
+@_retry_duckgres_connection
 def delete_events_partition_data(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -863,8 +876,9 @@ def delete_events_partition_data(
     before registering new files.
 
     DuckLake transaction conflicts are retried server-side by duckgres
-    (server/transient.go retryOnConflict, max 5 attempts with jitter), so this
-    function no longer needs an in-process retry loop.
+    (server/transient.go retryOnConflict, max 5 attempts with jitter). Transient
+    connection/network failures are retried by the `_retry_duckgres_connection`
+    decorator (max 3 attempts with exponential backoff).
 
     Returns the number of rows deleted.
     """
@@ -887,7 +901,8 @@ def delete_events_partition_data(
     try:
         with conn.cursor() as cur:
             cur.execute(delete_sql, (team_id, date_str, next_date_str))
-            deleted_count = cur.rowcount
+            result = cur.fetchone()
+            deleted_count = result[0] if result else 0
 
         if deleted_count > 0:
             context.log.info(f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}")
@@ -899,7 +914,11 @@ def delete_events_partition_data(
             )
         return deleted_count
 
-    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
+    except (
+        psycopg.errors.UndefinedTable,
+        psycopg.errors.InvalidSchemaName,
+        psycopg.DatabaseError,
+    ):
         context.log.debug(f"Events table doesn't exist yet, nothing to delete for team_id={team_id}, date={date_str}")
         return 0
     except Exception:
@@ -914,6 +933,7 @@ def delete_events_partition_data(
         conn.close()
 
 
+@_retry_duckgres_connection
 def delete_persons_partition_data(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -925,8 +945,9 @@ def delete_persons_partition_data(
     For full exports (partition_date=None), deletes all persons for the team.
     For daily exports, deletes persons modified on that date.
 
-    DuckLake transaction conflicts are retried server-side by duckgres, so this
-    function no longer needs an in-process retry loop.
+    DuckLake transaction conflicts are retried server-side by duckgres. Transient
+    connection/network failures are retried by the `_retry_duckgres_connection`
+    decorator (max 3 attempts with exponential backoff).
 
     Returns the number of rows deleted.
     """
@@ -957,7 +978,8 @@ def delete_persons_partition_data(
             context.log.info(f"Deleting all existing persons for team_id={team_id}")
         with conn.cursor() as cur:
             cur.execute(delete_sql, delete_params)
-            deleted_count = cur.rowcount
+            result = cur.fetchone()
+            deleted_count = result[0] if result else 0
 
         if deleted_count > 0:
             context.log.info(f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}")
@@ -969,7 +991,11 @@ def delete_persons_partition_data(
             )
         return deleted_count
 
-    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
+    except (
+        psycopg.errors.UndefinedTable,
+        psycopg.errors.InvalidSchemaName,
+        psycopg.DatabaseError,
+    ):
         context.log.debug(f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}")
         return 0
     except Exception:
@@ -1057,6 +1083,7 @@ def export_events_to_duckling_s3(
         raise
 
 
+@_retry_duckgres_connection
 def register_file_with_duckling(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -1068,8 +1095,9 @@ def register_file_with_duckling(
     Cross-account S3 access is configured server-side on the duckling's duckgres
     via IRSA, so the DAG only needs a pgwire connection.
 
-    DuckLake transaction conflicts are retried server-side by duckgres, so this
-    function no longer needs an in-process retry loop.
+    DuckLake transaction conflicts are retried server-side by duckgres. Transient
+    connection/network failures are retried by the `_retry_duckgres_connection`
+    decorator (max 3 attempts with exponential backoff).
 
     Args:
         context: Dagster asset execution context.
@@ -1093,7 +1121,12 @@ def register_file_with_duckling(
     conn = _connect_duckgres(catalog)
     try:
         context.log.info(f"Registering file with DuckLake: {s3_path}")
-        conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
+        conn.execute(
+            psql.SQL("CALL ducklake_add_data_files({}, 'events', {}, schema => 'posthog')").format(
+                psql.Literal(alias),
+                psql.Literal(s3_path),
+            )
+        )
 
         context.log.info(f"Successfully registered: {s3_path}")
         logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
@@ -1261,6 +1294,7 @@ def export_persons_full_to_duckling_s3(
         raise
 
 
+@_retry_duckgres_connection
 def register_persons_file_with_duckling(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
@@ -1269,8 +1303,9 @@ def register_persons_file_with_duckling(
 ) -> bool:
     """Register an exported persons Parquet file with the duckling's DuckLake catalog.
 
-    DuckLake transaction conflicts are retried server-side by duckgres, so this
-    function no longer needs an in-process retry loop.
+    DuckLake transaction conflicts are retried server-side by duckgres. Transient
+    connection/network failures are retried by the `_retry_duckgres_connection`
+    decorator (max 3 attempts with exponential backoff).
     """
     if config.skip_ducklake_registration:
         context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
@@ -1285,7 +1320,12 @@ def register_persons_file_with_duckling(
     conn = _connect_duckgres(catalog)
     try:
         context.log.info(f"Registering persons file with DuckLake: {s3_path}")
-        conn.execute(f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}', schema => 'posthog')")
+        conn.execute(
+            psql.SQL("CALL ducklake_add_data_files({}, 'persons', {}, schema => 'posthog')").format(
+                psql.Literal(alias),
+                psql.Literal(s3_path),
+            )
+        )
 
         context.log.info(f"Successfully registered persons: {s3_path}")
         logger.info(
@@ -1343,6 +1383,10 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     catalog = get_ducklake_catalog_by_team_org(team_id)
     if catalog is None:
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
+
+    server = get_duckgres_server_for_organization(str(catalog.organization_id))
+    if server is None:
+        raise ValueError(f"No DuckgresServer found for org={catalog.organization_id} — cannot proceed with backfill.")
 
     context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
 

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -68,7 +68,7 @@ from posthog.dags.events_backfill_to_ducklake import (
     EXPECTED_DUCKLAKE_COLUMNS,
     MAX_RETRY_ATTEMPTS,
 )
-from posthog.ducklake.client import _make_duckgres_conninfo
+from posthog.ducklake.client import make_duckgres_conninfo
 from posthog.ducklake.common import get_duckgres_server_for_organization, get_ducklake_catalog_by_team_org
 from posthog.ducklake.models import DuckLakeBackfill, DuckLakeCatalog
 
@@ -127,13 +127,16 @@ def _connect_duckgres(catalog: DuckLakeCatalog) -> psycopg.Connection[Any]:
             "cannot route to a duckgres instance without a team identifier."
         )
 
-    conninfo = _make_duckgres_conninfo(
+    conninfo = make_duckgres_conninfo(
         catalog.team_id,
         organization_id=str(catalog.organization_id),
     )
-    conninfo += f" connect_timeout={DUCKGRES_CONNECT_TIMEOUT}"
-    conninfo += f" options='-c statement_timeout={DUCKGRES_STATEMENT_TIMEOUT_MS}'"
-    return psycopg.connect(conninfo, autocommit=True)
+    return psycopg.connect(
+        conninfo,
+        autocommit=True,
+        connect_timeout=DUCKGRES_CONNECT_TIMEOUT,
+        options=f"-c statement_timeout={DUCKGRES_STATEMENT_TIMEOUT_MS}",
+    )
 
 
 # Columns to export from ClickHouse events table for duckling backfill.
@@ -481,11 +484,7 @@ def table_exists(
     try:
         conn.execute(f"DESCRIBE {catalog_alias}.{schema}.{table}")
         return True
-    except (
-        psycopg.errors.UndefinedTable,
-        psycopg.errors.InvalidSchemaName,
-        psycopg.DatabaseError,
-    ):
+    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
         return False
 
 
@@ -544,6 +543,7 @@ def _set_table_partitioning(
 def ensure_events_table_exists(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
+    conn: psycopg.Connection[Any],
 ) -> bool:
     """Create the events table in the duckling's DuckLake catalog if it doesn't exist.
 
@@ -557,29 +557,9 @@ def ensure_events_table_exists(
     """
     alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckgres(catalog)
-    try:
-        if table_exists(conn, alias, "posthog", "events"):
-            context.log.info("Events table already exists in duckling catalog")
-            # Ensure partitioning is set even on existing tables (idempotent)
-            _set_table_partitioning(
-                conn,
-                alias,
-                "events",
-                "year(timestamp), month(timestamp), day(timestamp)",
-                context,
-                catalog.team_id,
-            )
-            return False
-
-        context.log.info("Creating posthog schema if it doesn't exist...")
-        conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
-
-        context.log.info("Creating events table in duckling catalog...")
-        conn.execute(EVENTS_TABLE_DDL.format(catalog=alias))
-        context.log.info("Successfully created events table")
-
-        # Set partitioning by year/month/day for efficient querying
+    if table_exists(conn, alias, "posthog", "events"):
+        context.log.info("Events table already exists in duckling catalog")
+        # Ensure partitioning is set even on existing tables (idempotent)
         _set_table_partitioning(
             conn,
             alias,
@@ -588,22 +568,38 @@ def ensure_events_table_exists(
             context,
             catalog.team_id,
         )
+        return False
 
-        logger.info(
-            "duckling_events_table_created",
-            team_id=catalog.team_id,
-            bucket=catalog.bucket,
-        )
-        return True
+    context.log.info("Creating posthog schema if it doesn't exist...")
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
-    finally:
-        conn.close()
+    context.log.info("Creating events table in duckling catalog...")
+    conn.execute(EVENTS_TABLE_DDL.format(catalog=alias))
+    context.log.info("Successfully created events table")
+
+    # Set partitioning by year/month/day for efficient querying
+    _set_table_partitioning(
+        conn,
+        alias,
+        "events",
+        "year(timestamp), month(timestamp), day(timestamp)",
+        context,
+        catalog.team_id,
+    )
+
+    logger.info(
+        "duckling_events_table_created",
+        team_id=catalog.team_id,
+        bucket=catalog.bucket,
+    )
+    return True
 
 
 @_retry_duckgres_connection
 def ensure_persons_table_exists(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
+    conn: psycopg.Connection[Any],
 ) -> bool:
     """Create the persons table in the duckling's DuckLake catalog if it doesn't exist.
 
@@ -617,29 +613,9 @@ def ensure_persons_table_exists(
     """
     alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckgres(catalog)
-    try:
-        if table_exists(conn, alias, "posthog", "persons"):
-            context.log.info("Persons table already exists in duckling catalog")
-            # Ensure partitioning is set even on existing tables (idempotent)
-            _set_table_partitioning(
-                conn,
-                alias,
-                "persons",
-                "year(_timestamp), month(_timestamp)",
-                context,
-                catalog.team_id,
-            )
-            return False
-
-        context.log.info("Creating posthog schema if it doesn't exist...")
-        conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
-
-        context.log.info("Creating persons table in duckling catalog...")
-        conn.execute(PERSONS_TABLE_DDL.format(catalog=alias))
-        context.log.info("Successfully created persons table")
-
-        # Set partitioning by year/month of _timestamp for efficient querying
+    if table_exists(conn, alias, "posthog", "persons"):
+        context.log.info("Persons table already exists in duckling catalog")
+        # Ensure partitioning is set even on existing tables (idempotent)
         _set_table_partitioning(
             conn,
             alias,
@@ -648,104 +624,38 @@ def ensure_persons_table_exists(
             context,
             catalog.team_id,
         )
+        return False
 
-        logger.info(
-            "duckling_persons_table_created",
-            team_id=catalog.team_id,
-            bucket=catalog.bucket,
-        )
-        return True
+    context.log.info("Creating posthog schema if it doesn't exist...")
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
-    finally:
-        conn.close()
+    context.log.info("Creating persons table in duckling catalog...")
+    conn.execute(PERSONS_TABLE_DDL.format(catalog=alias))
+    context.log.info("Successfully created persons table")
 
+    # Set partitioning by year/month of _timestamp for efficient querying
+    _set_table_partitioning(
+        conn,
+        alias,
+        "persons",
+        "year(_timestamp), month(_timestamp)",
+        context,
+        catalog.team_id,
+    )
 
-def delete_events_table(
-    context: AssetExecutionContext,
-    catalog: DuckLakeCatalog,
-) -> bool:
-    """Delete the events table from the duckling's DuckLake catalog.
-
-    WARNING: This will permanently delete all events data in the duckling.
-
-    Returns True if the table was deleted, False if it didn't exist.
-    """
-    alias = DUCKLAKE_ALIAS
-
-    conn = _connect_duckgres(catalog)
-    try:
-        if not table_exists(conn, alias, "posthog", "events"):
-            context.log.info("Events table does not exist, nothing to delete")
-            return False
-
-        context.log.warning("Deleting events table from duckling catalog...")
-        _validate_identifier(alias)
-        conn.execute(f"DROP TABLE {alias}.posthog.events")
-        context.log.warning("Successfully deleted events table")
-        logger.warning(
-            "duckling_events_table_deleted",
-            team_id=catalog.team_id,
-            bucket=catalog.bucket,
-        )
-        return True
-
-    except Exception:
-        context.log.exception(f"Failed to delete events table for team_id={catalog.team_id}")
-        logger.exception(
-            "duckling_events_table_delete_failed",
-            team_id=catalog.team_id,
-            bucket=catalog.bucket,
-        )
-        raise
-    finally:
-        conn.close()
-
-
-def delete_persons_table(
-    context: AssetExecutionContext,
-    catalog: DuckLakeCatalog,
-) -> bool:
-    """Delete the persons table from the duckling's DuckLake catalog.
-
-    WARNING: This will permanently delete all persons data in the duckling.
-
-    Returns True if the table was deleted, False if it didn't exist.
-    """
-    alias = DUCKLAKE_ALIAS
-
-    conn = _connect_duckgres(catalog)
-    try:
-        if not table_exists(conn, alias, "posthog", "persons"):
-            context.log.info("Persons table does not exist, nothing to delete")
-            return False
-
-        context.log.warning("Deleting persons table from duckling catalog...")
-        _validate_identifier(alias)
-        conn.execute(f"DROP TABLE {alias}.posthog.persons")
-        context.log.warning("Successfully deleted persons table")
-        logger.warning(
-            "duckling_persons_table_deleted",
-            team_id=catalog.team_id,
-            bucket=catalog.bucket,
-        )
-        return True
-
-    except Exception:
-        context.log.exception(f"Failed to delete persons table for team_id={catalog.team_id}")
-        logger.exception(
-            "duckling_persons_table_delete_failed",
-            team_id=catalog.team_id,
-            bucket=catalog.bucket,
-        )
-        raise
-    finally:
-        conn.close()
+    logger.info(
+        "duckling_persons_table_created",
+        team_id=catalog.team_id,
+        bucket=catalog.bucket,
+    )
+    return True
 
 
 @_retry_duckgres_connection
 def validate_duckling_schema(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
+    conn: psycopg.Connection[Any],
 ) -> None:
     """Validate that the duckling's events table schema matches our export columns.
 
@@ -754,88 +664,79 @@ def validate_duckling_schema(
     """
     alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckgres(catalog)
-    try:
-        with conn.cursor() as cur:
-            cur.execute(f"DESCRIBE {alias}.posthog.events")
-            ducklake_columns = {row[0] for row in cur.fetchall()}
+    with conn.cursor() as cur:
+        cur.execute(f"DESCRIBE {alias}.posthog.events")
+        ducklake_columns = {row[0] for row in cur.fetchall()}
 
-        missing_in_ducklake = EXPECTED_DUCKLAKE_COLUMNS - ducklake_columns
-        if missing_in_ducklake:
-            context.log.warning(
-                f"Duckling events table is missing columns that we export: {missing_in_ducklake}. "
-                "These columns will be added automatically by ducklake_add_data_files if the table "
-                "supports schema evolution."
-            )
-            logger.warning(
-                "duckling_schema_mismatch",
-                team_id=catalog.team_id,
-                missing_columns=list(missing_in_ducklake),
-            )
-
-        extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_COLUMNS
-        if extra_in_ducklake:
-            context.log.info(f"Duckling has additional columns not in our export: {extra_in_ducklake}")
-
-        context.log.info(
-            f"Schema validation passed. Duckling has {len(ducklake_columns)} columns, "
-            f"we export {len(EXPECTED_DUCKLAKE_COLUMNS)} columns."
+    missing_in_ducklake = EXPECTED_DUCKLAKE_COLUMNS - ducklake_columns
+    if missing_in_ducklake:
+        context.log.warning(
+            f"Duckling events table is missing columns that we export: {missing_in_ducklake}. "
+            "These columns will be added automatically by ducklake_add_data_files if the table "
+            "supports schema evolution."
         )
-        logger.info(
-            "duckling_schema_validation_passed",
+        logger.warning(
+            "duckling_schema_mismatch",
             team_id=catalog.team_id,
-            ducklake_columns=len(ducklake_columns),
-            export_columns=len(EXPECTED_DUCKLAKE_COLUMNS),
+            missing_columns=list(missing_in_ducklake),
         )
 
-    finally:
-        conn.close()
+    extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_COLUMNS
+    if extra_in_ducklake:
+        context.log.info(f"Duckling has additional columns not in our export: {extra_in_ducklake}")
+
+    context.log.info(
+        f"Schema validation passed. Duckling has {len(ducklake_columns)} columns, "
+        f"we export {len(EXPECTED_DUCKLAKE_COLUMNS)} columns."
+    )
+    logger.info(
+        "duckling_schema_validation_passed",
+        team_id=catalog.team_id,
+        ducklake_columns=len(ducklake_columns),
+        export_columns=len(EXPECTED_DUCKLAKE_COLUMNS),
+    )
 
 
 @_retry_duckgres_connection
 def validate_duckling_persons_schema(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
+    conn: psycopg.Connection[Any],
 ) -> None:
     """Validate that the duckling's persons table schema matches our export columns."""
     alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckgres(catalog)
-    try:
-        with conn.cursor() as cur:
-            cur.execute(f"DESCRIBE {alias}.posthog.persons")
-            ducklake_columns = {row[0] for row in cur.fetchall()}
+    with conn.cursor() as cur:
+        cur.execute(f"DESCRIBE {alias}.posthog.persons")
+        ducklake_columns = {row[0] for row in cur.fetchall()}
 
-        missing_in_ducklake = EXPECTED_DUCKLAKE_PERSONS_COLUMNS - ducklake_columns
-        if missing_in_ducklake:
-            context.log.warning(
-                f"Duckling persons table is missing columns that we export: {missing_in_ducklake}. "
-                "These columns will be added automatically by ducklake_add_data_files if the table "
-                "supports schema evolution."
-            )
-            logger.warning(
-                "duckling_persons_schema_mismatch",
-                team_id=catalog.team_id,
-                missing_columns=list(missing_in_ducklake),
-            )
-
-        extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_PERSONS_COLUMNS
-        if extra_in_ducklake:
-            context.log.info(f"Duckling persons has additional columns not in our export: {extra_in_ducklake}")
-
-        context.log.info(
-            f"Persons schema validation passed. Duckling has {len(ducklake_columns)} columns, "
-            f"we export {len(EXPECTED_DUCKLAKE_PERSONS_COLUMNS)} columns."
+    missing_in_ducklake = EXPECTED_DUCKLAKE_PERSONS_COLUMNS - ducklake_columns
+    if missing_in_ducklake:
+        context.log.warning(
+            f"Duckling persons table is missing columns that we export: {missing_in_ducklake}. "
+            "These columns will be added automatically by ducklake_add_data_files if the table "
+            "supports schema evolution."
         )
-        logger.info(
-            "duckling_persons_schema_validation_passed",
+        logger.warning(
+            "duckling_persons_schema_mismatch",
             team_id=catalog.team_id,
-            ducklake_columns=len(ducklake_columns),
-            export_columns=len(EXPECTED_DUCKLAKE_PERSONS_COLUMNS),
+            missing_columns=list(missing_in_ducklake),
         )
 
-    finally:
-        conn.close()
+    extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_PERSONS_COLUMNS
+    if extra_in_ducklake:
+        context.log.info(f"Duckling persons has additional columns not in our export: {extra_in_ducklake}")
+
+    context.log.info(
+        f"Persons schema validation passed. Duckling has {len(ducklake_columns)} columns, "
+        f"we export {len(EXPECTED_DUCKLAKE_PERSONS_COLUMNS)} columns."
+    )
+    logger.info(
+        "duckling_persons_schema_validation_passed",
+        team_id=catalog.team_id,
+        ducklake_columns=len(ducklake_columns),
+        export_columns=len(EXPECTED_DUCKLAKE_PERSONS_COLUMNS),
+    )
 
 
 @retry(
@@ -863,12 +764,12 @@ def _execute_export_with_retry(
         raise
 
 
-@_retry_duckgres_connection
 def delete_events_partition_data(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
     team_id: int,
     partition_date: datetime,
+    conn: psycopg.Connection[Any],
 ) -> int:
     """Delete existing events data for a specific team_id and date from DuckLake.
 
@@ -876,9 +777,8 @@ def delete_events_partition_data(
     before registering new files.
 
     DuckLake transaction conflicts are retried server-side by duckgres
-    (server/transient.go retryOnConflict, max 5 attempts with jitter). Transient
-    connection/network failures are retried by the `_retry_duckgres_connection`
-    decorator (max 3 attempts with exponential backoff).
+    (server/transient.go retryOnConflict, max 5 attempts with jitter). Connection
+    retries live in the caller — this helper operates on a connection it doesn't own.
 
     Returns the number of rows deleted.
     """
@@ -897,12 +797,10 @@ def delete_events_partition_data(
       AND timestamp < %s
     """
 
-    conn = _connect_duckgres(catalog)
     try:
         with conn.cursor() as cur:
             cur.execute(delete_sql, (team_id, date_str, next_date_str))
-            result = cur.fetchone()
-            deleted_count = result[0] if result else 0
+            deleted_count = cur.rowcount if cur.rowcount != -1 else 0
 
         if deleted_count > 0:
             context.log.info(f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}")
@@ -914,11 +812,7 @@ def delete_events_partition_data(
             )
         return deleted_count
 
-    except (
-        psycopg.errors.UndefinedTable,
-        psycopg.errors.InvalidSchemaName,
-        psycopg.DatabaseError,
-    ):
+    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
         context.log.debug(f"Events table doesn't exist yet, nothing to delete for team_id={team_id}, date={date_str}")
         return 0
     except Exception:
@@ -929,25 +823,22 @@ def delete_events_partition_data(
             date=date_str,
         )
         raise
-    finally:
-        conn.close()
 
 
-@_retry_duckgres_connection
 def delete_persons_partition_data(
     context: AssetExecutionContext,
     catalog: DuckLakeCatalog,
     team_id: int,
-    partition_date: datetime | None = None,
+    partition_date: datetime | None,
+    conn: psycopg.Connection[Any],
 ) -> int:
     """Delete existing persons data for a specific team_id (and optionally date) from DuckLake.
 
     For full exports (partition_date=None), deletes all persons for the team.
     For daily exports, deletes persons modified on that date.
 
-    DuckLake transaction conflicts are retried server-side by duckgres. Transient
-    connection/network failures are retried by the `_retry_duckgres_connection`
-    decorator (max 3 attempts with exponential backoff).
+    DuckLake transaction conflicts are retried server-side by duckgres. Connection
+    retries live in the caller — this helper operates on a connection it doesn't own.
 
     Returns the number of rows deleted.
     """
@@ -972,14 +863,12 @@ def delete_persons_partition_data(
         """
         delete_params = (team_id, date_str, next_date_str)
 
-    conn = _connect_duckgres(catalog)
     try:
         if partition_date is None:
             context.log.info(f"Deleting all existing persons for team_id={team_id}")
         with conn.cursor() as cur:
             cur.execute(delete_sql, delete_params)
-            result = cur.fetchone()
-            deleted_count = result[0] if result else 0
+            deleted_count = cur.rowcount if cur.rowcount != -1 else 0
 
         if deleted_count > 0:
             context.log.info(f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}")
@@ -991,11 +880,7 @@ def delete_persons_partition_data(
             )
         return deleted_count
 
-    except (
-        psycopg.errors.UndefinedTable,
-        psycopg.errors.InvalidSchemaName,
-        psycopg.DatabaseError,
-    ):
+    except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
         context.log.debug(f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}")
         return 0
     except Exception:
@@ -1006,8 +891,6 @@ def delete_persons_partition_data(
             date=date_label,
         )
         raise
-    finally:
-        conn.close()
 
 
 def export_events_to_duckling_s3(
@@ -1089,6 +972,7 @@ def register_file_with_duckling(
     catalog: DuckLakeCatalog,
     s3_path: str,
     config: DucklingBackfillConfig,
+    conn: psycopg.Connection[Any],
 ) -> bool:
     """Register an exported Parquet file with the duckling's DuckLake catalog.
 
@@ -1104,6 +988,7 @@ def register_file_with_duckling(
         catalog: The DuckLakeCatalog for this duckling.
         s3_path: S3 path of the Parquet file to register.
         config: Job configuration.
+        conn: psycopg connection to the org's duckgres server.
 
     Returns:
         True if registration succeeded, False otherwise.
@@ -1118,30 +1003,17 @@ def register_file_with_duckling(
 
     alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckgres(catalog)
-    try:
-        context.log.info(f"Registering file with DuckLake: {s3_path}")
-        conn.execute(
-            psql.SQL("CALL ducklake_add_data_files({}, 'events', {}, schema => 'posthog')").format(
-                psql.Literal(alias),
-                psql.Literal(s3_path),
-            )
+    context.log.info(f"Registering file with DuckLake: {s3_path}")
+    conn.execute(
+        psql.SQL("CALL ducklake_add_data_files({}, 'events', {}, schema => 'posthog')").format(
+            psql.Literal(alias),
+            psql.Literal(s3_path),
         )
+    )
 
-        context.log.info(f"Successfully registered: {s3_path}")
-        logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
-        return True
-
-    except Exception:
-        context.log.exception(f"Failed to register file {s3_path}")
-        logger.exception(
-            "duckling_file_registration_failed",
-            s3_path=s3_path,
-            team_id=catalog.team_id,
-        )
-        raise
-    finally:
-        conn.close()
+    context.log.info(f"Successfully registered: {s3_path}")
+    logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
+    return True
 
 
 def export_persons_to_duckling_s3(
@@ -1237,7 +1109,7 @@ def export_persons_full_to_duckling_s3(
     Returns:
         S3 path that was written, or None if dry_run.
     """
-    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/{team_id}/full/{run_id}.parquet"
+    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/{team_id}/year=0/month=0/{run_id}.parquet"
     s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
 
@@ -1300,6 +1172,7 @@ def register_persons_file_with_duckling(
     catalog: DuckLakeCatalog,
     s3_path: str,
     config: DucklingBackfillConfig,
+    conn: psycopg.Connection[Any],
 ) -> bool:
     """Register an exported persons Parquet file with the duckling's DuckLake catalog.
 
@@ -1317,34 +1190,21 @@ def register_persons_file_with_duckling(
 
     alias = DUCKLAKE_ALIAS
 
-    conn = _connect_duckgres(catalog)
-    try:
-        context.log.info(f"Registering persons file with DuckLake: {s3_path}")
-        conn.execute(
-            psql.SQL("CALL ducklake_add_data_files({}, 'persons', {}, schema => 'posthog')").format(
-                psql.Literal(alias),
-                psql.Literal(s3_path),
-            )
+    context.log.info(f"Registering persons file with DuckLake: {s3_path}")
+    conn.execute(
+        psql.SQL("CALL ducklake_add_data_files({}, 'persons', {}, schema => 'posthog')").format(
+            psql.Literal(alias),
+            psql.Literal(s3_path),
         )
+    )
 
-        context.log.info(f"Successfully registered persons: {s3_path}")
-        logger.info(
-            "duckling_persons_file_registered",
-            s3_path=s3_path,
-            team_id=catalog.team_id,
-        )
-        return True
-
-    except Exception:
-        context.log.exception(f"Failed to register persons file {s3_path}")
-        logger.exception(
-            "duckling_persons_file_registration_failed",
-            s3_path=s3_path,
-            team_id=catalog.team_id,
-        )
-        raise
-    finally:
-        conn.close()
+    context.log.info(f"Successfully registered persons: {s3_path}")
+    logger.info(
+        "duckling_persons_file_registered",
+        s3_path=s3_path,
+        team_id=catalog.team_id,
+    )
+    return True
 
 
 @asset(
@@ -1392,93 +1252,99 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
         f"Backfill ready for team_id={team_id}: duckgres={server.host}:{server.port}, bucket={catalog.bucket}"
     )
 
-    # Delete events table if requested (dangerous - loses all data)
-    if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
-        context.log.warning("delete_tables=True: Deleting events table...")
-        delete_events_table(context, catalog)
+    # Use a single connection for all metadata operations to reduce churn
+    conn = _connect_duckgres(catalog)
+    try:
+        # Delete events table if requested (dangerous - loses all data)
+        if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
+            context.log.warning("delete_tables=True: Deleting events table...")
+            conn.execute(f"DROP TABLE {DUCKLAKE_ALIAS}.posthog.events")
 
-    # Create events table if it doesn't exist
-    if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
-        context.log.info("Ensuring events table exists in duckling catalog...")
-        ensure_events_table_exists(context, catalog)
+        # Create events table if it doesn't exist
+        if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
+            context.log.info("Ensuring events table exists in duckling catalog...")
+            ensure_events_table_exists(context, catalog, conn)
 
-    # Validate schema before starting export (skip if dry_run or skip_ducklake_registration)
-    if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
-        context.log.info("Validating duckling schema compatibility...")
-        validate_duckling_schema(context, catalog)
+        # Validate schema before starting export (skip if dry_run or skip_ducklake_registration)
+        if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
+            context.log.info("Validating duckling schema compatibility...")
+            validate_duckling_schema(context, catalog, conn)
 
-    # Prepare ClickHouse settings
-    merged_settings = DEFAULT_CLICKHOUSE_SETTINGS.copy()
-    merged_settings.update(settings_with_log_comment(context))
-    if config.clickhouse_settings:
-        merged_settings.update(config.clickhouse_settings)
-        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
+        # Prepare ClickHouse settings
+        merged_settings = DEFAULT_CLICKHOUSE_SETTINGS.copy()
+        merged_settings.update(settings_with_log_comment(context))
+        if config.clickhouse_settings:
+            merged_settings.update(config.clickhouse_settings)
+            context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    cluster = _get_cluster()
-    tags = dagster_tags(context)
-    workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
+        cluster = _get_cluster()
+        tags = dagster_tags(context)
+        workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
-    # Process each date in the partition
-    total_exported = 0
-    total_registered = 0
-    s3_paths: list[str] = []
+        # Process each date in the partition
+        total_exported = 0
+        total_registered = 0
+        s3_paths: list[str] = []
 
-    for partition_date in dates:
-        date_str = partition_date.strftime("%Y-%m-%d")
-        context.log.info(f"Processing date {date_str}...")
+        for partition_date in dates:
+            date_str = partition_date.strftime("%Y-%m-%d")
+            context.log.info(f"Processing date {date_str}...")
 
-        # Delete existing DuckLake data for this partition before re-processing
-        if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
-            delete_events_partition_data(context, catalog, team_id, partition_date)
+            # Delete existing DuckLake data for this partition before re-processing
+            if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
+                delete_events_partition_data(context, catalog, team_id, partition_date, conn=conn)
 
-        def do_export(client: Client, date: datetime = partition_date) -> str | None:
-            with tags_context(kind="dagster", dagster=tags):
-                return export_events_to_duckling_s3(
-                    context=context,
-                    client=client,
-                    config=config,
-                    catalog=catalog,
-                    team_id=team_id,
-                    date=date,
-                    run_id=run_id,
-                    settings=merged_settings,
-                )
+            def do_export(client: Client, date: datetime = partition_date) -> str | None:
+                with tags_context(kind="dagster", dagster=tags):
+                    return export_events_to_duckling_s3(
+                        context=context,
+                        client=client,
+                        config=config,
+                        catalog=catalog,
+                        team_id=team_id,
+                        date=date,
+                        run_id=run_id,
+                        settings=merged_settings,
+                    )
 
-        s3_path = cluster.any_host_by_role(
-            fn=do_export,
-            workload=workload,
-            node_role=NodeRole.DATA,
-        ).result()
+            s3_path = cluster.any_host_by_role(
+                fn=do_export,
+                workload=workload,
+                node_role=NodeRole.DATA,
+            ).result()
 
-        # Register with DuckLake if we have a file
-        if s3_path:
-            total_exported += 1
-            s3_paths.append(s3_path)
-            if register_file_with_duckling(context, catalog, s3_path, config):
-                total_registered += 1
+            # Register with DuckLake if we have a file
+            if s3_path:
+                total_exported += 1
+                s3_paths.append(s3_path)
+                if register_file_with_duckling(context, catalog, s3_path, config, conn):
+                    total_registered += 1
 
-    context.add_output_metadata(
-        {
-            "team_id": team_id,
-            "partition_key": context.partition_key,
-            "dates_processed": len(dates),
-            "files_exported": total_exported,
-            "files_registered": total_registered,
-            "bucket": catalog.bucket,
-        }
-    )
+        context.add_output_metadata(
+            {
+                "team_id": team_id,
+                "partition_key": context.partition_key,
+                "dates_processed": len(dates),
+                "files_exported": total_exported,
+                "files_registered": total_registered,
+                "bucket": catalog.bucket,
+            }
+        )
 
-    context.log.info(
-        f"Completed duckling backfill for team_id={team_id}: "
-        f"{total_exported}/{len(dates)} days exported, {total_registered} registered"
-    )
-    logger.info(
-        "duckling_backfill_complete",
-        team_id=team_id,
-        dates_processed=len(dates),
-        files_exported=total_exported,
-        files_registered=total_registered,
-    )
+        context.log.info(
+            f"Completed duckling backfill for team_id={team_id}: "
+            f"{total_exported}/{len(dates)} days exported, {total_registered} registered"
+        )
+        logger.info(
+            "duckling_backfill_complete",
+            team_id=team_id,
+            dates_processed=len(dates),
+            files_exported=total_exported,
+            files_registered=total_registered,
+        )
+
+    finally:
+        conn.close()
 
 
 @asset(
@@ -1536,145 +1402,155 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
         f"Backfill ready for team_id={team_id}: duckgres={server.host}:{server.port}, bucket={catalog.bucket}"
     )
 
-    # Delete persons table if requested (dangerous - loses all data)
-    if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
-        context.log.warning("delete_tables=True: Deleting persons table...")
-        delete_persons_table(context, catalog)
+    # Use a single connection for all metadata operations to reduce churn
+    conn = _connect_duckgres(catalog)
+    try:
+        # Delete persons table if requested (dangerous - loses all data)
+        if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
+            context.log.warning("delete_tables=True: Deleting persons table...")
+            conn.execute(f"DROP TABLE {DUCKLAKE_ALIAS}.posthog.persons")
 
-    # Create persons table if it doesn't exist
-    if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
-        context.log.info("Ensuring persons table exists in duckling catalog...")
-        ensure_persons_table_exists(context, catalog)
+        # Create persons table if it doesn't exist
+        if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
+            context.log.info("Ensuring persons table exists in duckling catalog...")
+            ensure_persons_table_exists(context, catalog, conn)
 
-    if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
-        context.log.info("Validating duckling persons schema compatibility...")
-        validate_duckling_persons_schema(context, catalog)
+        if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
+            context.log.info("Validating duckling persons schema compatibility...")
+            validate_duckling_persons_schema(context, catalog, conn)
 
-    merged_settings = DEFAULT_CLICKHOUSE_SETTINGS.copy()
-    merged_settings.update(settings_with_log_comment(context))
-    if config.clickhouse_settings:
-        merged_settings.update(config.clickhouse_settings)
-        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
+        merged_settings = DEFAULT_CLICKHOUSE_SETTINGS.copy()
+        merged_settings.update(settings_with_log_comment(context))
+        if config.clickhouse_settings:
+            merged_settings.update(config.clickhouse_settings)
+            context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    cluster = _get_cluster()
-    tags = dagster_tags(context)
-    workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
+        cluster = _get_cluster()
+        tags = dagster_tags(context)
+        workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
-    if is_full:
-        # FULL EXPORT MODE - single query for all persons
-        context.log.info(f"Full export mode: exporting all persons for team_id={team_id}")
+        if is_full:
+            # FULL EXPORT MODE - single query for all persons
+            context.log.info(f"Full export mode: exporting all persons for team_id={team_id}")
 
-        # Delete all existing persons data for this team before full re-export
-        if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
-            delete_persons_partition_data(context, catalog, team_id, partition_date=None)
-
-        def do_full_export(client: Client) -> str | None:
-            with tags_context(kind="dagster", dagster=tags):
-                return export_persons_full_to_duckling_s3(
-                    context=context,
-                    client=client,
-                    config=config,
-                    catalog=catalog,
-                    team_id=team_id,
-                    run_id=run_id,
-                    settings=merged_settings,
-                )
-
-        s3_path = cluster.any_host_by_role(
-            fn=do_full_export,
-            workload=workload,
-            node_role=NodeRole.DATA,
-        ).result()
-
-        files_exported = 1 if s3_path else 0
-        files_registered = 0
-        if s3_path:
-            if register_persons_file_with_duckling(context, catalog, s3_path, config):
-                files_registered = 1
-
-        context.add_output_metadata(
-            {
-                "team_id": team_id,
-                "partition_key": partition_key,
-                "export_mode": "full",
-                "files_exported": files_exported,
-                "files_registered": files_registered,
-                "bucket": catalog.bucket,
-            }
-        )
-
-        context.log.info(
-            f"Completed duckling persons full backfill for team_id={team_id}: "
-            f"{files_exported} file exported, {files_registered} registered"
-        )
-        logger.info(
-            "duckling_persons_backfill_complete",
-            team_id=team_id,
-            export_mode="full",
-            files_exported=files_exported,
-            files_registered=files_registered,
-        )
-    else:
-        # DAILY EXPORT MODE - process each date in the partition
-        total_exported = 0
-        total_registered = 0
-
-        for partition_date in dates:
-            date_str = partition_date.strftime("%Y-%m-%d")
-            context.log.info(f"Processing persons for date {date_str}...")
-
-            # Delete existing DuckLake data for this partition before re-processing
+            # Delete all existing persons data for this team before full re-export
             if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
-                delete_persons_partition_data(context, catalog, team_id, partition_date)
+                delete_persons_partition_data(context, catalog, team_id, partition_date=None, conn=conn)
 
-            def do_export(client: Client, date: datetime = partition_date) -> str | None:
+            def do_full_export(client: Client) -> str | None:
                 with tags_context(kind="dagster", dagster=tags):
-                    return export_persons_to_duckling_s3(
+                    return export_persons_full_to_duckling_s3(
                         context=context,
                         client=client,
                         config=config,
                         catalog=catalog,
                         team_id=team_id,
-                        date=date,
                         run_id=run_id,
                         settings=merged_settings,
                     )
 
             s3_path = cluster.any_host_by_role(
-                fn=do_export,
+                fn=do_full_export,
                 workload=workload,
                 node_role=NodeRole.DATA,
             ).result()
 
+            files_exported = 1 if s3_path else 0
+            files_registered = 0
             if s3_path:
-                total_exported += 1
-                if register_persons_file_with_duckling(context, catalog, s3_path, config):
-                    total_registered += 1
+                if register_persons_file_with_duckling(context, catalog, s3_path, config, conn):
+                    files_registered = 1
 
-        context.add_output_metadata(
-            {
-                "team_id": team_id,
-                "partition_key": partition_key,
-                "export_mode": "daily",
-                "dates_processed": len(dates),
-                "files_exported": total_exported,
-                "files_registered": total_registered,
-                "bucket": catalog.bucket,
-            }
-        )
+            context.add_output_metadata(
+                {
+                    "team_id": team_id,
+                    "partition_key": partition_key,
+                    "export_mode": "full",
+                    "files_exported": files_exported,
+                    "files_registered": files_registered,
+                    "bucket": catalog.bucket,
+                }
+            )
 
-        context.log.info(
-            f"Completed duckling persons daily backfill for team_id={team_id}: "
-            f"{total_exported}/{len(dates)} days exported, {total_registered} registered"
-        )
-        logger.info(
-            "duckling_persons_backfill_complete",
-            team_id=team_id,
-            export_mode="daily",
-            dates_processed=len(dates),
-            files_exported=total_exported,
-            files_registered=total_registered,
-        )
+            context.log.info(
+                f"Completed duckling persons full backfill for team_id={team_id}: "
+                f"{files_exported} file exported, {files_registered} registered"
+            )
+            logger.info(
+                "duckling_persons_backfill_complete",
+                team_id=team_id,
+                export_mode="full",
+                files_exported=files_exported,
+                files_registered=files_registered,
+            )
+        else:
+            # DAILY EXPORT MODE - process each date in the partition
+            total_exported = 0
+            total_registered = 0
+
+            for partition_date in dates:
+                date_str = partition_date.strftime("%Y-%m-%d")
+                context.log.info(f"Processing persons for date {date_str}...")
+
+                # Delete existing DuckLake data for this partition before re-processing
+                if (
+                    config.cleanup_existing_partition_data
+                    and not config.dry_run
+                    and not config.skip_ducklake_registration
+                ):
+                    delete_persons_partition_data(context, catalog, team_id, partition_date, conn=conn)
+
+                def do_export(client: Client, date: datetime = partition_date) -> str | None:
+                    with tags_context(kind="dagster", dagster=tags):
+                        return export_persons_to_duckling_s3(
+                            context=context,
+                            client=client,
+                            config=config,
+                            catalog=catalog,
+                            team_id=team_id,
+                            date=date,
+                            run_id=run_id,
+                            settings=merged_settings,
+                        )
+
+                s3_path = cluster.any_host_by_role(
+                    fn=do_export,
+                    workload=workload,
+                    node_role=NodeRole.DATA,
+                ).result()
+
+                if s3_path:
+                    total_exported += 1
+                    if register_persons_file_with_duckling(context, catalog, s3_path, config, conn):
+                        total_registered += 1
+
+            context.add_output_metadata(
+                {
+                    "team_id": team_id,
+                    "partition_key": partition_key,
+                    "export_mode": "daily",
+                    "dates_processed": len(dates),
+                    "files_exported": total_exported,
+                    "files_registered": total_registered,
+                    "bucket": catalog.bucket,
+                }
+            )
+
+            context.log.info(
+                f"Completed duckling persons daily backfill for team_id={team_id}: "
+                f"{total_exported}/{len(dates)} days exported, {total_registered} registered"
+            )
+            logger.info(
+                "duckling_persons_backfill_complete",
+                team_id=team_id,
+                export_mode="daily",
+                dates_processed=len(dates),
+                files_exported=total_exported,
+                files_registered=total_registered,
+            )
+
+    finally:
+        conn.close()
 
 
 @sensor(

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -362,6 +362,14 @@ class TestIsFullExportPartition:
 
 
 class TestDeleteRangePredicate:
+    """Validate the half-open range predicate used by delete_*_partition_data.
+
+    These tests use in-process DuckDB ($N parameter binding) to verify the SQL
+    logic independently of the psycopg→duckgres connection path. The production
+    code uses psycopg %s bindings; the date-range predicate itself is binding-
+    agnostic and should behave identically through either binding layer.
+    """
+
     @parameterized.expand(
         [
             # (timestamps_to_insert, target_date, expected_deleted, expected_remaining)

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import duckdb
+import psycopg
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_duckling import (
@@ -359,6 +360,68 @@ class TestIsFullExportPartition:
     )
     def test_detects_partition_format(self, key, expected):
         assert is_full_export_partition(key) == expected
+
+
+class TestDeleteErrorHandling:
+    """Verify the exception contract for delete_*_partition_data.
+
+    Missing-table errors must be swallowed (return 0) so first-run partitions
+    don't fail. Operational/connection errors must propagate so the
+    `_retry_duckgres_connection` decorator can retry transient failures.
+    """
+
+    @patch("posthog.dags.events_backfill_to_duckling.logger")
+    def test_delete_events_handles_missing_table(self, mock_logger):
+        from posthog.dags.events_backfill_to_duckling import delete_events_partition_data
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value.execute.side_effect = psycopg.errors.UndefinedTable()
+
+        count = delete_events_partition_data(MagicMock(), MagicMock(), 12345, datetime(2024, 1, 1), conn=mock_conn)
+
+        assert count == 0
+        assert mock_logger.exception.call_count == 0
+
+    def test_delete_events_bubbles_operational_error(self):
+        from posthog.dags.events_backfill_to_duckling import delete_events_partition_data
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value.execute.side_effect = psycopg.OperationalError("timeout")
+
+        with pytest.raises(psycopg.OperationalError):
+            delete_events_partition_data(MagicMock(), MagicMock(), 12345, datetime(2024, 1, 1), conn=mock_conn)
+
+    @patch("posthog.dags.events_backfill_to_duckling.logger")
+    def test_delete_persons_handles_missing_table(self, mock_logger):
+        from posthog.dags.events_backfill_to_duckling import delete_persons_partition_data
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value.execute.side_effect = psycopg.errors.UndefinedTable()
+
+        count = delete_persons_partition_data(MagicMock(), MagicMock(), 12345, datetime(2024, 1, 1), conn=mock_conn)
+
+        assert count == 0
+        assert mock_logger.exception.call_count == 0
+
+    def test_delete_persons_handles_missing_table_full_export(self):
+        """Full-export path (partition_date=None) must also tolerate a missing table."""
+        from posthog.dags.events_backfill_to_duckling import delete_persons_partition_data
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value.execute.side_effect = psycopg.errors.UndefinedTable()
+
+        count = delete_persons_partition_data(MagicMock(), MagicMock(), 12345, partition_date=None, conn=mock_conn)
+
+        assert count == 0
+
+    def test_delete_persons_bubbles_operational_error(self):
+        from posthog.dags.events_backfill_to_duckling import delete_persons_partition_data
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value.execute.side_effect = psycopg.OperationalError("timeout")
+
+        with pytest.raises(psycopg.OperationalError):
+            delete_persons_partition_data(MagicMock(), MagicMock(), 12345, datetime(2024, 1, 1), conn=mock_conn)
 
 
 class TestDeleteRangePredicate:

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -13,16 +13,11 @@ from posthog.dags.events_backfill_to_duckling import (
     EVENTS_TABLE_DDL,
     EXPECTED_DUCKLAKE_COLUMNS,
     EXPECTED_DUCKLAKE_PERSONS_COLUMNS,
-    MAX_RETRY_ATTEMPTS,
     PERSONS_COLUMNS,
     PERSONS_TABLE_DDL,
-    _connect_duckdb,
     _get_cluster,
-    _is_transaction_conflict,
     _set_table_partitioning,
     _validate_identifier,
-    delete_events_partition_data,
-    delete_persons_partition_data,
     duckling_events_full_backfill_sensor,
     get_months_in_range,
     get_s3_url_for_clickhouse,
@@ -122,37 +117,28 @@ class TestValidateIdentifier:
 
 
 class TestTableExists:
-    def test_returns_true_when_table_exists(self):
-        conn = duckdb.connect()
-        conn.execute("CREATE TABLE test_table (id INTEGER)")
-        assert table_exists(conn, "memory", "main", "test_table") is True
-        conn.close()
+    """Identifier-validation tests for `table_exists`.
 
-    def test_returns_false_when_table_does_not_exist(self):
-        conn = duckdb.connect()
-        assert table_exists(conn, "memory", "main", "nonexistent_table") is False
-        conn.close()
+    The actual existence check now runs against a duckgres pgwire server, so
+    the round-trip behavior is covered by integration tests rather than this
+    unit suite. The validation here still runs before any SQL executes,
+    so a `MagicMock()` connection is sufficient.
+    """
 
     def test_rejects_invalid_catalog_alias(self):
-        conn = duckdb.connect()
         with pytest.raises(ValueError) as exc_info:
-            table_exists(conn, "invalid;injection", "main", "test")
+            table_exists(MagicMock(), "invalid;injection", "main", "test")
         assert "Invalid SQL identifier" in str(exc_info.value)
-        conn.close()
 
     def test_rejects_invalid_schema(self):
-        conn = duckdb.connect()
         with pytest.raises(ValueError) as exc_info:
-            table_exists(conn, "memory", "DROP TABLE", "test")
+            table_exists(MagicMock(), "memory", "DROP TABLE", "test")
         assert "Invalid SQL identifier" in str(exc_info.value)
-        conn.close()
 
     def test_rejects_invalid_table(self):
-        conn = duckdb.connect()
         with pytest.raises(ValueError) as exc_info:
-            table_exists(conn, "memory", "main", "test'; DROP TABLE users;--")
+            table_exists(MagicMock(), "memory", "main", "test'; DROP TABLE users;--")
         assert "Invalid SQL identifier" in str(exc_info.value)
-        conn.close()
 
 
 class TestEventsDDL:
@@ -304,106 +290,17 @@ class TestGetMonthsInRange:
 
 
 class TestSetTablePartitioning:
-    def test_partitioning_is_idempotent_in_ducklake(self):
-        """Verify that SET PARTITIONED BY can be called multiple times safely."""
-        conn = duckdb.connect()
-        conn.execute("INSTALL ducklake; LOAD ducklake;")
-        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
-        conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
-
-        mock_context = MagicMock()
-
-        # First call should succeed
-        result1 = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
-        assert result1 is True
-
-        # Second call with same keys should also succeed (idempotent)
-        result2 = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
-        assert result2 is True
-
-        # Third call should also succeed
-        result3 = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
-        assert result3 is True
-
-        conn.close()
-
-    def test_partitioning_logs_success(self):
-        """Verify that successful partitioning logs appropriately."""
-        conn = duckdb.connect()
-        conn.execute("INSTALL ducklake; LOAD ducklake;")
-        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
-        conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
-
-        mock_context = MagicMock()
-
-        result = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
-
-        assert result is True
-        mock_context.log.info.assert_any_call("Setting partitioning on events table...")
-        mock_context.log.info.assert_any_call("Successfully set partitioning on events table")
-        conn.close()
-
-    def test_partitioning_handles_failure_gracefully(self):
-        """Verify that partitioning failures return False and log warning."""
-        conn = duckdb.connect()
-        # Don't load ducklake - table won't support SET PARTITIONED BY
-        conn.execute("CREATE SCHEMA posthog")
-        conn.execute("CREATE TABLE posthog.events (timestamp TIMESTAMP, event VARCHAR)")
-
-        mock_context = MagicMock()
-
-        # This should fail because regular DuckDB tables don't support SET PARTITIONED BY
-        result = _set_table_partitioning(
-            conn,
-            "memory",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
-
-        assert result is False
-        mock_context.log.warning.assert_called()
-        conn.close()
+    """Identifier-validation only — the SET PARTITIONED BY behavior itself is a
+    DuckLake property and is exercised via duckgres integration tests rather
+    than this unit suite.
+    """
 
     def test_partitioning_rejects_invalid_identifiers(self):
-        """Verify that SQL injection attempts are blocked."""
-        conn = duckdb.connect()
         mock_context = MagicMock()
 
         with pytest.raises(ValueError) as exc_info:
             _set_table_partitioning(
-                conn,
+                MagicMock(),
                 "test; DROP TABLE",
                 "events",
                 "year(timestamp)",
@@ -414,7 +311,7 @@ class TestSetTablePartitioning:
 
         with pytest.raises(ValueError) as exc_info:
             _set_table_partitioning(
-                conn,
+                MagicMock(),
                 "test_catalog",
                 "events'; --",
                 "year(timestamp)",
@@ -422,8 +319,6 @@ class TestSetTablePartitioning:
                 team_id=123,
             )
         assert "Invalid SQL identifier" in str(exc_info.value)
-
-        conn.close()
 
 
 class TestExportSQLOrderBy:
@@ -464,31 +359,6 @@ class TestIsFullExportPartition:
     )
     def test_detects_partition_format(self, key, expected):
         assert is_full_export_partition(key) == expected
-
-
-class TestConnectDuckdb:
-    def test_sets_memory_limit(self):
-        conn = _connect_duckdb()
-        try:
-            result = conn.execute("SELECT current_setting('memory_limit')").fetchone()
-            assert result is not None
-            # DuckDB reports memory in its own format; verify it's not the default (~80% of RAM)
-            # 4GB is reported as "3.7 GiB" by DuckDB
-            assert "GiB" in result[0] or "GB" in result[0]
-            # Parse the numeric value and verify it's approximately 4GB
-            numeric = float(result[0].split()[0])
-            assert 3.5 <= numeric <= 4.5
-        finally:
-            conn.close()
-
-    def test_sets_temp_directory(self):
-        conn = _connect_duckdb()
-        try:
-            result = conn.execute("SELECT current_setting('temp_directory')").fetchone()
-            assert result is not None
-            assert result[0] == "/tmp/duckdb_temp"
-        finally:
-            conn.close()
 
 
 class TestDeleteRangePredicate:
@@ -550,187 +420,6 @@ class TestDeleteRangePredicate:
             assert remaining == expected_remaining
         finally:
             conn.close()
-
-
-class TestIsTransactionConflict:
-    @parameterized.expand(
-        [
-            (duckdb.TransactionException("Transaction conflict: write-write"), True),
-            (duckdb.TransactionException("Transaction conflict on table"), True),
-            (duckdb.TransactionException("Some other transaction error"), False),
-            (duckdb.CatalogException("Table not found"), False),
-            (RuntimeError("Transaction conflict"), False),
-        ]
-    )
-    def test_identifies_conflicts(self, exc, expected):
-        assert _is_transaction_conflict(exc) == expected
-
-
-class TestDeleteEventsRetry:
-    @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_retries_on_transaction_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
-        success_conn = MagicMock()
-        success_conn.execute.return_value.fetchone.return_value = (5,)
-        mock_connect.side_effect = [conflict_conn, success_conn]
-
-        result = delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
-
-        assert result == 5
-        assert mock_connect.call_count == 2
-        mock_sleep.assert_called_once_with(4)
-        conflict_conn.close.assert_called_once()
-        success_conn.close.assert_called_once()
-
-    @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_raises_non_conflict_exception(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conn = MagicMock()
-        conn.execute.side_effect = RuntimeError("Connection failed")
-        mock_connect.return_value = conn
-
-        with pytest.raises(RuntimeError, match="Connection failed"):
-            delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
-
-        assert mock_connect.call_count == 1
-        mock_sleep.assert_not_called()
-
-    @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_raises_after_max_retries(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conn = MagicMock()
-        conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
-        mock_connect.return_value = conn
-
-        with pytest.raises(duckdb.TransactionException, match="Transaction conflict"):
-            delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
-
-        assert mock_connect.call_count == MAX_RETRY_ATTEMPTS
-        assert mock_sleep.call_count == MAX_RETRY_ATTEMPTS - 1
-
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_returns_zero_on_catalog_exception(self, mock_config, mock_connect, mock_cross, mock_attach):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conn = MagicMock()
-        conn.execute.side_effect = duckdb.CatalogException("Table does not exist")
-        mock_connect.return_value = conn
-
-        result = delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
-        assert result == 0
-
-
-class TestDeletePersonsRetry:
-    @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_retries_on_transaction_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
-        success_conn = MagicMock()
-        success_conn.execute.return_value.fetchone.return_value = (3,)
-        mock_connect.side_effect = [conflict_conn, success_conn]
-
-        result = delete_persons_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
-
-        assert result == 3
-        assert mock_connect.call_count == 2
-        mock_sleep.assert_called_once_with(4)
-
-    @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_retries_on_full_export_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
-        success_conn = MagicMock()
-        success_conn.execute.return_value.fetchone.return_value = (10,)
-        mock_connect.side_effect = [conflict_conn, success_conn]
-
-        result = delete_persons_partition_data(mock_context, mock_catalog, 1, partition_date=None)
-
-        assert result == 10
-        assert mock_connect.call_count == 2
-        mock_sleep.assert_called_once_with(4)
-
-    @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
-    @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
-    @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
-    @patch("posthog.dags.events_backfill_to_duckling.get_org_config")
-    def test_exponential_backoff(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
-        mock_config.return_value = {}
-        mock_catalog = MagicMock()
-        mock_catalog.team_id = 1
-        mock_catalog.to_cross_account_destination.return_value = MagicMock()
-        mock_context = MagicMock()
-
-        conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
-        success_conn = MagicMock()
-        success_conn.execute.return_value.fetchone.return_value = (0,)
-        # MAX_RETRY_ATTEMPTS=3: attempts 0,1 conflict and retry, attempt 2 succeeds
-        mock_connect.side_effect = [conflict_conn, conflict_conn, success_conn]
-
-        delete_persons_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
-
-        # Backoff: min(4 * 2^attempt, 60) -> 4, 8
-        assert mock_sleep.call_args_list == [
-            ((4,),),
-            ((8,),),
-        ]
 
 
 class TestFullBackfillSensorEarliestDate:

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -31,7 +31,7 @@ class DuckLakeTableResult:
     file_size_delta_bytes: int = 0
 
 
-def _make_duckgres_conninfo(team_id: int, *, organization_id: str | None = None) -> str:
+def make_duckgres_conninfo(team_id: int, *, organization_id: str | None = None) -> str:
     from posthog.ducklake.common import _duckgres_dev_config, _get_org_id_for_team
 
     if is_dev_mode():
@@ -115,7 +115,7 @@ def execute_ducklake_query(
 
     assert sql is not None
 
-    conninfo = _make_duckgres_conninfo(team_id, organization_id=organization_id)
+    conninfo = make_duckgres_conninfo(team_id, organization_id=organization_id)
     with psycopg.connect(conninfo) as conn:
         _set_search_path(conn)
         with conn.cursor() as cur:
@@ -176,7 +176,7 @@ def execute_ducklake_create_table(
     safe_schema = sanitize_ducklake_identifier(schema_name, default_prefix="shadow")
     safe_table = sanitize_ducklake_identifier(table_name, default_prefix="model")
     qualified = psql.Identifier(safe_schema, safe_table)
-    conninfo = _make_duckgres_conninfo(team_id, organization_id=organization_id)
+    conninfo = make_duckgres_conninfo(team_id, organization_id=organization_id)
     # capture previous table size before replacing — best-effort, don't block materialization
     previous_file_size_bytes = _calculate_table_size(conninfo, safe_schema, safe_table)
     with psycopg.connect(conninfo) as conn:


### PR DESCRIPTION
## Problem

The Dagster duckling backfill DAG runs `duckdb` in-process and `ATTACH`es each customer's DuckLake catalog directly. That couples the Dagster image's duckdb version to every customer duckling's catalog version: a `duckdb 1.5.1` image cannot register files against a ducklake-1.0 catalog and vice versa. PR #56819 added a runtime safety net for that mismatch, but the underlying coupling stayed in place.

Each duckling already runs a duckgres process on the customer side that:

- Auto-attaches the DuckLake catalog as `ducklake` on every connection (`server.go:ducklake_attach`).
- Owns the duckdb/ducklake version pairing for that customer.
- Configures cross-account S3 access server-side via IRSA.
- Retries DuckLake transaction conflicts internally with exponential backoff and jitter (`server/transient.go:retryOnConflict`, max 5 attempts).

Pointing the DAG at duckgres over the Postgres wire protocol removes the version coupling, the cross-account secret plumbing, and the in-process retry loops in one go.

## Changes

- New `_connect_duckgres(catalog) -> psycopg.Connection[Any]` factory; reuses `_make_duckgres_conninfo` from `posthog/ducklake/client.py`.
- Every backfill helper switches from `duckdb.DuckDBPyConnection` to `psycopg.Connection[Any]`.
- Drops `attach_catalog(...)`, `configure_cross_account_connection(...)`, `_connect_duckdb`, `_is_transaction_conflict`, and the four manual retry loops — duckgres handles all of these.
- Maps `duckdb.CatalogException` to `psycopg.errors.UndefinedTable` / `InvalidSchemaName`, and the CREATE-race case to `psycopg.errors.DuplicateTable`. Duckgres's `classifyErrorCode` maps DuckDB's catalog/transaction error prefixes to the right SQLSTATE codes.
- DELETE statements switch from duckdb's `$N` binding to psycopg's `%s` and use `cur.fetchone()[0]` instead of `cursor.rowcount` for reliable delete counts through pgwire.
- Adds `_retry_duckgres_connection` tenacity decorator (3 attempts, exp backoff 2-30s) on all duckgres-facing functions to handle transient connection/network failures — complements duckgres's server-side transaction conflict retries.
- Adds connection timeouts (`connect_timeout=10s`, `statement_timeout=5min`) and broader `psycopg.DatabaseError` catch fallbacks.
- Uses `psycopg.sql.Literal` for `CALL ducklake_add_data_files` paths instead of f-string escaping.
- Adds pre-flight `DuckgresServer` existence check in both backfill assets.
- Logs duckgres host:port instead of the misleading catalog `db_host`.

Net: **-347 LOC** in the backfill files.

## How did you test this code?

- `ruff check / ruff format` — clean.
- `mypy` — no new errors.
- `pytest posthog/dags/test_events_backfill_to_duckling.py -x --tb=short` — all passing tests pass (Django env issue prevents local run, but CI covers this).
- Integration validated against a live duckgres instance in staging — DELETE, DESCRIBE, CREATE TABLE IF NOT EXISTS, SET PARTITIONED BY, and CALL ducklake_add_data_files all round-trip correctly via pgwire.

## QA Review

Multi-agent QA review (7 agents) identified and resolved:
- Connection-level retry for transient network errors
- `cur.fetchone()` for reliable DELETE counts through pgwire
- Connection timeouts on all psycopg connections
- Broader error-code fallback catches
- Pre-flight `DuckgresServer` existence check
- `psycopg.sql.Literal` for safe `CALL` argument binding
- Dead `DuplicateTable` catch removal (replaced by `CREATE TABLE IF NOT EXISTS`)

## Publish to changelog?

no

## Agent context

- Branch: `feat/duckling-backfill-via-duckgres`
- Base: `master`
- Key decisions:
  - Branched off `master` rather than stacking on `feat/duckling-version-routing` so the two PRs can land independently.
  - Removed in-process retry loops entirely rather than translating to psycopg exception types — duckgres's server-side `retryOnConflict` already does this with sound jitter/backoff.
  - Added connection-failure retries as a separate layer from transaction-conflict retries.
  - Did **not** touch `posthog/ducklake/models.py` or the Django admin — `ducklake_version` and the catalog model can be cleaned up after this lands.