### PR TITLE
test(insights): cover annotations, inSharedMode, tooltip lifecycle

### DIFF
--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
@@ -1,14 +1,15 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { setupJsdom } from 'lib/hog-charts/test-helpers'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildTrendsQuery, chart, personsModal, renderInsight } from '~/test/insight-testing'
+import { buildAnnotation } from '~/test/insight-testing/test-data'
 import { createTooltipAccessor } from '~/test/insight-testing/tooltip-helpers'
-import { ChartDisplayType } from '~/types'
+import { AnnotationScope, ChartDisplayType } from '~/types'
 
 let cleanupJsdom: () => void
 
@@ -218,6 +219,112 @@ describe('TrendsLineChart', () => {
             await waitFor(() => {
                 expect(screen.getByRole('img', { name: /chart with 1 data series/i })).toBeInTheDocument()
             })
+        })
+    })
+
+    describe('annotations', () => {
+        it('renders an annotation badge when an annotation exists', async () => {
+            renderInsight({
+                query: buildTrendsQuery(),
+                mocks: {
+                    annotations: [
+                        buildAnnotation({
+                            scope: AnnotationScope.Project,
+                            content: 'Hedgehog spotted',
+                            date_marker: '2024-06-12T12:00:00Z',
+                        }),
+                    ],
+                },
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await waitFor(() => {
+                const badges = document.querySelectorAll('.AnnotationsBadge')
+                expect(badges.length).toBeGreaterThan(0)
+            })
+        })
+
+        it('does not render annotations when inSharedMode is true', async () => {
+            renderInsight({
+                query: buildTrendsQuery(),
+                mocks: {
+                    annotations: [
+                        buildAnnotation({
+                            scope: AnnotationScope.Project,
+                            content: 'Hidden in shared mode',
+                            date_marker: '2024-06-12T12:00:00Z',
+                        }),
+                    ],
+                },
+                inSharedMode: true,
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await screen.findByRole('img', { name: /chart with/i })
+            expect(document.querySelectorAll('.AnnotationsBadge')).toHaveLength(0)
+        })
+    })
+
+    describe('tooltip date title', () => {
+        it('shows the hovered day in the tooltip title row', async () => {
+            renderInsight({
+                query: buildTrendsQuery({ interval: 'day' }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            // Wednesday is the third day (index 2) in our pageview fixture (2024-06-12).
+            expect(tooltip.title()).toMatch(/Wednesday/i)
+            expect(tooltip.title()).toMatch(/12.+Jun/)
+        })
+    })
+
+    describe('tooltip pin lifecycle', () => {
+        it('unpins when Escape is pressed', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+            expect(chart.getTooltip()).toBeInTheDocument()
+
+            fireEvent.keyDown(document, { key: 'Escape' })
+
+            await waitFor(() => {
+                expect(chart.getTooltip()).not.toBeInTheDocument()
+            })
+        })
+
+        it('unpins when clicking outside the chart', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+            expect(chart.getTooltip()).toBeInTheDocument()
+
+            // The chart attaches its outside-click listener via setTimeout(0); flush
+            // the microtask queue first so the listener actually intercepts the click.
+            await new Promise((resolve) => setTimeout(resolve, 5))
+
+            const outsideTarget = document.body.appendChild(document.createElement('div'))
+            try {
+                fireEvent.click(outsideTarget)
+                await waitFor(() => {
+                    expect(chart.getTooltip()).not.toBeInTheDocument()
+                })
+            } finally {
+                outsideTarget.remove()
+            }
         })
     })
 

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx
@@ -281,7 +281,25 @@ describe('TrendsLineChart', () => {
     })
 
     describe('tooltip pin lifecycle', () => {
-        it('unpins when Escape is pressed', async () => {
+        it.each([
+            {
+                trigger: 'Escape key press',
+                unpin: async () => {
+                    fireEvent.keyDown(document, { key: 'Escape' })
+                },
+            },
+            {
+                trigger: 'click outside the chart',
+                unpin: async () => {
+                    // The chart attaches its outside-click listener via setTimeout(0); flush
+                    // first so the listener actually intercepts the click.
+                    await new Promise((resolve) => setTimeout(resolve, 5))
+                    const outside = document.body.appendChild(document.createElement('div'))
+                    fireEvent.click(outside)
+                    outside.remove()
+                },
+            },
+        ])('unpins on $trigger', async ({ unpin }) => {
             renderInsight({
                 query: buildTrendsQuery({
                     series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
@@ -293,38 +311,11 @@ describe('TrendsLineChart', () => {
             await chart.clickAtIndex(2)
             expect(chart.getTooltip()).toBeInTheDocument()
 
-            fireEvent.keyDown(document, { key: 'Escape' })
+            await unpin()
 
             await waitFor(() => {
                 expect(chart.getTooltip()).not.toBeInTheDocument()
             })
-        })
-
-        it('unpins when clicking outside the chart', async () => {
-            renderInsight({
-                query: buildTrendsQuery({
-                    series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
-                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
-                }),
-                featureFlags: HOG_CHARTS_FLAG,
-            })
-
-            await chart.clickAtIndex(2)
-            expect(chart.getTooltip()).toBeInTheDocument()
-
-            // The chart attaches its outside-click listener via setTimeout(0); flush
-            // the microtask queue first so the listener actually intercepts the click.
-            await new Promise((resolve) => setTimeout(resolve, 5))
-
-            const outsideTarget = document.body.appendChild(document.createElement('div'))
-            try {
-                fireEvent.click(outsideTarget)
-                await waitFor(() => {
-                    expect(chart.getTooltip()).not.toBeInTheDocument()
-                })
-            } finally {
-                outsideTarget.remove()
-            }
         })
     })
 

--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -2,7 +2,7 @@ import { RestRequest } from 'msw'
 
 import { useMocks } from '~/mocks/jest'
 import { ActorsQueryResponse, NodeKind, TrendsQueryResponse } from '~/queries/schema/schema-general'
-import { EventDefinition, PropertyDefinition } from '~/types'
+import { EventDefinition, PropertyDefinition, RawAnnotationType } from '~/types'
 
 import {
     actionDefinitions,
@@ -135,6 +135,8 @@ export interface SetupMocksOptions {
      *  test wants to intercept one query kind (e.g. capture the ActorsQuery
      *  body) without losing the default mocks for the others. */
     additionalMockResponses?: MockResponse[]
+    /** Annotations returned by `/annotations/`. Defaults to []. */
+    annotations?: RawAnnotationType[]
 }
 
 // eslint-disable-next-line react-hooks/rules-of-hooks -- useMocks is an MSW helper, not a React hook
@@ -144,6 +146,7 @@ export function setupInsightMocks({
     propertyValues: propValues = defaultPropValues,
     mockResponses,
     additionalMockResponses,
+    annotations = [],
 }: SetupMocksOptions = {}): void {
     const defaults: MockResponse[] = [
         {
@@ -183,7 +186,12 @@ export function setupInsightMocks({
             '/api/environments/:team_id/insights/trend': [],
             // Annotations layer fetches this on mount; resolve immediately so async
             // state changes don't race against tooltip/click assertions.
-            '/api/projects/:team_id/annotations/': { results: [], count: 0, next: null, previous: null },
+            '/api/projects/:team_id/annotations/': {
+                results: annotations,
+                count: annotations.length,
+                next: null,
+                previous: null,
+            },
         },
         post: {
             '/api/environments/:team_id/query/:kind': (req: RestRequest) => {

--- a/frontend/src/test/insight-testing/render-insight.tsx
+++ b/frontend/src/test/insight-testing/render-insight.tsx
@@ -58,16 +58,19 @@ export interface RenderInsightProps {
     mocks?: SetupMocksOptions
     featureFlags?: Record<string, string | boolean>
     context?: QueryContext<InsightVizNode>
+    inSharedMode?: boolean
 }
 
 function InsightWrapper({
     query,
     showFilters = false,
     context,
+    inSharedMode,
 }: {
     query: TrendsQuery
     showFilters: boolean
     context?: QueryContext<InsightVizNode>
+    inSharedMode?: boolean
 }): JSX.Element {
     const [vizQuery, setVizQuery] = useState<InsightVizNode>({
         kind: NodeKind.InsightVizNode,
@@ -82,7 +85,15 @@ function InsightWrapper({
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { InsightViz } = require('~/queries/nodes/InsightViz/InsightViz')
 
-    return <InsightViz uniqueKey={INSIGHT_TEST_KEY} query={vizQuery} setQuery={setVizQuery} context={context} />
+    return (
+        <InsightViz
+            uniqueKey={INSIGHT_TEST_KEY}
+            query={vizQuery}
+            setQuery={setVizQuery}
+            context={context}
+            inSharedMode={inSharedMode}
+        />
+    )
 }
 
 export function renderInsight(props: RenderInsightProps = {}): ReturnType<typeof render> {
@@ -93,6 +104,7 @@ export function renderInsight(props: RenderInsightProps = {}): ReturnType<typeof
             query={props.query ?? buildTrendsQuery()}
             showFilters={props.showFilters ?? true}
             context={props.context}
+            inSharedMode={props.inSharedMode}
         />
     )
 }

--- a/frontend/src/test/insight-testing/test-data.ts
+++ b/frontend/src/test/insight-testing/test-data.ts
@@ -233,12 +233,11 @@ export interface ActorsLookupQuery {
     day?: string | number | null
 }
 
-let nextAnnotationId = 1
-
-/** Build a RawAnnotationType for use in setupInsightMocks({ annotations }). */
+/** Build a RawAnnotationType for use in setupInsightMocks({ annotations }).
+ *  Generates a random id so identifiers don't carry deterministic state across tests. */
 export function buildAnnotation(overrides: Partial<RawAnnotationType> = {}): RawAnnotationType {
     return {
-        id: nextAnnotationId++,
+        id: Math.floor(Math.random() * 1_000_000),
         scope: AnnotationScope.Project,
         content: 'Hedgehog spotted',
         date_marker: '2024-06-12T12:00:00Z',

--- a/frontend/src/test/insight-testing/test-data.ts
+++ b/frontend/src/test/insight-testing/test-data.ts
@@ -1,4 +1,4 @@
-import { EventDefinition, PropertyDefinition, PropertyType } from '~/types'
+import { AnnotationScope, EventDefinition, PropertyDefinition, PropertyType, RawAnnotationType } from '~/types'
 
 const friday = '2024-06-14T16:00:00.000Z'
 const setupWeek = '2024-06-03T10:00:00.000Z'
@@ -231,6 +231,21 @@ export interface ActorsLookupQuery {
     event?: string
     breakdown?: string | number | null
     day?: string | number | null
+}
+
+let nextAnnotationId = 1
+
+/** Build a RawAnnotationType for use in setupInsightMocks({ annotations }). */
+export function buildAnnotation(overrides: Partial<RawAnnotationType> = {}): RawAnnotationType {
+    return {
+        id: nextAnnotationId++,
+        scope: AnnotationScope.Project,
+        content: 'Hedgehog spotted',
+        date_marker: '2024-06-12T12:00:00Z',
+        created_at: '2024-06-10T00:00:00Z',
+        updated_at: '2024-06-10T00:00:00Z',
+        ...overrides,
+    }
 }
 
 export function lookupActors({ event, breakdown, day }: ActorsLookupQuery): ActorFixture[] {

--- a/frontend/src/test/insight-testing/tooltip-helpers.ts
+++ b/frontend/src/test/insight-testing/tooltip-helpers.ts
@@ -1,14 +1,26 @@
 export interface TooltipAccessor {
     element: HTMLElement
+    /** Header text — typically the hovered date (e.g. "Wednesday, 12 Jun (UTC)"). */
+    title(): string
+    /** Value cell text for the row whose datum column contains `label`. */
     row(label: string): string | undefined
+    /** Ordered list of row datum labels (skips the header row). */
+    rows(): string[]
 }
 
 export function createTooltipAccessor(element: HTMLElement): TooltipAccessor {
     return {
         element,
 
+        title(): string {
+            // The InsightTooltip's first column carries the date/header text. Its <th>
+            // doesn't have a stable class hook in either tooltip variant, so we just
+            // pick off the first <th> in the table head.
+            return element.querySelector('thead th')?.textContent?.trim() ?? ''
+        },
+
         row(label: string): string | undefined {
-            const rows = element.querySelectorAll('tr')
+            const rows = element.querySelectorAll('tbody tr')
             for (let i = 0; i < rows.length; i++) {
                 const row = rows[i]
                 if (row.textContent?.includes(label)) {
@@ -17,6 +29,13 @@ export function createTooltipAccessor(element: HTMLElement): TooltipAccessor {
                 }
             }
             return undefined
+        },
+
+        rows(): string[] {
+            const rows = element.querySelectorAll('tbody tr')
+            return Array.from(rows)
+                .map((r) => r.querySelector('.datum-column')?.textContent?.trim() ?? '')
+                .filter(Boolean)
         },
     }
 }


### PR DESCRIPTION
## Problem

The insight-testing harness had no way to seed annotations into a render or to assert on the tooltip's date header / pin lifecycle. `inSharedMode` also wasn't plumbed through `renderInsight`, so tests couldn't exercise the annotation-suppression branch in `TrendsLineChart`.

## Changes

- Adds an \`annotations\` option to \`SetupMocksOptions\` and a \`buildAnnotation\` fixture helper in \`frontend/src/test/insight-testing/\`.
- Threads \`inSharedMode\` through \`renderInsight\` to the underlying \`InsightViz\`.
- Extends \`TooltipAccessor\` with \`title()\` (header text) and \`rows()\` (ordered datum labels); narrows the existing \`row()\` selector to \`tbody tr\`.
- Adds 5 component tests against \`TrendsLineChart\`:
  - annotation badge renders when an annotation exists at a tick day
  - annotations are suppressed when \`inSharedMode\` is true
  - tooltip header shows the hovered day for \`interval: 'day'\`
  - pinned tooltip unpins on Escape
  - pinned tooltip unpins on click outside the chart wrapper

## How did you test this code?

I'm an agent (Claude). Verified \`frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.test.tsx\` runs green (32/32) via \`pnpm exec jest --runTestsByPath ...\`. No manual UI testing.

## Publish to changelog?

## 🤖 Agent context

Authored by Claude Opus 4.7 in Claude Code. Stacked on top of PR #56981 (\`sam/insight-tests-1-no-harness\`); leave the base branch as \`sam/insight-tests-1-no-harness\` until that lands. The third PR in the stack (\`sam/insight-tests-3-inspector\`) lands the hog-chart DOM inspector + the remaining overlay-driven tests.