### PR TITLE
fix(proxy): enforce minimum TLS 1.2 for new Cloudflare custom hostnames

### DIFF
--- a/posthog/temporal/proxy_service/cloudflare.py
+++ b/posthog/temporal/proxy_service/cloudflare.py
@@ -9,7 +9,7 @@ This module provides functions to interact with Cloudflare's API for:
 
 import typing as t
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 
 from django.conf import settings
 
@@ -29,7 +29,7 @@ class CloudflareAPIError(Exception):
         return any(err.get("code") == 10000 for err in self.errors) or "rate limit" in str(self).lower()
 
 
-class CustomHostnameSSLStatus(str, Enum):
+class CustomHostnameSSLStatus(StrEnum):
     """SSL certificate status for a Custom Hostname."""
 
     INITIALIZING = "initializing"
@@ -41,7 +41,7 @@ class CustomHostnameSSLStatus(str, Enum):
     DELETED = "deleted"
 
 
-class CustomHostnameStatus(str, Enum):
+class CustomHostnameStatus(StrEnum):
     """Status for a Custom Hostname."""
 
     ACTIVE = "active"
@@ -122,6 +122,9 @@ def create_custom_hostname(domain: str) -> CustomHostnameInfo:
         "ssl": {
             "method": "http",
             "type": "dv",
+            "settings": {
+                "min_tls_version": "1.2",
+            },
         },
     }
 


### PR DESCRIPTION
## Problem

New Cloudflare custom hostnames created for the managed reverse proxy were not explicitly enforcing a minimum TLS version, falling back to the zone default. This means new proxy hostnames could potentially accept TLS 1.0/1.1 connections.

## Changes

Set `ssl.settings.min_tls_version` to `"1.2"` in the `create_custom_hostname` payload in `posthog/temporal/proxy_service/cloudflare.py`. This follows the [Cloudflare Custom Hostnames API](https://developers.cloudflare.com/api/resources/custom_hostnames/methods/create/) structure where `min_tls_version` lives under `ssl.settings`, not directly under `ssl`.

Also fixed two pre-existing ruff `UP042` violations in the same file (`str, Enum` → `StrEnum`).

## How did you test this code?

I'm an agent. I validated the correct field path against the Cloudflare API docs (`ssl.settings.min_tls_version` with valid values `"1.0"`, `"1.1"`, `"1.2"`, `"1.3"`). No automated tests exist for this API call; the change only affects the payload sent to Cloudflare at custom hostname creation time. Manual testing would require a Cloudflare account with the proxy configured.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Sonnet 4.6 via Claude Code. The key decision was using `ssl.settings.min_tls_version` (not `ssl.min_tls_version`) — confirmed against the Cloudflare API reference. The pre-existing `UP042` violations were fixed to avoid CI failures since they are in the same file.