### PR TITLE
chore(security): tighten secret defaults and remove unused SQL helpers

### DIFF
--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -80,9 +80,21 @@ For the safety of your instance, you must generate and set a unique key.
 SANDBOX_JWT_PRIVATE_KEY: str | None = os.getenv("SANDBOX_JWT_PRIVATE_KEY")
 
 # These are legacy values only kept around for backwards compatibility with self hosted versions
-SALT_KEY = get_list(os.getenv("SALT_KEY", "0123456789abcdefghijklmnopqrstuvwxyz"))
+DEFAULT_SALT_KEY = "0123456789abcdefghijklmnopqrstuvwxyz"
+SALT_KEY = get_list(os.getenv("SALT_KEY", DEFAULT_SALT_KEY))
 # We provide a default as it is needed for hobby deployments
-ENCRYPTION_SALT_KEYS = get_list(os.getenv("ENCRYPTION_SALT_KEYS", "00beef0000beef0000beef0000beef00"))
+DEFAULT_ENCRYPTION_SALT_KEYS = "00beef0000beef0000beef0000beef00"
+ENCRYPTION_SALT_KEYS = get_list(os.getenv("ENCRYPTION_SALT_KEYS", DEFAULT_ENCRYPTION_SALT_KEYS))
+
+if not DEBUG and not TEST and not STATIC_COLLECTION and ENCRYPTION_SALT_KEYS == [DEFAULT_ENCRYPTION_SALT_KEYS]:
+    logger.critical(
+        """
+You are using the default ENCRYPTION_SALT_KEYS in a production environment!
+This key encrypts integration tokens and other secrets at rest.
+For the safety of your instance, you must set ENCRYPTION_SALT_KEYS to a unique value.
+"""
+    )
+    sys.exit("[ERROR] Default ENCRYPTION_SALT_KEYS in production. Stopping Django server…\n")
 
 INTERNAL_IPS = ["127.0.0.1", "172.18.0.1"]  # Docker IP
 if os.getenv("CORS_ALLOWED_ORIGINS", False):

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -82,7 +82,7 @@ SANDBOX_JWT_PRIVATE_KEY: str | None = os.getenv("SANDBOX_JWT_PRIVATE_KEY")
 # These are legacy values only kept around for backwards compatibility with self hosted versions
 DEFAULT_SALT_KEY = "0123456789abcdefghijklmnopqrstuvwxyz"
 SALT_KEY = get_list(os.getenv("SALT_KEY", DEFAULT_SALT_KEY))
-# We provide a default as it is needed for hobby deployments
+# A default is provided so that non-production environments (DEBUG/TEST) can start without configuration.
 DEFAULT_ENCRYPTION_SALT_KEYS = "00beef0000beef0000beef0000beef00"
 ENCRYPTION_SALT_KEYS = get_list(os.getenv("ENCRYPTION_SALT_KEYS", DEFAULT_ENCRYPTION_SALT_KEYS))
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1,12 +1,13 @@
 # Web app specific settings/middleware/apps setup
 import os
+import sys
 from datetime import timedelta
 
 import structlog
 from corsheaders.defaults import default_headers
 
 from posthog.scopes import get_scope_descriptions
-from posthog.settings.base_variables import BASE_DIR, DEBUG, TEST
+from posthog.settings.base_variables import BASE_DIR, DEBUG, STATIC_COLLECTION, TEST
 from posthog.settings.utils import get_from_env, get_list, str_to_bool
 from posthog.utils_cors import CORS_ALLOWED_TRACING_HEADERS
 
@@ -258,7 +259,17 @@ SOCIAL_AUTH_GITLAB_KEY: str | None = os.getenv("SOCIAL_AUTH_GITLAB_KEY")
 SOCIAL_AUTH_GITLAB_SECRET: str | None = os.getenv("SOCIAL_AUTH_GITLAB_SECRET")
 SOCIAL_AUTH_GITLAB_API_URL: str = os.getenv("SOCIAL_AUTH_GITLAB_API_URL", "https://gitlab.com")
 
-LICENSE_SECRET_KEY = os.getenv("LICENSE_SECRET_KEY", "license-so-secret")
+DEFAULT_LICENSE_SECRET_KEY = "license-so-secret"
+LICENSE_SECRET_KEY = os.getenv("LICENSE_SECRET_KEY", DEFAULT_LICENSE_SECRET_KEY)
+
+if not DEBUG and not TEST and not STATIC_COLLECTION and LICENSE_SECRET_KEY == DEFAULT_LICENSE_SECRET_KEY:
+    logger.critical(
+        """
+You are using the default LICENSE_SECRET_KEY in a production environment!
+For the safety of your instance, you must set LICENSE_SECRET_KEY to a unique value.
+"""
+    )
+    sys.exit("[ERROR] Default LICENSE_SECRET_KEY in production. Stopping Django server…\n")
 
 # Cookie age in seconds (default 2 weeks) - these are the standard defaults for Django but having it here to be explicit
 SESSION_COOKIE_AGE = get_from_env("SESSION_COOKIE_AGE", 60 * 60 * 24 * 14, type_cast=int)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -998,28 +998,6 @@ def get_machine_id() -> str:
     return hashlib.md5(uuid.getnode().to_bytes(6, "little")).hexdigest()
 
 
-def get_table_size(table_name) -> str:
-    from django.db import connection
-
-    query = (
-        f'SELECT pg_size_pretty(pg_total_relation_size(relid)) AS "size" '
-        f"FROM pg_catalog.pg_statio_user_tables "
-        f"WHERE relname = '{table_name}'"
-    )
-    cursor = connection.cursor()
-    cursor.execute(query)
-    return dict_from_cursor_fetchall(cursor)[0]["size"]
-
-
-def get_table_approx_count(table_name) -> str:
-    from django.db import connection
-
-    query = f"SELECT reltuples::BIGINT as \"approx_count\" FROM pg_class WHERE relname = '{table_name}'"
-    cursor = connection.cursor()
-    cursor.execute(query)
-    return compact_number(dict_from_cursor_fetchall(cursor)[0]["approx_count"])
-
-
 def compact_number(value: Union[int, float]) -> str:
     """Return a number in a compact format, with a SI suffix if applicable.
     Client-side equivalent: utils.tsx#compactNumber.


### PR DESCRIPTION
## Problem

A security audit flagged three issues in defaults and unused code that are worth tightening as defense-in-depth:

1. `ENCRYPTION_SALT_KEYS` falls back to a publicly known string (`00beef0000beef0000beef0000beef00`) that is base64-encoded directly as a Fernet key. Self-hosted operators who miss the env var run with a key
anyone can recover from source. This key protects integration tokens, OAuth credentials, and other encrypted-at-rest fields.
2. `LICENSE_SECRET_KEY` falls back to `license-so-secret`. Used to mint dev-mode synthetic licenses; harmless in production today but trivial to harden.
3. `get_table_size` / `get_table_approx_count` in `posthog/utils.py` built SQL via f-string interpolation of a `table_name` argument. Repo-wide grep showed zero callers — they were stale.

## Changes

Three independent commits:

- **`chore(settings): refuse to start with default ENCRYPTION_SALT_KEYS in prod`** — mirrors the existing `SECRET_KEY` startup guard at `posthog/settings/access.py:69-76`. Refuses to start when not
`DEBUG`/`TEST`/`STATIC_COLLECTION` and the value still equals the default.
- **`chore(settings): refuse to start with default LICENSE_SECRET_KEY in prod`** — same pattern, in `posthog/settings/web.py`.
- **`chore: remove unused get_table_size and get_table_approx_count helpers`** — deletes both functions outright. No callers in the repo or git history.

No behavior change for any instance that already configures these env vars (i.e. all production deployments and the `bin/deploy-hobby` installer, which generates a random `ENCRYPTION_SALT_KEYS` value).

## How did you test this code?

I'm an agent. I did not run a Django startup repro manually. Verification performed:

- `python3 -c "import ast; ast.parse(open(p).read())"` on all three files — clean parse.
- Repo-wide grep confirmed `get_table_size` / `get_table_approx_count` had no callers before deletion.
- Pre-commit hooks (`ruff check --fix`, `ruff format`, `uv run ty check`) passed on each commit.

The new guards follow the existing `SECRET_KEY` precedent, which itself ships without a unit test. If we want unit-testable guards, a small follow-up could extract a shared `_check_required_secret(name, value,
default)` helper.

## Publish to changelog?

no

## 🤖 Agent context

- Co-authored with Claude Code (Opus 4.7) running `/triage-vuln` against an external static-analysis report.