### PR TITLE
feat(dashboards): add variables_override and filters_override to dashboard MCP tools

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1102,6 +1102,26 @@ class DashboardsViewSet(
 
         return results
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "variables_override",
+                OpenApiTypes.STR,
+                description=(
+                    "JSON object to override dashboard variables for this request only (does not persist). "
+                    'Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.'
+                ),
+            ),
+            OpenApiParameter(
+                "filters_override",
+                OpenApiTypes.STR,
+                description=(
+                    "JSON object to override dashboard filters for this request only (does not persist). "
+                    "See dashboard filters schema for available keys."
+                ),
+            ),
+        ],
+    )
     @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="GET")
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         dashboard = self.get_object()
@@ -1175,6 +1195,32 @@ class DashboardsViewSet(
     # ******************************************
     # /projects/:id/dashboard/:id/stream_tiles
     # ******************************************
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "variables_override",
+                OpenApiTypes.STR,
+                description=(
+                    "JSON object to override dashboard variables for this request only (does not persist). "
+                    'Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.'
+                ),
+            ),
+            OpenApiParameter(
+                "filters_override",
+                OpenApiTypes.STR,
+                description=(
+                    "JSON object to override dashboard filters for this request only (does not persist). "
+                    "See dashboard filters schema for available keys."
+                ),
+            ),
+            OpenApiParameter(
+                "layoutSize",
+                OpenApiTypes.STR,
+                enum=["sm", "xs"],
+                description="Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.",
+            ),
+        ],
+    )
     @action(methods=["GET"], detail=True, url_path="stream_tiles")
     def stream_tiles(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
         """Stream dashboard metadata and tiles via Server-Sent Events. Sends metadata first, then tiles as they are rendered."""
@@ -1440,6 +1486,23 @@ class DashboardsViewSet(
                 description=(
                     "'optimized' (default) returns LLM-friendly formatted text per insight. "
                     "'json' returns the raw query result objects."
+                ),
+            ),
+            OpenApiParameter(
+                "variables_override",
+                OpenApiTypes.STR,
+                description=(
+                    "JSON object to override dashboard variables for this request only (does not persist). "
+                    'Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. '
+                    "Use dashboard-get to see the dashboard's current variables and their IDs."
+                ),
+            ),
+            OpenApiParameter(
+                "filters_override",
+                OpenApiTypes.STR,
+                description=(
+                    "JSON object to override dashboard filters for this request only (does not persist). "
+                    "See dashboard filters schema for available keys (e.g., date_from, date_to)."
                 ),
             ),
         ],

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -105,6 +105,38 @@ DASHBOARD_SHARED_FIELDS = [
 ]
 
 
+# Shared OpenAPI parameter definitions for the variables_override / filters_override
+# query params. These three semantics are easy to miss without reading
+# posthog/utils.py and posthog/api/insight_variable.py:
+#   1. Each variable entry needs `code_name` to match — `map_stale_to_latest` drops
+#      entries that lack it, so an override of `{"value": ...}` alone silently no-ops.
+#   2. Both helpers shallow-merge — top-level keys replace wholesale, nested values
+#      are not deep-merged.
+#   3. Both helpers ignore overrides when the request is authenticated via a
+#      dashboard sharing token, returning the persisted state with no error.
+VARIABLES_OVERRIDE_PARAM = OpenApiParameter(
+    "variables_override",
+    OpenApiTypes.STR,
+    description=(
+        "JSON object to override dashboard variables for this request only (not persisted). "
+        'Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. '
+        "Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call "
+        "`dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. "
+        "Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token."
+    ),
+)
+FILTERS_OVERRIDE_PARAM = OpenApiParameter(
+    "filters_override",
+    OpenApiTypes.STR,
+    description=(
+        "JSON object to override dashboard filters for this request only (not persisted). "
+        "Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. "
+        "See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). "
+        "Ignored when accessed via a dashboard sharing token."
+    ),
+)
+
+
 tracer = trace.get_tracer(__name__)
 
 
@@ -1102,26 +1134,7 @@ class DashboardsViewSet(
 
         return results
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "variables_override",
-                OpenApiTypes.STR,
-                description=(
-                    "JSON object to override dashboard variables for this request only (does not persist). "
-                    'Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.'
-                ),
-            ),
-            OpenApiParameter(
-                "filters_override",
-                OpenApiTypes.STR,
-                description=(
-                    "JSON object to override dashboard filters for this request only (does not persist). "
-                    "See dashboard filters schema for available keys."
-                ),
-            ),
-        ],
-    )
+    @extend_schema(parameters=[VARIABLES_OVERRIDE_PARAM, FILTERS_OVERRIDE_PARAM])
     @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="GET")
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         dashboard = self.get_object()
@@ -1197,27 +1210,16 @@ class DashboardsViewSet(
     # ******************************************
     @extend_schema(
         parameters=[
-            OpenApiParameter(
-                "variables_override",
-                OpenApiTypes.STR,
-                description=(
-                    "JSON object to override dashboard variables for this request only (does not persist). "
-                    'Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.'
-                ),
-            ),
-            OpenApiParameter(
-                "filters_override",
-                OpenApiTypes.STR,
-                description=(
-                    "JSON object to override dashboard filters for this request only (does not persist). "
-                    "See dashboard filters schema for available keys."
-                ),
-            ),
+            VARIABLES_OVERRIDE_PARAM,
+            FILTERS_OVERRIDE_PARAM,
             OpenApiParameter(
                 "layoutSize",
                 OpenApiTypes.STR,
                 enum=["sm", "xs"],
-                description="Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.",
+                description=(
+                    "Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile. "
+                    "The snake_case alias `layout_size` is also accepted for backward compatibility."
+                ),
             ),
         ],
     )
@@ -1488,23 +1490,8 @@ class DashboardsViewSet(
                     "'json' returns the raw query result objects."
                 ),
             ),
-            OpenApiParameter(
-                "variables_override",
-                OpenApiTypes.STR,
-                description=(
-                    "JSON object to override dashboard variables for this request only (does not persist). "
-                    'Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. '
-                    "Use dashboard-get to see the dashboard's current variables and their IDs."
-                ),
-            ),
-            OpenApiParameter(
-                "filters_override",
-                OpenApiTypes.STR,
-                description=(
-                    "JSON object to override dashboard filters for this request only (does not persist). "
-                    "See dashboard filters schema for available keys (e.g., date_from, date_to)."
-                ),
-            ),
+            VARIABLES_OVERRIDE_PARAM,
+            FILTERS_OVERRIDE_PARAM,
         ],
         responses={200: RunInsightsResponseSerializer},
     )

--- a/products/dashboards/backend/api/test/test_run_insights.py
+++ b/products/dashboards/backend/api/test/test_run_insights.py
@@ -1,3 +1,5 @@
+import json
+
 from posthog.test.base import APIBaseTest
 
 from rest_framework import status
@@ -6,6 +8,7 @@ from posthog.schema import DateRange, EventsNode, InsightVizNode, TrendsFilter, 
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.models import Insight
+from posthog.models.insight_variable import InsightVariable
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 
@@ -151,3 +154,54 @@ class TestDashboardRunInsights(APIBaseTest):
 
         self.assertEqual([tile["insight"]["id"] for tile in body["results"]], [second_id, first_id])
         self.assertEqual([tile["order"] for tile in body["results"]], [0, 1])
+
+    def test_variables_override_query_param_applies_to_insight_results(self) -> None:
+        # Locks the contract documented by the VARIABLES_OVERRIDE_PARAM @extend_schema annotation:
+        # an MCP / API caller passing variables_override with the documented {code_name, variableId, value}
+        # shape gets results computed against the overridden value, not the persisted default.
+        # Without this test the override path through DashboardTileResultSerializer →
+        # InsightResultSerializer's inherited SerializerMethodField is fragile under future refactors.
+        variable = InsightVariable.objects.create(
+            team=self.team, name="Threshold", code_name="threshold", default_value=10, type="Number"
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="dash")
+        insight = Insight.objects.create(
+            team=self.team,
+            name="threshold check",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "query": "SELECT {variables.threshold}",
+                    "variables": {
+                        str(variable.id): {
+                            "code_name": variable.code_name,
+                            "variableId": str(variable.id),
+                        }
+                    },
+                },
+                "display": "BoldNumber",
+            },
+        )
+        DashboardTile.objects.create(insight=insight, dashboard=dashboard)
+
+        # Without override → default value.
+        baseline = self._run(dashboard.pk, output_format="json", refresh="blocking")
+        self.assertEqual(baseline["results"][0]["insight"]["result"][0][0], 10)
+
+        # With override → overridden value.
+        overridden = self._run(
+            dashboard.pk,
+            output_format="json",
+            refresh="blocking",
+            variables_override=json.dumps(
+                {
+                    str(variable.id): {
+                        "code_name": variable.code_name,
+                        "variableId": str(variable.id),
+                        "value": 99,
+                    }
+                }
+            ),
+        )
+        self.assertEqual(overridden["results"][0]["insight"]["result"][0][0], 99)

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -597,7 +597,15 @@ export const DashboardsCreateFormat = {
 } as const
 
 export type DashboardsRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     */
+    filters_override?: string
     format?: DashboardsRetrieveFormat
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     */
+    variables_override?: string
 }
 
 export type DashboardsRetrieveFormat = (typeof DashboardsRetrieveFormat)[keyof typeof DashboardsRetrieveFormat]
@@ -690,6 +698,10 @@ export const DashboardsReorderTilesCreateFormat = {
 } as const
 
 export type DashboardsRunInsightsRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).
+     */
+    filters_override?: string
     format?: DashboardsRunInsightsRetrieveFormat
     /**
      * 'optimized' (default) returns LLM-friendly formatted text per insight. 'json' returns the raw query result objects.
@@ -699,6 +711,10 @@ export type DashboardsRunInsightsRetrieveParams = {
      * Cache behavior. 'force_cache' (default) serves from cache even if stale. 'blocking' uses cache if fresh, otherwise recalculates. 'force_blocking' always recalculates.
      */
     refresh?: DashboardsRunInsightsRetrieveRefresh
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.
+     */
+    variables_override?: string
 }
 
 export type DashboardsRunInsightsRetrieveFormat =
@@ -739,7 +755,19 @@ export const DashboardsSnapshotCreateFormat = {
 } as const
 
 export type DashboardsStreamTilesRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     */
+    filters_override?: string
     format?: DashboardsStreamTilesRetrieveFormat
+    /**
+     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.
+     */
+    layoutSize?: DashboardsStreamTilesRetrieveLayoutSize
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     */
+    variables_override?: string
 }
 
 export type DashboardsStreamTilesRetrieveFormat =
@@ -748,6 +776,14 @@ export type DashboardsStreamTilesRetrieveFormat =
 export const DashboardsStreamTilesRetrieveFormat = {
     Json: 'json',
     Txt: 'txt',
+} as const
+
+export type DashboardsStreamTilesRetrieveLayoutSize =
+    (typeof DashboardsStreamTilesRetrieveLayoutSize)[keyof typeof DashboardsStreamTilesRetrieveLayoutSize]
+
+export const DashboardsStreamTilesRetrieveLayoutSize = {
+    Sm: 'sm',
+    Xs: 'xs',
 } as const
 
 export type DashboardsBulkUpdateTagsCreateParams = {

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -598,12 +598,12 @@ export const DashboardsCreateFormat = {
 
 export type DashboardsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string
     format?: DashboardsRetrieveFormat
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string
 }
@@ -699,7 +699,7 @@ export const DashboardsReorderTilesCreateFormat = {
 
 export type DashboardsRunInsightsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string
     format?: DashboardsRunInsightsRetrieveFormat
@@ -712,7 +712,7 @@ export type DashboardsRunInsightsRetrieveParams = {
      */
     refresh?: DashboardsRunInsightsRetrieveRefresh
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string
 }
@@ -756,16 +756,16 @@ export const DashboardsSnapshotCreateFormat = {
 
 export type DashboardsStreamTilesRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string
     format?: DashboardsStreamTilesRetrieveFormat
     /**
-     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.
+     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile. The snake_case alias `layout_size` is also accepted for backward compatibility.
      */
     layoutSize?: DashboardsStreamTilesRetrieveLayoutSize
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string
 }

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -9,324 +9,337 @@ feature: dashboards
 url_prefix: /dashboard
 ui_apps: {}
 tools:
-    dashboard-create:
-        operation: dashboards_create
-        enabled: true
-        scopes:
-            - dashboard:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        enrich_url: '{id}'
-        title: Create dashboard
-        description: >
-            Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
-            from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
-            — use dashboard-insights-run to fetch the actual data for each insight.
-        exclude_params:
-            - creation_mode
-            - effective_restriction_level
-            - effective_privilege_level
-            - is_shared
-            - access_control_version
-            - last_refresh
-            - last_accessed_at
-            - deleted
-            - persisted_filters
-            - persisted_variables
-            - _create_in_folder
-        response:
-            exclude:
-                - effective_restriction_level
-                - effective_privilege_level
-                - user_access_level
-                - access_control_version
-                - restriction_level
-                - creation_mode
-                - deleted
-                - breakdown_colors
-                - data_color_theme_id
-                - quick_filter_ids
-                - tiles.*.color
-                - tiles.*.transparent_background
-                - tiles.*.show_description
-                - tiles.*.button_tile
-                - tiles.*.insight.result
-                - tiles.*.insight.hasMore
-                - tiles.*.insight.columns
-                - tiles.*.insight.hogql
-                - tiles.*.insight.types
-                - tiles.*.insight.query_status
-                - tiles.*.insight.cache_target_age
-                - tiles.*.insight.next_allowed_client_refresh
-                - tiles.*.insight.filters_hash
-                - tiles.*.insight.dashboards
-                - tiles.*.insight.dashboard_tiles
-                - tiles.*.insight.effective_restriction_level
-                - tiles.*.insight.effective_privilege_level
-                - tiles.*.insight.user_access_level
-                - tiles.*.insight.filters
-                - tiles.*.insight.is_sample
-                - tiles.*.insight.saved
-                - tiles.*.insight.order
-                - tiles.*.insight.deleted
-                - tiles.*.insight.alerts
-                - tiles.*.insight.last_viewed_at
-                - tiles.*.insight.timezone
-                - tiles.*.insight.resolved_date_range
-    dashboard-delete:
-        operation: dashboards_destroy
-        enabled: true
-        scopes:
-            - dashboard:write
-        annotations:
-            readOnly: false
-            destructive: true
-            idempotent: false
-        title: Delete dashboard
-        description: |
-            Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.
-        soft_delete: true
-    dashboard-get:
-        operation: dashboards_retrieve
-        enabled: true
-        scopes:
-            - dashboard:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        enrich_url: '{id}'
-        title: Get dashboard
-        description: >
-            Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
-            layout information. Insight results, filters, and query metadata are omitted to save context — use
-            dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
-            insight-query for a single insight.
-        response:
-            exclude:
-                - effective_restriction_level
-                - effective_privilege_level
-                - user_access_level
-                - access_control_version
-                - restriction_level
-                - creation_mode
-                - deleted
-                - breakdown_colors
-                - data_color_theme_id
-                - quick_filter_ids
-                - tiles.*.color
-                - tiles.*.transparent_background
-                - tiles.*.show_description
-                - tiles.*.button_tile
-                - tiles.*.insight.result
-                - tiles.*.insight.hasMore
-                - tiles.*.insight.columns
-                - tiles.*.insight.hogql
-                - tiles.*.insight.types
-                - tiles.*.insight.query_status
-                - tiles.*.insight.cache_target_age
-                - tiles.*.insight.next_allowed_client_refresh
-                - tiles.*.insight.filters_hash
-                - tiles.*.insight.dashboards
-                - tiles.*.insight.dashboard_tiles
-                - tiles.*.insight.effective_restriction_level
-                - tiles.*.insight.effective_privilege_level
-                - tiles.*.insight.user_access_level
-                - tiles.*.insight.filters
-                - tiles.*.insight.is_sample
-                - tiles.*.insight.order
-                - tiles.*.insight.deleted
-                - tiles.*.insight.alerts
-                - tiles.*.insight.timezone
-                - tiles.*.insight.resolved_date_range
-    dashboard-insights-run:
-        operation: dashboards_run_insights_retrieve
-        enabled: true
-        scopes:
-            - query:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        enrich_url: '{params.id}'
-        title: Run dashboard insights
-        description: >
-            Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
-            refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
-            'json' for raw query results. Use this after dashboard-get to see the actual data behind each insight tile.
-    dashboard-reorder-tiles:
-        operation: dashboards_reorder_tiles_create
-        enabled: true
-        scopes:
-            - dashboard:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: true
-        enrich_url: '{id}'
-        title: Reorder dashboard tiles
-        description: >
-            Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
-            2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
-            IDs.
-    dashboard-templates-copy-between-projects-create:
-        operation: dashboard_templates_copy_between_projects_create
-        enabled: false
-    dashboard-templates-create:
-        operation: dashboard_templates_create
-        enabled: false
-    dashboard-templates-json-schema-retrieve:
-        operation: dashboard_templates_json_schema_retrieve
-        enabled: false
-    dashboard-templates-list:
-        operation: dashboard_templates_list
-        enabled: false
-    dashboard-update:
-        operation: dashboards_partial_update
-        enabled: true
-        scopes:
-            - dashboard:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: true
-        enrich_url: '{id}'
-        title: Update dashboard
-        description: >
-            Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and
-            restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to
-            fetch the actual data for each insight.
-        exclude_params:
-            - creation_mode
-            - effective_restriction_level
-            - effective_privilege_level
-            - is_shared
-            - access_control_version
-            - last_refresh
-            - last_accessed_at
-            - deleted
-            - persisted_filters
-            - persisted_variables
-            - _create_in_folder
-        response:
-            exclude:
-                - effective_restriction_level
-                - effective_privilege_level
-                - user_access_level
-                - access_control_version
-                - restriction_level
-                - creation_mode
-                - deleted
-                - breakdown_colors
-                - data_color_theme_id
-                - quick_filter_ids
-                - tiles.*.color
-                - tiles.*.transparent_background
-                - tiles.*.show_description
-                - tiles.*.button_tile
-                - tiles.*.insight.result
-                - tiles.*.insight.hasMore
-                - tiles.*.insight.columns
-                - tiles.*.insight.hogql
-                - tiles.*.insight.types
-                - tiles.*.insight.query_status
-                - tiles.*.insight.cache_target_age
-                - tiles.*.insight.next_allowed_client_refresh
-                - tiles.*.insight.filters_hash
-                - tiles.*.insight.dashboards
-                - tiles.*.insight.dashboard_tiles
-                - tiles.*.insight.effective_restriction_level
-                - tiles.*.insight.effective_privilege_level
-                - tiles.*.insight.user_access_level
-                - tiles.*.insight.filters
-                - tiles.*.insight.is_sample
-                - tiles.*.insight.order
-                - tiles.*.insight.deleted
-                - tiles.*.insight.alerts
-                - tiles.*.insight.timezone
-                - tiles.*.insight.resolved_date_range
-    dashboards-analyze-refresh-result-create:
-        operation: dashboards_analyze_refresh_result_create
-        enabled: false
-    dashboards-bulk-update-tags-create:
-        operation: dashboards_bulk_update_tags_create
-        enabled: false
-    dashboards-collaborators-create:
-        operation: dashboards_collaborators_create
-        enabled: false
-    dashboards-collaborators-destroy:
-        operation: dashboards_collaborators_destroy
-        enabled: false
-    dashboards-collaborators-list:
-        operation: dashboards_collaborators_list
-        enabled: false
-    dashboards-copy-tile-create:
-        operation: dashboards_copy_tile_create
-        enabled: false
-    dashboards-create-from-template-json-create:
-        operation: dashboards_create_from_template_json_create
-        enabled: false
-    dashboards-create-unlisted-dashboard-create:
-        operation: dashboards_create_unlisted_dashboard_create
-        enabled: false
-    dashboards-get-all:
-        operation: dashboards_list
-        enabled: true
-        scopes:
-            - dashboard:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        enrich_url: '{id}'
-        list: true
-        title: Get all dashboards
-        description: >
-            Get all dashboards in the project with optional filtering by pinned status or search term. Returns name,
-            description, pinned status, tags, and creation metadata. Tiles and insights are not included — use
-            dashboard-get to fetch a dashboard's tiles, then dashboard-insights-run to fetch the actual data for each
-            insight.
-    dashboards-move-tile-partial-update:
-        operation: dashboards_move_tile_partial_update
-        enabled: false
-    dashboards-sharing-list:
-        operation: dashboards_sharing_list
-        enabled: false
-    dashboards-sharing-passwords-create:
-        operation: dashboards_sharing_passwords_create
-        enabled: false
-    dashboards-sharing-passwords-destroy:
-        operation: dashboards_sharing_passwords_destroy
-        enabled: false
-    dashboards-sharing-refresh-create:
-        operation: dashboards_sharing_refresh_create
-        enabled: false
-    dashboards-snapshot-create:
-        operation: dashboards_snapshot_create
-        enabled: false
-    dashboards-stream-tiles-retrieve:
-        operation: dashboards_stream_tiles_retrieve
-        enabled: false
-    dashboards-update:
-        operation: dashboards_update
-        enabled: false
-    data-color-themes-create:
-        operation: data_color_themes_create
-        enabled: false
-    data-color-themes-destroy:
-        operation: data_color_themes_destroy
-        enabled: false
-    data-color-themes-list:
-        operation: data_color_themes_list
-        enabled: false
-    data-color-themes-partial-update:
-        operation: data_color_themes_partial_update
-        enabled: false
-    data-color-themes-retrieve:
-        operation: data_color_themes_retrieve
-        enabled: false
-    data-color-themes-update:
-        operation: data_color_themes_update
-        enabled: false
+  dashboard-create:
+    operation: dashboards_create
+    enabled: true
+    scopes:
+      - dashboard:write
+    annotations:
+      readOnly: false
+      destructive: false
+      idempotent: false
+    enrich_url: "{id}"
+    title: Create dashboard
+    description: >
+      Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
+      from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
+      — use dashboard-insights-run to fetch the actual data for each insight.
+    exclude_params:
+      - creation_mode
+      - effective_restriction_level
+      - effective_privilege_level
+      - is_shared
+      - access_control_version
+      - last_refresh
+      - last_accessed_at
+      - deleted
+      - persisted_filters
+      - persisted_variables
+      - _create_in_folder
+    response:
+      exclude:
+        - effective_restriction_level
+        - effective_privilege_level
+        - user_access_level
+        - access_control_version
+        - restriction_level
+        - creation_mode
+        - deleted
+        - breakdown_colors
+        - data_color_theme_id
+        - quick_filter_ids
+        - tiles.*.color
+        - tiles.*.transparent_background
+        - tiles.*.show_description
+        - tiles.*.button_tile
+        - tiles.*.insight.result
+        - tiles.*.insight.hasMore
+        - tiles.*.insight.columns
+        - tiles.*.insight.hogql
+        - tiles.*.insight.types
+        - tiles.*.insight.query_status
+        - tiles.*.insight.cache_target_age
+        - tiles.*.insight.next_allowed_client_refresh
+        - tiles.*.insight.filters_hash
+        - tiles.*.insight.dashboards
+        - tiles.*.insight.dashboard_tiles
+        - tiles.*.insight.effective_restriction_level
+        - tiles.*.insight.effective_privilege_level
+        - tiles.*.insight.user_access_level
+        - tiles.*.insight.filters
+        - tiles.*.insight.is_sample
+        - tiles.*.insight.saved
+        - tiles.*.insight.order
+        - tiles.*.insight.deleted
+        - tiles.*.insight.alerts
+        - tiles.*.insight.last_viewed_at
+        - tiles.*.insight.timezone
+        - tiles.*.insight.resolved_date_range
+  dashboard-delete:
+    operation: dashboards_destroy
+    enabled: true
+    scopes:
+      - dashboard:write
+    annotations:
+      readOnly: false
+      destructive: true
+      idempotent: false
+    title: Delete dashboard
+    description: |
+      Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.
+    soft_delete: true
+  dashboard-get:
+    operation: dashboards_retrieve
+    enabled: true
+    scopes:
+      - dashboard:read
+    annotations:
+      readOnly: true
+      destructive: false
+      idempotent: true
+    enrich_url: "{id}"
+    title: Get dashboard
+    description: >
+      Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
+      layout information. Insight results, filters, and query metadata are omitted to save context — use
+      dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
+      insight-query for a single insight. Supports variables_override and filters_override query params to
+      apply one-off overrides without persisting changes.
+    response:
+      exclude:
+        - effective_restriction_level
+        - effective_privilege_level
+        - user_access_level
+        - access_control_version
+        - restriction_level
+        - creation_mode
+        - deleted
+        - breakdown_colors
+        - data_color_theme_id
+        - quick_filter_ids
+        - tiles.*.color
+        - tiles.*.transparent_background
+        - tiles.*.show_description
+        - tiles.*.button_tile
+        - tiles.*.insight.result
+        - tiles.*.insight.hasMore
+        - tiles.*.insight.columns
+        - tiles.*.insight.hogql
+        - tiles.*.insight.types
+        - tiles.*.insight.query_status
+        - tiles.*.insight.cache_target_age
+        - tiles.*.insight.next_allowed_client_refresh
+        - tiles.*.insight.filters_hash
+        - tiles.*.insight.dashboards
+        - tiles.*.insight.dashboard_tiles
+        - tiles.*.insight.effective_restriction_level
+        - tiles.*.insight.effective_privilege_level
+        - tiles.*.insight.user_access_level
+        - tiles.*.insight.filters
+        - tiles.*.insight.is_sample
+        - tiles.*.insight.order
+        - tiles.*.insight.deleted
+        - tiles.*.insight.alerts
+        - tiles.*.insight.timezone
+        - tiles.*.insight.resolved_date_range
+  dashboard-insights-run:
+    operation: dashboards_run_insights_retrieve
+    enabled: true
+    scopes:
+      - query:read
+    annotations:
+      readOnly: true
+      destructive: false
+      idempotent: true
+    enrich_url: "{params.id}"
+    title: Run dashboard insights
+    description: >
+      Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
+      refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
+      'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value": "new_value"}})
+      and filters_override query params to run insights with one-off overrides without persisting changes to the
+      dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
+  dashboard-reorder-tiles:
+    operation: dashboards_reorder_tiles_create
+    enabled: true
+    scopes:
+      - dashboard:write
+    annotations:
+      readOnly: false
+      destructive: false
+      idempotent: true
+    enrich_url: "{id}"
+    title: Reorder dashboard tiles
+    description: >
+      Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
+      2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
+      IDs.
+  dashboard-templates-copy-between-projects-create:
+    operation: dashboard_templates_copy_between_projects_create
+    enabled: false
+  dashboard-templates-create:
+    operation: dashboard_templates_create
+    enabled: false
+  dashboard-templates-json-schema-retrieve:
+    operation: dashboard_templates_json_schema_retrieve
+    enabled: false
+  dashboard-templates-list:
+    operation: dashboard_templates_list
+    enabled: false
+  dashboard-update:
+    operation: dashboards_partial_update
+    enabled: true
+    scopes:
+      - dashboard:write
+    annotations:
+      readOnly: false
+      destructive: false
+      idempotent: true
+    enrich_url: "{id}"
+    title: Update dashboard
+    description: >
+      Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and
+      restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to
+      fetch the actual data for each insight.
+    exclude_params:
+      - creation_mode
+      - effective_restriction_level
+      - effective_privilege_level
+      - is_shared
+      - access_control_version
+      - last_refresh
+      - last_accessed_at
+      - deleted
+      - persisted_filters
+      - persisted_variables
+      - _create_in_folder
+    response:
+      exclude:
+        - effective_restriction_level
+        - effective_privilege_level
+        - user_access_level
+        - access_control_version
+        - restriction_level
+        - creation_mode
+        - deleted
+        - breakdown_colors
+        - data_color_theme_id
+        - quick_filter_ids
+        - tiles.*.color
+        - tiles.*.transparent_background
+        - tiles.*.show_description
+        - tiles.*.button_tile
+        - tiles.*.insight.result
+        - tiles.*.insight.hasMore
+        - tiles.*.insight.columns
+        - tiles.*.insight.hogql
+        - tiles.*.insight.types
+        - tiles.*.insight.query_status
+        - tiles.*.insight.cache_target_age
+        - tiles.*.insight.next_allowed_client_refresh
+        - tiles.*.insight.filters_hash
+        - tiles.*.insight.dashboards
+        - tiles.*.insight.dashboard_tiles
+        - tiles.*.insight.effective_restriction_level
+        - tiles.*.insight.effective_privilege_level
+        - tiles.*.insight.user_access_level
+        - tiles.*.insight.filters
+        - tiles.*.insight.is_sample
+        - tiles.*.insight.order
+        - tiles.*.insight.deleted
+        - tiles.*.insight.alerts
+        - tiles.*.insight.timezone
+        - tiles.*.insight.resolved_date_range
+  dashboards-analyze-refresh-result-create:
+    operation: dashboards_analyze_refresh_result_create
+    enabled: false
+  dashboards-bulk-update-tags-create:
+    operation: dashboards_bulk_update_tags_create
+    enabled: false
+  dashboards-collaborators-create:
+    operation: dashboards_collaborators_create
+    enabled: false
+  dashboards-collaborators-destroy:
+    operation: dashboards_collaborators_destroy
+    enabled: false
+  dashboards-collaborators-list:
+    operation: dashboards_collaborators_list
+    enabled: false
+  dashboards-copy-tile-create:
+    operation: dashboards_copy_tile_create
+    enabled: false
+  dashboards-create-from-template-json-create:
+    operation: dashboards_create_from_template_json_create
+    enabled: false
+  dashboards-create-unlisted-dashboard-create:
+    operation: dashboards_create_unlisted_dashboard_create
+    enabled: false
+  dashboards-get-all:
+    operation: dashboards_list
+    enabled: true
+    scopes:
+      - dashboard:read
+    annotations:
+      readOnly: true
+      destructive: false
+      idempotent: true
+    enrich_url: "{id}"
+    list: true
+    title: Get all dashboards
+    description: >
+      Get all dashboards in the project with optional filtering by pinned status or search term. Returns name,
+      description, pinned status, tags, and creation metadata. Tiles and insights are not included — use
+      dashboard-get to fetch a dashboard's tiles, then dashboard-insights-run to fetch the actual data for each
+      insight.
+  dashboards-move-tile-partial-update:
+    operation: dashboards_move_tile_partial_update
+    enabled: false
+  dashboards-sharing-list:
+    operation: dashboards_sharing_list
+    enabled: false
+  dashboards-sharing-passwords-create:
+    operation: dashboards_sharing_passwords_create
+    enabled: false
+  dashboards-sharing-passwords-destroy:
+    operation: dashboards_sharing_passwords_destroy
+    enabled: false
+  dashboards-sharing-refresh-create:
+    operation: dashboards_sharing_refresh_create
+    enabled: false
+  dashboards-snapshot-create:
+    operation: dashboards_snapshot_create
+    enabled: false
+  dashboards-stream-tiles-retrieve:
+    operation: dashboards_stream_tiles_retrieve
+    enabled: false
+    scopes:
+      - dashboard:read
+    annotations:
+      readOnly: true
+      destructive: false
+      idempotent: true
+    title: Stream dashboard tiles
+    description: >
+      Stream dashboard metadata and tiles via Server-Sent Events. Supports variables_override and filters_override
+      query params to apply one-off overrides without persisting changes.
+  dashboards-update:
+    operation: dashboards_update
+    enabled: false
+  data-color-themes-create:
+    operation: data_color_themes_create
+    enabled: false
+  data-color-themes-destroy:
+    operation: data_color_themes_destroy
+    enabled: false
+  data-color-themes-list:
+    operation: data_color_themes_list
+    enabled: false
+  data-color-themes-partial-update:
+    operation: data_color_themes_partial_update
+    enabled: false
+  data-color-themes-retrieve:
+    operation: data_color_themes_retrieve
+    enabled: false
+  data-color-themes-update:
+    operation: data_color_themes_update
+    enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -103,9 +103,9 @@ tools:
             Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
             layout information. Insight results, filters, and query metadata are omitted to save context — use
             dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
-            insight-query for a single insight. Supports variables_override and filters_override query params to
-            preview the merged variable/filter state without persisting; use dashboard-insights-run to get results
-            with those overrides applied.
+            insight-query for a single insight. Supports variables_override and filters_override query params to preview
+            the merged variable/filter state without persisting; use dashboard-insights-run to get results with those
+            overrides applied.
         response:
             exclude:
                 - effective_restriction_level
@@ -157,9 +157,9 @@ tools:
         description: >
             Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
             refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
-            'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value": "new_value"}})
-            and filters_override query params to run insights with one-off overrides without persisting changes to the
-            dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
+            'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value":
+            "new_value"}}) and filters_override query params to run insights with one-off overrides without persisting
+            changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -157,15 +157,9 @@ tools:
         description: >
             Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
             refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
-<<<<<<< HEAD
-            'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value":
-            "new_value"}}) and filters_override query params to run insights with one-off overrides without persisting
-            changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
-=======
             'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value": "new_value"}})
             and filters_override query params to run insights with one-off overrides without persisting changes to the
             dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
->>>>>>> 0ffb47d9 (chore(dashboards): clarify dashboard-get override params only show merged state)
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -103,9 +103,9 @@ tools:
             Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
             layout information. Insight results, filters, and query metadata are omitted to save context — use
             dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
-            insight-query for a single insight. Supports variables_override and filters_override query params to preview
-            the merged variable/filter state without persisting; use dashboard-insights-run to get results with those
-            overrides applied.
+            insight-query for a single insight. Supports variables_override and filters_override query params; on
+            this endpoint they affect only the merged `filters` and `variables` fields in the response (preview).
+            To execute insights with the same overrides, pass the same query params to dashboard-insights-run.
         response:
             exclude:
                 - effective_restriction_level
@@ -157,9 +157,8 @@ tools:
         description: >
             Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
             refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
-            'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value":
-            "new_value"}}) and filters_override query params to run insights with one-off overrides without persisting
-            changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
+            'json' for raw query results. Supports variables_override and filters_override query params to run insights
+            with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true
@@ -313,16 +312,6 @@ tools:
     dashboards-stream-tiles-retrieve:
         operation: dashboards_stream_tiles_retrieve
         enabled: false
-        scopes:
-            - dashboard:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Stream dashboard tiles
-        description: >
-            Stream dashboard metadata and tiles via Server-Sent Events. Supports variables_override and filters_override
-            query params to apply one-off overrides without persisting changes.
     dashboards-update:
         operation: dashboards_update
         enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -9,337 +9,337 @@ feature: dashboards
 url_prefix: /dashboard
 ui_apps: {}
 tools:
-  dashboard-create:
-    operation: dashboards_create
-    enabled: true
-    scopes:
-      - dashboard:write
-    annotations:
-      readOnly: false
-      destructive: false
-      idempotent: false
-    enrich_url: "{id}"
-    title: Create dashboard
-    description: >
-      Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
-      from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
-      — use dashboard-insights-run to fetch the actual data for each insight.
-    exclude_params:
-      - creation_mode
-      - effective_restriction_level
-      - effective_privilege_level
-      - is_shared
-      - access_control_version
-      - last_refresh
-      - last_accessed_at
-      - deleted
-      - persisted_filters
-      - persisted_variables
-      - _create_in_folder
-    response:
-      exclude:
-        - effective_restriction_level
-        - effective_privilege_level
-        - user_access_level
-        - access_control_version
-        - restriction_level
-        - creation_mode
-        - deleted
-        - breakdown_colors
-        - data_color_theme_id
-        - quick_filter_ids
-        - tiles.*.color
-        - tiles.*.transparent_background
-        - tiles.*.show_description
-        - tiles.*.button_tile
-        - tiles.*.insight.result
-        - tiles.*.insight.hasMore
-        - tiles.*.insight.columns
-        - tiles.*.insight.hogql
-        - tiles.*.insight.types
-        - tiles.*.insight.query_status
-        - tiles.*.insight.cache_target_age
-        - tiles.*.insight.next_allowed_client_refresh
-        - tiles.*.insight.filters_hash
-        - tiles.*.insight.dashboards
-        - tiles.*.insight.dashboard_tiles
-        - tiles.*.insight.effective_restriction_level
-        - tiles.*.insight.effective_privilege_level
-        - tiles.*.insight.user_access_level
-        - tiles.*.insight.filters
-        - tiles.*.insight.is_sample
-        - tiles.*.insight.saved
-        - tiles.*.insight.order
-        - tiles.*.insight.deleted
-        - tiles.*.insight.alerts
-        - tiles.*.insight.last_viewed_at
-        - tiles.*.insight.timezone
-        - tiles.*.insight.resolved_date_range
-  dashboard-delete:
-    operation: dashboards_destroy
-    enabled: true
-    scopes:
-      - dashboard:write
-    annotations:
-      readOnly: false
-      destructive: true
-      idempotent: false
-    title: Delete dashboard
-    description: |
-      Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.
-    soft_delete: true
-  dashboard-get:
-    operation: dashboards_retrieve
-    enabled: true
-    scopes:
-      - dashboard:read
-    annotations:
-      readOnly: true
-      destructive: false
-      idempotent: true
-    enrich_url: "{id}"
-    title: Get dashboard
-    description: >
-      Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
-      layout information. Insight results, filters, and query metadata are omitted to save context — use
-      dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
-      insight-query for a single insight. Supports variables_override and filters_override query params to
-      apply one-off overrides without persisting changes.
-    response:
-      exclude:
-        - effective_restriction_level
-        - effective_privilege_level
-        - user_access_level
-        - access_control_version
-        - restriction_level
-        - creation_mode
-        - deleted
-        - breakdown_colors
-        - data_color_theme_id
-        - quick_filter_ids
-        - tiles.*.color
-        - tiles.*.transparent_background
-        - tiles.*.show_description
-        - tiles.*.button_tile
-        - tiles.*.insight.result
-        - tiles.*.insight.hasMore
-        - tiles.*.insight.columns
-        - tiles.*.insight.hogql
-        - tiles.*.insight.types
-        - tiles.*.insight.query_status
-        - tiles.*.insight.cache_target_age
-        - tiles.*.insight.next_allowed_client_refresh
-        - tiles.*.insight.filters_hash
-        - tiles.*.insight.dashboards
-        - tiles.*.insight.dashboard_tiles
-        - tiles.*.insight.effective_restriction_level
-        - tiles.*.insight.effective_privilege_level
-        - tiles.*.insight.user_access_level
-        - tiles.*.insight.filters
-        - tiles.*.insight.is_sample
-        - tiles.*.insight.order
-        - tiles.*.insight.deleted
-        - tiles.*.insight.alerts
-        - tiles.*.insight.timezone
-        - tiles.*.insight.resolved_date_range
-  dashboard-insights-run:
-    operation: dashboards_run_insights_retrieve
-    enabled: true
-    scopes:
-      - query:read
-    annotations:
-      readOnly: true
-      destructive: false
-      idempotent: true
-    enrich_url: "{params.id}"
-    title: Run dashboard insights
-    description: >
-      Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
-      refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
-      'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value": "new_value"}})
-      and filters_override query params to run insights with one-off overrides without persisting changes to the
-      dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
-  dashboard-reorder-tiles:
-    operation: dashboards_reorder_tiles_create
-    enabled: true
-    scopes:
-      - dashboard:write
-    annotations:
-      readOnly: false
-      destructive: false
-      idempotent: true
-    enrich_url: "{id}"
-    title: Reorder dashboard tiles
-    description: >
-      Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
-      2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
-      IDs.
-  dashboard-templates-copy-between-projects-create:
-    operation: dashboard_templates_copy_between_projects_create
-    enabled: false
-  dashboard-templates-create:
-    operation: dashboard_templates_create
-    enabled: false
-  dashboard-templates-json-schema-retrieve:
-    operation: dashboard_templates_json_schema_retrieve
-    enabled: false
-  dashboard-templates-list:
-    operation: dashboard_templates_list
-    enabled: false
-  dashboard-update:
-    operation: dashboards_partial_update
-    enabled: true
-    scopes:
-      - dashboard:write
-    annotations:
-      readOnly: false
-      destructive: false
-      idempotent: true
-    enrich_url: "{id}"
-    title: Update dashboard
-    description: >
-      Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and
-      restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to
-      fetch the actual data for each insight.
-    exclude_params:
-      - creation_mode
-      - effective_restriction_level
-      - effective_privilege_level
-      - is_shared
-      - access_control_version
-      - last_refresh
-      - last_accessed_at
-      - deleted
-      - persisted_filters
-      - persisted_variables
-      - _create_in_folder
-    response:
-      exclude:
-        - effective_restriction_level
-        - effective_privilege_level
-        - user_access_level
-        - access_control_version
-        - restriction_level
-        - creation_mode
-        - deleted
-        - breakdown_colors
-        - data_color_theme_id
-        - quick_filter_ids
-        - tiles.*.color
-        - tiles.*.transparent_background
-        - tiles.*.show_description
-        - tiles.*.button_tile
-        - tiles.*.insight.result
-        - tiles.*.insight.hasMore
-        - tiles.*.insight.columns
-        - tiles.*.insight.hogql
-        - tiles.*.insight.types
-        - tiles.*.insight.query_status
-        - tiles.*.insight.cache_target_age
-        - tiles.*.insight.next_allowed_client_refresh
-        - tiles.*.insight.filters_hash
-        - tiles.*.insight.dashboards
-        - tiles.*.insight.dashboard_tiles
-        - tiles.*.insight.effective_restriction_level
-        - tiles.*.insight.effective_privilege_level
-        - tiles.*.insight.user_access_level
-        - tiles.*.insight.filters
-        - tiles.*.insight.is_sample
-        - tiles.*.insight.order
-        - tiles.*.insight.deleted
-        - tiles.*.insight.alerts
-        - tiles.*.insight.timezone
-        - tiles.*.insight.resolved_date_range
-  dashboards-analyze-refresh-result-create:
-    operation: dashboards_analyze_refresh_result_create
-    enabled: false
-  dashboards-bulk-update-tags-create:
-    operation: dashboards_bulk_update_tags_create
-    enabled: false
-  dashboards-collaborators-create:
-    operation: dashboards_collaborators_create
-    enabled: false
-  dashboards-collaborators-destroy:
-    operation: dashboards_collaborators_destroy
-    enabled: false
-  dashboards-collaborators-list:
-    operation: dashboards_collaborators_list
-    enabled: false
-  dashboards-copy-tile-create:
-    operation: dashboards_copy_tile_create
-    enabled: false
-  dashboards-create-from-template-json-create:
-    operation: dashboards_create_from_template_json_create
-    enabled: false
-  dashboards-create-unlisted-dashboard-create:
-    operation: dashboards_create_unlisted_dashboard_create
-    enabled: false
-  dashboards-get-all:
-    operation: dashboards_list
-    enabled: true
-    scopes:
-      - dashboard:read
-    annotations:
-      readOnly: true
-      destructive: false
-      idempotent: true
-    enrich_url: "{id}"
-    list: true
-    title: Get all dashboards
-    description: >
-      Get all dashboards in the project with optional filtering by pinned status or search term. Returns name,
-      description, pinned status, tags, and creation metadata. Tiles and insights are not included — use
-      dashboard-get to fetch a dashboard's tiles, then dashboard-insights-run to fetch the actual data for each
-      insight.
-  dashboards-move-tile-partial-update:
-    operation: dashboards_move_tile_partial_update
-    enabled: false
-  dashboards-sharing-list:
-    operation: dashboards_sharing_list
-    enabled: false
-  dashboards-sharing-passwords-create:
-    operation: dashboards_sharing_passwords_create
-    enabled: false
-  dashboards-sharing-passwords-destroy:
-    operation: dashboards_sharing_passwords_destroy
-    enabled: false
-  dashboards-sharing-refresh-create:
-    operation: dashboards_sharing_refresh_create
-    enabled: false
-  dashboards-snapshot-create:
-    operation: dashboards_snapshot_create
-    enabled: false
-  dashboards-stream-tiles-retrieve:
-    operation: dashboards_stream_tiles_retrieve
-    enabled: false
-    scopes:
-      - dashboard:read
-    annotations:
-      readOnly: true
-      destructive: false
-      idempotent: true
-    title: Stream dashboard tiles
-    description: >
-      Stream dashboard metadata and tiles via Server-Sent Events. Supports variables_override and filters_override
-      query params to apply one-off overrides without persisting changes.
-  dashboards-update:
-    operation: dashboards_update
-    enabled: false
-  data-color-themes-create:
-    operation: data_color_themes_create
-    enabled: false
-  data-color-themes-destroy:
-    operation: data_color_themes_destroy
-    enabled: false
-  data-color-themes-list:
-    operation: data_color_themes_list
-    enabled: false
-  data-color-themes-partial-update:
-    operation: data_color_themes_partial_update
-    enabled: false
-  data-color-themes-retrieve:
-    operation: data_color_themes_retrieve
-    enabled: false
-  data-color-themes-update:
-    operation: data_color_themes_update
-    enabled: false
+    dashboard-create:
+        operation: dashboards_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Create dashboard
+        description: >
+            Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
+            from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
+            — use dashboard-insights-run to fetch the actual data for each insight.
+        exclude_params:
+            - creation_mode
+            - effective_restriction_level
+            - effective_privilege_level
+            - is_shared
+            - access_control_version
+            - last_refresh
+            - last_accessed_at
+            - deleted
+            - persisted_filters
+            - persisted_variables
+            - _create_in_folder
+        response:
+            exclude:
+                - effective_restriction_level
+                - effective_privilege_level
+                - user_access_level
+                - access_control_version
+                - restriction_level
+                - creation_mode
+                - deleted
+                - breakdown_colors
+                - data_color_theme_id
+                - quick_filter_ids
+                - tiles.*.color
+                - tiles.*.transparent_background
+                - tiles.*.show_description
+                - tiles.*.button_tile
+                - tiles.*.insight.result
+                - tiles.*.insight.hasMore
+                - tiles.*.insight.columns
+                - tiles.*.insight.hogql
+                - tiles.*.insight.types
+                - tiles.*.insight.query_status
+                - tiles.*.insight.cache_target_age
+                - tiles.*.insight.next_allowed_client_refresh
+                - tiles.*.insight.filters_hash
+                - tiles.*.insight.dashboards
+                - tiles.*.insight.dashboard_tiles
+                - tiles.*.insight.effective_restriction_level
+                - tiles.*.insight.effective_privilege_level
+                - tiles.*.insight.user_access_level
+                - tiles.*.insight.filters
+                - tiles.*.insight.is_sample
+                - tiles.*.insight.saved
+                - tiles.*.insight.order
+                - tiles.*.insight.deleted
+                - tiles.*.insight.alerts
+                - tiles.*.insight.last_viewed_at
+                - tiles.*.insight.timezone
+                - tiles.*.insight.resolved_date_range
+    dashboard-delete:
+        operation: dashboards_destroy
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: false
+        title: Delete dashboard
+        description: |
+            Delete a dashboard by ID. The dashboard will be soft-deleted and no longer appear in lists.
+        soft_delete: true
+    dashboard-get:
+        operation: dashboards_retrieve
+        enabled: true
+        scopes:
+            - dashboard:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Get dashboard
+        description: >
+            Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
+            layout information. Insight results, filters, and query metadata are omitted to save context — use
+            dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
+            insight-query for a single insight. Supports variables_override and filters_override query params to apply
+            one-off overrides without persisting changes.
+        response:
+            exclude:
+                - effective_restriction_level
+                - effective_privilege_level
+                - user_access_level
+                - access_control_version
+                - restriction_level
+                - creation_mode
+                - deleted
+                - breakdown_colors
+                - data_color_theme_id
+                - quick_filter_ids
+                - tiles.*.color
+                - tiles.*.transparent_background
+                - tiles.*.show_description
+                - tiles.*.button_tile
+                - tiles.*.insight.result
+                - tiles.*.insight.hasMore
+                - tiles.*.insight.columns
+                - tiles.*.insight.hogql
+                - tiles.*.insight.types
+                - tiles.*.insight.query_status
+                - tiles.*.insight.cache_target_age
+                - tiles.*.insight.next_allowed_client_refresh
+                - tiles.*.insight.filters_hash
+                - tiles.*.insight.dashboards
+                - tiles.*.insight.dashboard_tiles
+                - tiles.*.insight.effective_restriction_level
+                - tiles.*.insight.effective_privilege_level
+                - tiles.*.insight.user_access_level
+                - tiles.*.insight.filters
+                - tiles.*.insight.is_sample
+                - tiles.*.insight.order
+                - tiles.*.insight.deleted
+                - tiles.*.insight.alerts
+                - tiles.*.insight.timezone
+                - tiles.*.insight.resolved_date_range
+    dashboard-insights-run:
+        operation: dashboards_run_insights_retrieve
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: '{params.id}'
+        title: Run dashboard insights
+        description: >
+            Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
+            refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
+            'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value":
+            "new_value"}}) and filters_override query params to run insights with one-off overrides without persisting
+            changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
+    dashboard-reorder-tiles:
+        operation: dashboards_reorder_tiles_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Reorder dashboard tiles
+        description: >
+            Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. Computes a
+            2-column grid layout (6 columns wide, 5 rows tall per tile). First, use dashboard-get to see current tile
+            IDs.
+    dashboard-templates-copy-between-projects-create:
+        operation: dashboard_templates_copy_between_projects_create
+        enabled: false
+    dashboard-templates-create:
+        operation: dashboard_templates_create
+        enabled: false
+    dashboard-templates-json-schema-retrieve:
+        operation: dashboard_templates_json_schema_retrieve
+        enabled: false
+    dashboard-templates-list:
+        operation: dashboard_templates_list
+        enabled: false
+    dashboard-update:
+        operation: dashboards_partial_update
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        title: Update dashboard
+        description: >
+            Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and
+            restriction level. The returned tiles omit insight results to save context — use dashboard-insights-run to
+            fetch the actual data for each insight.
+        exclude_params:
+            - creation_mode
+            - effective_restriction_level
+            - effective_privilege_level
+            - is_shared
+            - access_control_version
+            - last_refresh
+            - last_accessed_at
+            - deleted
+            - persisted_filters
+            - persisted_variables
+            - _create_in_folder
+        response:
+            exclude:
+                - effective_restriction_level
+                - effective_privilege_level
+                - user_access_level
+                - access_control_version
+                - restriction_level
+                - creation_mode
+                - deleted
+                - breakdown_colors
+                - data_color_theme_id
+                - quick_filter_ids
+                - tiles.*.color
+                - tiles.*.transparent_background
+                - tiles.*.show_description
+                - tiles.*.button_tile
+                - tiles.*.insight.result
+                - tiles.*.insight.hasMore
+                - tiles.*.insight.columns
+                - tiles.*.insight.hogql
+                - tiles.*.insight.types
+                - tiles.*.insight.query_status
+                - tiles.*.insight.cache_target_age
+                - tiles.*.insight.next_allowed_client_refresh
+                - tiles.*.insight.filters_hash
+                - tiles.*.insight.dashboards
+                - tiles.*.insight.dashboard_tiles
+                - tiles.*.insight.effective_restriction_level
+                - tiles.*.insight.effective_privilege_level
+                - tiles.*.insight.user_access_level
+                - tiles.*.insight.filters
+                - tiles.*.insight.is_sample
+                - tiles.*.insight.order
+                - tiles.*.insight.deleted
+                - tiles.*.insight.alerts
+                - tiles.*.insight.timezone
+                - tiles.*.insight.resolved_date_range
+    dashboards-analyze-refresh-result-create:
+        operation: dashboards_analyze_refresh_result_create
+        enabled: false
+    dashboards-bulk-update-tags-create:
+        operation: dashboards_bulk_update_tags_create
+        enabled: false
+    dashboards-collaborators-create:
+        operation: dashboards_collaborators_create
+        enabled: false
+    dashboards-collaborators-destroy:
+        operation: dashboards_collaborators_destroy
+        enabled: false
+    dashboards-collaborators-list:
+        operation: dashboards_collaborators_list
+        enabled: false
+    dashboards-copy-tile-create:
+        operation: dashboards_copy_tile_create
+        enabled: false
+    dashboards-create-from-template-json-create:
+        operation: dashboards_create_from_template_json_create
+        enabled: false
+    dashboards-create-unlisted-dashboard-create:
+        operation: dashboards_create_unlisted_dashboard_create
+        enabled: false
+    dashboards-get-all:
+        operation: dashboards_list
+        enabled: true
+        scopes:
+            - dashboard:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        enrich_url: '{id}'
+        list: true
+        title: Get all dashboards
+        description: >
+            Get all dashboards in the project with optional filtering by pinned status or search term. Returns name,
+            description, pinned status, tags, and creation metadata. Tiles and insights are not included — use
+            dashboard-get to fetch a dashboard's tiles, then dashboard-insights-run to fetch the actual data for each
+            insight.
+    dashboards-move-tile-partial-update:
+        operation: dashboards_move_tile_partial_update
+        enabled: false
+    dashboards-sharing-list:
+        operation: dashboards_sharing_list
+        enabled: false
+    dashboards-sharing-passwords-create:
+        operation: dashboards_sharing_passwords_create
+        enabled: false
+    dashboards-sharing-passwords-destroy:
+        operation: dashboards_sharing_passwords_destroy
+        enabled: false
+    dashboards-sharing-refresh-create:
+        operation: dashboards_sharing_refresh_create
+        enabled: false
+    dashboards-snapshot-create:
+        operation: dashboards_snapshot_create
+        enabled: false
+    dashboards-stream-tiles-retrieve:
+        operation: dashboards_stream_tiles_retrieve
+        enabled: false
+        scopes:
+            - dashboard:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Stream dashboard tiles
+        description: >
+            Stream dashboard metadata and tiles via Server-Sent Events. Supports variables_override and filters_override
+            query params to apply one-off overrides without persisting changes.
+    dashboards-update:
+        operation: dashboards_update
+        enabled: false
+    data-color-themes-create:
+        operation: data_color_themes_create
+        enabled: false
+    data-color-themes-destroy:
+        operation: data_color_themes_destroy
+        enabled: false
+    data-color-themes-list:
+        operation: data_color_themes_list
+        enabled: false
+    data-color-themes-partial-update:
+        operation: data_color_themes_partial_update
+        enabled: false
+    data-color-themes-retrieve:
+        operation: data_color_themes_retrieve
+        enabled: false
+    data-color-themes-update:
+        operation: data_color_themes_update
+        enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -103,8 +103,9 @@ tools:
             Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
             layout information. Insight results, filters, and query metadata are omitted to save context — use
             dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
-            insight-query for a single insight. Supports variables_override and filters_override query params to apply
-            one-off overrides without persisting changes.
+            insight-query for a single insight. Supports variables_override and filters_override query params to
+            preview the merged variable/filter state without persisting; use dashboard-insights-run to get results
+            with those overrides applied.
         response:
             exclude:
                 - effective_restriction_level
@@ -156,9 +157,15 @@ tools:
         description: >
             Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set
             refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or
+<<<<<<< HEAD
             'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value":
             "new_value"}}) and filters_override query params to run insights with one-off overrides without persisting
             changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
+=======
+            'json' for raw query results. Supports variables_override (JSON object with {"variable_id": {"value": "new_value"}})
+            and filters_override query params to run insights with one-off overrides without persisting changes to the
+            dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.
+>>>>>>> 0ffb47d9 (chore(dashboards): clarify dashboard-get override params only show merged state)
     dashboard-reorder-tiles:
         operation: dashboards_reorder_tiles_create
         enabled: true

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -103,9 +103,9 @@ tools:
             Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and
             layout information. Insight results, filters, and query metadata are omitted to save context — use
             dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or
-            insight-query for a single insight. Supports variables_override and filters_override query params; on
-            this endpoint they affect only the merged `filters` and `variables` fields in the response (preview).
-            To execute insights with the same overrides, pass the same query params to dashboard-insights-run.
+            insight-query for a single insight. Supports variables_override and filters_override query params; on this
+            endpoint they affect only the merged `filters` and `variables` fields in the response (preview). To execute
+            insights with the same overrides, pass the same query params to dashboard-insights-run.
         response:
             exclude:
                 - effective_restriction_level

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -750,7 +750,7 @@
         }
     },
     "dashboard-get": {
-        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight.",
+        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to apply one-off overrides without persisting changes.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Get dashboard",
@@ -765,7 +765,7 @@
         }
     },
     "dashboard-insights-run": {
-        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Use this after dashboard-get to see the actual data behind each insight tile.",
+        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override (JSON object with {\"variable_id\": {\"value\": \"new_value\"}}) and filters_override query params to run insights with one-off overrides without persisting changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Run dashboard insights",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -750,7 +750,7 @@
         }
     },
     "dashboard-get": {
-        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to preview the merged variable/filter state without persisting; use dashboard-insights-run to get results with those overrides applied.",
+        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params; on this endpoint they affect only the merged `filters` and `variables` fields in the response (preview). To execute insights with the same overrides, pass the same query params to dashboard-insights-run.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Get dashboard",
@@ -765,7 +765,7 @@
         }
     },
     "dashboard-insights-run": {
-        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override (JSON object with {\"variable_id\": {\"value\": \"new_value\"}}) and filters_override query params to run insights with one-off overrides without persisting changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.",
+        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override and filters_override query params to run insights with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Run dashboard insights",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -750,7 +750,7 @@
         }
     },
     "dashboard-get": {
-        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to apply one-off overrides without persisting changes.",
+        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to preview the merged variable/filter state without persisting; use dashboard-insights-run to get results with those overrides applied.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Get dashboard",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -750,7 +750,7 @@
         }
     },
     "dashboard-get": {
-        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight.",
+        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to apply one-off overrides without persisting changes.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Get dashboard",
@@ -765,7 +765,7 @@
         }
     },
     "dashboard-insights-run": {
-        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Use this after dashboard-get to see the actual data behind each insight tile.",
+        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override (JSON object with {\"variable_id\": {\"value\": \"new_value\"}}) and filters_override query params to run insights with one-off overrides without persisting changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Run dashboard insights",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -750,7 +750,7 @@
         }
     },
     "dashboard-get": {
-        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to preview the merged variable/filter state without persisting; use dashboard-insights-run to get results with those overrides applied.",
+        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params; on this endpoint they affect only the merged `filters` and `variables` fields in the response (preview). To execute insights with the same overrides, pass the same query params to dashboard-insights-run.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Get dashboard",
@@ -765,7 +765,7 @@
         }
     },
     "dashboard-insights-run": {
-        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override (JSON object with {\"variable_id\": {\"value\": \"new_value\"}}) and filters_override query params to run insights with one-off overrides without persisting changes to the dashboard. Use dashboard-get to see the dashboard's current variables and their IDs.",
+        "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override and filters_override query params to run insights with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Run dashboard insights",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -750,7 +750,7 @@
         }
     },
     "dashboard-get": {
-        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to apply one-off overrides without persisting changes.",
+        "description": "Get a specific dashboard by ID. Returns the full dashboard including all tiles with their insights and layout information. Insight results, filters, and query metadata are omitted to save context — use dashboard-insights-run to fetch the actual data for every insight on the dashboard in one call, or insight-query for a single insight. Supports variables_override and filters_override query params to preview the merged variable/filter state without persisting; use dashboard-insights-run to get results with those overrides applied.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Get dashboard",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37585,7 +37585,15 @@ export namespace Schemas {
     } as const;
 
     export type EnvironmentsDashboardsRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     */
+    filters_override?: string;
     format?: EnvironmentsDashboardsRetrieveFormat;
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     */
+    variables_override?: string;
     };
 
     export type EnvironmentsDashboardsRetrieveFormat = typeof EnvironmentsDashboardsRetrieveFormat[keyof typeof EnvironmentsDashboardsRetrieveFormat];
@@ -37681,6 +37689,10 @@ export namespace Schemas {
     } as const;
 
     export type EnvironmentsDashboardsRunInsightsRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).
+     */
+    filters_override?: string;
     format?: EnvironmentsDashboardsRunInsightsRetrieveFormat;
     /**
      * 'optimized' (default) returns LLM-friendly formatted text per insight. 'json' returns the raw query result objects.
@@ -37690,6 +37702,10 @@ export namespace Schemas {
      * Cache behavior. 'force_cache' (default) serves from cache even if stale. 'blocking' uses cache if fresh, otherwise recalculates. 'force_blocking' always recalculates.
      */
     refresh?: EnvironmentsDashboardsRunInsightsRetrieveRefresh;
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.
+     */
+    variables_override?: string;
     };
 
     export type EnvironmentsDashboardsRunInsightsRetrieveFormat = typeof EnvironmentsDashboardsRunInsightsRetrieveFormat[keyof typeof EnvironmentsDashboardsRunInsightsRetrieveFormat];
@@ -37730,7 +37746,19 @@ export namespace Schemas {
     } as const;
 
     export type EnvironmentsDashboardsStreamTilesRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     */
+    filters_override?: string;
     format?: EnvironmentsDashboardsStreamTilesRetrieveFormat;
+    /**
+     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.
+     */
+    layoutSize?: EnvironmentsDashboardsStreamTilesRetrieveLayoutSize;
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     */
+    variables_override?: string;
     };
 
     export type EnvironmentsDashboardsStreamTilesRetrieveFormat = typeof EnvironmentsDashboardsStreamTilesRetrieveFormat[keyof typeof EnvironmentsDashboardsStreamTilesRetrieveFormat];
@@ -37739,6 +37767,14 @@ export namespace Schemas {
     export const EnvironmentsDashboardsStreamTilesRetrieveFormat = {
       Json: 'json',
       Txt: 'txt',
+    } as const;
+
+    export type EnvironmentsDashboardsStreamTilesRetrieveLayoutSize = typeof EnvironmentsDashboardsStreamTilesRetrieveLayoutSize[keyof typeof EnvironmentsDashboardsStreamTilesRetrieveLayoutSize];
+
+
+    export const EnvironmentsDashboardsStreamTilesRetrieveLayoutSize = {
+      Sm: 'sm',
+      Xs: 'xs',
     } as const;
 
     export type EnvironmentsDashboardsBulkUpdateTagsCreateParams = {
@@ -41636,7 +41672,15 @@ export namespace Schemas {
     } as const;
 
     export type DashboardsRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     */
+    filters_override?: string;
     format?: DashboardsRetrieveFormat;
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     */
+    variables_override?: string;
     };
 
     export type DashboardsRetrieveFormat = typeof DashboardsRetrieveFormat[keyof typeof DashboardsRetrieveFormat];
@@ -41732,6 +41776,10 @@ export namespace Schemas {
     } as const;
 
     export type DashboardsRunInsightsRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).
+     */
+    filters_override?: string;
     format?: DashboardsRunInsightsRetrieveFormat;
     /**
      * 'optimized' (default) returns LLM-friendly formatted text per insight. 'json' returns the raw query result objects.
@@ -41741,6 +41789,10 @@ export namespace Schemas {
      * Cache behavior. 'force_cache' (default) serves from cache even if stale. 'blocking' uses cache if fresh, otherwise recalculates. 'force_blocking' always recalculates.
      */
     refresh?: DashboardsRunInsightsRetrieveRefresh;
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.
+     */
+    variables_override?: string;
     };
 
     export type DashboardsRunInsightsRetrieveFormat = typeof DashboardsRunInsightsRetrieveFormat[keyof typeof DashboardsRunInsightsRetrieveFormat];
@@ -41781,7 +41833,19 @@ export namespace Schemas {
     } as const;
 
     export type DashboardsStreamTilesRetrieveParams = {
+    /**
+     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     */
+    filters_override?: string;
     format?: DashboardsStreamTilesRetrieveFormat;
+    /**
+     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.
+     */
+    layoutSize?: DashboardsStreamTilesRetrieveLayoutSize;
+    /**
+     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     */
+    variables_override?: string;
     };
 
     export type DashboardsStreamTilesRetrieveFormat = typeof DashboardsStreamTilesRetrieveFormat[keyof typeof DashboardsStreamTilesRetrieveFormat];
@@ -41790,6 +41854,14 @@ export namespace Schemas {
     export const DashboardsStreamTilesRetrieveFormat = {
       Json: 'json',
       Txt: 'txt',
+    } as const;
+
+    export type DashboardsStreamTilesRetrieveLayoutSize = typeof DashboardsStreamTilesRetrieveLayoutSize[keyof typeof DashboardsStreamTilesRetrieveLayoutSize];
+
+
+    export const DashboardsStreamTilesRetrieveLayoutSize = {
+      Sm: 'sm',
+      Xs: 'xs',
     } as const;
 
     export type DashboardsBulkUpdateTagsCreateParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37586,12 +37586,12 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsDashboardsRetrieveFormat;
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string;
     };
@@ -37690,7 +37690,7 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsRunInsightsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsDashboardsRunInsightsRetrieveFormat;
@@ -37703,7 +37703,7 @@ export namespace Schemas {
      */
     refresh?: EnvironmentsDashboardsRunInsightsRetrieveRefresh;
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string;
     };
@@ -37747,16 +37747,16 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsStreamTilesRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsDashboardsStreamTilesRetrieveFormat;
     /**
-     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.
+     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile. The snake_case alias `layout_size` is also accepted for backward compatibility.
      */
     layoutSize?: EnvironmentsDashboardsStreamTilesRetrieveLayoutSize;
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string;
     };
@@ -41673,12 +41673,12 @@ export namespace Schemas {
 
     export type DashboardsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string;
     format?: DashboardsRetrieveFormat;
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string;
     };
@@ -41777,7 +41777,7 @@ export namespace Schemas {
 
     export type DashboardsRunInsightsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string;
     format?: DashboardsRunInsightsRetrieveFormat;
@@ -41790,7 +41790,7 @@ export namespace Schemas {
      */
     refresh?: DashboardsRunInsightsRetrieveRefresh;
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string;
     };
@@ -41834,16 +41834,16 @@ export namespace Schemas {
 
     export type DashboardsStreamTilesRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.
+     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.
      */
     filters_override?: string;
     format?: DashboardsStreamTilesRetrieveFormat;
     /**
-     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile.
+     * Layout size for tile positioning. 'sm' (default) for standard, 'xs' for mobile. The snake_case alias `layout_size` is also accepted for backward compatibility.
      */
     layoutSize?: DashboardsStreamTilesRetrieveLayoutSize;
     /**
-     * JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.
+     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.
      */
     variables_override?: string;
     };

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -82,14 +82,14 @@ export const DashboardsRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.'
+            'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.'
         ),
     format: zod.enum(['json', 'txt']).optional(),
     variables_override: zod
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.'
+            'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response\'s `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.'
         ),
 })
 
@@ -191,7 +191,7 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).'
+            'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.'
         ),
     format: zod.enum(['json', 'txt']).optional(),
     output_format: zod
@@ -210,6 +210,6 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard\'s current variables and their IDs.'
+            'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response\'s `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.'
         ),
 })

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -78,7 +78,19 @@ export const DashboardsRetrieveParams = /* @__PURE__ */ zod.object({
 })
 
 export const DashboardsRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    filters_override: zod
+        .string()
+        .optional()
+        .describe(
+            'JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.'
+        ),
     format: zod.enum(['json', 'txt']).optional(),
+    variables_override: zod
+        .string()
+        .optional()
+        .describe(
+            'JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable.'
+        ),
 })
 
 export const DashboardsPartialUpdateParams = /* @__PURE__ */ zod.object({
@@ -175,6 +187,12 @@ export const DashboardsRunInsightsRetrieveParams = /* @__PURE__ */ zod.object({
 })
 
 export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    filters_override: zod
+        .string()
+        .optional()
+        .describe(
+            'JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).'
+        ),
     format: zod.enum(['json', 'txt']).optional(),
     output_format: zod
         .enum(['json', 'optimized'])
@@ -187,5 +205,11 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .optional()
         .describe(
             "Cache behavior. 'force_cache' (default) serves from cache even if stale. 'blocking' uses cache if fresh, otherwise recalculates. 'force_blocking' always recalculates."
+        ),
+    variables_override: zod
+        .string()
+        .optional()
+        .describe(
+            'JSON object to override dashboard variables for this request only (does not persist). Format: {"variable_id": {"value": "new_value"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard\'s current variables and their IDs.'
         ),
 })

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -11,6 +11,7 @@ import {
     DashboardsReorderTilesCreateBody,
     DashboardsReorderTilesCreateParams,
     DashboardsRetrieveParams,
+    DashboardsRetrieveQueryParams,
     DashboardsRunInsightsRetrieveParams,
     DashboardsRunInsightsRetrieveQueryParams,
 } from '@/generated/dashboards/api'
@@ -122,7 +123,9 @@ const dashboardDelete = (): ToolBase<typeof DashboardDeleteSchema, Schemas.Dashb
     },
 })
 
-const DashboardGetSchema = DashboardsRetrieveParams.omit({ project_id: true })
+const DashboardGetSchema = DashboardsRetrieveParams.omit({ project_id: true }).extend(
+    DashboardsRetrieveQueryParams.omit({ format: true }).shape
+)
 
 const dashboardGet = (): ToolBase<typeof DashboardGetSchema, WithPostHogUrl<Schemas.Dashboard>> => ({
     name: 'dashboard-get',
@@ -132,6 +135,10 @@ const dashboardGet = (): ToolBase<typeof DashboardGetSchema, WithPostHogUrl<Sche
         const result = await context.api.request<Schemas.Dashboard>({
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/`,
+            query: {
+                filters_override: params.filters_override,
+                variables_override: params.variables_override,
+            },
         })
         const filtered = omitResponseFields(result, [
             'effective_restriction_level',
@@ -190,8 +197,10 @@ const dashboardInsightsRun = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/run_insights/`,
             query: {
+                filters_override: params.filters_override,
                 output_format: params.output_format,
                 refresh: params.refresh,
+                variables_override: params.variables_override,
             },
         })
         return await withPostHogUrl(context, result, `/dashboard/${params.id}`)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
@@ -1,9 +1,17 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "filters_override": {
+            "description": "JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.",
+            "type": "string"
+        },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
+        },
+        "variables_override": {
+            "description": "JSON object to override dashboard variables for this request only (does not persist). Format: {\"variable_id\": {\"value\": \"new_value\"}} where variable_id is the UUID of a SQL variable.",
+            "type": "string"
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "filters_override": {
-            "description": "JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys.",
+            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.",
             "type": "string"
         },
         "id": {
@@ -10,7 +10,7 @@
             "type": "number"
         },
         "variables_override": {
-            "description": "JSON object to override dashboard variables for this request only (does not persist). Format: {\"variable_id\": {\"value\": \"new_value\"}} where variable_id is the UUID of a SQL variable.",
+            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "filters_override": {
-            "description": "JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).",
+            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. See the dashboard filters schema for available keys (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a dashboard sharing token.",
             "type": "string"
         },
         "id": {
@@ -20,7 +20,7 @@
             "type": "string"
         },
         "variables_override": {
-            "description": "JSON object to override dashboard variables for this request only (does not persist). Format: {\"variable_id\": {\"value\": \"new_value\"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.",
+            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response's `variables` field, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a dashboard sharing token.",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "filters_override": {
+            "description": "JSON object to override dashboard filters for this request only (does not persist). See dashboard filters schema for available keys (e.g., date_from, date_to).",
+            "type": "string"
+        },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
@@ -13,6 +17,10 @@
         "refresh": {
             "description": "Cache behavior. 'force_cache' (default) serves from cache even if stale. 'blocking' uses cache if fresh, otherwise recalculates. 'force_blocking' always recalculates.",
             "enum": ["blocking", "force_blocking", "force_cache"],
+            "type": "string"
+        },
+        "variables_override": {
+            "description": "JSON object to override dashboard variables for this request only (does not persist). Format: {\"variable_id\": {\"value\": \"new_value\"}} where variable_id is the UUID of a SQL variable. Use dashboard-get to see the dashboard's current variables and their IDs.",
             "type": "string"
         }
     },


### PR DESCRIPTION
## Problem

Agents using dashboard MCP tools cannot run insights with temporary variable/filter overrides. The workaround is to `dashboard-update` to change variables, run, then revert — but this mutates shared state, causing race conditions when multiple agents query the same dashboard with different parameters.

Slack thread: https://posthog.slack.com/archives/C09BDQLM8KA/p1777531482525349?thread_ts=1777392014.771229&cid=C09BDQLM8KA

## Changes

- Add `variables_override` and `filters_override` query parameters to the OpenAPI schema for:
  - `dashboard-get` (retrieve endpoint)
  - `dashboard-insights-run` (run_insights endpoint)
  - `dashboards-stream-tiles-retrieve` (stream_tiles endpoint)
- Update MCP tool descriptions to document the new capability

The backend already supported these overrides via query params — this change documents them in the OpenAPI schema so they appear in the generated MCP tool definitions.

## How did you test this code?

I am an agent. I verified:
- Python syntax with `ruff check` (passed)
- YAML validity with Python yaml parser (valid)
- YAML formatting with prettier

CI will run the full test suite. The OpenAPI regeneration (`hogli build:openapi`) will need to run locally or in CI to update generated types.

✅ Manual MCP test

Ran the following prompt in my local Claude setup (wired with the local PostHog MCP):

```
Verify PR #57073 — variables_override and filters_override on dashboard MCP
  tools. Project: 1.

  Use the local PostHog MCP only — i.e. the one wired up to your local dev
  backend (not the cloud `mcp.posthog.com` deployment). If multiple PostHog MCP
  namespaces are connected, use whichever one points at localhost. If only the
  cloud `PostHog MCP` is connected, STOP and tell me — the local MCP isn't
  reachable from this client and the test cannot run here.

  Step 0 — Schema sanity check (fail fast).
  For both `dashboard-get` and `dashboard-insights-run` on the local MCP,
  list the input properties advertised by the live server. Confirm both tools
  declare `variables_override` and `filters_override`. If either is absent on
  either tool, STOP — the MCP didn't pick up the rebuild.

  Step 1 — Pick a dashboard.
  Use dashboard id 2 ("💸 Revenue") if it exists. Otherwise list dashboards and
  pick one with at least one tile. Record the chosen dashboard id, name, and
  each tile's `insight.query.kind`.

  Step 2 — Filter override E2E.

    A. Baseline. Call `dashboard-insights-run` with id=<chosen>,
       refresh=force_blocking, output_format=json, no overrides.
       Confirm: HTTP 200, every tile has `result != null` and
       `query_status.error` is null/false. Record one numeric data point per
       tile (count, sum, or first value) for comparison.

    B. With filter override. Same call, plus
       filters_override = {"date_from": "-7d"}.
       Confirm: HTTP 200, every tile has `result != null` and
       `query_status.error` is null/false. Confirm at least one tile's numeric
       data point differs from baseline — proving the override changed query
       execution, not just transit.

    C. No persistence. Call `dashboard-get` with id=<chosen> and no overrides.
       Confirm `filters` and `persisted_filters` show no override-residue from
       step B — the dashboard's stored state was not mutated.

  Step 3 — Variable override preview.
  On any dashboard with a non-empty `variables` field (dashboard 2 has variable
  019d4838-1da4-0000-33c7-2561bf01f1c9, code_name `eventname`, persisted value
  "$pageview"), call `dashboard-get` with:
    variables_override = {
      "<variable_id>": {
        "code_name": "eventname",
        "variableId": "<variable_id>",
        "value": "signed_up"
      }
    }
  Confirm: response `variables.<id>.value` shows "signed_up" AND
  `persisted_variables.<id>.value` shows the original "$pageview". This proves
  the merge logic on the retrieve endpoint works without persisting.

  Report format (suitable to attach to the PR):
  - Step 0: PASS/FAIL with the params each tool advertises.
  - Step 1: dashboard id, name, list of tile query kinds.
  - Step 2A/B/C: PASS/FAIL each, with the numeric data point shift in B and
    the persisted-state confirmation in C.
  - Step 3: PASS/FAIL with the merged-vs-persisted values.
  - Final summary table (one row per check).

  Do not create dashboards, insights, or variables. Read-only.
```

The response being:
<img width="1736" height="1238" alt="CleanShot 2026-05-01 at 14 33 23@2x" src="https://github.com/user-attachments/assets/ebebb6f4-947d-4b9f-8bd4-9013abd79b6a" />




## Publish to changelog?

No — this is an API documentation improvement, not a user-facing feature.

## 🤖 Agent context

- **Agent**: Claude Code (Opus 4.5)
- **Session**: https://claude.ai/code/session_016YNiU4qhyJCT3iyfZxJwNn
- **Request**: Add one-off variable overrides to dashboard MCP tools per Slack discussion
- **Key decisions**:
  - Added both `variables_override` and `filters_override` since both are already supported by the backend
  - Used `@extend_schema` with `OpenApiParameter` to document query params in OpenAPI
  - Updated tool descriptions in `tools.yaml` to mention the new capability
  - Also added parameters to the disabled `stream_tiles` endpoint for completeness


---
_Generated by [Claude Code](https://claude.ai/code/session_016YNiU4qhyJCT3iyfZxJwNn)_