### PR TITLE
chore: remove false metabase:login hint

### DIFF
--- a/.agents/skills/query-clickhouse-via-metabase/SKILL.md
+++ b/.agents/skills/query-clickhouse-via-metabase/SKILL.md
@@ -62,6 +62,17 @@ hogli metabase:login --region eu
 blocks Keychain access from agent shells, so the user has to authenticate
 interactively.
 
+### Login can take up to ~30 seconds after SSO completes
+
+Chrome batches cookie writes to its on-disk SQLite store every ~30 seconds
+(`kCommitInterval = base::Seconds(30)` in Chromium's
+`sqlite_persistent_cookie_store.cc`). Until Chrome flushes, the new
+`metabase.SESSION` cookie is invisible to the CLI even though SSO succeeded.
+
+There is no reliable way to force an earlier flush — closing the tab/window
+does **not** trigger a write, and Cmd+Q is racy. The CLI handles this by
+polling once a second up to a 3-minute timeout; just wait.
+
 ### Agents: use `metabase:query`
 
 `hogli metabase:query` reads the cached cookie internally and only emits

--- a/.agents/skills/query-clickhouse-via-metabase/SKILL.md
+++ b/.agents/skills/query-clickhouse-via-metabase/SKILL.md
@@ -62,17 +62,6 @@ hogli metabase:login --region eu
 blocks Keychain access from agent shells, so the user has to authenticate
 interactively.
 
-### Login can take up to ~30 seconds after SSO completes
-
-Chrome batches cookie writes to its on-disk SQLite store every ~30 seconds
-(`kCommitInterval = base::Seconds(30)` in Chromium's
-`sqlite_persistent_cookie_store.cc`). Until Chrome flushes, the new
-`metabase.SESSION` cookie is invisible to the CLI even though SSO succeeded.
-
-There is no reliable way to force an earlier flush — closing the tab/window
-does **not** trigger a write, and Cmd+Q is racy. The CLI handles this by
-polling once a second up to a 3-minute timeout; just wait.
-
 ### Agents: use `metabase:query`
 
 `hogli metabase:query` reads the cached cookie internally and only emits

--- a/tools/hogli-commands/hogli_commands/metabase.py
+++ b/tools/hogli-commands/hogli_commands/metabase.py
@@ -32,13 +32,6 @@ from hogli.cli import cli
 
 LOGIN_TIMEOUT_SECONDS: float = 180.0
 LOGIN_POLL_INTERVAL_SECONDS: float = 1.0
-# Chrome batches cookie writes and only commits to SQLite every ~30s
-# (constexpr kCommitInterval = base::Seconds(30); in
-# net/extras/sqlite/sqlite_persistent_cookie_store.cc). There's no public API
-# to force an earlier flush — closing tabs/windows doesn't trigger it, and
-# even Cmd+Q is racy. The honest UX is to keep polling and tell the user the
-# 30s lower bound.
-FLUSH_HINT_AFTER_SECONDS: float = 8.0
 
 # Per-browser profile-cookie locations. Each entry is (loader_name, base_directory).
 # We glob `<base>/*/Cookies` to discover every profile (Default, Profile 1, ...).
@@ -190,18 +183,10 @@ def _wait_for_valid_cookie(
 
     Returns the cookie header on success. Raises `click.ClickException` after
     `timeout` seconds without finding a valid session.
-
-    Chrome flushes cookies to its on-disk SQLite store roughly every 30s, so a
-    freshly-set `metabase.SESSION` can be invisible to us for a while. After
-    `FLUSH_HINT_AFTER_SECONDS` we surface a status note explaining the wait.
-    There's no reliable way to force an earlier flush — closing the
-    tab/window does nothing, and Cmd+Q is racy.
     """
-    start = time.monotonic()
-    deadline = start + timeout
+    deadline = time.monotonic() + timeout
     last_status = ""
     last_header: str | None = None
-    flush_hint_shown = False
     while True:
         cookies = _load_cookies_from_browser(domain, browser)
         missing = [name for name in REQUIRED_COOKIES if name not in cookies]
@@ -220,14 +205,6 @@ def _wait_for_valid_cookie(
         if status != last_status:
             click.echo(status)
             last_status = status
-
-        if not flush_hint_shown and time.monotonic() - start >= FLUSH_HINT_AFTER_SECONDS:
-            click.echo(
-                "  note: Chrome batches cookie writes to disk every ~30s. "
-                "If you've signed in, just wait — the CLI will pick them up on the next flush. "
-                "Closing the tab or window does NOT force a flush.",
-            )
-            flush_hint_shown = True
 
         if time.monotonic() >= deadline:
             raise click.ClickException(

--- a/tools/hogli-commands/hogli_commands/metabase.py
+++ b/tools/hogli-commands/hogli_commands/metabase.py
@@ -32,9 +32,12 @@ from hogli.cli import cli
 
 LOGIN_TIMEOUT_SECONDS: float = 180.0
 LOGIN_POLL_INTERVAL_SECONDS: float = 1.0
-# Chrome buffers cookies in memory and flushes to SQLite roughly every 30s.
-# After this many seconds without progress we hint at closing the tab to
-# force a flush.
+# Chrome batches cookie writes and only commits to SQLite every ~30s
+# (constexpr kCommitInterval = base::Seconds(30); in
+# net/extras/sqlite/sqlite_persistent_cookie_store.cc). There's no public API
+# to force an earlier flush — closing tabs/windows doesn't trigger it, and
+# even Cmd+Q is racy. The honest UX is to keep polling and tell the user the
+# 30s lower bound.
 FLUSH_HINT_AFTER_SECONDS: float = 8.0
 
 # Per-browser profile-cookie locations. Each entry is (loader_name, base_directory).
@@ -190,8 +193,9 @@ def _wait_for_valid_cookie(
 
     Chrome flushes cookies to its on-disk SQLite store roughly every 30s, so a
     freshly-set `metabase.SESSION` can be invisible to us for a while. After
-    `FLUSH_HINT_AFTER_SECONDS` we surface a hint suggesting the user close the
-    Metabase tab — closing a tab forces an immediate flush.
+    `FLUSH_HINT_AFTER_SECONDS` we surface a status note explaining the wait.
+    There's no reliable way to force an earlier flush — closing the
+    tab/window does nothing, and Cmd+Q is racy.
     """
     start = time.monotonic()
     deadline = start + timeout
@@ -219,8 +223,9 @@ def _wait_for_valid_cookie(
 
         if not flush_hint_shown and time.monotonic() - start >= FLUSH_HINT_AFTER_SECONDS:
             click.echo(
-                "  hint: if you've already signed in, close the Metabase tab — "
-                "Chrome only flushes cookies to disk every ~30s, but closing a tab forces it.",
+                "  note: Chrome batches cookie writes to disk every ~30s. "
+                "If you've signed in, just wait — the CLI will pick them up on the next flush. "
+                "Closing the tab or window does NOT force a flush.",
             )
             flush_hint_shown = True
 


### PR DESCRIPTION
## Problem

Closing tab after `hogli metabase:login` to persist cookies doesn't work, users just have to wait. 


## Changes

- Get rid of close tab hint, it isn't true

## How did you test this code?

N/A

## Publish to changelog?

No
## Docs update

No