### PR TITLE
fix(web-analytics): group bot events into single Requests series

### DIFF
--- a/frontend/src/scenes/web-analytics/botAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/botAnalyticsLogic.ts
@@ -5,6 +5,7 @@ import { isNotNil } from 'lib/utils'
 
 import {
     EventsNode,
+    GroupNode,
     NodeKind,
     TrendsFilter,
     WebAnalyticsPropertyFilter,
@@ -14,6 +15,7 @@ import {
     BaseMathType,
     BreakdownType,
     ChartDisplayType,
+    FilterLogicalOperator,
     InsightLogicProps,
     PropertyFilterBaseValue,
     PropertyFilterType,
@@ -172,13 +174,24 @@ export const botAnalyticsLogic = kea<botAnalyticsLogicType>([
                     dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
                 })
 
-                const botTrendsSeries: EventsNode[] = BOT_ANALYTICS_EVENTS.map((event) => ({
+                const botTrendsNodes: EventsNode[] = BOT_ANALYTICS_EVENTS.map((event) => ({
                     event,
                     kind: NodeKind.EventsNode as const,
                     math: BaseMathType.TotalCount,
                     name: event,
-                    custom_name: 'Requests',
                 }))
+                // Combine bot events into a single "Requests" series so the tooltip shows one
+                // unified value per breakdown bucket instead of one column per underlying event.
+                const botTrendsSeries: GroupNode[] = [
+                    {
+                        kind: NodeKind.GroupNode,
+                        name: BOT_ANALYTICS_EVENTS.join(', '),
+                        custom_name: 'Requests',
+                        operator: FilterLogicalOperator.Or,
+                        nodes: botTrendsNodes,
+                        math: BaseMathType.TotalCount,
+                    },
+                ]
 
                 const createBotTrendsTab = (
                     id: string,


### PR DESCRIPTION
## Problem

On the Bots tab in web analytics, the trends insight rendered each bot event (`$pageview`, `$screen`, `$http_log`) as its own series. With a breakdown applied, the tooltip showed a separate column per event, so a single host/crawler/category appeared as two or three disjoint columns instead of one combined "Requests" total.

## Changes

Wrap the three event nodes in a single `GroupNode` with operator `OR` and `custom_name: "Requests"`. The trends query now returns one logical series per breakdown bucket — the tooltip and legend collapse to a single "Requests" column that sums the underlying events.

## How did you test this code?

I'm an agent. I did not manually test this in the browser.

- Ran `pnpm --filter=@posthog/frontend typescript:check` — passes.
- Verified the generated query shape matches the example payload that produces a unified tooltip.

## Publish to changelog?

no
