### PR TITLE
fix(web-analytics): show insight loading state on bot crawler/path tables

### DIFF
--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -30,6 +30,7 @@ import {
     countryCodeToFlag,
     languageCodeToFlag,
 } from 'lib/utils/geography/country'
+import { StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -51,6 +52,8 @@ import { webAnalyticsFilterLogic } from 'scenes/web-analytics/webAnalyticsFilter
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { Query } from '~/queries/Query/Query'
 import {
     DataTableNode,
@@ -1227,6 +1230,18 @@ const BotHogQLTableTile = ({ uniqueKey, attachTo, query, insightProps, tileId }:
     const { setBotAnalyticsFilters } = useActions(botAnalyticsLogic)
     const { rawBotAnalyticsFilters } = useValues(botAnalyticsLogic)
 
+    // Mirror the props DataTable uses internally so we share the same dataNodeLogic instance —
+    // mounting it here lets us drive a richer initial loading state without triggering a duplicate fetch.
+    const dataNodeLogicKey = insightVizDataNodeKey(insightProps)
+    const { response, responseLoading, queryId, pollResponse } = useValues(
+        dataNodeLogic({
+            query: query.source,
+            key: dataNodeLogicKey,
+            dataNodeCollectionId: insightProps.dataNodeCollectionId || dataNodeLogicKey,
+        })
+    )
+    const isInitialLoading = responseLoading && !response
+
     const context = useMemo((): QueryContext => {
         // Single-select toggle: clicking the same value clears it, any other click replaces.
         const toggleFilter = (key: string, value: string): void => {
@@ -1273,7 +1288,13 @@ const BotHogQLTableTile = ({ uniqueKey, attachTo, query, insightProps, tileId }:
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col py-2 px-1">
-            <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
+            {isInitialLoading ? (
+                <div className="flex flex-1 p-2 w-full justify-center items-center">
+                    <StatelessInsightLoadingState queryId={queryId} pollResponse={pollResponse} />
+                </div>
+            ) : (
+                <Query uniqueKey={uniqueKey} attachTo={attachTo} query={query} readOnly={true} context={context} />
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The bot Crawlers and Most-crawled-paths tables on \`/web/bots\` are HogQL \`DataTableNode\` queries. While they fetch, the user sees an empty \`LemonTable\` with a thin spinner — visually inconsistent with the trends chart above, which shows the full \`InsightLoadingState\` while loading.

## Changes

In \`BotHogQLTableTile\`, mount \`dataNodeLogic\` with the same key the inner \`DataTable\` uses (no duplicate fetch — kea logic is reference-counted) and read \`responseLoading\` / \`response\`. On the first load (no cached response yet), render \`StatelessInsightLoadingState\` instead of the empty table. After the first response arrives, the table mounts as before, and refresh-time loading still flows through \`LemonTable\`'s built-in indicator.

## How did you test this code?

I'm an agent. I did not manually test this in the browser.

- Ran \`pnpm exec tsc --noEmit\` — change compiles clean.
- Verified the same loading pattern is used by \`scenes/data-warehouse/editor/OutputPane.tsx\` for SQL DataTable nodes.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7) at the user's direction after they asked for a loading state matching insights/query components.
- File touched: \`frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx\`.