### PR TITLE
chore(semgrep): semgrep persons orm rule

### DIFF
--- a/.semgrep/rules/no-direct-persons-db-orm.yaml
+++ b/.semgrep/rules/no-direct-persons-db-orm.yaml
@@ -1,0 +1,36 @@
+rules:
+    - id: no-direct-persons-db-orm
+      message: >-
+          Do not query persons DB models via the Django ORM. Use the personhog
+          client helpers in `posthog/models/person/util.py` (e.g.
+          `get_person_by_uuid`, `get_persons_by_distinct_ids`) and
+          `posthog/models/group_type_mapping.py` (`get_group_types_for_project`).
+          These route through the personhog gRPC service with ORM fallback.
+          When adding new access patterns, follow the `_personhog_routed()`
+          pattern in `posthog/models/person/util.py`.
+          See `posthog/personhog_client/README.md` for client details.
+      severity: WARNING
+      languages: [python]
+      patterns:
+          - pattern: $MODEL.objects
+          - metavariable-regex:
+                metavariable: $MODEL
+                regex: >-
+                    ^(Person|PersonDistinctId|PersonlessDistinctId|PersonOverrideMapping|PersonOverride|PendingPersonOverride|FlatPersonOverride|FeatureFlagHashKeyOverride|CohortPeople|Group|GroupTypeMapping)$
+      paths:
+          exclude:
+              # personhog client implementation
+              - '**/posthog/personhog_client/**'
+              # Routing helpers — intentional ORM fallback inside _personhog_routed()
+              - '**/posthog/models/person/util.py'
+              - '**/posthog/models/group_type_mapping.py'
+              # semgrep test cases
+              - '**/.semgrep/**'
+              # Migrations
+              - '**/migrations/**'
+              # Test files
+              - '**/test/**'
+              - '**/tests/**'
+              - '**/*_test.py'
+              - '**/test_*.py'
+              - '**/conftest*.py'

--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -50,7 +50,7 @@ class RelatedActorsQuery:
         results.extend(self._query_related_people())
 
         group_type_indexes = list(
-            GroupTypeMapping.objects.filter(project_id=self.team.project_id)
+            GroupTypeMapping.objects.filter(project_id=self.team.project_id)  # nosemgrep: no-direct-persons-db-orm
             .exclude(group_type_index=self.group_type_index)
             .order_by("group_type_index")
             .values_list("group_type_index", flat=True)

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -103,7 +103,7 @@ class GroupsTypesViewSet(
 ):
     scope_object = "group"
     serializer_class = GroupTypeSerializer
-    queryset = GroupTypeMapping.objects.all().order_by("group_type_index")
+    queryset = GroupTypeMapping.objects.all().order_by("group_type_index")  # nosemgrep: no-direct-persons-db-orm
     pagination_class = None
     sharing_enabled_actions = ["list"]
     lookup_field = "group_type_index"
@@ -115,7 +115,7 @@ class GroupsTypesViewSet(
     @action(detail=False, methods=["PATCH"], name="Update group types metadata")
     def update_metadata(self, request: request.Request, *args, **kwargs):
         for row in cast(list[dict], request.data):
-            instance = GroupTypeMapping.objects.get(
+            instance = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
                 project_id=self.team.project_id, group_type_index=row["group_type_index"]
             )
             # Pre-populate the team FK cache so serializer access control checks
@@ -130,7 +130,7 @@ class GroupsTypesViewSet(
     @action(methods=["PUT"], detail=False)
     def create_detail_dashboard(self, request: request.Request, **kw):
         try:
-            group_type_mapping = GroupTypeMapping.objects.get(
+            group_type_mapping = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
                 project_id=self.team.project_id, group_type_index=request.data["group_type_index"]
             )
         except GroupTypeMapping.DoesNotExist:
@@ -155,7 +155,7 @@ class GroupsTypesViewSet(
     @action(methods=["PUT"], detail=False)
     def set_default_columns(self, request: request.Request, **kw):
         try:
-            group_type_mapping = GroupTypeMapping.objects.get(
+            group_type_mapping = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
                 project_id=self.team.project_id, group_type_index=request.data["group_type_index"]
             )
         except GroupTypeMapping.DoesNotExist:
@@ -201,7 +201,7 @@ class CreateGroupSerializer(serializers.ModelSerializer):
 @extend_schema(tags=["core"])
 class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet):
     scope_object = "group"
-    queryset = Group.objects.all()
+    queryset = Group.objects.all()  # nosemgrep: no-direct-persons-db-orm
     pagination_class = GroupCursorPagination
     serializer_classes = {
         "find": FindGroupSerializer,
@@ -267,7 +267,9 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 )
 
         try:
-            obj = GroupTypeMapping.objects.get(project_id=self.team.project_id, group_type_index=group_type_index)
+            obj = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
+                project_id=self.team.project_id, group_type_index=group_type_index
+            )  # nosemgrep: no-direct-persons-db-orm
             PERSONHOG_ROUTING_TOTAL.labels(
                 operation="get_group_type_mapping_or_404", source="django_orm", client_name=get_client_name()
             ).inc()

--- a/ee/hogai/chat_agent/query_planner/nodes.py
+++ b/ee/hogai/chat_agent/query_planner/nodes.py
@@ -183,7 +183,7 @@ class QueryPlannerNode(TaxonomyUpdateDispatcherNodeMixin, AssistantNode):
     @cached_property
     def _team_group_types(self) -> list[str]:
         return list(
-            GroupTypeMapping.objects.filter(project_id=self._team.project_id)
+            GroupTypeMapping.objects.filter(project_id=self._team.project_id)  # nosemgrep: no-direct-persons-db-orm
             .order_by("group_type_index")
             .values_list("group_type", flat=True)
         )

--- a/ee/hogai/chat_agent/query_planner/toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/toolkit.py
@@ -98,7 +98,12 @@ class TaxonomyAgentToolkit:
 
     @property
     def _groups(self):
-        return GroupTypeMapping.objects.filter(project_id=self._team.project_id).order_by("group_type_index")
+        # nosemgrep: no-direct-persons-db-orm
+        return GroupTypeMapping.objects.filter(
+            project_id=self._team.project_id
+        ).order_by(  # nosemgrep: no-direct-persons-db-orm
+            "group_type_index"
+        )  # nosemgrep: no-direct-persons-db-orm
 
     @cached_property
     def _entity_names(self) -> list[str]:

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -164,7 +164,12 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
         return "next"
 
     async def _get_group_mapping_prompt(self) -> str:
-        groups = GroupTypeMapping.objects.filter(project_id=self._team.project_id).order_by("group_type_index")
+        # nosemgrep: no-direct-persons-db-orm
+        groups = GroupTypeMapping.objects.filter(
+            project_id=self._team.project_id
+        ).order_by(  # nosemgrep: no-direct-persons-db-orm
+            "group_type_index"
+        )  # nosemgrep: no-direct-persons-db-orm
         group_names = [f'name "{group.group_type}", index {group.group_type_index}' async for group in groups]
         if not group_names:
             return "The user has not defined any groups."

--- a/ee/hogai/chat_agent/taxonomy/nodes.py
+++ b/ee/hogai/chat_agent/taxonomy/nodes.py
@@ -57,7 +57,7 @@ class TaxonomyAgentNode(
     def _team_group_types(self) -> list[str]:
         """Get all available group names for this team."""
         return list(
-            GroupTypeMapping.objects.filter(project_id=self._team.project.id)
+            GroupTypeMapping.objects.filter(project_id=self._team.project.id)  # nosemgrep: no-direct-persons-db-orm
             .order_by("group_type_index")
             .values_list("group_type", flat=True)
         )

--- a/ee/hogai/chat_agent/taxonomy/toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/toolkit.py
@@ -148,7 +148,12 @@ class TaxonomyAgentToolkit:
 
     @property
     def _groups(self):
-        return GroupTypeMapping.objects.filter(project_id=self._team.project_id).order_by("group_type_index")
+        # nosemgrep: no-direct-persons-db-orm
+        return GroupTypeMapping.objects.filter(
+            project_id=self._team.project_id
+        ).order_by(  # nosemgrep: no-direct-persons-db-orm
+            "group_type_index"
+        )  # nosemgrep: no-direct-persons-db-orm
 
     @cached_property
     def _team_group_types(self) -> list[str]:

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -143,7 +143,12 @@ class AssistantContextManager(AssistantContextMixin):
         """
         Returns the ORM chain of the team's groups.
         """
-        return GroupTypeMapping.objects.filter(project_id=self._team.project_id).order_by("group_type_index")
+        # nosemgrep: no-direct-persons-db-orm
+        return GroupTypeMapping.objects.filter(
+            project_id=self._team.project_id
+        ).order_by(  # nosemgrep: no-direct-persons-db-orm
+            "group_type_index"
+        )  # nosemgrep: no-direct-persons-db-orm
 
     async def get_group_names(self) -> list[str]:
         """

--- a/ee/hogai/eval/data_setup.py
+++ b/ee/hogai/eval/data_setup.py
@@ -179,10 +179,12 @@ def copy_demo_data_to_new_team(
         sync_execute(COPY_EVENTS_BETWEEN_TEAMS, copy_params)
         sync_execute(COPY_GROUPS_BETWEEN_TEAMS, copy_params)
 
-        GroupTypeMapping.objects.filter(project_id=team.project_id).delete()
-        GroupTypeMapping.objects.bulk_create(
+        GroupTypeMapping.objects.filter(project_id=team.project_id).delete()  # nosemgrep: no-direct-persons-db-orm
+        GroupTypeMapping.objects.bulk_create(  # nosemgrep: no-direct-persons-db-orm
             GroupTypeMapping(team_id=team.id, project_id=team.project_id, **record)
-            for record in GroupTypeMapping.objects.filter(project_id=master_team.project_id).values(
+            for record in GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                project_id=master_team.project_id
+            ).values(  # nosemgrep: no-direct-persons-db-orm
                 "group_type", "group_type_index", "name_singular", "name_plural"
             )
         )

--- a/ee/hogai/eval/offline/snapshot_loader.py
+++ b/ee/hogai/eval/offline/snapshot_loader.py
@@ -141,7 +141,9 @@ class SnapshotLoader:
         group_type_mappings = GroupTypeMappingSnapshot.deserialize_for_team(
             snapshot, team_id=team.id, project_id=project.id
         )
-        return await GroupTypeMapping.objects.abulk_create(group_type_mappings, batch_size=500)
+        return await GroupTypeMapping.objects.abulk_create(  # nosemgrep: no-direct-persons-db-orm
+            group_type_mappings, batch_size=500
+        )  # nosemgrep: no-direct-persons-db-orm
 
     async def _load_data_warehouse_tables(self, buffer: BytesIO, *, team: Team, project: Project):
         snapshot = list(self._parse_snapshot_to_schema(DataWarehouseTableSnapshot, buffer))

--- a/ee/hogai/eval/schema.py
+++ b/ee/hogai/eval/schema.py
@@ -92,7 +92,9 @@ class GroupTypeMappingSnapshot(BaseSnapshot[GroupTypeMapping]):
 
     @classmethod
     def serialize_for_team(cls, *, team_id: int):
-        for mapping in GroupTypeMapping.objects.filter(team_id=team_id).iterator(500):
+        for mapping in GroupTypeMapping.objects.filter(team_id=team_id).iterator(  # nosemgrep: no-direct-persons-db-orm
+            500
+        ):  # nosemgrep: no-direct-persons-db-orm
             yield GroupTypeMappingSnapshot(
                 group_type=mapping.group_type,
                 group_type_index=mapping.group_type_index,

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -78,7 +78,12 @@ def get_model_counts_for_organization(organization: Organization) -> list[dict]:
     # Must first get cohort_ids from default db, then count CohortPeople by cohort_id
     try:
         cohort_ids = list(Cohort.objects.filter(team_id__in=team_ids).values_list("id", flat=True))
-        cohort_people_count = CohortPeople.objects.filter(cohort_id__in=cohort_ids).count() if cohort_ids else 0
+        cohort_people_count = (
+            # nosemgrep: no-direct-persons-db-orm
+            CohortPeople.objects.filter(cohort_id__in=cohort_ids).count()
+            if cohort_ids
+            else 0  # nosemgrep: no-direct-persons-db-orm
+        )  # nosemgrep: no-direct-persons-db-orm
         results.append(
             {
                 "name": "Cohort People",

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1404,7 +1404,12 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         # Check if person exists and belongs to this team
         try:
-            person_uuid = Person.objects.db_manager(READ_DB_FOR_PERSONS).get(team_id=self.team_id, uuid=person_id).uuid
+            person_uuid = (
+                # nosemgrep: no-direct-persons-db-orm
+                Person.objects.db_manager(READ_DB_FOR_PERSONS)
+                .get(team_id=self.team_id, uuid=person_id)
+                .uuid  # nosemgrep: no-direct-persons-db-orm
+            )  # nosemgrep: no-direct-persons-db-orm
         except Person.DoesNotExist:
             raise NotFound("Person with this UUID does not exist in the cohort's team")
 
@@ -1613,7 +1618,7 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
         # We pre-filter all persons to be ones that will match the feature flag, so that we don't have to
         # iterate through all persons
         queryset = (
-            Person.objects.db_manager(READ_DB_FOR_PERSONS)
+            Person.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(team_id=team_id)
             .filter(property_group_to_Q(team_id, flag_property_group, cohorts_cache=cohorts_cache))
             .order_by("id")
@@ -1628,7 +1633,7 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
             #     "distinct_id", flat=True
             # )[0]
             distinct_id_subquery = Subquery(
-                PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+                PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
                 .filter(team_id=team_id, person_id=OuterRef("person_id"))
                 .values_list("id", flat=True)[:3]
             )
@@ -1637,7 +1642,9 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
                 Prefetch(
                     "persondistinctid_set",
                     to_attr="distinct_ids_cache",
-                    queryset=PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS).filter(
+                    queryset=PersonDistinctId.objects.db_manager(  # nosemgrep: no-direct-persons-db-orm
+                        READ_DB_FOR_PERSONS
+                    ).filter(  # nosemgrep: no-direct-persons-db-orm
                         id__in=distinct_id_subquery
                     ),
                 ),

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1758,7 +1758,7 @@ class FeatureFlagSerializer(
 
                 if group_keys:
                     group_names: dict[str, str] = {}
-                    for group in Group.objects.filter(
+                    for group in Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
                         team_id=instance.team_id,
                         group_type_index__in=group_type_indices,
                         group_key__in=group_keys,

--- a/posthog/api/insight_metadata.py
+++ b/posthog/api/insight_metadata.py
@@ -344,7 +344,9 @@ def _resolve_group_type_name(team: Team, group_type_index: int) -> str:
     from posthog.models.group_type_mapping import GroupTypeMapping
 
     try:
-        mapping = GroupTypeMapping.objects.get(team=team, group_type_index=group_type_index)
+        mapping = GroupTypeMapping.objects.get(  # nosemgrep: no-direct-persons-db-orm
+            team=team, group_type_index=group_type_index
+        )  # nosemgrep: no-direct-persons-db-orm
         return mapping.name_plural or mapping.name_singular or mapping.group_type
     except GroupTypeMapping.DoesNotExist:
         return f"group type {group_type_index}"

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -422,7 +422,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         (*tuple(api_settings.DEFAULT_RENDERER_CLASSES), csvrenderers.PaginatedCSVRenderer),
     )
     parser_classes = [JSONParser]
-    queryset = Person.objects.all()
+    queryset = Person.objects.all()  # nosemgrep: no-direct-persons-db-orm
     serializer_class = PersonSerializer
     pagination_class = PersonLimitOffsetPagination
     lifecycle_class = Lifecycle
@@ -446,7 +446,12 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         queryset = queryset.prefetch_related(
             Prefetch(
                 "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=self.team_id).order_by("id"),
+                # nosemgrep: no-direct-persons-db-orm
+                queryset=PersonDistinctId.objects.filter(
+                    team_id=self.team_id
+                ).order_by(  # nosemgrep: no-direct-persons-db-orm
+                    "id"
+                ),  # nosemgrep: no-direct-persons-db-orm
                 to_attr="distinct_ids_cache",
             )
         )

--- a/posthog/demo/legacy/data_generator.py
+++ b/posthog/demo/legacy/data_generator.py
@@ -30,13 +30,13 @@ class DataGenerator:
     def create_people(self):
         self.people = [self.make_person(i) for i in range(self.n_people)]
         self.distinct_ids = [str(UUIDT()) for _ in self.people]
-        self.people = Person.objects.bulk_create(self.people)
+        self.people = Person.objects.bulk_create(self.people)  # nosemgrep: no-direct-persons-db-orm
 
         pids = [
             PersonDistinctId(team=self.team, person=person, distinct_id=distinct_id)
             for person, distinct_id in zip(self.people, self.distinct_ids)
         ]
-        PersonDistinctId.objects.bulk_create(pids)
+        PersonDistinctId.objects.bulk_create(pids)  # nosemgrep: no-direct-persons-db-orm
         from posthog.models.person.util import create_person, create_person_distinct_id
 
         for person in self.people:

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -182,7 +182,7 @@ class MatrixManager:
                     self.matrix.now,
                 )
         try:
-            GroupTypeMapping.objects.bulk_create(bulk_group_type_mappings)
+            GroupTypeMapping.objects.bulk_create(bulk_group_type_mappings)  # nosemgrep: no-direct-persons-db-orm
         except IntegrityError as e:
             print(f"SKIPPING GROUP TYPE MAPPING CREATION: {e}")
         for sim_person in sim_persons:
@@ -218,7 +218,7 @@ class MatrixManager:
         #         )
         #     ]
         # )
-        GroupTypeMapping.objects.filter(project_id=cls.MASTER_TEAM_ID).delete()
+        GroupTypeMapping.objects.filter(project_id=cls.MASTER_TEAM_ID).delete()  # nosemgrep: no-direct-persons-db-orm
 
     def _copy_analytics_data_from_master_team(self, target_team: Team):
         from posthog.models.event.sql import COPY_EVENTS_BETWEEN_TEAMS
@@ -236,11 +236,15 @@ class MatrixManager:
         sync_execute(COPY_PERSON_DISTINCT_ID2S_BETWEEN_TEAMS, copy_params)
         sync_execute(COPY_EVENTS_BETWEEN_TEAMS, copy_params)
         sync_execute(COPY_GROUPS_BETWEEN_TEAMS, copy_params)
-        GroupTypeMapping.objects.filter(project_id=target_team.project_id).delete()
-        GroupTypeMapping.objects.bulk_create(
+        GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+            project_id=target_team.project_id
+        ).delete()  # nosemgrep: no-direct-persons-db-orm
+        GroupTypeMapping.objects.bulk_create(  # nosemgrep: no-direct-persons-db-orm
             (
                 GroupTypeMapping(team_id=target_team.id, project_id=target_team.project_id, **record)
-                for record in GroupTypeMapping.objects.filter(project_id=self.MASTER_TEAM_ID).values(
+                for record in GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                    project_id=self.MASTER_TEAM_ID
+                ).values(  # nosemgrep: no-direct-persons-db-orm
                     "group_type", "group_type_index", "name_singular", "name_plural"
                 )
             ),
@@ -265,9 +269,11 @@ class MatrixManager:
             properties = json.loads(filtered_row.pop("properties", "{}"))
             bulk_persons[row["uuid"]] = Person(team_id=target_team_id, properties=properties, **filtered_row)
         # This sets the pk in the bulk_persons dict so we can use them later
-        Person.objects.bulk_create(bulk_persons.values())
+        Person.objects.bulk_create(bulk_persons.values())  # nosemgrep: no-direct-persons-db-orm
         # Person distinct IDs
-        pre_existing_id_count = PersonDistinctId.objects.filter(team_id=target_team_id).count()
+        pre_existing_id_count = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+            team_id=target_team_id
+        ).count()  # nosemgrep: no-direct-persons-db-orm
         clickhouse_distinct_ids = query_with_columns(
             SELECT_PERSON_DISTINCT_ID2S_OF_TEAM,
             list_params,
@@ -291,7 +297,9 @@ class MatrixManager:
                 pre_existing_id_count -= 1
         if pre_existing_id_count > 0:
             print(f"{pre_existing_id_count} IDS UNACCOUNTED FOR")
-        PersonDistinctId.objects.bulk_create(bulk_person_distinct_ids, ignore_conflicts=True)
+        PersonDistinctId.objects.bulk_create(  # nosemgrep: no-direct-persons-db-orm
+            bulk_person_distinct_ids, ignore_conflicts=True
+        )  # nosemgrep: no-direct-persons-db-orm
         # Groups
         clickhouse_groups = query_with_columns(
             SELECT_GROUPS_OF_TEAM,
@@ -312,7 +320,7 @@ class MatrixManager:
                 )
             )
         try:
-            Group.objects.bulk_create(bulk_groups)
+            Group.objects.bulk_create(bulk_groups)  # nosemgrep: no-direct-persons-db-orm
         except IntegrityError as e:
             print(f"SKIPPING GROUP CREATION: {e}")
 

--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -191,7 +191,7 @@ class GroupStrategy(ActorStrategy):
                 "properties": p["group_properties"],  # TODO: Legacy for frontend
                 **p,
             }
-            for p in Group.objects.filter(
+            for p in Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
                 team_id=self.team.pk, group_type_index=self.group_type_index, group_key__in=actor_ids
             )
             .values("group_key", "group_type_index", "created_at", "group_properties")

--- a/posthog/management/commands/export_distinct_ids.py
+++ b/posthog/management/commands/export_distinct_ids.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"Exporting distinct IDs for team: {team.name}"))
 
         # Build the query
-        distinct_ids_query = PersonDistinctId.objects.filter(team=team)
+        distinct_ids_query = PersonDistinctId.objects.filter(team=team)  # nosemgrep: no-direct-persons-db-orm
 
         if identified_only:
             distinct_ids_query = distinct_ids_query.filter(person__is_identified=True)
@@ -126,9 +126,13 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Error writing to file: {e}"))
 
         # Also show some stats
-        total_persons = Person.objects.filter(team=team).count()
-        identified_persons = Person.objects.filter(team=team, is_identified=True).count()
-        demo_persons = Person.objects.filter(team=team, properties__is_demo=True).count()
+        total_persons = Person.objects.filter(team=team).count()  # nosemgrep: no-direct-persons-db-orm
+        identified_persons = Person.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+            team=team, is_identified=True
+        ).count()  # nosemgrep: no-direct-persons-db-orm
+        demo_persons = Person.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+            team=team, properties__is_demo=True
+        ).count()  # nosemgrep: no-direct-persons-db-orm
 
         self.stdout.write(f"\nTeam statistics:")
         self.stdout.write(f"  Total persons: {total_persons}")

--- a/posthog/management/commands/fix_future_person_created_at.py
+++ b/posthog/management/commands/fix_future_person_created_at.py
@@ -41,7 +41,7 @@ def run(options):
     future_date = now() + timedelta(days=2)
 
     # Get all persons with future created_at value
-    persons = Person.objects.filter(team_id=team_id, created_at__gt=future_date)
+    persons = Person.objects.filter(team_id=team_id, created_at__gt=future_date)  # nosemgrep: no-direct-persons-db-orm
 
     logger.info(
         f"Found {len(persons)} persons with future created_at value, updating them to {new_date.strftime('%Y-%m-%d %H:%M:%S.%f')}"
@@ -51,7 +51,9 @@ def run(options):
     for person in persons:
         logger.info(f"Updating person {person.uuid} created_at to {new_date.strftime('%Y-%m-%d %H:%M:%S.%f')}")
         if live_run:
-            Person.objects.filter(pk=person.id).update(version=F("version") + 1, created_at=new_date)
+            Person.objects.filter(pk=person.id).update(  # nosemgrep: no-direct-persons-db-orm
+                version=F("version") + 1, created_at=new_date
+            )  # nosemgrep: no-direct-persons-db-orm
             create_person(
                 uuid=str(person.uuid),
                 team_id=team_id,

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -141,7 +141,12 @@ class Command(BaseCommand):
             days_future=options["days_future"],
             n_clusters=options["n_clusters"],
             group_type_index_offset=(
-                GroupTypeMapping.objects.filter(project_id=existing_team.project_id).count() if existing_team else 0
+                # nosemgrep: no-direct-persons-db-orm
+                GroupTypeMapping.objects.filter(
+                    project_id=existing_team.project_id
+                ).count()  # nosemgrep: no-direct-persons-db-orm
+                if existing_team
+                else 0  # nosemgrep: no-direct-persons-db-orm
             ),
         )
         print("Running simulation...")

--- a/posthog/management/commands/generate_persons.py
+++ b/posthog/management/commands/generate_persons.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
                 person_data = self._generate_person_data(i, identified_ratio)
 
                 # Create person in Django only
-                person = Person.objects.create(
+                person = Person.objects.create(  # nosemgrep: no-direct-persons-db-orm
                     team=team,
                     properties=person_data["properties"],
                     is_identified=person_data["is_identified"],
@@ -79,7 +79,7 @@ class Command(BaseCommand):
 
                 # Create distinct ID
                 distinct_id = str(UUIDT())
-                PersonDistinctId.objects.create(
+                PersonDistinctId.objects.create(  # nosemgrep: no-direct-persons-db-orm
                     team=team,
                     person=person,
                     distinct_id=distinct_id,
@@ -858,7 +858,7 @@ class Command(BaseCommand):
 
         events_created = 0
         for _i in range(min(person_count, 50)):  # Limit events to avoid overwhelming
-            person = Person.objects.filter(team=team).order_by("?").first()
+            person = Person.objects.filter(team=team).order_by("?").first()  # nosemgrep: no-direct-persons-db-orm
             if not person:
                 continue
 

--- a/posthog/management/commands/generate_random_product_tours.py
+++ b/posthog/management/commands/generate_random_product_tours.py
@@ -146,13 +146,15 @@ class Command(BaseCommand):
         persons_data: list[PersonData] = []
 
         persons = (
-            Person.objects.filter(team_id=team.id)
+            Person.objects.filter(team_id=team.id)  # nosemgrep: no-direct-persons-db-orm
             .prefetch_related("persondistinctid_set")
             .order_by("-created_at")[:limit]
         )
 
         for person in persons:
-            distinct_ids = PersonDistinctId.objects.filter(person=person, team_id=team.id).values_list(
+            distinct_ids = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                person=person, team_id=team.id
+            ).values_list(  # nosemgrep: no-direct-persons-db-orm
                 "distinct_id", flat=True
             )
 

--- a/posthog/management/commands/generate_random_surveys.py
+++ b/posthog/management/commands/generate_random_surveys.py
@@ -277,13 +277,15 @@ class Command(BaseCommand):
 
         # Query persons with their distinct IDs
         persons = (
-            Person.objects.filter(team_id=team.id)
+            Person.objects.filter(team_id=team.id)  # nosemgrep: no-direct-persons-db-orm
             .prefetch_related("persondistinctid_set")
             .order_by("-created_at")[:limit]
         )
 
         for person in persons:
-            distinct_ids = PersonDistinctId.objects.filter(person=person, team_id=team.id).values_list(
+            distinct_ids = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                person=person, team_id=team.id
+            ).values_list(  # nosemgrep: no-direct-persons-db-orm
                 "distinct_id", flat=True
             )
 

--- a/posthog/management/commands/setup_orphan_test_data.py
+++ b/posthog/management/commands/setup_orphan_test_data.py
@@ -105,12 +105,12 @@ class Command(BaseCommand):
             distinct_id = f"{prefix}-fixable-{i}-{person_uuid[:8]}"
 
             # Create person in PostgreSQL with distinct ID
-            person = Person.objects.db_manager(PERSONS_DB_FOR_WRITE).create(
+            person = Person.objects.db_manager(PERSONS_DB_FOR_WRITE).create(  # nosemgrep: no-direct-persons-db-orm
                 team=team,
                 uuid=person_uuid,
                 properties={"test_type": "fixable", "index": i},
             )
-            PersonDistinctId.objects.db_manager(PERSONS_DB_FOR_WRITE).create(
+            PersonDistinctId.objects.db_manager(PERSONS_DB_FOR_WRITE).create(  # nosemgrep: no-direct-persons-db-orm
                 team=team,
                 person=person,
                 distinct_id=distinct_id,
@@ -130,7 +130,7 @@ class Command(BaseCommand):
             person_uuid = str(uuid.uuid4())
 
             # Create person in PostgreSQL WITHOUT distinct ID
-            Person.objects.db_manager(PERSONS_DB_FOR_WRITE).create(
+            Person.objects.db_manager(PERSONS_DB_FOR_WRITE).create(  # nosemgrep: no-direct-persons-db-orm
                 team=team,
                 uuid=person_uuid,
                 properties={"test_type": "truly_orphaned", "index": i},
@@ -168,7 +168,7 @@ class Command(BaseCommand):
         self.stdout.write(f"\nCleaning up test data for team {team.id} with prefix '{prefix}'...")
 
         # Find test persons in PostgreSQL by properties
-        pg_persons = Person.objects.db_manager(PERSONS_DB_FOR_WRITE).filter(
+        pg_persons = Person.objects.db_manager(PERSONS_DB_FOR_WRITE).filter(  # nosemgrep: no-direct-persons-db-orm
             team=team,
             properties__test_type__in=["fixable", "truly_orphaned"],
         )
@@ -176,7 +176,7 @@ class Command(BaseCommand):
 
         # Delete from PostgreSQL
         deleted_dids = (
-            PersonDistinctId.objects.db_manager(PERSONS_DB_FOR_WRITE)
+            PersonDistinctId.objects.db_manager(PERSONS_DB_FOR_WRITE)  # nosemgrep: no-direct-persons-db-orm
             .filter(
                 team=team,
                 distinct_id__startswith=prefix,

--- a/posthog/management/commands/split_person.py
+++ b/posthog/management/commands/split_person.py
@@ -52,7 +52,7 @@ def run(options):
     person_id = options["person_id"]
     max_splits = options["max_splits"]
 
-    person = Person.objects.get(team_id=team_id, pk=person_id)
+    person = Person.objects.get(team_id=team_id, pk=person_id)  # nosemgrep: no-direct-persons-db-orm
     if person.team_id != team_id:
         logger.error(f"Specified person belongs to different team {person.team_id}")
         exit(1)

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -69,7 +69,7 @@ def run(options):
 def run_person_sync(team_id: int, live_run: bool, deletes: bool):
     logger.info("Running person table sync")
     # lookup what needs to be updated in ClickHouse and send kafka messages for only those
-    persons = Person.objects.filter(team_id=team_id)
+    persons = Person.objects.filter(team_id=team_id)  # nosemgrep: no-direct-persons-db-orm
     rows = sync_execute(
         """
             SELECT id, max(version) FROM person WHERE team_id = %(team_id)s GROUP BY id HAVING max(is_deleted) = 0
@@ -124,7 +124,12 @@ def run_person_sync(team_id: int, live_run: bool, deletes: bool):
 def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool):
     logger.info("Running person distinct id table sync")
     # lookup what needs to be updated in ClickHouse and send kafka messages for only those
-    person_distinct_ids = PersonDistinctId.objects.filter(team_id=team_id).select_related("person")
+    # nosemgrep: no-direct-persons-db-orm
+    person_distinct_ids = PersonDistinctId.objects.filter(
+        team_id=team_id
+    ).select_related(  # nosemgrep: no-direct-persons-db-orm
+        "person"
+    )  # nosemgrep: no-direct-persons-db-orm
     rows = sync_execute(
         """
             SELECT distinct_id, max(version) FROM person_distinct_id2 WHERE team_id = %(team_id)s GROUP BY distinct_id HAVING max(is_deleted) = 0
@@ -175,7 +180,7 @@ def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool):
 def run_group_sync(team_id: int, live_run: bool):
     logger.info("Running group table sync")
     # lookup what needs to be updated in ClickHouse and send kafka messages for only those
-    pg_groups = Group.objects.filter(team_id=team_id).values(
+    pg_groups = Group.objects.filter(team_id=team_id).values(  # nosemgrep: no-direct-persons-db-orm
         "group_type_index", "group_key", "group_properties", "created_at"
     )
     # unfortunately we don't have version column for groups table

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -438,7 +438,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
         # ORM path: lightweight values_list queries — no full model instantiation
         person_ids_qs = (
-            PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+            PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(team_id=team_id, distinct_id__in=distinct_ids)
             .values_list("person_id", flat=True)
             .distinct()
@@ -446,7 +446,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
         return [
             str(uuid)
-            for uuid in Person.objects.db_manager(READ_DB_FOR_PERSONS)
+            for uuid in Person.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(team_id=team_id, id__in=person_ids_qs)
             .values_list("uuid", flat=True)
         ]
@@ -616,7 +616,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
         uuids = [
             str(uuid)
-            for uuid in Person.objects.db_manager(READ_DB_FOR_PERSONS)
+            for uuid in Person.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(team_id=team_id)
             .filter(**filter_kwargs)
             .values_list("uuid", flat=True)
@@ -717,7 +717,12 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             for batch_index, batch in batch_iterator:
                 current_batch_index = batch_index
 
-                persons_query = Person.objects.db_manager(db_read).filter(team_id=team_id).filter(uuid__in=batch)
+                persons_query = (
+                    # nosemgrep: no-direct-persons-db-orm
+                    Person.objects.db_manager(db_read)
+                    .filter(team_id=team_id)
+                    .filter(uuid__in=batch)  # nosemgrep: no-direct-persons-db-orm
+                )  # nosemgrep: no-direct-persons-db-orm
                 if insert_in_clickhouse:
                     # Both querysets must use db_write so Django can merge the
                     # .exclude() into a single NOT IN subquery. Using db_read
@@ -725,10 +730,10 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
                     # "Subqueries aren't allowed across different databases"
                     # ValueError when the aliases differ (production config).
                     insert_uuids_query = (
-                        Person.objects.using(db_write)
+                        Person.objects.using(db_write)  # nosemgrep: no-direct-persons-db-orm
                         .filter(team_id=team_id, uuid__in=batch)
                         .exclude(
-                            id__in=CohortPeople.objects.using(db_write)
+                            id__in=CohortPeople.objects.using(db_write)  # nosemgrep: no-direct-persons-db-orm
                             .filter(cohort_id=self.id)
                             .values_list("person_id", flat=True)
                         )
@@ -823,7 +828,9 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             # The delete itself still goes through the ORM — no personhog RPC exists yet
             # for removing a cohort member.
             if is_member:
-                CohortPeople.objects.filter(cohort_id=self.id, person_id=person.id).delete()
+                CohortPeople.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                    cohort_id=self.id, person_id=person.id
+                ).delete()  # nosemgrep: no-direct-persons-db-orm
             else:
                 # Person not in PG - this is expected when handling CH/PG sync issues
                 logger.info(

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -636,7 +636,9 @@ def remove_person_from_static_cohort(person_uuid: uuid.UUID, cohort_id: int, *, 
 
 
 def get_static_cohort_size(*, cohort_id: int, team_id: int, using_database: str | None = None) -> int:
-    qs = CohortPeople.objects.filter(cohort_id=cohort_id, person__team_id=team_id)
+    qs = CohortPeople.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+        cohort_id=cohort_id, person__team_id=team_id
+    )  # nosemgrep: no-direct-persons-db-orm
     if using_database:
         qs = qs.using(using_database)
     return qs.count()

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -182,7 +182,7 @@ def bulk_create_events(
             person_created_at = person.created_at or datetime64_default_timestamp
         else:
             try:
-                person = Person.objects.get(
+                person = Person.objects.get(  # nosemgrep: no-direct-persons-db-orm
                     persondistinctid__distinct_id=event["distinct_id"],
                     persondistinctid__team_id=team_id,
                 )
@@ -209,7 +209,7 @@ def bulk_create_events(
             if property_key.startswith("$group_"):
                 group_type_index = property_key[-1]
                 try:
-                    group = Group.objects.get(
+                    group = Group.objects.get(  # nosemgrep: no-direct-persons-db-orm
                         team_id=team_id,
                         group_type_index=group_type_index,
                         group_key=value,

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -146,7 +146,9 @@ class FlagsMatcherCache:
             raise DatabaseError("Failed to fetch group type mapping previously, not trying again.")
         try:
             with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS, READ_ONLY_DATABASE_FOR_PERSONS):
-                group_type_mapping_rows = GroupTypeMapping.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
+                group_type_mapping_rows = GroupTypeMapping.objects.db_manager(  # nosemgrep: no-direct-persons-db-orm
+                    READ_ONLY_DATABASE_FOR_PERSONS
+                ).filter(  # nosemgrep: no-direct-persons-db-orm
                     project_id=self.project_id
                 )
                 return {row.group_type: cast(GroupTypeIndex, row.group_type_index) for row in group_type_mapping_rows}
@@ -498,12 +500,16 @@ class FeatureFlagMatcher:
                 # Some extra wiggle room here for timeouts because this depends on the number of flags as well,
                 # and not just the database query.
                 all_conditions: dict = {}
-                person_query: QuerySet = Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
+                person_query: QuerySet = Person.objects.db_manager(  # nosemgrep: no-direct-persons-db-orm
+                    READ_ONLY_DATABASE_FOR_PERSONS
+                ).filter(  # nosemgrep: no-direct-persons-db-orm
                     team_id=self.team_id,
                     persondistinctid__distinct_id=self.distinct_id,
                     persondistinctid__team_id=self.team_id,
                 )
-                basic_group_query: QuerySet = Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
+                basic_group_query: QuerySet = Group.objects.db_manager(  # nosemgrep: no-direct-persons-db-orm
+                    READ_ONLY_DATABASE_FOR_PERSONS
+                ).filter(  # nosemgrep: no-direct-persons-db-orm
                     team_id=self.team_id
                 )
                 group_query_per_group_type_mapping: dict[GroupTypeIndex, tuple[QuerySet, list[str]]] = {}
@@ -793,7 +799,7 @@ def get_feature_flag_hash_key_overrides(
 
     if not person_id_to_distinct_id_mapping:
         person_and_distinct_ids = list(
-            PersonDistinctId.objects.db_manager(using_database)
+            PersonDistinctId.objects.db_manager(using_database)  # nosemgrep: no-direct-persons-db-orm
             .filter(distinct_id__in=distinct_ids, team_id=team_id)
             .values_list("person_id", "distinct_id")
         )
@@ -804,7 +810,7 @@ def get_feature_flag_hash_key_overrides(
     person_ids = list(person_id_to_distinct_id.keys())
 
     for feature_flag, override, _ in sorted(
-        FeatureFlagHashKeyOverride.objects.db_manager(using_database)
+        FeatureFlagHashKeyOverride.objects.db_manager(using_database)  # nosemgrep: no-direct-persons-db-orm
         .filter(person_id__in=person_ids, team_id=team_id)
         .values_list("feature_flag_key", "hash_key", "person_id"),
         key=lambda x: 1 if person_id_to_distinct_id.get(x[2], "") == distinct_ids[0] else -1,
@@ -1273,9 +1279,11 @@ def check_flag_evaluation_query_is_ok(feature_flag: FeatureFlag, team_id: int, p
     group_type_index = feature_flag.aggregation_group_type_index
 
     base_query: QuerySet = (
-        Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(team_id=team_id)
+        Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(  # nosemgrep: no-direct-persons-db-orm
+            team_id=team_id
+        )  # nosemgrep: no-direct-persons-db-orm
         if group_type_index is None
-        else Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
+        else Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(  # nosemgrep: no-direct-persons-db-orm
             team_id=team_id, group_type_index=group_type_index
         )
     )

--- a/posthog/models/feature_flag/flag_validation.py
+++ b/posthog/models/feature_flag/flag_validation.py
@@ -121,8 +121,10 @@ def _exclude_realtime_backfilled_cohort_properties(
 def _base_query_for_aggregation(group_type_index: Optional[int], team_id: int) -> QuerySet:
     """Return the appropriate Person or Group queryset for a given aggregation type."""
     if group_type_index is None:
-        return Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(team_id=team_id)
-    return Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
+        return Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(  # nosemgrep: no-direct-persons-db-orm
+            team_id=team_id
+        )  # nosemgrep: no-direct-persons-db-orm
+    return Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(  # nosemgrep: no-direct-persons-db-orm
         team_id=team_id, group_type_index=group_type_index
     )
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -580,7 +580,12 @@ def _get_flags_response_for_local_evaluation_batch(
 
     # Bulk load group type mappings for all projects
     gtm_by_project: dict[int, dict[str, str]] = defaultdict(dict)
-    for row in GroupTypeMapping.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(project_id__in=project_ids):
+    # nosemgrep: no-direct-persons-db-orm
+    for row in GroupTypeMapping.objects.db_manager(
+        READ_ONLY_DATABASE_FOR_PERSONS
+    ).filter(  # nosemgrep: no-direct-persons-db-orm
+        project_id__in=project_ids
+    ):  # nosemgrep: no-direct-persons-db-orm
         gtm_by_project[row.project_id][str(row.group_type_index)] = row.group_type
 
     results: dict[int, dict[str, Any]] = {}

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -67,7 +67,7 @@ def create_group(
         timestamp,
         timestamp=timestamp,
     )
-    group = Group.objects.create(
+    group = Group.objects.create(  # nosemgrep: no-direct-persons-db-orm
         team_id=team_id,
         group_type_index=group_type_index,
         group_key=group_key,

--- a/posthog/models/person/bulk_delete.py
+++ b/posthog/models/person/bulk_delete.py
@@ -52,12 +52,17 @@ def resolve_persons_for_deletion(
     """
 
     persons_queryset = (
-        Person.objects.filter(team_id=team_id)
+        Person.objects.filter(team_id=team_id)  # nosemgrep: no-direct-persons-db-orm
         .only(*_PERSON_DELETION_COLUMNS)
         .prefetch_related(
             Prefetch(
                 "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=team_id).order_by("id"),
+                # nosemgrep: no-direct-persons-db-orm
+                queryset=PersonDistinctId.objects.filter(
+                    team_id=team_id
+                ).order_by(  # nosemgrep: no-direct-persons-db-orm
+                    "id"
+                ),  # nosemgrep: no-direct-persons-db-orm
                 to_attr="distinct_ids_cache",
             )
         )
@@ -65,7 +70,9 @@ def resolve_persons_for_deletion(
     if uuids:
         persons_queryset = persons_queryset.filter(uuid__in=uuids)
     elif distinct_ids:
-        person_ids = PersonDistinctId.objects.filter(team_id=team_id, distinct_id__in=distinct_ids).values_list(
+        person_ids = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+            team_id=team_id, distinct_id__in=distinct_ids
+        ).values_list(  # nosemgrep: no-direct-persons-db-orm
             "person_id", flat=True
         )
         persons_queryset = persons_queryset.filter(id__in=person_ids)

--- a/posthog/models/person/deletion.py
+++ b/posthog/models/person/deletion.py
@@ -97,7 +97,9 @@ def _updated_distinct_ids(team_id: int, distinct_id_versions: list[tuple[str, in
 
 def _update_distinct_id_in_postgres(distinct_id: str, version: int, team_id: int) -> Optional[PersonDistinctId]:
     person_distinct_id = (
-        PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).select_related("person").first()
+        PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id)  # nosemgrep: no-direct-persons-db-orm
+        .select_related("person")
+        .first()  # nosemgrep: no-direct-persons-db-orm
     )
     if person_distinct_id is None:
         logger.info(f"Distinct id {distinct_id} hasn't been re-used yet and can cause problems in the future")
@@ -136,7 +138,12 @@ def _reset_person_in_clickhouse(team_id: int, person: Person, db_alias: str) -> 
 
     # Update Postgres version so future updates from the plugin-server
     # (which reads version from Postgres) won't be ignored by ClickHouse
-    Person.objects.using(db_alias).filter(pk=person.pk, version__lt=new_version).update(version=new_version)
+    # nosemgrep: no-direct-persons-db-orm
+    Person.objects.using(db_alias).filter(
+        pk=person.pk, version__lt=new_version
+    ).update(  # nosemgrep: no-direct-persons-db-orm
+        version=new_version
+    )  # nosemgrep: no-direct-persons-db-orm
 
     create_person(
         uuid=person_uuid,

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -214,7 +214,7 @@ class Person(models.Model):
             return self._distinct_ids
         return [
             id[0]
-            for id in PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+            for id in PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(person=self, team_id=self.team_id)
             .order_by("id")
             .values_list("distinct_id")
@@ -250,7 +250,9 @@ class Person(models.Model):
             # Delete PersonDistinctId records with explicit team_id for partition pruning.
             # Django's Collector.delete() generates: DELETE FROM posthog_persondistinctid WHERE person_id IN (...)
             # which misses team_id and would scan all partitions on a partitioned table.
-            PersonDistinctId.objects.filter(team_id=person_team_id, person_id=person_pk).delete()
+            PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                team_id=person_team_id, person_id=person_pk
+            ).delete()  # nosemgrep: no-direct-persons-db-orm
 
             # Now delete the Person itself with explicit team_id for partition pruning
             db_connection = connections[using]
@@ -264,7 +266,9 @@ class Person(models.Model):
 
     # :DEPRECATED: This should happen through the plugin server
     def add_distinct_id(self, distinct_id: str) -> None:
-        PersonDistinctId.objects.create(person=self, distinct_id=distinct_id, team_id=self.team_id)
+        PersonDistinctId.objects.create(  # nosemgrep: no-direct-persons-db-orm
+            person=self, distinct_id=distinct_id, team_id=self.team_id
+        )  # nosemgrep: no-direct-persons-db-orm
 
     # :DEPRECATED: This should happen through the plugin server
     def _add_distinct_ids(self, distinct_ids: list[str]) -> None:
@@ -290,7 +294,12 @@ class Person(models.Model):
         ``max_splits`` of them). If ``main_distinct_id`` is also None, properties are
         wiped from the original person and the first distinct_id becomes the main.
         """
-        original_person = Person.objects.only("id", "team_id", "uuid", "version").get(team_id=self.team_id, pk=self.pk)
+        # nosemgrep: no-direct-persons-db-orm
+        original_person = Person.objects.only(
+            "id", "team_id", "uuid", "version"
+        ).get(  # nosemgrep: no-direct-persons-db-orm
+            team_id=self.team_id, pk=self.pk
+        )  # nosemgrep: no-direct-persons-db-orm
         distinct_ids = original_person.distinct_ids
         original_person_version = original_person.version or 0
 
@@ -366,7 +375,7 @@ class Person(models.Model):
         """Lock and return PDIs for the given distinct_ids. Raises if any are missing."""
         locked = {
             person_distinct_id.distinct_id: person_distinct_id
-            for person_distinct_id in PersonDistinctId.objects.select_for_update().filter(
+            for person_distinct_id in PersonDistinctId.objects.select_for_update().filter(  # nosemgrep: no-direct-persons-db-orm
                 team_id=self.team_id, person=self, distinct_id__in=distinct_ids
             )
         }
@@ -397,7 +406,7 @@ class Person(models.Model):
         """
         new_person_by_uuid = {}
         for new_uuid in new_uuid_by_distinct_id.values():
-            new_person, _created = Person.objects.update_or_create(
+            new_person, _created = Person.objects.update_or_create(  # nosemgrep: no-direct-persons-db-orm
                 uuid=new_uuid,
                 team_id=self.team_id,
                 defaults={"version": original_person_version + 101},
@@ -427,7 +436,9 @@ class Person(models.Model):
             # This ensures the split distinct_id overrides any deleted distinct_id.
             person_distinct_id.version = (person_distinct_id.version or 0) + 101
 
-        PersonDistinctId.objects.bulk_update(list(locked_pdis.values()), ["person_id", "version"])
+        PersonDistinctId.objects.bulk_update(  # nosemgrep: no-direct-persons-db-orm
+            list(locked_pdis.values()), ["person_id", "version"]
+        )  # nosemgrep: no-direct-persons-db-orm
 
     def _publish_split_to_kafka(
         self,
@@ -617,13 +628,13 @@ def get_distinct_ids_for_subquery(person: Person | None, team: Team) -> list[str
             return list(set(ids[:first_ids_limit] + ids[-last_ids_limit:]))
 
         first_ids = (
-            PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+            PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(person=person, team=team)
             .order_by("id")
             .values_list("distinct_id", flat=True)[:first_ids_limit]
         )
         last_ids = (
-            PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+            PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(person=person, team=team)
             .order_by("-id")
             .values_list("distinct_id", flat=True)[:last_ids_limit]

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -42,17 +42,17 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     _raw_delete(Node.objects.filter(team_id__in=team_ids))
 
     _raw_delete(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
-    _raw_delete_batch(PersonlessDistinctId.objects.filter(team_id__in=team_ids))
+    _raw_delete_batch(PersonlessDistinctId.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm
     _raw_delete(ErrorTrackingIssueFingerprintV2.objects.filter(team_id__in=team_ids))
 
     # Get cohort_ids from the default database first to avoid cross-database join
     # CohortPeople is in persons_db, Cohort is in default db
     cohort_ids = list(Cohort.objects.filter(team_id__in=team_ids).values_list("id", flat=True))
-    _raw_delete(CohortPeople.objects.filter(cohort_id__in=cohort_ids))
+    _raw_delete(CohortPeople.objects.filter(cohort_id__in=cohort_ids))  # nosemgrep: no-direct-persons-db-orm
 
-    _raw_delete(FeatureFlagHashKeyOverride.objects.filter(team_id__in=team_ids))
-    _raw_delete(Group.objects.filter(team_id__in=team_ids))
-    _raw_delete(GroupTypeMapping.objects.filter(team_id__in=team_ids))
+    _raw_delete(FeatureFlagHashKeyOverride.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm
+    _raw_delete(Group.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm
+    _raw_delete(GroupTypeMapping.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm
 
     # Delete Person + PersonDistinctId via personhog RPC (handles both tables).
     # Falls back to ORM batch deletion when personhog is not available.
@@ -98,8 +98,8 @@ def _delete_persons_for_team_via_personhog(team_id: int) -> None:
 def _delete_persons_for_team_via_orm(team_id: int) -> None:
     from posthog.models.person import Person, PersonDistinctId
 
-    _raw_delete_batch(PersonDistinctId.objects.filter(team_id=team_id))
-    _raw_delete_batch(Person.objects.filter(team_id=team_id))
+    _raw_delete_batch(PersonDistinctId.objects.filter(team_id=team_id))  # nosemgrep: no-direct-persons-db-orm
+    _raw_delete_batch(Person.objects.filter(team_id=team_id))  # nosemgrep: no-direct-persons-db-orm
 
 
 def _raw_delete(queryset: Any):

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -260,7 +260,7 @@ def get_groups(
     value_per_actor_id: Optional[dict[str, float]] = None,
 ) -> tuple[QuerySet[Group], list[SerializedGroup]]:
     """Get groups from raw SQL results in data model and dict formats"""
-    groups: QuerySet[Group] = Group.objects.filter(
+    groups: QuerySet[Group] = Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
         team_id=team_id, group_type_index=group_type_index, group_key__in=group_ids
     )
     return groups, serialize_groups(groups, value_per_actor_id)
@@ -324,18 +324,23 @@ def get_people(
             logger.warning("personhog_get_people_failure", team_id=team.pk, exc_info=True)
 
     distinct_id_subquery = Subquery(
-        PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+        PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
         .filter(team_id=team.pk, person_id=OuterRef("person_id"))
         .values_list("id", flat=True)[:distinct_id_limit]
     )
     persons_qs: QuerySet[Person] = (
-        Person.objects.db_manager(READ_DB_FOR_PERSONS)
+        Person.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
         .filter(team_id=team.pk, uuid__in=people_ids)
         .prefetch_related(
             Prefetch(
                 "persondistinctid_set",
                 to_attr="distinct_ids_cache",
-                queryset=PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS).filter(id__in=distinct_id_subquery),
+                # nosemgrep: no-direct-persons-db-orm
+                queryset=PersonDistinctId.objects.db_manager(
+                    READ_DB_FOR_PERSONS
+                ).filter(  # nosemgrep: no-direct-persons-db-orm
+                    id__in=distinct_id_subquery
+                ),  # nosemgrep: no-direct-persons-db-orm
             )
         )
         .order_by("-created_at", "uuid")

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -371,7 +371,7 @@ def property_to_Q(
 
             return Q(
                 Exists(
-                    CohortPeople.objects.db_manager(using_database)
+                    CohortPeople.objects.db_manager(using_database)  # nosemgrep: no-direct-persons-db-orm
                     .filter(
                         cohort_id=cohort_id,
                         person_id=OuterRef("id"),

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -179,7 +179,7 @@ class SessionRecording(UUIDTModel):
                 logger.warning("personhog_load_person_failure", team_id=self.team.pk, exc_info=True)
 
         try:
-            self.person = Person.objects.db_manager(READ_DB_FOR_PERSONS).get(
+            self.person = Person.objects.db_manager(READ_DB_FOR_PERSONS).get(  # nosemgrep: no-direct-persons-db-orm
                 persondistinctid__distinct_id=self.distinct_id,
                 persondistinctid__team_id=self.team.pk,
                 team=self.team,

--- a/posthog/tasks/split_person.py
+++ b/posthog/tasks/split_person.py
@@ -61,7 +61,12 @@ def split_person(
                 person_id=person_id,
             )
             # Lookup team_id via PersonDistinctId which has person_id FK
-            pdi = PersonDistinctId.objects.filter(person_id=person_id).only("team_id").first()
+            pdi = (
+                # nosemgrep: no-direct-persons-db-orm
+                PersonDistinctId.objects.filter(person_id=person_id)
+                .only("team_id")
+                .first()  # nosemgrep: no-direct-persons-db-orm
+            )  # nosemgrep: no-direct-persons-db-orm
             if not pdi:
                 raise ValueError(f"Cannot find team_id for person_id={person_id}")
 
@@ -71,7 +76,7 @@ def split_person(
                 person_id=person_id,
                 team_id=resolved_team_id,
             )
-            person = Person.objects.get(team_id=resolved_team_id, pk=person_id)
+            person = Person.objects.get(team_id=resolved_team_id, pk=person_id)  # nosemgrep: no-direct-persons-db-orm
             logger.info(
                 "split_person legacy path: calling split_person on model",
                 person_id=person_id,
@@ -89,7 +94,7 @@ def split_person(
                 person_id=person_id,
                 team_id=resolved_team_id,
             )
-            person = Person.objects.get(team_id=resolved_team_id, pk=person_id)
+            person = Person.objects.get(team_id=resolved_team_id, pk=person_id)  # nosemgrep: no-direct-persons-db-orm
             logger.info(
                 "split_person new path: calling split_person on model",
                 person_id=person_id,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1885,7 +1885,9 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             period_start, period_end, FlagRequestType.LOCAL_EVALUATION
         ),
         "teams_with_group_types_total": list(
-            GroupTypeMapping.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            GroupTypeMapping.objects.values("team_id")  # nosemgrep: no-direct-persons-db-orm
+            .annotate(total=Count("id"))
+            .order_by("team_id")  # nosemgrep: no-direct-persons-db-orm
         ),
         "teams_with_dashboard_count": list(
             Dashboard.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -51,9 +51,14 @@ def verify_persons_data_in_sync(
 ) -> Counter:
     # :KLUDGE: Rather than filter on created_at directly which is unindexed, we look up the latest value in 'id' column
     #   and leverage that to narrow down filtering in an index-efficient way
-    max_pk = Person.objects.filter(created_at__lte=now() - period_start).latest("id").id
+    max_pk = (
+        # nosemgrep: no-direct-persons-db-orm
+        Person.objects.filter(created_at__lte=now() - period_start)
+        .latest("id")
+        .id  # nosemgrep: no-direct-persons-db-orm
+    )  # nosemgrep: no-direct-persons-db-orm
     person_data = list(
-        Person.objects.filter(
+        Person.objects.filter(  # nosemgrep: no-direct-persons-db-orm
             pk__lte=max_pk,
             pk__gte=max_pk - LIMIT * 5,
             created_at__gte=now() - period_end,
@@ -89,10 +94,17 @@ def _team_integrity_statistics(person_data: list[Any]) -> Counter:
     # :TRICKY: To speed up processing, we fetch all models in batch at once and store results in dictionary indexed by person uuid
     pg_persons = _index_by(
         list(
-            Person.objects.filter(id__in=person_ids, team_id__in=team_ids).prefetch_related(
+            Person.objects.filter(  # nosemgrep: no-direct-persons-db-orm
+                id__in=person_ids, team_id__in=team_ids
+            ).prefetch_related(  # nosemgrep: no-direct-persons-db-orm
                 Prefetch(
                     "persondistinctid_set",
-                    queryset=PersonDistinctId.objects.filter(team_id__in=team_ids).order_by("id"),
+                    # nosemgrep: no-direct-persons-db-orm
+                    queryset=PersonDistinctId.objects.filter(
+                        team_id__in=team_ids
+                    ).order_by(  # nosemgrep: no-direct-persons-db-orm
+                        "id"
+                    ),  # nosemgrep: no-direct-persons-db-orm
                     to_attr="distinct_ids_cache",
                 )
             )

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -662,7 +662,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 primary_dashboard=instance,
                 id=instance.team_id,
             ).update(primary_dashboard=None)
-            group_type_mapping = GroupTypeMapping.objects.filter(
+            group_type_mapping = GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
                 team=instance.team, project_id=instance.team.project_id, detail_dashboard_id=instance.id
             ).first()
             if group_type_mapping:

--- a/products/dashboards/backend/models/dashboard.py
+++ b/products/dashboards/backend/models/dashboard.py
@@ -115,7 +115,9 @@ class Dashboard(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.M
 
         # Handle SET_NULL for GroupTypeMapping.detail_dashboard in persons database
         # This is needed because GroupTypeMapping is in the persons database
-        GroupTypeMapping.objects.using(PERSONS_DB_FOR_WRITE).filter(detail_dashboard_id=self.id).update(
+        GroupTypeMapping.objects.using(PERSONS_DB_FOR_WRITE).filter(  # nosemgrep: no-direct-persons-db-orm
+            detail_dashboard_id=self.id
+        ).update(  # nosemgrep: no-direct-persons-db-orm
             detail_dashboard_id=None
         )
         return super().delete(*args, **kwargs)

--- a/products/feature_flags/backend/max_tools.py
+++ b/products/feature_flags/backend/max_tools.py
@@ -220,7 +220,7 @@ class CreateFeatureFlagTool(MaxTool):
 
                 @database_sync_to_async
                 def get_group_mapping() -> GroupTypeMapping | None:
-                    return GroupTypeMapping.objects.filter(
+                    return GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
                         team=self._team,
                         group_type=flag_schema.group_type.lower() if flag_schema.group_type else None,
                     ).first()

--- a/products/posthog_ai/dags/snapshot_team_data.py
+++ b/products/posthog_ai/dags/snapshot_team_data.py
@@ -247,7 +247,10 @@ def snapshot_actors_property_taxonomy(
     results: list[ActorsPropertyTaxonomySnapshot] = []
     group_type_mappings: list[int | None] = [
         None,
-        *(g.group_type_index for g in GroupTypeMapping.objects.filter(team=team)),
+        *(
+            g.group_type_index
+            for g in GroupTypeMapping.objects.filter(team=team)  # nosemgrep: no-direct-persons-db-orm
+        ),  # nosemgrep: no-direct-persons-db-orm
     ]
 
     for index in group_type_mappings:


### PR DESCRIPTION
## Problem

We're migrating person/group data access from the Django ORM to the personhog gRPC service. As this migration progresses, we need to prevent new direct ORM queries from being introduced — otherwise every PR that touches person models can regress the migration.

## Changes

- Added a new semgrep rule `.semgrep/rules/no-direct-persons-db-orm.yaml` that flags direct `.objects` access on person/group Django models (`Person`, `PersonDistinctId`, `CohortPeople`, `Group`, `GroupTypeMapping`, and related override tables)
- The rule excludes files that are expected to contain direct ORM access: the personhog client, the `_personhog_routed()` helpers in `posthog/models/person/util.py` and `posthog/models/group_type_mapping.py`, migrations, tests, and semgrep test cases
- All 122 existing violations across 48 files are grandfathered with `# nosemgrep: no-direct-persons-db-orm` annotations so the rule passes cleanly today
- New code adding direct ORM queries to these models will be caught by semgrep in CI

## How did you test this code?

- Ran `semgrep --config .semgrep/rules/no-direct-persons-db-orm.yaml .` locally — reports 0 violations after annotations
- Ran `ruff format` and `ruff check` to confirm formatting stability — the nosemgrep comments survive reformatting (uses above-line comments where inline would cause ruff to split the line)
- Verified the rule correctly catches un-annotated `Person.objects.filter(...)` etc. by temporarily removing a nosemgrep comment and re-running