### PR TITLE
chore(ci): refresh dagster timings and fix overlapping artifact download

### DIFF
--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -6,8 +6,12 @@ on:
             - '.github/scripts/optimize_test_durations.py'
     workflow_dispatch:
         inputs:
-            run_id:
-                description: 'CI run ID to collect timing data from (leave empty to use latest successful run)'
+            backend_run_id:
+                description: 'Backend CI run ID (leave empty to use latest successful run)'
+                required: false
+                type: string
+            dagster_run_id:
+                description: 'Dagster CI run ID (leave empty to use latest successful run)'
                 required: false
                 type: string
     schedule:
@@ -48,11 +52,11 @@ jobs:
               id: find-backend-run
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  INPUT_RUN_ID: ${{ inputs.run_id }}
+                  INPUT_RUN_ID: ${{ inputs.backend_run_id }}
               run: |
                   if [ -n "$INPUT_RUN_ID" ]; then
                       echo "run_id=$INPUT_RUN_ID" >> $GITHUB_OUTPUT
-                      echo "Using provided CI run: $INPUT_RUN_ID"
+                      echo "Using provided Backend CI run: $INPUT_RUN_ID"
                       exit 0
                   fi
 
@@ -92,7 +96,14 @@ jobs:
               id: find-dagster-run
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  INPUT_RUN_ID: ${{ inputs.dagster_run_id }}
               run: |
+                  if [ -n "$INPUT_RUN_ID" ]; then
+                      echo "run_id=$INPUT_RUN_ID" >> $GITHUB_OUTPUT
+                      echo "Using provided Dagster CI run: $INPUT_RUN_ID"
+                      exit 0
+                  fi
+
                   # Find a recent successful ci-dagster.yml run with timing artifacts
                   # Only consider runs from the past 14 days to ensure artifacts haven't expired
                   echo "Searching for Dagster CI run with timing artifacts..."
@@ -129,8 +140,15 @@ jobs:
                   BACKEND_RUN_ID: ${{ steps.find-backend-run.outputs.run_id }}
                   DAGSTER_RUN_ID: ${{ steps.find-dagster-run.outputs.run_id }}
               run: |
-                  # Download backend timing artifacts
-                  gh run download "$BACKEND_RUN_ID" --pattern "timing_data-*" --dir timing_artifacts
+                  # Download backend timing artifacts. Use segment-specific patterns
+                  # so we don't accidentally pull Dagster artifacts here when the same
+                  # run ID is provided for both jobs (they share the timing_data- prefix
+                  # and would otherwise collide on extraction into the same dir).
+                  gh run download "$BACKEND_RUN_ID" \
+                      --pattern "timing_data-Core-*" \
+                      --pattern "timing_data-Temporal-*" \
+                      --pattern "timing_data-Products-*" \
+                      --dir timing_artifacts
 
                   # Download dagster timing artifacts if available
                   if [ -n "$DAGSTER_RUN_ID" ]; then


### PR DESCRIPTION
## Problem

Dagster timings hadn't been refreshed since #56859 landed a bunch of new dagster tests. The auto-update workflow is also stuck — last run [crashed](https://github.com/PostHog/posthog/actions/runs/25119439317/job/73615714378) with `error extracting ".test_durations": file exists` because the backend artifact download pattern (`timing_data-*`) greedily matched Dagster artifacts, which then collided with the second (Dagster) download into the same dir.

## Changes

**Timings:** Refreshed Dagster entries in `.test_durations` from Dagster CI run [25116537242](https://github.com/PostHog/posthog/actions/runs/25116537242). Filtered to tests that actually exist under `posthog/dags/` and `products/*/dags/` (830 entries, up from 160 — picks up the new tests). Backend / Temporal / Products entries untouched.

**Workflow:**
- Split the single `run_id` workflow_dispatch input into `backend_run_id` and `dagster_run_id` — passing a Dagster run no longer gets misrouted into the Backend slot.
- Tightened the backend download pattern to `timing_data-{Core,Temporal,Products}-*` instead of the catch-all `timing_data-*`. The two downloads can't collide on extraction paths anymore.

## How did you test this code?

Agent-authored. Reproduced the merge logic locally — pulled the Dagster artifacts from run 25116537242, ran `pytest --collect-only` against `posthog/dags products/*/dags` (excluding `node_modules`) to get the live test set (830), filtered the artifact durations to that set, applied the same 60s ceiling cap, and merged into the existing `.test_durations` (replacing only dagster-prefixed keys). Workflow change is config-only; no automated test for it.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at the user's direction. Run links and the failing-job log were provided by the user; I diagnosed the collision, refreshed the timings, and edited the workflow.