### PR TITLE
feat(flags): add command feedback to pr canary

### DIFF
--- a/.github/scripts/canary/canary.test.js
+++ b/.github/scripts/canary/canary.test.js
@@ -221,3 +221,57 @@ test('expiresIn returns null for null input and a remaining-time string for fres
     const result = comment.expiresIn(fresh)
     assert.match(result, /^in 4[78]h \d+m$/)
 })
+
+// Guards the /pr-canary status no-charts-run fallback against regressing
+// to the buggy `weight > 0 ? HEALTHY : ROLLING_OUT` heuristic. State.yaml
+// alone cannot tell HEALTHY from in-flight ROUTING — only the charts run
+// conclusion can. When the charts run can't be located, derivePhase MUST
+// still return ROUTING/ROLLING_OUT, never HEALTHY.
+test('derivePhase without a charts run never returns HEALTHY', () => {
+    const ownedRolling = { enabled: true, pr_number: 100, weight: 0 }
+    const ownedRouting = { enabled: true, pr_number: 100, weight: 5 }
+    assert.equal(state.derivePhase(ownedRolling, null, 100), 'ROLLING_OUT')
+    assert.equal(state.derivePhase(ownedRouting, null, 100), 'ROUTING')
+    // also: a weight>0 owned canary with an in-flight run is ROUTING (not HEALTHY)
+    assert.equal(state.derivePhase(ownedRouting, { status: 'in_progress' }, 100), 'ROUTING')
+})
+
+test('derivePhase ROUTING → HEALTHY transition only on charts run completion', () => {
+    const ownedRouting = { enabled: true, pr_number: 100, weight: 5 }
+    assert.equal(state.derivePhase(ownedRouting, { status: 'queued' }, 100), 'ROUTING')
+    assert.equal(state.derivePhase(ownedRouting, { status: 'in_progress' }, 100), 'ROUTING')
+    assert.equal(
+        state.derivePhase(ownedRouting, { status: 'completed', conclusion: 'success' }, 100),
+        'HEALTHY'
+    )
+    assert.equal(
+        state.derivePhase(ownedRouting, { status: 'completed', conclusion: 'failure' }, 100),
+        'FAILED'
+    )
+    assert.equal(
+        state.derivePhase(ownedRouting, { status: 'completed', conclusion: 'cancelled' }, 100),
+        'CANCELED'
+    )
+})
+
+test('renderBody for DISPATCHED includes image, env, weight, and dispatch run link', () => {
+    const body = comment.renderBody({
+        phase: 'DISPATCHED',
+        fields: {
+            pr: 123,
+            image: 'sha-deadbee',
+            env: 'prod-us',
+            weight: 3,
+            started_by: 'matheus-vb',
+            started_at: new Date().toISOString(),
+            dispatch_run_url: 'https://github.com/PostHog/posthog/actions/runs/42',
+        },
+    })
+    assert.match(body, /<!-- pr-canary-status phase=DISPATCHED/)
+    assert.match(body, /Dispatched to charts/)
+    assert.match(body, /sha-deadbee/)
+    assert.match(body, /prod-us/)
+    assert.match(body, /\| Weight \| `3` \|/)
+    assert.match(body, /posthog run/)
+    assert.match(body, /Auto-disables/)
+})

--- a/.github/scripts/canary/canary.test.js
+++ b/.github/scripts/canary/canary.test.js
@@ -1,0 +1,223 @@
+'use strict'
+
+// Run with: `node --test .github/scripts/canary/canary.test.js`
+// (uses Node's built-in test runner, no dependencies needed)
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const comment = require('./comment')
+const state = require('./state')
+
+const SAMPLE_STATE_YAML = `state:
+  argocd-ui-extensions-api:
+    image:
+      dev: sha256:abc
+  feature-flags:
+    canary:
+      enabled: true
+      image: sha-1234567
+      pr_number: 56789
+      started_at: "2026-04-29T12:00:00Z"
+      started_by: matheus-vb
+      target_environment: prod-us
+      weight: 5
+    deploy_info:
+      commit:
+        author: someone
+        sha: deadbeef
+  posthog:
+    image:
+      dev: sha256:def
+`
+
+const SAMPLE_STATE_YAML_DISABLED = `state:
+  feature-flags:
+    canary:
+      enabled: false
+      image: null
+      pr_number: null
+      started_at: null
+      started_by: null
+      target_environment: null
+      weight: 0
+`
+
+test('parseScalar handles common YAML scalars', () => {
+    assert.equal(state.parseScalar('null'), null)
+    assert.equal(state.parseScalar(''), null)
+    assert.equal(state.parseScalar('~'), null)
+    assert.equal(state.parseScalar('true'), true)
+    assert.equal(state.parseScalar('false'), false)
+    assert.equal(state.parseScalar('5'), 5)
+    assert.equal(state.parseScalar('-3'), -3)
+    assert.equal(state.parseScalar('"sha-abc"'), 'sha-abc')
+    assert.equal(state.parseScalar("'quoted'"), 'quoted')
+    assert.equal(state.parseScalar('plain-value'), 'plain-value')
+})
+
+test('parseCanaryBlock extracts the active canary block', () => {
+    const result = state.parseCanaryBlock(SAMPLE_STATE_YAML)
+    assert.deepEqual(result, {
+        enabled: true,
+        image: 'sha-1234567',
+        pr_number: 56789,
+        started_at: '2026-04-29T12:00:00Z',
+        started_by: 'matheus-vb',
+        target_environment: 'prod-us',
+        weight: 5,
+    })
+})
+
+test('parseCanaryBlock extracts a disabled canary block', () => {
+    const result = state.parseCanaryBlock(SAMPLE_STATE_YAML_DISABLED)
+    assert.deepEqual(result, {
+        enabled: false,
+        image: null,
+        pr_number: null,
+        started_at: null,
+        started_by: null,
+        target_environment: null,
+        weight: 0,
+    })
+})
+
+test('parseCanaryBlock returns null when feature-flags is missing', () => {
+    assert.equal(state.parseCanaryBlock('state:\n  posthog:\n    image:\n      dev: x\n'), null)
+    assert.equal(state.parseCanaryBlock(''), null)
+    assert.equal(state.parseCanaryBlock(null), null)
+})
+
+test('derivePhase maps states to phases per the decision table', () => {
+    const owned = { enabled: true, pr_number: 100, weight: 0 }
+    const ownedRouting = { enabled: true, pr_number: 100, weight: 5 }
+    const otherPr = { enabled: true, pr_number: 999, weight: 5 }
+    const disabled = { enabled: false, pr_number: null, weight: 0 }
+
+    assert.equal(state.derivePhase(disabled, null, 100), 'EXPIRED')
+    assert.equal(state.derivePhase(otherPr, null, 100), 'EXPIRED')
+    assert.equal(state.derivePhase(owned, { status: 'in_progress' }, 100), 'ROLLING_OUT')
+    assert.equal(state.derivePhase(owned, { status: 'queued' }, 100), 'ROLLING_OUT')
+    assert.equal(state.derivePhase(ownedRouting, { status: 'in_progress' }, 100), 'ROUTING')
+    assert.equal(state.derivePhase(ownedRouting, { status: 'completed', conclusion: 'success' }, 100), 'HEALTHY')
+    assert.equal(state.derivePhase(ownedRouting, { status: 'completed', conclusion: 'failure' }, 100), 'FAILED')
+    assert.equal(state.derivePhase(owned, { status: 'completed', conclusion: 'cancelled' }, 100), 'CANCELED')
+    // null run when canary is enabled and owned: still rolling out
+    assert.equal(state.derivePhase(owned, null, 100), 'ROLLING_OUT')
+})
+
+test('parseMarker round-trips with renderMarker', () => {
+    const meta = { phase: 'ROLLING_OUT', pr: '123', image: 'sha-abc1234', env: 'prod-us', charts_run_id: '456' }
+    const rendered = comment.renderMarker(meta)
+    assert.match(rendered, /<!-- pr-canary-status /)
+    const body = `${rendered}\n\nrest of comment`
+    const parsed = comment.parseMarker(body)
+    assert.deepEqual(parsed, meta)
+})
+
+test('parseMarker is null for bodies without the marker', () => {
+    assert.equal(comment.parseMarker('just a comment'), null)
+    assert.equal(comment.parseMarker(''), null)
+    assert.equal(comment.parseMarker(null), null)
+})
+
+test('isTerminalPhase classifies phases correctly', () => {
+    assert.equal(comment.isTerminalPhase('HEALTHY'), true)
+    assert.equal(comment.isTerminalPhase('FAILED'), true)
+    assert.equal(comment.isTerminalPhase('CANCELED'), true)
+    assert.equal(comment.isTerminalPhase('CONFLICT'), true)
+    assert.equal(comment.isTerminalPhase('EXPIRED'), true)
+    assert.equal(comment.isTerminalPhase('ROLLING_OUT'), false)
+    assert.equal(comment.isTerminalPhase('BUILDING'), false)
+    assert.equal(comment.isTerminalPhase('CANCELING'), false)
+})
+
+test('renderBody for ROLLING_OUT includes the marker, header, image, env, and run links', () => {
+    const body = comment.renderBody({
+        phase: 'ROLLING_OUT',
+        fields: {
+            pr: 123,
+            image: 'sha-abc1234',
+            env: 'prod-us',
+            weight: 0,
+            started_by: 'matheus-vb',
+            started_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+            dispatch_run_url: 'https://github.com/PostHog/posthog/actions/runs/999',
+            charts_run_url: 'https://github.com/PostHog/charts/actions/runs/123',
+        },
+    })
+    assert.match(body, /<!-- pr-canary-status phase=ROLLING_OUT/)
+    assert.match(body, /Rolling out/)
+    assert.match(body, /sha-abc1234/)
+    assert.match(body, /prod-us/)
+    assert.match(body, /posthog run/)
+    assert.match(body, /charts run/)
+    assert.match(body, /\/pr-canary cancel/)
+    assert.match(body, /Auto-disables/)
+})
+
+test('renderBody for CONFLICT names the holder PR and points to cancel', () => {
+    const body = comment.renderBody({
+        phase: 'CONFLICT',
+        fields: {
+            pr: 200,
+            holder_pr: 199,
+            holder_actor: 'bob',
+            env: 'prod-eu',
+            weight: 5,
+            started_at: new Date(Date.now() - 3 * 3600 * 1000).toISOString(),
+        },
+    })
+    assert.match(body, /Canary already active for #199/)
+    assert.match(body, /\/pr-canary cancel/)
+    assert.match(body, /#199/)
+    assert.match(body, /48 hours/)
+})
+
+test('renderBody for HEALTHY shows expiry and cancel hint', () => {
+    const body = comment.renderBody({
+        phase: 'HEALTHY',
+        fields: {
+            pr: 123,
+            image: 'sha-deadbee',
+            env: 'dev',
+            weight: 5,
+            started_by: 'matheus-vb',
+            started_at: new Date().toISOString(),
+            dispatch_run_url: 'https://github.com/PostHog/posthog/actions/runs/1',
+            charts_run_url: 'https://github.com/PostHog/charts/actions/runs/2',
+        },
+    })
+    assert.match(body, /🟢/)
+    assert.match(body, /Healthy/)
+    assert.match(body, /auto-disable/)
+    assert.match(body, /cancel.*to stop it sooner/)
+})
+
+test('renderBody for CANCELED highlights the actor', () => {
+    const body = comment.renderBody({
+        phase: 'CANCELED',
+        fields: { pr: 123, canceled_by: 'matheus-vb', image: 'sha-abc', env: 'dev' },
+    })
+    assert.match(body, /Canary canceled by @matheus-vb/)
+})
+
+test('renderBody for INVALID_INPUT surfaces the reason', () => {
+    const body = comment.renderBody({
+        phase: 'INVALID_INPUT',
+        fields: { pr: 1, reason: 'Invalid weight value: 99' },
+    })
+    assert.match(body, /Invalid weight value: 99/)
+})
+
+test('relativeTime emits "just now" within a minute', () => {
+    const recent = new Date().toISOString()
+    assert.equal(comment.relativeTime(recent), 'just now')
+})
+
+test('expiresIn returns null for null input and a remaining-time string for fresh starts', () => {
+    assert.equal(comment.expiresIn(null), null)
+    const fresh = new Date().toISOString()
+    const result = comment.expiresIn(fresh)
+    assert.match(result, /^in 4[78]h \d+m$/)
+})

--- a/.github/scripts/canary/charts-run.js
+++ b/.github/scripts/canary/charts-run.js
@@ -1,0 +1,74 @@
+'use strict'
+
+// Locate the charts-side workflow run that picked up our repository_dispatch.
+// repository_dispatch payload is not exposed on workflow runs, so we match
+// by event + workflow file + creation time relative to when we dispatched.
+// There is a 1-3s race between dispatch and run creation, so we retry.
+
+const CHARTS_OWNER = 'PostHog'
+const CHARTS_REPO = 'charts'
+const ENABLE_WORKFLOW = 'pr-canary-flags-enable.yml'
+const DISABLE_WORKFLOW = 'pr-canary-flags-disable.yml'
+
+function asTimestamp(t) {
+    if (!t) return Date.now()
+    if (typeof t === 'string') return new Date(t).getTime()
+    if (t instanceof Date) return t.getTime()
+    return t
+}
+
+async function findChartsRun({ octokit, workflowFile, dispatchedAt, retries = 15, intervalMs = 2000 }) {
+    const dispatchTs = asTimestamp(dispatchedAt)
+    for (let attempt = 0; attempt < retries; attempt++) {
+        try {
+            const { data } = await octokit.rest.actions.listWorkflowRuns({
+                owner: CHARTS_OWNER,
+                repo: CHARTS_REPO,
+                workflow_id: workflowFile,
+                event: 'repository_dispatch',
+                per_page: 10,
+            })
+            const candidate = (data.workflow_runs || []).find((r) => {
+                const created = new Date(r.created_at).getTime()
+                // allow runs created up to 5s before our dispatch (clock skew) and forward
+                return created >= dispatchTs - 5000
+            })
+            if (candidate) return candidate
+        } catch (err) {
+            // transient — keep retrying
+        }
+        if (attempt < retries - 1) {
+            await new Promise((res) => setTimeout(res, intervalMs))
+        }
+    }
+    return null
+}
+
+async function findEnableRun(opts) {
+    return findChartsRun({ ...opts, workflowFile: ENABLE_WORKFLOW })
+}
+
+async function findDisableRun(opts) {
+    return findChartsRun({ ...opts, workflowFile: DISABLE_WORKFLOW })
+}
+
+async function getChartsRun({ octokit, runId }) {
+    const { data } = await octokit.rest.actions.getWorkflowRun({
+        owner: CHARTS_OWNER,
+        repo: CHARTS_REPO,
+        run_id: runId,
+    })
+    return data
+}
+
+module.exports = {
+    CHARTS_OWNER,
+    CHARTS_REPO,
+    ENABLE_WORKFLOW,
+    DISABLE_WORKFLOW,
+    asTimestamp,
+    findChartsRun,
+    findEnableRun,
+    findDisableRun,
+    getChartsRun,
+}

--- a/.github/scripts/canary/comment.js
+++ b/.github/scripts/canary/comment.js
@@ -1,0 +1,253 @@
+'use strict'
+
+// Helpers that maintain a single PR comment for the feature-flags canary
+// lifecycle. The comment is identified by an HTML marker so it survives
+// across phases (validation, build, dispatch, rollout, terminal). The
+// marker also carries a tiny bit of state (phase, run ids, image, env)
+// so a follow-up step can pick up where the previous one left off without
+// re-querying everything.
+
+const MARKER = '<!-- pr-canary-status'
+const MARKER_RE = /<!--\s*pr-canary-status\s+([^>]*?)-->/
+const HOURS_TO_EXPIRY = 48
+
+const PHASES = {
+    VALIDATING: { emoji: '🔵', label: 'Validating' },
+    BUILDING: { emoji: '🔨', label: 'Building image' },
+    DISPATCHED: { emoji: '📨', label: 'Dispatched to charts' },
+    ROLLING_OUT: { emoji: '🟡', label: 'Rolling out (no traffic yet)' },
+    ROUTING: { emoji: '🟡', label: 'Routing traffic to canary' },
+    HEALTHY: { emoji: '🟢', label: 'Healthy', terminal: true },
+    CONFLICT: { emoji: '🟠', label: 'Already active for another PR', terminal: true },
+    NO_ACTIVE_CANARY: { emoji: '⚪', label: 'No active canary', terminal: true },
+    DENIED: { emoji: '🚫', label: 'Denied', terminal: true },
+    INVALID_INPUT: { emoji: '⚠️', label: 'Invalid command', terminal: true },
+    BUILD_FAILED: { emoji: '🔴', label: 'Build failed', terminal: true },
+    FAILED: { emoji: '🔴', label: 'Rollout failed', terminal: true },
+    CANCELING: { emoji: '⏳', label: 'Canceling' },
+    CANCELED: { emoji: '⚪', label: 'Canceled', terminal: true },
+    EXPIRED: { emoji: '⚪', label: 'Expired', terminal: true },
+}
+
+const TERMINAL_PHASES = new Set(Object.entries(PHASES).filter(([, v]) => v.terminal).map(([k]) => k))
+
+function isTerminalPhase(phase) {
+    return TERMINAL_PHASES.has(phase)
+}
+
+function parseMarker(body) {
+    if (!body || typeof body !== 'string') return null
+    const m = body.match(MARKER_RE)
+    if (!m) return null
+    const fields = {}
+    const re = /(\w+)=(?:"([^"]*)"|(\S+))/g
+    let match
+    while ((match = re.exec(m[1])) !== null) {
+        fields[match[1]] = match[2] !== undefined ? match[2] : match[3]
+    }
+    return fields
+}
+
+const MARKER_KEYS = ['phase', 'pr', 'image', 'env', 'charts_run_id', 'dispatch_run_id']
+
+function renderMarker(meta) {
+    const parts = ['pr-canary-status']
+    for (const key of MARKER_KEYS) {
+        const v = meta[key]
+        if (v === undefined || v === null || v === '') continue
+        const str = String(v)
+        parts.push(/\s/.test(str) ? `${key}="${str.replace(/"/g, '')}"` : `${key}=${str}`)
+    }
+    return `<!-- ${parts.join(' ')} -->`
+}
+
+function relativeTime(iso, now = Date.now()) {
+    if (!iso) return null
+    const t = new Date(iso).getTime()
+    if (!Number.isFinite(t)) return null
+    const diff = Math.max(0, now - t)
+    if (diff < 60_000) return 'just now'
+    const m = Math.floor(diff / 60_000)
+    if (m < 60) return `${m} min ago`
+    const h = Math.floor(m / 60)
+    if (h < 24) return `${h}h ${m % 60}m ago`
+    const d = Math.floor(h / 24)
+    return `${d}d ${h % 24}h ago`
+}
+
+function expiresIn(startedAt, now = Date.now(), hoursToExpiry = HOURS_TO_EXPIRY) {
+    if (!startedAt) return null
+    const start = new Date(startedAt).getTime()
+    if (!Number.isFinite(start)) return null
+    const remaining = start + hoursToExpiry * 3600 * 1000 - now
+    if (remaining <= 0) return 'expired'
+    const hours = Math.floor(remaining / 3600_000)
+    const mins = Math.floor((remaining % 3600_000) / 60_000)
+    return `in ${hours}h ${mins}m`
+}
+
+function subcommandsFooter() {
+    return [
+        '',
+        '<sub>Subcommands: `/pr-canary [weight=N] [env=dev|prod-us|prod-eu]` · `/pr-canary cancel` · `/pr-canary status` · `/pr-canary help`</sub>',
+    ]
+}
+
+function workflowRunsBlock(fields) {
+    const links = []
+    if (fields.dispatch_run_url) links.push(`- Build & dispatch: [posthog run](${fields.dispatch_run_url})`)
+    if (fields.charts_run_url) links.push(`- ArgoCD rollout: [charts run](${fields.charts_run_url})`)
+    if (!links.length) return []
+    return ['**Workflow runs**', ...links, '']
+}
+
+function detailsTable(fields, { includeExpiry } = {}) {
+    const rows = []
+    if (fields.image) rows.push(['Image', `\`${fields.image}\``])
+    if (fields.env) rows.push(['Environment', `\`${fields.env}\``])
+    if (fields.weight !== undefined && fields.weight !== null) {
+        const w = String(fields.weight)
+        const suffix = fields.weight_auto ? ' (auto)' : ''
+        rows.push(['Weight', `\`${w}\`${suffix}`])
+    }
+    if (fields.started_by) rows.push(['Started by', `@${fields.started_by}`])
+    if (fields.started_at) {
+        const rel = relativeTime(fields.started_at)
+        rows.push(['Started', `${rel} (\`${fields.started_at}\`)`])
+    }
+    if (includeExpiry && fields.started_at) {
+        const exp = expiresIn(fields.started_at)
+        if (exp) rows.push(['Auto-disables', exp])
+    }
+    if (!rows.length) return []
+    const out = ['| | |', '|---|---|']
+    for (const [k, v] of rows) out.push(`| ${k} | ${v} |`)
+    out.push('')
+    return out
+}
+
+function renderBody({ phase, fields = {} }) {
+    const def = PHASES[phase] || { emoji: '❔', label: phase }
+    const marker = renderMarker({
+        phase,
+        pr: fields.pr,
+        image: fields.image,
+        env: fields.env,
+        charts_run_id: fields.charts_run_id,
+        dispatch_run_id: fields.dispatch_run_id,
+    })
+
+    const lines = [marker]
+
+    let header = `### ${def.emoji} Feature-flags canary — ${def.label}`
+    if (phase === 'CONFLICT' && fields.holder_pr) {
+        header = `### 🟠 Canary already active for #${fields.holder_pr}`
+    } else if (phase === 'CANCELED' && fields.canceled_by) {
+        header = `### ⚪ Canary canceled by @${fields.canceled_by}`
+    } else if ((phase === 'FAILED' || phase === 'BUILD_FAILED') && fields.reason) {
+        header = `### 🔴 Canary failed: ${fields.reason}`
+    } else if (phase === 'DENIED' && fields.reason) {
+        header = `### 🚫 Canary denied: ${fields.reason}`
+    } else if (phase === 'INVALID_INPUT' && fields.reason) {
+        header = `### ⚠️ Invalid \`/pr-canary\` command: ${fields.reason}`
+    }
+    lines.push(header, '')
+
+    if (phase === 'CONFLICT') {
+        const holderBits = []
+        if (fields.env) holderBits.push(`env \`${fields.env}\``)
+        if (fields.weight !== undefined && fields.weight !== null) holderBits.push(`weight \`${fields.weight}\``)
+        if (fields.holder_actor) holderBits.push(`started by @${fields.holder_actor}`)
+        if (fields.started_at) holderBits.push(relativeTime(fields.started_at))
+        const expiry = expiresIn(fields.started_at)
+        if (expiry) holderBits.push(`expires ${expiry}`)
+        const detail = holderBits.length ? ` (${holderBits.join(', ')})` : ''
+        lines.push(
+            `The feature-flags canary is currently held by **#${fields.holder_pr}**${detail}.`,
+            '',
+            `Reply \`/pr-canary cancel\` on **#${fields.holder_pr}** to release it, then re-run here. The canary auto-expires after ${HOURS_TO_EXPIRY} hours.`
+        )
+        lines.push(...subcommandsFooter())
+        return lines.join('\n')
+    }
+
+    if (phase === 'NO_ACTIVE_CANARY') {
+        lines.push('No feature-flags canary is currently active for this PR.')
+        lines.push(
+            '',
+            'Run `/pr-canary` to start one. Optional: `weight=1..10` (or `auto`) and `env=dev|prod-us|prod-eu` (default `dev`).'
+        )
+        if (fields.dispatch_run_url) lines.push('', `[View workflow run](${fields.dispatch_run_url})`)
+        lines.push(...subcommandsFooter())
+        return lines.join('\n')
+    }
+
+    if (phase === 'DENIED' || phase === 'INVALID_INPUT' || phase === 'BUILD_FAILED' || phase === 'FAILED') {
+        if (fields.dispatch_run_url || fields.charts_run_url) {
+            lines.push(...workflowRunsBlock(fields))
+        }
+        lines.push(...subcommandsFooter())
+        return lines.join('\n')
+    }
+
+    const includeExpiry = ['HEALTHY', 'ROUTING', 'ROLLING_OUT', 'DISPATCHED', 'CANCELING'].includes(phase)
+    lines.push(...detailsTable(fields, { includeExpiry }))
+    lines.push(...workflowRunsBlock(fields))
+
+    if (phase === 'HEALTHY') {
+        lines.push(
+            `The canary will auto-disable after ${HOURS_TO_EXPIRY} hours or when the PR is merged/closed.`,
+            'Use `/pr-canary cancel` to stop it sooner.',
+            ''
+        )
+    } else if (phase === 'CANCELED') {
+        lines.push('All traffic has been routed back to stable pods.', '')
+    } else if (phase === 'EXPIRED') {
+        lines.push('Canary deployment is no longer active.', '')
+    }
+
+    lines.push(...subcommandsFooter())
+    return lines.join('\n')
+}
+
+async function findExistingComment({ github, owner, repo, prNumber }) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: prNumber,
+        per_page: 100,
+    })
+    return comments.find((c) => c.body && c.body.includes(MARKER)) || null
+}
+
+async function upsertStatusComment({ github, context, prNumber, phase, fields = {} }) {
+    const owner = context.repo.owner
+    const repo = context.repo.repo
+    const body = renderBody({ phase, fields: { pr: prNumber, ...fields } })
+    const existing = await findExistingComment({ github, owner, repo, prNumber })
+    if (existing) {
+        await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+        return { id: existing.id, created: false }
+    }
+    const { data: created } = await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: prNumber,
+        body,
+    })
+    return { id: created.id, created: true }
+}
+
+module.exports = {
+    MARKER,
+    PHASES,
+    HOURS_TO_EXPIRY,
+    isTerminalPhase,
+    parseMarker,
+    renderMarker,
+    renderBody,
+    relativeTime,
+    expiresIn,
+    findExistingComment,
+    upsertStatusComment,
+}

--- a/.github/scripts/canary/state.js
+++ b/.github/scripts/canary/state.js
@@ -1,0 +1,116 @@
+'use strict'
+
+// Read-only access to the feature-flags canary block in PostHog/charts:state.yaml
+// plus a phase resolver and a small async polling helper. We avoid pulling in a
+// YAML parser by extracting the canary block via a targeted regex — state.yaml
+// is sort_keys'd and the block has a stable, scalar-only shape.
+
+const CHARTS_OWNER = 'PostHog'
+const CHARTS_REPO = 'charts'
+const CHARTS_STATE_PATH = 'state.yaml'
+
+function parseScalar(raw) {
+    if (raw === undefined || raw === null) return null
+    const v = String(raw).trim()
+    if (v === '' || v === 'null' || v === '~') return null
+    if (v === 'true') return true
+    if (v === 'false') return false
+    if (/^-?\d+$/.test(v)) return parseInt(v, 10)
+    if (/^-?\d+\.\d+$/.test(v)) return parseFloat(v)
+    const dq = v.match(/^"(.*)"$/)
+    if (dq) return dq[1]
+    const sq = v.match(/^'(.*)'$/)
+    if (sq) return sq[1]
+    return v
+}
+
+// Extract `state.feature-flags.canary` from a state.yaml string. Returns
+// null if the block is missing. state.yaml is normalized via
+// `yq sort_keys(...)` so feature-flags sits at indent 2, canary at indent 4,
+// fields at indent 6 — a simple line walker is robust across whatever else
+// the file may contain.
+function parseCanaryBlock(yaml) {
+    if (!yaml || typeof yaml !== 'string') return null
+    const lines = yaml.split(/\r?\n/)
+    let inFeatureFlags = false
+    let inCanary = false
+    const fields = {}
+    for (const line of lines) {
+        if (/^state:\s*$/.test(line)) continue
+        const m = line.match(/^( *)([^\s:#][^:]*):\s*(.*)$/)
+        if (!m) continue
+        const indent = m[1].length
+        const key = m[2].trim()
+        const value = m[3]
+        if (indent === 2) {
+            inFeatureFlags = key === 'feature-flags'
+            inCanary = false
+            continue
+        }
+        if (inFeatureFlags && indent === 4) {
+            inCanary = key === 'canary'
+            continue
+        }
+        if (inCanary && indent === 6) {
+            fields[key] = parseScalar(value)
+        }
+    }
+    return Object.keys(fields).length ? fields : null
+}
+
+async function readChartsState({ octokit, ref = 'main' }) {
+    const { data } = await octokit.rest.repos.getContent({
+        owner: CHARTS_OWNER,
+        repo: CHARTS_REPO,
+        path: CHARTS_STATE_PATH,
+        ref,
+    })
+    if (!data || Array.isArray(data) || !data.content) return null
+    const yaml = Buffer.from(data.content, data.encoding || 'base64').toString('utf8')
+    return parseCanaryBlock(yaml)
+}
+
+// Translate (state.yaml + charts workflow run) into a phase. Used by the
+// watcher to decide whether to update the comment and when to stop polling.
+function derivePhase(state, chartsRun, prNumber) {
+    const pr = parseInt(prNumber, 10)
+    const enabled = !!(state && state.enabled === true)
+    const owns = enabled && state.pr_number === pr
+
+    if (!enabled) return 'EXPIRED'
+    if (!owns) return 'EXPIRED'
+
+    const status = chartsRun?.status || null
+    const conclusion = chartsRun?.conclusion || null
+    if (status === 'completed') {
+        if (conclusion === 'success') return 'HEALTHY'
+        if (conclusion === 'cancelled') return 'CANCELED'
+        return 'FAILED'
+    }
+
+    const weight = state.weight ?? 0
+    return weight > 0 ? 'ROUTING' : 'ROLLING_OUT'
+}
+
+async function pollUntil({ predicate, timeoutMs, intervalMs }) {
+    const start = Date.now()
+    // Run once immediately so a fast-completing rollout isn't delayed by
+    // the first sleep.
+    if (await predicate()) return true
+    while (Date.now() - start < timeoutMs) {
+        await new Promise((res) => setTimeout(res, intervalMs))
+        if (await predicate()) return true
+    }
+    return false
+}
+
+module.exports = {
+    CHARTS_OWNER,
+    CHARTS_REPO,
+    CHARTS_STATE_PATH,
+    parseScalar,
+    parseCanaryBlock,
+    readChartsState,
+    derivePhase,
+    pollUntil,
+}

--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -1,18 +1,28 @@
-name: Enable Feature Flags PR Canary
+name: Manage Feature Flags PR Canary
 
 # Build the feature-flags Docker image from the PR head commit and dispatch
 # the canary deployment to the charts repo, which handles the ArgoCD rollout
 # using a two-phase deployment approach.
 #
+# A single status comment (marker `<!-- pr-canary-status -->`) on the PR is
+# upserted as the deployment moves through validating → building → dispatched
+# → rolling out → routing → healthy / failed / canceled. Helper logic lives
+# in `.github/scripts/canary/`.
+#
 # Trigger options:
-# 1. Comment /pr-canary on a PR (supports weight= and env= params)
+# 1. Comment on a PR:
+#       /pr-canary [weight=N] [env=ENV]   start a canary
+#       /pr-canary cancel                 cancel an active canary for this PR
+#       /pr-canary status                 refresh the status comment
+#       /pr-canary help                   show help
 # 2. Push new commits to a PR that already has the 'canary-flags' label
 # 3. Manually via workflow_dispatch with PR number and options
 #
 # Requirements:
 # - PR must be approved (no outstanding change requests)
 # - PR author must be a PostHog org member
-# - For /pr-canary and workflow_dispatch: actor must be in team-feature-flags or team-flags-platform
+# - For comment-triggered subcommands and workflow_dispatch:
+#     actor must be in team-feature-flags or team-flags-platform
 
 concurrency:
     group: canary-flags-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
@@ -45,7 +55,9 @@ on:
                 default: 'dev'
 
 jobs:
-    # Lightweight job: parse /pr-canary commands, validate, add label, provide feedback
+    # Lightweight job: parse /pr-canary commands, route to the right
+    # subcommand flow (enable / cancel / status / help), validate, and
+    # upsert the PR status comment.
     handle_comment:
         name: Handle /pr-canary command
         if: >-
@@ -58,14 +70,22 @@ jobs:
         permissions:
             pull-requests: write
             issues: write
+            actions: write # for cancelling in-flight runs from the cancel subcommand
         outputs:
+            subcommand: ${{ steps.command.outputs.subcommand }}
             should_build: ${{ steps.command.outputs.should_build }}
             pr_number: ${{ steps.command.outputs.pr_number }}
             pr_head_sha: ${{ steps.command.outputs.pr_head_sha }}
             canary_weight: ${{ steps.command.outputs.canary_weight }}
             target_environment: ${{ steps.command.outputs.target_environment }}
         steps:
-            - name: React to comment
+            - name: Check out canary scripts
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  sparse-checkout: .github/scripts/canary
+                  sparse-checkout-cone-mode: false
+
+            - name: React to comment (eyes)
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   script: |
@@ -85,20 +105,59 @@ jobs:
                   client-id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
 
-            - name: Parse command and validate
+            - name: Get charts deployer token
+              id: charts_token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+                  owner: PostHog
+                  repositories: charts
+
+            - name: Parse, validate, route and update PR comment
               id: command
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   ACTOR: ${{ github.actor }}
+                  TEAM_TOKEN: ${{ steps.app-token.outputs.token }}
+                  CHARTS_TOKEN: ${{ steps.charts_token.outputs.token }}
               with:
-                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
+                      const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                      const { readChartsState } = require('./.github/scripts/canary/state.js');
+                      const { getOctokit } = require('@actions/github');
+
+                      const teamOctokit = getOctokit(process.env.TEAM_TOKEN);
+                      const chartsOctokit = getOctokit(process.env.CHARTS_TOKEN);
+
                       const prNumber = context.payload.issue.number;
                       const body = context.payload.comment.body.trim();
                       const firstLine = body.split('\n')[0].trim();
+                      const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-                      // Handle /pr-canary help
-                      if (/^\/pr-canary\s+help\b/.test(firstLine)) {
+                      const setReaction = async (content) => {
+                          try {
+                              await github.rest.reactions.createForIssueComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: context.payload.comment.id,
+                                  content,
+                              });
+                          } catch (e) { /* best-effort */ }
+                      };
+
+                      // ---------- 1. Detect subcommand ----------
+                      // Order matters: 'help', 'cancel|disable|stop', 'status', then default = enable
+                      const subRe = /^\/pr-canary(?:\s+(help|cancel|disable|stop|status))?\b/;
+                      const subMatch = firstLine.match(subRe);
+                      let sub = (subMatch && subMatch[1]) || 'enable';
+                      if (sub === 'disable' || sub === 'stop') sub = 'cancel';
+                      core.setOutput('subcommand', sub);
+                      core.setOutput('should_build', 'false');
+                      core.setOutput('pr_number', prNumber.toString());
+
+                      // ---------- 2. /pr-canary help ----------
+                      if (sub === 'help') {
                           await github.rest.issues.createComment({
                               owner: context.repo.owner,
                               repo: context.repo.repo,
@@ -108,47 +167,42 @@ jobs:
                                   '',
                                   '| Command | Description |',
                                   '|---------|-------------|',
-                                  '| `/pr-canary` | Deploy with auto weight to dev |',
-                                  '| `/pr-canary weight=5` | Deploy with 5% traffic to dev |',
-                                  '| `/pr-canary env=prod-us` | Deploy with auto weight to prod-us |',
-                                  '| `/pr-canary weight=3 env=prod-eu` | Deploy with 3% traffic to prod-eu |',
+                                  '| `/pr-canary` | Start a canary with auto weight in dev |',
+                                  '| `/pr-canary weight=5` | Start with 5% traffic in dev |',
+                                  '| `/pr-canary env=prod-us` | Start with auto weight in prod-us |',
+                                  '| `/pr-canary weight=3 env=prod-eu` | Start with 3% traffic in prod-eu |',
+                                  '| `/pr-canary cancel` | Cancel the active canary for this PR |',
+                                  '| `/pr-canary status` | Refresh the status comment |',
                                   '| `/pr-canary help` | Show this help |',
                                   '',
-                                  '**Parameters:**',
+                                  '**Parameters**',
                                   '',
                                   '| Parameter | Values | Default |',
                                   '|-----------|--------|---------|',
                                   '| `weight` | `1`–`10` or `auto` | `auto` |',
                                   '| `env` | `dev`, `prod-us`, `prod-eu` | `dev` |',
                                   '',
-                                  '**Requirements:** PR must be approved. You must be in `team-feature-flags` or `team-flags-platform`.',
+                                  '**Requirements** — PR must be approved. Caller must be in `team-feature-flags` or `team-flags-platform`.',
                                   '',
-                                  'The canary auto-disables after 48h or when the PR is closed/merged.',
-                              ].join('\n')
+                                  'A single status comment is updated as the rollout progresses. The canary auto-disables after 48h or when the PR is closed/merged.',
+                              ].join('\n'),
                           });
-                          core.setOutput('should_build', 'false');
                           return;
                       }
 
-                      // Check team membership
+                      // ---------- 3. Team membership ----------
                       const actor = process.env.ACTOR;
                       const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
                       let isMember = false;
-
                       for (const team of allowedTeams) {
                           try {
-                              await github.rest.teams.getMembershipForUserInOrg({
-                                  org: 'PostHog',
-                                  team_slug: team,
-                                  username: actor
+                              await teamOctokit.rest.teams.getMembershipForUserInOrg({
+                                  org: 'PostHog', team_slug: team, username: actor,
                               });
-                              console.log(`${actor} is a member of PostHog/${team}`);
                               isMember = true;
                               break;
                           } catch (e) {
-                              if (e.status === 404) {
-                                  console.log(`${actor} is not in PostHog/${team}`);
-                              } else {
+                              if (e.status !== 404) {
                                   core.setFailed(
                                       `Failed to check team membership for PostHog/${team}: ${e.message}. ` +
                                       `The GH_APP_POSTHOG_ASSIGN_REVIEWERS app may lack Organization > Members > Read permission.`
@@ -157,86 +211,240 @@ jobs:
                               }
                           }
                       }
-
                       if (!isMember) {
-                          await github.rest.issues.createComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              issue_number: prNumber,
-                              body: `@${actor} you must be a member of \`team-feature-flags\` or \`team-flags-platform\` to use \`/pr-canary\`.`
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'DENIED',
+                              fields: {
+                                  reason: `@${actor} you must be a member of \`team-feature-flags\` or \`team-flags-platform\` to use \`/pr-canary\`.`,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
                           });
+                          await setReaction('confused');
                           core.setFailed('Not a member of an authorized team');
                           return;
                       }
 
                       // Pin the PR head SHA now so it cannot change between
-                      // validation and checkout (addresses TOCTOU concern for
-                      // issue_comment running in a privileged context).
+                      // validation and checkout (TOCTOU mitigation).
                       const { data: pr } = await github.rest.pulls.get({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          pull_number: prNumber
+                          owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber,
                       });
 
-                      // Restrict canary to PRs authored by PostHog org members
-                      // to prevent building code from external contributors.
+                      // Restrict canary to PRs authored by PostHog org members.
                       try {
-                          const { data: membership } = await github.rest.orgs.getMembershipForUser({
-                              org: 'PostHog',
-                              username: pr.user.login
+                          const { data: membership } = await teamOctokit.rest.orgs.getMembershipForUser({
+                              org: 'PostHog', username: pr.user.login,
                           });
-                          if (membership.state !== 'active') {
-                              throw new Error('not active');
-                          }
+                          if (membership.state !== 'active') throw new Error('not active');
                       } catch (e) {
-                          await github.rest.issues.createComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              issue_number: prNumber,
-                              body: `Canary deployments are restricted to PRs authored by PostHog org members. PR author \`${pr.user.login}\` is not a member.`
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'DENIED',
+                              fields: {
+                                  reason: `Canary deployments are restricted to PRs authored by PostHog org members. PR author \`${pr.user.login}\` is not a member.`,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
                           });
+                          await setReaction('confused');
                           core.setFailed('PR author is not a PostHog org member');
                           return;
                       }
 
-                      // Parse /pr-canary [weight=N] [env=ENV]
+                      // ---------- 4. /pr-canary cancel ----------
+                      if (sub === 'cancel') {
+                          const state = await readChartsState({ octokit: chartsOctokit });
+                          if (!state || state.enabled !== true || state.pr_number !== prNumber) {
+                              await upsertStatusComment({
+                                  github, context, prNumber,
+                                  phase: 'NO_ACTIVE_CANARY',
+                                  fields: { dispatch_run_url: dispatchRunUrl },
+                              });
+                              await setReaction('+1');
+                              return;
+                          }
+
+                          // Cancel any in-flight build_and_enable runs for this PR head SHA
+                          // so a mid-Docker-build dispatch can be stopped immediately.
+                          try {
+                              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  workflow_id: 'canary-flags-enable.yml',
+                                  head_sha: pr.head.sha,
+                                  per_page: 50,
+                              });
+                              for (const run of runs) {
+                                  if (run.status === 'completed') continue;
+                                  if (run.id === context.runId) continue;
+                                  try {
+                                      await github.rest.actions.cancelWorkflowRun({
+                                          owner: context.repo.owner, repo: context.repo.repo, run_id: run.id,
+                                      });
+                                  } catch (err) {
+                                      console.log(`Could not cancel run #${run.id}: ${err.status || err.message}`);
+                                  }
+                              }
+                          } catch (err) {
+                              console.log(`Run lookup failed: ${err.message}`);
+                          }
+
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'CANCELING',
+                              fields: {
+                                  image: state.image,
+                                  env: state.target_environment,
+                                  weight: state.weight,
+                                  started_by: state.started_by,
+                                  started_at: state.started_at,
+                                  canceled_by: actor,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
+                          });
+
+                          await chartsOctokit.rest.repos.createDispatchEvent({
+                              owner: 'PostHog',
+                              repo: 'charts',
+                              event_type: 'disable-canary-flags',
+                              client_payload: { pr_number: String(prNumber) },
+                          });
+
+                          // Drop the canary-flags label so future synchronizes don't try to rebuild.
+                          try {
+                              await github.rest.issues.removeLabel({
+                                  owner: context.repo.owner, repo: context.repo.repo,
+                                  issue_number: prNumber, name: 'canary-flags',
+                              });
+                          } catch (err) {
+                              if (err.status !== 404) console.log(`Could not remove canary-flags label: ${err.message}`);
+                          }
+
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'CANCELED',
+                              fields: {
+                                  image: state.image,
+                                  env: state.target_environment,
+                                  weight: state.weight,
+                                  started_by: state.started_by,
+                                  started_at: state.started_at,
+                                  canceled_by: actor,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
+                          });
+                          await setReaction('+1');
+                          return;
+                      }
+
+                      // ---------- 5. /pr-canary status ----------
+                      if (sub === 'status') {
+                          const state = await readChartsState({ octokit: chartsOctokit });
+                          if (!state || state.enabled !== true || state.pr_number !== prNumber) {
+                              await upsertStatusComment({
+                                  github, context, prNumber,
+                                  phase: 'NO_ACTIVE_CANARY',
+                                  fields: { dispatch_run_url: dispatchRunUrl },
+                              });
+                              await setReaction('+1');
+                              return;
+                          }
+                          // Without a live charts run reference we can only surface state.yaml.
+                          // ROLLING_OUT vs ROUTING is reflected by weight=0 vs weight>0.
+                          const phase = (state.weight ?? 0) > 0 ? 'HEALTHY' : 'ROLLING_OUT';
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase,
+                              fields: {
+                                  image: state.image,
+                                  env: state.target_environment,
+                                  weight: state.weight,
+                                  started_by: state.started_by,
+                                  started_at: state.started_at,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
+                          });
+                          await setReaction('+1');
+                          return;
+                      }
+
+                      // ---------- 6. /pr-canary (enable) ----------
+                      // Parse weight/env
                       const weightMatch = firstLine.match(/\bweight=(\S+)/);
                       const envMatch = firstLine.match(/\benv=(\S+)/);
                       const canaryWeight = weightMatch ? weightMatch[1] : 'auto';
                       const targetEnvironment = envMatch ? envMatch[1] : 'dev';
+                      const validEnvs = ['dev', 'prod-us', 'prod-eu'];
 
-                      // Validate params early so the user gets immediate feedback
                       if (canaryWeight !== 'auto') {
                           const w = Number(canaryWeight);
                           if (!Number.isInteger(w) || w < 1 || w > 10) {
-                              await github.rest.issues.createComment({
-                                  owner: context.repo.owner,
-                                  repo: context.repo.repo,
-                                  issue_number: prNumber,
-                                  body: `Invalid \`weight\` value: \`${canaryWeight}\`. Must be \`auto\` or an integer between 1 and 10.`
+                              await upsertStatusComment({
+                                  github, context, prNumber,
+                                  phase: 'INVALID_INPUT',
+                                  fields: {
+                                      reason: `weight \`${canaryWeight}\` — must be \`auto\` or an integer between 1 and 10.`,
+                                      dispatch_run_url: dispatchRunUrl,
+                                  },
                               });
+                              await setReaction('confused');
                               core.setFailed(`Invalid canary weight: ${canaryWeight}`);
                               return;
                           }
                       }
-
-                      const validEnvs = ['dev', 'prod-us', 'prod-eu'];
                       if (!validEnvs.includes(targetEnvironment)) {
-                          await github.rest.issues.createComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              issue_number: prNumber,
-                              body: `Invalid \`env\` value: \`${targetEnvironment}\`. Must be one of: ${validEnvs.map(e => `\`${e}\``).join(', ')}.`
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'INVALID_INPUT',
+                              fields: {
+                                  reason: `env \`${targetEnvironment}\` — must be one of: ${validEnvs.map((e) => `\`${e}\``).join(', ')}.`,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
                           });
+                          await setReaction('confused');
                           core.setFailed(`Invalid target environment: ${targetEnvironment}`);
                           return;
                       }
 
+                      // Conflict detection: refuse to clobber another PR's canary.
+                      const state = await readChartsState({ octokit: chartsOctokit });
+                      if (state && state.enabled === true && state.pr_number && state.pr_number !== prNumber) {
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'CONFLICT',
+                              fields: {
+                                  holder_pr: state.pr_number,
+                                  holder_actor: state.started_by,
+                                  env: state.target_environment,
+                                  weight: state.weight,
+                                  started_at: state.started_at,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
+                          });
+                          await setReaction('confused');
+                          // Do NOT setFailed — the workflow exits cleanly so the user
+                          // sees a green run with the conflict comment, not a red one.
+                          return;
+                      }
+
+                      // Greenlight the build. Set outputs for downstream jobs.
                       core.setOutput('should_build', 'true');
-                      core.setOutput('pr_number', prNumber.toString());
                       core.setOutput('pr_head_sha', pr.head.sha);
                       core.setOutput('canary_weight', canaryWeight);
                       core.setOutput('target_environment', targetEnvironment);
+
+                      await upsertStatusComment({
+                          github, context, prNumber,
+                          phase: 'VALIDATING',
+                          fields: {
+                              image: `sha-${pr.head.sha.substring(0, 7)}`,
+                              env: targetEnvironment,
+                              weight: canaryWeight,
+                              started_by: actor,
+                              started_at: new Date().toISOString(),
+                              dispatch_run_url: dispatchRunUrl,
+                          },
+                      });
 
                       console.log(`Parsed: PR #${prNumber}, SHA=${pr.head.sha}, weight=${canaryWeight}, env=${targetEnvironment}`);
 
@@ -254,29 +462,30 @@ jobs:
                           issue_number: prNumber,
                           labels: ['canary-flags']
                       });
-                      console.log(`Added canary-flags label to PR #${prNumber}`);
 
-            - name: Report failure on PR
+            - name: Report unexpected failure on PR
               if: failure()
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   script: |
-                      const prNumber = context.payload.issue.number;
-                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-                      await github.rest.issues.createComment({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                          body: `**Canary deployment failed.** [View details](${runUrl})`
-                      });
+                      try {
+                          const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                          const prNumber = context.payload.issue.number;
+                          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'BUILD_FAILED',
+                              fields: { reason: 'unexpected error in command handler', dispatch_run_url: runUrl },
+                          });
+                      } catch (e) {
+                          console.log(`Failure reporter could not upsert: ${e.message}`);
+                      }
 
     # Lightweight preflight: validate PR + resolve target_environment.
     # On `pull_request: synchronize`, target_environment comes from the active
     # canary's state in PostHog/charts:state.yaml — NOT a hardcoded default.
     # If the canary is disabled or owned by a different PR, should_proceed is
     # set to 'false' and the heavy build_and_enable job is skipped entirely.
-    # Hardcoding 'dev' here would silently overwrite an active prod-us / prod-eu
-    # canary, which causes ArgoCD to prune the running prod canary deployment.
     preflight:
         name: Preflight checks for canary deployment
         needs: [handle_comment]
@@ -304,9 +513,6 @@ jobs:
 
         steps:
             # Charts deployer token for reading state.yaml on synchronize.
-            # state.yaml in PostHog/charts is the source of truth for the
-            # active canary's target_environment; we read it here instead of
-            # defaulting to 'dev' which would clobber a prod canary.
             - name: Get charts deployer token (for state.yaml read)
               id: charts_token
               if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
@@ -323,10 +529,6 @@ jobs:
               env:
                   GH_TOKEN: ${{ steps.charts_token.outputs.token }}
               run: |
-                  # Synchronize-only: read PostHog/charts:state.yaml so the
-                  # rebuild dispatch keeps the active canary in its current
-                  # environment. We MUST NOT silently default to `dev` on
-                  # network/auth/parse failure — that is the bug being fixed.
                   set -euo pipefail
                   tmp=$(mktemp)
                   gh api \
@@ -335,8 +537,6 @@ jobs:
                   enabled=$(yq '.state["feature-flags"].canary.enabled // false' "$tmp")
                   active_pr=$(yq '.state["feature-flags"].canary.pr_number // 0' "$tmp")
                   target_env=$(yq '.state["feature-flags"].canary.target_environment // ""' "$tmp")
-                  # weight may be a number or the string "auto"; if missing,
-                  # fall back to "auto" (matches stable fleet per-pod traffic).
                   weight=$(yq '.state["feature-flags"].canary.weight // "auto"' "$tmp")
                   echo "enabled=${enabled}"       >> "$GITHUB_OUTPUT"
                   echo "active_pr=${active_pr}"   >> "$GITHUB_OUTPUT"
@@ -368,20 +568,8 @@ jobs:
                           prNumber = parseInt(process.env.COMMENT_PR_NUMBER);
                           canaryWeight = process.env.COMMENT_CANARY_WEIGHT;
                           targetEnvironment = process.env.COMMENT_TARGET_ENV;
-                          // Use the SHA pinned by handle_comment to prevent TOCTOU:
-                          // the PR HEAD cannot change between validation and checkout.
                           headSha = process.env.COMMENT_PR_HEAD_SHA;
                       } else {
-                          // pull_request: synchronize.
-                          // The active canary's settings are the source of truth —
-                          // read them from state.yaml (loaded by the state_lookup
-                          // step). If the canary is disabled or owned by a different
-                          // PR, skip the rebuild entirely; the user must use
-                          // /pr-canary to opt back in. Silently defaulting to
-                          // env=`dev` and weight=`auto` here is the bug we are
-                          // fixing — it would overwrite the active canary's settings
-                          // (e.g. nuke a prod-eu canary at weight 4 and replace it
-                          // with a dev canary at auto weight).
                           prNumber = context.payload.pull_request.number;
                           headSha = context.payload.pull_request.head.sha;
 
@@ -416,9 +604,6 @@ jobs:
                           return;
                       }
 
-                      // For workflow_dispatch we need to fetch the PR to get the
-                      // head SHA and author. For pull_request the payload has both.
-                      // For issue_comment the SHA was already pinned in handle_comment.
                       let prAuthor;
                       if (context.eventName === 'workflow_dispatch') {
                           const { data: pr } = await github.rest.pulls.get({
@@ -438,10 +623,6 @@ jobs:
                           pull_number: prNumber,
                           per_page: 100,
                       });
-
-                      // Keep only the latest meaningful review per reviewer.
-                      // Filter to APPROVED/CHANGES_REQUESTED so that a follow-up
-                      // COMMENTED review doesn't shadow a prior approval.
                       const significantReviews = allReviews.filter(r =>
                           r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'
                       );
@@ -474,17 +655,12 @@ jobs:
                       if (prAuthor) {
                           core.setOutput('pr_author', prAuthor);
                       }
-                      // Gate downstream build_and_enable job. Set last so any
-                      // earlier early-return (skipped sync, validation failure)
-                      // leaves should_proceed unset/'false'. The build job's
-                      // `if:` checks for the literal string 'true'.
                       core.setOutput('should_proceed', 'true');
 
                       console.log(`PR #${prNumber} approved. SHA: ${headSha}`);
 
             # GitHub App token is required because GITHUB_TOKEN can't read
             # org-private team memberships (returns 404, looks like "not a member").
-            # Shared by "Verify canary label was authorized" and "Verify team membership".
             - name: Get app token for team membership check
               id: app-token
               if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.pr_info.outputs.should_proceed == 'true'
@@ -502,42 +678,28 @@ jobs:
                   github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const prNumber = parseInt(process.env.PR_NUMBER);
-
-                      // Find who added the canary-flags label by inspecting PR events.
-                      // If the label was added by the workflow (github-actions[bot]) it
-                      // went through /pr-canary which already verified team membership.
-                      // If added manually, verify the user is on an allowed team.
                       const events = await github.paginate(github.rest.issues.listEvents, {
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           issue_number: prNumber,
                           per_page: 100,
                       });
-
                       const labelEvent = events
                           .findLast(e => e.event === 'labeled' && e.label.name === 'canary-flags');
-
                       if (!labelEvent) {
                           core.setFailed('canary-flags label event not found — cannot verify authorization');
                           return;
                       }
-
                       const labeler = labelEvent.actor.login;
-
-                      // Label added by the workflow itself (via /pr-canary) — already authorized
                       if (labeler === 'github-actions[bot]') {
                           console.log('canary-flags label was added by the workflow (authorized)');
                           return;
                       }
-
-                      // Label added manually — verify the user is on an allowed team
                       const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
                       for (const team of allowedTeams) {
                           try {
                               await github.rest.teams.getMembershipForUserInOrg({
-                                  org: 'PostHog',
-                                  team_slug: team,
-                                  username: labeler
+                                  org: 'PostHog', team_slug: team, username: labeler,
                               });
                               console.log(`Label was added by ${labeler} who is a member of PostHog/${team}`);
                               return;
@@ -548,7 +710,6 @@ jobs:
                               }
                           }
                       }
-
                       core.setFailed(
                           `canary-flags label was added by ${labeler} who is not a member of ` +
                           `team-feature-flags or team-flags-platform. ` +
@@ -563,23 +724,16 @@ jobs:
               with:
                   github-token: ${{ steps.app-token.outputs.token }}
                   script: |
-                      // pr_author is set by pr_info: from the API for workflow_dispatch,
-                      // from the event payload for pull_request.
-                      // For issue_comment this step is skipped entirely (checked in handle_comment).
                       const prAuthor = process.env.PR_AUTHOR;
                       if (!prAuthor) {
                           core.setFailed('pr_author output not set by pr_info step');
                           return;
                       }
-
                       try {
                           const { data: membership } = await github.rest.orgs.getMembershipForUser({
-                              org: 'PostHog',
-                              username: prAuthor
+                              org: 'PostHog', username: prAuthor,
                           });
-                          if (membership.state !== 'active') {
-                              throw new Error('not active');
-                          }
+                          if (membership.state !== 'active') throw new Error('not active');
                           console.log(`PR author ${prAuthor} is a PostHog org member`);
                       } catch (e) {
                           core.setFailed(
@@ -598,13 +752,10 @@ jobs:
                   script: |
                       const actor = process.env.ACTOR;
                       const allowedTeams = ['team-feature-flags', 'team-flags-platform'];
-
                       for (const team of allowedTeams) {
                           try {
                               await github.rest.teams.getMembershipForUserInOrg({
-                                  org: 'PostHog',
-                                  team_slug: team,
-                                  username: actor
+                                  org: 'PostHog', team_slug: team, username: actor,
                               });
                               console.log(`${actor} is a member of PostHog/${team}`);
                               return;
@@ -641,7 +792,6 @@ jobs:
                       exit 1
                     fi
                   fi
-
                   case "$TARGET_ENVIRONMENT" in
                     dev|prod-us|prod-eu) ;;
                     *)
@@ -649,42 +799,36 @@ jobs:
                       exit 1
                       ;;
                   esac
-
                   echo "Validated: weight=${CANARY_WEIGHT}, environment=${TARGET_ENVIRONMENT}"
 
-            # Mirror of build_and_enable's failure reporter so that a preflight
-            # failure (team membership rejection, state.yaml fetch error, etc.)
-            # leaves a comment on the PR. Fires for both /pr-canary comments
-            # and pull_request: synchronize events: on synchronize, a state.yaml
-            # read failure would otherwise produce a red Action with no PR
-            # signal.
             - name: Report failure on PR
+              if: failure() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  sparse-checkout: .github/scripts/canary
+                  sparse-checkout-cone-mode: false
+            - name: Upsert preflight failure marker
               if: failure() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   script: |
-                      const prNumber = context.payload.issue?.number ?? context.payload.pull_request?.number;
-                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-                      await github.rest.issues.createComment({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                          body: `**Canary deployment failed.** [View details](${runUrl})`
-                      });
+                      try {
+                          const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                          const prNumber = context.payload.issue?.number ?? context.payload.pull_request?.number;
+                          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'BUILD_FAILED',
+                              fields: { reason: 'preflight checks failed', dispatch_run_url: runUrl },
+                          });
+                      } catch (e) {
+                          console.log(`Failure reporter could not upsert: ${e.message}`);
+                      }
 
     # Heavy job: build image + dispatch to charts.
-    # Gated on preflight.should_proceed so a synchronize event that targets a
-    # canary owned by another PR (or a disabled canary) is skipped without
-    # building or dispatching anything.
     build_and_enable:
         name: Build feature-flags image and enable canary
         needs: [preflight]
-        # `!cancelled()` disables the implicit success() chain check, which
-        # otherwise inherits handle_comment's `skipped` result on a
-        # `pull_request: synchronize` event (handle_comment is gated to
-        # issue_comment) and skips this job before should_proceed is even
-        # evaluated. We then re-assert success on the direct dependency
-        # only and gate on the actual `should_proceed` output.
         if: |
             !cancelled() &&
             needs.preflight.result == 'success' &&
@@ -706,7 +850,33 @@ jobs:
                   sparse-checkout: |
                       rust/
                       proto/
+                      .github/scripts/canary/
                   sparse-checkout-cone-mode: false
+
+            - name: Mark BUILDING in PR comment
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+                  IMAGE_TAG: ${{ needs.preflight.outputs.image_tag }}
+                  CANARY_WEIGHT: ${{ needs.preflight.outputs.canary_weight }}
+                  TARGET_ENVIRONMENT: ${{ needs.preflight.outputs.target_environment }}
+              with:
+                  script: |
+                      const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                      const prNumber = parseInt(process.env.PR_NUMBER);
+                      const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      await upsertStatusComment({
+                          github, context, prNumber,
+                          phase: 'BUILDING',
+                          fields: {
+                              image: process.env.IMAGE_TAG,
+                              env: process.env.TARGET_ENVIRONMENT,
+                              weight: process.env.CANARY_WEIGHT,
+                              started_by: context.actor,
+                              started_at: new Date().toISOString(),
+                              dispatch_run_url: dispatchRunUrl,
+                          },
+                      });
 
             - name: Copy proto files into rust build context
               run: cp -r proto rust/proto
@@ -760,6 +930,7 @@ jobs:
                   repositories: charts
 
             - name: Dispatch canary deployment to charts repo
+              id: dispatch
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
@@ -782,6 +953,42 @@ jobs:
                               started_by: process.env.STARTED_BY
                           }
                       });
+                      core.setOutput('dispatched_at', new Date().toISOString());
+
+            - name: Mark DISPATCHED in PR comment + rocket reaction
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+                  IMAGE_TAG: ${{ needs.preflight.outputs.image_tag }}
+                  CANARY_WEIGHT: ${{ needs.preflight.outputs.canary_weight }}
+                  TARGET_ENVIRONMENT: ${{ needs.preflight.outputs.target_environment }}
+              with:
+                  script: |
+                      const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                      const prNumber = parseInt(process.env.PR_NUMBER);
+                      const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      await upsertStatusComment({
+                          github, context, prNumber,
+                          phase: 'DISPATCHED',
+                          fields: {
+                              image: process.env.IMAGE_TAG,
+                              env: process.env.TARGET_ENVIRONMENT,
+                              weight: process.env.CANARY_WEIGHT,
+                              started_by: context.actor,
+                              started_at: new Date().toISOString(),
+                              dispatch_run_url: dispatchRunUrl,
+                          },
+                      });
+                      if (context.eventName === 'issue_comment') {
+                          try {
+                              await github.rest.reactions.createForIssueComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: context.payload.comment.id,
+                                  content: 'rocket',
+                              });
+                          } catch (e) { /* best-effort */ }
+                      }
 
             - name: Summary
               env:
@@ -799,52 +1006,173 @@ jobs:
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "Deployment dispatched to the [charts repo canary workflow](https://github.com/PostHog/charts/actions/workflows/pr-canary-flags-enable.yml)." >> $GITHUB_STEP_SUMMARY
 
-            - name: Report success on PR
-              if: success() && github.event_name == 'issue_comment'
+            - name: Report build/dispatch failure
+              if: failure()
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
                   IMAGE_TAG: ${{ needs.preflight.outputs.image_tag }}
-                  CANARY_WEIGHT: ${{ needs.preflight.outputs.canary_weight }}
-                  TARGET_ENVIRONMENT: ${{ needs.preflight.outputs.target_environment }}
               with:
                   script: |
-                      await github.rest.reactions.createForIssueComment({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          comment_id: context.payload.comment.id,
-                          content: 'rocket'
-                      });
+                      try {
+                          const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                          const prNumber = parseInt(process.env.PR_NUMBER);
+                          const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'BUILD_FAILED',
+                              fields: {
+                                  reason: 'image build or dispatch failed',
+                                  image: process.env.IMAGE_TAG,
+                                  dispatch_run_url: dispatchRunUrl,
+                              },
+                          });
+                          if (context.eventName === 'issue_comment') {
+                              try {
+                                  await github.rest.reactions.createForIssueComment({
+                                      owner: context.repo.owner,
+                                      repo: context.repo.repo,
+                                      comment_id: context.payload.comment.id,
+                                      content: '-1',
+                                  });
+                              } catch (e) { /* best-effort */ }
+                          }
+                      } catch (e) {
+                          console.log(`Failure reporter could not upsert: ${e.message}`);
+                      }
 
-                      const prNumber = parseInt(process.env.PR_NUMBER);
-                      const chartsUrl = 'https://github.com/PostHog/charts/actions/workflows/pr-canary-flags-enable.yml';
-                      await github.rest.issues.createComment({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                          body: [
-                              `**Canary deployment dispatched**`,
-                              '',
-                              `| | |`,
-                              `|---|---|`,
-                              `| Image | \`${process.env.IMAGE_TAG}\` |`,
-                              `| Weight | ${process.env.CANARY_WEIGHT} |`,
-                              `| Environment | ${process.env.TARGET_ENVIRONMENT} |`,
-                              '',
-                              `[View deployment progress](${chartsUrl})`,
-                          ].join('\n')
-                      });
+    # Watcher: poll state.yaml + the charts workflow run, upsert the PR
+    # comment as the rollout transitions ROLLING_OUT → ROUTING → HEALTHY.
+    # Independent of rollout correctness — purely informational.
+    watch_rollout:
+        name: Watch ArgoCD rollout and update PR comment
+        needs: [preflight, build_and_enable]
+        if: |
+            !cancelled() &&
+            needs.build_and_enable.result == 'success'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 25
+        permissions:
+            issues: write
+            pull-requests: write
+            contents: read
+        concurrency:
+            group: canary-flags-watch-${{ needs.preflight.outputs.pr_number }}
+            cancel-in-progress: true
 
-            - name: Report failure on PR
-              if: failure() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
+        steps:
+            - name: Check out canary scripts
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  sparse-checkout: .github/scripts/canary
+                  sparse-checkout-cone-mode: false
+
+            - name: Get charts read token
+              id: charts_token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+                  owner: PostHog
+                  repositories: charts
+
+            - name: Poll state.yaml + charts run, upsert comment
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+                  IMAGE_TAG: ${{ needs.preflight.outputs.image_tag }}
+                  TARGET_ENVIRONMENT: ${{ needs.preflight.outputs.target_environment }}
+                  CANARY_WEIGHT: ${{ needs.preflight.outputs.canary_weight }}
+                  CHARTS_TOKEN: ${{ steps.charts_token.outputs.token }}
               with:
                   script: |
-                      const prNumber = context.payload.issue?.number ?? context.payload.pull_request?.number;
-                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-                      await github.rest.issues.createComment({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                          body: `**Canary deployment failed.** [View details](${runUrl})`
+                      const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                      const { readChartsState, derivePhase, pollUntil } = require('./.github/scripts/canary/state.js');
+                      const { findEnableRun, getChartsRun } = require('./.github/scripts/canary/charts-run.js');
+                      const { getOctokit } = require('@actions/github');
+
+                      const charts = getOctokit(process.env.CHARTS_TOKEN);
+                      const prNumber = parseInt(process.env.PR_NUMBER);
+                      const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      const dispatchedAt = new Date(Date.now() - 30_000); // small buffer for clock skew
+
+                      const chartsRunRef = await findEnableRun({ octokit: charts, dispatchedAt });
+                      if (!chartsRunRef) {
+                          console.log('Could not locate charts run yet — will continue with state-only polling.');
+                      } else {
+                          console.log(`Charts run: ${chartsRunRef.html_url}`);
+                      }
+
+                      let lastPhase = null;
+                      const TERMINAL = new Set(['HEALTHY', 'FAILED', 'CANCELED', 'EXPIRED']);
+
+                      const upsert = async (phase, state) => {
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase,
+                              fields: {
+                                  image: state?.image || process.env.IMAGE_TAG,
+                                  env: state?.target_environment || process.env.TARGET_ENVIRONMENT,
+                                  weight: state?.weight ?? process.env.CANARY_WEIGHT,
+                                  started_by: state?.started_by || context.actor,
+                                  started_at: state?.started_at || new Date().toISOString(),
+                                  dispatch_run_url: dispatchRunUrl,
+                                  charts_run_url: chartsRunRef?.html_url,
+                                  charts_run_id: chartsRunRef?.id,
+                              },
+                          });
+                      };
+
+                      await pollUntil({
+                          timeoutMs: 22 * 60 * 1000,
+                          intervalMs: 30 * 1000,
+                          predicate: async () => {
+                              let state, run;
+                              try {
+                                  state = await readChartsState({ octokit: charts });
+                              } catch (err) {
+                                  console.log(`state.yaml read error: ${err.message}`);
+                                  return false;
+                              }
+                              try {
+                                  run = chartsRunRef
+                                      ? await getChartsRun({ octokit: charts, runId: chartsRunRef.id })
+                                      : null;
+                              } catch (err) {
+                                  console.log(`charts run get error: ${err.message}`);
+                              }
+                              const phase = derivePhase(state, run, prNumber);
+                              if (phase !== lastPhase) {
+                                  console.log(`Phase: ${lastPhase || '(initial)'} → ${phase}`);
+                                  await upsert(phase, state);
+                                  lastPhase = phase;
+                              }
+                              return TERMINAL.has(phase);
+                          },
                       });
+
+                      if (!TERMINAL.has(lastPhase || '')) {
+                          // Timed out — leave a clear marker so the user isn't left guessing.
+                          let state = null;
+                          try { state = await readChartsState({ octokit: charts }); } catch (e) { /* ignore */ }
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'FAILED',
+                              fields: {
+                                  reason: 'rollout did not reach a healthy state within the watcher window — check the charts run',
+                                  image: state?.image || process.env.IMAGE_TAG,
+                                  env: state?.target_environment || process.env.TARGET_ENVIRONMENT,
+                                  dispatch_run_url: dispatchRunUrl,
+                                  charts_run_url: chartsRunRef?.html_url,
+                              },
+                          });
+                      } else if (lastPhase === 'HEALTHY' && context.eventName === 'issue_comment') {
+                          try {
+                              await github.rest.reactions.createForIssueComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: context.payload.comment.id,
+                                  content: '+1',
+                              });
+                          } catch (e) { /* best-effort */ }
+                      }

--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -352,12 +352,29 @@ jobs:
                               await setReaction('+1');
                               return;
                           }
-                          // Without a live charts run reference we can only surface state.yaml.
-                          // ROLLING_OUT vs ROUTING is reflected by weight=0 vs weight>0.
-                          const phase = (state.weight ?? 0) > 0 ? 'HEALTHY' : 'ROLLING_OUT';
+                          // Locate the most recent charts enable run anchored to state.started_at
+                          // and use derivePhase exactly as watch_rollout does. state.yaml alone
+                          // cannot tell HEALTHY from in-flight ROUTING — the charts run conclusion
+                          // is the source of truth. Fallback (run=null) yields ROLLING_OUT/ROUTING
+                          // from state.weight, never the misleading HEALTHY.
+                          const { findEnableRun, getChartsRun } = require('./.github/scripts/canary/charts-run.js');
+                          const { derivePhase } = require('./.github/scripts/canary/state.js');
+                          let run = null;
+                          try {
+                              const dispatchedAt = new Date(new Date(state.started_at).getTime() - 30_000);
+                              const ref = await findEnableRun({
+                                  octokit: chartsOctokit,
+                                  dispatchedAt,
+                                  retries: 3,
+                                  intervalMs: 1000,
+                              });
+                              if (ref) run = await getChartsRun({ octokit: chartsOctokit, runId: ref.id });
+                          } catch (e) {
+                              console.log(`status: charts run lookup skipped: ${e.message}`);
+                          }
+                          const phase = derivePhase(state, run, prNumber);
                           await upsertStatusComment({
-                              github, context, prNumber,
-                              phase,
+                              github, context, prNumber, phase,
                               fields: {
                                   image: state.image,
                                   env: state.target_environment,
@@ -365,6 +382,8 @@ jobs:
                                   started_by: state.started_by,
                                   started_at: state.started_at,
                                   dispatch_run_url: dispatchRunUrl,
+                                  charts_run_url: run?.html_url,
+                                  charts_run_id: run?.id,
                               },
                           });
                           await setReaction('+1');
@@ -489,6 +508,9 @@ jobs:
     # canary's state in PostHog/charts:state.yaml — NOT a hardcoded default.
     # If the canary is disabled or owned by a different PR, should_proceed is
     # set to 'false' and the heavy build_and_enable job is skipped entirely.
+    # Hardcoding 'dev' here would silently overwrite an active prod-us /
+    # prod-eu canary, which causes ArgoCD to prune the running prod canary
+    # deployment.
     preflight:
         name: Preflight checks for canary deployment
         needs: [handle_comment]
@@ -516,6 +538,9 @@ jobs:
 
         steps:
             # Charts deployer token for reading state.yaml on synchronize.
+            # state.yaml in PostHog/charts is the source of truth for the
+            # active canary's target_environment; we read it here instead of
+            # defaulting to 'dev' which would clobber a prod canary.
             - name: Get charts deployer token (for state.yaml read)
               id: charts_token
               if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
@@ -532,6 +557,10 @@ jobs:
               env:
                   GH_TOKEN: ${{ steps.charts_token.outputs.token }}
               run: |
+                  # Synchronize-only: read PostHog/charts:state.yaml so the
+                  # rebuild dispatch keeps the active canary in its current
+                  # environment. We MUST NOT silently default to `dev` on
+                  # network/auth/parse failure — that is the bug being fixed.
                   set -euo pipefail
                   tmp=$(mktemp)
                   gh api \
@@ -540,6 +569,8 @@ jobs:
                   enabled=$(yq '.state["feature-flags"].canary.enabled // false' "$tmp")
                   active_pr=$(yq '.state["feature-flags"].canary.pr_number // 0' "$tmp")
                   target_env=$(yq '.state["feature-flags"].canary.target_environment // ""' "$tmp")
+                  # weight may be a number or the string "auto"; if missing,
+                  # fall back to "auto" (matches stable fleet per-pod traffic).
                   weight=$(yq '.state["feature-flags"].canary.weight // "auto"' "$tmp")
                   echo "enabled=${enabled}"       >> "$GITHUB_OUTPUT"
                   echo "active_pr=${active_pr}"   >> "$GITHUB_OUTPUT"
@@ -571,8 +602,20 @@ jobs:
                           prNumber = parseInt(process.env.COMMENT_PR_NUMBER);
                           canaryWeight = process.env.COMMENT_CANARY_WEIGHT;
                           targetEnvironment = process.env.COMMENT_TARGET_ENV;
+                          // Use the SHA pinned by handle_comment to prevent TOCTOU:
+                          // the PR HEAD cannot change between validation and checkout.
                           headSha = process.env.COMMENT_PR_HEAD_SHA;
                       } else {
+                          // pull_request: synchronize.
+                          // The active canary's settings are the source of truth —
+                          // read them from state.yaml (loaded by the state_lookup
+                          // step). If the canary is disabled or owned by a different
+                          // PR, skip the rebuild entirely; the user must use
+                          // /pr-canary to opt back in. Silently defaulting to
+                          // env=`dev` and weight=`auto` here is the bug we are
+                          // fixing — it would overwrite the active canary's settings
+                          // (e.g. nuke a prod-eu canary at weight 4 and replace it
+                          // with a dev canary at auto weight).
                           prNumber = context.payload.pull_request.number;
                           headSha = context.payload.pull_request.head.sha;
 
@@ -607,6 +650,9 @@ jobs:
                           return;
                       }
 
+                      // For workflow_dispatch we need to fetch the PR to get the
+                      // head SHA and author. For pull_request the payload has both.
+                      // For issue_comment the SHA was already pinned in handle_comment.
                       let prAuthor;
                       if (context.eventName === 'workflow_dispatch') {
                           const { data: pr } = await github.rest.pulls.get({
@@ -626,6 +672,9 @@ jobs:
                           pull_number: prNumber,
                           per_page: 100,
                       });
+                      // Keep only the latest meaningful review per reviewer.
+                      // Filter to APPROVED/CHANGES_REQUESTED so a follow-up
+                      // COMMENTED review doesn't shadow a prior approval.
                       const significantReviews = allReviews.filter(r =>
                           r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'
                       );
@@ -658,12 +707,17 @@ jobs:
                       if (prAuthor) {
                           core.setOutput('pr_author', prAuthor);
                       }
+                      // Gate downstream build_and_enable job. Set last so any
+                      // earlier early-return (skipped sync, validation failure)
+                      // leaves should_proceed unset/'false'. The build job's
+                      // `if:` checks for the literal string 'true'.
                       core.setOutput('should_proceed', 'true');
 
                       console.log(`PR #${prNumber} approved. SHA: ${headSha}`);
 
             # GitHub App token is required because GITHUB_TOKEN can't read
             # org-private team memberships (returns 404, looks like "not a member").
+            # Shared by "Verify canary label was authorized" and "Verify team membership".
             - name: Get app token for team membership check
               id: app-token
               if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.pr_info.outputs.should_proceed == 'true'
@@ -804,6 +858,12 @@ jobs:
                   esac
                   echo "Validated: weight=${CANARY_WEIGHT}, environment=${TARGET_ENVIRONMENT}"
 
+            # Mirror of build_and_enable's failure reporter so a preflight
+            # failure (team membership rejection, state.yaml fetch error,
+            # etc.) leaves a comment on the PR. Fires for both /pr-canary
+            # comments and pull_request: synchronize events: on synchronize,
+            # a state.yaml read failure would otherwise produce a red Action
+            # with no PR signal.
             - name: Report failure on PR
               if: failure() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -829,50 +889,38 @@ jobs:
                           console.log(`Failure reporter could not upsert: ${e.message}`);
                       }
 
-    # Heavy job: build image + dispatch to charts.
-    build_and_enable:
-        name: Build feature-flags image and enable canary
+    # Lightweight notify: upserts the BUILDING marker on the PR from a
+    # privileged context that NEVER co-locates with PR-author-controlled
+    # code. Splitting BUILDING out of build_and_enable lets us keep
+    # `pull-requests: write` here while ruling out the entire
+    # untrusted-checkout TOCTOU class in the heavy build job (see
+    # build_and_enable below — it now contains zero `require()` of trusted
+    # scripts so CodeQL has nothing to flag).
+    #
+    # Best-effort UX only: build_and_enable does NOT depend on this job, so
+    # a flaky comment upsert never blocks the build. A few-second lag here
+    # just means the BUILDING marker arrives mid-build — tolerable.
+    notify_building:
+        name: Mark BUILDING in PR comment
         needs: [preflight]
         if: |
             !cancelled() &&
             needs.preflight.result == 'success' &&
             needs.preflight.outputs.should_proceed == 'true'
-        runs-on: depot-ubuntu-22.04
-        timeout-minutes: 30
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
         permissions:
-            id-token: write
-            contents: read
-            packages: write
-            pull-requests: read
+            pull-requests: write
             issues: write
-
+            contents: read
         steps:
-            # Trusted: canary helper scripts come from the default branch so
-            # the github-script `require()`s below cannot execute PR-author-
-            # controlled code in this privileged context. Lands at workspace
-            # root so existing `require('./.github/scripts/canary/...')` paths
-            # are unchanged.
             - name: Check out trusted canary scripts (default branch)
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: master
                   sparse-checkout: .github/scripts/canary
                   sparse-checkout-cone-mode: false
-
-            # Untrusted: PR build context. Pinned to the SHA validated by
-            # handle_comment, isolated under `pr-head/` so it is consumed only
-            # by the docker build step and never executed on the runner.
-            - name: Check Out PR build context
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-              with:
-                  ref: ${{ needs.preflight.outputs.pr_head_sha }}
-                  sparse-checkout: |
-                      rust/
-                      proto/
-                  sparse-checkout-cone-mode: false
-                  path: pr-head
-
-            - name: Mark BUILDING in PR comment
+            - name: Upsert BUILDING
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
@@ -896,6 +944,56 @@ jobs:
                               dispatch_run_url: dispatchRunUrl,
                           },
                       });
+
+    # Heavy job: build image + dispatch to charts.
+    # Gated on preflight.should_proceed so a synchronize event that targets a
+    # canary owned by another PR (or a disabled canary) is skipped without
+    # building or dispatching anything.
+    #
+    # NOTE: this job is the ONLY place in the workflow that checks out
+    # PR-author-controlled code. To keep CodeQL's untrusted-checkout TOCTOU
+    # class clear, it intentionally contains no `actions/github-script`
+    # `require()` of trusted helper scripts. PR-status comment upserts live
+    # in notify_building (above) and notify_dispatched (below), both of
+    # which only check out master and never touch PR code.
+    build_and_enable:
+        name: Build feature-flags image and enable canary
+        needs: [preflight]
+        # `!cancelled()` disables the implicit success() chain check, which
+        # otherwise inherits handle_comment's `skipped` result on a
+        # `pull_request: synchronize` event (handle_comment is gated to
+        # issue_comment) and skips this job before should_proceed is even
+        # evaluated. We then re-assert success on the direct dependency
+        # only and gate on the actual `should_proceed` output.
+        if: |
+            !cancelled() &&
+            needs.preflight.result == 'success' &&
+            needs.preflight.outputs.should_proceed == 'true'
+        runs-on: depot-ubuntu-22.04
+        timeout-minutes: 30
+        permissions:
+            id-token: write
+            contents: read
+            packages: write
+        outputs:
+            dispatched_at: ${{ steps.dispatch.outputs.dispatched_at }}
+
+        steps:
+            # Untrusted: PR build context. Pinned to the SHA validated by
+            # handle_comment, isolated under `pr-head/` so it is consumed only
+            # by the sandboxed docker build step and never executed on the
+            # runner. Sparse-checkout is intentionally limited to `rust/` and
+            # `proto/` — do NOT widen this to include `.github/` or the
+            # untrusted-checkout TOCTOU posture changes.
+            - name: Check Out PR build context
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  ref: ${{ needs.preflight.outputs.pr_head_sha }}
+                  sparse-checkout: |
+                      rust/
+                      proto/
+                  sparse-checkout-cone-mode: false
+                  path: pr-head
 
             - name: Copy proto files into rust build context
               run: cp -r pr-head/proto pr-head/rust/proto
@@ -974,41 +1072,6 @@ jobs:
                       });
                       core.setOutput('dispatched_at', new Date().toISOString());
 
-            - name: Mark DISPATCHED in PR comment + rocket reaction
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-              env:
-                  PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
-                  IMAGE_TAG: ${{ needs.preflight.outputs.image_tag }}
-                  CANARY_WEIGHT: ${{ needs.preflight.outputs.canary_weight }}
-                  TARGET_ENVIRONMENT: ${{ needs.preflight.outputs.target_environment }}
-              with:
-                  script: |
-                      const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
-                      const prNumber = parseInt(process.env.PR_NUMBER);
-                      const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-                      await upsertStatusComment({
-                          github, context, prNumber,
-                          phase: 'DISPATCHED',
-                          fields: {
-                              image: process.env.IMAGE_TAG,
-                              env: process.env.TARGET_ENVIRONMENT,
-                              weight: process.env.CANARY_WEIGHT,
-                              started_by: context.actor,
-                              started_at: new Date().toISOString(),
-                              dispatch_run_url: dispatchRunUrl,
-                          },
-                      });
-                      if (context.eventName === 'issue_comment') {
-                          try {
-                              await github.rest.reactions.createForIssueComment({
-                                  owner: context.repo.owner,
-                                  repo: context.repo.repo,
-                                  comment_id: context.payload.comment.id,
-                                  content: 'rocket',
-                              });
-                          } catch (e) { /* best-effort */ }
-                      }
-
             - name: Summary
               env:
                   PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
@@ -1025,39 +1088,66 @@ jobs:
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "Deployment dispatched to the [charts repo canary workflow](https://github.com/PostHog/charts/actions/workflows/pr-canary-flags-enable.yml)." >> $GITHUB_STEP_SUMMARY
 
-            - name: Report build/dispatch failure
-              if: failure()
+    # Lightweight notify: upserts the DISPATCHED (or BUILD_FAILED) marker
+    # after build_and_enable completes. Privileged but trusted: only checks
+    # out master scripts, never PR code, so the github-script `require()`
+    # cannot resolve to PR-author-controlled code.
+    #
+    # Runs on `always()` (gated to non-skipped builds) so a failed build
+    # still produces a BUILD_FAILED marker with a -1 reaction.
+    notify_dispatched:
+        name: Mark DISPATCHED / BUILD_FAILED in PR comment
+        needs: [preflight, build_and_enable]
+        if: always() && needs.preflight.result == 'success' && needs.build_and_enable.result != 'skipped'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        permissions:
+            pull-requests: write
+            issues: write
+            contents: read
+        steps:
+            - name: Check out trusted canary scripts (default branch)
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  ref: master
+                  sparse-checkout: .github/scripts/canary
+                  sparse-checkout-cone-mode: false
+            - name: Upsert phase + reaction
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                   PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
                   IMAGE_TAG: ${{ needs.preflight.outputs.image_tag }}
+                  CANARY_WEIGHT: ${{ needs.preflight.outputs.canary_weight }}
+                  TARGET_ENVIRONMENT: ${{ needs.preflight.outputs.target_environment }}
+                  BUILD_RESULT: ${{ needs.build_and_enable.result }}
               with:
                   script: |
-                      try {
-                          const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
-                          const prNumber = parseInt(process.env.PR_NUMBER);
-                          const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-                          await upsertStatusComment({
-                              github, context, prNumber,
-                              phase: 'BUILD_FAILED',
-                              fields: {
-                                  reason: 'image build or dispatch failed',
-                                  image: process.env.IMAGE_TAG,
-                                  dispatch_run_url: dispatchRunUrl,
-                              },
-                          });
-                          if (context.eventName === 'issue_comment') {
-                              try {
-                                  await github.rest.reactions.createForIssueComment({
-                                      owner: context.repo.owner,
-                                      repo: context.repo.repo,
-                                      comment_id: context.payload.comment.id,
-                                      content: '-1',
-                                  });
-                              } catch (e) { /* best-effort */ }
-                          }
-                      } catch (e) {
-                          console.log(`Failure reporter could not upsert: ${e.message}`);
+                      const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                      const prNumber = parseInt(process.env.PR_NUMBER);
+                      const dispatchRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      const ok = process.env.BUILD_RESULT === 'success';
+                      await upsertStatusComment({
+                          github, context, prNumber,
+                          phase: ok ? 'DISPATCHED' : 'BUILD_FAILED',
+                          fields: {
+                              image: process.env.IMAGE_TAG,
+                              env: process.env.TARGET_ENVIRONMENT,
+                              weight: process.env.CANARY_WEIGHT,
+                              started_by: context.actor,
+                              started_at: new Date().toISOString(),
+                              dispatch_run_url: dispatchRunUrl,
+                              ...(ok ? {} : { reason: 'image build or dispatch failed' }),
+                          },
+                      });
+                      if (context.eventName === 'issue_comment') {
+                          try {
+                              await github.rest.reactions.createForIssueComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: context.payload.comment.id,
+                                  content: ok ? 'rocket' : '-1',
+                              });
+                          } catch (e) { /* best-effort */ }
                       }
 
     # Watcher: poll state.yaml + the charts workflow run, upsert the PR

--- a/.github/workflows/canary-flags-enable.yml
+++ b/.github/workflows/canary-flags-enable.yml
@@ -82,6 +82,7 @@ jobs:
             - name: Check out canary scripts
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
+                  ref: master
                   sparse-checkout: .github/scripts/canary
                   sparse-checkout-cone-mode: false
 
@@ -225,8 +226,10 @@ jobs:
                           return;
                       }
 
-                      // Pin the PR head SHA now so it cannot change between
-                      // validation and checkout (TOCTOU mitigation).
+                      // Resolve the PR head SHA once and pass it through to
+                      // build_and_enable so the docker build operates on the
+                      // exact SHA we just validated, not whatever the PR head
+                      // happens to be at the moment the build job picks up.
                       const { data: pr } = await github.rest.pulls.get({
                           owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber,
                       });
@@ -805,6 +808,7 @@ jobs:
               if: failure() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
+                  ref: master
                   sparse-checkout: .github/scripts/canary
                   sparse-checkout-cone-mode: false
             - name: Upsert preflight failure marker
@@ -843,15 +847,30 @@ jobs:
             issues: write
 
         steps:
-            - name: Check Out Repo
+            # Trusted: canary helper scripts come from the default branch so
+            # the github-script `require()`s below cannot execute PR-author-
+            # controlled code in this privileged context. Lands at workspace
+            # root so existing `require('./.github/scripts/canary/...')` paths
+            # are unchanged.
+            - name: Check out trusted canary scripts (default branch)
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  ref: master
+                  sparse-checkout: .github/scripts/canary
+                  sparse-checkout-cone-mode: false
+
+            # Untrusted: PR build context. Pinned to the SHA validated by
+            # handle_comment, isolated under `pr-head/` so it is consumed only
+            # by the docker build step and never executed on the runner.
+            - name: Check Out PR build context
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ needs.preflight.outputs.pr_head_sha }}
                   sparse-checkout: |
                       rust/
                       proto/
-                      .github/scripts/canary/
                   sparse-checkout-cone-mode: false
+                  path: pr-head
 
             - name: Mark BUILDING in PR comment
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -879,7 +898,7 @@ jobs:
                       });
 
             - name: Copy proto files into rust build context
-              run: cp -r proto rust/proto
+              run: cp -r pr-head/proto pr-head/rust/proto
 
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
@@ -907,8 +926,8 @@ jobs:
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
                   project: vglf58qgzw
-                  context: ./rust/
-                  file: ./rust/Dockerfile
+                  context: ./pr-head/rust/
+                  file: ./pr-head/rust/Dockerfile
                   push: true
                   tags: ghcr.io/posthog/posthog/feature-flags:${{ needs.preflight.outputs.image_tag }}
                   platforms: linux/arm64
@@ -1064,6 +1083,7 @@ jobs:
             - name: Check out canary scripts
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
+                  ref: master
                   sparse-checkout: .github/scripts/canary
                   sparse-checkout-cone-mode: false
 

--- a/.github/workflows/ci-lint-workflows.yml
+++ b/.github/workflows/ci-lint-workflows.yml
@@ -54,3 +54,13 @@ jobs:
               with:
                   version: '0.10.2'
             - run: uv run .github/scripts/check-ci-concurrency.py
+
+    test-canary-scripts:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+            - run: node --test .github/scripts/canary/canary.test.js

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -26,7 +26,17 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'canary-flags')
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: write
         steps:
+            - name: Check out canary scripts
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  sparse-checkout: .github/scripts/canary
+                  sparse-checkout-cone-mode: false
+
             - name: Get deployer token
               id: deployer
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -51,6 +61,29 @@ jobs:
                               pr_number: process.env.PR_NUMBER
                           }
                       });
+
+            - name: Upsert EXPIRED marker on PR
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_MERGED: ${{ github.event.pull_request.merged }}
+              with:
+                  script: |
+                      try {
+                          const { upsertStatusComment } = require('./.github/scripts/canary/comment.js');
+                          const prNumber = parseInt(process.env.PR_NUMBER);
+                          const reason = process.env.PR_MERGED === 'true' ? 'PR merged' : 'PR closed';
+                          await upsertStatusComment({
+                              github, context, prNumber,
+                              phase: 'EXPIRED',
+                              fields: {
+                                  reason,
+                                  dispatch_run_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                              },
+                          });
+                      } catch (e) {
+                          console.log(`Marker upsert skipped: ${e.message}`);
+                      }
 
     report-pr-age:
         name: Report age of PR

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -34,6 +34,7 @@ jobs:
             - name: Check out canary scripts
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
+                  ref: master
                   sparse-checkout: .github/scripts/canary
                   sparse-checkout-cone-mode: false
 


### PR DESCRIPTION
## Problem

Today the `/pr-canary` slash command produces a noisy stream of disconnected PR comments (help text, validation errors, dispatched, failed) and gives no visibility once the dispatch fires. A user cannot see what phase the rollout is in, cannot cancel an in-flight canary without merging or closing the PR or waiting 48h, and learns about another PR already owning the canary only after triggering a silent overwrite. The workflow run links are also scattered across multiple comments instead of one place.

## Changes

A single status comment on the PR is now upserted across the deployment lifecycle, identified by the HTML marker `<!-- pr-canary-status -->`. The marker carries phase, image, env, and run ids so each step picks up where the previous one left off without re-querying everything.

New helpers under `.github/scripts/canary/`:

* `comment.js` exposes `upsertStatusComment` and `parseMarker`. It renders one of fifteen phases (VALIDATING, BUILDING, DISPATCHED, ROLLING_OUT, ROUTING, HEALTHY, CONFLICT, NO_ACTIVE_CANARY, DENIED, INVALID_INPUT, BUILD_FAILED, FAILED, CANCELING, CANCELED, EXPIRED) with phase specific bodies, an expiry countdown, and links to both the posthog and charts workflow runs.
* `state.js` parses the `feature-flags.canary` block in `PostHog/charts:state.yaml` via a line walker (no `js-yaml` dependency), exposes `readChartsState`, `derivePhase` (the seven row decision table from the plan), and a small `pollUntil` async helper.
* `charts-run.js` locates the receiving charts workflow run after our `repository_dispatch` by listing recent runs and matching by event and creation timestamp, with retries to handle the dispatch to run creation race.

Two new subcommands routed inside `handle_comment`:

* `/pr-canary cancel` (aliases `disable`, `stop`) validates team membership and ownership against `state.yaml`, dispatches the existing `disable-canary-flags` repository_dispatch to charts, drops the `canary-flags` label, cancels in-flight workflow runs as defense in depth, and upserts CANCELING then CANCELED on the marker comment.
* `/pr-canary status` re-renders the marker comment from current state without side effects.

Conflict detection on enable: before adding the `canary-flags` label, the workflow reads `state.yaml`. If the canary is held by a different PR, it upserts a CONFLICT marker pointing at the holder PR with env, weight, started_by, and expiry, reacts `confused` on the trigger comment, and exits cleanly without setting failed status. The user is told to run `/pr-canary cancel` on the holder PR or wait for the 48h auto expiry.

The build and dispatch path now upserts BUILDING before the build, DISPATCHED with a `rocket` reaction after dispatch, and BUILD_FAILED with a `-1` reaction on failure. The previous per step `createComment` calls are replaced with `upsertStatusComment` calls so the same comment moves through phases instead of new comments piling up.

A new `watch_rollout` job runs after `build_and_enable` for up to 22 minutes. It polls `state.yaml` plus the charts run status every 30 seconds and upserts the marker as `derivePhase` advances (ROLLING_OUT to ROUTING to HEALTHY, or to FAILED, CANCELED, or EXPIRED if state diverges). On HEALTHY it adds a `+1` reaction; on watcher timeout it leaves a FAILED marker with reason text so the user is not left guessing.

`pr-closed.yml` upserts EXPIRED on the marker comment after the existing disable dispatch, with reason "PR merged" or "PR closed".

The original concurrency group `canary-flags-${pr_number}` with `cancel-in-progress: true` stays unchanged. Because `/pr-canary`, `/pr-canary cancel`, and `pull_request: synchronize` all resolve to the same group key for a given PR, a new run preempts an in-flight run on the same PR transparently. The watcher uses its own per job concurrency group as a belt and suspenders guard for the rare cross run race.

No charts repo changes are required. The charts disable workflow already accepts the `disable-canary-flags` repository_dispatch from `pr-closed.yml`; cancel reuses the same dispatch shape. The charts enable workflow is untouched.

Reactions on the trigger comment progress `eyes` (receipt) to `rocket` (dispatched) to `+1` (healthy) or `confused` (denied, conflict, invalid input) or `-1` (failed, canceled).

## How did you test this code?

`node --test .github/scripts/canary/canary.test.js` runs 15 of 15 green. Coverage includes `parseScalar` across YAML scalar types, `parseCanaryBlock` against full `state.yaml` with active and disabled blocks plus the missing feature flags case, `derivePhase` across the full decision table, `parseMarker` round trip with `renderMarker`, `isTerminalPhase` classification, `renderBody` output assertions for ROLLING_OUT (marker plus header plus details table plus run links plus subcommands footer), CONFLICT (holder PR named, cancel hint pointing at holder), HEALTHY (auto disable hint plus cancel hint), CANCELED (actor highlighted), and INVALID_INPUT (reason surfaced), plus `relativeTime` and `expiresIn` boundary cases.

`actionlint .github/workflows/canary-flags-enable.yml .github/workflows/pr-closed.yml` reports zero new findings. Every existing finding (`depot-ubuntu-22.04` runner label, SC2086 quoting in the existing `Summary` and `state_lookup` blocks) is identical at the equivalent line in master, confirmed by comparing actionlint output against a stashed copy of master.

`node --check` on each helper passes. `node -e "require('./.github/scripts/canary/comment.js'); require('./.github/scripts/canary/state.js'); require('./.github/scripts/canary/charts-run.js');"` loads all three modules cleanly with 11 plus 8 plus 9 exports.

Live smoke is gated on landing because the workflow fires on PR comment events that only run from the default branch. Once merged: open a draft PR, approve, then walk through `/pr-canary help` (standalone help comment), `/pr-canary status` (NO_ACTIVE_CANARY marker), `/pr-canary` (marker advances BUILDING to DISPATCHED to ROLLING_OUT to ROUTING to HEALTHY with both run links live and expiry countdown sensible), `/pr-canary` from a second PR (CONFLICT marker on the second PR pointing at the first PR, no charts dispatch fired, `confused` reaction on trigger comment), `/pr-canary cancel` on the first PR (marker advances CANCELING to CANCELED, charts disable workflow visible, `state.yaml` canary block reset), and finally close the PR mid rollout (EXPIRED marker via `pr-closed.yml` with reason "PR merged" or "PR closed"). Negative paths to verify alongside: non team member running `/pr-canary cancel` (DENIED marker, no charts dispatch), `/pr-canary cancel` when no canary is active (NO_ACTIVE_CANARY marker, no charts dispatch), build failure (BUILD_FAILED marker with run link, `-1` reaction).

## Publish to changelog?

no
