### PR TITLE
fix(web-analytics) Correct channel drill-down classification

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -157,13 +157,8 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             level = self.config.drill_down_level
             if level == MarketingAnalyticsDrillDownLevel.CHANNEL:
                 # Repurpose campaign_name to hold the channel derived from source
-                select_columns.extend(
-                    [
-                        ast.Alias(alias=self.config.campaign_field, expr=self._build_channel_type_expr()),
-                        ast.Alias(alias=self.config.id_field, expr=ast.Constant(value="")),
-                        ast.Alias(alias=self.config.source_field, expr=ast.Constant(value="")),
-                        ast.Alias(alias=self.config.match_key_field, expr=ast.Constant(value="")),
-                    ]
+                select_columns.append(
+                    ast.Alias(alias=self.config.campaign_field, expr=self._build_channel_type_expr()),
                 )
             elif level == MarketingAnalyticsDrillDownLevel.SOURCE:
                 # Repurpose campaign_name to hold the source

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py
@@ -9,6 +9,7 @@ from posthog.schema import (
     ConversionGoalFilter3,
     DateRange,
     MarketingAnalyticsBaseColumns,
+    MarketingAnalyticsColumnsSchemaNames,
     MarketingAnalyticsDrillDownLevel,
     MarketingAnalyticsTableQuery,
     MarketingAnalyticsTableQueryResponse,
@@ -21,7 +22,11 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 from products.data_warehouse.backend.models import DataWarehouseTable
 from products.marketing_analytics.backend.hogql_queries.adapters.base import MarketingSourceAdapter
-from products.marketing_analytics.backend.hogql_queries.constants import DEFAULT_LIMIT, DRILL_DOWN_LEVEL_CONFIG
+from products.marketing_analytics.backend.hogql_queries.constants import (
+    DEFAULT_LIMIT,
+    DRILL_DOWN_LEVEL_CONFIG,
+    MATCH_KEY_FIELD,
+)
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_table_query_runner import (
     MarketingAnalyticsTableQueryRunner,
 )
@@ -433,6 +438,62 @@ class TestMarketingAnalyticsTableQueryRunner(ClickhouseTestMixin, BaseTest):
         assert isinstance(result, MarketingAnalyticsTableQueryResponse)
         assert result.columns is not None
         assert config_alias_in_columns(result.columns, DRILL_DOWN_LEVEL_CONFIG[level]["column_alias"])
+
+    def _build_fake_adapter_for_source(self, source_name: str) -> Mock:
+        adapter = Mock(spec=MarketingSourceAdapter)
+        adapter.config = Mock(source_id=f"fake-{source_name}")
+        adapter.validate.return_value = Mock(is_valid=True)
+        adapter.build_query.return_value = ast.SelectQuery(
+            select=[
+                ast.Alias(alias=MATCH_KEY_FIELD, expr=ast.Constant(value="Test Campaign")),
+                ast.Alias(
+                    alias=MarketingAnalyticsColumnsSchemaNames.CAMPAIGN, expr=ast.Constant(value="Test Campaign")
+                ),
+                ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.ID, expr=ast.Constant(value="12345")),
+                ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.SOURCE, expr=ast.Constant(value=source_name)),
+                ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.IMPRESSIONS, expr=ast.Constant(value=8900.0)),
+                ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.CLICKS, expr=ast.Constant(value=1675.0)),
+                ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.COST, expr=ast.Constant(value=5148.75)),
+                ast.Alias(
+                    alias=MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION, expr=ast.Constant(value=153.0)
+                ),
+                ast.Alias(
+                    alias=MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION_VALUE,
+                    expr=ast.Constant(value=1532.0),
+                ),
+            ],
+        )
+        return adapter
+
+    @parameterized.expand(
+        [
+            ("google", "Paid Search"),
+            ("linkedin", "Paid Social"),
+            ("bing", "Paid Search"),
+        ]
+    )
+    def test_channel_drill_down_classifies_paid_sources(self, source_name, expected_channel):
+        query = MarketingAnalyticsTableQuery(
+            dateRange=self.default_date_range,
+            limit=DEFAULT_LIMIT,
+            offset=0,
+            properties=[],
+            drillDownLevel=MarketingAnalyticsDrillDownLevel.CHANNEL,
+        )
+        runner = self._create_query_runner(query)
+
+        fake_adapter = self._build_fake_adapter_for_source(source_name)
+        with patch.object(MarketingAnalyticsTableQueryRunner, "_get_marketing_source_adapters") as mock_get:
+            mock_get.return_value = [fake_adapter]
+            result = runner.calculate()
+
+        assert isinstance(result, MarketingAnalyticsTableQueryResponse)
+        assert result.columns is not None
+        channel_idx = next(i for i, c in enumerate(result.columns) if str(c) == "Channel")
+        channels = [getattr(row[channel_idx], "value", row[channel_idx]) for row in (result.results or [])]
+        assert channels == [expected_channel], (
+            f"Expected Channel='{expected_channel}' for source='{source_name}', got {channels}"
+        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem
The Channel breakdown in Marketing analytics was showing paid traffic source as "Paid Unknown" instead of classifying it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Drop the shadowing literal aliases (id, source, match_key) at Channel drill-drown

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
