### PR TITLE
feat(cdp): add prometheus metric for unexpected transformation errs

### DIFF
--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -69,7 +69,6 @@ export const hogTransformationPendingInvocationResults = new Gauge({
 export const hogTransformationUnexpectedErrors = new Counter({
     name: 'hog_transformation_unexpected_errors_total',
     help: 'Number of unexpected errors during transformation execution. Any occurrence should trigger an alert as the transformation is skipped.',
-    labelNames: ['team_id', 'function_id'],
 })
 
 export interface TransformationResult {
@@ -248,7 +247,7 @@ export class HogTransformerService {
             try {
                 result = await this.executeHogFunction(hogFunction, globals)
             } catch (err) {
-                hogTransformationUnexpectedErrors.inc({ team_id: event.team_id, function_id: hogFunction.id })
+                hogTransformationUnexpectedErrors.inc()
                 logger.error('⚠️', 'Unexpected error executing transformation', {
                     function_id: hogFunction.id,
                     team_id: event.team_id,

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -66,6 +66,12 @@ export const hogTransformationPendingInvocationResults = new Gauge({
     help: 'Number of invocation results accumulated and waiting to be processed. High values indicate memory accumulation.',
 })
 
+export const hogTransformationUnexpectedErrors = new Counter({
+    name: 'hog_transformation_unexpected_errors_total',
+    help: 'Number of unexpected errors during transformation execution. Any occurrence should trigger an alert as the transformation is skipped.',
+    labelNames: ['team_id', 'function_id'],
+})
+
 export interface TransformationResult {
     event: PluginEvent | null
     invocationResults: CyclotronJobInvocationResult[]
@@ -242,6 +248,7 @@ export class HogTransformerService {
             try {
                 result = await this.executeHogFunction(hogFunction, globals)
             } catch (err) {
+                hogTransformationUnexpectedErrors.inc({ team_id: event.team_id, function_id: hogFunction.id })
                 logger.error('⚠️', 'Unexpected error executing transformation', {
                     function_id: hogFunction.id,
                     team_id: event.team_id,


### PR DESCRIPTION
This counter allows alerting on any unexpected failure in the transformation execution path, where the transformation is skipped and the event continues without it.

With this metric we can have an alert that would fire like this per broken transformation

```                                                                                                        
  alert: HogTransformationUnexpectedErrors                                                                
  expr: rate(hog_transformation_unexpected_errors_total[5m]) > 0                                          
  for: 1m                                                                                                 
  labels:                                                                                                 
  severity: critical                                                                                    
  annotations:                                                                                            
    summary: "Unexpected hog transformation errors detected — transformations are being skipped. Check    
  logs for team_id and function_id details."
```