### PR TITLE
fix(integrations): Let users pick any GitHub org

### DIFF
--- a/posthog/api/test/test_user_integration.py
+++ b/posthog/api/test/test_user_integration.py
@@ -144,10 +144,12 @@ class TestUserIntegrationEndpoints(APIBaseTest):
         self.assertEqual(data.get("connect_flow"), "app_install")
         self.assertIn("github.com/apps/posthog-dev/installations/new", data["install_url"])
 
-    @override_settings(
-        GITHUB_APP_CLIENT_ID="gh_client_123", SITE_URL="https://us.posthog.com", GITHUB_APP_CLIENT_SECRET="s"
+    @override_settings(GITHUB_APP_CLIENT_ID="gh_client_123")
+    @patch(
+        "posthog.api.user_integration.get_instance_settings",
+        return_value={"GITHUB_APP_SLUG": "posthog-dev"},
     )
-    def test_github_start_returns_oauth_url_when_team_has_github_integration(self):
+    def test_github_start_returns_install_url_even_when_team_has_github_integration(self, _mock_settings):
         Integration.objects.create(
             team=self.team,
             kind="github",
@@ -160,11 +162,65 @@ class TestUserIntegrationEndpoints(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertIn("install_url", data)
+        self.assertEqual(data.get("connect_flow"), "app_install")
+        self.assertIn("github.com/apps/posthog-dev/installations/new", data["install_url"])
+
+    @override_settings(
+        GITHUB_APP_CLIENT_ID="gh_client_123", SITE_URL="https://us.posthog.com", GITHUB_APP_CLIENT_SECRET="s"
+    )
+    def test_github_start_posthog_code_fast_path_returns_oauth_url(self):
+        Integration.objects.create(
+            team=self.team,
+            kind="github",
+            integration_id="12345678",
+            config={"account": {"name": "acme"}},
+            sensitive_config={},
+            created_by=self.user,
+        )
+        response = self.client.post(
+            "/api/users/@me/integrations/github/start/",
+            {"connect_from": "posthog_code"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("install_url", data)
         self.assertEqual(data.get("connect_flow"), "oauth_authorize")
         url = data["install_url"]
         self.assertIn("github.com/login/oauth/authorize", url)
         self.assertIn("client_id=gh_client_123", url)
         self.assertIn("redirect_uri=https%3A%2F%2Fus.posthog.com%2Fcomplete%2Fgithub-link%2F", url)
+
+    @override_settings(GITHUB_APP_CLIENT_ID="gh_client_123")
+    @patch(
+        "posthog.api.user_integration.get_instance_settings",
+        return_value={"GITHUB_APP_SLUG": "posthog-dev"},
+    )
+    def test_github_start_posthog_code_skips_fast_path_when_already_linked(self, _mock_settings):
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="github",
+            integration_id="12345678",
+            config={"account": {"name": "acme"}},
+            sensitive_config={},
+            created_by=self.user,
+        )
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="github",
+            integration_id=integration.integration_id,
+            config={},
+            sensitive_config={},
+        )
+        response = self.client.post(
+            "/api/users/@me/integrations/github/start/",
+            {"connect_from": "posthog_code"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data.get("connect_flow"), "app_install")
+        self.assertIn("github.com/apps/posthog-dev/installations/new", data["install_url"])
 
     def test_github_start_without_app_slug_returns_400(self):
         with patch(

--- a/posthog/api/test/test_user_integration.py
+++ b/posthog/api/test/test_user_integration.py
@@ -222,6 +222,24 @@ class TestUserIntegrationEndpoints(APIBaseTest):
         self.assertEqual(data.get("connect_flow"), "app_install")
         self.assertIn("github.com/apps/posthog-dev/installations/new", data["install_url"])
 
+    @override_settings(GITHUB_APP_CLIENT_ID="gh_client_123")
+    @patch("posthog.api.user_integration._has_unlinked_github_installations", return_value=False)
+    @patch(
+        "posthog.api.user_integration.get_instance_settings",
+        return_value={"GITHUB_APP_SLUG": "posthog-dev"},
+    )
+    def test_github_start_rejects_when_all_installations_linked(self, _mock_settings, _mock_unlinked):
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="github",
+            integration_id="12345678",
+            config={},
+            sensitive_config={"user_access_token": "ghu_test"},
+        )
+        response = self.client.post("/api/users/@me/integrations/github/start/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("already linked", response.json()["detail"])
+
     def test_github_start_without_app_slug_returns_400(self):
         with patch(
             "posthog.api.user_integration.get_instance_settings",

--- a/posthog/api/user_integration.py
+++ b/posthog/api/user_integration.py
@@ -58,7 +58,10 @@ PERSONAL_INTEGRATIONS_SETTINGS_PATH = "/settings/user-personal-integrations"
 # PostHog Code: personal GitHub integration complete → web → deep-link (see ``AccountConnected`` / ``github-integration``).
 ACCOUNT_CONNECTED_GITHUB_INTEGRATION_PATH = "/account-connected/github-integration"
 
-GITHUB_OAUTH_REDIRECT_URI = f"{settings.SITE_URL.rstrip('/')}/complete/github-link/"
+
+def github_oauth_redirect_uri() -> str:
+    """GitHub OAuth redirect for personal link; reads SITE_URL at call time so tests can override."""
+    return f"{settings.SITE_URL.rstrip('/')}/complete/github-link/"
 
 
 class UserGitHubAccountSerializer(serializers.Serializer):
@@ -400,7 +403,7 @@ def github_link_complete(request: HttpRequest) -> HttpResponseRedirect:
 
     # Exchange code for user-to-server tokens
     if oauth_flow:
-        authorization = GitHubIntegration.github_user_from_code(code, redirect_uri=GITHUB_OAUTH_REDIRECT_URI)
+        authorization = GitHubIntegration.github_user_from_code(code, redirect_uri=github_oauth_redirect_uri())
     else:
         authorization = GitHubIntegration.github_user_from_code(code)
     if authorization is None:
@@ -520,7 +523,7 @@ def _attempt_posthog_code_oauth_fast_path(user: User, team: Any, token: str, sta
         timeout=GITHUB_INSTALL_STATE_TTL_SECONDS,
     )
     install_url = "https://github.com/login/oauth/authorize?" + urlencode(
-        {"client_id": settings.GITHUB_APP_CLIENT_ID, "redirect_uri": GITHUB_OAUTH_REDIRECT_URI, "state": state}
+        {"client_id": settings.GITHUB_APP_CLIENT_ID, "redirect_uri": github_oauth_redirect_uri(), "state": state}
     )
     return Response({"install_url": install_url, "connect_flow": "oauth_authorize"})
 

--- a/posthog/api/user_integration.py
+++ b/posthog/api/user_integration.py
@@ -58,60 +58,7 @@ PERSONAL_INTEGRATIONS_SETTINGS_PATH = "/settings/user-personal-integrations"
 # PostHog Code: personal GitHub integration complete → web → deep-link (see ``AccountConnected`` / ``github-integration``).
 ACCOUNT_CONNECTED_GITHUB_INTEGRATION_PATH = "/account-connected/github-integration"
 
-
-def _github_oauth_redirect_uri() -> str:
-    """Callback URL registered on the GitHub App; must match the authorize request."""
-    return f"{settings.SITE_URL.rstrip('/')}/complete/github-link/"
-
-
-def _connect_from_github_start(request: Request) -> str | None:
-    """Optional ``connect_from`` from JSON body (e.g. PostHog Code)."""
-    data: Any = request.data
-    if not isinstance(data, dict):
-        return None
-    raw = data.get("connect_from")
-    if raw == "posthog_code":
-        return "posthog_code"
-    return None
-
-
-def _team_for_github_start(user: User, request: Request):
-    """Resolve which team to use for team-level GitHub install discovery.
-
-    PostHog Code passes ``team_id`` (project/team) in the JSON body because the
-    session's ``user.current_team`` may not match the app UI. The web app omits
-    it and uses ``current_team``.
-    """
-    data: Any = request.data
-    if not isinstance(data, dict):
-        data = {}
-    raw_id = data.get("team_id")
-    if raw_id is not None and raw_id != "":
-        try:
-            tid = int(raw_id)
-        except (TypeError, ValueError):
-            raise exceptions.ValidationError("team_id must be an integer")
-        team = user.teams.filter(id=tid).first()
-        if team is None:
-            raise exceptions.ValidationError("Invalid or inaccessible team_id for this user.")
-        return team
-    return user.current_team
-
-
-def _serialize_github_integration(
-    integration: UserIntegration,
-    *,
-    team_integration_installation_ids: set[str],
-) -> dict[str, Any]:
-    """Build the response payload for a single GitHub UserIntegration."""
-    return {
-        "kind": "github",
-        "installation_id": integration.integration_id,
-        "repository_selection": integration.config.get("repository_selection"),
-        "account": integration.config.get("account"),
-        "uses_shared_installation": integration.integration_id in team_integration_installation_ids,
-        "created_at": integration.created_at,
-    }
+GITHUB_OAUTH_REDIRECT_URI = f"{settings.SITE_URL.rstrip('/')}/complete/github-link/"
 
 
 class UserGitHubAccountSerializer(serializers.Serializer):
@@ -300,11 +247,16 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
         ``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
         under projects).
 
-        - If the current project has **no** team-level GitHub ``Integration``, returns
-          ``install_url`` pointing at ``/installations/new`` (configure org + repos).
-        - If the team **already** has a GitHub installation, returns ``install_url``
-          pointing at ``/login/oauth/authorize`` so the user only authorizes as
-          themselves for that installation (no repo scoping UI on GitHub).
+        Usually returns ``install_url`` pointing at ``/installations/new`` so the
+        user can pick any GitHub org (new or already connected).  GitHub's install
+        page handles both cases: orgs where the app is installed show "Configure"
+        (no admin needed), orgs where it isn't show "Install" (needs admin).
+
+        **PostHog Code fast path:** when ``connect_from`` is ``"posthog_code"``,
+        the current project already has a team-level GitHub installation, and the
+        user has no ``UserIntegration`` for that installation yet, we skip the org
+        picker and redirect straight to ``/login/oauth/authorize`` so the user
+        only authorizes themselves and returns to PostHog Code immediately.
 
         In both cases the response key is ``install_url`` for compatibility with callers.
         """
@@ -313,47 +265,14 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
         token = get_random_string(48)
         state = urlencode({"token": token, "source": "user_integration"})
         user = self._get_user()
-        team = _team_for_github_start(user, self.request)
-        connect_from = _connect_from_github_start(self.request)
+        team = _resolve_team_for_github_start(user, self.request)
+        connect_from = request.data.get("connect_from")
 
-        has_team_github = False
-        team_installation_id: str | None = None
-        if team is not None:
-            team_row = (
-                Integration.objects.filter(team=team, kind="github")
-                .exclude(integration_id__isnull=True)
-                .exclude(integration_id="")
-                .order_by("id")
-                .first()
-            )
-            if team_row is not None and team_row.integration_id:
-                has_team_github = True
-                team_installation_id = str(team_row.integration_id)
+        if connect_from == "posthog_code":
+            if fast_path_response := _attempt_posthog_code_oauth_fast_path(user, team, token, state):
+                return fast_path_response
 
-        if has_team_github and team_installation_id:
-            client_id = settings.GITHUB_APP_CLIENT_ID
-            if not client_id:
-                raise exceptions.ValidationError(
-                    "GitHub App client ID is not configured (GITHUB_APP_CLIENT_ID missing)."
-                )
-            oauth_state_payload: dict[str, Any] = {
-                "user_id": user.id,
-                "installation_id": team_installation_id,
-                "flow": "oauth_authorize",
-            }
-            if connect_from:
-                oauth_state_payload["connect_from"] = connect_from
-            cache.set(
-                f"{GITHUB_INSTALL_STATE_CACHE_PREFIX}{token}",
-                oauth_state_payload,
-                timeout=GITHUB_INSTALL_STATE_TTL_SECONDS,
-            )
-            redirect_uri = _github_oauth_redirect_uri()
-            install_url = "https://github.com/login/oauth/authorize?" + urlencode(
-                {"client_id": client_id, "redirect_uri": redirect_uri, "state": state}
-            )
-            return Response({"install_url": install_url, "connect_flow": "oauth_authorize"})
-
+        # Default: full install flow — user picks an org on GitHub's install page.
         instance_settings = get_instance_settings(["GITHUB_APP_SLUG"])
         app_slug = instance_settings.get("GITHUB_APP_SLUG")
         if not app_slug:
@@ -481,7 +400,7 @@ def github_link_complete(request: HttpRequest) -> HttpResponseRedirect:
 
     # Exchange code for user-to-server tokens
     if oauth_flow:
-        authorization = GitHubIntegration.github_user_from_code(code, redirect_uri=_github_oauth_redirect_uri())
+        authorization = GitHubIntegration.github_user_from_code(code, redirect_uri=GITHUB_OAUTH_REDIRECT_URI)
     else:
         authorization = GitHubIntegration.github_user_from_code(code)
     if authorization is None:
@@ -541,3 +460,82 @@ def github_link_complete(request: HttpRequest) -> HttpResponseRedirect:
     if posthog_code_flow:
         return redirect(f"{ACCOUNT_CONNECTED_GITHUB_INTEGRATION_PATH}?{urlencode({'provider': 'github'})}")
     return redirect(f"{PERSONAL_INTEGRATIONS_SETTINGS_PATH}?github_link_success=1")
+
+
+def _resolve_team_for_github_start(user: User, request: Request):
+    """Resolve which team to use for team-level GitHub install discovery.
+
+    PostHog Code passes ``team_id`` (project/team) in the JSON body because the
+    session's ``user.current_team`` may not match the app UI. The web app omits
+    it and uses ``current_team``.
+    """
+    data: Any = request.data
+    if not isinstance(data, dict):
+        data = {}
+    raw_id = data.get("team_id")
+    if raw_id is not None and raw_id != "":
+        try:
+            tid = int(raw_id)
+        except (TypeError, ValueError):
+            raise exceptions.ValidationError("team_id must be an integer")
+        team = user.teams.filter(id=tid).first()
+        if team is None:
+            raise exceptions.ValidationError("Invalid or inaccessible team_id for this user.")
+        return team
+    return user.current_team
+
+
+def _attempt_posthog_code_oauth_fast_path(user: User, team: Any, token: str, state: str) -> Response | None:
+    """If the team has a GitHub installation the user hasn't linked yet, return
+    an OAuth-only ``/login/oauth/authorize`` redirect so PostHog Code users
+    authorize and return immediately — no org picker needed.
+
+    Returns ``None`` when the fast path doesn't apply (no team integration,
+    user already linked, or missing config).
+    """
+    if team is None:
+        return None
+    team_row = (
+        Integration.objects.filter(team=team, kind="github")
+        .exclude(integration_id__isnull=True)
+        .exclude(integration_id="")
+        .order_by("id")
+        .first()
+    )
+    if team_row is None or not team_row.integration_id:
+        return None
+    team_installation_id = str(team_row.integration_id)
+    if UserIntegration.objects.filter(user=user, kind="github", integration_id=team_installation_id).exists():
+        return None
+    if not settings.GITHUB_APP_CLIENT_ID:
+        raise exceptions.ValidationError("GitHub App client ID is not configured (GITHUB_APP_CLIENT_ID missing).")
+    cache.set(
+        f"{GITHUB_INSTALL_STATE_CACHE_PREFIX}{token}",
+        {
+            "user_id": user.id,
+            "installation_id": team_installation_id,
+            "flow": "oauth_authorize",
+            "connect_from": "posthog_code",
+        },
+        timeout=GITHUB_INSTALL_STATE_TTL_SECONDS,
+    )
+    install_url = "https://github.com/login/oauth/authorize?" + urlencode(
+        {"client_id": settings.GITHUB_APP_CLIENT_ID, "redirect_uri": GITHUB_OAUTH_REDIRECT_URI, "state": state}
+    )
+    return Response({"install_url": install_url, "connect_flow": "oauth_authorize"})
+
+
+def _serialize_github_integration(
+    integration: UserIntegration,
+    *,
+    team_integration_installation_ids: set[str],
+) -> dict[str, Any]:
+    """Build the response payload for a single GitHub UserIntegration."""
+    return {
+        "kind": "github",
+        "installation_id": integration.integration_id,
+        "repository_selection": integration.config.get("repository_selection"),
+        "account": integration.config.get("account"),
+        "uses_shared_installation": integration.integration_id in team_integration_installation_ids,
+        "created_at": integration.created_at,
+    }

--- a/posthog/api/user_integration.py
+++ b/posthog/api/user_integration.py
@@ -275,6 +275,15 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
             if fast_path_response := _attempt_posthog_code_oauth_fast_path(user, team, token, state):
                 return fast_path_response
 
+        # If the user already has linked integrations, check whether there are
+        # any GitHub App installations they haven't linked yet. If everything
+        # accessible is already linked, there's nothing to add.
+        has_unlinked = _has_unlinked_github_installations(user)
+        if has_unlinked is False:
+            raise exceptions.ValidationError(
+                "All GitHub App installations accessible to your account are already linked."
+            )
+
         # Default: full install flow — user picks an org on GitHub's install page.
         instance_settings = get_instance_settings(["GITHUB_APP_SLUG"])
         app_slug = instance_settings.get("GITHUB_APP_SLUG")
@@ -486,6 +495,53 @@ def _resolve_team_for_github_start(user: User, request: Request):
             raise exceptions.ValidationError("Invalid or inaccessible team_id for this user.")
         return team
     return user.current_team
+
+
+def _has_unlinked_github_installations(user: User) -> bool | None:
+    """Check whether the user has GitHub App installations they haven't linked yet.
+
+    Uses the user's existing OAuth token to call ``GET /user/installations``
+    and compares against their ``UserIntegration`` rows.
+
+    Returns ``True`` if unlinked installations exist, ``False`` if all are
+    linked, or ``None`` if the check couldn't be performed (no existing
+    integration, token refresh failed, network error).
+    """
+    any_integration = UserIntegration.objects.filter(user=user, kind="github").exclude(sensitive_config={}).first()
+    if any_integration is None:
+        return None
+
+    github = UserGitHubIntegration(any_integration)
+    try:
+        token = github.get_usable_user_access_token()
+    except Exception:
+        return None
+
+    try:
+        response = requests.get(
+            "https://api.github.com/user/installations",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            params={"per_page": 100},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    try:
+        installations = response.json().get("installations", [])
+    except Exception:
+        return None
+
+    github_installation_ids = {str(inst["id"]) for inst in installations if isinstance(inst, dict) and "id" in inst}
+    linked_ids = set(UserIntegration.objects.filter(user=user, kind="github").values_list("integration_id", flat=True))
+    return bool(github_installation_ids - linked_ids)
 
 
 def _attempt_posthog_code_oauth_fast_path(user: User, team: Any, token: str, state: str) -> Response | None:

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -161,13 +161,90 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM events
+     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.2
@@ -292,6 +369,17 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.1
   '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
+  '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
@@ -310,7 +398,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -325,7 +421,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -335,8 +431,15 @@
                             and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
             quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
                             0) AS previous_avg_time_on_page
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
      GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
   LEFT JOIN
     (SELECT breakdown_value AS breakdown_value,
@@ -347,7 +450,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -357,7 +466,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -664,11 +664,16 @@ export const usersIntegrationsGithubReposRetrieve = async (
 ``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
 under projects).
 
-- If the current project has **no** team-level GitHub ``Integration``, returns
-  ``install_url`` pointing at ``/installations/new`` (configure org + repos).
-- If the team **already** has a GitHub installation, returns ``install_url``
-  pointing at ``/login/oauth/authorize`` so the user only authorizes as
-  themselves for that installation (no repo scoping UI on GitHub).
+Usually returns ``install_url`` pointing at ``/installations/new`` so the
+user can pick any GitHub org (new or already connected).  GitHub's install
+page handles both cases: orgs where the app is installed show "Configure"
+(no admin needed), orgs where it isn't show "Install" (needs admin).
+
+**PostHog Code fast path:** when ``connect_from`` is ``"posthog_code"``,
+the current project already has a team-level GitHub installation, and the
+user has no ``UserIntegration`` for that installation yet, we skip the org
+picker and redirect straight to ``/login/oauth/authorize`` so the user
+only authorizes themselves and returns to PostHog Code immediately.
 
 In both cases the response key is ``install_url`` for compatibility with callers.
  * @summary Start GitHub personal integration linking

--- a/products/integrations/frontend/generated/api.zod.ts
+++ b/products/integrations/frontend/generated/api.zod.ts
@@ -253,11 +253,16 @@ export const IntegrationsDomainConnectApplyUrlCreateBody = /* @__PURE__ */ zod
 ``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
 under projects).
 
-- If the current project has **no** team-level GitHub ``Integration``, returns
-  ``install_url`` pointing at ``/installations/new`` (configure org + repos).
-- If the team **already** has a GitHub installation, returns ``install_url``
-  pointing at ``/login/oauth/authorize`` so the user only authorizes as
-  themselves for that installation (no repo scoping UI on GitHub).
+Usually returns ``install_url`` pointing at ``/installations/new`` so the
+user can pick any GitHub org (new or already connected).  GitHub's install
+page handles both cases: orgs where the app is installed show "Configure"
+(no admin needed), orgs where it isn't show "Install" (needs admin).
+
+**PostHog Code fast path:** when ``connect_from`` is ``"posthog_code"``,
+the current project already has a team-level GitHub installation, and the
+user has no ``UserIntegration`` for that installation yet, we skip the org
+picker and redirect straight to ``/login/oauth/authorize`` so the user
+only authorizes themselves and returns to PostHog Code immediately.
 
 In both cases the response key is ``install_url`` for compatibility with callers.
  * @summary Start GitHub personal integration linking


### PR DESCRIPTION
## Problem

Two issues with the Personal integrations GitHub linking flow:

1. It always redirected to GitHub's OAuth authorize flow when the team had an existing GitHub integration, locking users into that single org - clicking "Add account/organization" would just re-authorize on the same installation instead of showing the org picker.
2. If all accessible installations are already linked, clicking "Add account/organization" would redirect to GitHub's install page which just confusignly loops back to the existing installation.

## Changes

1. Default to `/installations/new` so users can pick any org (new or already connected). GitHub's install page handles both: installed orgs show "Configure" (no admin needed), new ones show "Install".
	 - HOWEVER PostHog Code retains the fast OAuth-only path for first-time linking on the team's existing installation (gated on `connect_from == "posthog_code"`).
2. Before redirecting to `/installations/new`, check `GET /user/installations` with the user's token - if all accessible installations are already linked, return a 400 instead of a useless redirect.

## How did you test this code?

Got some tests here.