### PR TITLE
fix(flags): preserve payloads when variant keys are numeric strings

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -49,43 +49,30 @@ describe('payload conversion helpers', () => {
         { key: 'test', rollout_percentage: 50 },
     ]
 
-    it('converts multivariate payloads keyed by variant index', () => {
-        expect(
-            convertIndexBasedPayloadsToVariantKeys(variants, {
-                0: '{"color":"red"}',
-                1: '{"color":"blue"}',
-            })
-        ).toEqual({
-            control: '{"color":"red"}',
-            test: '{"color":"blue"}',
-        })
-    })
-
-    it('preserves payload-to-variant mapping when variant keys are numeric strings', () => {
-        const numericVariants = [
-            { key: '2', rollout_percentage: 50 },
-            { key: '0', rollout_percentage: 50 },
-        ]
-        expect(
-            convertIndexBasedPayloadsToVariantKeys(numericVariants, {
-                0: '{"for":"variant-2"}',
-                1: '{"for":"variant-0"}',
-            })
-        ).toEqual({
-            '2': '{"for":"variant-2"}',
-            '0': '{"for":"variant-0"}',
-        })
-    })
-
-    it('skips indices without a matching variant', () => {
-        expect(
-            convertIndexBasedPayloadsToVariantKeys(variants, {
-                0: '{"color":"red"}',
-                5: '{"orphan":true}',
-            })
-        ).toEqual({
-            control: '{"color":"red"}',
-        })
+    it.each([
+        [
+            'keyed by variant index',
+            variants,
+            { 0: '{"color":"red"}', 1: '{"color":"blue"}' },
+            { control: '{"color":"red"}', test: '{"color":"blue"}' },
+        ],
+        [
+            'numeric-string variant keys (regression)',
+            [
+                { key: '2', rollout_percentage: 50 },
+                { key: '0', rollout_percentage: 50 },
+            ],
+            { 0: '{"for":"variant-2"}', 1: '{"for":"variant-0"}' },
+            { '2': '{"for":"variant-2"}', '0': '{"for":"variant-0"}' },
+        ],
+        [
+            'skips indices without a matching variant',
+            variants,
+            { 0: '{"color":"red"}', 5: '{"orphan":true}' },
+            { control: '{"color":"red"}' },
+        ],
+    ])('converts multivariate payloads %s', (_label, vars, payloads, expected) => {
+        expect(convertIndexBasedPayloadsToVariantKeys(vars, payloads)).toEqual(expected)
     })
 
     it('keeps boolean flag payload handling unchanged', () => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -49,43 +49,43 @@ describe('payload conversion helpers', () => {
         { key: 'test', rollout_percentage: 50 },
     ]
 
-    it.each([
-        [
-            'already keyed by variant key',
-            {
-                control: '{"color":"red"}',
-                test: '{"color":"blue"}',
-            },
-            {
-                control: '{"color":"red"}',
-                test: '{"color":"blue"}',
-            },
-        ],
-        [
-            'keyed by variant index',
-            {
+    it('converts multivariate payloads keyed by variant index', () => {
+        expect(
+            convertIndexBasedPayloadsToVariantKeys(variants, {
                 0: '{"color":"red"}',
                 1: '{"color":"blue"}',
-            },
-            {
-                control: '{"color":"red"}',
-                test: '{"color":"blue"}',
-            },
-        ],
-        [
-            'with mixed keys while preferring explicit variant keys',
-            {
-                control: '{"color":"red"}',
-                0: '{"color":"green"}',
-                1: '{"color":"blue"}',
-            },
-            {
-                control: '{"color":"red"}',
-                test: '{"color":"blue"}',
-            },
-        ],
-    ])('converts multivariate payloads %s', (_label, payloads, expected) => {
-        expect(convertIndexBasedPayloadsToVariantKeys(variants, payloads)).toEqual(expected)
+            })
+        ).toEqual({
+            control: '{"color":"red"}',
+            test: '{"color":"blue"}',
+        })
+    })
+
+    it('preserves payload-to-variant mapping when variant keys are numeric strings', () => {
+        const numericVariants = [
+            { key: '2', rollout_percentage: 50 },
+            { key: '0', rollout_percentage: 50 },
+        ]
+        expect(
+            convertIndexBasedPayloadsToVariantKeys(numericVariants, {
+                0: '{"for":"variant-2"}',
+                1: '{"for":"variant-0"}',
+            })
+        ).toEqual({
+            '2': '{"for":"variant-2"}',
+            '0': '{"for":"variant-0"}',
+        })
+    })
+
+    it('skips indices without a matching variant', () => {
+        expect(
+            convertIndexBasedPayloadsToVariantKeys(variants, {
+                0: '{"color":"red"}',
+                5: '{"orphan":true}',
+            })
+        ).toEqual({
+            control: '{"color":"red"}',
+        })
     })
 
     it('keeps boolean flag payload handling unchanged', () => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -316,9 +316,14 @@ export const variantKeyToIndexFeatureFlagPayloads = (flag: FeatureFlagType): Fea
     }
 }
 
+// Reverse of `variantKeyToIndexFeatureFlagPayloads`: converts form-state payloads
+// (keyed by variant index) back to API-shape payloads (keyed by variant key).
+// Inputs MUST be index-keyed — passing variant-key-keyed payloads here will drop them.
+// This matters when variant keys are numeric strings (e.g. "0", "1"), which would
+// otherwise collide with index keys.
 export const convertIndexBasedPayloadsToVariantKeys = (
     variants: MultivariateFlagVariant[] = [],
-    payloads?: Record<string | number, JsonType>
+    payloads?: Record<number, JsonType>
 ): Record<string, JsonType> => {
     const newPayloads: Record<string, JsonType> = {}
 

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -321,22 +321,11 @@ export const convertIndexBasedPayloadsToVariantKeys = (
     payloads?: Record<string | number, JsonType>
 ): Record<string, JsonType> => {
     const newPayloads: Record<string, JsonType> = {}
-    const variantKeys = new Set(variants.map(({ key }) => key))
 
-    Object.entries(payloads || {}).forEach(([payloadKey, payloadValue]) => {
-        if (variantKeys.has(payloadKey)) {
-            newPayloads[payloadKey] = payloadValue
-            return
-        }
-
-        const payloadIndex = Number(payloadKey)
-        if (!Number.isInteger(payloadIndex) || String(payloadIndex) !== payloadKey) {
-            return
-        }
-
-        const variantKey = variants[payloadIndex]?.key
-        if (variantKey && newPayloads[variantKey] === undefined) {
-            newPayloads[variantKey] = payloadValue
+    variants.forEach((variant, index) => {
+        const payload = payloads?.[index]
+        if (payload !== undefined && variant.key) {
+            newPayloads[variant.key] = payload
         }
     })
 


### PR DESCRIPTION
## Problem

When creating a multivariate feature flag with numeric string variant keys like `"2"` and `"0"` (in that order), the saved payloads come back wrong: the first variant's payload is empty, and the second variant displays what was supposed to be the first variant's payload.

## Changes

`convertIndexBasedPayloadsToVariantKeys` had a defensive shortcut that treated a payload key as a variant key whenever it matched any variant's key. The form, however, always stores payloads keyed by array index — so when a variant key happened to be a numeric string that collided with an index, the function bound the payload to the wrong variant and dropped the rest.

Made the function purely index-based: iterate `variants`, look up `payloads[index]`, write to `variant.key`. Form state is always index-keyed (enforced by `variantKeyToIndexFeatureFlagPayloads`), so the dual-mode handling was unnecessary and harmful.

<img width="1280" height="611" alt="chrome-capture-2026-04-29" src="https://github.com/user-attachments/assets/08171c85-1da9-4849-bc82-6f313f96bcba" />

## How did you test this code?

I am an agent. Automated tests run:

- `frontend/src/scenes/feature-flags/featureFlagLogic.test.ts` — 84/84 pass, including a new regression test that covers variant keys `"2"` and `"0"` and asserts payloads stay bound to the correct variants.
- `oxlint` clean on the changed files.

- Manually reproduced the bug before and tested it after to check that it fixed it

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code. Human review required before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*