### PR TITLE
feat(web-analytics): open as new insight and livestream sync

### DIFF
--- a/frontend/src/scenes/web-analytics/botAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/botAnalyticsLogic.ts
@@ -281,7 +281,7 @@ LIMIT 50`,
                         },
                         insightProps: createInsightProps(TileId.BOT_CRAWLERS, 'table'),
                         canOpenModal: false,
-                        canOpenInsight: false,
+                        canOpenInsight: true,
                     },
                     {
                         kind: 'query',
@@ -321,7 +321,7 @@ LIMIT 50`,
                         },
                         insightProps: createInsightProps(TileId.BOT_PATHS, 'table'),
                         canOpenModal: false,
-                        canOpenInsight: false,
+                        canOpenInsight: true,
                     },
                 ]
 

--- a/frontend/src/scenes/web-analytics/webAnalyticsModalLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsModalLogic.ts
@@ -3,6 +3,7 @@ import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { NodeKind, QuerySchema } from '~/queries/schema/schema-general'
 import { InsightLogicProps } from '~/types'
 
+import { botAnalyticsLogic } from './botAnalyticsLogic'
 import { TileId, WEB_ANALYTICS_DATA_COLLECTION_NODE_ID, WebAnalyticsTile } from './common'
 import { getDashboardItemId, getNewInsightUrlFactory } from './insightsUtils'
 import { pageReportsLogic } from './pageReportsLogic'
@@ -28,7 +29,14 @@ export const webAnalyticsModalLogic = kea<webAnalyticsModalLogicType>([
     path(['scenes', 'webAnalytics', 'webAnalyticsModalLogic']),
 
     connect(() => ({
-        values: [webAnalyticsLogic, ['tiles as webAnalyticsTiles'], pageReportsLogic, ['tiles as pageReportsTiles']],
+        values: [
+            webAnalyticsLogic,
+            ['tiles as webAnalyticsTiles'],
+            pageReportsLogic,
+            ['tiles as pageReportsTiles'],
+            botAnalyticsLogic,
+            ['tiles as botAnalyticsTiles'],
+        ],
     })),
 
     actions({
@@ -50,10 +58,14 @@ export const webAnalyticsModalLogic = kea<webAnalyticsModalLogicType>([
     }),
 
     selectors({
-        // Combine tiles from both webAnalyticsLogic and flattened pageReportsLogic section tiles.
+        // Combine tiles from webAnalyticsLogic, flattened pageReportsLogic section tiles, and botAnalyticsLogic.
         combinedTiles: [
-            (s) => [s.webAnalyticsTiles, s.pageReportsTiles],
-            (webAnalyticsTiles: WebAnalyticsTile[], pageReportsTiles: WebAnalyticsTile[]): WebAnalyticsTile[] => {
+            (s) => [s.webAnalyticsTiles, s.pageReportsTiles, s.botAnalyticsTiles],
+            (
+                webAnalyticsTiles: WebAnalyticsTile[],
+                pageReportsTiles: WebAnalyticsTile[],
+                botAnalyticsTiles: WebAnalyticsTile[]
+            ): WebAnalyticsTile[] => {
                 const flattenedPageReportsTiles = pageReportsTiles.flatMap((tile) => {
                     if (tile.kind === 'section' && tile.tiles) {
                         return [tile, ...tile.tiles]
@@ -61,7 +73,7 @@ export const webAnalyticsModalLogic = kea<webAnalyticsModalLogicType>([
                     return tile
                 })
 
-                return [...webAnalyticsTiles, ...flattenedPageReportsTiles]
+                return [...webAnalyticsTiles, ...flattenedPageReportsTiles, ...botAnalyticsTiles]
             },
         ],
 

--- a/livestream/bot/definitions.json
+++ b/livestream/bot/definitions.json
@@ -156,6 +156,12 @@
     "traffic_type": "AI Agent"
   },
   {
+    "pattern": "meta-externalfetcher",
+    "name": "Meta Fetcher",
+    "category": "ai_assistant",
+    "traffic_type": "AI Agent"
+  },
+  {
     "pattern": "Meta-ExternalFetcher",
     "name": "Meta Fetcher",
     "category": "ai_assistant",
@@ -170,6 +176,18 @@
   {
     "pattern": "MistralAI-User",
     "name": "Mistral AI",
+    "category": "ai_assistant",
+    "traffic_type": "AI Agent"
+  },
+  {
+    "pattern": "Manus-User",
+    "name": "Manus",
+    "category": "ai_assistant",
+    "traffic_type": "AI Agent"
+  },
+  {
+    "pattern": "Google-NotebookLM",
+    "name": "NotebookLM",
     "category": "ai_assistant",
     "traffic_type": "AI Agent"
   },
@@ -222,6 +240,12 @@
     "traffic_type": "Bot"
   },
   {
+    "pattern": "Yeti/",
+    "name": "Naver",
+    "category": "search_crawler",
+    "traffic_type": "Bot"
+  },
+  {
     "pattern": "AdsBot-Google",
     "name": "Google Ads",
     "category": "search_crawler",
@@ -258,6 +282,12 @@
     "traffic_type": "Bot"
   },
   {
+    "pattern": "SERankingBacklinksBot",
+    "name": "SE Ranking",
+    "category": "seo_crawler",
+    "traffic_type": "Bot"
+  },
+  {
     "pattern": "MJ12bot",
     "name": "Majestic",
     "category": "seo_crawler",
@@ -266,6 +296,12 @@
   {
     "pattern": "DotBot",
     "name": "Moz",
+    "category": "seo_crawler",
+    "traffic_type": "Bot"
+  },
+  {
+    "pattern": "Lighthouse",
+    "name": "Lighthouse",
     "category": "seo_crawler",
     "traffic_type": "Bot"
   },
@@ -306,6 +342,12 @@
     "traffic_type": "Bot"
   },
   {
+    "pattern": "Slack-ImgProxy",
+    "name": "Slack Image Proxy",
+    "category": "social_crawler",
+    "traffic_type": "Bot"
+  },
+  {
     "pattern": "TelegramBot",
     "name": "Telegram",
     "category": "social_crawler",
@@ -314,6 +356,18 @@
   {
     "pattern": "WhatsApp",
     "name": "WhatsApp",
+    "category": "social_crawler",
+    "traffic_type": "Bot"
+  },
+  {
+    "pattern": "GoogleImageProxy",
+    "name": "Google Image Proxy",
+    "category": "social_crawler",
+    "traffic_type": "Bot"
+  },
+  {
+    "pattern": "Iframely",
+    "name": "Iframely",
     "category": "social_crawler",
     "traffic_type": "Bot"
   },


### PR DESCRIPTION
## Problem

Three small follow-ups to the Web Analytics bot tab:

1. The **\"Open as new insight\"** button was missing on the *Bot crawlers* and *Most crawled paths* tiles, so users couldn't pivot bot data into a saveable insight.
2. The livestream service's bot list (\`livestream/bot/definitions.json\`) was 9 bots out of sync with the Python source of truth (\`bot_definitions.py\`) — Yeti, SE Ranking, GoogleImageProxy, Iframely, Lighthouse, Manus-User, Slack-ImgProxy, meta-externalfetcher, Google-NotebookLM. Real-time bot classification was missing those.

## Changes

- \`botAnalyticsLogic.ts\`: \`canOpenInsight: false → true\` on \`BOT_CRAWLERS\` and \`BOT_PATHS\`.
- \`livestream/bot/definitions.json\`: regenerated via \`hogli run build:bot-definitions\` — now matches Python (84 patterns, was 75).

## How did you test this code?

I'm an agent. Tests I actually ran:

- \`pnpm --filter=@posthog/frontend typescript:check\` — clean
- \`python livestream/bot/generate_definitions.py\` — wrote 84 patterns; eyeballed diff

## Publish to changelog?

no

