### PR TITLE
fix(replay): seekbar preview mousemove listener never removed

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarPreview.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarPreview.tsx
@@ -114,16 +114,13 @@ export const PlayerSeekbarPreview = memo(function PlayerSeekbarPreview({
 
             const relativeX = e.clientX - rect.x
             const newPercentage = Math.max(Math.min(relativeX / rect.width, 1), 0)
-
-            if (newPercentage !== percentage) {
-                setPercentage(newPercentage)
-            }
+            setPercentage(newPercentage)
         }
 
         const seekBar = seekBarRef.current
         seekBar.addEventListener('mousemove', handleMouseMove)
         return () => seekBar.removeEventListener('mousemove', handleMouseMove)
-    }, [seekBarRef, percentage])
+    }, [seekBarRef])
 
     return (
         <div className="PlayerSeekBarPreview" ref={ref}>

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarPreview.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarPreview.tsx
@@ -120,10 +120,9 @@ export const PlayerSeekbarPreview = memo(function PlayerSeekbarPreview({
             }
         }
 
-        seekBarRef.current.addEventListener('mousemove', handleMouseMove)
-        // fixes react-hooks/exhaustive-deps warning about stale ref elements
-        const { current } = ref
-        return () => current?.removeEventListener('mousemove', handleMouseMove)
+        const seekBar = seekBarRef.current
+        seekBar.addEventListener('mousemove', handleMouseMove)
+        return () => seekBar.removeEventListener('mousemove', handleMouseMove)
     }, [seekBarRef, percentage])
 
     return (


### PR DESCRIPTION
## Problem

`/replay/home` accumulates detached DOM elements as users click through recordings. Production telemetry (`detached_elements` event) shows up to 43,139 detached elements on busy session-recordings sessions; per-team averages range from a few hundred to ~11,000.

`PlayerSeekbarPreview` adds a `mousemove` handler to `seekBarRef.current` but its cleanup runs `current?.removeEventListener(...)` against `ref.current` (the inner wrapper, a different element). The listener is never removed; each recording switch — and each `percentage` update via `[seekBarRef, percentage]` deps — appends a new listener to the outer seekbar, with a closure that pins the previous wrapper div in detached state.

## Changes

Snapshot `seekBarRef.current` to a stable local `seekBar` and remove the listener from the same node it was added to. Drops the inline comment that explained the no-longer-applicable `react-hooks/exhaustive-deps` workaround.

```diff
-    seekBarRef.current.addEventListener('mousemove', handleMouseMove)
-    // fixes react-hooks/exhaustive-deps warning about stale ref elements
-    const { current } = ref
-    return () => current?.removeEventListener('mousemove', handleMouseMove)
+    const seekBar = seekBarRef.current
+    seekBar.addEventListener('mousemove', handleMouseMove)
+    return () => seekBar.removeEventListener('mousemove', handleMouseMove)
```

## How did you test this code?

I'm an agent; this is automated measurement and a manual smoke check via Playwright MCP, no existing test suite covers this listener cleanup directly.

Workload on `/project/1/replay/home`: cycle through 15 recording previews with 1.5s settle, then `HeapProfiler.collectGarbage` twice via CDP, then `__leakHunter.scan()`.

| state | clicks | detached after GC | leaky components |
|---|---|---|---|
| before | 5 | 29 | PlayerSeekbarPreview2:12, PlayerFrame:6, BindLogic:3 |
| before | 15 | 43 | PlayerSeekbarPreview2:16, PlayerFrame:8, BindLogic:4 |
| after | 15 | 11 | (empty) |
| after | 45 | 4 | (empty) |

After the fix, `detachedComponentToFiberNodeCount` is empty — no named React components in the detached set. The remaining 4-11 are the Blink `(Traced handles)` residual we've seen on every scene (V8/Oilpan boundary bookkeeping).

Verified the seekbar preview still works: dispatched synthetic `mousemove` on the actual `.PlayerSeekbar__slider` at 25%/50%/75% positions and the tooltip's `transform: translateX(...)` updated to the latest percentage.

Heap retainer walk before the fix (via `HeapProfiler.takeHeapSnapshot` + tagged-element reverse-edge index) confirmed the chain: orphan ← `[context:current]` from `closure handleMouseMove` ← `V8EventListener` ← `EventListener`.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) during a detached-element leak hunt session driven by Paul. Reviewed by Paul before opening.

Tools used:
- `@memlab/lens` scanner with custom `__leakHunter` helpers (scan/forensics/inspect/rawElements/scanStrict)
- CDP `HeapProfiler.collectGarbage` + `takeHeapSnapshot` for stable measurements
- Custom heap retainer walker (`tools/leak-hunter/heap-find-by-tag-streaming.mjs`) to identify the closure→listener chain on a 735MB snapshot

The retainer walk pointed at `closure::handleMouseMove` directly. The diff was guided by the heap output, not by guess-and-check.