### PR TITLE
chore(quill): scope postcss config to quill workspace

### DIFF
--- a/packages/quill/postcss.config.cjs
+++ b/packages/quill/postcss.config.cjs
@@ -1,0 +1,5 @@
+// Scopes postcss config to the quill workspace so vite builds don't walk up
+// and pick up the repo-root config (which targets webpack/Storybook v7 and
+// pulls in autoprefixer/cssnano deps that aren't part of the quill graph).
+// Quill uses Tailwind v4 via @tailwindcss/vite, no extra postcss plugins needed.
+module.exports = { plugins: [] }


### PR DESCRIPTION
## Problem

Setting up Cloudflare Pages for the Quill Storybook. Vite's postcss walks up the directory tree looking for a config and lands on the repo-root `postcss.config.js`, which targets webpack/Storybook v7 and requires `autoprefixer` / `postcss-preset-env` / `cssnano`. CF Pages installs only the quill workspace subset (`pnpm --filter=@posthog/quill-storybook... install`), so those root-only deps aren't present and the build crashes with `Cannot find module 'autoprefixer'`.

Falling back to a full `pnpm install` works but pulls in the rest of the monorepo, including `node-rdkafka`'s native compile — slow and fragile on CF builders.

## Changes

Add an empty `packages/quill/postcss.config.cjs`. Quill uses Tailwind v4 via `@tailwindcss/vite` and doesn't need any postcss plugins, so an empty config is enough to halt the upward search and keep postcss scoped to the quill workspace.

## How did you test this code?

Agent-authored. Ran `pnpm --filter=@posthog/quill-workspace build` locally — all five quill packages (tokens, primitives, components, blocks, quill) build clean. Will verify the CF Pages deploy after merge with the filtered install command back in place.

## Publish to changelog?

no

## 🤖 Agent context

Authored via Claude Code while wiring up CF Pages for the Quill Storybook. The deploy log surfaced the postcss config leak from the repo root; this PR scopes it. CF Pages build command can stay on the filtered install (`pnpm --filter=@posthog/quill-storybook... install --frozen-lockfile && pnpm --filter=@posthog/quill-workspace build && pnpm --filter=@posthog/quill-storybook build-storybook`) once this lands.