### PR TITLE
feat(personhog-leader): add cache warming

### DIFF
--- a/rust/personhog-leader/README.md
+++ b/rust/personhog-leader/README.md
@@ -50,12 +50,78 @@ TBD:
 - this offset is the boundary:
 - below the offset: state is durably in Postgres
 - at or above the offset: state is PG + the changes in our distributed log (the kafka topic)
-TBD:
-- new pods can warm their caches/materialize state by seeding from PG then applying messages from kafka changelog past the indicated offset O_pg_writer(P) (could change depending on caching/embedded store choice)
+
+#### Cache warming on partition handoff
+
+When a partition moves between leader pods, the new owner repopulates
+its cache by replaying the slice of `personhog_updates` that the
+writer has not yet persisted to PG. The warming pipeline lives in
+`src/warming.rs` and is invoked by `LeaderHandoffHandler::warm_partition`
+when the handoff reaches the `Warming` phase (see
+`personhog-coordination`'s README for the full
+`Freezing → Draining → Warming → Complete` protocol).
+
+**Pre-conditions established by the protocol:**
+
+- `Freezing` collected freeze quorum from every router → no router
+  forwards to the old owner anymore.
+- `Draining` waited for the old owner's in-flight handlers to complete
+  and produced `PodDrainedAck` → no producer can append to this
+  partition's Kafka log.
+
+By the time `Warming` runs, the partition's HWM is therefore stable
+and warming can consume to a known endpoint without racing producers.
+
+**The pipeline:**
+
+1. Query the writer's consumer group's committed offset
+   (`O_pg_writer(P)`) via a short-lived OffsetFetch consumer. Anything
+   at or after this offset still needs to be in cache; anything below
+   is already durable in PG.
+2. Resolve the start offset: `committed_offset - lookback_offsets`,
+   clamped to the partition's earliest available offset. The lookback
+   is a configurable safety margin against momentary races between
+   the writer's commit and our read of it.
+3. `assign()` (not `subscribe()`) the warming consumer to the
+   partition at the resolved start offset and consume until HWM.
+4. Buffer decoded records locally; only commit them to the cache
+   after the entire range warms successfully via
+   `PartitionedCache::install_warmed_partition`, which builds the
+   populated `PersonCache` first and publishes it via a single
+   `DashMap::insert`. Any decode/IO failure mid-range aborts warming
+   with no observable cache mutation, preventing a partial cache from
+   silently masking PG fallback reads.
+
+**Configurable knobs** (env vars, see `src/config.rs`):
+
+- `WRITER_CONSUMER_GROUP` — group whose committed offset bounds the
+  warming range.
+- `WARM_LOOKBACK_OFFSETS` — safety margin to rewind past the writer's
+  commit.
+- `WARM_COMMITTED_OFFSETS_TIMEOUT_SECS`, `WARM_FETCH_WATERMARKS_TIMEOUT_SECS`,
+  `WARM_RECV_TIMEOUT_SECS` — Kafka call timeouts.
+- `WARM_RETRY_MAX_ATTEMPTS`, `WARM_RETRY_INITIAL_BACKOFF_MS`,
+  `WARM_RETRY_MAX_BACKOFF_MS` — retry policy for transient Kafka
+  metadata failures.
+
+The synchronous rdkafka calls (`committed_offsets`, `fetch_watermarks`)
+run on the blocking pool via `tokio::task::spawn_blocking` so a slow
+broker can't park the runtime thread.
 
 #### vNode ownership
 
-TBD
+The pod participates in `personhog-coordination`'s handoff protocol
+via `LeaderHandoffHandler` (see `src/coordination/mod.rs`):
+
+- `drain_partition_inflight` (Draining): waits for `InflightTracker`'s
+  per-partition counter to drop to zero, then writes `PodDrainedAck`.
+  Combined with the produce path's sync-await on Kafka delivery, this
+  gives the protocol the guarantee that "no in-flight" implies
+  "every acked write durable in Kafka."
+- `warm_partition` (Warming): see the section above.
+- `release_partition` (Complete): drops the partition's cache slot
+  via `PartitionedCache::drop_partition` once the routing table has
+  flipped to the new owner.
 
 #### Request Path
 

--- a/rust/personhog-leader/src/cache/partitioned.rs
+++ b/rust/personhog-leader/src/cache/partitioned.rs
@@ -33,6 +33,27 @@ impl PartitionedCache {
             .insert(partition, PersonCache::new(self.per_partition_capacity));
     }
 
+    /// Atomically install a fully-populated partition cache. The records
+    /// are inserted into a fresh `PersonCache` *before* the partition is
+    /// added to the shared `DashMap`, so any thread that observes
+    /// `has_partition(partition) == true` will also see every record —
+    /// no observer can land in the window where the partition exists
+    /// but its keys haven't been put yet. Used by warming so reads that
+    /// arrive immediately after a handoff Complete don't fall through
+    /// to PG and return stale values for records that the writer hasn't
+    /// yet persisted.
+    pub fn install_warmed_partition(
+        &self,
+        partition: u32,
+        records: impl IntoIterator<Item = (PersonCacheKey, CachedPerson)>,
+    ) {
+        let cache = PersonCache::new(self.per_partition_capacity);
+        for (key, person) in records {
+            cache.put(key, person);
+        }
+        self.partitions.insert(partition, cache);
+    }
+
     /// Drop the cache for the given partition, evicting all entries.
     pub fn drop_partition(&self, partition: u32) {
         self.partitions.remove(&partition);

--- a/rust/personhog-leader/src/config.rs
+++ b/rust/personhog-leader/src/config.rs
@@ -23,6 +23,52 @@ pub struct Config {
     #[envconfig(default = "personhog_updates")]
     pub kafka_person_state_topic: String,
 
+    // ── Warming ──────────────────────────────────────────────────
+    /// Consumer group name used by the writer pod. The leader queries this
+    /// group's committed offsets during warming: any Kafka message at or
+    /// after the writer's committed offset has not yet been persisted to PG,
+    /// so it must live in the leader's cache to avoid stale PG fallback
+    /// reads.
+    #[envconfig(default = "personhog-writer")]
+    pub writer_consumer_group: String,
+
+    /// How many offsets to rewind past the writer's committed offset when
+    /// warming. Pure safety margin — any non-negative value is correct, but
+    /// a larger value is more forgiving of momentary races between the
+    /// writer's commit and our observation of it. Bounded above by Kafka's
+    /// earliest available offset.
+    #[envconfig(default = "1000")]
+    pub warm_lookback_offsets: i64,
+
+    /// Timeout for the OffsetFetch round-trip that asks the writer's
+    /// consumer group for its committed offset.
+    #[envconfig(default = "5")]
+    pub warm_committed_offsets_timeout_secs: u64,
+
+    /// Timeout for the per-partition `fetch_watermarks` metadata call.
+    #[envconfig(default = "5")]
+    pub warm_fetch_watermarks_timeout_secs: u64,
+
+    /// Per-message receive timeout while consuming the warming range. If
+    /// hit, warming aborts with the offsets seen so far so the partition
+    /// can be retried fresh.
+    #[envconfig(default = "10")]
+    pub warm_recv_timeout_secs: u64,
+
+    /// Maximum attempts for retryable warming metadata calls
+    /// (committed-offset query, fetch-watermarks).
+    #[envconfig(default = "3")]
+    pub warm_retry_max_attempts: u32,
+
+    /// Initial backoff between warming-step retries; doubles each attempt
+    /// up to `warm_retry_max_backoff_ms`.
+    #[envconfig(default = "500")]
+    pub warm_retry_initial_backoff_ms: u64,
+
+    /// Cap on the exponential backoff between warming-step retries.
+    #[envconfig(default = "5000")]
+    pub warm_retry_max_backoff_ms: u64,
+
     // ── PG fallback ───────────────────────────────────────────────
     /// Read-only Postgres URL for cache miss fallback. If empty, cache
     /// misses return NotFound without querying PG.

--- a/rust/personhog-leader/src/coordination/mod.rs
+++ b/rust/personhog-leader/src/coordination/mod.rs
@@ -14,15 +14,24 @@ const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Handles partition ownership lifecycle events for a leader pod.
 ///
-/// Drives three phase responses via the `HandoffHandler` trait:
-///   - `drain_partition_inflight`: waits until no in-flight request handlers
-///     remain for the partition. Because the produce path awaits the Kafka
-///     delivery future before returning, this implies every write this pod
-///     ever acked is durable in Kafka.
-///   - `warm_partition`: consumes the `personhog_updates` topic for the
-///     partition and repopulates the in-memory cache. Returns the HWM
-///     reached so the coordinator can record it.
-///   - `release_partition`: drops the partition's cache.
+/// Drives three phase responses via the `HandoffHandler` trait,
+/// matching the four-phase handoff protocol
+/// (`Freezing → Draining → Warming → Complete`):
+///   - `drain_partition_inflight` (fired in `Draining` for the
+///     old owner): waits until no in-flight request handlers remain
+///     for the partition. By the time the coordinator advances to
+///     `Draining`, every router has acked freeze and stopped
+///     forwarding, so the inflight count strictly drops to zero.
+///     Because the produce path awaits the Kafka delivery future
+///     before returning, "no in-flight" implies "every write this
+///     pod ever acked is durable in Kafka." The pod then writes
+///     `PodDrainedAck` so the coordinator can advance to `Warming`.
+///   - `warm_partition` (fired in `Warming` for the new owner):
+///     consumes the `personhog_updates` topic for the partition and
+///     repopulates the in-memory cache up to the now-stable HWM.
+///   - `release_partition` (fired in `Complete` for the old owner):
+///     drops the partition's cache after the routing table has
+///     flipped to the new owner.
 pub struct LeaderHandoffHandler {
     cache: Arc<PartitionedCache>,
     inflight: Arc<InflightTracker>,

--- a/rust/personhog-leader/src/coordination/mod.rs
+++ b/rust/personhog-leader/src/coordination/mod.rs
@@ -8,6 +8,7 @@ use tracing::info;
 
 use crate::cache::PartitionedCache;
 use crate::inflight::InflightTracker;
+use crate::warming::{warm_from_kafka, WarmingConfig};
 
 const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -18,19 +19,27 @@ const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(50);
 ///     remain for the partition. Because the produce path awaits the Kafka
 ///     delivery future before returning, this implies every write this pod
 ///     ever acked is durable in Kafka.
-///   - `warm_partition`: creates an empty per-partition cache slot. A
-///     follow-up change wires this to consume the changelog topic and
-///     repopulate state; until then, the new owner takes over with an empty
-///     cache and falls back to PG on miss.
+///   - `warm_partition`: consumes the `personhog_updates` topic for the
+///     partition and repopulates the in-memory cache. Returns the HWM
+///     reached so the coordinator can record it.
 ///   - `release_partition`: drops the partition's cache.
 pub struct LeaderHandoffHandler {
     cache: Arc<PartitionedCache>,
     inflight: Arc<InflightTracker>,
+    warming: WarmingConfig,
 }
 
 impl LeaderHandoffHandler {
-    pub fn new(cache: Arc<PartitionedCache>, inflight: Arc<InflightTracker>) -> Self {
-        Self { cache, inflight }
+    pub fn new(
+        cache: Arc<PartitionedCache>,
+        inflight: Arc<InflightTracker>,
+        warming: WarmingConfig,
+    ) -> Self {
+        Self {
+            cache,
+            inflight,
+            warming,
+        }
     }
 
     pub fn owns_partition(&self, partition: u32) -> bool {
@@ -50,8 +59,8 @@ impl HandoffHandler for LeaderHandoffHandler {
     }
 
     async fn warm_partition(&self, partition: u32) -> Result<()> {
-        info!(partition, "warming partition cache");
-        self.cache.create_partition(partition);
+        info!(partition, "warming partition cache from kafka");
+        warm_from_kafka(&self.warming, &self.cache, partition).await?;
         info!(partition, "partition warmed");
         Ok(())
     }
@@ -67,43 +76,93 @@ impl HandoffHandler for LeaderHandoffHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::warming::WarmingRetryPolicy;
+    use common_kafka::config::KafkaConfig;
 
+    /// `warm_partition` is exercised end-to-end in
+    /// `tests/warming_integration.rs` against a mock Kafka cluster
+    /// because it now consumes from a real broker. These unit tests
+    /// cover the parts of `LeaderHandoffHandler` that don't require
+    /// Kafka: drain semantics, release semantics, and `owns_partition`.
     fn handler() -> LeaderHandoffHandler {
         LeaderHandoffHandler::new(
             Arc::new(PartitionedCache::new(100)),
             Arc::new(InflightTracker::new()),
+            WarmingConfig {
+                kafka: KafkaConfig {
+                    kafka_producer_linger_ms: 0,
+                    kafka_producer_queue_mib: 50,
+                    kafka_message_timeout_ms: 5000,
+                    kafka_compression_codec: "none".to_string(),
+                    kafka_hosts: "localhost:9092".to_string(),
+                    kafka_tls: false,
+                    kafka_producer_queue_messages: 1000,
+                    kafka_client_rack: String::new(),
+                    kafka_client_id: String::new(),
+                },
+                topic: "personhog_updates".to_string(),
+                pod_name: "test".to_string(),
+                writer_consumer_group: "personhog-writer".to_string(),
+                lookback_offsets: 0,
+                committed_offsets_timeout: Duration::from_secs(5),
+                fetch_watermarks_timeout: Duration::from_secs(5),
+                recv_timeout: Duration::from_secs(10),
+                retry: WarmingRetryPolicy {
+                    max_attempts: 3,
+                    initial_backoff: Duration::from_millis(500),
+                    max_backoff: Duration::from_secs(5),
+                },
+            },
         )
     }
 
     #[tokio::test]
-    async fn warm_partition_adds_ownership() {
+    async fn release_partition_drops_cache_entry() {
         let handler = handler();
-        assert!(!handler.owns_partition(42));
-        handler.warm_partition(42).await.unwrap();
+        // Simulate a successful prior warm by creating the partition
+        // directly. We can't call `warm_partition` here because it
+        // would try to talk to Kafka.
+        handler.cache.create_partition(42);
         assert!(handler.owns_partition(42));
-    }
 
-    #[tokio::test]
-    async fn release_partition_removes_ownership() {
-        let handler = handler();
-        handler.warm_partition(42).await.unwrap();
-        assert!(handler.owns_partition(42));
         handler.release_partition(42).await.unwrap();
         assert!(!handler.owns_partition(42));
     }
 
     #[tokio::test]
-    async fn multiple_partitions() {
+    async fn release_partition_is_idempotent_for_unknown_partition() {
         let handler = handler();
-        handler.warm_partition(1).await.unwrap();
-        handler.warm_partition(2).await.unwrap();
-        handler.warm_partition(3).await.unwrap();
+        // Releasing a partition that was never warmed must be a no-op,
+        // not an error. The pod's watch loop can deliver Complete events
+        // for partitions this pod never owned (e.g., during a rapid
+        // assignment churn) and we shouldn't fail the protocol.
+        handler.release_partition(99).await.unwrap();
+        assert!(!handler.owns_partition(99));
+    }
+
+    #[tokio::test]
+    async fn owns_partition_reflects_cache_state_across_lifecycle() {
+        let handler = handler();
+        assert!(!handler.owns_partition(1));
+        handler.cache.create_partition(1);
         assert!(handler.owns_partition(1));
+        handler.cache.create_partition(2);
+        handler.cache.create_partition(3);
         assert!(handler.owns_partition(2));
         assert!(handler.owns_partition(3));
+
         handler.release_partition(2).await.unwrap();
         assert!(handler.owns_partition(1));
         assert!(!handler.owns_partition(2));
         assert!(handler.owns_partition(3));
+    }
+
+    #[tokio::test]
+    async fn drain_partition_inflight_returns_immediately_when_empty() {
+        let handler = handler();
+        // No request handlers in flight → drain returns immediately.
+        // The protocol relies on this for partitions that never
+        // received traffic between Freezing and the actual drain call.
+        handler.drain_partition_inflight(7).await.unwrap();
     }
 }

--- a/rust/personhog-leader/src/lib.rs
+++ b/rust/personhog-leader/src/lib.rs
@@ -6,3 +6,4 @@ pub mod kafka;
 pub mod person_update;
 pub mod pg;
 pub mod service;
+pub mod warming;

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -158,7 +158,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to connect to etcd");
     let store = Arc::new(PersonhogStore::new(etcd_store));
 
-    let handler = LeaderHandoffHandler::new(Arc::clone(&cache), Arc::clone(&inflight));
+    let handler = LeaderHandoffHandler::new(
+        Arc::clone(&cache),
+        Arc::clone(&inflight),
+        personhog_leader::warming::WarmingConfig {
+            kafka: config.kafka.clone(),
+            topic: config.kafka_person_state_topic.clone(),
+            pod_name: config.pod_name.clone(),
+            writer_consumer_group: config.writer_consumer_group.clone(),
+            lookback_offsets: config.warm_lookback_offsets,
+            committed_offsets_timeout: Duration::from_secs(
+                config.warm_committed_offsets_timeout_secs,
+            ),
+            fetch_watermarks_timeout: Duration::from_secs(
+                config.warm_fetch_watermarks_timeout_secs,
+            ),
+            recv_timeout: Duration::from_secs(config.warm_recv_timeout_secs),
+            retry: personhog_leader::warming::WarmingRetryPolicy {
+                max_attempts: config.warm_retry_max_attempts,
+                initial_backoff: Duration::from_millis(config.warm_retry_initial_backoff_ms),
+                max_backoff: Duration::from_millis(config.warm_retry_max_backoff_ms),
+            },
+        },
+    );
     let pod = PodHandle::new(
         store,
         PodConfig {

--- a/rust/personhog-leader/src/warming.rs
+++ b/rust/personhog-leader/src/warming.rs
@@ -190,10 +190,21 @@ fn resolve_start_offset(committed: Option<i64>, earliest: i64, lookback: i64) ->
 
 /// Populate the cache from Kafka for a single partition.
 ///
-/// Invariants at call time (enforced by the handoff protocol's `Warming`
-/// phase): no one is producing to the partition, and the old owner has
-/// drained its in-flight handlers. That means HWM is stable and we can
-/// consume to a known endpoint without racing producers.
+/// Invariants at call time (enforced by the handoff protocol). The
+/// coordinator only advances to `Warming` once two predecessor phases
+/// have closed:
+///
+///   * `Freezing → Draining`: every router has acked freeze and stopped
+///     forwarding to the old owner.
+///   * `Draining → Warming`: the old owner has drained its in-flight
+///     request handlers and written `PodDrainedAck`. Because the leader's
+///     produce path awaits the Kafka delivery future before returning,
+///     "no in-flight" implies "every acked write is durable in Kafka."
+///
+/// Together those mean: by the time `warm_from_kafka` runs, no producer
+/// can append to this partition's Kafka log. The HWM we snapshot here
+/// is therefore stable, and we can consume to a known endpoint without
+/// racing producers.
 pub async fn warm_from_kafka(
     cfg: &WarmingConfig,
     cache: &PartitionedCache,

--- a/rust/personhog-leader/src/warming.rs
+++ b/rust/personhog-leader/src/warming.rs
@@ -38,11 +38,22 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = CoordResult<T>>,
 {
+    // `max_attempts = 0` would make the loop body never run and the
+    // trailing `unreachable!` panic the warming task. Clamp to at least
+    // one so a misconfigured env var still produces a single attempt
+    // and a real error on failure rather than a panic. `debug_assert`
+    // surfaces the misconfiguration during development.
+    debug_assert!(
+        policy.max_attempts >= 1,
+        "warming retry max_attempts must be >= 1; got {}",
+        policy.max_attempts,
+    );
+    let max_attempts = policy.max_attempts.max(1);
     let mut backoff = policy.initial_backoff;
-    for attempt in 1..=policy.max_attempts {
+    for attempt in 1..=max_attempts {
         match f().await {
             Ok(v) => return Ok(v),
-            Err(e) if attempt == policy.max_attempts => {
+            Err(e) if attempt == max_attempts => {
                 counter!(
                     "personhog_leader_warm_retries_exhausted_total",
                     "stage" => stage.to_string()
@@ -258,8 +269,11 @@ pub async fn warm_from_kafka(
         .map_err(|e| CoordError::invalid_state(format!("consumer assign: {e}")))?;
 
     if hwm <= start_offset {
-        // Empty range — mark the partition as owned with an empty cache.
-        cache.create_partition(partition);
+        // Empty range — install an empty partition cache. Use the
+        // atomic install path so this matches the populated path's
+        // publication semantics (the partition becomes observable in
+        // a single dashmap insert).
+        cache.install_warmed_partition(partition, std::iter::empty());
         tracing::info!(partition, hwm, start_offset, "no messages to warm in range");
         return Ok(());
     }
@@ -311,6 +325,19 @@ pub async fn warm_from_kafka(
                 person_id: cached.id,
             };
             buffered.push((key, cached));
+        } else {
+            // The writer never produces null-payload (tombstone) records
+            // to `personhog_updates` today. If one ever appears it would
+            // semantically represent a deletion, but the warming pipeline
+            // has no concept of evictions — so we silently skip and
+            // surface the occurrence via metrics + logs so an operator
+            // notices if this assumption ever stops holding.
+            counter!("personhog_leader_warm_tombstones_skipped_total").increment(1);
+            tracing::warn!(
+                partition,
+                offset,
+                "skipped null-payload (tombstone) record; the writer is not expected to produce these"
+            );
         }
 
         // HWM is exclusive — it's one past the last offset present.
@@ -319,14 +346,16 @@ pub async fn warm_from_kafka(
         }
     }
 
-    // Commit the buffered records all at once. By the time another caller
-    // can observe `cache.has_partition(partition) == true`, every record
-    // is already in place.
+    // Atomic install: the populated `PersonCache` is built first, then a
+    // single `DashMap::insert` publishes it. The previous pattern
+    // (`create_partition` + per-record `put` loop) created a window
+    // where readers could observe `has_partition == true` while the
+    // cache was still being populated, and then fall through to PG —
+    // potentially returning stale values for records the writer hasn't
+    // yet persisted. Atomicity here removes the dependency on the
+    // protocol invariant ("no reads during Warming") for correctness.
     let count = buffered.len() as u64;
-    cache.create_partition(partition);
-    for (key, cached) in buffered {
-        cache.put(partition, key, cached);
-    }
+    cache.install_warmed_partition(partition, buffered);
 
     let elapsed = start.elapsed();
     tracing::info!(
@@ -439,5 +468,36 @@ mod tests {
         .await;
         assert!(result.is_ok());
         assert_eq!(attempts.load(Ordering::Acquire), 1);
+    }
+
+    /// `max_attempts = 0` is meaningless (would mean "never try") but
+    /// could arrive via a misconfigured env var. Clamp to 1 instead of
+    /// panicking via the trailing `unreachable!`. Build in release mode
+    /// to skip the `debug_assert` and exercise the runtime clamp.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[cfg(not(debug_assertions))]
+    async fn retry_clamps_zero_max_attempts_to_one() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = Arc::clone(&attempts);
+        let zero_policy = WarmingRetryPolicy {
+            max_attempts: 0,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+        };
+        let result: CoordResult<()> = with_warm_retry("test", 0, zero_policy, || {
+            let a = Arc::clone(&a);
+            async move {
+                a.fetch_add(1, Ordering::AcqRel);
+                Err(CoordError::invalid_state("always fails".to_string()))
+            }
+        })
+        .await;
+        assert!(result.is_err(), "must produce an Err, not panic");
+        assert_eq!(
+            attempts.load(Ordering::Acquire),
+            1,
+            "clamped to a single attempt"
+        );
     }
 }

--- a/rust/personhog-leader/src/warming.rs
+++ b/rust/personhog-leader/src/warming.rs
@@ -1,0 +1,443 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use common_kafka::config::KafkaConfig;
+use metrics::{counter, histogram};
+use prost::Message as ProtoMessage;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::{ClientConfig, Offset, TopicPartitionList};
+use tokio::time::timeout;
+
+use personhog_coordination::error::{Error as CoordError, Result as CoordResult};
+use personhog_proto::personhog::types::v1::Person;
+
+use crate::cache::{CachedPerson, PartitionedCache, PersonCacheKey};
+
+/// Retry policy for transient warming-metadata failures.
+#[derive(Clone, Copy)]
+pub struct WarmingRetryPolicy {
+    pub max_attempts: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+/// Retry a fallible warming step with exponential backoff. Used for the
+/// metadata calls that talk to Kafka brokers (fetch watermarks, committed
+/// offsets) so a single transient network blip doesn't cycle the pod.
+///
+/// The consume loop itself is not retried — it holds partial progress and
+/// re-seeking is its own concern; leave to a follow-up if we see flakes.
+async fn with_warm_retry<T, F, Fut>(
+    stage: &str,
+    partition: u32,
+    policy: WarmingRetryPolicy,
+    mut f: F,
+) -> CoordResult<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = CoordResult<T>>,
+{
+    let mut backoff = policy.initial_backoff;
+    for attempt in 1..=policy.max_attempts {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) if attempt == policy.max_attempts => {
+                counter!(
+                    "personhog_leader_warm_retries_exhausted_total",
+                    "stage" => stage.to_string()
+                )
+                .increment(1);
+                return Err(e);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    partition,
+                    attempt,
+                    stage,
+                    error = %e,
+                    backoff_ms = backoff.as_millis() as u64,
+                    "warming step failed, retrying"
+                );
+                counter!(
+                    "personhog_leader_warm_retries_total",
+                    "stage" => stage.to_string()
+                )
+                .increment(1);
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(policy.max_backoff);
+            }
+        }
+    }
+    unreachable!("the last iteration returns either Ok or Err explicitly")
+}
+
+/// Configuration for the warming pipeline. Owned by the leader handoff
+/// handler and borrowed at each `warm_from_kafka` call.
+#[derive(Clone)]
+pub struct WarmingConfig {
+    pub kafka: KafkaConfig,
+    pub topic: String,
+    pub pod_name: String,
+    /// Writer's consumer group id. We query this group's committed offset
+    /// for the partition to find "everything at or after this offset has
+    /// not yet been written to PG."
+    pub writer_consumer_group: String,
+    /// Number of offsets to rewind past the writer's committed offset as a
+    /// safety margin. Bounded by Kafka's earliest-available offset.
+    pub lookback_offsets: i64,
+    /// Timeout for the OffsetFetch metadata call.
+    pub committed_offsets_timeout: Duration,
+    /// Timeout for the per-partition `fetch_watermarks` call.
+    pub fetch_watermarks_timeout: Duration,
+    /// Per-message receive timeout during the consume loop.
+    pub recv_timeout: Duration,
+    /// Retry policy for transient metadata failures.
+    pub retry: WarmingRetryPolicy,
+}
+
+/// Build a consumer used by warming. Auto-commit and auto-offset-store are
+/// disabled so this is safe to instantiate with any group id — including
+/// the writer's, where mutating stored offsets would corrupt the writer's
+/// durable-progress marker. Two callers reuse it: the warming consume loop
+/// (which seeks explicitly per partition) and a short-lived OffsetFetch
+/// query against the writer's group (which never subscribes or consumes).
+fn make_consumer(
+    kafka: &KafkaConfig,
+    group_id: &str,
+) -> Result<StreamConsumer, rdkafka::error::KafkaError> {
+    let mut cfg = ClientConfig::new();
+    cfg.set("bootstrap.servers", &kafka.kafka_hosts)
+        .set("group.id", group_id)
+        .set("enable.auto.commit", "false")
+        .set("enable.auto.offset.store", "false")
+        .set("auto.offset.reset", "earliest");
+    if kafka.kafka_tls {
+        cfg.set("security.protocol", "ssl")
+            .set("enable.ssl.certificate.verification", "false");
+    }
+    if !kafka.kafka_client_rack.is_empty() {
+        cfg.set("client.rack", &kafka.kafka_client_rack);
+    }
+    cfg.create()
+}
+
+/// Query the writer consumer group's committed offset for a partition.
+/// Returns `None` if the writer has no commit yet for the partition
+/// (typical for a freshly-created topic).
+///
+/// The OffsetFetch RPC inside `committed_offsets` is synchronous in rdkafka
+/// and parks the calling thread for up to `timeout`. We run it on the
+/// blocking pool so a slow broker can't stall the tokio runtime.
+async fn fetch_writer_committed_offset(
+    kafka: &KafkaConfig,
+    writer_group: &str,
+    topic: &str,
+    partition: i32,
+    timeout: Duration,
+) -> CoordResult<Option<i64>> {
+    let kafka = kafka.clone();
+    let writer_group = writer_group.to_string();
+    let topic = topic.to_string();
+    tokio::task::spawn_blocking(move || {
+        let consumer = make_consumer(&kafka, &writer_group)
+            .map_err(|e| CoordError::invalid_state(format!("create offset query consumer: {e}")))?;
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition(&topic, partition);
+        let committed = consumer
+            .committed_offsets(tpl, timeout)
+            .map_err(|e| CoordError::invalid_state(format!("committed_offsets for group: {e}")))?;
+        Ok(committed
+            .find_partition(&topic, partition)
+            .and_then(|tp| match tp.offset() {
+                Offset::Offset(o) => Some(o),
+                _ => None,
+            }))
+    })
+    .await
+    .map_err(|e| CoordError::invalid_state(format!("offset query join: {e}")))?
+}
+
+/// Decide where to start consuming for a partition.
+///
+/// The writer's committed offset is the authoritative "everything up to
+/// here is durable in PG" marker. Messages at or after it need to be warmed
+/// into the leader's cache — otherwise a cache miss for a key in that
+/// range would fall through to PG and return a stale value (PG hasn't seen
+/// the update yet).
+///
+/// We rewind an extra `lookback` offsets as a safety margin against races
+/// between the writer's commit and our read of it, and clamp to the
+/// earliest available offset so we don't seek past Kafka's retention.
+fn resolve_start_offset(committed: Option<i64>, earliest: i64, lookback: i64) -> i64 {
+    let lookback = lookback.max(0);
+    match committed {
+        Some(c) => (c - lookback).max(earliest),
+        None => earliest,
+    }
+}
+
+/// Populate the cache from Kafka for a single partition.
+///
+/// Invariants at call time (enforced by the handoff protocol's `Warming`
+/// phase): no one is producing to the partition, and the old owner has
+/// drained its in-flight handlers. That means HWM is stable and we can
+/// consume to a known endpoint without racing producers.
+pub async fn warm_from_kafka(
+    cfg: &WarmingConfig,
+    cache: &PartitionedCache,
+    partition: u32,
+) -> CoordResult<()> {
+    let start = Instant::now();
+    let partition_i32 = i32::try_from(partition).map_err(|_| {
+        CoordError::invalid_state(format!("partition {partition} exceeds i32::MAX"))
+    })?;
+
+    // Query the writer's committed offset via a separate, short-lived client.
+    // This keeps our long-lived warming consumer isolated from the writer's
+    // consumer group.
+    let committed_offset = with_warm_retry("committed_offset", partition, cfg.retry, || async {
+        fetch_writer_committed_offset(
+            &cfg.kafka,
+            &cfg.writer_consumer_group,
+            &cfg.topic,
+            partition_i32,
+            cfg.committed_offsets_timeout,
+        )
+        .await
+    })
+    .await?;
+
+    let warming_group = format!(
+        "personhog-leader-warm-{pod}-p{partition}",
+        pod = cfg.pod_name
+    );
+    let consumer = Arc::new(
+        make_consumer(&cfg.kafka, &warming_group)
+            .map_err(|e| CoordError::invalid_state(format!("create warming consumer: {e}")))?,
+    );
+
+    // `fetch_watermarks` is synchronous in rdkafka and may block for the
+    // full timeout. Run it on the blocking pool so retries don't park the
+    // runtime thread.
+    let (low, hwm) = with_warm_retry("fetch_watermarks", partition, cfg.retry, || {
+        let consumer = Arc::clone(&consumer);
+        let topic = cfg.topic.clone();
+        let timeout = cfg.fetch_watermarks_timeout;
+        async move {
+            tokio::task::spawn_blocking(move || {
+                consumer
+                    .fetch_watermarks(&topic, partition_i32, timeout)
+                    .map_err(|e| CoordError::invalid_state(format!("fetch watermarks: {e}")))
+            })
+            .await
+            .map_err(|e| CoordError::invalid_state(format!("fetch_watermarks join: {e}")))?
+        }
+    })
+    .await?;
+
+    let start_offset = resolve_start_offset(committed_offset, low, cfg.lookback_offsets);
+
+    tracing::info!(
+        partition,
+        writer_group = cfg.writer_consumer_group,
+        committed = ?committed_offset,
+        earliest = low,
+        hwm,
+        lookback = cfg.lookback_offsets,
+        start_offset,
+        "computed warming range"
+    );
+
+    let mut assign_tpl = TopicPartitionList::new();
+    assign_tpl
+        .add_partition_offset(&cfg.topic, partition_i32, Offset::Offset(start_offset))
+        .map_err(|e| CoordError::invalid_state(format!("tpl add_partition_offset: {e}")))?;
+    consumer
+        .assign(&assign_tpl)
+        .map_err(|e| CoordError::invalid_state(format!("consumer assign: {e}")))?;
+
+    if hwm <= start_offset {
+        // Empty range — mark the partition as owned with an empty cache.
+        cache.create_partition(partition);
+        tracing::info!(partition, hwm, start_offset, "no messages to warm in range");
+        return Ok(());
+    }
+
+    // Buffer records locally and only commit them to the cache after the
+    // entire range warms successfully. Any decode/IO failure mid-range
+    // aborts warming with no observable cache mutation, which keeps a
+    // partial cache from masking PG fallback reads.
+    let mut buffered: Vec<(PersonCacheKey, CachedPerson)> = Vec::new();
+    let mut last_offset: i64 = -1;
+
+    loop {
+        let msg = match timeout(cfg.recv_timeout, consumer.recv()).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(e)) => {
+                return Err(CoordError::invalid_state(format!("warm recv: {e}")));
+            }
+            Err(_) => {
+                return Err(CoordError::invalid_state(format!(
+                    "warm timeout; consumed {count} msgs, last_offset={last_offset}, hwm={hwm}",
+                    count = buffered.len()
+                )));
+            }
+        };
+
+        let offset = msg.offset();
+        last_offset = offset;
+
+        if let Some(payload) = msg.payload() {
+            let person = <Person as ProtoMessage>::decode(payload).map_err(|e| {
+                CoordError::invalid_state(format!("warm decode failed at offset {offset}: {e}"))
+            })?;
+            let properties = serde_json::from_slice(&person.properties).map_err(|e| {
+                CoordError::invalid_state(format!(
+                    "warm properties decode failed at offset {offset}: {e}"
+                ))
+            })?;
+            let cached = CachedPerson {
+                id: person.id,
+                uuid: person.uuid,
+                team_id: person.team_id,
+                properties,
+                created_at: person.created_at,
+                version: person.version,
+                is_identified: person.is_identified,
+            };
+            let key = PersonCacheKey {
+                team_id: cached.team_id,
+                person_id: cached.id,
+            };
+            buffered.push((key, cached));
+        }
+
+        // HWM is exclusive — it's one past the last offset present.
+        if offset + 1 >= hwm {
+            break;
+        }
+    }
+
+    // Commit the buffered records all at once. By the time another caller
+    // can observe `cache.has_partition(partition) == true`, every record
+    // is already in place.
+    let count = buffered.len() as u64;
+    cache.create_partition(partition);
+    for (key, cached) in buffered {
+        cache.put(partition, key, cached);
+    }
+
+    let elapsed = start.elapsed();
+    tracing::info!(
+        pod = cfg.pod_name,
+        partition,
+        messages = count,
+        hwm,
+        start_offset,
+        elapsed_ms = elapsed.as_millis() as u64,
+        "warmed partition from kafka"
+    );
+    histogram!("personhog_leader_warm_duration_ms").record(elapsed.as_secs_f64() * 1000.0);
+    counter!("personhog_leader_warmed_messages_total").increment(count);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    const TEST_RETRY_POLICY: WarmingRetryPolicy = WarmingRetryPolicy {
+        max_attempts: 3,
+        initial_backoff: Duration::from_millis(500),
+        max_backoff: Duration::from_secs(5),
+    };
+
+    #[test]
+    fn resolve_uses_committed_minus_lookback() {
+        assert_eq!(resolve_start_offset(Some(500), 0, 100), 400);
+    }
+
+    #[test]
+    fn resolve_clamps_to_earliest() {
+        // Lookback would take us to 50, but earliest is 200.
+        assert_eq!(resolve_start_offset(Some(100), 200, 50), 200);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_earliest_when_no_commit() {
+        assert_eq!(resolve_start_offset(None, 42, 100), 42);
+    }
+
+    #[test]
+    fn resolve_treats_negative_lookback_as_zero() {
+        assert_eq!(resolve_start_offset(Some(500), 0, -10), 500);
+    }
+
+    #[test]
+    fn resolve_handles_zero_lookback() {
+        assert_eq!(resolve_start_offset(Some(500), 0, 0), 500);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn retry_succeeds_on_second_attempt() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = Arc::clone(&attempts);
+        let result: CoordResult<&'static str> =
+            with_warm_retry("test", 0, TEST_RETRY_POLICY, || {
+                let a = Arc::clone(&a);
+                async move {
+                    let n = a.fetch_add(1, Ordering::AcqRel) + 1;
+                    if n == 1 {
+                        Err(CoordError::invalid_state("first fails".to_string()))
+                    } else {
+                        Ok("second succeeds")
+                    }
+                }
+            })
+            .await;
+        assert_eq!(result.unwrap(), "second succeeds");
+        assert_eq!(attempts.load(Ordering::Acquire), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn retry_exhausts_and_returns_last_error() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = Arc::clone(&attempts);
+        let result: CoordResult<()> = with_warm_retry("test", 0, TEST_RETRY_POLICY, || {
+            let a = Arc::clone(&a);
+            async move {
+                a.fetch_add(1, Ordering::AcqRel);
+                Err(CoordError::invalid_state("always fails".to_string()))
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            attempts.load(Ordering::Acquire),
+            TEST_RETRY_POLICY.max_attempts
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn retry_returns_immediately_on_success() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = Arc::clone(&attempts);
+        let result: CoordResult<()> = with_warm_retry("test", 0, TEST_RETRY_POLICY, || {
+            let a = Arc::clone(&a);
+            async move {
+                a.fetch_add(1, Ordering::AcqRel);
+                Ok(())
+            }
+        })
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::Acquire), 1);
+    }
+}

--- a/rust/personhog-leader/tests/common/mod.rs
+++ b/rust/personhog-leader/tests/common/mod.rs
@@ -1,3 +1,8 @@
+// Each `tests/*.rs` integration test compiles as its own binary and imports
+// `common` via `mod common;`. Helpers used by some test files but not others
+// would otherwise fire `dead_code` per-binary; suppress at the module level.
+#![allow(dead_code)]
+
 use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -159,6 +164,50 @@ pub struct LeaderPodHandles {
     pub _mock_cluster: MockCluster<'static, DefaultProducerContext>,
 }
 
+/// Kafka config pointing at local kafka for e2e tests. Used for both the
+/// producer and the warming consumer inside `LeaderHandoffHandler`.
+pub fn test_kafka_config() -> KafkaConfig {
+    KafkaConfig {
+        kafka_producer_linger_ms: 0,
+        kafka_producer_queue_mib: 50,
+        kafka_message_timeout_ms: 5000,
+        kafka_compression_codec: "none".to_string(),
+        kafka_hosts: KAFKA_BOOTSTRAP.to_string(),
+        kafka_tls: false,
+        kafka_producer_queue_messages: 1000,
+        kafka_client_rack: String::new(),
+        kafka_client_id: String::new(),
+    }
+}
+
+/// Default warming knobs for e2e tests — production-equivalent timeouts and
+/// retry policy. `kafka_bootstrap` must match the broker the test's
+/// producer is publishing to, so the warming consumer reads from the same
+/// place. With a mock cluster, that's `mock_cluster.bootstrap_servers()`;
+/// with real local Kafka, `KAFKA_BOOTSTRAP`.
+pub fn test_warming_config(
+    pod_name: &str,
+    kafka_bootstrap: &str,
+) -> personhog_leader::warming::WarmingConfig {
+    let mut kafka = test_kafka_config();
+    kafka.kafka_hosts = kafka_bootstrap.to_string();
+    personhog_leader::warming::WarmingConfig {
+        kafka,
+        topic: CHANGELOG_TOPIC.to_string(),
+        pod_name: pod_name.to_string(),
+        writer_consumer_group: "personhog-writer".to_string(),
+        lookback_offsets: 0,
+        committed_offsets_timeout: Duration::from_secs(5),
+        fetch_watermarks_timeout: Duration::from_secs(5),
+        recv_timeout: Duration::from_secs(10),
+        retry: personhog_leader::warming::WarmingRetryPolicy {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(500),
+            max_backoff: Duration::from_secs(5),
+        },
+    }
+}
+
 /// Create a producer against local Kafka for e2e tests.
 pub async fn create_local_kafka_producer() -> FutureProducer<KafkaContext> {
     let registry = HealthRegistry::new("test");
@@ -181,14 +230,31 @@ pub async fn create_local_kafka_producer() -> FutureProducer<KafkaContext> {
         .expect("failed to connect to local Kafka")
 }
 
-/// Create a mock Kafka cluster and producer for tests.
+/// Create a mock Kafka cluster and producer for tests. The mock topic is
+/// pre-created with `NUM_PARTITIONS` partitions so the warming pipeline's
+/// `fetch_watermarks` calls succeed for every partition the test exercises;
+/// otherwise warming aborts trying to query a non-existent partition and
+/// the handoff stalls.
 pub async fn create_test_kafka() -> (
+    MockCluster<'static, DefaultProducerContext>,
+    FutureProducer<KafkaContext>,
+) {
+    create_test_kafka_with_partitions(NUM_PARTITIONS as i32).await
+}
+
+/// Variant of `create_test_kafka` that lets a test pin the topic to a
+/// specific partition count. Use this for tests that exercise the
+/// producer's partition-routing behavior — they need a topology they
+/// control, not the default warming-friendly multi-partition setup.
+pub async fn create_test_kafka_with_partitions(
+    partitions: i32,
+) -> (
     MockCluster<'static, DefaultProducerContext>,
     FutureProducer<KafkaContext>,
 ) {
     let (cluster, producer) = common_kafka::test::create_mock_kafka().await;
     cluster
-        .create_topic(CHANGELOG_TOPIC, 1, 1)
+        .create_topic(CHANGELOG_TOPIC, partitions, 1)
         .expect("failed to create mock topic");
     (cluster, producer)
 }
@@ -204,9 +270,15 @@ pub async fn start_leader_pod(
     let cache = Arc::new(PartitionedCache::new(cache_capacity));
     let (mock_cluster, kafka_producer) = create_test_kafka().await;
 
-    // Pod with real handoff handler
+    // Pod with real handoff handler. Warming consumer reads from the same
+    // mock broker the producer is publishing to so the topic actually
+    // exists when warming queries watermarks.
     let inflight = Arc::new(personhog_leader::inflight::InflightTracker::new());
-    let handler = LeaderHandoffHandler::new(Arc::clone(&cache), Arc::clone(&inflight));
+    let handler = LeaderHandoffHandler::new(
+        Arc::clone(&cache),
+        Arc::clone(&inflight),
+        test_warming_config(name, &mock_cluster.bootstrap_servers()),
+    );
     let pod = PodHandle::new(
         store,
         PodConfig {
@@ -264,7 +336,11 @@ pub async fn start_leader_pod_with_lease_ttl(
 
     let heartbeat_secs = (lease_ttl as u64 / 3).max(1);
     let inflight = Arc::new(personhog_leader::inflight::InflightTracker::new());
-    let handler = LeaderHandoffHandler::new(Arc::clone(&cache), Arc::clone(&inflight));
+    let handler = LeaderHandoffHandler::new(
+        Arc::clone(&cache),
+        Arc::clone(&inflight),
+        test_warming_config(name, &mock_cluster.bootstrap_servers()),
+    );
     let pod = PodHandle::new(
         store,
         PodConfig {

--- a/rust/personhog-leader/tests/integration.rs
+++ b/rust/personhog-leader/tests/integration.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 use dashmap::DashMap;
 
 use common::{
-    create_leader_client, create_local_kafka_producer, create_test_kafka, seed_person,
-    start_coordinator, start_leader_pod, start_leader_pod_with_lease_ttl,
-    start_leader_with_pg_fallback, start_router, test_cached_person, test_store,
-    wait_for_condition, CHANGELOG_TOPIC, KAFKA_BOOTSTRAP, NUM_PARTITIONS, POLL_INTERVAL,
-    WAIT_TIMEOUT,
+    create_leader_client, create_local_kafka_producer, create_test_kafka,
+    create_test_kafka_with_partitions, seed_person, start_coordinator, start_leader_pod,
+    start_leader_pod_with_lease_ttl, start_leader_with_pg_fallback, start_router,
+    test_cached_person, test_store, wait_for_condition, CHANGELOG_TOPIC, KAFKA_BOOTSTRAP,
+    NUM_PARTITIONS, POLL_INTERVAL, WAIT_TIMEOUT,
 };
 use personhog_coordination::strategy::StickyBalancedStrategy;
 use personhog_leader::cache::{CacheLookup, PartitionedCache};
@@ -434,7 +434,11 @@ async fn rewarm_after_pod_crash() {
 #[tokio::test]
 async fn update_produces_person_state_to_kafka() {
     let cache = Arc::new(PartitionedCache::new(100));
-    let (mock_cluster, kafka_producer) = create_test_kafka().await;
+    // Single-partition topic: this test verifies the producer's delivery
+    // path, not partition routing. Using a single partition makes the
+    // assertion (consume from partition 0) deterministic regardless of
+    // rdkafka's default key-hash partitioner.
+    let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(1).await;
 
     let service = PersonHogLeaderService::new(
         Arc::clone(&cache),

--- a/rust/personhog-leader/tests/warming_integration.rs
+++ b/rust/personhog-leader/tests/warming_integration.rs
@@ -1,0 +1,433 @@
+//! Integration tests for the Kafka warming pipeline. Drives the real
+//! `warm_from_kafka` function against a mock Kafka cluster, producing
+//! known Person messages and asserting the resulting cache state matches.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{create_test_kafka, test_warming_config, CHANGELOG_TOPIC, NUM_PARTITIONS};
+use personhog_leader::cache::{CacheLookup, PartitionedCache, PersonCacheKey};
+use personhog_leader::warming::{warm_from_kafka, WarmingConfig};
+use personhog_proto::personhog::types::v1::Person;
+use prost::Message as ProtoMessage;
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, CommitMode, Consumer};
+use rdkafka::mocking::MockCluster;
+use rdkafka::producer::{DefaultProducerContext, FutureProducer, FutureRecord};
+use rdkafka::{Offset, TopicPartitionList};
+
+/// Build a Person proto with deterministic fields — enough that the
+/// warming pipeline's decode + JSON-parse + cache-write round-trip
+/// covers every code path.
+fn make_person(team_id: i64, person_id: i64) -> Person {
+    Person {
+        id: person_id,
+        uuid: format!("00000000-0000-0000-0000-{person_id:012}"),
+        team_id,
+        properties: serde_json::to_vec(&serde_json::json!({
+            "email": format!("p{person_id}@example.com"),
+        }))
+        .unwrap(),
+        properties_last_updated_at: Vec::new(),
+        properties_last_operation: Vec::new(),
+        created_at: 1700000000,
+        version: 1,
+        is_identified: false,
+        is_user_id: None,
+        last_seen_at: None,
+    }
+}
+
+/// Produce a Person to a specific partition. Uses the mock cluster's
+/// producer; the warming consumer must point at the same broker.
+async fn produce_person_to_partition(
+    producer: &FutureProducer<common_kafka::kafka_producer::KafkaContext>,
+    partition: i32,
+    person: &Person,
+) {
+    let key = format!("{}:{}", person.team_id, person.id);
+    let payload = person.encode_to_vec();
+    let record = FutureRecord::to(CHANGELOG_TOPIC)
+        .key(&key)
+        .partition(partition)
+        .payload(&payload);
+    producer
+        .send(record, Duration::from_secs(5))
+        .await
+        .expect("produce should succeed");
+}
+
+/// Produce a malformed message (raw bytes that don't decode as a Person
+/// proto) to exercise the fail-loud decode branch.
+async fn produce_garbage_to_partition(
+    producer: &FutureProducer<common_kafka::kafka_producer::KafkaContext>,
+    partition: i32,
+) {
+    let key = "garbage";
+    // Payload that isn't valid Person proto: a long byte string of 0xFFs
+    // — prost's varint decoder rejects these immediately.
+    let payload = vec![0xFFu8; 32];
+    let record = FutureRecord::to(CHANGELOG_TOPIC)
+        .key(key)
+        .partition(partition)
+        .payload(&payload);
+    producer
+        .send(record, Duration::from_secs(5))
+        .await
+        .expect("produce should succeed");
+}
+
+fn warming_config_for(
+    pod_name: &str,
+    cluster: &MockCluster<'static, DefaultProducerContext>,
+) -> WarmingConfig {
+    test_warming_config(pod_name, &cluster.bootstrap_servers())
+}
+
+/// Happy path: produce N messages to a partition, warm, assert every
+/// record landed in the cache. Also asserts FIFO ordering by relying on
+/// the cache's `put` semantics — later puts overwrite earlier ones, so
+/// distinct `person_id`s produce distinct entries that we can count.
+#[tokio::test]
+async fn warming_populates_cache_from_kafka() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Produce 5 records to partition 0.
+    for person_id in 1..=5 {
+        let person = make_person(1, person_id);
+        produce_person_to_partition(&producer, 0, &person).await;
+    }
+
+    let cache = PartitionedCache::new(100);
+    let cfg = warming_config_for("warmer-0", &cluster);
+
+    warm_from_kafka(&cfg, &cache, 0)
+        .await
+        .expect("warming should succeed");
+
+    assert!(cache.has_partition(0), "partition 0 must be marked owned");
+    for person_id in 1..=5 {
+        let key = PersonCacheKey {
+            team_id: 1,
+            person_id,
+        };
+        match cache.get(0, &key) {
+            CacheLookup::Found(entry) => {
+                assert_eq!(entry.id, person_id);
+                assert_eq!(entry.team_id, 1);
+            }
+            other => panic!(
+                "expected Found for person_id={person_id}, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+}
+
+/// Empty partition: no messages produced. Warming must mark the partition
+/// owned (so future routes find a cache entry) but with no records.
+#[tokio::test]
+async fn warming_handles_empty_partition() {
+    let (cluster, _producer) = create_test_kafka().await;
+
+    let cache = PartitionedCache::new(100);
+    let cfg = warming_config_for("warmer-empty", &cluster);
+
+    warm_from_kafka(&cfg, &cache, 0)
+        .await
+        .expect("warming an empty partition should succeed");
+
+    assert!(
+        cache.has_partition(0),
+        "empty warming must still mark the partition owned"
+    );
+    let key = PersonCacheKey {
+        team_id: 1,
+        person_id: 99,
+    };
+    assert!(
+        matches!(cache.get(0, &key), CacheLookup::PersonNotFound),
+        "no records were produced, so cache must be empty"
+    );
+}
+
+/// Partition isolation: warming partition 0 must not populate cache
+/// entries for any other partition. Proves the consumer's seek + assign
+/// is correctly scoped.
+#[tokio::test]
+async fn warming_only_populates_target_partition() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Produce one record to partition 0 and one to partition 1.
+    produce_person_to_partition(&producer, 0, &make_person(1, 100)).await;
+    produce_person_to_partition(&producer, 1, &make_person(1, 200)).await;
+
+    let cache = PartitionedCache::new(100);
+    let cfg = warming_config_for("warmer-iso", &cluster);
+
+    warm_from_kafka(&cfg, &cache, 0)
+        .await
+        .expect("warming partition 0 should succeed");
+
+    assert!(cache.has_partition(0), "partition 0 was warmed");
+    assert!(
+        !cache.has_partition(1),
+        "partition 1 must not be touched when warming partition 0"
+    );
+    let p0_key = PersonCacheKey {
+        team_id: 1,
+        person_id: 100,
+    };
+    assert!(
+        matches!(cache.get(0, &p0_key), CacheLookup::Found(_)),
+        "partition 0's record must be in cache"
+    );
+}
+
+/// Decode failure: a single unparseable message in the warming range
+/// must fail the entire warm with no observable cache mutation. The
+/// atomic-commit invariant means a partial cache (only the records
+/// before the bad one) would silently mask PG fallback reads.
+#[tokio::test]
+async fn warming_fails_loudly_on_decode_error_and_leaves_cache_clean() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Produce a valid record, then a garbage one. Warming should buffer
+    // the valid record locally, hit the garbage on the next iteration,
+    // and abort before flushing anything to the cache.
+    produce_person_to_partition(&producer, 0, &make_person(1, 1)).await;
+    produce_garbage_to_partition(&producer, 0).await;
+
+    let cache = PartitionedCache::new(100);
+    let cfg = warming_config_for("warmer-decode", &cluster);
+
+    let result = warm_from_kafka(&cfg, &cache, 0).await;
+    assert!(
+        result.is_err(),
+        "a malformed message must fail the entire warm"
+    );
+    assert!(
+        !cache.has_partition(0),
+        "atomic commit: cache must not have been touched on decode failure"
+    );
+}
+
+/// All partitions exercised in sequence: verifies the warming pipeline
+/// is reusable across the full partition set. Catches regressions where
+/// per-partition consumer setup leaks state across calls.
+#[tokio::test]
+async fn warming_works_across_all_partitions() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Produce one record to each partition with a partition-specific
+    // person_id so we can verify the right record landed in each cache
+    // slot.
+    for partition in 0..NUM_PARTITIONS {
+        let person = make_person(1, (partition as i64 + 1) * 100);
+        produce_person_to_partition(&producer, partition as i32, &person).await;
+    }
+
+    let cache = Arc::new(PartitionedCache::new(100));
+    let cfg = warming_config_for("warmer-all", &cluster);
+
+    for partition in 0..NUM_PARTITIONS {
+        warm_from_kafka(&cfg, &cache, partition)
+            .await
+            .unwrap_or_else(|e| panic!("warming partition {partition} failed: {e}"));
+    }
+
+    for partition in 0..NUM_PARTITIONS {
+        assert!(cache.has_partition(partition));
+        let key = PersonCacheKey {
+            team_id: 1,
+            person_id: (partition as i64 + 1) * 100,
+        };
+        assert!(
+            matches!(cache.get(partition, &key), CacheLookup::Found(_)),
+            "partition {partition} should have its dedicated record"
+        );
+    }
+}
+
+/// Commit a specific offset for the writer's consumer group on a given
+/// partition. Mirrors what the writer pod would do after persisting
+/// records up through that offset to PG. The warming pipeline reads
+/// this committed offset to bound the range it needs to repopulate.
+fn commit_writer_offset_at(
+    cluster: &MockCluster<'static, DefaultProducerContext>,
+    writer_group: &str,
+    partition: i32,
+    offset: i64,
+) {
+    let consumer: BaseConsumer = ClientConfig::new()
+        .set("bootstrap.servers", cluster.bootstrap_servers())
+        .set("group.id", writer_group)
+        .set("enable.auto.commit", "false")
+        .create()
+        .expect("failed to create writer-group consumer");
+
+    let mut tpl = TopicPartitionList::new();
+    tpl.add_partition_offset(CHANGELOG_TOPIC, partition, Offset::Offset(offset))
+        .expect("tpl add_partition_offset");
+    consumer
+        .commit(&tpl, CommitMode::Sync)
+        .expect("writer-group commit");
+}
+
+/// Warming must consult the writer's committed offset and skip records
+/// the writer has already durably persisted to PG. Produce 8 records;
+/// commit the writer's offset at 5 (meaning records 0..4 are durable,
+/// records 5..7 still need to be in cache); warm with `lookback=0` and
+/// assert only records with offsets ≥ 5 land in the cache.
+#[tokio::test]
+async fn warming_starts_from_writer_committed_offset() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Produce 8 records to partition 0. person_id matches offset for
+    // easy assertion (offset N → person_id N+1).
+    for i in 0..8 {
+        let person = make_person(1, i + 1);
+        produce_person_to_partition(&producer, 0, &person).await;
+    }
+
+    // Writer "committed" through offset 5 — meaning records at offsets
+    // 0..4 are durable in PG, the records at 5..7 are still in flight
+    // and must be warmed.
+    commit_writer_offset_at(&cluster, "personhog-writer", 0, 5);
+
+    let cache = PartitionedCache::new(100);
+    let mut cfg = warming_config_for("warmer-committed", &cluster);
+    // Set lookback to 0 so the start offset is exactly the committed
+    // value; otherwise it would rewind further and include earlier
+    // records, defeating the point of this assertion.
+    cfg.lookback_offsets = 0;
+
+    warm_from_kafka(&cfg, &cache, 0)
+        .await
+        .expect("warming should succeed");
+
+    // Records 5..7 (person_ids 6, 7, 8) must be in cache.
+    for person_id in 6..=8 {
+        let key = PersonCacheKey {
+            team_id: 1,
+            person_id,
+        };
+        assert!(
+            matches!(cache.get(0, &key), CacheLookup::Found(_)),
+            "record after committed offset (person_id={person_id}) must be warmed"
+        );
+    }
+
+    // Records 0..4 (person_ids 1..5) must NOT be in cache — they're
+    // durable in PG and warming correctly skipped them.
+    for person_id in 1..=5 {
+        let key = PersonCacheKey {
+            team_id: 1,
+            person_id,
+        };
+        assert!(
+            matches!(cache.get(0, &key), CacheLookup::PersonNotFound),
+            "record before committed offset (person_id={person_id}) must NOT be warmed"
+        );
+    }
+}
+
+/// Atomic-commit invariant: a Person whose proto decodes successfully
+/// but whose `properties` field contains invalid JSON must fail the
+/// entire warm. The proto-decode branch and the JSON-decode branch are
+/// distinct error paths in the consume loop; the garbage-bytes test
+/// only exercises the proto branch.
+#[tokio::test]
+async fn warming_fails_loudly_on_properties_json_error() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Valid record first so warming actually enters the consume loop
+    // and buffers something before hitting the failure.
+    produce_person_to_partition(&producer, 0, &make_person(1, 1)).await;
+
+    // Person with invalid JSON in properties — proto decodes, but
+    // `serde_json::from_slice` on `properties` fails.
+    let bad = Person {
+        id: 2,
+        uuid: "00000000-0000-0000-0000-000000000002".to_string(),
+        team_id: 1,
+        properties: vec![0xFFu8; 16], // not valid JSON
+        properties_last_updated_at: Vec::new(),
+        properties_last_operation: Vec::new(),
+        created_at: 1700000000,
+        version: 1,
+        is_identified: false,
+        is_user_id: None,
+        last_seen_at: None,
+    };
+    produce_person_to_partition(&producer, 0, &bad).await;
+
+    let cache = PartitionedCache::new(100);
+    let cfg = warming_config_for("warmer-bad-props", &cluster);
+
+    let result = warm_from_kafka(&cfg, &cache, 0).await;
+    assert!(
+        result.is_err(),
+        "invalid JSON in properties must fail the entire warm"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("properties decode failed"),
+        "error must point at the properties JSON branch, not proto decode: {msg}"
+    );
+    assert!(
+        !cache.has_partition(0),
+        "atomic commit: cache must not have been touched on JSON failure"
+    );
+}
+
+/// Last-write-wins: the changelog can contain multiple updates for the
+/// same `person_id` (each update produces a new record). After warming,
+/// the cache must reflect the *latest* update — proven by checking the
+/// version field, which the writer increments per update.
+#[tokio::test]
+async fn warming_preserves_last_write_for_same_key() {
+    let (cluster, producer) = create_test_kafka().await;
+
+    // Three sequential updates for the same person, each with an
+    // incrementing version. Producing in order to the same partition
+    // preserves Kafka's per-partition ordering.
+    for version in 1..=3 {
+        let mut person = make_person(1, 42);
+        person.version = version;
+        // Tag the email with the version so we can also verify the
+        // properties payload matches the latest write.
+        person.properties = serde_json::to_vec(&serde_json::json!({
+            "email": format!("v{version}@example.com"),
+        }))
+        .unwrap();
+        produce_person_to_partition(&producer, 0, &person).await;
+    }
+
+    let cache = PartitionedCache::new(100);
+    let cfg = warming_config_for("warmer-lww", &cluster);
+
+    warm_from_kafka(&cfg, &cache, 0)
+        .await
+        .expect("warming should succeed");
+
+    let key = PersonCacheKey {
+        team_id: 1,
+        person_id: 42,
+    };
+    match cache.get(0, &key) {
+        CacheLookup::Found(entry) => {
+            assert_eq!(
+                entry.version, 3,
+                "cache must reflect the latest update's version"
+            );
+            assert_eq!(
+                entry.properties["email"], "v3@example.com",
+                "cache must reflect the latest update's properties"
+            );
+        }
+        other => panic!("expected Found, got {:?}", std::mem::discriminant(&other)),
+    }
+}


### PR DESCRIPTION
## Problem

implement cache warming for personhog leader - this will look up the last committed offset by the writer, and consume from that to the stable hwm.
