### PR TITLE
fix(web-analytics): unbound bot query rows and use comparable denominator for bot %

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
@@ -188,6 +188,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map([
@@ -203,6 +204,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map([
@@ -228,6 +230,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map([['Mobile', new Set(['device-1', 'device-2'])]]),
@@ -239,6 +242,7 @@ describe('LiveMetricsSlidingWindow', () => {
             })
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map([['Mobile', new Set(['device-1', 'device-3'])]]),
@@ -263,6 +267,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map([
@@ -291,6 +296,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -306,6 +312,7 @@ describe('LiveMetricsSlidingWindow', () => {
             })
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -338,6 +345,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -397,6 +405,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(minuteStart, {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -408,6 +417,7 @@ describe('LiveMetricsSlidingWindow', () => {
             })
             window.extendBucketData(minuteStart, {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -722,6 +732,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 10,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -747,6 +758,49 @@ describe('LiveMetricsSlidingWindow', () => {
             window.prune()
 
             expect(window.getTotalPageviews()).toBe(10)
+        })
+    })
+
+    describe('incremental totalBotEligibleEvents', () => {
+        it('tracks botEligibleEvents incrementally via addDataPoint', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { botEligibleEvents: 1 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-4 * MINUTE)), 'user-2', { botEligibleEvents: 4 })
+            expect(window.getTotalBotEligibleEvents()).toBe(5)
+        })
+
+        it('tracks botEligibleEvents via extendBucketData', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
+                pageviews: 0,
+                botEligibleEvents: 12,
+                newUserCount: 0,
+                returningUserCount: 0,
+                devices: new Map(),
+                browsers: new Map(),
+                paths: new Map(),
+                referrers: new Map(),
+                uniqueUsers: new Set(),
+                countries: new Map<string, Set<string>>(),
+            })
+
+            expect(window.getTotalBotEligibleEvents()).toBe(12)
+        })
+
+        it('decrements totalBotEligibleEvents when buckets are pruned', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-30 * MINUTE)), 'user-old', { botEligibleEvents: 8 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-2 * MINUTE)), 'user-new', { botEligibleEvents: 3 })
+
+            expect(window.getTotalBotEligibleEvents()).toBe(11)
+
+            tickMinute()
+            window.prune()
+
+            expect(window.getTotalBotEligibleEvents()).toBe(3)
         })
     })
 
@@ -800,6 +854,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -863,6 +918,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -875,6 +931,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -988,6 +1045,7 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),
@@ -1061,6 +1119,7 @@ describe('LiveMetricsSlidingWindow', () => {
             const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map(),

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
@@ -24,6 +24,7 @@ export class LiveMetricsSlidingWindow {
 
     // Incrementally-maintained aggregates
     private _totalPageviews = 0
+    private _totalBotEligibleEvents = 0
     private _globalPathCounts = new Map<string, number>()
     private _globalReferrerCounts = new Map<string, number>()
     private _globalBotCounts = new Map<string, number>()
@@ -39,6 +40,7 @@ export class LiveMetricsSlidingWindow {
         distinctId: string,
         data: {
             pageviews?: number
+            botEligibleEvents?: number
             pathname?: string
             referringDomain?: string
             device?: { deviceId: string; deviceType: string }
@@ -53,6 +55,11 @@ export class LiveMetricsSlidingWindow {
         if (data.pageviews) {
             bucket.pageviews += data.pageviews
             this._totalPageviews += data.pageviews
+        }
+
+        if (data.botEligibleEvents) {
+            bucket.botEligibleEvents += data.botEligibleEvents
+            this._totalBotEligibleEvents += data.botEligibleEvents
         }
 
         if (data.pathname) {
@@ -109,6 +116,11 @@ export class LiveMetricsSlidingWindow {
         if (data.pageviews) {
             bucket.pageviews += data.pageviews
             this._totalPageviews += data.pageviews
+        }
+
+        if (data.botEligibleEvents) {
+            bucket.botEligibleEvents += data.botEligibleEvents
+            this._totalBotEligibleEvents += data.botEligibleEvents
         }
 
         if (data.devices) {
@@ -370,6 +382,7 @@ export class LiveMetricsSlidingWindow {
                     this.decrementBotCounts(bucket.bots)
                 }
                 this._totalPageviews -= bucket.pageviews
+                this._totalBotEligibleEvents -= bucket.botEligibleEvents
                 this.buckets.delete(ts)
             }
         }
@@ -400,6 +413,10 @@ export class LiveMetricsSlidingWindow {
 
     getTotalPageviews(): number {
         return this._totalPageviews
+    }
+
+    getTotalBotEligibleEvents(): number {
+        return this._totalBotEligibleEvents
     }
 
     getDeviceBreakdown(): { device: string; count: number; percentage: number }[] {
@@ -598,6 +615,7 @@ export class LiveMetricsSlidingWindow {
         if (!bucket) {
             bucket = {
                 pageviews: 0,
+                botEligibleEvents: 0,
                 newUserCount: 0,
                 returningUserCount: 0,
                 devices: new Map<string, Set<string>>(),

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -126,6 +126,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
         totalBrowsers,
         botBreakdown,
         totalBotEvents,
+        totalBotEligibleEvents,
         liveUserCount,
         selectedHost,
         isLoading,
@@ -276,7 +277,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                     <LiveBotTrafficCard
                         data={botBreakdown}
                         totalBotEvents={totalBotEvents}
-                        totalEvents={totalPageviews}
+                        totalEvents={totalBotEligibleEvents}
                         isLoading={isLoading}
                     />
                 )

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
@@ -34,6 +34,9 @@ export interface ReferrerItem {
 
 export interface SlidingWindowBucket {
     pageviews: number
+    // Total events of the bot-eligible types (the 5 events the bot detector classifies).
+    // Used as the denominator for "% of total" on the bot traffic tile.
+    botEligibleEvents: number
     newUserCount: number
     returningUserCount: number
     devices: Map<string, Set<string>>
@@ -47,6 +50,20 @@ export interface SlidingWindowBucket {
     // Optional so that existing tests and backfill helpers don't have to
     // construct bot maps when they are not asserting on bot traffic.
     bots?: Map<string, { count: number; category: string }>
+}
+
+export const BOT_KEY_SEPARATOR = '|||'
+
+export const BOT_ELIGIBLE_EVENTS = ['$pageview', '$pageleave', '$screen', '$http_log', '$autocapture'] as const
+
+export const buildBotKey = (botName: string, category: string): string => `${botName}${BOT_KEY_SEPARATOR}${category}`
+
+export const parseBotKey = (key: string): { botName: string; category: string } => {
+    const sepIdx = key.indexOf(BOT_KEY_SEPARATOR)
+    if (sepIdx === -1) {
+        return { botName: key, category: '' }
+    }
+    return { botName: key.slice(0, sepIdx), category: key.slice(sepIdx + BOT_KEY_SEPARATOR.length) }
 }
 
 export interface BotBreakdownItem {

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -28,6 +28,8 @@ import { createStreamConnection } from './createStreamConnection'
 import { LiveMetricsSlidingWindow } from './LiveMetricsSlidingWindow'
 import type { liveWebAnalyticsMetricsLogicType } from './liveWebAnalyticsMetricsLogicType'
 import {
+    BOT_ELIGIBLE_EVENTS,
+    BOT_KEY_SEPARATOR,
     BotBreakdownItem,
     BrowserBreakdownItem,
     ChartDataPoint,
@@ -37,6 +39,7 @@ import {
     DeviceBreakdownItem,
     DIRECT_REFERRER,
     LiveGeoEvent,
+    parseBotKey,
     PathItem,
     ReferrerItem,
     SlidingWindowBucket,
@@ -142,6 +145,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                             }
 
                             const isPageview = event.event === '$pageview'
+                            const isBotEligibleEvent = (BOT_ELIGIBLE_EVENTS as readonly string[]).includes(event.event)
                             const normalizedReferrer =
                                 isPageview &&
                                 referringDomain &&
@@ -170,6 +174,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
 
                             window.addDataPoint(eventTs, event.distinct_id, {
                                 pageviews: isPageview ? 1 : 0,
+                                botEligibleEvents: isBotEligibleEvent ? 1 : 0,
                                 device: deviceType ? { deviceId: deviceKey, deviceType } : undefined,
                                 browser: browser ? { deviceId: deviceKey, browserType: browser } : undefined,
                                 pathname: isPageview ? pathname : undefined,
@@ -347,6 +352,10 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         totalBotEvents: [
             (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBotEvents(),
+        ],
+        totalBotEligibleEvents: [
+            (s) => [s.slidingWindow, s.eventsVersion],
+            (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBotEligibleEvents(),
         ],
         liveUserCount: [
             (s) => [s.recentUsersByLastSeen],
@@ -637,12 +646,15 @@ const loadQueryData = async (
     const hostFilterClause = host ? `AND properties.$host = {host}` : ''
     const hostValues = host ? { host } : {}
 
+    const botEligibleEventsTuple = `(${BOT_ELIGIBLE_EVENTS.map((e) => `'${e}'`).join(', ')})`
+
     const usersPageviewsQuery: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
         query: `SELECT
                     toStartOfMinute(timestamp) AS minute_bucket,
                     arrayDistinct(groupArray(distinct_id)) AS distinct_ids,
-                    countIf(event = '$pageview') AS pageviews
+                    countIf(event = '$pageview') AS pageviews,
+                    countIf(event IN ${botEligibleEventsTuple}) AS bot_eligible_events
                 FROM events
                 WHERE
                     timestamp >= toDateTime({dateFrom})
@@ -790,26 +802,45 @@ const loadQueryData = async (
         },
     }
 
+    // Aggregate per-minute first then re-group so the response is bounded by the
+    // number of minutes in the window (not by the bot-name cardinality). Without this
+    // the default HogQL row cap (100) silently truncates high-traffic projects.
     const botQuery: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
         query: `SELECT
-                    toStartOfMinute(timestamp) AS minute_bucket,
-                    \`$virt_bot_name\` AS bot_name,
-                    \`$virt_traffic_category\` AS bot_category,
-                    count() AS event_count
-                FROM events
-                WHERE
-                    timestamp >= toDateTime({dateFrom})
-                    AND timestamp <= toDateTime({dateTo})
-                    AND \`$virt_is_bot\` = true
-                    AND \`$virt_bot_name\` != ''
-                    AND event IN ('$pageview', '$pageleave', '$screen', '$http_log', '$autocapture')
-                    ${hostFilterClause}
-                GROUP BY minute_bucket, bot_name, bot_category
+                    minute_bucket,
+                    mapFromArrays(
+                        groupArray(bot_key),
+                        groupArray(event_count)
+                    ) AS counts_by_bot
+                FROM
+                (
+                    SELECT
+                        toStartOfMinute(timestamp) AS minute_bucket,
+                        concat(
+                            \`$virt_bot_name\`,
+                            {botSeparator},
+                            ifNull(\`$virt_traffic_category\`, '')
+                        ) AS bot_key,
+                        count() AS event_count
+                    FROM events
+                    WHERE
+                        timestamp >= toDateTime({dateFrom})
+                        AND timestamp <= toDateTime({dateTo})
+                        AND \`$virt_is_bot\` = true
+                        AND \`$virt_bot_name\` != ''
+                        AND event IN ${botEligibleEventsTuple}
+                        ${hostFilterClause}
+                    GROUP BY
+                        minute_bucket,
+                        bot_key
+                )
+                GROUP BY minute_bucket
                 ORDER BY minute_bucket ASC`,
         values: {
             dateFrom: dateFrom.toISOString(),
             dateTo: dateTo.toISOString(),
+            botSeparator: BOT_KEY_SEPARATOR,
             ...hostValues,
         },
     }
@@ -899,13 +930,14 @@ const addUserDataToBuckets = (
     usersPageviewsResponse: HogQLQueryResponse,
     bucketMap: Map<number, SlidingWindowBucket>
 ): void => {
-    const usersResults = usersPageviewsResponse.results as [string, string[], number][]
+    const usersResults = usersPageviewsResponse.results as [string, string[], number, number][]
 
-    for (const [timestampStr, distinctIds, viewCount] of usersResults) {
+    for (const [timestampStr, distinctIds, viewCount, botEligibleCount] of usersResults) {
         const timestamp = Date.parse(timestampStr)
         const bucket = getOrCreateBucket(bucketMap, timestamp)
 
         bucket.pageviews = viewCount
+        bucket.botEligibleEvents = botEligibleCount ?? 0
         bucket.uniqueUsers = new Set<string>(distinctIds)
     }
 }
@@ -1017,24 +1049,29 @@ const addCityDataToBuckets = (
 }
 
 const addBotDataToBuckets = (botResponse: HogQLQueryResponse, bucketMap: Map<number, SlidingWindowBucket>): void => {
-    const results = botResponse.results as [string, string, string, number][]
+    // Response shape: [[minute_bucket_iso, { 'BotName|||category': eventCount, ... }], ...]
+    const results = botResponse.results as [string, Record<string, number>][]
 
-    for (const [timestampStr, botName, rawCategory, eventCount] of results) {
-        if (!botName) {
-            continue
-        }
+    for (const [timestampStr, countsByBotKey] of results) {
         const timestamp = Date.parse(timestampStr)
         const bucket = getOrCreateBucket(bucketMap, timestamp)
 
-        const categoryLabel = translateCategoryLabel(rawCategory)
         if (!bucket.bots) {
             bucket.bots = new Map<string, { count: number; category: string }>()
         }
-        const existing = bucket.bots.get(botName)
-        bucket.bots.set(botName, {
-            count: (existing?.count ?? 0) + eventCount,
-            category: categoryLabel,
-        })
+
+        for (const [botKey, eventCount] of Object.entries(countsByBotKey)) {
+            const { botName, category: rawCategory } = parseBotKey(botKey)
+            if (!botName) {
+                continue
+            }
+            const categoryLabel = translateCategoryLabel(rawCategory)
+            const existing = bucket.bots.get(botName)
+            bucket.bots.set(botName, {
+                count: (existing?.count ?? 0) + eventCount,
+                category: categoryLabel,
+            })
+        }
     }
 }
 
@@ -1057,6 +1094,7 @@ const getOrCreateBucket = (map: Map<number, SlidingWindowBucket>, timestamp: num
 const createEmptyBucket = (): SlidingWindowBucket => {
     return {
         pageviews: 0,
+        botEligibleEvents: 0,
         newUserCount: 0,
         returningUserCount: 0,
         devices: new Map<string, Set<string>>(),


### PR DESCRIPTION
## Problem

Two bugs on the Web Analytics live dashboard's bot tiles (behind the \`WEB_ANALYTICS_BOT_ANALYSIS\` flag):

1. **Bot requests per minute chart had a multi-minute gap on initial load.** Root cause was *not* ClickHouse ingestion lag — the historical bot HogQL query grouped by \`(minute_bucket, bot_name, bot_category)\`, which produces ~15 rows per minute on a project with diverse bot traffic. HogQL's default 100-row cap silently truncated the response to roughly the first 5–6 minutes. Verified end-to-end against a high-bot-traffic project: the unmodified query returned exactly 100 rows covering only 5 minutes, while the actual data spanned the full 30 minutes.
2. **Bot traffic tile showed nonsensical "% of total"** (typically \`0.0%\` or much greater than 100%) because the parent passed \`totalPageviews\` as the denominator, while the numerator counts events of 5 types. Mismatched units → meaningless ratio.

The "Active users per minute" chart didn't have the gap because its query groups only by \`minute_bucket\` (≤30 rows).

## Changes

- Restructured the bot query into a per-minute aggregate with bot data nested in a \`mapFromArrays(...)\`. Mirrors the existing \`deviceQuery\`/\`browserQuery\`/\`cityQuery\` pattern. Output is bounded to the number of minutes in the window, regardless of bot diversity.
- Added a \`totalBotEligibleEvents\` aggregate (events of the same 5 types the bot count uses) and use it as the denominator in the Bot traffic tile so the percentage is apples-to-apples.

## How did you test this code?

I'm an agent. Tests I actually ran:

- \`hogli test frontend/src/scenes/web-analytics/LiveMetricsDashboard/\` — 81/81 pass (3 new tests for the totalBotEligibleEvents aggregate)
- \`pnpm --filter=@posthog/frontend typescript:check\` — clean after \`typegen:write\`
- Ran the new bot HogQL query against a live high-bot-traffic project — it returns one row per minute (30 rows for the 30-minute window), no truncation

I did **not** load the dev frontend to visually verify the gap is gone or the % renders sanely.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7 1M context)
- Author flow: planning → root-cause analysis (queried project data via the PostHog MCP to confirm it was the HogQL row cap, not ingestion lag) → implementation → tests
- Notable decisions:
  - Reused the existing \`mapFromArrays\` aggregation pattern rather than adding an explicit \`LIMIT\` so the row count is bounded by structure, not a magic number
  - Separator between bot name and category is \`|||\` (matches existing \`COOKIELESS_TRANSFORM_SEPARATOR\` for visual familiarity); avoids collision with bot names that contain spaces or single \`|\`
  - Denominator counts only the 5 bot-eligible event types (not all events) to keep numerator/denominator units aligned
- Followup not in scope: \`referrerQuery\` groups by \`(minute_bucket, referring_domain)\` and could hit the same row cap on high-traffic sites with many referrers