### PR TITLE
feat(llma): instrument skills creation and edits

### DIFF
--- a/products/llm_analytics/backend/api/skills.py
+++ b/products/llm_analytics/backend/api/skills.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 from django.db import IntegrityError
 from django.db.models import Q, QuerySet
 
+import structlog
 import posthoganalytics
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, serializers, status, viewsets
@@ -65,7 +66,35 @@ from .skill_services import (
     resolve_versions_page,
 )
 
+logger = structlog.get_logger(__name__)
+
 LLM_SKILL_FEATURE_FLAG = "llm-analytics-skills"
+
+
+def _skill_analytics_props(skill: LLMSkill) -> dict[str, Any]:
+    """Properties shared by every skill report_user_action event.
+
+    These power the internal LLMA skills adoption/usage dashboards — keep stable
+    and additive (renaming a key here will rename it on every dashboard).
+    """
+    files = list(skill.files.all()) if skill.pk else []
+    body = skill.body or ""
+    description = skill.description or ""
+    allowed_tools = skill.allowed_tools or []
+    return {
+        "skill_id": str(skill.id),
+        "skill_name": skill.name,
+        "skill_version": skill.version,
+        "skill_is_latest": skill.is_latest,
+        "skill_body_length": len(body),
+        "skill_description_length": len(description),
+        "skill_file_count": len(files),
+        "skill_has_files": bool(files),
+        "skill_has_license": bool(skill.license),
+        "skill_has_compatibility": bool(skill.compatibility),
+        "skill_has_allowed_tools": bool(allowed_tools),
+        "skill_allowed_tools_count": len(allowed_tools),
+    }
 
 
 class LLMSkillFeatureFlagPermission(BasePermission):
@@ -243,14 +272,17 @@ class LLMSkillViewSet(
     def perform_create(self, serializer: BaseSerializer[Any]) -> None:
         instance = cast(LLMSkill, serializer.save())
 
+        props = _skill_analytics_props(instance)
+        logger.info(
+            "llma_skill_created",
+            team_id=self.team.id,
+            user_id=cast(User, self.request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, self.request.user),
             "llma skill created",
-            {
-                "skill_id": str(instance.id),
-                "skill_name": instance.name,
-                "skill_version": instance.version,
-            },
+            props,
             team=self.team,
             request=self.request,
         )
@@ -331,15 +363,35 @@ class LLMSkillViewSet(
                 error_body["file_path"] = err.file_path
             return Response(error_body, status=status.HTTP_400_BAD_REQUEST)
 
+        edits_value = payload.validated_data.get("edits")
+        file_edits_value = payload.validated_data.get("file_edits")
+        files_value = payload.validated_data.get("files")
+        props = {
+            **_skill_analytics_props(published_skill),
+            "base_version": payload.validated_data["base_version"],
+            "body_changed": payload.validated_data.get("body") is not None or edits_value is not None,
+            "files_replaced": files_value is not None,
+            "files_replaced_count": len(files_value) if files_value is not None else 0,
+            "edits_used": edits_value is not None,
+            "edits_count": len(edits_value) if edits_value is not None else 0,
+            "file_edits_used": file_edits_value is not None,
+            "file_edits_count": len(file_edits_value) if file_edits_value is not None else 0,
+            "description_changed": payload.validated_data.get("description") is not None,
+            "license_changed": payload.validated_data.get("license") is not None,
+            "compatibility_changed": payload.validated_data.get("compatibility") is not None,
+            "allowed_tools_changed": payload.validated_data.get("allowed_tools") is not None,
+            "metadata_changed": payload.validated_data.get("metadata") is not None,
+        }
+        logger.info(
+            "llma_skill_version_published",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, request.user),
             "llma skill version published",
-            {
-                "skill_id": str(published_skill.id),
-                "skill_name": published_skill.name,
-                "skill_version": published_skill.version,
-                "base_version": payload.validated_data["base_version"],
-            },
+            props,
             team=self.team,
             request=request,
         )
@@ -408,13 +460,22 @@ class LLMSkillViewSet(
         except LLMSkillNotFoundError:
             return self._skill_not_found_response(skill_name)
 
+        props = {
+            "skill_name": skill_name,
+            "skill_versions": skill_versions,
+            "skill_version_count": len(skill_versions),
+            "skill_latest_version": max(skill_versions) if skill_versions else None,
+        }
+        logger.info(
+            "llma_skill_archived",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, request.user),
             "llma skill archived",
-            {
-                "skill_name": skill_name,
-                "skill_versions": skill_versions,
-            },
+            props,
             team=self.team,
             request=request,
         )
@@ -453,14 +514,20 @@ class LLMSkillViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        props = {
+            **_skill_analytics_props(new_skill),
+            "source_skill_name": skill_name,
+        }
+        logger.info(
+            "llma_skill_duplicated",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, request.user),
             "llma skill duplicated",
-            {
-                "skill_id": str(new_skill.id),
-                "skill_name": new_skill.name,
-                "source_skill_name": skill_name,
-            },
+            props,
             team=self.team,
             request=request,
         )
@@ -548,15 +615,25 @@ class LLMSkillViewSet(
                 status=status.HTTP_409_CONFLICT,
             )
 
+        path_value = payload.validated_data["path"]
+        content_value = payload.validated_data["content"]
+        props = {
+            **_skill_analytics_props(published_skill),
+            "path": path_value,
+            "content_type": payload.validated_data.get("content_type", "text/plain"),
+            "file_content_length": len(content_value),
+            "file_extension": path_value.rsplit(".", 1)[1].lower() if "." in path_value else "",
+        }
+        logger.info(
+            "llma_skill_file_created",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, request.user),
             "llma skill file created",
-            {
-                "skill_id": str(published_skill.id),
-                "skill_name": published_skill.name,
-                "skill_version": published_skill.version,
-                "path": payload.validated_data["path"],
-            },
+            props,
             team=self.team,
             request=request,
         )
@@ -603,15 +680,21 @@ class LLMSkillViewSet(
                 status=status.HTTP_404_NOT_FOUND,
             )
 
+        props = {
+            **_skill_analytics_props(published_skill),
+            "path": file_path,
+            "file_extension": file_path.rsplit(".", 1)[1].lower() if "." in file_path else "",
+        }
+        logger.info(
+            "llma_skill_file_deleted",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, request.user),
             "llma skill file deleted",
-            {
-                "skill_id": str(published_skill.id),
-                "skill_name": published_skill.name,
-                "skill_version": published_skill.version,
-                "path": file_path,
-            },
+            props,
             team=self.team,
             request=request,
         )
@@ -664,16 +747,26 @@ class LLMSkillViewSet(
                 status=status.HTTP_409_CONFLICT,
             )
 
+        old_path_value = payload.validated_data["old_path"]
+        new_path_value = payload.validated_data["new_path"]
+        props = {
+            **_skill_analytics_props(published_skill),
+            "old_path": old_path_value,
+            "new_path": new_path_value,
+            "old_file_extension": old_path_value.rsplit(".", 1)[1].lower() if "." in old_path_value else "",
+            "new_file_extension": new_path_value.rsplit(".", 1)[1].lower() if "." in new_path_value else "",
+            "extension_changed": (old_path_value.rsplit(".", 1)[1:] != new_path_value.rsplit(".", 1)[1:]),
+        }
+        logger.info(
+            "llma_skill_file_renamed",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
         report_user_action(
             cast(User, request.user),
             "llma skill file renamed",
-            {
-                "skill_id": str(published_skill.id),
-                "skill_name": published_skill.name,
-                "skill_version": published_skill.version,
-                "old_path": payload.validated_data["old_path"],
-                "new_path": payload.validated_data["new_path"],
-            },
+            props,
             team=self.team,
             request=request,
         )

--- a/products/llm_analytics/backend/api/skills.py
+++ b/products/llm_analytics/backend/api/skills.py
@@ -71,6 +71,10 @@ logger = structlog.get_logger(__name__)
 LLM_SKILL_FEATURE_FLAG = "llm-analytics-skills"
 
 
+def _file_extension(path: str) -> str:
+    return path.rsplit(".", 1)[1].lower() if "." in path else ""
+
+
 def _skill_analytics_props(skill: LLMSkill) -> dict[str, Any]:
     """Properties shared by every skill report_user_action event.
 
@@ -622,7 +626,7 @@ class LLMSkillViewSet(
             "path": path_value,
             "content_type": payload.validated_data.get("content_type", "text/plain"),
             "file_content_length": len(content_value),
-            "file_extension": path_value.rsplit(".", 1)[1].lower() if "." in path_value else "",
+            "file_extension": _file_extension(path_value),
         }
         logger.info(
             "llma_skill_file_created",
@@ -683,7 +687,7 @@ class LLMSkillViewSet(
         props = {
             **_skill_analytics_props(published_skill),
             "path": file_path,
-            "file_extension": file_path.rsplit(".", 1)[1].lower() if "." in file_path else "",
+            "file_extension": _file_extension(file_path),
         }
         logger.info(
             "llma_skill_file_deleted",
@@ -749,13 +753,15 @@ class LLMSkillViewSet(
 
         old_path_value = payload.validated_data["old_path"]
         new_path_value = payload.validated_data["new_path"]
+        old_extension = _file_extension(old_path_value)
+        new_extension = _file_extension(new_path_value)
         props = {
             **_skill_analytics_props(published_skill),
             "old_path": old_path_value,
             "new_path": new_path_value,
-            "old_file_extension": old_path_value.rsplit(".", 1)[1].lower() if "." in old_path_value else "",
-            "new_file_extension": new_path_value.rsplit(".", 1)[1].lower() if "." in new_path_value else "",
-            "extension_changed": (old_path_value.rsplit(".", 1)[1:] != new_path_value.rsplit(".", 1)[1:]),
+            "old_file_extension": old_extension,
+            "new_file_extension": new_extension,
+            "extension_changed": old_extension != new_extension,
         }
         logger.info(
             "llma_skill_file_renamed",

--- a/products/llm_analytics/backend/api/skills.py
+++ b/products/llm_analytics/backend/api/skills.py
@@ -77,7 +77,7 @@ def _skill_analytics_props(skill: LLMSkill) -> dict[str, Any]:
     These power the internal LLMA skills adoption/usage dashboards — keep stable
     and additive (renaming a key here will rename it on every dashboard).
     """
-    files = list(skill.files.all()) if skill.pk else []
+    file_count = skill.files.count() if skill.pk else 0
     body = skill.body or ""
     description = skill.description or ""
     allowed_tools = skill.allowed_tools or []
@@ -88,8 +88,8 @@ def _skill_analytics_props(skill: LLMSkill) -> dict[str, Any]:
         "skill_is_latest": skill.is_latest,
         "skill_body_length": len(body),
         "skill_description_length": len(description),
-        "skill_file_count": len(files),
-        "skill_has_files": bool(files),
+        "skill_file_count": file_count,
+        "skill_has_files": file_count > 0,
         "skill_has_license": bool(skill.license),
         "skill_has_compatibility": bool(skill.compatibility),
         "skill_has_allowed_tools": bool(allowed_tools),

--- a/products/llm_analytics/frontend/skills/LLMSkillScene.tsx
+++ b/products/llm_analytics/frontend/skills/LLMSkillScene.tsx
@@ -563,6 +563,7 @@ function SkillFileViewer({
                 type="button"
                 className="flex w-full cursor-pointer items-center gap-2 border-none bg-transparent px-3 py-2 text-left text-sm hover:bg-fill-secondary"
                 onClick={toggleExpand}
+                data-attr={`llma-skill-file-toggle-${file.path}`}
             >
                 <IconChevronRight
                     className={`h-3.5 w-3.5 shrink-0 text-muted transition-transform ${expanded ? 'rotate-90' : ''}`}
@@ -653,6 +654,7 @@ function SkillEditForm({
                 }
             >
                 <LemonInput
+                    data-attr="llma-skill-name-input"
                     placeholder="my-skill-name"
                     maxLength={SKILL_NAME_MAX_LENGTH}
                     fullWidth
@@ -666,6 +668,7 @@ function SkillEditForm({
                 help="Explain what this skill does and when to use it. Agents use this to discover the right skill for a task."
             >
                 <LemonTextArea
+                    data-attr="llma-skill-description-input"
                     placeholder="Extract PDF text, fill forms, merge files. Use when handling PDFs."
                     maxLength={SKILL_DESCRIPTION_MAX_LENGTH}
                     minRows={2}
@@ -679,6 +682,7 @@ function SkillEditForm({
                 help="The main instruction content (SKILL.md body). Write markdown that tells agents how to perform the task."
             >
                 <LemonTextArea
+                    data-attr="llma-skill-body-input"
                     placeholder="# My Skill&#10;&#10;## When to use&#10;Use this skill when...&#10;&#10;## Steps&#10;1. First...&#10;2. Then..."
                     minRows={10}
                     className="font-mono"
@@ -686,7 +690,7 @@ function SkillEditForm({
             </LemonField>
 
             <LemonField name="license" label="License" help="Optional. License name or reference.">
-                <LemonInput placeholder="Apache-2.0" maxLength={255} fullWidth />
+                <LemonInput data-attr="llma-skill-license-input" placeholder="Apache-2.0" maxLength={255} fullWidth />
             </LemonField>
 
             <LemonField
@@ -694,7 +698,12 @@ function SkillEditForm({
                 label="Compatibility"
                 help="Optional. Environment requirements (intended product, system packages, network access)."
             >
-                <LemonInput placeholder="Requires git, docker, and internet access" maxLength={500} fullWidth />
+                <LemonInput
+                    data-attr="llma-skill-compatibility-input"
+                    placeholder="Requires git, docker, and internet access"
+                    maxLength={500}
+                    fullWidth
+                />
             </LemonField>
 
             <div>
@@ -787,6 +796,7 @@ function SkillFileEditor({
                         <div className="flex-1">
                             <label className="mb-1 block text-xs font-medium text-secondary">Path</label>
                             <LemonInput
+                                data-attr={`llma-skill-file-path-${index}`}
                                 value={file.path}
                                 onChange={(val) => onUpdate(index, 'path', val)}
                                 placeholder="scripts/setup.sh"
@@ -797,6 +807,7 @@ function SkillFileEditor({
                         <div className="w-48">
                             <label className="mb-1 block text-xs font-medium text-secondary">Content type</label>
                             <LemonSelect
+                                data-attr={`llma-skill-file-content-type-${index}`}
                                 value={file.content_type}
                                 onChange={(val) => onUpdate(index, 'content_type', val)}
                                 options={COMMON_CONTENT_TYPES}
@@ -808,6 +819,7 @@ function SkillFileEditor({
                     <div>
                         <label className="mb-1 block text-xs font-medium text-secondary">Content</label>
                         <LemonTextArea
+                            data-attr={`llma-skill-file-content-${index}`}
                             value={file.content}
                             onChange={(val) => onUpdate(index, 'content', val)}
                             placeholder="File content..."


### PR DESCRIPTION
## Problem

We want to build internal feature dashboards around LLMA skills adoption and usage, but the existing `report_user_action` events for skills only carry `skill_id` / `skill_name` / `skill_version` — not enough to slice usage by body size, file count, edit shape, etc. There's also no structured logging on skill mutations and several skill form inputs lack `data-attr`s for product analytics.

## Changes

**Backend (`products/llm_analytics/backend/api/skills.py`)**
- New `_skill_analytics_props()` helper that produces a stable property bag for every skill event: `skill_id`, `skill_name`, `skill_version`, `skill_is_latest`, `skill_body_length`, `skill_description_length`, `skill_file_count`, `skill_has_files`, `skill_has_license`, `skill_has_compatibility`, `skill_has_allowed_tools`, `skill_allowed_tools_count`.
- Enriched `llma skill version published` with edit-shape properties: `body_changed`, `edits_used`/`edits_count`, `file_edits_used`/`file_edits_count`, `files_replaced`/`files_replaced_count`, plus `*_changed` flags for description / license / compatibility / allowed_tools / metadata.
- `llma skill archived` now reports `skill_version_count` and `skill_latest_version`. File create/delete/rename events now carry `file_extension` and `file_content_length`; rename also reports `extension_changed`.
- Added a `structlog` logger and parallel `logger.info("llma_skill_*", team_id=..., user_id=..., **props)` lines on every mutation so the same data lands in PostHog logs.

Existing event names are unchanged — the new fields are additive, so existing dashboards/filters keep working.

**Frontend (`products/llm_analytics/frontend/skills/LLMSkillScene.tsx`)**
- Filled missing `data-attr`s on the skill edit form: `llma-skill-name-input`, `llma-skill-description-input`, `llma-skill-body-input`, `llma-skill-license-input`, `llma-skill-compatibility-input`.
- Added per-row `data-attr`s on the bundled-file editor: `llma-skill-file-path-${index}`, `llma-skill-file-content-type-${index}`, `llma-skill-file-content-${index}`.
- Added `llma-skill-file-toggle-${path}` on the bundled-file expander in the view.

## How did you test this code?

I'm an agent — I did not perform manual UI testing. Verification I actually ran:

- `ruff check products/llm_analytics/backend/api/skills.py` — passed
- `python -m py_compile products/llm_analytics/backend/api/skills.py` — passed
- `uv run ty check products/llm_analytics/backend/api/skills.py` (via pre-commit hook) — passed
- `pnpm exec oxfmt` + `pnpm oxlint --fix` on the modified frontend file (via pre-commit hook) — passed
- Audited the existing skill test file (`test_skills.py`) — it doesn't assert on `report_user_action` payload structure, so the additive properties are safe.

The full backend test suite was not run locally (no Python 3.12.12 available without downloading python-build-standalone, which I did to satisfy the pre-commit hook but not for full test execution). CI will exercise the skill tests.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7) on branch `claude/add-skill-analytics-CrP3A`.
- Scope was kept tight: no event renames, no new endpoints, no schema changes — just additive property fields, structlog calls, and missing `data-attr`s, so existing dashboards and tests keep working.
- Key decision: did **not** rename the existing mixed-prefix `data-attr`s (`new-skill-button`, `skills-search-input`, `skill-create-button`, etc.) to avoid breaking any external instrumentation; only added new `llma-skill-*` attrs where coverage was missing.
- Requires human review before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_018WPfqEaKx2tSFHG9HS6x6E)_