### PR TITLE
feat(retention): allow selecting data warehouse properties for aggregation

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32634,8 +32634,8 @@
                 },
                 "aggregationPropertyType": {
                     "default": "event",
-                    "description": "The type of property to aggregate on (event or person). Defaults to event.",
-                    "enum": ["event", "person"],
+                    "description": "The type of property to aggregate on (event, person or data_warehouse). Defaults to event.",
+                    "enum": ["event", "person", "data_warehouse"],
                     "type": "string"
                 },
                 "aggregationType": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1641,9 +1641,9 @@ export type RetentionFilter = {
     aggregationType?: 'count' | 'sum' | 'avg'
     /** @description The property to aggregate when aggregationType is sum or avg */
     aggregationProperty?: string
-    /** @description The type of property to aggregate on (event or person). Defaults to event.
+    /** @description The type of property to aggregate on (event, person or data_warehouse). Defaults to event.
      * @default event */
-    aggregationPropertyType?: 'event' | 'person'
+    aggregationPropertyType?: 'event' | 'person' | 'data_warehouse'
     /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
     customAggregationTarget?: boolean
 

--- a/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
@@ -12,8 +12,21 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { PROPERTY_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
-import { DatabaseSchemaField } from '~/queries/schema/schema-general'
+import { DatabaseSchemaField, RetentionFilter } from '~/queries/schema/schema-general'
 import { PropertyMathType } from '~/types'
+
+const aggregationTypeToTaxonomicType = {
+    event: TaxonomicFilterGroupType.EventProperties,
+    person: TaxonomicFilterGroupType.PersonProperties,
+    data_warehouse: TaxonomicFilterGroupType.DataWarehouseProperties,
+} satisfies Record<NonNullable<RetentionFilter['aggregationPropertyType']>, TaxonomicFilterGroupType>
+
+const taxonomicTypeToAggregationTypeMap = Object.fromEntries(
+    Object.entries(aggregationTypeToTaxonomicType).map(([aggregationType, taxonomicType]) => [
+        taxonomicType,
+        aggregationType,
+    ])
+) as Record<TaxonomicFilterGroupType, RetentionFilter['aggregationPropertyType']>
 
 export function RetentionAggregationSelector(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
@@ -35,12 +48,7 @@ export function RetentionAggregationSelector(): JSX.Element {
         ? Object.values(dataWarehouseTablesMap[dwhTableName]?.fields ?? {})
         : []
 
-    const propertyGroupType =
-        aggregationPropertyType === 'person'
-            ? TaxonomicFilterGroupType.PersonProperties
-            : aggregationPropertyType === 'data_warehouse'
-              ? TaxonomicFilterGroupType.DataWarehouseProperties
-              : TaxonomicFilterGroupType.EventProperties
+    const propertyGroupType = aggregationTypeToTaxonomicType[aggregationPropertyType]
     const groupTypes = isReturningDwh
         ? [TaxonomicFilterGroupType.DataWarehouseProperties]
         : [TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.PersonProperties]
@@ -136,15 +144,10 @@ export function RetentionAggregationSelector(): JSX.Element {
                     showNumericalPropsOnly={true}
                     value={aggregationProperty || ''}
                     onChange={(val, groupType) => {
-                        const newType =
-                            groupType === TaxonomicFilterGroupType.DataWarehouseProperties
-                                ? 'data_warehouse'
-                                : groupType === TaxonomicFilterGroupType.PersonProperties
-                                  ? 'person'
-                                  : 'event'
+                        const aggregationType = taxonomicTypeToAggregationTypeMap[groupType]
                         updateInsightFilter({
                             aggregationProperty: val,
-                            aggregationPropertyType: newType,
+                            aggregationPropertyType: aggregationType,
                         })
                     }}
                     placeholder="Select property"
@@ -175,17 +178,7 @@ export function RetentionAggregationSelector(): JSX.Element {
                             }
                             placement="right"
                         >
-                            <PropertyKeyInfo
-                                value={currentValue}
-                                disablePopover
-                                type={
-                                    aggregationPropertyType === 'person'
-                                        ? TaxonomicFilterGroupType.PersonProperties
-                                        : aggregationPropertyType === 'data_warehouse'
-                                          ? TaxonomicFilterGroupType.DataWarehouseProperties
-                                          : TaxonomicFilterGroupType.EventProperties
-                                }
-                            />
+                            <PropertyKeyInfo value={currentValue} disablePopover type={propertyGroupType} />
                         </Tooltip>
                     )}
                 />

--- a/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
@@ -160,13 +160,8 @@ export function RetentionAggregationSelector(): JSX.Element {
                                     {aggregationType === 'sum'
                                         ? PROPERTY_MATH_DEFINITIONS[PropertyMathType.Sum].name.toLowerCase()
                                         : PROPERTY_MATH_DEFINITIONS[PropertyMathType.Average].name.toLowerCase()}{' '}
-                                    from{' '}
-                                    {aggregationPropertyType === 'person'
-                                        ? 'person'
-                                        : aggregationPropertyType === 'data_warehouse'
-                                          ? 'data warehouse'
-                                          : 'event'}{' '}
-                                    property <code>{currentValue}</code>.
+                                    from {aggregationPropertyType.replace('_', ' ')} property{' '}
+                                    <code>{currentValue}</code>.
                                     {aggregationPropertyType === 'event' && (
                                         <>
                                             <br />

--- a/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
@@ -7,21 +7,43 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicStringPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { PROPERTY_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
+import { DatabaseSchemaField } from '~/queries/schema/schema-general'
 import { PropertyMathType } from '~/types'
 
 export function RetentionAggregationSelector(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { dataWarehouseTablesMap } = useValues(databaseTableListLogic)
 
     const aggregationType = retentionFilter?.aggregationType || 'count'
     const aggregationProperty = retentionFilter?.aggregationProperty
     const aggregationPropertyType = retentionFilter?.aggregationPropertyType || 'event'
     const isPropertyValueAggregation = aggregationType === 'sum' || aggregationType === 'avg'
+
+    const returningEntity = retentionFilter?.returningEntity
+    const isReturningDwh = returningEntity?.type === 'data_warehouse'
+    const dwhTableName = returningEntity
+        ? (returningEntity.table_name ?? (returningEntity.id as string | undefined))
+        : null
+    const schemaColumns: DatabaseSchemaField[] = dwhTableName
+        ? Object.values(dataWarehouseTablesMap[dwhTableName]?.fields ?? {})
+        : []
+
+    const propertyGroupType =
+        aggregationPropertyType === 'person'
+            ? TaxonomicFilterGroupType.PersonProperties
+            : aggregationPropertyType === 'data_warehouse'
+              ? TaxonomicFilterGroupType.DataWarehouseProperties
+              : TaxonomicFilterGroupType.EventProperties
+    const groupTypes = isReturningDwh
+        ? [TaxonomicFilterGroupType.DataWarehouseProperties]
+        : [TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.PersonProperties]
 
     // Local state to track which property math type to show in the dropdown label
     // This mirrors the behavior in Trends where the "Property value" option remembers the last selected math type
@@ -86,11 +108,6 @@ export function RetentionAggregationSelector(): JSX.Element {
         },
     ]
 
-    const propertyGroupType =
-        aggregationPropertyType === 'person'
-            ? TaxonomicFilterGroupType.PersonProperties
-            : TaxonomicFilterGroupType.EventProperties
-
     return (
         <div className="flex flex-col items-start gap-2">
             <LemonSelect
@@ -114,11 +131,17 @@ export function RetentionAggregationSelector(): JSX.Element {
             {isPropertyValueAggregation && (
                 <TaxonomicStringPopover
                     groupType={propertyGroupType}
-                    groupTypes={[TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.PersonProperties]}
+                    groupTypes={groupTypes}
+                    schemaColumns={schemaColumns}
                     showNumericalPropsOnly={true}
                     value={aggregationProperty || ''}
                     onChange={(val, groupType) => {
-                        const newType = groupType === TaxonomicFilterGroupType.PersonProperties ? 'person' : 'event'
+                        const newType =
+                            groupType === TaxonomicFilterGroupType.DataWarehouseProperties
+                                ? 'data_warehouse'
+                                : groupType === TaxonomicFilterGroupType.PersonProperties
+                                  ? 'person'
+                                  : 'event'
                         updateInsightFilter({
                             aggregationProperty: val,
                             aggregationPropertyType: newType,
@@ -134,8 +157,13 @@ export function RetentionAggregationSelector(): JSX.Element {
                                     {aggregationType === 'sum'
                                         ? PROPERTY_MATH_DEFINITIONS[PropertyMathType.Sum].name.toLowerCase()
                                         : PROPERTY_MATH_DEFINITIONS[PropertyMathType.Average].name.toLowerCase()}{' '}
-                                    from {aggregationPropertyType === 'person' ? 'person' : 'event'} property{' '}
-                                    <code>{currentValue}</code>.
+                                    from{' '}
+                                    {aggregationPropertyType === 'person'
+                                        ? 'person'
+                                        : aggregationPropertyType === 'data_warehouse'
+                                          ? 'data warehouse'
+                                          : 'event'}{' '}
+                                    property <code>{currentValue}</code>.
                                     {aggregationPropertyType === 'event' && (
                                         <>
                                             <br />
@@ -153,7 +181,9 @@ export function RetentionAggregationSelector(): JSX.Element {
                                 type={
                                     aggregationPropertyType === 'person'
                                         ? TaxonomicFilterGroupType.PersonProperties
-                                        : TaxonomicFilterGroupType.EventProperties
+                                        : aggregationPropertyType === 'data_warehouse'
+                                          ? TaxonomicFilterGroupType.DataWarehouseProperties
+                                          : TaxonomicFilterGroupType.EventProperties
                                 }
                             />
                         </Tooltip>

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -247,6 +247,115 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.2
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users
   '''
   
@@ -366,7 +475,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -381,7 +498,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -391,8 +508,15 @@
                             and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
             quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
                             0) AS previous_avg_time_on_page
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
      GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
   LEFT JOIN
     (SELECT breakdown_value AS breakdown_value,
@@ -403,7 +527,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -413,7 +543,116 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -533,23 +772,13 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate
-  '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate.1
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user.2
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
   FROM
     (SELECT breakdown_value AS breakdown_value,
@@ -563,7 +792,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -578,10 +815,26 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
   LEFT JOIN
     (SELECT breakdown_value AS breakdown_value,
             avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
@@ -591,7 +844,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -601,7 +860,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -622,29 +881,29 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate.1
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate.2
-  '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user
-  '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
   '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
@@ -663,7 +922,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -678,7 +945,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -691,7 +958,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -701,7 +974,121 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -753,92 +1140,6 @@
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
         FROM events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(events__session.`$entry_pathname`, '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.2
-  '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -1774,7 +2075,14 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
      LEFT JOIN
        (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
@@ -1791,7 +2099,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -564,115 +564,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
-  '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
-         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            0) AS previous_avg_time_on_page
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.properties,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user
   '''
   
@@ -894,13 +785,80 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate.2
@@ -1008,13 +966,80 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4103,6 +4103,12 @@ class RetentionEntityKind(StrEnum):
     EVENTS_NODE = "EventsNode"
 
 
+class AggregationPropertyType1(StrEnum):
+    EVENT = "event"
+    PERSON = "person"
+    DATA_WAREHOUSE = "data_warehouse"
+
+
 class RetentionPeriod(StrEnum):
     HOUR = "Hour"
     DAY = "Day"
@@ -17454,9 +17460,9 @@ class RetentionFilter(BaseModel):
         default=None,
         description="The property to aggregate when aggregationType is sum or avg",
     )
-    aggregationPropertyType: AggregationPropertyType | None = Field(
-        default=AggregationPropertyType.EVENT,
-        description=("The type of property to aggregate on (event or person). Defaults to event."),
+    aggregationPropertyType: AggregationPropertyType1 | None = Field(
+        default=AggregationPropertyType1.EVENT,
+        description=("The type of property to aggregate on (event, person or data_warehouse). Defaults to event."),
     )
     aggregationType: AggregationType | None = Field(
         default=AggregationType.COUNT,

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2635,11 +2635,12 @@ export interface RetentionQueryResponseApi {
     timings?: QueryTimingApi[] | null
 }
 
-export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[keyof typeof AggregationPropertyTypeApi]
+export type AggregationPropertyType1Api = (typeof AggregationPropertyType1Api)[keyof typeof AggregationPropertyType1Api]
 
-export const AggregationPropertyTypeApi = {
+export const AggregationPropertyType1Api = {
     Event: 'event',
     Person: 'person',
+    DataWarehouse: 'data_warehouse',
 } as const
 
 export type AggregationTypeApi = (typeof AggregationTypeApi)[keyof typeof AggregationTypeApi]
@@ -2778,8 +2779,8 @@ export interface RetentionFilterApi {
      * @nullable
      */
     aggregationProperty?: string | null
-    /** The type of property to aggregate on (event or person). Defaults to event. */
-    aggregationPropertyType?: AggregationPropertyTypeApi | null
+    /** The type of property to aggregate on (event, person or data_warehouse). Defaults to event. */
+    aggregationPropertyType?: AggregationPropertyType1Api | null
     /** The aggregation type to use for retention */
     aggregationType?: AggregationTypeApi | null
     /** @nullable */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2957,12 +2957,13 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
     }
 
-    export type AggregationPropertyType = typeof AggregationPropertyType[keyof typeof AggregationPropertyType];
+    export type AggregationPropertyType1 = typeof AggregationPropertyType1[keyof typeof AggregationPropertyType1];
 
 
-    export const AggregationPropertyType = {
+    export const AggregationPropertyType1 = {
       Event: 'event',
       Person: 'person',
+      DataWarehouse: 'data_warehouse',
     } as const;
 
     export type AggregationType = typeof AggregationType[keyof typeof AggregationType];
@@ -3086,8 +3087,8 @@ export namespace Schemas {
        * @nullable
        */
       aggregationProperty?: string | null;
-      /** The type of property to aggregate on (event or person). Defaults to event. */
-      aggregationPropertyType?: AggregationPropertyType | null;
+      /** The type of property to aggregate on (event, person or data_warehouse). Defaults to event. */
+      aggregationPropertyType?: AggregationPropertyType1 | null;
       /** The aggregation type to use for retention */
       aggregationType?: AggregationType | null;
       /** @nullable */


### PR DESCRIPTION
## Problem

Retention insights with a data warehouse series don't support property aggregation yet.

## Changes

In this first PR, we expose data warehouse fields when the returning property is a data warehouse entity.

This does not show up for customers yet, as the feature flag for data warehouse in retention isn't rolled out and they can't select a data warehouse entity. 

I will be changing the property aggregation to always be based on the returning entity (details in the respective PR) and add support for data warehouse backend side in follow up PRs.

## How did you test this code?

Tested manually with the feature flag enabled