### PR TITLE
fix(flox): isolate go caches from host toolchains

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -91,6 +91,11 @@ bash = '''
     # ensure even with your shell prefs in place we know this is a Flox.dev env
     export PS1="\033[47m(flox)\033[0m $PS1"
   fi
+  unset GOROOT
+  export GOTOOLCHAIN=local
+  export GOPATH="$FLOX_ENV_CACHE/go"
+  export GOCACHE="$FLOX_ENV_CACHE/go-build"
+  export GOMODCACHE="$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   export PATH="$FLOX_ENV/bin:$PATH"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
@@ -110,6 +115,11 @@ zsh = '''
     # ensure even with your shell prefs in place we know this is a Flox.dev env
     export PS1="%K{white}%F{black}(flox)%k%f $PS1"
   fi
+  unset GOROOT
+  export GOTOOLCHAIN=local
+  export GOPATH="$FLOX_ENV_CACHE/go"
+  export GOCACHE="$FLOX_ENV_CACHE/go-build"
+  export GOMODCACHE="$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   export PATH="$FLOX_ENV/bin:$PATH"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
@@ -125,6 +135,11 @@ zsh = '''
   autoload -Uz compinit && compinit -i
 '''
 fish = '''
+  set -e GOROOT
+  set -gx GOTOOLCHAIN local
+  set -gx GOPATH "$FLOX_ENV_CACHE/go"
+  set -gx GOCACHE "$FLOX_ENV_CACHE/go-build"
+  set -gx GOMODCACHE "$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   fish_add_path "$FLOX_ENV/bin"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
@@ -137,6 +152,11 @@ fish = '''
   source $UV_PROJECT_ENVIRONMENT/bin/activate.fish
 '''
 tcsh = '''
+  unsetenv GOROOT
+  setenv GOTOOLCHAIN local
+  setenv GOPATH "$FLOX_ENV_CACHE/go"
+  setenv GOCACHE "$FLOX_ENV_CACHE/go-build"
+  setenv GOMODCACHE "$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   setenv PATH "$FLOX_ENV/bin:$PATH"
   # Recreate venv if it was deleted (on-activate only runs on first activation)

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -162,6 +162,16 @@ if [[ -t 0 ]] && [[ -z "${POSTHOG_CODE:-}" ]]; then
   _interactive=true
 fi
 
+# ── Go toolchain isolation ─────────────────────────────────────────
+# User shells often export GOROOT/GOCACHE for Homebrew, asdf, or other local Go
+# installs. Keep flox builds on the pinned Go toolchain and cache compiled
+# packages inside the flox environment so host Go upgrades cannot poison builds.
+unset GOROOT
+export GOTOOLCHAIN=local
+export GOPATH="$FLOX_ENV_CACHE/go"
+export GOCACHE="$FLOX_ENV_CACHE/go-build"
+export GOMODCACHE="$GOPATH/pkg/mod"
+
 # ── Direnv first-time setup (interactive only) ─────────────────────
 if [[ "$_interactive" == true ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]]; then
   read -p "$(echo -e "${C_BOLD}direnv${C_RESET} recommended for auto-activation. Set up now? (Y/n) ")" -n 1 -r


### PR DESCRIPTION
## Problem

Flox activation can fail while building `phrocs` when a developer's shell has Go environment from another local toolchain.

We hit this activation error with flox's pinned Go `1.25.5` while the host shell had Go `1.26.1` paths/cache state:

```text
compile: version "go1.26.1" does not match go tool version "go1.25.5"
```

The failure happened during `make -C tools/phrocs build`. The pinned flox Go toolchain was correct, but user-level Go settings such as `GOROOT`, `GOPATH`, and `GOCACHE` could leak into activation and make Go reuse compiled package metadata from another compiler version.

## Changes

Isolate Go inside the flox environment:

- unset host `GOROOT`
- force `GOTOOLCHAIN=local` so flox uses the pinned Go toolchain
- set `GOPATH`, `GOCACHE`, and `GOMODCACHE` under `$FLOX_ENV_CACHE`
- apply the same isolation in activation and shell profiles for bash, zsh, fish, and tcsh

This keeps `phrocs` and any Go commands run inside flox from sharing compiler-sensitive cache state with Homebrew/asdf/system Go installs.

## How did you test this code?

Agent-tested with:

```bash
bash -n .flox/env/on-activate.sh
git diff --check -- .flox/env/manifest.toml .flox/env/on-activate.sh
GOROOT=/tmp/not-the-flox-go GOCACHE=/tmp/not-the-flox-cache GOPATH=/tmp/not-the-flox-gopath GOTOOLCHAIN=auto flox activate -- bash -c 'go version && go env GOROOT GOPATH GOCACHE GOMODCACHE GOTOOLCHAIN GOVERSION'
```

The flox activation completed, `Build phrocs` passed, and `go env` reported Go `1.25.5` with cache/module paths under `.flox/cache`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed. This changes developer environment setup only.

## 🤖 Agent context

Authored with Codex in Lucas Faria's local checkout.

Key decision: fix the root cause by isolating compiler-sensitive Go state inside flox instead of asking every developer to manually clean their global Go build cache when local Go versions change.

The branch had unrelated local edits in frontend files and `uv.lock`; this PR stages and commits only `.flox/env/manifest.toml` and `.flox/env/on-activate.sh`.