### PR TITLE
refactor(dwh): align slack source channel listing with destination implementation

### DIFF
--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -142,12 +142,15 @@ def _fetch_channels_page(
     return data.get("channels", []), next_cursor
 
 
-def _fetch_channels_by_type(access_token: str, channel_type: str) -> list[dict[str, Any]]:
-    # For private channels, use users.conversations so we only get channels the calling
-    # token (the bot) is a member of, which is the only set we can sync history from.
+def _fetch_channels_by_type(
+    access_token: str, channel_type: str, authed_user: str | None = None
+) -> list[dict[str, Any]]:
+    # For private channels, use users.conversations scoped to the installer so we only
+    # surface channels the installer is in.
+    use_users_conversations = channel_type == "private_channel"
     url = (
         "https://slack.com/api/users.conversations"
-        if channel_type == "private_channel"
+        if use_users_conversations
         else "https://slack.com/api/conversations.list"
     )
     channels: list[dict[str, Any]] = []
@@ -159,6 +162,8 @@ def _fetch_channels_by_type(access_token: str, channel_type: str) -> list[dict[s
             "limit": _CHANNELS_PAGE_SIZE,
             "exclude_archived": "false",
         }
+        if use_users_conversations and authed_user:
+            params["user"] = authed_user
         if cursor:
             params["cursor"] = cursor
 
@@ -176,11 +181,11 @@ def _fetch_channels_by_type(access_token: str, channel_type: str) -> list[dict[s
     return channels
 
 
-def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
+def _fetch_all_channels(access_token: str, authed_user: str | None = None) -> list[dict[str, Any]]:
     # Fetch public and private separately — Slack's conversations.list pagination is buggy
     # when public and private types are requested in a single call.
     public = _fetch_channels_by_type(access_token, "public_channel")
-    private = _fetch_channels_by_type(access_token, "private_channel")
+    private = _fetch_channels_by_type(access_token, "private_channel", authed_user)
     return public + private
 
 
@@ -261,9 +266,9 @@ def _fetch_thread_replies(
         has_more = cursor is not None
 
 
-def get_channels(access_token: str) -> list[dict[str, str]]:
+def get_channels(access_token: str, authed_user: str | None = None) -> list[dict[str, str]]:
     """Return channel id + name pairs for all accessible channels."""
-    return [{"id": ch["id"], "name": ch["name"]} for ch in _fetch_all_channels(access_token)]
+    return [{"id": ch["id"], "name": ch["name"]} for ch in _fetch_all_channels(access_token, authed_user)]
 
 
 def _add_timestamp(msg: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -1,3 +1,4 @@
+import time
 import datetime
 import dataclasses
 from collections.abc import AsyncIterable, Callable, Iterable, Iterator
@@ -155,6 +156,8 @@ def _fetch_channels_by_type(
     )
     channels: list[dict[str, Any]] = []
     cursor: str | None = None
+    pages = 0
+    t_start = time.monotonic()
 
     for _ in range(_CHANNELS_MAX_PAGES):
         params: dict[str, Any] = {
@@ -169,6 +172,7 @@ def _fetch_channels_by_type(
 
         page, cursor = _fetch_channels_page(url, access_token, params)
         channels.extend(page)
+        pages += 1
         if cursor is None:
             break
     else:
@@ -177,6 +181,15 @@ def _fetch_channels_by_type(
             channel_type=channel_type,
             max_pages=_CHANNELS_MAX_PAGES,
         )
+
+    logger.info(
+        "Slack channel fetch complete",
+        channel_type=channel_type,
+        url=url,
+        pages=pages,
+        channel_count=len(channels),
+        elapsed_ms=int((time.monotonic() - t_start) * 1000),
+    )
 
     return channels
 

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -122,18 +122,21 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
     raise ValueError(f"Unknown Slack resource: {name}")
 
 
-def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
+_CHANNELS_PAGE_SIZE = 200
+_CHANNELS_MAX_PAGES = 50
+
+
+def _fetch_channels_by_type(access_token: str, channel_type: str) -> list[dict[str, Any]]:
     channels: list[dict[str, Any]] = []
-    has_more = True
     cursor: str | None = None
     url = "https://slack.com/api/conversations.list"
     headers = {"Authorization": f"Bearer {access_token}"}
 
-    while has_more:
+    for _ in range(_CHANNELS_MAX_PAGES):
         params: dict[str, Any] = {
-            "types": "public_channel,private_channel",
-            "limit": 999,
-            "exclude_archived": "false",
+            "types": channel_type,
+            "limit": _CHANNELS_PAGE_SIZE,
+            "exclude_archived": "true",
         }
         if cursor:
             params["cursor"] = cursor
@@ -149,9 +152,18 @@ def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
         channels.extend(data.get("channels", []))
 
         cursor = data.get("response_metadata", {}).get("next_cursor", "") or None
-        has_more = cursor is not None
+        if cursor is None:
+            break
 
     return channels
+
+
+def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
+    # Fetch public and private separately — Slack's conversations.list pagination is buggy
+    # when public and private types are requested in a single call.
+    public = _fetch_channels_by_type(access_token, "public_channel")
+    private = _fetch_channels_by_type(access_token, "private_channel")
+    return public + private
 
 
 def _fetch_messages_page(

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -126,43 +126,76 @@ _CHANNELS_PAGE_SIZE = 200
 _CHANNELS_MAX_PAGES = 50
 
 
-def _fetch_channels_by_type(access_token: str, channel_type: str) -> list[dict[str, Any]]:
+def _fetch_channels_page(
+    url: str, access_token: str, params: dict[str, Any]
+) -> tuple[list[dict[str, Any]], str | None]:
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = _slack_get(url, headers=headers, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+
+    if not data.get("ok"):
+        error = data.get("error", "unknown_error")
+        raise Exception(f"Slack API error fetching channels: {error}")
+
+    next_cursor = data.get("response_metadata", {}).get("next_cursor", "") or None
+    return data.get("channels", []), next_cursor
+
+
+def _fetch_public_channels(access_token: str) -> list[dict[str, Any]]:
+    url = "https://slack.com/api/conversations.list"
     channels: list[dict[str, Any]] = []
     cursor: str | None = None
-    url = "https://slack.com/api/conversations.list"
-    headers = {"Authorization": f"Bearer {access_token}"}
 
     for _ in range(_CHANNELS_MAX_PAGES):
         params: dict[str, Any] = {
-            "types": channel_type,
+            "types": "public_channel",
             "limit": _CHANNELS_PAGE_SIZE,
             "exclude_archived": "true",
         }
         if cursor:
             params["cursor"] = cursor
 
-        response = _slack_get(url, headers=headers, params=params, timeout=10)
-        response.raise_for_status()
-        data = response.json()
-
-        if not data.get("ok"):
-            error = data.get("error", "unknown_error")
-            raise Exception(f"Slack API error fetching channels: {error}")
-
-        channels.extend(data.get("channels", []))
-
-        cursor = data.get("response_metadata", {}).get("next_cursor", "") or None
+        page, cursor = _fetch_channels_page(url, access_token, params)
+        channels.extend(page)
         if cursor is None:
             break
 
     return channels
 
 
-def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
+def _fetch_private_channels(access_token: str, authed_user: str | None) -> list[dict[str, Any]]:
+    # users.conversations only returns channels the user is a member of, which is the
+    # only set we can sync history for anyway. Avoids enumerating private channels the
+    # token can see but cannot read.
+    url = "https://slack.com/api/users.conversations"
+    channels: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    for _ in range(_CHANNELS_MAX_PAGES):
+        params: dict[str, Any] = {
+            "types": "private_channel",
+            "limit": _CHANNELS_PAGE_SIZE,
+            "exclude_archived": "true",
+        }
+        if authed_user:
+            params["user"] = authed_user
+        if cursor:
+            params["cursor"] = cursor
+
+        page, cursor = _fetch_channels_page(url, access_token, params)
+        channels.extend(page)
+        if cursor is None:
+            break
+
+    return channels
+
+
+def _fetch_all_channels(access_token: str, authed_user: str | None = None) -> list[dict[str, Any]]:
     # Fetch public and private separately — Slack's conversations.list pagination is buggy
     # when public and private types are requested in a single call.
-    public = _fetch_channels_by_type(access_token, "public_channel")
-    private = _fetch_channels_by_type(access_token, "private_channel")
+    public = _fetch_public_channels(access_token)
+    private = _fetch_private_channels(access_token, authed_user)
     return public + private
 
 
@@ -243,9 +276,9 @@ def _fetch_thread_replies(
         has_more = cursor is not None
 
 
-def get_channels(access_token: str) -> list[dict[str, str]]:
+def get_channels(access_token: str, authed_user: str | None = None) -> list[dict[str, str]]:
     """Return channel id + name pairs for all accessible channels."""
-    return [{"id": ch["id"], "name": ch["name"]} for ch in _fetch_all_channels(access_token)]
+    return [{"id": ch["id"], "name": ch["name"]} for ch in _fetch_all_channels(access_token, authed_user)]
 
 
 def _add_timestamp(msg: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -142,16 +142,22 @@ def _fetch_channels_page(
     return data.get("channels", []), next_cursor
 
 
-def _fetch_public_channels(access_token: str) -> list[dict[str, Any]]:
-    url = "https://slack.com/api/conversations.list"
+def _fetch_channels_by_type(access_token: str, channel_type: str) -> list[dict[str, Any]]:
+    # For private channels, use users.conversations so we only get channels the calling
+    # token (the bot) is a member of, which is the only set we can sync history from.
+    url = (
+        "https://slack.com/api/users.conversations"
+        if channel_type == "private_channel"
+        else "https://slack.com/api/conversations.list"
+    )
     channels: list[dict[str, Any]] = []
     cursor: str | None = None
 
     for _ in range(_CHANNELS_MAX_PAGES):
         params: dict[str, Any] = {
-            "types": "public_channel",
+            "types": channel_type,
             "limit": _CHANNELS_PAGE_SIZE,
-            "exclude_archived": "true",
+            "exclude_archived": "false",
         }
         if cursor:
             params["cursor"] = cursor
@@ -160,42 +166,21 @@ def _fetch_public_channels(access_token: str) -> list[dict[str, Any]]:
         channels.extend(page)
         if cursor is None:
             break
+    else:
+        logger.warning(
+            "Slack channel page cap reached; some channels may be missing",
+            channel_type=channel_type,
+            max_pages=_CHANNELS_MAX_PAGES,
+        )
 
     return channels
 
 
-def _fetch_private_channels(access_token: str, authed_user: str | None) -> list[dict[str, Any]]:
-    # users.conversations only returns channels the user is a member of, which is the
-    # only set we can sync history for anyway. Avoids enumerating private channels the
-    # token can see but cannot read.
-    url = "https://slack.com/api/users.conversations"
-    channels: list[dict[str, Any]] = []
-    cursor: str | None = None
-
-    for _ in range(_CHANNELS_MAX_PAGES):
-        params: dict[str, Any] = {
-            "types": "private_channel",
-            "limit": _CHANNELS_PAGE_SIZE,
-            "exclude_archived": "true",
-        }
-        if authed_user:
-            params["user"] = authed_user
-        if cursor:
-            params["cursor"] = cursor
-
-        page, cursor = _fetch_channels_page(url, access_token, params)
-        channels.extend(page)
-        if cursor is None:
-            break
-
-    return channels
-
-
-def _fetch_all_channels(access_token: str, authed_user: str | None = None) -> list[dict[str, Any]]:
+def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
     # Fetch public and private separately — Slack's conversations.list pagination is buggy
     # when public and private types are requested in a single call.
-    public = _fetch_public_channels(access_token)
-    private = _fetch_private_channels(access_token, authed_user)
+    public = _fetch_channels_by_type(access_token, "public_channel")
+    private = _fetch_channels_by_type(access_token, "private_channel")
     return public + private
 
 
@@ -276,9 +261,9 @@ def _fetch_thread_replies(
         has_more = cursor is not None
 
 
-def get_channels(access_token: str, authed_user: str | None = None) -> list[dict[str, str]]:
+def get_channels(access_token: str) -> list[dict[str, str]]:
     """Return channel id + name pairs for all accessible channels."""
-    return [{"id": ch["id"], "name": ch["name"]} for ch in _fetch_all_channels(access_token, authed_user)]
+    return [{"id": ch["id"], "name": ch["name"]} for ch in _fetch_all_channels(access_token)]
 
 
 def _add_timestamp(msg: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -1,4 +1,3 @@
-import time
 import datetime
 import dataclasses
 from collections.abc import AsyncIterable, Callable, Iterable, Iterator
@@ -156,8 +155,6 @@ def _fetch_channels_by_type(
     )
     channels: list[dict[str, Any]] = []
     cursor: str | None = None
-    pages = 0
-    t_start = time.monotonic()
 
     for _ in range(_CHANNELS_MAX_PAGES):
         params: dict[str, Any] = {
@@ -172,7 +169,6 @@ def _fetch_channels_by_type(
 
         page, cursor = _fetch_channels_page(url, access_token, params)
         channels.extend(page)
-        pages += 1
         if cursor is None:
             break
     else:
@@ -181,15 +177,6 @@ def _fetch_channels_by_type(
             channel_type=channel_type,
             max_pages=_CHANNELS_MAX_PAGES,
         )
-
-    logger.info(
-        "Slack channel fetch complete",
-        channel_type=channel_type,
-        url=url,
-        pages=pages,
-        channel_count=len(channels),
-        elapsed_ms=int((time.monotonic() - t_start) * 1000),
-    )
 
     return channels
 

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -179,7 +179,8 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
 
         msg_config = messages_endpoint_config()
         webhook_flag_enabled = is_webhook_feature_flag_enabled(team_id)
-        channels = get_channels(access_token)
+        authed_user = (integration.config or {}).get("authed_user", {}).get("id")
+        channels = get_channels(access_token, authed_user)
         for ch in channels:
             if ch["id"] in ENDPOINTS:
                 continue

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -1,7 +1,4 @@
-import time
 from typing import TYPE_CHECKING, Optional, cast
-
-import structlog
 
 if TYPE_CHECKING:
     from posthog.cdp.templates.hog_function_template import HogFunctionTemplateDC
@@ -40,8 +37,6 @@ from posthog.temporal.data_imports.sources.slack.slack import (
 )
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
-
-logger = structlog.get_logger(__name__)
 
 
 @SourceRegistry.register
@@ -177,34 +172,15 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
             for name, endpoint_config in ENDPOINTS.items()
         ]
 
-        t0 = time.monotonic()
         integration = self.get_oauth_integration(config.slack_integration_id, team_id)
-        get_integration_ms = int((time.monotonic() - t0) * 1000)
-
         access_token = integration.access_token
         if not access_token:
             raise ValueError("Slack access token not found")
 
         msg_config = messages_endpoint_config()
-        t1 = time.monotonic()
         webhook_flag_enabled = is_webhook_feature_flag_enabled(team_id)
-        webhook_flag_ms = int((time.monotonic() - t1) * 1000)
-
         authed_user = (integration.config or {}).get("authed_user", {}).get("id")
-        t2 = time.monotonic()
         channels = get_channels(access_token, authed_user)
-        get_channels_ms = int((time.monotonic() - t2) * 1000)
-
-        logger.info(
-            "Slack get_schemas timings",
-            team_id=team_id,
-            integration_id=config.slack_integration_id,
-            get_oauth_integration_ms=get_integration_ms,
-            is_webhook_feature_flag_enabled_ms=webhook_flag_ms,
-            get_channels_ms=get_channels_ms,
-            channel_count=len(channels),
-        )
-
         for ch in channels:
             if ch["id"] in ENDPOINTS:
                 continue

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -1,4 +1,7 @@
+import time
 from typing import TYPE_CHECKING, Optional, cast
+
+import structlog
 
 if TYPE_CHECKING:
     from posthog.cdp.templates.hog_function_template import HogFunctionTemplateDC
@@ -37,6 +40,8 @@ from posthog.temporal.data_imports.sources.slack.slack import (
 )
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
+
+logger = structlog.get_logger(__name__)
 
 
 @SourceRegistry.register
@@ -172,15 +177,34 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
             for name, endpoint_config in ENDPOINTS.items()
         ]
 
+        t0 = time.monotonic()
         integration = self.get_oauth_integration(config.slack_integration_id, team_id)
+        get_integration_ms = int((time.monotonic() - t0) * 1000)
+
         access_token = integration.access_token
         if not access_token:
             raise ValueError("Slack access token not found")
 
         msg_config = messages_endpoint_config()
+        t1 = time.monotonic()
         webhook_flag_enabled = is_webhook_feature_flag_enabled(team_id)
+        webhook_flag_ms = int((time.monotonic() - t1) * 1000)
+
         authed_user = (integration.config or {}).get("authed_user", {}).get("id")
+        t2 = time.monotonic()
         channels = get_channels(access_token, authed_user)
+        get_channels_ms = int((time.monotonic() - t2) * 1000)
+
+        logger.info(
+            "Slack get_schemas timings",
+            team_id=team_id,
+            integration_id=config.slack_integration_id,
+            get_oauth_integration_ms=get_integration_ms,
+            is_webhook_feature_flag_enabled_ms=webhook_flag_ms,
+            get_channels_ms=get_channels_ms,
+            channel_count=len(channels),
+        )
+
         for ch in channels:
             if ch["id"] in ENDPOINTS:
                 continue

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -179,8 +179,7 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
 
         msg_config = messages_endpoint_config()
         webhook_flag_enabled = is_webhook_feature_flag_enabled(team_id)
-        authed_user = (integration.config or {}).get("authed_user", {}).get("id")
-        channels = get_channels(access_token, authed_user)
+        channels = get_channels(access_token)
         for ch in channels:
             if ch["id"] in ENDPOINTS:
                 continue

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 import dataclasses
 from collections.abc import Callable
@@ -1455,12 +1456,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         source_config: Config = source.parse_config(request.data)
 
         access_method = request.data.get("access_method", ExternalDataSource.AccessMethod.WAREHOUSE)
+        t_validate = time.monotonic()
         if source_type_model == ExternalDataSourceType.POSTGRES and isinstance(source, PostgresSource):
             credentials_valid, credentials_error = source.validate_credentials_for_access_method(
                 cast(Any, source_config), self.team_id, access_method
             )
         else:
             credentials_valid, credentials_error = source.validate_credentials(source_config, self.team_id)
+        validate_credentials_ms = int((time.monotonic() - t_validate) * 1000)
         if not credentials_valid:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -1468,13 +1471,23 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             )
 
         try:
+            t_schemas = time.monotonic()
             schemas = source.get_schemas(source_config, self.team_id)
+            get_schemas_ms = int((time.monotonic() - t_schemas) * 1000)
         except Exception as e:
             capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": str(e)},
             )
+
+        logger.info(
+            "database_schema timings",
+            source_type=source_type,
+            team_id=self.team_id,
+            validate_credentials_ms=validate_credentials_ms,
+            get_schemas_ms=get_schemas_ms,
+        )
 
         data = [
             {

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 import uuid
 import dataclasses
 from collections.abc import Callable
@@ -1456,14 +1455,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         source_config: Config = source.parse_config(request.data)
 
         access_method = request.data.get("access_method", ExternalDataSource.AccessMethod.WAREHOUSE)
-        t_validate = time.monotonic()
         if source_type_model == ExternalDataSourceType.POSTGRES and isinstance(source, PostgresSource):
             credentials_valid, credentials_error = source.validate_credentials_for_access_method(
                 cast(Any, source_config), self.team_id, access_method
             )
         else:
             credentials_valid, credentials_error = source.validate_credentials(source_config, self.team_id)
-        validate_credentials_ms = int((time.monotonic() - t_validate) * 1000)
         if not credentials_valid:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -1471,23 +1468,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             )
 
         try:
-            t_schemas = time.monotonic()
             schemas = source.get_schemas(source_config, self.team_id)
-            get_schemas_ms = int((time.monotonic() - t_schemas) * 1000)
         except Exception as e:
             capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": str(e)},
             )
-
-        logger.info(
-            "database_schema timings",
-            source_type=source_type,
-            team_id=self.team_id,
-            validate_credentials_ms=validate_credentials_ms,
-            get_schemas_ms=get_schemas_ms,
-        )
 
         data = [
             {


### PR DESCRIPTION
## Problem

`get_schemas` on the Slack DWH source synchronously walks the full workspace via `conversations.list` on every call. The original implementation:

- requested public + private channels in one call (`types=public_channel,private_channel`)
- `limit=999`
- no upper bound on page count
- enumerated *all* private channels the token could see (not just the installer's)

Slack's pagination is documented to misbehave when public and private types are mixed, and `conversations.list` is Tier 2 rate-limited. The endpoint runs on at least six synchronous request paths (database_schema, source create, refresh_schemas, webhook info, incremental_fields, schema save) and once per sync workflow per schema (`sync_new_schemas_activity`), so any latency hits both setup *and* every recurring sync.

This rewrites the channel walk to match the shape used by `SlackIntegration._list_channels_by_type` in `posthog/models/integration.py` (the path used by the slack notification picker), which has had this fixed for a while.

> Note: this PR does **not** demonstrably fix the prod 504 we originally chased. Tested against the same real workspace (~1,700 active / 3,200 incl. archived channels), local fetch completes in ~5s with this change *and* with master. The prod 504 still reproduces. The actual root cause is environmental (egress, smokescreen, pgbouncer, or workspace+IP-specific Slack-side throttling) and isn't addressed here. The change is still worth shipping — it brings the DWH source in line with the hog-functions pattern, removes the pagination footgun, and bounds worst-case latency — but it's not the cure for the original symptom.

## Changes

`posthog/temporal/data_imports/sources/slack/slack.py`

- Split public and private into two calls — Slack's pagination misbehaves when mixed.
- Public via `conversations.list` (`types=public_channel`).
- Private via `users.conversations` with `user=authed_user` so the picker only surfaces private channels the installer is in (matches what `SlackIntegration._list_channels_by_type` does).
- Page size 200 (was 999), page cap of 50.
- `exclude_archived=false` retained — archived channels can still hold history worth syncing.
- Warning log if the page cap is hit, so silent truncation is visible.

`posthog/temporal/data_imports/sources/slack/source.py`

- Read `authed_user` from `integration.config` and thread it through `get_channels`.

## How did you test this code?

tested locally

Agent-authored. Verified with `ruff check` / `ruff format --check`. No new unit tests; existing tests in `posthog/temporal/data_imports/sources/slack/test_slack.py` cover `_channel_messages_generator` only. Marcus tested manually against the real workspace and a dummy workspace; both complete locally in ~5–10s.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) while triaging a 504 on the Slack source setup wizard. Approach modeled on `SlackIntegration._list_channels_by_type` (CDP/notification path). Reviewer findings from greptile/codex were addressed in follow-up commits — collapsed into a single helper, added the page-cap warning, kept the installer-scoped private filter at the author's direction.