### PR TITLE
test(insights): cover empty state, click context, trend lines, CI, log y-scale

### DIFF
--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
@@ -242,27 +242,22 @@ describe('TrendsLineChart', () => {
     })
 
     describe('confidence intervals overlay', () => {
-        it('adds a CI band series when enabled', async () => {
+        beforeEach(() => {
             renderInsight({
                 query: buildTrendsQuery({
                     trendsFilter: { showConfidenceIntervals: true, confidenceLevel: 95 },
                 }),
                 featureFlags: HOG_CHARTS_FLAG,
             })
+        })
 
+        it('adds a CI band series when enabled', async () => {
             await waitFor(() => {
                 expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
             })
         })
 
         it('omits the CI series from tooltip rows', async () => {
-            renderInsight({
-                query: buildTrendsQuery({
-                    trendsFilter: { showConfidenceIntervals: true, confidenceLevel: 95 },
-                }),
-                featureFlags: HOG_CHARTS_FLAG,
-            })
-
             const tooltip = await chart.hoverTooltip(2)
 
             expect(tooltip.row('Pageview')).toContain('134')
@@ -271,27 +266,22 @@ describe('TrendsLineChart', () => {
     })
 
     describe('trend lines overlay', () => {
-        it('adds a dashed trend-line series when enabled', async () => {
+        beforeEach(() => {
             renderInsight({
                 query: buildTrendsQuery({
                     trendsFilter: { showTrendLines: true },
                 }),
                 featureFlags: HOG_CHARTS_FLAG,
             })
+        })
 
+        it('adds a dashed trend-line series when enabled', async () => {
             await waitFor(() => {
                 expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
             })
         })
 
         it('omits the trend-line series from tooltip rows', async () => {
-            renderInsight({
-                query: buildTrendsQuery({
-                    trendsFilter: { showTrendLines: true },
-                }),
-                featureFlags: HOG_CHARTS_FLAG,
-            })
-
             const tooltip = await chart.hoverTooltip(2)
 
             expect(tooltip.row('Pageview')).toContain('134')
@@ -302,7 +292,9 @@ describe('TrendsLineChart', () => {
             )
             expect(rows).toHaveLength(1)
         })
+    })
 
+    describe('trend lines + moving average', () => {
         it('renders separate trend lines for the raw and moving-average series', async () => {
             renderInsight({
                 query: buildTrendsQuery({

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
@@ -90,6 +90,28 @@ describe('TrendsLineChart', () => {
             expect(tooltip.row('Previous')).toContain('100')
         })
 
+        it('uses context.formatCompareLabel to override Current/Previous in compare mode', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    compareFilter: { compare: true },
+                }),
+                context: {
+                    formatCompareLabel: (label) => (label === 'current' ? 'This week' : 'Last week'),
+                },
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            expect(tooltip.row('This week')).toContain('134')
+            expect(tooltip.row('Last week')).toContain('100')
+            expect(tooltip.element.textContent).not.toContain('Current')
+        })
+
         it('formats values as percentages in percent stack view', async () => {
             renderInsight({
                 query: buildTrendsQuery({
@@ -199,6 +221,137 @@ describe('TrendsLineChart', () => {
         })
     })
 
+    describe('log y-scale', () => {
+        it('renders without crashing when series contain zero values', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [{ kind: NodeKind.EventsNode, event: 'ZeroCounts', name: 'ZeroCounts' }],
+                    trendsFilter: { yAxisScaleType: 'log10' },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+            expect(tooltip.row('ActiveSeries')).toContain('3')
+            expect(tooltip.row('EmptySeries')).toContain('0')
+        })
+    })
+
+    describe('confidence intervals overlay', () => {
+        it('adds a CI band series when enabled', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: { showConfidenceIntervals: true, confidenceLevel: 95 },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+        })
+
+        it('omits the CI series from tooltip rows', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: { showConfidenceIntervals: true, confidenceLevel: 95 },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            expect(tooltip.row('Pageview')).toContain('134')
+            expect(tooltip.element.textContent).not.toContain('(CI)')
+        })
+    })
+
+    describe('trend lines overlay', () => {
+        it('adds a dashed trend-line series when enabled', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: { showTrendLines: true },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+        })
+
+        it('omits the trend-line series from tooltip rows', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: { showTrendLines: true },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            expect(tooltip.row('Pageview')).toContain('134')
+            // The trend-line carries the same series label; only the main
+            // row should appear, so there must be exactly one row matching.
+            const rows = Array.from(tooltip.element.querySelectorAll('tr')).filter((r) =>
+                r.textContent?.includes('Pageview')
+            )
+            expect(rows).toHaveLength(1)
+        })
+
+        it('renders separate trend lines for the raw and moving-average series', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: {
+                        showTrendLines: true,
+                        showMovingAverage: true,
+                        movingAverageIntervals: 3,
+                    },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            // main + raw trendline + moving avg + moving-avg trendline = 4 series.
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 4 data series/i })).toBeInTheDocument()
+            })
+        })
+    })
+
+    describe('empty state', () => {
+        it('renders InsightEmptyState when all series are zero', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [{ kind: NodeKind.EventsNode, event: 'NoActivity', name: 'NoActivity' }],
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('insight-empty-state')).toBeInTheDocument()
+            })
+            expect(screen.queryByRole('img', { name: /chart with/i })).not.toBeInTheDocument()
+        })
+
+        it('uses context.emptyStateHeading override when provided', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [{ kind: NodeKind.EventsNode, event: 'NoActivity', name: 'NoActivity' }],
+                }),
+                context: { emptyStateHeading: 'Nothing to see here, hedgehog' },
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                expect(screen.getByText('Nothing to see here, hedgehog')).toBeInTheDocument()
+            })
+        })
+    })
+
     describe('click → persons modal', () => {
         it('single series: direct click shows the actors for the clicked day', async () => {
             renderInsight({ query: buildTrendsQuery(), featureFlags: HOG_CHARTS_FLAG })
@@ -245,6 +398,42 @@ describe('TrendsLineChart', () => {
             await waitFor(() => {
                 expect(personsModal.actorNames()).toEqual(expectedActors)
             })
+        })
+
+        it('fires context.onDataPointClick instead of opening the persons modal', async () => {
+            const onDataPointClick = jest.fn()
+            renderInsight({
+                query: buildTrendsQuery(),
+                context: { onDataPointClick },
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+
+            await waitFor(() => {
+                expect(onDataPointClick).toHaveBeenCalledTimes(1)
+            })
+            const [seriesArg] = onDataPointClick.mock.calls[0]
+            expect(seriesArg.day).toBe('2024-06-12')
+            expect(personsModal.get()).not.toBeInTheDocument()
+        })
+
+        it('does nothing when there is no persons modal and no onDataPointClick', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: { formula: 'A + B' },
+                    series: [
+                        { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+                        { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+                    ],
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+
+            // Without a click handler the canvas still renders; clicking is a no-op.
+            expect(personsModal.get()).not.toBeInTheDocument()
         })
     })
 })

--- a/frontend/src/test/insight-testing/test-data.ts
+++ b/frontend/src/test/insight-testing/test-data.ts
@@ -39,6 +39,14 @@ export const eventDefinitions: EventDefinition[] = [
         last_seen_at: friday,
         created_at: setupWeek,
     },
+    {
+        id: 'evt-005',
+        name: 'NoActivity',
+        description: 'Event whose series is all zeros (drives empty-state branch)',
+        tags: [],
+        last_seen_at: friday,
+        created_at: setupWeek,
+    },
 ]
 
 export const propertyDefinitions: PropertyDefinition[] = [
@@ -115,6 +123,12 @@ export const trendsSeries = {
         days,
         labels,
     } satisfies CannedSeries,
+    noActivity: {
+        label: 'NoActivity',
+        data: [0, 0, 0, 0, 0],
+        days,
+        labels,
+    } satisfies CannedSeries,
     pageviewsCompare: [
         { label: '$pageview', data: [45, 82, 134, 210, 95], days, labels, compare: true, compare_label: 'current' },
         {
@@ -148,6 +162,7 @@ const seriesByEvent: Record<string, EventSeriesConfig> = {
     },
     ZeroCounts: { default: trendsSeries.withZeroCounts[0], multi: trendsSeries.withZeroCounts },
     Minimal: { default: trendsSeries.minimal },
+    NoActivity: { default: trendsSeries.noActivity },
 }
 
 /** Resolver for compare queries — returns current + previous period series. */


### PR DESCRIPTION
## Problem

`TrendsLineChart` had thin component-test coverage on the new hog-charts path: only the tooltip glyph/value, moving-average overlay, and persons-modal click flows were exercised. Several other branches the component compiles for — empty state, the alternative click handlers via `QueryContext`, `formatCompareLabel`, trend lines, confidence intervals, log y-scale — had no behavioral assertion.

## Changes

- Adds a `NoActivity` (all-zero) fixture to `frontend/src/test/insight-testing/test-data.ts` so the empty-state branch is reachable from a query.
- Adds 11 component tests against `TrendsLineChart` using the existing `~/test/insight-testing` harness — no new harness extensions:
  - empty state + `context.emptyStateHeading` override
  - `context.onDataPointClick` fires & suppresses the persons modal
  - canvas is a no-op when neither `hasPersonsModal` nor `onDataPointClick` is set
  - `context.formatCompareLabel` overrides Current/Previous in compare mode
  - trend lines: presence, tooltip exclusion, combined-with-MA series count
  - confidence intervals: presence, tooltip exclusion
  - log y-scale tolerates zero values

## How did you test this code?

I'm an agent (Claude). Verified `frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx` runs green (27/27) via `pnpm exec jest --runTestsByPath ...`. No manual UI testing.

## Publish to changelog?
no