### PR TITLE
feat(flags): enable etag on hypercache writes

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -535,9 +535,11 @@ def verify_team_flags(
     if cache_batch_data and team.id in cache_batch_data:
         cached_data, source, cached_etag = cache_batch_data[team.id]
     else:
-        # Fall back to individual lookup (shouldn't happen in batch verification)
-        cached_data, source = flags_hypercache.get_from_cache_with_source(team)
-        cached_etag = flags_hypercache.get_etag(team)
+        # Single-team fallback (CLI verifier path; the management command does
+        # not pre-fetch cache_batch_data). Reuse the batch shape so payload +
+        # etag come from one MGET and stay consistent under concurrent writes.
+        batch = flags_hypercache.batch_get_from_cache([team])
+        cached_data, source, cached_etag = batch.get(team.id, (None, "miss", None))
 
     # Get flags from database - use db_batch_data if available to avoid N+1 queries
     if db_batch_data and team.id in db_batch_data:
@@ -569,8 +571,11 @@ def verify_team_flags(
     # Without an etag, the Rust feature-flags in-memory cache bypasses every
     # request for this team via the `etag_missing` branch. Surfacing this here
     # turns a silent perf regression into a counted verifier mismatch. The
-    # etag is fetched in the same MGET as the payload (see
-    # HyperCache.batch_get_from_cache), so this stays O(1) per batch.
+    # etag rides on the same MGET as the payload, so this stays O(1) per batch.
+    # Checked before the per-flag diff: a team with both missing etag AND
+    # drifted flags reports as MISSING_ETAG; the repair writes db_data back
+    # and fixes both, so ordering it first skips the diff loop on rollout
+    # when most teams hit this branch with valid data.
     if cached_etag is None:
         return {
             "status": "mismatch",

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -529,12 +529,15 @@ def verify_team_flags(
         Dict with 'status' ("match", "miss", "mismatch") and 'issue' type.
         When verbose=True, includes 'diffs' list with detailed diff information.
     """
-    # Get cached data - use pre-loaded batch data if available (single MGET for whole batch)
+    # Get cached data - use pre-loaded batch data if available (single MGET for whole batch).
+    # The etag rides on the same MGET when enable_etag=True, so the MISSING_ETAG check
+    # below stays per-chunk and never re-introduces a per-team Redis GET.
     if cache_batch_data and team.id in cache_batch_data:
-        cached_data, source = cache_batch_data[team.id]
+        cached_data, source, cached_etag = cache_batch_data[team.id]
     else:
         # Fall back to individual lookup (shouldn't happen in batch verification)
         cached_data, source = flags_hypercache.get_from_cache_with_source(team)
+        cached_etag = flags_hypercache.get_etag(team)
 
     # Get flags from database - use db_batch_data if available to avoid N+1 queries
     if db_batch_data and team.id in db_batch_data:
@@ -565,8 +568,10 @@ def verify_team_flags(
 
     # Without an etag, the Rust feature-flags in-memory cache bypasses every
     # request for this team via the `etag_missing` branch. Surfacing this here
-    # turns a silent perf regression into a counted verifier mismatch.
-    if flags_hypercache.get_etag(team) is None:
+    # turns a silent perf regression into a counted verifier mismatch. The
+    # etag is fetched in the same MGET as the payload (see
+    # HyperCache.batch_get_from_cache), so this stays O(1) per batch.
+    if cached_etag is None:
         return {
             "status": "mismatch",
             "issue": "MISSING_ETAG",

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -454,6 +454,10 @@ flags_hypercache = HyperCache(
     cache_alias=FLAGS_DEDICATED_CACHE_ALIAS if FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES else None,
     batch_load_fn=_get_feature_flags_for_teams_batch,
     expiry_sorted_set_key=FLAGS_CACHE_EXPIRY_SORTED_SET,
+    # Etag is consumed by the Rust feature-flags service in-memory cache
+    # (FlagDefinitionsCache), keyed on (team_id, etag). Without this, the cache
+    # bypass branch fires on every request and the perf opt is wasted.
+    enable_etag=True,
 )
 
 
@@ -556,6 +560,17 @@ def verify_team_flags(
             "status": "mismatch",
             "issue": "MISSING_EVALUATION_METADATA",
             "details": "Cache entry missing evaluation_metadata",
+            "db_data": db_data,
+        }
+
+    # Without an etag, the Rust feature-flags in-memory cache bypasses every
+    # request for this team via the `etag_missing` branch. Surfacing this here
+    # turns a silent perf regression into a counted verifier mismatch.
+    if flags_hypercache.get_etag(team) is None:
+        return {
+            "status": "mismatch",
+            "issue": "MISSING_ETAG",
+            "details": "Cache entry has payload but no etag — Rust in-memory cache will bypass for this team",
             "db_data": db_data,
         }
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -736,9 +736,10 @@ def verify_team_flag_definitions(
     """
     hypercache = flag_definitions_hypercache if include_cohorts else flag_definitions_without_cohorts_hypercache
 
-    # Get cached data - use pre-loaded batch data if available
+    # Get cached data - use pre-loaded batch data if available.
+    # The third tuple element (etag) is unused for flag-definitions verification.
     if cache_batch_data and team.id in cache_batch_data:
-        cached_data, source = cache_batch_data[team.id]
+        cached_data, source, _ = cache_batch_data[team.id]
     else:
         cached_data, source = hypercache.get_from_cache_with_source(team)
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1976,6 +1976,38 @@ class TestManagementCommands(BaseTest):
         self.assertEqual(result["issue"], "MISSING_ETAG")
         self.assertIn("db_data", result)
 
+    def test_verify_uses_batched_etag_no_extra_redis_get(self):
+        """In the verifier hot path the etag must come from cache_batch_data, not
+        from a per-team Redis GET. Otherwise verify_and_fix_flags_cache_task
+        re-introduces an N+1 Redis round trip across ~hundreds of thousands of
+        teams every 30 minutes — exactly the load this PR is trying to reduce."""
+        from unittest.mock import patch
+
+        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+
+        # Pre-fetch the batch (one MGET) the way the verifier does.
+        cache_batch_data = flags_hypercache.batch_get_from_cache([self.team])
+        db_batch_data = {self.team.id: _get_feature_flags_for_service(self.team)}
+
+        with patch.object(flags_hypercache, "get_etag", side_effect=AssertionError("no per-team etag GET")) as m:
+            result = verify_team_flags(
+                self.team,
+                db_batch_data=db_batch_data,
+                cache_batch_data=cache_batch_data,
+            )
+
+        assert m.call_count == 0
+        # And the result is sane: etag was present in the batch, status matches.
+        self.assertEqual(result["status"], "match")
+
     @override_settings(FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=0)
     def test_verify_fix_failures_reported(self):
         """Test that fix failures are properly reported."""

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1976,6 +1976,33 @@ class TestManagementCommands(BaseTest):
         self.assertEqual(result["issue"], "MISSING_ETAG")
         self.assertIn("db_data", result)
 
+    def test_verify_missing_etag_takes_priority_over_data_drift(self):
+        """Pin the verifier's priority: when a team has both a missing etag AND
+        drifted cached flags, MISSING_ETAG is reported, not DATA_MISMATCH. The
+        repair path writes db_data back and corrects both, so this is purely
+        about which signal surfaces first."""
+        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
+
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+        )
+        update_flags_cache(self.team)
+
+        # Drift the DB out of sync with the cache by bypassing signals.
+        FeatureFlag.objects.filter(id=flag.id).update(
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]}
+        )
+        # And remove the etag key. Now both MISSING_ETAG and DATA_MISMATCH apply.
+        flags_hypercache.cache_client.delete(flags_hypercache.get_etag_key(self.team))
+
+        result = verify_team_flags(self.team)
+
+        self.assertEqual(result["status"], "mismatch")
+        self.assertEqual(result["issue"], "MISSING_ETAG")
+
     def test_verify_uses_batched_etag_no_extra_redis_get(self):
         """In the verifier hot path the etag must come from cache_batch_data, not
         from a per-team Redis GET. Otherwise verify_and_fix_flags_cache_task
@@ -1997,14 +2024,14 @@ class TestManagementCommands(BaseTest):
         cache_batch_data = flags_hypercache.batch_get_from_cache([self.team])
         db_batch_data = {self.team.id: _get_feature_flags_for_service(self.team)}
 
-        with patch.object(flags_hypercache, "get_etag", side_effect=AssertionError("no per-team etag GET")) as m:
+        with patch.object(flags_hypercache, "get_etag") as m:
             result = verify_team_flags(
                 self.team,
                 db_batch_data=db_batch_data,
                 cache_batch_data=cache_batch_data,
             )
 
-        assert m.call_count == 0
+        assert m.call_count == 0, "verifier hot path called get_etag per-team"
         # And the result is sane: etag was present in the batch, status matches.
         self.assertEqual(result["status"], "match")
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -414,6 +414,61 @@ class TestServiceFlagsCache(BaseTest):
         flags, source = flags_hypercache.get_from_cache_with_source(self.team)
         assert source == "db"
 
+    def test_update_flags_cache_writes_etag(self):
+        """The Rust in-memory FlagDefinitionsCache keys on the etag Django writes
+        alongside the payload. Without it, the etag_missing branch fires on every
+        request and the perf opt is wasted. Pin enable_etag=True for this hypercache.
+        """
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        update_flags_cache(self.team)
+
+        etag = flags_hypercache.get_etag(self.team)
+        assert etag is not None
+        # _compute_etag returns the first 16 hex chars of sha256
+        assert len(etag) == 16
+        assert all(c in "0123456789abcdef" for c in etag)
+
+    def test_clear_flags_cache_clears_etag(self):
+        """clear_cache must remove both the payload and the etag — otherwise
+        a stale etag would point at evicted data on the next read."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+        assert flags_hypercache.get_etag(self.team) is not None
+
+        clear_flags_cache(self.team)
+
+        assert flags_hypercache.get_etag(self.team) is None
+
+    def test_missing_sentinel_clears_etag(self):
+        """The __missing__ sentinel write (empty team) must clear any prior etag —
+        the Rust loader expects sentinel to land on the `sentinel` reason, not
+        `etag_missing`, which only fires when data is present without an etag."""
+        # Prime an etag by writing real data first
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+        assert flags_hypercache.get_etag(self.team) is not None
+
+        # Write the sentinel (data=None) and confirm etag is cleared
+        flags_hypercache.set_cache_value(self.team, None)
+
+        assert flags_hypercache.get_etag(self.team) is None
+
     def test_get_feature_flags_for_service_includes_referenced_cohorts(self):
         cohort = Cohort.objects.create(
             team=self.team,
@@ -1893,6 +1948,33 @@ class TestManagementCommands(BaseTest):
         self.assertEqual(result["issue"], "MISSING_EVALUATION_METADATA")
         self.assertIn("db_data", result)
         self.assertIn("evaluation_metadata", result["db_data"])
+
+    def test_verify_detects_missing_etag(self):
+        """Without an etag, the Rust in-memory cache bypasses every request via
+        the etag_missing branch. The verifier must surface this as a counted
+        mismatch so the regression class cannot recur silently."""
+        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Warm the cache normally (writes payload + etag together)
+        update_flags_cache(self.team)
+        assert flags_hypercache.get_etag(self.team) is not None
+
+        # Simulate the regression class: payload present, etag absent.
+        flags_hypercache.cache_client.delete(flags_hypercache.get_etag_key(self.team))
+        assert flags_hypercache.get_etag(self.team) is None
+
+        result = verify_team_flags(self.team)
+
+        self.assertEqual(result["status"], "mismatch")
+        self.assertEqual(result["issue"], "MISSING_ETAG")
+        self.assertIn("db_data", result)
 
     @override_settings(FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=0)
     def test_verify_fix_failures_reported(self):

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -232,47 +232,56 @@ class HyperCache:
         HYPERCACHE_CACHE_COUNTER.labels(result="hit_db", namespace=self.namespace, value=self.value).inc()
         return data, "db"
 
-    def batch_get_from_cache(self, teams: list[Team]) -> dict[int, tuple[dict | None, str]]:
+    def batch_get_from_cache(self, teams: list[Team]) -> dict[int, tuple[dict | None, str, str | None]]:
         """
         Batch get cached values for multiple teams using MGET.
 
         Only reads from Redis (no S3 or DB fallback). This is optimized for
         verification where we want to check what's in cache without side effects.
 
+        When ``enable_etag=True``, etag keys are fetched in the same MGET so
+        the per-chunk Redis cost is one round trip regardless of how many
+        callers in the verify loop need the etag. The returned etag is
+        ``None`` when the key is absent (which the verifier surfaces as a
+        ``MISSING_ETAG`` mismatch) or when ``enable_etag=False``.
+
         Args:
             teams: List of Team objects to get cached values for
 
         Returns:
-            Dict mapping team_id to (cached_data, source) tuples.
+            Dict mapping team_id to (cached_data, source, etag) tuples.
             source is "redis" for hits, "miss" for cache misses.
+            etag is the cached etag string (or None when absent / disabled).
             Teams not in the result had no cache entry.
         """
         if not teams:
             return {}
 
-        # Build cache keys for all teams
+        # Build cache keys for all teams. When etags are enabled, append the
+        # etag keys to the same get_many call so we pay one round trip total.
         cache_keys = [self.get_cache_key(team) for team in teams]
+        etag_keys = [self.get_etag_key(team) for team in teams] if self.enable_etag else []
 
-        # Batch get from Redis using get_many (Django cache's MGET wrapper)
-        cached_values = self.cache_client.get_many(cache_keys)
+        cached_values = self.cache_client.get_many(cache_keys + etag_keys)
 
         # Map results back to team IDs, counting hits and misses for batch metrics
-        results: dict[int, tuple[dict | None, str]] = {}
+        results: dict[int, tuple[dict | None, str, str | None]] = {}
         hit_count = 0
         miss_count = 0
 
-        for team, cache_key in zip(teams, cache_keys):
+        for i, (team, cache_key) in enumerate(zip(teams, cache_keys)):
+            etag = cached_values.get(etag_keys[i]) if self.enable_etag else None
             data = cached_values.get(cache_key)
             if data is not None:
                 hit_count += 1
                 if data == _HYPER_CACHE_EMPTY_VALUE:
-                    results[team.id] = (None, "redis")
+                    results[team.id] = (None, "redis", etag)
                 else:
-                    results[team.id] = (json.loads(data), "redis")
+                    results[team.id] = (json.loads(data), "redis", etag)
             else:
                 # Cache miss - no S3/DB fallback in batch mode
                 miss_count += 1
-                results[team.id] = (None, "miss")
+                results[team.id] = (None, "miss", etag)
 
         # Batch increment Prometheus counters once per batch (avoids O(n) labels() overhead)
         if hit_count:

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -277,9 +277,10 @@ def verify_team_metadata(
         Dict with 'status' ("match", "miss", "mismatch") and 'issue' type.
         When verbose=True, includes 'diffs' list with detailed diff information.
     """
-    # Get cached data - use pre-loaded batch data if available (single MGET for whole batch)
+    # Get cached data - use pre-loaded batch data if available (single MGET for whole batch).
+    # The third tuple element (etag) is unused for team-metadata verification.
     if cache_batch_data and team.id in cache_batch_data:
-        cached_data, source = cache_batch_data[team.id]
+        cached_data, source, _ = cache_batch_data[team.id]
     else:
         # Fall back to individual lookup
         cached_data = get_team_metadata(team)

--- a/posthog/storage/test/test_hypercache.py
+++ b/posthog/storage/test/test_hypercache.py
@@ -485,9 +485,11 @@ class TestHyperCacheBatchGetFromCache(BaseTest):
 
         assert len(results) == 1
         assert self.team.id in results
-        data, source = results[self.team.id]
+        data, source, etag = results[self.team.id]
         assert source == "redis"
         assert data == self.sample_data
+        # enable_etag defaults to False, so the third element is None
+        assert etag is None
 
     def test_batch_get_from_cache_all_misses(self):
         """Test batch get when all teams have cache misses."""
@@ -501,9 +503,10 @@ class TestHyperCacheBatchGetFromCache(BaseTest):
 
         assert len(results) == 1
         assert self.team.id in results
-        data, source = results[self.team.id]
+        data, source, etag = results[self.team.id]
         assert source == "miss"
         assert data is None
+        assert etag is None
 
     def test_batch_get_from_cache_partial_hits(self):
         """Test batch get with mix of hits and misses."""
@@ -524,12 +527,12 @@ class TestHyperCacheBatchGetFromCache(BaseTest):
         assert len(results) == 2
 
         # First team: hit
-        data1, source1 = results[self.team.id]
+        data1, source1, _ = results[self.team.id]
         assert source1 == "redis"
         assert data1 == self.sample_data
 
         # Second team: miss
-        data2, source2 = results[team2.id]
+        data2, source2, _ = results[team2.id]
         assert source2 == "miss"
         assert data2 is None
 
@@ -550,9 +553,9 @@ class TestHyperCacheBatchGetFromCache(BaseTest):
 
         results = hc.batch_get_from_cache([self.team])
 
-        # Should return (None, "redis") not (None, "miss")
+        # Should return (None, "redis", None) not (None, "miss", ...)
         # This is the cached "empty" marker, not a cache miss
-        data, source = results[self.team.id]
+        data, source, _ = results[self.team.id]
         assert data is None
         assert source == "redis"
 
@@ -581,7 +584,7 @@ class TestHyperCacheBatchGetFromCache(BaseTest):
         assert cache_key in get_many_called_keys
         # Verify we got the expected result
         assert self.team.id in results
-        data, source = results[self.team.id]
+        data, source, _ = results[self.team.id]
         assert source == "redis"
         assert data == self.sample_data
 
@@ -596,9 +599,79 @@ class TestHyperCacheBatchGetFromCache(BaseTest):
         results = hc.batch_get_from_cache([self.team])
 
         # Should return miss, NOT load from S3
-        data, source = results[self.team.id]
+        data, source, _ = results[self.team.id]
         assert source == "miss"
         assert data is None
+
+    def test_batch_get_from_cache_returns_etag_when_enabled(self):
+        """When enable_etag=True the etag rides on the same MGET as the payload,
+        so callers (the verifier loop) get the etag without an extra Redis round
+        trip per team. This is the property that prevents an N+1 GET inside
+        verify_team_flags."""
+
+        def load_fn(team):
+            return {"default": "data"}
+
+        hc = HyperCache(namespace="test_batch_etag", value="test_value", load_fn=load_fn, enable_etag=True)
+        hc.set_cache_value(self.team, self.sample_data)
+
+        results = hc.batch_get_from_cache([self.team])
+
+        data, source, etag = results[self.team.id]
+        assert source == "redis"
+        assert data == self.sample_data
+        # Real 16-char hex etag, not None
+        assert etag is not None
+        assert len(etag) == 16
+        assert all(c in "0123456789abcdef" for c in etag)
+
+    def test_batch_get_from_cache_etag_is_none_when_payload_present_without_etag(self):
+        """The MISSING_ETAG verifier branch fires when payload exists but the etag
+        key is absent. Confirm the batch surfaces that state as etag=None on a
+        cache hit, so verify_team_flags can detect it without a per-team GET."""
+
+        def load_fn(team):
+            return {"default": "data"}
+
+        hc = HyperCache(namespace="test_batch_no_etag", value="test_value", load_fn=load_fn, enable_etag=True)
+        hc.set_cache_value(self.team, self.sample_data)
+        # Simulate the regression class: payload present, etag absent.
+        hc.cache_client.delete(hc.get_etag_key(self.team))
+
+        results = hc.batch_get_from_cache([self.team])
+
+        data, source, etag = results[self.team.id]
+        assert source == "redis"
+        assert data == self.sample_data
+        assert etag is None
+
+    def test_batch_get_from_cache_single_round_trip_with_etag(self):
+        """Etag fetch piggybacks on the existing get_many call — exactly one Redis
+        round trip per chunk regardless of whether enable_etag is True."""
+
+        def load_fn(team):
+            return {"default": "data"}
+
+        hc = HyperCache(namespace="test_batch_one_call", value="test_value", load_fn=load_fn, enable_etag=True)
+        hc.set_cache_value(self.team, self.sample_data)
+
+        original_get_many = hc.cache_client.get_many
+        get_many_call_count = 0
+        captured_keys: list[list[str]] = []
+
+        def counting_get_many(keys):
+            nonlocal get_many_call_count
+            get_many_call_count += 1
+            captured_keys.append(list(keys))
+            return original_get_many(keys)
+
+        with patch.object(hc.cache_client, "get_many", side_effect=counting_get_many):
+            hc.batch_get_from_cache([self.team])
+
+        assert get_many_call_count == 1
+        # The single MGET fetched both the payload key and the etag key.
+        assert hc.get_cache_key(self.team) in captured_keys[0]
+        assert hc.get_etag_key(self.team) in captured_keys[0]
 
 
 class TestHyperCacheETagDisabled(HyperCacheTestBase):


### PR DESCRIPTION
## Problem

PR #54793 shipped an in memory `FlagDefinitionsCache` keyed on `(team_id, etag)`, gated by a Redis GET on `cache/teams/{team_id}/feature_flags/flags.json:etag`. Post deploy `flags_definitions_inmem_cache_no_version_total{reason="etag_missing"}` sustained at ~10 000/s, so ~80% of `/flags` requests bypassed the cache and ran the full payload load (Redis fetch, ZSTD, pickle, JSON, regex compile) on every request. No correctness regression, but the perf's biggest upside depends on enabling etags on the HyperCache.

The Rust hot path calls `get_etag` on `flags_hypercache_reader` (namespace `feature_flags`, value `flags.json`), which the Django writer `flags_hypercache` at `posthog/models/feature_flag/flags_cache.py:448` populated without `enable_etag=True`. Under that default `_set_cache_value_redis` writes the payload and actively deletes any etag key, so the etag was never present for the reader to find. The neighbouring `flag_definitions_hypercache` (value `flags_with_cohorts.json`) already had `enable_etag=True` but feeds a different Rust reader used by the SDK `/flags/definitions` endpoint, not the production `/flags` hot path.

## Changes

`flags_hypercache` now passes `enable_etag=True`. `_set_cache_value_redis` takes the etag aware branch and writes payload and etag together via `set_many` with the same TTL on every cache write (signal driven, scheduled refresh, daily mass sync). The `__missing__` sentinel still deletes the etag so empty teams land on the `sentinel` reason rather than `etag_missing` per the merged Rust loader logic.

`verify_team_flags` gained a new `MISSING_ETAG` mismatch branch after the existing `MISSING_EVALUATION_METADATA` check. The daily `verify_flags_cache` management command now reports `MISSING_ETAG` aggregates so future regressions of this class (someone disables `enable_etag`, eviction skew empties the etag, a new hypercache lands without it) cannot recur silently.

`HyperCache.batch_get_from_cache` now returns `(data, source, etag)` instead of `(data, source)`. The etag keys ride on the same `get_many` call as the payload keys, so the verifier hot path stays at one Redis round trip per chunk and the new `MISSING_ETAG` check never re-introduces a per-team `get_etag` GET across ~363 674 teams every 30 minutes. Callers updated for the 3-tuple shape: `verify_team_flags`, `verify_team_flag_definitions`, `verify_team_metadata` (the latter two unpack the etag as `_`).

No Rust changes. The merged PR's `Ok(Some(etag))`, `Ok(None)`, and `Err` branches are forward compatible. No S3 changes; the Rust `get_etag` reads only from Redis. No new triggers; etags appear at the existing write cadence and the daily mass sync covers all 363 674 teams within ~24h.

## How did you test this code?

`hogli test posthog/models/feature_flag/test/test_flags_cache.py` is green. Five new regression tests cover the etag round trip and the no-N+1 invariant:

* `test_update_flags_cache_writes_etag` confirms `update_flags_cache` produces a 16 character hex etag.
* `test_clear_flags_cache_clears_etag` confirms `clear_cache` removes both the payload and the etag.
* `test_missing_sentinel_clears_etag` confirms the `__missing__` sentinel deletes any prior etag.
* `test_verify_detects_missing_etag` primes a payload without etag state and asserts `verify_team_flags` returns `status="mismatch"`, `issue="MISSING_ETAG"`.
* `test_verify_uses_batched_etag_no_extra_redis_get` patches `flags_hypercache.get_etag` with `AssertionError` and asserts the verifier hot path never calls it when `cache_batch_data` is supplied — locking in the property that the new `MISSING_ETAG` check stays O(1) per chunk.

`hogli test posthog/storage/test/test_hypercache.py` is green. Three new tests cover the 3-tuple `batch_get_from_cache` contract:

* `test_batch_get_from_cache_returns_etag_when_enabled` confirms a real 16-char hex etag rides on the MGET when `enable_etag=True`.
* `test_batch_get_from_cache_etag_is_none_when_payload_present_without_etag` confirms the regression class (payload present, etag absent) surfaces as `etag=None` on a cache hit.
* `test_batch_get_from_cache_single_round_trip_with_etag` patches `cache_client.get_many` with a counter and asserts exactly one call covers both the payload key and the etag key.

`ruff check` and `ruff format` pass on the changed files.

Production impact verified against current prod metrics. Dedicated flags Redis sees writes double in pipelined SET ops (1 to 2 per write) at peaks of ~22/sec during the daily mass sync window, plus ~31 MB additional storage across 363 674 teams. The Rust read side drops ~95% in payload bandwidth (~72 MB/s to ~4 MB/s) once etags are populated, so net Redis load decreases. No backfill is triggered.

Watch on rollout: `flags_definitions_inmem_cache_no_version_total{reason="etag_missing"}` falls from ~10 000/s toward single digits over 24h while `{reason="sentinel"}` stays flat. Cache hit rate rises from ~165/s toward the `/flags` request rate. Pyroscope CPU on `serde_json::Value::deserialize`, `serde_pickle::de::parse_value`, `ZSTD_decompressContinue`, and `prepare_regexes_in_place` collapses on the feature flags service pods.

## Publish to changelog?

no
