### PR TITLE
chore(insights): add chart-level snapshot coverage for LineChart

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -437,9 +437,9 @@ snapshots:
     components-hogcharts-confidenceintervals--with-confidence-interval--light:
         hash: v1.k794b7964.872d5390447a4e85f525f4f79bd9a6a007ee1cfa90bf1a4341ce22e857cf6918.ay7TMZRj8gV2tKRZEujR_vpiuDCMbPePuNdwxdIPGOk
     components-hogcharts-linechart--combined-overlays--dark:
-        hash: v1.k794b7964.c5a8a474aea07c75839570ecfc81757a6b06a18e04f9baa4241fe2a2b129d4d1.DApkA71DQZR0Y-Y54VTJqmVLBsmRAEnR3-y92O4uZjw
+        hash: v1.k794b7964.7a5d75d739b30755468fe69e4b938e16d93630e7d2f444d2a76563563879a8f5.-qZogPFTjOPrh2r16ccI1VbZlTPiwhGHuF4WbzwpHT4
     components-hogcharts-linechart--combined-overlays--light:
-        hash: v1.k794b7964.e667333199005e111ec7d7362a336ac65388c18c95ec072e04abd0836e53d4cb.AUvjlwH_XTgxgJ1ucQl_6K4XuZLIn0Kn4m8NtbjTBQo
+        hash: v1.k794b7964.2278588bb82f5838d3fec1cd9404a616c63d92de1093847ff6b0efce95882cea.WiBltYxSZN09NESRdqGqFHCF58HTluiMubxTgu1EqoE
     components-hogcharts-linechart--empty--dark:
         hash: v1.k794b7964.7a6b8e36701b93a9bebab15b93727325eaf346c0481197d5d27cd78a73a5f4bb.aUIOXdmfVTD3jj9zPc0Kp34ea-id895WSIn2d8H6PFw
     components-hogcharts-linechart--empty--light:
@@ -451,11 +451,11 @@ snapshots:
     components-hogcharts-linechart--hovering-interior--dark:
         hash: v1.k794b7964.18d2c15b48bc79e3aabb0637be32ab73f9c58ee5584f83e0ebf1b73cc9053043.imV72kIK_Qi2MeMFHU4MaaVYuUQsk605X6qEn_KLPiI
     components-hogcharts-linechart--hovering-interior--light:
-        hash: v1.k794b7964.192d63dda0258f8efd5ed76d9c0986cbec382e96568fda741b8a348e9786cd74.9b4t93IthoEWwQP6XjL5cDuddraG7EPn7F5gj9foL7A
+        hash: v1.k794b7964.97b24842568d31e103fbc14a74dbde8d127b1c989a286fb9335f6cd3fcbbadee.Thj7lo_fVYhKC-fmbyENCRb4oTWjQ-NaS68fQqQXGvU
     components-hogcharts-linechart--hovering-multi-series--dark:
-        hash: v1.k794b7964.016606042c4e7cc6319b1a03f826801f1148549fed614e7a4a15d2551740c65b.WHxY8eFvzwH_5UHVVhLrSQ16XlRQBCPb3KnZvEQ9qA4
+        hash: v1.k794b7964.11d54b94370b999de8977132e50b4922f7edb9a87fdba8c42db0f7a58e48d095.L6hlWxJuv0iwtqypuSwtCnVO0h3rBreA-khfP5Qjko0
     components-hogcharts-linechart--hovering-multi-series--light:
-        hash: v1.k794b7964.2f07e5a71d7e5e5f4ae5a4f2d30744e93cf3edac3e8551897e8b66c66ad9b619.AuL5J46cFwxmbU-dtrz6pCWeUQvE8WNstX9HFsesl5Q
+        hash: v1.k794b7964.70f132cdf8f58bbf43c6106ac793ac4f501afe8a94c7ed14346a8976aabe6e6d.6AF-ONm6_CqLz9nn5YutOAKlPcDXTpp26xS4OCT0n0A
     components-hogcharts-linechart--many-series--dark:
         hash: v1.k794b7964.651d26aee99cdf52eaabede15157f44744373c2ee95c7ebe272213091992e155.A3UxxLDnt4fDzoyS6DZ8OQheGo_26ekphLERuShmyvY
     components-hogcharts-linechart--many-series--light:
@@ -463,11 +463,11 @@ snapshots:
     components-hogcharts-linechart--multi-series--dark:
         hash: v1.k794b7964.d17376a7ca912b10bf71077e011fdafa6d227a01be83dcc4b24008543e0c7054.7dY7490s_ZW4y9vK659DwPdPxWGGznM3OnxM5nNyz9w
     components-hogcharts-linechart--multi-series--light:
-        hash: v1.k794b7964.8e9d92926fcf762002dedb0c89a19cea579bcead5dce6f990900e397d4f6c40b.tUxYT-eGTqMPTq0YQIaYWziXTnx5UFACBpIr4DikdkU
+        hash: v1.k794b7964.db034f8fe411906e06b1ff3e3c8e4ac2d76d07ce9476a0765f308c874cd42f39._M2mLsUzM1ERnbl99iETXWR2rVRQwwSs5Ag7LHvxRLs
     components-hogcharts-linechart--percent-stacked--dark:
-        hash: v1.k794b7964.151e4b2eceb7038e4a11fc550dba7363cad1808867ea916b66917b569d9358e0.3o8YSSgHnWl_oL5apqGZwAvFulwQ3vFecTN4lIBTSI8
+        hash: v1.k794b7964.2d6be6ef557131c137770d4b0a80187a987f57692d93c9b45cb7934bc6123451.9gYpZI3PxZXqpbkYW4k0GRaThIs8o-TI_rAabh9woHM
     components-hogcharts-linechart--percent-stacked--light:
-        hash: v1.k794b7964.14e2fed601af006cd8555117669d2f27157f83a5d306d79c36031b1773cc6b05.a4B7Bx2kCLn1Dv0Q9xhgdq3661rjiJSbqjfWDx8DH4c
+        hash: v1.k794b7964.b6fe03ee1438dffbfbe2bf8394c2a3108fb89ff9444bf0d7264f5d3623d4ea6e.uHPWMqqFXORnRPN2wLgW1KxrN79TLNwXLXAs1bAKYJs
     components-hogcharts-linechart--single-point--dark:
         hash: v1.k794b7964.084f4f1e65ab3d0abd675392d90e5560e180c35f45875adfd4bc28ff75b8c969.0eQfxCHv6jI1cHyxFUmQCZsWnovj76qePLK6eL_175o
     components-hogcharts-linechart--single-point--light:
@@ -475,19 +475,19 @@ snapshots:
     components-hogcharts-linechart--single-series--dark:
         hash: v1.k794b7964.905b7a8104c293e4bffb689b1c572c852f0c925b3d632378ee2b4d3f8cce17cd.IeN1kOdiwrSLPxQ3-Xn3fxFWHIbZtqtCzPW3Ufp3wXw
     components-hogcharts-linechart--single-series--light:
-        hash: v1.k794b7964.893c557f630b80c9ad0861f7f9f195759dede32383ba5b1796769d71de0c638c.wKP1vsrJm91moYLjcArBlPLLysQiwBzJSnq8-7hBz9o
+        hash: v1.k794b7964.7e06990d72eba73cbe98a56980d6ad8b5dd848bb6795ad4a4567cfae9b7e5a6d.xs3PwlPLTw2m_aKKvNMgG3Rumqlx0PK5Faqabb3wBYw
     components-hogcharts-linechart--stacked-area--dark:
-        hash: v1.k794b7964.238710a67ddd71972e624bbe574996b5db00b791cd323677d5aca21030788b17.2eTL_QhJJVM3_frQvjh-UefbfIOmKLg9fKOX7qsZ6hY
+        hash: v1.k794b7964.69ef6aab838398322997d2bc1831762000119207c817656955184482bc47bfb3.i7DnJy-de0j7Jyjt0tVLPsyQ_X6TLHhm7lujuTNF-UE
     components-hogcharts-linechart--stacked-area--light:
-        hash: v1.k794b7964.2f27494adfb437c5c197d95589d6ae25ddaa3afd6d3e905b85d8d58088fb15ff.L8lxmnRniEtBb1BJSMdZusvu1zG8IZutNhgtJK3LMIU
+        hash: v1.k794b7964.3bad452cd2aea2ca7374f0ab0e0b01527fca6ac9e258d39e91df50c8111486cc.zNi1BvI1s7bNfkosyRZW9U7fotrMAJws-77UJXJ4UN4
     components-hogcharts-linechart--visibility-flags--dark:
-        hash: v1.k794b7964.4d878f081e713ada47c146e4a6a1c85628439ca85c958ff0b6fb8baaabbeba04.tOVsPSNTruJSLHO0kfSbpV-mvLgeC7VJ22E-wmlLXdU
+        hash: v1.k794b7964.b926b5acefb82767f156e3f0b76fbe19be12f7f4bb998800f139b42a285fc536.fThACiM4ZrtUpqOnt30pzbkVKujO_1Sj7nSS9e7lNhk
     components-hogcharts-linechart--visibility-flags--light:
-        hash: v1.k794b7964.fcd96dcf2bd5ced1dd6c1a2190d5b8a2dc18453ad1815c60ff65f1d9ec9adc5f.t1glTKDyKZSwSpg4o929Rt8lRH0MroC_lPxXmGlyye4
+        hash: v1.k794b7964.6e76d4f8e3a05dc0aaae9c828ef04c17a0a50af821e96422470131825ebaa196.a4Ms3oBBGFa67KmLc71cm8Wx5dn7ySk_N868Hzl_c0s
     components-hogcharts-linechart--with-zeros-and-negatives--dark:
         hash: v1.k794b7964.6b868dd41cf9c31e7919efbb69ee9ea7a31ba146125aa8b5b2b5a2fb0469f700.wpxwS5Ve4o8Mm_dPNbQv1-jqbENsLJpIv02AY6N_WeQ
     components-hogcharts-linechart--with-zeros-and-negatives--light:
-        hash: v1.k794b7964.161cf54ec116cc7fd641120a88308799364ce4ee5f75c01433b17db832e8d7cc.avIHcqyVmkkAQgP6IOigLWHa88C05xEz459sVXhpIEo
+        hash: v1.k794b7964.3c2096610dd967b7736f6f9f2a4be43cee495d6b19586894aeceadf2849aa8e8.bMQyMS8C1ZbkdWveYKjwBPbilQUHrqiOfKWZ8crSfUk
     components-hogcharts-referenceline--fill-sides--dark:
         hash: v1.k794b7964.90f4952ddfc3e8b1645a462a24fcbde0a40584ffb0b2450fba6df79726a30033.4kZQt2UNtLSWspx7msbeULVNxN7Bm6mV9hNEZ6hZNXs
     components-hogcharts-referenceline--fill-sides--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -436,6 +436,58 @@ snapshots:
         hash: v1.k794b7964.2361a0c1dfa2cd3d505400852acf783ed1bbd387445b8a6b5db1764f3e28bafc.2OgFJ6v3t7A7Z-SFc340tRdOW6yVKOp5-2GoQxI1GHM
     components-hogcharts-confidenceintervals--with-confidence-interval--light:
         hash: v1.k794b7964.872d5390447a4e85f525f4f79bd9a6a007ee1cfa90bf1a4341ce22e857cf6918.ay7TMZRj8gV2tKRZEujR_vpiuDCMbPePuNdwxdIPGOk
+    components-hogcharts-linechart--combined-overlays--dark:
+        hash: v1.k794b7964.c5a8a474aea07c75839570ecfc81757a6b06a18e04f9baa4241fe2a2b129d4d1.DApkA71DQZR0Y-Y54VTJqmVLBsmRAEnR3-y92O4uZjw
+    components-hogcharts-linechart--combined-overlays--light:
+        hash: v1.k794b7964.e667333199005e111ec7d7362a336ac65388c18c95ec072e04abd0836e53d4cb.AUvjlwH_XTgxgJ1ucQl_6K4XuZLIn0Kn4m8NtbjTBQo
+    components-hogcharts-linechart--empty--dark:
+        hash: v1.k794b7964.7a6b8e36701b93a9bebab15b93727325eaf346c0481197d5d27cd78a73a5f4bb.aUIOXdmfVTD3jj9zPc0Kp34ea-id895WSIn2d8H6PFw
+    components-hogcharts-linechart--empty--light:
+        hash: v1.k794b7964.da0284f9a90b3c06906e3414c7c3bf5cf362b7bb056d1ff4433007a429115cb0.tEKJxW2KmrBvuxxv_-WGNExaAbQL5Q04mvOAzObrnrg
+    components-hogcharts-linechart--error-boundary--dark:
+        hash: v1.k794b7964.985e4fee358d8b78e99b9f44e36cb47d031c9acf2d5fcbeeedfd9df922fc2325.WdrzatVDLo9cB3tkcFBe8jUY0A4WAmYlhFJFdjmOqVM
+    components-hogcharts-linechart--error-boundary--light:
+        hash: v1.k794b7964.71c1966fb319e455c7d712cd4a480e99ea73e66b04d72d4d1fe4222b058a5a3e.A2RMx3ED_wk_NM0l603i9XWa8hTv5r9JQgHOT5M7L9U
+    components-hogcharts-linechart--hovering-interior--dark:
+        hash: v1.k794b7964.18d2c15b48bc79e3aabb0637be32ab73f9c58ee5584f83e0ebf1b73cc9053043.imV72kIK_Qi2MeMFHU4MaaVYuUQsk605X6qEn_KLPiI
+    components-hogcharts-linechart--hovering-interior--light:
+        hash: v1.k794b7964.192d63dda0258f8efd5ed76d9c0986cbec382e96568fda741b8a348e9786cd74.9b4t93IthoEWwQP6XjL5cDuddraG7EPn7F5gj9foL7A
+    components-hogcharts-linechart--hovering-multi-series--dark:
+        hash: v1.k794b7964.016606042c4e7cc6319b1a03f826801f1148549fed614e7a4a15d2551740c65b.WHxY8eFvzwH_5UHVVhLrSQ16XlRQBCPb3KnZvEQ9qA4
+    components-hogcharts-linechart--hovering-multi-series--light:
+        hash: v1.k794b7964.2f07e5a71d7e5e5f4ae5a4f2d30744e93cf3edac3e8551897e8b66c66ad9b619.AuL5J46cFwxmbU-dtrz6pCWeUQvE8WNstX9HFsesl5Q
+    components-hogcharts-linechart--many-series--dark:
+        hash: v1.k794b7964.651d26aee99cdf52eaabede15157f44744373c2ee95c7ebe272213091992e155.A3UxxLDnt4fDzoyS6DZ8OQheGo_26ekphLERuShmyvY
+    components-hogcharts-linechart--many-series--light:
+        hash: v1.k794b7964.a73151386f30dcd2c2150b124ca80a57656f0a22c6aaf4953a23dc268bca2ef9.EymtQzCmC3RTiKKTBQYVj_J5nASJZVgE709nJLgAd38
+    components-hogcharts-linechart--multi-series--dark:
+        hash: v1.k794b7964.d17376a7ca912b10bf71077e011fdafa6d227a01be83dcc4b24008543e0c7054.7dY7490s_ZW4y9vK659DwPdPxWGGznM3OnxM5nNyz9w
+    components-hogcharts-linechart--multi-series--light:
+        hash: v1.k794b7964.8e9d92926fcf762002dedb0c89a19cea579bcead5dce6f990900e397d4f6c40b.tUxYT-eGTqMPTq0YQIaYWziXTnx5UFACBpIr4DikdkU
+    components-hogcharts-linechart--percent-stacked--dark:
+        hash: v1.k794b7964.151e4b2eceb7038e4a11fc550dba7363cad1808867ea916b66917b569d9358e0.3o8YSSgHnWl_oL5apqGZwAvFulwQ3vFecTN4lIBTSI8
+    components-hogcharts-linechart--percent-stacked--light:
+        hash: v1.k794b7964.14e2fed601af006cd8555117669d2f27157f83a5d306d79c36031b1773cc6b05.a4B7Bx2kCLn1Dv0Q9xhgdq3661rjiJSbqjfWDx8DH4c
+    components-hogcharts-linechart--single-point--dark:
+        hash: v1.k794b7964.084f4f1e65ab3d0abd675392d90e5560e180c35f45875adfd4bc28ff75b8c969.0eQfxCHv6jI1cHyxFUmQCZsWnovj76qePLK6eL_175o
+    components-hogcharts-linechart--single-point--light:
+        hash: v1.k794b7964.76efd9de8c7c8aa527ac72fed88c33acaee91a73ab2cdba292394ee7754d1886.tcI38O9AEQ0k6fgvYrNT1L00pSgSoIKQPb0Y5tq0YnQ
+    components-hogcharts-linechart--single-series--dark:
+        hash: v1.k794b7964.905b7a8104c293e4bffb689b1c572c852f0c925b3d632378ee2b4d3f8cce17cd.IeN1kOdiwrSLPxQ3-Xn3fxFWHIbZtqtCzPW3Ufp3wXw
+    components-hogcharts-linechart--single-series--light:
+        hash: v1.k794b7964.893c557f630b80c9ad0861f7f9f195759dede32383ba5b1796769d71de0c638c.wKP1vsrJm91moYLjcArBlPLLysQiwBzJSnq8-7hBz9o
+    components-hogcharts-linechart--stacked-area--dark:
+        hash: v1.k794b7964.238710a67ddd71972e624bbe574996b5db00b791cd323677d5aca21030788b17.2eTL_QhJJVM3_frQvjh-UefbfIOmKLg9fKOX7qsZ6hY
+    components-hogcharts-linechart--stacked-area--light:
+        hash: v1.k794b7964.2f27494adfb437c5c197d95589d6ae25ddaa3afd6d3e905b85d8d58088fb15ff.L8lxmnRniEtBb1BJSMdZusvu1zG8IZutNhgtJK3LMIU
+    components-hogcharts-linechart--visibility-flags--dark:
+        hash: v1.k794b7964.4d878f081e713ada47c146e4a6a1c85628439ca85c958ff0b6fb8baaabbeba04.tOVsPSNTruJSLHO0kfSbpV-mvLgeC7VJ22E-wmlLXdU
+    components-hogcharts-linechart--visibility-flags--light:
+        hash: v1.k794b7964.fcd96dcf2bd5ced1dd6c1a2190d5b8a2dc18453ad1815c60ff65f1d9ec9adc5f.t1glTKDyKZSwSpg4o929Rt8lRH0MroC_lPxXmGlyye4
+    components-hogcharts-linechart--with-zeros-and-negatives--dark:
+        hash: v1.k794b7964.6b868dd41cf9c31e7919efbb69ee9ea7a31ba146125aa8b5b2b5a2fb0469f700.wpxwS5Ve4o8Mm_dPNbQv1-jqbENsLJpIv02AY6N_WeQ
+    components-hogcharts-linechart--with-zeros-and-negatives--light:
+        hash: v1.k794b7964.161cf54ec116cc7fd641120a88308799364ce4ee5f75c01433b17db832e8d7cc.avIHcqyVmkkAQgP6IOigLWHa88C05xEz459sVXhpIEo
     components-hogcharts-referenceline--fill-sides--dark:
         hash: v1.k794b7964.90f4952ddfc3e8b1645a462a24fcbde0a40584ffb0b2450fba6df79726a30033.4kZQt2UNtLSWspx7msbeULVNxN7Bm6mV9hNEZ6hZNXs
     components-hogcharts-referenceline--fill-sides--light:

--- a/frontend/src/lib/hog-charts/LineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/LineChart.stories.tsx
@@ -1,0 +1,281 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { LineChart, ReferenceLine, ValueLabels } from 'lib/hog-charts'
+import type { LineChartConfig, Series } from 'lib/hog-charts'
+import { ciRanges, trendLine } from 'lib/statistics'
+
+import { playHoverAtFraction, Stage, useReactiveTheme } from './story-helpers'
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const BASIC: LineChartConfig = { showGrid: true }
+const HOVER: LineChartConfig = { showGrid: true, showCrosshair: true }
+
+const SINGLE: Series[] = [{ key: 'visits', label: 'Visits', color: '', data: [20, 35, 28, 60, 45, 70, 52] }]
+
+const PAIR: Series[] = [
+    { key: 'visits', label: 'Visits', color: '', data: [20, 35, 28, 60, 45, 70, 52] },
+    { key: 'signups', label: 'Sign-ups', color: '', data: [4, 8, 6, 14, 11, 19, 13] },
+]
+
+const STACK: Series[] = [
+    { key: 'web', label: 'Web', color: '', data: [10, 14, 12, 22, 18, 26, 20], fill: { opacity: 0.5 } },
+    { key: 'ios', label: 'iOS', color: '', data: [6, 9, 8, 12, 14, 17, 13], fill: { opacity: 0.5 } },
+    { key: 'android', label: 'Android', color: '', data: [4, 6, 7, 11, 10, 14, 12], fill: { opacity: 0.5 } },
+]
+
+const meta: Meta = { title: 'Components/HogCharts/LineChart', parameters: { layout: 'centered' } }
+export default meta
+
+type Story = StoryObj<{}>
+
+export const SingleSeries: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart series={SINGLE} labels={DAYS} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const MultiSeries: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart series={PAIR} labels={DAYS} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const StackedArea: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart series={STACK} labels={DAYS} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const PercentStacked: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart series={STACK} labels={DAYS} config={{ ...BASIC, percentStackView: true }} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const SinglePoint: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart
+                    series={[{ key: 'v', label: 'Visits', color: '', data: [42] }]}
+                    labels={['Today']}
+                    config={BASIC}
+                    theme={theme}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const ManySeries: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const series: Series[] = Array.from({ length: 12 }, (_, i) => ({
+            key: `s${i}`,
+            label: `Series ${i + 1}`,
+            color: '',
+            data: DAYS.map((_, j) => 10 + ((i * 7 + j * 11) % 30)),
+        }))
+        return (
+            <Stage>
+                <LineChart series={series} labels={DAYS} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const WithZerosAndNegatives: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const series: Series[] = [{ key: 'a', label: 'Net flow', color: '', data: [0, -5, -12, 0, 8, 14, -3] }]
+        return (
+            <Stage>
+                <LineChart series={series} labels={DAYS} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+export const Empty: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart series={[]} labels={[]} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+/** Hover at an interior point — captures tooltip + crosshair + highlight rings. */
+export const HoveringInterior: Story = {
+    parameters: { layout: 'fullscreen' },
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+                <Stage>
+                    <LineChart series={PAIR} labels={DAYS} config={HOVER} theme={theme} />
+                </Stage>
+            </div>
+        )
+    },
+    play: async ({ canvasElement }) => {
+        await playHoverAtFraction(canvasElement, 0.5)
+    },
+}
+
+/** Multi-series hover with one series hidden from the tooltip via `fromTooltip`. */
+export const HoveringMultiSeries: Story = {
+    parameters: { layout: 'fullscreen' },
+    render: () => {
+        const theme = useReactiveTheme()
+        const series: Series[] = [
+            ...STACK,
+            {
+                key: 'baseline',
+                label: 'Baseline',
+                color: theme.colors[6],
+                data: DAYS.map(() => 30),
+                stroke: { pattern: [4, 4] },
+                visibility: { fromTooltip: true, fromStack: true },
+            },
+        ]
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+                <Stage>
+                    <LineChart series={series} labels={DAYS} config={HOVER} theme={theme} />
+                </Stage>
+            </div>
+        )
+    },
+    play: async ({ canvasElement }) => {
+        await playHoverAtFraction(canvasElement, 0.5)
+    },
+}
+
+/** Demonstrates each series-visibility flag side by side. */
+export const VisibilityFlags: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const base: Series[] = [
+            { key: 'a', label: 'A', color: '', data: [20, 35, 28, 60, 45, 70, 52] },
+            { key: 'b', label: 'B', color: '', data: [10, 14, 12, 22, 18, 26, 20] },
+            { key: 'c', label: 'C', color: '', data: [5, 9, 8, 12, 11, 16, 12] },
+        ]
+        const cases: { title: string; series: Series[] }[] = [
+            { title: 'excluded', series: [base[0], { ...base[1], visibility: { excluded: true } }, base[2]] },
+            {
+                title: 'fromValueLabels',
+                series: [base[0], { ...base[1], visibility: { fromValueLabels: true } }, base[2]],
+            },
+            {
+                title: 'fromStack (auxiliary)',
+                series: [
+                    { ...base[0], fill: { opacity: 0.5 } },
+                    { ...base[1], fill: { opacity: 0.5 } },
+                    {
+                        key: 'avg',
+                        label: 'Moving avg',
+                        color: theme.colors[6],
+                        data: [12, 18, 17, 25, 24, 33, 27],
+                        stroke: { pattern: [4, 4] },
+                        visibility: { fromStack: true },
+                    },
+                ],
+            },
+        ]
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 24 }}>
+                {cases.map((c) => (
+                    <Stage key={c.title}>
+                        {/* eslint-disable-next-line react/forbid-dom-props */}
+                        <div style={{ fontSize: 12, marginBottom: 4 }}>{c.title}</div>
+                        <LineChart series={c.series} labels={DAYS} config={BASIC} theme={theme}>
+                            <ValueLabels />
+                        </LineChart>
+                    </Stage>
+                ))}
+            </div>
+        )
+    },
+}
+
+/** Multiple overlays composed on the same chart — catches z-order / clipping regressions. */
+export const CombinedOverlays: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const color = theme.colors[0]
+        const data = [20, 35, 28, 60, 45, 70, 52]
+        const [lower, upper] = ciRanges(data, 0.95)
+        const series: Series[] = [
+            { key: 'visits', label: 'Visits', color, data, points: { radius: 3 } },
+            {
+                key: 'visits__ci',
+                label: 'Visits (CI)',
+                color,
+                data: upper,
+                fill: { opacity: 0.2, lowerData: lower },
+                visibility: { fromTooltip: true, fromValueLabels: true },
+            },
+            {
+                key: 'visits__trend',
+                label: 'Visits (trend)',
+                color,
+                data: trendLine(data),
+                stroke: { pattern: [1, 3] },
+                visibility: { fromTooltip: true, fromValueLabels: true, fromStack: true },
+            },
+        ]
+        return (
+            <Stage width={560} height={320}>
+                <LineChart series={series} labels={DAYS} config={BASIC} theme={theme}>
+                    <ReferenceLine value={50} label="Target" variant="goal" />
+                    <ReferenceLine value="Fri" orientation="vertical" label="Launch" variant="marker" />
+                    <ValueLabels />
+                </LineChart>
+            </Stage>
+        )
+    },
+}
+
+function ThrowOnRender(): JSX.Element {
+    throw new Error('intentional render error for ChartErrorBoundary story')
+}
+
+export const ErrorBoundary: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <LineChart series={SINGLE} labels={DAYS} config={BASIC} theme={theme}>
+                    <ThrowOnRender />
+                </LineChart>
+            </Stage>
+        )
+    },
+}

--- a/frontend/src/lib/hog-charts/LineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/LineChart.stories.tsx
@@ -263,7 +263,7 @@ export const CombinedOverlays: Story = {
     },
 }
 
-function ThrowOnRender(): JSX.Element {
+function ThrowOnRender(): never {
     throw new Error('intentional render error for ChartErrorBoundary story')
 }
 


### PR DESCRIPTION
## Problem

The existing hog-charts stories all focus on overlay components (ConfidenceIntervals, TrendLines, ValueLabels, ReferenceLine), so the chart itself has no visual baseline for common rendering states or hover-driven UI. A regression in the canvas renderer, layout, or interaction layer can ship without any snapshot diff to catch it.

## Changes

Adds `LineChart.stories.tsx` with thirteen stories covering:

- **Plain layouts**: `SingleSeries`, `MultiSeries`, `StackedArea`, `PercentStacked`, `SinglePoint`, `ManySeries`, `WithZerosAndNegatives`, `Empty`.
- **Hover paths**: `HoveringInterior`, `HoveringMultiSeries` — each uses a `play` function that dispatches a `mousemove` on the chart wrapper so the portaled tooltip and crosshair land in the body-level snapshot.
- **Mixed states**: `VisibilityFlags` (excluded / fromValueLabels / fromStack side by side), `CombinedOverlays` (CI band + trend line + reference lines + value labels stacked on the same chart), `ErrorBoundary` (child throws → captures the fallback UI).

Stacked on top of #56969 — reuses `Stage`, `useReactiveTheme`, and `playHoverAtFraction` from `story-helpers.tsx`.

## How did you test this code?

I'm an agent (PostHog Code / Claude Opus 4.7). I ran:

- `oxlint` against the new file — 0 warnings, 0 errors.
- `oxfmt` against the new file.
- Type-check via a scoped tsconfig — no errors in changed files.

I did not run the storybook test runner. Snapshots will be generated on the first CI run on this branch.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Claude Opus 4.7). This PR is the second half of a split — #56969 carries the helper extraction and color fix, and this PR layers the chart-level coverage on top so each branch stays under 500 lines of change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*