### PR TITLE
fix(cdp): guard against usage of non-existent globals in transformations

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -947,8 +947,22 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     }
                 }
 
+                const baseGlobals = sampleGlobals ?? exampleInvocationGlobals
+
+                // Transformations only receive `project` and `event` at runtime
+                // (see HogTransformerService.createInvocationGlobals). Hide `person`,
+                // `groups`, `source`, etc. so input templates can't reference them
+                // and trigger a "Global variable not found" failure in production.
+                if (configuration.type === 'transformation') {
+                    return {
+                        project: baseGlobals.project,
+                        event: baseGlobals.event,
+                        inputs,
+                    }
+                }
+
                 return {
-                    ...(sampleGlobals ?? exampleInvocationGlobals),
+                    ...baseGlobals,
                     inputs,
                 }
             },

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1745,6 +1745,28 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert function.filters.get("filter_test_accounts", None) is None
         assert function.filters.get("bytecode") is not None
 
+    def test_transformation_rejects_inputs_referencing_unavailable_globals(self):
+        # Realtime transformations only have project, event, and inputs in scope
+        # (HogTransformerService.createInvocationGlobals). Saving an input template
+        # that references person/groups/source must fail validation rather than
+        # crash ingestion at runtime.
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "name": "Bad transformation",
+                "type": "transformation",
+                "hog": "return event",
+                "enabled": False,
+                "inputs_schema": [{"key": "pid", "type": "string", "required": False}],
+                "inputs": {"pid": {"value": "person_id = {person?.id}"}},
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        body = response.json()
+        # Error is nested under inputs.pid by run_child_validation
+        assert "person" in json.dumps(body)
+        assert "transformation" in json.dumps(body).lower()
+
     def test_limits_transformation_functions_per_team(self):
         """Test that we can create unlimited disabled transformations but only 20 enabled ones"""
         # 1. Create several disabled transformations (more than the limit)

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1762,10 +1762,15 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             },
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-        body = response.json()
-        # Error is nested under inputs.pid by run_child_validation
-        assert "person" in json.dumps(body)
-        assert "transformation" in json.dumps(body).lower()
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "invalid_input",
+            "attr": "inputs__pid",
+            "detail": (
+                "Invalid template: Variable not available in transformations: person. "
+                "Transformations only have access to project, event, and inputs."
+            ),
+        }
 
     def test_limits_transformation_functions_per_team(self):
         """Test that we can create unlimited disabled transformations but only 20 enabled ones"""

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -371,37 +371,20 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         assert validated["A"].get("transpiled") is None
         assert validated["A"].get("value") == "{inputs.X} + A"
 
-    def test_validate_transformation_inputs_rejects_unavailable_globals(self):
-        # Transformations only have access to project, event, and inputs at runtime
-        # (HogTransformerService.createInvocationGlobals). Referencing other globals
-        # like person, groups, or source must be caught at validation time so we
-        # don't crash the realtime ingestion worker with a "Global variable not found"
-        # error from the Hog VM.
-        inputs_schema = [
-            {"key": "person_id", "type": "string", "required": True},
-        ]
-        inputs = {
-            "person_id": {"value": "{person?.id}"},
-        }
-
-        with self.assertRaises(ValidationError) as ctx:
-            validate_inputs(inputs_schema, inputs, function_type="transformation")
-
-        message = str(ctx.exception)
-        assert "person" in message
-        assert "transformation" in message.lower()
-
     @parameterized.expand(
         [
+            ("person", "{person?.id}"),
             ("groups", "{groups.organization.id}"),
             ("source", "{source.name}"),
             ("multiple", "{person?.id} {groups.organization.id}"),
         ]
     )
     def test_validate_transformation_inputs_rejects_unavailable_global(self, _name: str, value: str):
-        inputs_schema = [
-            {"key": "payload", "type": "string", "required": True},
-        ]
+        # Transformations only have access to project, event, and inputs at runtime
+        # (HogTransformerService.createInvocationGlobals). Referencing other globals
+        # must be caught at validation time so we don't crash the realtime ingestion
+        # worker with a "Global variable not found" error from the Hog VM.
+        inputs_schema = [{"key": "payload", "type": "string", "required": True}]
         inputs = {"payload": {"value": value}}
 
         with self.assertRaises(ValidationError) as ctx:

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -15,13 +15,13 @@ from posthog.cdp.validation import (
 from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
 
 
-def validate_inputs(schema, inputs):
+def validate_inputs(schema, inputs, function_type="destination"):
     serializer = MappingsSerializer(
         data={
             "inputs_schema": schema,
             "inputs": inputs,
         },
-        context={"function_type": "destination"},
+        context={"function_type": function_type},
     )
     serializer.is_valid(raise_exception=True)
     return serializer.validated_data["inputs"]
@@ -370,6 +370,75 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         assert validated["A"].get("bytecode") is None
         assert validated["A"].get("transpiled") is None
         assert validated["A"].get("value") == "{inputs.X} + A"
+
+    def test_validate_transformation_inputs_rejects_unavailable_globals(self):
+        # Transformations only have access to project, event, and inputs at runtime
+        # (HogTransformerService.createInvocationGlobals). Referencing other globals
+        # like person, groups, or source must be caught at validation time so we
+        # don't crash the realtime ingestion worker with a "Global variable not found"
+        # error from the Hog VM.
+        inputs_schema = [
+            {"key": "person_id", "type": "string", "required": True},
+        ]
+        inputs = {
+            "person_id": {"value": "{person?.id}"},
+        }
+
+        with self.assertRaises(ValidationError) as ctx:
+            validate_inputs(inputs_schema, inputs, function_type="transformation")
+
+        message = str(ctx.exception)
+        assert "person" in message
+        assert "transformation" in message.lower()
+
+    @parameterized.expand(
+        [
+            ("groups", "{groups.organization.id}"),
+            ("source", "{source.name}"),
+            ("multiple", "{person?.id} {groups.organization.id}"),
+        ]
+    )
+    def test_validate_transformation_inputs_rejects_unavailable_global(self, _name: str, value: str):
+        inputs_schema = [
+            {"key": "payload", "type": "string", "required": True},
+        ]
+        inputs = {"payload": {"value": value}}
+
+        with self.assertRaises(ValidationError) as ctx:
+            validate_inputs(inputs_schema, inputs, function_type="transformation")
+
+        assert "transformation" in str(ctx.exception).lower()
+
+    def test_validate_transformation_inputs_allows_event_project_inputs(self):
+        inputs_schema = [
+            {"key": "first", "type": "string", "required": True},
+            {"key": "second", "type": "string", "required": True},
+        ]
+        inputs = {
+            "first": {"value": "hello {event.distinct_id} from {project.name}"},
+            "second": {"value": "{inputs.first}!"},
+        }
+
+        validated = validate_inputs(inputs_schema, inputs, function_type="transformation")
+        assert validated["first"]["bytecode"] is not None
+        assert validated["second"]["bytecode"] is not None
+
+    def test_validate_transformation_inputs_allows_stl_and_runtime_functions(self):
+        # STL functions (e.g. now) and transformation runtime helpers (e.g. geoipLookup)
+        # are valid root identifiers because the Hog VM falls back to STL/runtime lookups
+        # when a global isn't found.
+        inputs_schema = [
+            {"key": "ts", "type": "string", "required": True},
+            {"key": "geo", "type": "string", "required": True},
+        ]
+        inputs = {
+            "ts": {"value": "{now()}"},
+            "geo": {"value": "{geoipLookup(event.properties.$ip)}"},
+        }
+
+        validated = validate_inputs(inputs_schema, inputs, function_type="transformation")
+        assert validated["ts"]["bytecode"] is not None
+        assert validated["geo"]["bytecode"] is not None
 
     def test_validate_inputs_with_secret_values(self):
         inputs_schema = [

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -15,6 +15,9 @@ from posthog.hogql.visitor import TraversingVisitor
 from posthog.cdp.filters import compile_filters_bytecode, compile_filters_expr
 from posthog.models.hog_functions.hog_function import TYPES_WITH_JAVASCRIPT_SOURCE, TYPES_WITH_TRANSPILED_FILTERS
 
+from common.hogvm.python.stl import STL
+from common.hogvm.python.stl.bytecode import BYTECODE_STL
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,6 +34,23 @@ register_supported_function("postHogGetTicket")
 register_supported_function("postHogUpdateTicket")
 
 
+# Globals that the realtime transformer actually populates at runtime.
+# Keep in sync with HogTransformerService.createInvocationGlobals
+# (nodejs/src/cdp/hog-transformations/hog-transformer.service.ts).
+TRANSFORMATION_AVAILABLE_GLOBALS = {"project", "event", "inputs"}
+
+# Helper functions that the transformer exposes via getTransformationFunctions
+# (nodejs/src/cdp/hog-transformations/transformation-functions.ts). These resolve
+# via GET_GLOBAL when referenced as a closure rather than called inline.
+TRANSFORMATION_RUNTIME_FUNCTIONS = {
+    "geoipLookup",
+    "cleanNullValues",
+    "isKnownBotUserAgent",
+    "isKnownBotIp",
+    "postHogCapture",
+}
+
+
 class InputCollector(TraversingVisitor):
     inputs: set[str]
 
@@ -43,6 +63,36 @@ class InputCollector(TraversingVisitor):
         if node.chain[0] == "inputs":
             if len(node.chain) > 1:
                 self.inputs.add(str(node.chain[1]))
+
+
+class TransformationGlobalsValidator(TraversingVisitor):
+    """Reject input templates that reference globals unavailable to the realtime
+    transformer (e.g. `person`, `groups`, `source`). Without this check, the bytecode
+    compiles fine and the failure surfaces only at ingestion time as
+    "Could not execute bytecode for input field" / "Global variable not found".
+    """
+
+    invalid_globals: set[str]
+
+    def __init__(self):
+        super().__init__()
+        self.invalid_globals = set()
+
+    def visit_field(self, node: ast.Field):
+        super().visit_field(node)
+        if not node.chain:
+            return
+        root = str(node.chain[0])
+        if (
+            root in TRANSFORMATION_AVAILABLE_GLOBALS
+            or root in TRANSFORMATION_RUNTIME_FUNCTIONS
+            or root in CORE_SUPPORTED_FUNCTIONS
+            or root in PRODUCT_ASYNC_FUNCTIONS
+            or root in STL
+            or root in BYTECODE_STL
+        ):
+            return
+        self.invalid_globals.add(root)
 
 
 class HyphenatedPropertyDetector(TraversingVisitor):
@@ -85,15 +135,19 @@ def collect_inputs(node: ast.Expr) -> set[str]:
     return input_collector.inputs
 
 
-def generate_template_bytecode(obj: Any, input_collector: set[str]) -> Any:
+def generate_template_bytecode(
+    obj: Any,
+    input_collector: set[str],
+    function_type: Optional[str] = None,
+) -> Any:
     """
     Clones an object, compiling any string values to bytecode templates
     """
 
     if isinstance(obj, dict):
-        return {key: generate_template_bytecode(value, input_collector) for key, value in obj.items()}
+        return {key: generate_template_bytecode(value, input_collector, function_type) for key, value in obj.items()}
     elif isinstance(obj, list):
-        return [generate_template_bytecode(item, input_collector) for item in obj]
+        return [generate_template_bytecode(item, input_collector, function_type) for item in obj]
     elif isinstance(obj, str):
         node = parse_string_template(obj)
         input_collector.update(collect_inputs(node))
@@ -101,6 +155,15 @@ def generate_template_bytecode(obj: Any, input_collector: set[str]) -> Any:
         detector.visit(node)
         if detector.errors:
             raise Exception(detector.errors[0])
+        if function_type == "transformation":
+            transformation_validator = TransformationGlobalsValidator()
+            transformation_validator.visit(node)
+            if transformation_validator.invalid_globals:
+                names = ", ".join(sorted(transformation_validator.invalid_globals))
+                raise Exception(
+                    f"Variable not available in transformations: {names}. "
+                    f"Transformations only have access to project, event, and inputs."
+                )
         return create_bytecode(node).bytecode
     else:
         return obj
@@ -273,7 +336,9 @@ class InputsItemSerializer(serializers.Serializer):
                                 del attrs["bytecode"]
                         else:
                             input_collector: set[str] = set()
-                            attrs["bytecode"] = generate_template_bytecode(value, input_collector)
+                            attrs["bytecode"] = generate_template_bytecode(
+                                value, input_collector, function_type=function_type
+                            )
                             attrs["input_deps"] = list(input_collector)
                             if "transpiled" in attrs:
                                 del attrs["transpiled"]

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -42,12 +42,12 @@ TRANSFORMATION_AVAILABLE_GLOBALS = {"project", "event", "inputs"}
 # Helper functions that the transformer exposes via getTransformationFunctions
 # (nodejs/src/cdp/hog-transformations/transformation-functions.ts). These resolve
 # via GET_GLOBAL when referenced as a closure rather than called inline.
+# postHogCapture is intentionally omitted — it lives in CORE_SUPPORTED_FUNCTIONS.
 TRANSFORMATION_RUNTIME_FUNCTIONS = {
     "geoipLookup",
     "cleanNullValues",
     "isKnownBotUserAgent",
     "isKnownBotIp",
-    "postHogCapture",
 }
 
 


### PR DESCRIPTION
## Problem

Context: https://posthog.slack.com/archives/C06GG249PR6/p1777485006873609

Transformations don't have access to certain globals like `person` or `groups` as they execute pre-ingestion

## Changes

- Don't include non-existent globals in the autocomplete on transformations client-side
- Validate the globals used when transformations are saved/compiled

## How did you test this code?

Added tests for validation changes

Validated autocomplete 
<img width="555" height="187" alt="image" src="https://github.com/user-attachments/assets/df4dfaef-d741-47ef-a455-41a0b5c1f024" />

and validated the error being passed when trying to use an invalid global:

<img width="866" height="628" alt="image" src="https://github.com/user-attachments/assets/18d025a6-d8a6-4282-a0db-9f69f856c388" />

Also validated neither of the above changes affect destinations or sources

## Publish to changelog?

No

## Docs update

Transformation globals only have `project` and `event`, and do not include `person`, `groups`, or `source`