### PR TITLE
fix(mcp): tag queries by product, use source=mcp for MCP attribution

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -48,7 +48,12 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import Feature, Product, get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
-from posthog.event_usage import get_request_analytics_properties, report_user_or_team_action
+from posthog.event_usage import (
+    EventSource,
+    get_event_source,
+    get_request_analytics_properties,
+    report_user_or_team_action,
+)
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters, apply_dashboard_variables
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -102,7 +107,7 @@ _SCENE_TO_TAGS: dict[str, dict[str, Product | ProductKey | Feature]] = {
 }
 
 
-def _infer_query_tags(query: BaseModel) -> dict[str, Product | ProductKey | Feature]:
+def _infer_query_tags(query: BaseModel, request: Request | None = None) -> dict[str, Product | ProductKey | Feature]:
     scene = getattr(getattr(query, "tags", None), "scene", None) or ""
     if mapped := _SCENE_TO_TAGS.get(scene):
         return mapped
@@ -112,6 +117,11 @@ def _infer_query_tags(query: BaseModel) -> dict[str, Product | ProductKey | Feat
     # so unmapped scenes don't trip UntaggedQueryError in DEBUG.
     if getattr(getattr(query, "tags", None), "productKey", None):
         return {"feature": Feature.QUERY}
+    # MCP queries without a scene or productKey are MCP-specific (e.g. raw HogQL
+    # via query-run). Product-specific tools inject tags.productKey so that the
+    # branch above fires instead. source=mcp is already set by CHQueries middleware.
+    if request is not None and get_event_source(request) == EventSource.MCP:
+        return {"product": Product.MCP, "feature": Feature.QUERY}
     return {}
 
 
@@ -220,16 +230,7 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
             # QueryRunner.run or QueryRunner.calculate before sync_execute fires. Scenes not
             # registered in `_infer_query_tags` stay untagged — they surface as
             # UntaggedQueryError in DEBUG, which is the signal to add them.
-            inferred_tags = _infer_query_tags(query)
-            if not inferred_tags and request.headers.get("x-posthog-client") == "mcp":
-                # MCP queries without a scene or productKey are MCP-specific (e.g. raw HogQL
-                # via query-run). Product-specific tools inject tags.productKey so that
-                # _infer_query_tags returns a non-empty dict above. source=mcp is already set
-                # by the CHQueries middleware for all MCP requests.
-                # Note: this header is client-supplied and not authenticated. Impact is
-                # attribution-only — a spoofed value can pollute `product=mcp` metrics but
-                # cannot bypass authorization.
-                inferred_tags = {"product": Product.MCP, "feature": Feature.QUERY}
+            inferred_tags = _infer_query_tags(query, request)
             if inferred_tags:
                 tag_queries(**inferred_tags)
             self._tag_client_query_id(client_query_id)

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -289,7 +289,7 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 else status.HTTP_200_OK
             )
 
-            if request.headers.get("x-posthog-client") == "mcp":
+            if get_event_source(request) == EventSource.MCP:
                 formatted = self._try_format_for_llm(query, result)
                 if formatted is not None:
                     result["formatted_results"] = formatted

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -220,7 +220,14 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
             # QueryRunner.run or QueryRunner.calculate before sync_execute fires. Scenes not
             # registered in `_infer_query_tags` stay untagged — they surface as
             # UntaggedQueryError in DEBUG, which is the signal to add them.
-            if inferred_tags := _infer_query_tags(query):
+            inferred_tags = _infer_query_tags(query)
+            if not inferred_tags and request.headers.get("x-posthog-client") == "mcp":
+                # MCP queries without a scene or productKey are MCP-specific (e.g. raw HogQL
+                # via query-run). Product-specific tools inject tags.productKey so that
+                # _infer_query_tags returns a non-empty dict above. source=mcp is already set
+                # by the CHQueries middleware for all MCP requests.
+                inferred_tags = {"product": Product.MCP, "feature": Feature.QUERY}
+            if inferred_tags:
                 tag_queries(**inferred_tags)
             self._tag_client_query_id(client_query_id)
             analytics_props = get_request_analytics_properties(request)

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -226,6 +226,9 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 # via query-run). Product-specific tools inject tags.productKey so that
                 # _infer_query_tags returns a non-empty dict above. source=mcp is already set
                 # by the CHQueries middleware for all MCP requests.
+                # Note: this header is client-supplied and not authenticated. Impact is
+                # attribution-only — a spoofed value can pollute `product=mcp` metrics but
+                # cannot bypass authorization.
                 inferred_tags = {"product": Product.MCP, "feature": Feature.QUERY}
             if inferred_tags:
                 tag_queries(**inferred_tags)

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -39,6 +39,7 @@ class Product(StrEnum):
     LLM_ANALYTICS = "llm_analytics"
     LOGS = "logs"
     MAX_AI = "max_ai"
+    MCP = "mcp"
     MESSAGING = "messaging"
     MOBILE_REPLAY = "mobile_replay"
     PIPELINE_DESTINATIONS = "pipeline_destinations"

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -323,6 +323,8 @@ def get_event_source(request) -> EventSource:
         return EventSource.POSTHOG_CODE
     if "posthog/mcp-server" in user_agent:
         return EventSource.MCP
+    if request.headers.get("x-posthog-client") == "mcp":
+        return EventSource.MCP
     # DRF sets successful_authenticator during view dispatch; before that
     # (e.g. in middleware), fall back to checking the Django session cookie
     # which is available after Django's AuthenticationMiddleware runs.

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -1009,9 +1009,13 @@ export class ApiClient {
                 const normalized = normalizeQuery(query)
                 const includeRecordings = Boolean(normalized.includeRecordings)
                 const sourceWithProductKey = injectProductKey(normalized)
+                const sourceTags = sourceWithProductKey.tags as Record<string, unknown> | undefined
                 const wrappedQuery = {
                     kind: 'ActorsQuery',
                     source: sourceWithProductKey,
+                    // Propagate productKey to the top-level wrappedQuery so _infer_query_tags
+                    // in query.py can find it — it only inspects the top-level query.tags.
+                    ...(sourceTags?.productKey ? { tags: { productKey: sourceTags.productKey } } : {}),
                     select: includeRecordings
                         ? ['actor', 'event_count', 'matched_recordings']
                         : ['actor', 'event_count'],

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -17,14 +17,15 @@ import { isShortId } from '@/tools/insights/utils'
 import type { Schemas } from './generated.js'
 import { globalRateLimiter } from './rate-limiter.js'
 
-// Maps query kinds to the productKey value used by `_infer_query_tags` on the Python
-// side. Values mirror the frontend `ProductKey` enum (e.g. `session_replay`, not
-// `replay`) so attribution stays consistent with queries originating from the web app.
-// `HogQLQuery` is intentionally omitted — those land via the raw query-run path and
-// fall through to the `product=mcp` backend default. New product-specific query kinds
-// must be added here; an unmapped kind silently attributes to MCP rather than the
-// owning product.
-const QUERY_KIND_TO_PRODUCT_KEY: Record<string, string> = {
+// Maps query kinds to the productKey used by `_infer_query_tags` on the Python side.
+// Values mirror the frontend `ProductKey` enum (e.g. `session_replay`, not `replay`)
+// so attribution stays consistent with queries originating from the web app.
+//
+// `null` means the kind is intentionally untagged — it falls through to the backend
+// `product=mcp` default. New product-specific query kinds must be added here; an entry
+// missing from this map silently attributes to MCP rather than the owning product.
+const QUERY_KIND_TO_PRODUCT_KEY: Record<string, string | null> = {
+    // Product analytics
     TrendsQuery: 'product_analytics',
     AssistantTrendsQuery: 'product_analytics',
     AssistantTrendsActorsQuery: 'product_analytics',
@@ -38,14 +39,22 @@ const QUERY_KIND_TO_PRODUCT_KEY: Record<string, string> = {
     AssistantPathsQuery: 'product_analytics',
     StickinessQuery: 'product_analytics',
     AssistantStickinessQuery: 'product_analytics',
+    // Error tracking
     ErrorTrackingQuery: 'error_tracking',
+    // LLM analytics
     LLMTracesQuery: 'llm_analytics',
     AssistantTracesQuery: 'llm_analytics',
     AssistantTraceQuery: 'llm_analytics',
+    // Session replay
     RecordingsQuery: 'session_replay',
     SessionRecordingListQuery: 'session_replay',
+    // Experiments
     ExperimentQuery: 'experiments',
     ExperimentExposureQuery: 'experiments',
+    // Raw HogQL — no product tag; backend MCP default applies
+    HogQLQuery: null,
+    HogQLMetadata: null,
+    HogQLAstQuery: null,
 }
 
 function injectProductKey(query: Record<string, unknown>): Record<string, unknown> {
@@ -54,6 +63,7 @@ function injectProductKey(query: Record<string, unknown>): Record<string, unknow
         return query
     }
     const productKey = QUERY_KIND_TO_PRODUCT_KEY[kind]
+    // null = explicitly untagged; undefined = unknown kind. Both skip injection.
     if (!productKey) {
         return query
     }

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -17,6 +17,13 @@ import { isShortId } from '@/tools/insights/utils'
 import type { Schemas } from './generated.js'
 import { globalRateLimiter } from './rate-limiter.js'
 
+// Maps query kinds to the productKey value used by `_infer_query_tags` on the Python
+// side. Values mirror the frontend `ProductKey` enum (e.g. `session_replay`, not
+// `replay`) so attribution stays consistent with queries originating from the web app.
+// `HogQLQuery` is intentionally omitted — those land via the raw query-run path and
+// fall through to the `product=mcp` backend default. New product-specific query kinds
+// must be added here; an unmapped kind silently attributes to MCP rather than the
+// owning product.
 const QUERY_KIND_TO_PRODUCT_KEY: Record<string, string> = {
     TrendsQuery: 'product_analytics',
     AssistantTrendsQuery: 'product_analytics',
@@ -50,7 +57,13 @@ function injectProductKey(query: Record<string, unknown>): Record<string, unknow
     if (!productKey) {
         return query
     }
-    const existingTags = (query.tags as Record<string, unknown> | undefined) ?? {}
+    const rawTags = query.tags
+    if (rawTags !== undefined && (typeof rawTags !== 'object' || rawTags === null || Array.isArray(rawTags))) {
+        // Preserve unexpected shapes (arrays, primitives) untouched rather than spreading
+        // them into an object and silently losing fields.
+        return query
+    }
+    const existingTags = (rawTags as Record<string, unknown> | undefined) ?? {}
     if (existingTags.productKey) {
         return query
     }
@@ -727,7 +740,8 @@ export class ApiClient {
                             )
 
                             return result.success ? result.data : null
-                        } catch {
+                        } catch (error) {
+                            console.error('Failed to fetch primary metric result', error)
                             return null
                         }
                     })
@@ -757,7 +771,8 @@ export class ApiClient {
                             )
 
                             return result.success ? result.data : null
-                        } catch {
+                        } catch (error) {
+                            console.error('Failed to fetch secondary metric result', error)
                             return null
                         }
                     })

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -17,6 +17,46 @@ import { isShortId } from '@/tools/insights/utils'
 import type { Schemas } from './generated.js'
 import { globalRateLimiter } from './rate-limiter.js'
 
+const QUERY_KIND_TO_PRODUCT_KEY: Record<string, string> = {
+    TrendsQuery: 'product_analytics',
+    AssistantTrendsQuery: 'product_analytics',
+    AssistantTrendsActorsQuery: 'product_analytics',
+    FunnelsQuery: 'product_analytics',
+    AssistantFunnelsQuery: 'product_analytics',
+    RetentionQuery: 'product_analytics',
+    AssistantRetentionQuery: 'product_analytics',
+    LifecycleQuery: 'product_analytics',
+    AssistantLifecycleQuery: 'product_analytics',
+    PathsQuery: 'product_analytics',
+    AssistantPathsQuery: 'product_analytics',
+    StickinessQuery: 'product_analytics',
+    AssistantStickinessQuery: 'product_analytics',
+    ErrorTrackingQuery: 'error_tracking',
+    LLMTracesQuery: 'llm_analytics',
+    AssistantTracesQuery: 'llm_analytics',
+    AssistantTraceQuery: 'llm_analytics',
+    RecordingsQuery: 'session_replay',
+    SessionRecordingListQuery: 'session_replay',
+    ExperimentQuery: 'experiments',
+    ExperimentExposureQuery: 'experiments',
+}
+
+function injectProductKey(query: Record<string, unknown>): Record<string, unknown> {
+    const kind = query?.kind as string | undefined
+    if (!kind) {
+        return query
+    }
+    const productKey = QUERY_KIND_TO_PRODUCT_KEY[kind]
+    if (!productKey) {
+        return query
+    }
+    const existingTags = (query.tags as Record<string, unknown> | undefined) ?? {}
+    if (existingTags.productKey) {
+        return query
+    }
+    return { ...query, tags: { ...existingTags, productKey } }
+}
+
 export interface GroupType {
     group_type: string
     group_type_index: number
@@ -574,7 +614,7 @@ export class ApiClient {
 
                 // The API expects a QueryRequest object with the query wrapped
                 const queryRequest: any = {
-                    query: validated,
+                    query: injectProductKey(validated),
                     ...(refresh ? { refresh: 'blocking' } : {}),
                 }
 
@@ -667,11 +707,11 @@ export class ApiClient {
                 const primaryResults = await Promise.all(
                     allPrimaryMetrics.map(async (metric) => {
                         try {
-                            const queryBody = {
+                            const queryBody = injectProductKey({
                                 kind: 'ExperimentQuery',
                                 metric,
                                 experiment_id: experimentId,
-                            }
+                            })
 
                             const queryRequest = {
                                 query: queryBody,
@@ -697,11 +737,11 @@ export class ApiClient {
                 const secondaryResults = await Promise.all(
                     allSecondaryMetrics.map(async (metric) => {
                         try {
-                            const queryBody = {
+                            const queryBody = injectProductKey({
                                 kind: 'ExperimentQuery',
                                 metric,
                                 experiment_id: experimentId,
-                            }
+                            })
 
                             const queryRequest = {
                                 query: queryBody,
@@ -852,7 +892,7 @@ export class ApiClient {
 
                 return this.fetchJson<{ results: unknown; columns?: unknown; formatted_results?: string }>(url, {
                     method: 'POST',
-                    body: JSON.stringify({ query }),
+                    body: JSON.stringify({ query: injectProductKey(query) }),
                 })
             },
 
@@ -940,7 +980,7 @@ export class ApiClient {
             execute: async ({ queryBody }: { queryBody: any }): Promise<Result<{ results: any[] }>> => {
                 return this.fetchJson<{ results: unknown[] }>(queryUrl, {
                     method: 'POST',
-                    body: JSON.stringify({ query: queryBody }),
+                    body: JSON.stringify({ query: injectProductKey(queryBody) }),
                 })
             },
 
@@ -952,7 +992,7 @@ export class ApiClient {
                 return this.request<{ results: unknown; formatted_results?: string }>({
                     method: 'POST',
                     path: `/api/environments/${projectId}/query/`,
-                    body: { query: normalizeQuery(query) },
+                    body: { query: injectProductKey(normalizeQuery(query)) },
                 })
             },
 
@@ -968,9 +1008,10 @@ export class ApiClient {
             }> => {
                 const normalized = normalizeQuery(query)
                 const includeRecordings = Boolean(normalized.includeRecordings)
+                const sourceWithProductKey = injectProductKey(normalized)
                 const wrappedQuery = {
                     kind: 'ActorsQuery',
-                    source: normalized,
+                    source: sourceWithProductKey,
                     select: includeRecordings
                         ? ['actor', 'event_count', 'matched_recordings']
                         : ['actor', 'event_count'],

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8267,9 +8267,9 @@ export namespace Schemas {
       _create_static_person_ids?: string[];
     }
 
-    export type CohortPersonResultProperties = {[key: string]: unknown};
+    export type CohortPersonResultProperties = { [key: string]: unknown };
 
-    export type CohortPersonResultMatchedRecordingsItem = {[key: string]: unknown};
+    export type CohortPersonResultMatchedRecordingsItem = { [key: string]: unknown };
 
     /**
      * * `person` - person


### PR DESCRIPTION
## Problem

MCP (Model Context Protocol) queries need to be properly tagged with product information for analytics and billing purposes. Currently, product-specific queries are tagged, but generic MCP queries (like raw HogQL) lack proper product attribution.

## Changes

- Added `QUERY_KIND_TO_PRODUCT_KEY` mapping in the MCP client to associate query types with their product categories (e.g., `TrendsQuery` → `product_analytics`, `ErrorTrackingQuery` → `error_tracking`)
- Implemented `injectProductKey()` function to automatically inject the appropriate product key into query tags based on query kind
- Applied `injectProductKey()` to all query execution paths in the API client (experiment queries, HogQL queries, actor queries, etc.)
- Added fallback tagging in the backend: MCP requests without inferred tags are tagged as `Product.MCP` with `Feature.QUERY`
- Added `MCP` to the `Product` enum in query tagging

This ensures all MCP queries are properly attributed to their product for analytics and billing, with product-specific tools injecting tags and generic MCP queries falling back to the MCP product tag.

## How did you test this code?

The changes are straightforward data flow modifications:
- Query kind to product key mapping is a static lookup table
- Tag injection is a pure function that adds metadata without changing query semantics
- Backend fallback only applies when no tags are already present

Existing tests should continue to pass as the changes are additive and preserve query functionality.

## Publish to changelog?

No

https://claude.ai/code/session_01YZD7P8xCuhNDXQyAvKv9P9