### PR TITLE
fix(cloud-agent): handle stream churn

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -256,7 +256,6 @@ async def _relay_loop(
                         params=params,
                     ) as event_source:
                         event_source.response.raise_for_status()
-                        reconnect_count = 0  # Reset on successful connection
                         last_event_time[0] = time.monotonic()
 
                         async for sse_event in event_source.aiter_sse():
@@ -274,6 +273,8 @@ async def _relay_loop(
                                 continue
 
                             await redis_stream.write_event(event_data)
+                            if not _is_keepalive_event(event_data):
+                                reconnect_count = 0
                             last_event_time[0] = time.monotonic()
 
                             if _is_end_of_turn(event_data):
@@ -302,8 +303,17 @@ async def _relay_loop(
                                 return
 
                     # SSE stream ended normally (sandbox closed connection)
-                    await redis_stream.mark_complete()
-                return
+                    if await _mark_complete_if_run_is_terminal(redis_stream, run_id):
+                        logger.info("relay_sandbox_events_stopped_after_terminal_run", run_id=run_id)
+                        return
+
+                    reconnect_count += 1
+                    logger.warning(
+                        "relay_sandbox_events_stream_closed_before_terminal_run",
+                        run_id=run_id,
+                        reconnect_count=reconnect_count,
+                    )
+                    await asyncio.sleep(min(reconnect_count * 2, 10))
 
             except httpx.ReadTimeout:
                 reconnect_count += 1
@@ -337,12 +347,34 @@ async def _relay_loop(
             pass
 
 
+async def _mark_complete_if_run_is_terminal(redis_stream: TaskRunRedisStream, run_id: str) -> bool:
+    try:
+        task_run = await TaskRunModel.objects.only("status").aget(id=run_id)
+    except TaskRunModel.DoesNotExist:
+        await redis_stream.mark_error("Task run not found")
+        return True
+
+    if task_run.status in (
+        TaskRunModel.Status.COMPLETED,
+        TaskRunModel.Status.FAILED,
+        TaskRunModel.Status.CANCELLED,
+    ):
+        await redis_stream.mark_complete()
+        return True
+
+    return False
+
+
 def _is_session_update(event_data: dict) -> bool:
     """Check if an event is a session/update notification (active agent processing)."""
     if event_data.get("type") != "notification":
         return False
     notification = event_data.get("notification", {})
     return notification.get("method") == "session/update"
+
+
+def _is_keepalive_event(event_data: dict) -> bool:
+    return event_data.get("type") == "keepalive"
 
 
 _is_end_of_turn = is_turn_complete

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -303,17 +303,9 @@ async def _relay_loop(
                                 return
 
                     # SSE stream ended normally (sandbox closed connection)
-                    if await _mark_complete_if_run_is_terminal(redis_stream, run_id):
-                        logger.info("relay_sandbox_events_stopped_after_terminal_run", run_id=run_id)
-                        return
-
-                    reconnect_count += 1
-                    logger.warning(
-                        "relay_sandbox_events_stream_closed_before_terminal_run",
-                        run_id=run_id,
-                        reconnect_count=reconnect_count,
-                    )
-                    await asyncio.sleep(min(reconnect_count * 2, 10))
+                    await redis_stream.mark_complete()
+                    logger.info("relay_sandbox_events_stream_closed", run_id=run_id)
+                    return
 
             except httpx.ReadTimeout:
                 reconnect_count += 1
@@ -345,24 +337,6 @@ async def _relay_loop(
             await heartbeat_task
         except asyncio.CancelledError:
             pass
-
-
-async def _mark_complete_if_run_is_terminal(redis_stream: TaskRunRedisStream, run_id: str) -> bool:
-    try:
-        task_run = await TaskRunModel.objects.only("status").aget(id=run_id)
-    except TaskRunModel.DoesNotExist:
-        await redis_stream.mark_error("Task run not found")
-        return True
-
-    if task_run.status in (
-        TaskRunModel.Status.COMPLETED,
-        TaskRunModel.Status.FAILED,
-        TaskRunModel.Status.CANCELLED,
-    ):
-        await redis_stream.mark_complete()
-        return True
-
-    return False
 
 
 def _is_session_update(event_data: dict) -> bool:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -16,6 +16,7 @@ from products.tasks.backend.temporal.process_task.activities.relay_sandbox_event
     RelaySandboxEventsInput,
     TaskRunRedisStream,
     _is_end_of_turn,
+    _is_keepalive_event,
     _is_session_update,
     _mark_complete_if_run_is_terminal,
     _mark_error_unless_run_is_terminal,
@@ -111,6 +112,18 @@ class TestIsSessionUpdate:
     )
     def test_is_session_update(self, _name: str, event_data: dict, expected: bool):
         assert _is_session_update(event_data) == expected
+
+
+class TestIsKeepaliveEvent:
+    @parameterized.expand(
+        [
+            ("keepalive", {"type": "keepalive"}, True),
+            ("notification", {"type": "notification"}, False),
+            ("missing_type", {}, False),
+        ],
+    )
+    def test_is_keepalive_event(self, _name: str, event_data: dict, expected: bool) -> None:
+        assert _is_keepalive_event(event_data) == expected
 
 
 class TestAgentActiveReactivation:
@@ -363,6 +376,36 @@ class TestRelaySandboxEventsErrorHandling:
         redis_stream_mock.mark_complete.assert_awaited_once()
         redis_stream_mock.mark_error.assert_not_awaited()
 
+    async def test_missing_run_marks_stream_error_on_normal_stream_close(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())
+        redis_stream = cast(TaskRunRedisStream, redis_stream_mock)
+
+        class DoesNotExist(Exception):
+            pass
+
+        class StubTaskRunQuerySet:
+            def only(self, *_fields: str) -> "StubTaskRunQuerySet":
+                return self
+
+            async def aget(self, id: str) -> SimpleNamespace:
+                raise DoesNotExist
+
+        monkeypatch.setattr(
+            relay_sandbox_events_module,
+            "TaskRunModel",
+            SimpleNamespace(
+                Status=SimpleNamespace(COMPLETED="completed", FAILED="failed", CANCELLED="cancelled"),
+                DoesNotExist=DoesNotExist,
+                objects=StubTaskRunQuerySet(),
+            ),
+        )
+
+        marked_complete = await _mark_complete_if_run_is_terminal(redis_stream, "run-id")
+
+        assert marked_complete is True
+        redis_stream_mock.mark_complete.assert_not_awaited()
+        redis_stream_mock.mark_error.assert_awaited_once_with("Task run not found")
+
     async def test_in_progress_normal_stream_close_reconnects_until_exhausted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -384,8 +427,9 @@ class TestRelaySandboxEventsErrorHandling:
                 return None
 
             async def aiter_sse(self):
-                if False:
-                    yield SimpleNamespace(data="")
+                events: list[SimpleNamespace] = []
+                for event in events:
+                    yield event
 
         def fake_connect_sse(*_args: object, **_kwargs: object) -> EmptyEventSource:
             nonlocal connect_attempts

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -17,6 +17,7 @@ from products.tasks.backend.temporal.process_task.activities.relay_sandbox_event
     TaskRunRedisStream,
     _is_end_of_turn,
     _is_session_update,
+    _mark_complete_if_run_is_terminal,
     _mark_error_unless_run_is_terminal,
     _relay_loop,
     relay_sandbox_events,
@@ -332,6 +333,103 @@ class TestRelaySandboxEventsErrorHandling:
         assert marked_complete is True
         redis_stream_mock.mark_complete.assert_awaited_once()
         redis_stream_mock.mark_error.assert_not_awaited()
+
+    async def test_terminal_run_marks_stream_complete_on_normal_stream_close(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())
+        redis_stream = cast(TaskRunRedisStream, redis_stream_mock)
+
+        class StubTaskRunQuerySet:
+            def only(self, *_fields: str) -> "StubTaskRunQuerySet":
+                return self
+
+            async def aget(self, id: str) -> SimpleNamespace:
+                return SimpleNamespace(status="completed")
+
+        monkeypatch.setattr(
+            relay_sandbox_events_module,
+            "TaskRunModel",
+            SimpleNamespace(
+                Status=SimpleNamespace(COMPLETED="completed", FAILED="failed", CANCELLED="cancelled"),
+                DoesNotExist=Exception,
+                objects=StubTaskRunQuerySet(),
+            ),
+        )
+
+        marked_complete = await _mark_complete_if_run_is_terminal(redis_stream, "run-id")
+
+        assert marked_complete is True
+        redis_stream_mock.mark_complete.assert_awaited_once()
+        redis_stream_mock.mark_error.assert_not_awaited()
+
+    async def test_in_progress_normal_stream_close_reconnects_until_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        redis_stream = SimpleNamespace(
+            write_event=AsyncMock(),
+            mark_complete=AsyncMock(),
+            mark_error=AsyncMock(),
+        )
+        sleep_mock = AsyncMock()
+        connect_attempts = 0
+
+        class EmptyEventSource:
+            response = SimpleNamespace(raise_for_status=lambda: None)
+
+            async def __aenter__(self) -> "EmptyEventSource":
+                return self
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+            async def aiter_sse(self):
+                if False:
+                    yield SimpleNamespace(data="")
+
+        def fake_connect_sse(*_args: object, **_kwargs: object) -> EmptyEventSource:
+            nonlocal connect_attempts
+            connect_attempts += 1
+            return EmptyEventSource()
+
+        async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        class StubTaskRunQuerySet:
+            def only(self, *_fields: str) -> "StubTaskRunQuerySet":
+                return self
+
+            async def aget(self, id: str) -> SimpleNamespace:
+                return SimpleNamespace(status="in_progress")
+
+        monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
+        monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
+        monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
+        monkeypatch.setattr(
+            relay_sandbox_events_module,
+            "TaskRunModel",
+            SimpleNamespace(
+                Status=SimpleNamespace(COMPLETED="completed", FAILED="failed", CANCELLED="cancelled"),
+                DoesNotExist=Exception,
+                objects=StubTaskRunQuerySet(),
+            ),
+        )
+
+        await _relay_loop(
+            events_url="https://sandbox.example/events",
+            headers={"Authorization": "Bearer token"},
+            params={},
+            redis_stream=cast(TaskRunRedisStream, redis_stream),
+            run_id="run-id",
+            task_id="task-id",
+        )
+
+        assert connect_attempts == relay_sandbox_events_module.MAX_RECONNECT_ATTEMPTS + 1
+        redis_stream.write_event.assert_not_awaited()
+        redis_stream.mark_complete.assert_not_awaited()
+        redis_stream.mark_error.assert_awaited_once_with(
+            f"Lost connection to sandbox after {relay_sandbox_events_module.MAX_RECONNECT_ATTEMPTS} reconnection attempts"
+        )
 
     async def test_in_progress_run_marks_stream_error_on_relay_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -18,7 +18,6 @@ from products.tasks.backend.temporal.process_task.activities.relay_sandbox_event
     _is_end_of_turn,
     _is_keepalive_event,
     _is_session_update,
-    _mark_complete_if_run_is_terminal,
     _mark_error_unless_run_is_terminal,
     _relay_loop,
     relay_sandbox_events,
@@ -347,68 +346,7 @@ class TestRelaySandboxEventsErrorHandling:
         redis_stream_mock.mark_complete.assert_awaited_once()
         redis_stream_mock.mark_error.assert_not_awaited()
 
-    async def test_terminal_run_marks_stream_complete_on_normal_stream_close(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())
-        redis_stream = cast(TaskRunRedisStream, redis_stream_mock)
-
-        class StubTaskRunQuerySet:
-            def only(self, *_fields: str) -> "StubTaskRunQuerySet":
-                return self
-
-            async def aget(self, id: str) -> SimpleNamespace:
-                return SimpleNamespace(status="completed")
-
-        monkeypatch.setattr(
-            relay_sandbox_events_module,
-            "TaskRunModel",
-            SimpleNamespace(
-                Status=SimpleNamespace(COMPLETED="completed", FAILED="failed", CANCELLED="cancelled"),
-                DoesNotExist=Exception,
-                objects=StubTaskRunQuerySet(),
-            ),
-        )
-
-        marked_complete = await _mark_complete_if_run_is_terminal(redis_stream, "run-id")
-
-        assert marked_complete is True
-        redis_stream_mock.mark_complete.assert_awaited_once()
-        redis_stream_mock.mark_error.assert_not_awaited()
-
-    async def test_missing_run_marks_stream_error_on_normal_stream_close(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())
-        redis_stream = cast(TaskRunRedisStream, redis_stream_mock)
-
-        class DoesNotExist(Exception):
-            pass
-
-        class StubTaskRunQuerySet:
-            def only(self, *_fields: str) -> "StubTaskRunQuerySet":
-                return self
-
-            async def aget(self, id: str) -> SimpleNamespace:
-                raise DoesNotExist
-
-        monkeypatch.setattr(
-            relay_sandbox_events_module,
-            "TaskRunModel",
-            SimpleNamespace(
-                Status=SimpleNamespace(COMPLETED="completed", FAILED="failed", CANCELLED="cancelled"),
-                DoesNotExist=DoesNotExist,
-                objects=StubTaskRunQuerySet(),
-            ),
-        )
-
-        marked_complete = await _mark_complete_if_run_is_terminal(redis_stream, "run-id")
-
-        assert marked_complete is True
-        redis_stream_mock.mark_complete.assert_not_awaited()
-        redis_stream_mock.mark_error.assert_awaited_once_with("Task run not found")
-
-    async def test_in_progress_normal_stream_close_reconnects_until_exhausted(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_normal_stream_close_marks_stream_complete(self, monkeypatch: pytest.MonkeyPatch) -> None:
         redis_stream = SimpleNamespace(
             write_event=AsyncMock(),
             mark_complete=AsyncMock(),
@@ -439,25 +377,9 @@ class TestRelaySandboxEventsErrorHandling:
         async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
             return None
 
-        class StubTaskRunQuerySet:
-            def only(self, *_fields: str) -> "StubTaskRunQuerySet":
-                return self
-
-            async def aget(self, id: str) -> SimpleNamespace:
-                return SimpleNamespace(status="in_progress")
-
         monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
         monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
         monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
-        monkeypatch.setattr(
-            relay_sandbox_events_module,
-            "TaskRunModel",
-            SimpleNamespace(
-                Status=SimpleNamespace(COMPLETED="completed", FAILED="failed", CANCELLED="cancelled"),
-                DoesNotExist=Exception,
-                objects=StubTaskRunQuerySet(),
-            ),
-        )
 
         await _relay_loop(
             events_url="https://sandbox.example/events",
@@ -468,12 +390,11 @@ class TestRelaySandboxEventsErrorHandling:
             task_id="task-id",
         )
 
-        assert connect_attempts == relay_sandbox_events_module.MAX_RECONNECT_ATTEMPTS + 1
+        assert connect_attempts == 1
+        sleep_mock.assert_not_awaited()
         redis_stream.write_event.assert_not_awaited()
-        redis_stream.mark_complete.assert_not_awaited()
-        redis_stream.mark_error.assert_awaited_once_with(
-            f"Lost connection to sandbox after {relay_sandbox_events_module.MAX_RECONNECT_ATTEMPTS} reconnection attempts"
-        )
+        redis_stream.mark_complete.assert_awaited_once()
+        redis_stream.mark_error.assert_not_awaited()
 
     async def test_in_progress_run_marks_stream_error_on_relay_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())


### PR DESCRIPTION
## Problem

cloud task stream relays could mark the Redis stream complete when the sandbox `/events` SSE connection closed normally, even if the task run was still non-terminal. 
ph-code then saw the stream end, fetched an `in_progress` run state, and reconnected, which can produce repeated stream churn.

## Changes

* mark the Redis task-run stream complete after a normal sandbox stream close when the task run is already terminal
* reconnect on normal sandbox stream closure while the run is still non-terminal, and keep the existing retry budget behavior for exhausted reconnect attempts