### PR TITLE
feat(ingestion): ensure failing hog functions notify but don't crash pods

### DIFF
--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -882,6 +882,83 @@ describe('HogTransformer', () => {
             expect(result.event?.properties?.$transformations_failed).toBeUndefined()
         })
 
+        it('should catch thrown executeHogFunction errors without crashing, track failure, and queue app metric', async () => {
+            const successTemplate: HogFunctionTemplate = {
+                free: true,
+                status: 'beta',
+                type: 'transformation',
+                id: 'template-success',
+                name: 'Success Template',
+                description: 'A template that should succeed',
+                category: ['Custom'],
+                code_language: 'hog',
+                code: `
+                    let returnEvent := event
+                    returnEvent.properties.success := true
+                    return returnEvent
+                `,
+                inputs_schema: [],
+            }
+
+            const brokenFunction = createHogFunction({
+                type: 'transformation',
+                name: 'Broken Template',
+                team_id: teamId,
+                enabled: true,
+                bytecode: await compileHog('return event'),
+                execution_order: 1,
+            })
+
+            const successFunction = createHogFunction({
+                type: 'transformation',
+                name: successTemplate.name,
+                team_id: teamId,
+                enabled: true,
+                bytecode: await compileHog(successTemplate.code),
+                execution_order: 2,
+            })
+
+            await insertHogFunction(hub.postgres, teamId, brokenFunction)
+            await insertHogFunction(hub.postgres, teamId, successFunction)
+
+            hogTransformer['hogFunctionManager']['onHogFunctionsReloaded'](teamId, [
+                brokenFunction.id,
+                successFunction.id,
+            ])
+
+            const executeHogFunctionSpy = jest.spyOn(hogTransformer as any, 'executeHogFunction')
+            executeHogFunctionSpy.mockRejectedValueOnce(
+                new Error('Could not execute bytecode for input field: person_id')
+            )
+
+            const queueAppMetricSpy = jest.spyOn(hogTransformer['hogFunctionMonitoringService'], 'queueAppMetric')
+
+            const event = createPluginEvent({ event: 'test', properties: {} }, teamId)
+            const result = await hogTransformer.transformEventAndProduceMessages(event)
+
+            expect(result.event?.properties?.$transformations_failed).toEqual([
+                `Broken Template (${brokenFunction.id})`,
+            ])
+            expect(result.event?.properties?.$transformations_succeeded).toEqual([
+                `Success Template (${successFunction.id})`,
+            ])
+            expect(result.event?.properties?.success).toBe(true)
+
+            expect(queueAppMetricSpy).toHaveBeenCalledWith(
+                {
+                    team_id: teamId,
+                    app_source_id: brokenFunction.id,
+                    metric_kind: 'failure',
+                    metric_name: 'failed',
+                    count: 1,
+                },
+                'hog_function'
+            )
+
+            executeHogFunctionSpy.mockRestore()
+            queueAppMetricSpy.mockRestore()
+        })
+
         it('should track both successful and skipped transformations in sequence', async () => {
             const successTemplate = {
                 free: true,

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -238,7 +238,28 @@ export class HogTransformerService {
                 }
             }
 
-            const result = await this.executeHogFunction(hogFunction, globals)
+            let result: CyclotronJobInvocationResult
+            try {
+                result = await this.executeHogFunction(hogFunction, globals)
+            } catch (err) {
+                logger.error('⚠️', 'Unexpected error executing transformation', {
+                    function_id: hogFunction.id,
+                    team_id: event.team_id,
+                    error: String(err),
+                })
+                this.hogFunctionMonitoringService.queueAppMetric(
+                    {
+                        team_id: event.team_id,
+                        app_source_id: hogFunction.id,
+                        metric_kind: 'failure',
+                        metric_name: 'failed',
+                        count: 1,
+                    },
+                    'hog_function'
+                )
+                transformationsFailed.push(transformationIdentifier)
+                continue
+            }
 
             results.push(result)
 


### PR DESCRIPTION
## Problem
After a bad HogFunction landed in prod today, we needed to find it and manually disable it to prevent hot partitions and crashing pods in ingestion. After discussing w/Workflows team, this isn't something we need to do as long as there's a log/metric trail that lets them know when something is wrong.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Wrap HogFunction fails and handle error gracefully instead of crashing the pod. Skip the broken transformation (it won't work anyway)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context
N/A
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
