### PR TITLE
perf(insights): hog-charts correctness and rerender fixes

### DIFF
--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from '../core/canvas-renderer'
 import type { DrawContext } from '../core/canvas-renderer'
@@ -19,10 +19,17 @@ import type {
     CreateScalesFn,
     LineChartConfig,
     PointClickData,
+    ResolvedSeries,
     Series,
     TooltipContext,
     YAxisScale,
 } from '../core/types'
+
+// Brand for the private ChartScales._private slot used by LineChart. The base Chart
+// and other chart types treat this as opaque; LineChart's drawStatic narrows back to it.
+interface LineChartPrivate {
+    __lineChart: ScaleSet
+}
 
 export interface LineChartProps<Meta = unknown> {
     series: Series<Meta>[]
@@ -69,12 +76,8 @@ export function LineChart<Meta = unknown>({
         }
     }, [config, percentStackView])
 
-    // Keep a ref to the raw d3 scales so the draw callback can use them
-    // without exposing d3 types through the ChartScales abstraction
-    const d3ScalesRef = useRef<ScaleSet | null>(null)
-
     const createScales: CreateScalesFn = useCallback(
-        (coloredSeries: Series[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
+        (coloredSeries: ResolvedSeries[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
             // When stacking (non-percent), use stacked top values so the y-domain
             // reflects the cumulative totals rather than individual series values
             let seriesForScale = coloredSeries
@@ -88,7 +91,6 @@ export function LineChart<Meta = unknown>({
                 scaleType: yScaleType,
                 percentStack: percentStackView,
             })
-            d3ScalesRef.current = d3Scales
 
             const yTickCount = yTickCountForHeight(dimensions.plotHeight)
 
@@ -104,24 +106,31 @@ export function LineChart<Meta = unknown>({
                 }
             }
 
+            // Stash raw d3 scales in the private slot so drawStatic can read them without
+            // a side-channel ref — every render gets a self-contained ChartScales object,
+            // which avoids strict-mode / concurrent-rendering races between the createScales
+            // pass and the static-draw effect.
+            const lineChartPrivate: LineChartPrivate = { __lineChart: d3Scales }
+
             return {
                 x: (label: string) => d3Scales.x(label),
                 y: (value: number) => d3Scales.y(value),
                 yTicks: () => d3Scales.y.ticks?.(yTickCount) ?? [],
                 yAxes,
+                _private: lineChartPrivate,
             }
         },
         [yScaleType, percentStackView, stackedData]
     )
 
     const drawStatic = useCallback(
-        ({ ctx, dimensions, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
-            const d3Scales = d3ScalesRef.current
+        ({ ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
+            const d3Scales = (scales._private as LineChartPrivate | undefined)?.__lineChart
             if (!d3Scales) {
                 return
             }
 
-            const resolveYScale = (s: Series): typeof d3Scales.y => {
+            const resolveYScale = (s: ResolvedSeries): typeof d3Scales.y => {
                 const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
                 return d3Scales.yAxes?.[axisId]?.scale ?? d3Scales.y
             }
@@ -164,12 +173,18 @@ export function LineChart<Meta = unknown>({
             if (hoverIndex < 0) {
                 return
             }
-            const resolveChartYScale = (s: Series): ((value: number) => number) => {
+            const resolveChartYScale = (s: ResolvedSeries): ((value: number) => number) => {
                 const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
                 return scales.yAxes?.[axisId]?.scale ?? scales.y
             }
             for (const s of coloredSeries) {
                 if (s.visibility?.excluded || s.fill?.lowerData) {
+                    continue
+                }
+                // Auxiliary overlays (moving averages, trend lines) opt out of stacking.
+                // In percent-stack mode the y-scale domain is [0, 1], so mapping their raw
+                // values produces a highlight ring far outside the plot — skip them entirely.
+                if (s.visibility?.fromStack) {
                     continue
                 }
                 const data = stackedData?.get(s.key)?.top ?? s.data

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -21,6 +21,7 @@ import type {
     ChartTheme,
     CreateScalesFn,
     PointClickData,
+    ResolvedSeries,
     ResolveValueFn,
     Series,
     TooltipContext,
@@ -32,6 +33,24 @@ const OVERLAY_STYLE: React.CSSProperties = {
     left: 0,
     width: '100%',
     height: '100%',
+    pointerEvents: 'none',
+}
+
+const WRAPPER_STYLE_BASE: React.CSSProperties = {
+    position: 'relative',
+    width: '100%',
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+}
+const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
+const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
+
+const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
+const OVERLAY_CANVAS_STYLE: React.CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
     pointerEvents: 'none',
 }
 
@@ -152,7 +171,7 @@ export function Chart<Meta = unknown>({
 
     const { canvasRef, overlayCanvasRef, wrapperRef, dimensions, ctx, overlayCtx } = useChartCanvas({ margins })
 
-    const coloredSeries = useMemo(
+    const coloredSeries = useMemo<ResolvedSeries<Meta>[]>(
         () =>
             series.map((s, i) => ({
                 ...s,
@@ -240,7 +259,12 @@ export function Chart<Meta = unknown>({
         drawHover: composedDrawHover,
     })
 
-    const cursorStyle = hoverIndex >= 0 && onPointClick ? 'pointer' : 'default'
+    const wrapperStyle = hoverIndex >= 0 && onPointClick ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
+
+    const ariaLabel = useMemo(() => {
+        const visible = coloredSeries.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)
+        return `Chart with ${visible} data series`
+    }, [coloredSeries])
 
     const canvasBounds = useCallback(
         (): DOMRect | null => canvasRef.current?.getBoundingClientRect() ?? null,
@@ -250,6 +274,12 @@ export function Chart<Meta = unknown>({
     // Wrap resolveValue in a ref + stable callback so callers don't have to memoize it.
     // An un-memoized arrow literal from a parent would otherwise invalidate the layout
     // context on every render and defeat the layout/hover split.
+    //
+    // The ref is written during render rather than via an effect because overlays read
+    // it during their render via `useChartLayout().resolveValue`; deferring the write
+    // would expose them to last-commit's value. This is safe under StrictMode/concurrent
+    // rendering: an aborted render that wrote the ref will be re-driven with the same
+    // props, so the kept render observes an idempotent state.
     const resolveValueRef = useRef<ResolveValueFn | undefined>(resolveValue)
     resolveValueRef.current = resolveValue
     const stableResolveValue = useCallback<ResolveValueFn>((s, i) => {
@@ -285,39 +315,13 @@ export function Chart<Meta = unknown>({
                     <div
                         ref={wrapperRef}
                         className={className}
-                        style={{
-                            position: 'relative',
-                            width: '100%',
-                            flex: 1,
-                            minHeight: 0,
-                            overflow: 'hidden',
-                            cursor: cursorStyle,
-                        }}
+                        style={wrapperStyle}
                         onMouseMove={handlers.onMouseMove}
                         onMouseLeave={handlers.onMouseLeave}
                         onClick={handlers.onClick}
                     >
-                        <canvas
-                            ref={canvasRef}
-                            role="img"
-                            aria-label={`Chart with ${coloredSeries.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)} data series`}
-                            style={{
-                                position: 'absolute',
-                                top: 0,
-                                left: 0,
-                                cursor: cursorStyle,
-                            }}
-                        />
-                        <canvas
-                            ref={overlayCanvasRef}
-                            aria-hidden="true"
-                            style={{
-                                position: 'absolute',
-                                top: 0,
-                                left: 0,
-                                pointerEvents: 'none',
-                            }}
-                        />
+                        <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
+                        <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
 
                         {dimensions && scales && (
                             <OverlayLayer>

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -72,7 +72,12 @@ export interface ChartProps<Meta = unknown> {
     onPointClick?: (data: PointClickData<Meta>) => void
     className?: string
     children?: React.ReactNode
-    /** Resolves the y-value for a series at a given index. Defaults to series.data[index]. */
+    /** Resolves the y-value for a series at a given index. Defaults to series.data[index].
+     *  Identity is read live for tooltip values and overlays, but the pinned-tooltip
+     *  rebuild only refires when `series`, `labels`, or `scales` change. Callers that
+     *  derive values from data not reflected in those (e.g. an external "%" toggle)
+     *  should ensure that toggle also updates `series` or the chart's scales — otherwise
+     *  a held pin will keep showing values from the previous resolver. */
     resolveValue?: ResolveValueFn
 }
 

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3'
 
 import { drawArea, drawGrid, drawLine, type DrawContext } from './canvas-renderer'
-import type { ChartDimensions, Series } from './types'
+import type { ChartDimensions, ResolvedSeries, Series } from './types'
 
 const dimensions: ChartDimensions = {
     width: 800,
@@ -12,7 +12,7 @@ const dimensions: ChartDimensions = {
     plotHeight: 352,
 }
 
-function makeSeries(overrides: Partial<Series> & { key: string; data: number[] }): Series {
+function makeSeries(overrides: Partial<Series> & { key: string; data: number[] }): ResolvedSeries {
     return { label: overrides.key, color: '#f00', ...overrides }
 }
 

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3'
 
 import { yTickCountForHeight } from './scales'
-import type { ChartDimensions, Series } from './types'
+import type { ChartDimensions, ResolvedSeries } from './types'
 
 export interface DrawContext {
     ctx: CanvasRenderingContext2D
@@ -11,7 +11,7 @@ export interface DrawContext {
     labels: string[]
 }
 
-export function drawLine(drawCtx: DrawContext, series: Series, yValues?: number[]): void {
+export function drawLine(drawCtx: DrawContext, series: ResolvedSeries, yValues?: number[]): void {
     const data = yValues ?? series.data
     if (data.length === 0) {
         return
@@ -44,7 +44,7 @@ interface Stroke {
  * Each entry is a contiguous index range drawn with a single dash pattern; adjacent strokes
  * share their boundary index so the visual seam between them is invisible.
  */
-function planLineStrokes(series: Series, length: number): Stroke[] {
+function planLineStrokes(series: ResolvedSeries, length: number): Stroke[] {
     const basePattern = series.stroke?.pattern ?? []
     const partialPattern = series.stroke?.partial?.pattern ?? [10, 10]
     const from = resolvePartialIndex(series.stroke?.partial?.fromIndex, length)
@@ -151,7 +151,12 @@ interface AreaPoint {
     dataIndex: number
 }
 
-export function drawArea(drawCtx: DrawContext, series: Series, yValues?: number[], bottomValues?: number[]): void {
+export function drawArea(
+    drawCtx: DrawContext,
+    series: ResolvedSeries,
+    yValues?: number[],
+    bottomValues?: number[]
+): void {
     const { ctx, xScale, yScale, labels, dimensions } = drawCtx
     const data = yValues ?? series.data
     const opacity = series.fill?.opacity ?? 0.5
@@ -262,7 +267,7 @@ function fillAreaPath(
     ctx.fill()
 }
 
-export function drawPoints(drawCtx: DrawContext, series: Series, yValues?: number[]): void {
+export function drawPoints(drawCtx: DrawContext, series: ResolvedSeries, yValues?: number[]): void {
     const { ctx, xScale, yScale, labels } = drawCtx
     const data = yValues ?? series.data
     const radius = series.points?.radius ?? 0

--- a/frontend/src/lib/hog-charts/core/chart-context.ts
+++ b/frontend/src/lib/hog-charts/core/chart-context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 
-import type { ChartDimensions, ChartScales, ChartTheme, ResolveValueFn, Series } from './types'
+import type { ChartDimensions, ChartScales, ChartTheme, ResolvedSeries, ResolveValueFn } from './types'
 
 /** Layout-stable values exposed to overlays. Identity does NOT change on hover —
  *  consumers reading from {@link useChartLayout} won't re-render on mousemove. */
@@ -10,7 +10,7 @@ export interface ChartLayoutContextValue<Meta = unknown> {
     /** X-axis labels. */
     labels: string[]
     /** Series with fallback colors already applied (post `theme.colors`). */
-    series: Series<Meta>[]
+    series: ResolvedSeries<Meta>[]
     /** Scale functions for mapping data to pixel coordinates. */
     scales: ChartScales
     /** Theme passed to the chart. Use {@link ChartTheme.backgroundColor} for borders/fills

--- a/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
@@ -97,9 +97,6 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
 
         return () => {
             observer.disconnect()
-            // Drop the cached ctx so a re-mount doesn't paint into a detached canvas.
-            setCanvasState(null)
-            rectRef.current = null
         }
     }, [])
 

--- a/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartCanvas.ts
@@ -21,6 +21,24 @@ interface UseChartCanvasResult {
     overlayCtx: CanvasRenderingContext2D | null
 }
 
+function sizeCanvas(canvas: HTMLCanvasElement, rect: DOMRect, dpr: number): void {
+    canvas.width = rect.width * dpr
+    canvas.height = rect.height * dpr
+    canvas.style.width = `${rect.width}px`
+    canvas.style.height = `${rect.height}px`
+}
+
+function buildDimensions(rect: DOMRect, margins: ChartMargins): ChartDimensions {
+    return {
+        width: rect.width,
+        height: rect.height,
+        plotLeft: margins.left,
+        plotTop: margins.top,
+        plotWidth: Math.max(0, rect.width - margins.left - margins.right),
+        plotHeight: Math.max(0, rect.height - margins.top - margins.bottom),
+    }
+}
+
 export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasResult {
     const { margins } = options
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -28,27 +46,30 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
     const wrapperRef = useRef<HTMLDivElement | null>(null)
     const [canvasState, setCanvasState] = useState<CanvasState | null>(null)
 
+    // Keep margins behind a ref so the ResizeObserver effect can read the latest values
+    // without re-binding when only margins change. Re-binding the observer on every margin
+    // tweak risks a feedback loop when y-tick-width measurement triggers margin recompute.
+    const marginsRef = useRef(margins)
+    marginsRef.current = margins
+    const rectRef = useRef<DOMRect | null>(null)
+
+    // Attach the ResizeObserver once. updateSize reads margins from the ref; when margins
+    // change, the secondary effect below recomputes dimensions from the cached rect.
     useEffect(() => {
         const wrapper = wrapperRef.current
         if (!wrapper) {
             return
         }
 
-        const sizeCanvas = (canvas: HTMLCanvasElement, rect: DOMRect, dpr: number): void => {
-            canvas.width = rect.width * dpr
-            canvas.height = rect.height * dpr
-            canvas.style.width = `${rect.width}px`
-            canvas.style.height = `${rect.height}px`
-        }
-
         const updateSize = (): void => {
             const canvas = canvasRef.current
             const overlayCanvas = overlayCanvasRef.current
-            if (!canvas || !overlayCanvas || !wrapper) {
+            if (!canvas || !overlayCanvas) {
                 return
             }
 
             const rect = wrapper.getBoundingClientRect()
+            rectRef.current = rect
             const dpr = window.devicePixelRatio || 1
 
             sizeCanvas(canvas, rect, dpr)
@@ -63,14 +84,7 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
             setCanvasState({
                 ctx: context,
                 overlayCtx: overlayContext,
-                dimensions: {
-                    width: rect.width,
-                    height: rect.height,
-                    plotLeft: margins.left,
-                    plotTop: margins.top,
-                    plotWidth: Math.max(0, rect.width - margins.left - margins.right),
-                    plotHeight: Math.max(0, rect.height - margins.top - margins.bottom),
-                },
+                dimensions: buildDimensions(rect, marginsRef.current),
             })
         }
 
@@ -83,7 +97,19 @@ export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasRe
 
         return () => {
             observer.disconnect()
+            // Drop the cached ctx so a re-mount doesn't paint into a detached canvas.
+            setCanvasState(null)
+            rectRef.current = null
         }
+    }, [])
+
+    // When margins change without a resize, recompute dimensions from the cached rect.
+    useEffect(() => {
+        const rect = rectRef.current
+        if (!rect) {
+            return
+        }
+        setCanvasState((prev) => (prev ? { ...prev, dimensions: buildDimensions(rect, margins) } : prev))
     }, [margins.left, margins.right, margins.top, margins.bottom])
 
     return {

--- a/frontend/src/lib/hog-charts/core/hooks/useChartDraw.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartDraw.ts
@@ -1,6 +1,6 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, Series } from '../types'
+import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, ResolvedSeries } from '../types'
 
 interface UseChartDrawOptions {
     /** Context for the static layer (grid, lines, areas, points). Redrawn only when chart inputs change. */
@@ -9,7 +9,7 @@ interface UseChartDrawOptions {
     overlayCtx: CanvasRenderingContext2D | null
     dimensions: ChartDimensions | null
     scales: ChartScales | null
-    series: Series[]
+    series: ResolvedSeries[]
     labels: string[]
     hoverIndex: number
     theme: ChartTheme
@@ -36,18 +36,34 @@ export function useChartDraw({
     drawStatic,
     drawHover,
 }: UseChartDrawOptions): void {
+    // Track the in-flight RAF id in a ref so each new effect run can cancel the previous
+    // RAF before scheduling its own. Relying on the React cleanup ordering alone leaves
+    // a window where a stale RAF from render N-1 can paint after render N's setup runs.
+    const staticRafRef = useRef<number | null>(null)
+    const hoverRafRef = useRef<number | null>(null)
+
     // Static layer — redraws only when chart inputs change. Excluded `hoverIndex` from deps
     // on purpose so a hover sweep doesn't repaint every line/area/point per move.
     useEffect(() => {
+        if (staticRafRef.current != null) {
+            cancelAnimationFrame(staticRafRef.current)
+            staticRafRef.current = null
+        }
         if (!ctx || !dimensions || !scales) {
             return
         }
-        const id = requestAnimationFrame(() => {
+        staticRafRef.current = requestAnimationFrame(() => {
+            staticRafRef.current = null
             clearAndPrepare(ctx, dimensions)
             drawStatic({ ctx, dimensions, scales, series, labels, hoverIndex: -1, theme })
             ctx.restore()
         })
-        return () => cancelAnimationFrame(id)
+        return () => {
+            if (staticRafRef.current != null) {
+                cancelAnimationFrame(staticRafRef.current)
+                staticRafRef.current = null
+            }
+        }
         // hoverIndex deliberately omitted — see comment above.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ctx, dimensions, scales, series, labels, theme, drawStatic])
@@ -55,14 +71,24 @@ export function useChartDraw({
     // Hover overlay — redraws only when hoverIndex changes (or chart inputs do). Cheap path:
     // clears the overlay canvas and draws a few highlight rings per series, nothing else.
     useEffect(() => {
+        if (hoverRafRef.current != null) {
+            cancelAnimationFrame(hoverRafRef.current)
+            hoverRafRef.current = null
+        }
         if (!overlayCtx || !dimensions || !scales) {
             return
         }
-        const id = requestAnimationFrame(() => {
+        hoverRafRef.current = requestAnimationFrame(() => {
+            hoverRafRef.current = null
             clearAndPrepare(overlayCtx, dimensions)
             drawHover({ ctx: overlayCtx, dimensions, scales, series, labels, hoverIndex, theme })
             overlayCtx.restore()
         })
-        return () => cancelAnimationFrame(id)
+        return () => {
+            if (hoverRafRef.current != null) {
+                cancelAnimationFrame(hoverRafRef.current)
+                hoverRafRef.current = null
+            }
+        }
     }, [overlayCtx, dimensions, scales, series, labels, hoverIndex, theme, drawHover])
 }

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -327,6 +327,40 @@ describe('useChartInteraction — tooltip pinning', () => {
         expect(result.current.tooltipCtx?.seriesData[0].value).toBe(updatedSeries[0].data[initialIndex])
     })
 
+    it('keeps the same tooltipCtx reference when a rerender produces value-equal series', () => {
+        const { rerender, result } = renderHook(
+            ({ s }: { s: typeof series }) =>
+                useChartInteraction({
+                    scales,
+                    dimensions,
+                    labels,
+                    series: s,
+                    canvasRef: refs.canvasRef,
+                    wrapperRef: refs.wrapperRef,
+                    showTooltip: true,
+                    pinnable: true,
+                    resolveValue: (sr, i) => sr.data[i],
+                }),
+            { initialProps: { s: series } }
+        )
+
+        act(() => {
+            simulateMouseMove(result.current.handlers, refs, 200, 100)
+        })
+        act(() => {
+            result.current.handlers.onClick()
+        })
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
+        const initialCtx = result.current.tooltipCtx
+
+        // Rerender with new series array containing new object identities but identical
+        // values. The equivalence-bail in the rebuild effect should keep the prev ctx.
+        const sameValuesNewIdentity = series.map((s) => ({ ...s }))
+        rerender({ s: sameValuesNewIdentity })
+
+        expect(result.current.tooltipCtx).toBe(initialCtx)
+    })
+
     it('clears the pinned tooltip when labels shrink so the pinned dataIndex no longer exists', () => {
         const { rerender, result } = renderHook(
             ({ ls }: { ls: string[] }) =>

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -32,7 +32,10 @@ function isTooltipContextEquivalent<Meta>(a: TooltipContext<Meta>, b: TooltipCon
     for (let i = 0; i < a.seriesData.length; i++) {
         const ai = a.seriesData[i]
         const bi = b.seriesData[i]
-        if (ai.value !== bi.value || ai.color !== bi.color || ai.series !== bi.series) {
+        // Compare series by stable `key` rather than identity: the parent rebuilds
+        // `coloredSeries` (and so each entry's `series` reference) on every render, so
+        // an identity check would defeat the equivalence bail.
+        if (ai.value !== bi.value || ai.color !== bi.color || ai.series.key !== bi.series.key) {
             return false
         }
     }

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import {
     buildLabelPositions,
@@ -7,15 +7,43 @@ import {
     findNearestIndexFromPositions,
     isInPlotArea,
 } from '../interaction'
-import type { ChartDimensions, ChartScales, PointClickData, ResolveValueFn, Series, TooltipContext } from '../types'
+import type {
+    ChartDimensions,
+    ChartScales,
+    PointClickData,
+    ResolvedSeries,
+    ResolveValueFn,
+    TooltipContext,
+} from '../types'
+import { useLatest } from './useLatest'
 
 const defaultResolveValue: ResolveValueFn = (series, dataIndex) => series.data[dataIndex] ?? 0
+
+function isTooltipContextEquivalent<Meta>(a: TooltipContext<Meta>, b: TooltipContext<Meta>): boolean {
+    if (a.dataIndex !== b.dataIndex || a.label !== b.label) {
+        return false
+    }
+    if (a.position.x !== b.position.x || a.position.y !== b.position.y) {
+        return false
+    }
+    if (a.seriesData.length !== b.seriesData.length) {
+        return false
+    }
+    for (let i = 0; i < a.seriesData.length; i++) {
+        const ai = a.seriesData[i]
+        const bi = b.seriesData[i]
+        if (ai.value !== bi.value || ai.color !== bi.color || ai.series !== bi.series) {
+            return false
+        }
+    }
+    return true
+}
 
 interface UseChartInteractionOptions<Meta> {
     scales: ChartScales | null
     dimensions: ChartDimensions | null
     labels: string[]
-    series: Series<Meta>[]
+    series: ResolvedSeries<Meta>[]
     canvasRef: React.RefObject<HTMLCanvasElement>
     wrapperRef: React.RefObject<HTMLDivElement>
     showTooltip: boolean
@@ -48,8 +76,9 @@ export function useChartInteraction<Meta = unknown>({
 }: UseChartInteractionOptions<Meta>): UseChartInteractionResult<Meta> {
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
     const [tooltipCtx, setTooltipCtx] = useState<TooltipContext<Meta> | null>(null)
-    const hoverIndexRef = useRef<number>(hoverIndex)
-    hoverIndexRef.current = hoverIndex
+    // Read by onClick to decide pin/unpin/passthrough. Event handlers fire after the
+    // most recent commit, so an effect-deferred ref is correct here.
+    const hoverIndexRef = useLatest(hoverIndex)
 
     const clearTooltip = useCallback(() => {
         setHoverIndex(-1)
@@ -69,8 +98,7 @@ export function useChartInteraction<Meta = unknown>({
     // Without this, the pin keeps stale values at stale pixel positions after the
     // parent updates series/labels/scales/dimensions. resolveValue is read live via a
     // ref so each render's new closure doesn't trigger a rebuild.
-    const resolveValueRef = useRef(resolveValue)
-    resolveValueRef.current = resolveValue
+    const resolveValueRef = useLatest(resolveValue)
     useEffect(() => {
         if (!isPinned || !scales || !dimensions) {
             return
@@ -93,7 +121,16 @@ export function useChartInteraction<Meta = unknown>({
                 resolveValueRef.current,
                 scales.yAxes
             )
-            return fresh ? { ...fresh, isPinned: true, onUnpin: unpin } : null
+            if (!fresh) {
+                return null
+            }
+            // Bail when the rebuilt context is value-equal to prev. Avoids identity churn
+            // re-rendering the tooltip overlay when the parent rerenders for unrelated
+            // reasons (e.g. dashboard-level state) while the pin is held.
+            if (isTooltipContextEquivalent(prev, fresh)) {
+                return prev
+            }
+            return { ...fresh, isPinned: true, onUnpin: unpin }
         })
         // Omitted on purpose:
         //   - isPinned / tooltipCtx: would feedback-loop with setTooltipCtx

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -99,8 +99,10 @@ export function useChartInteraction<Meta = unknown>({
 
     // Rebuild or clear the pinned tooltip when its underlying inputs change.
     // Without this, the pin keeps stale values at stale pixel positions after the
-    // parent updates series/labels/scales/dimensions. resolveValue is read live via a
-    // ref so each render's new closure doesn't trigger a rebuild.
+    // parent updates series/labels/scales/dimensions. resolveValue is read live via
+    // a ref so unmemoized closures don't trigger a rebuild every render — see the
+    // contract on `ChartProps.resolveValue`: any external toggle that changes the
+    // resolver's output must also update series or scales.
     const resolveValueRef = useLatest(resolveValue)
     useEffect(() => {
         if (!isPinned || !scales || !dimensions) {

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -34,8 +34,14 @@ function isTooltipContextEquivalent<Meta>(a: TooltipContext<Meta>, b: TooltipCon
         const bi = b.seriesData[i]
         // Compare series by stable `key` rather than identity: the parent rebuilds
         // `coloredSeries` (and so each entry's `series` reference) on every render, so
-        // an identity check would defeat the equivalence bail.
-        if (ai.value !== bi.value || ai.color !== bi.color || ai.series.key !== bi.series.key) {
+        // an identity check would defeat the equivalence bail. `label` is also compared
+        // because it's user-visible in the tooltip and can change while the key stays.
+        if (
+            ai.value !== bi.value ||
+            ai.color !== bi.color ||
+            ai.series.key !== bi.series.key ||
+            ai.series.label !== bi.series.label
+        ) {
             return false
         }
     }

--- a/frontend/src/lib/hog-charts/core/hooks/useLatest.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useLatest.ts
@@ -1,0 +1,19 @@
+import type { MutableRefObject } from 'react'
+import { useEffect, useRef } from 'react'
+
+/** Holds the latest value of a non-render-driving prop in a ref so callbacks can read
+ *  it without being re-created on every change. The write happens in a `useEffect` so
+ *  React's concurrent / strict-mode pre-commit renders don't observably mutate the ref.
+ *
+ *  Reads from the ref inside event handlers always see the value committed during the
+ *  most recent render — the one the user is interacting with — because event handlers
+ *  fire after the commit phase has run. Reads inside other effects or async work may
+ *  observe a previous commit's value if they fire between render and commit; for those
+ *  cases prefer threading the value through the effect's deps directly. */
+export function useLatest<T>(value: T): MutableRefObject<T> {
+    const ref = useRef<T>(value)
+    useEffect(() => {
+        ref.current = value
+    }, [value])
+    return ref
+}

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -1,6 +1,13 @@
 import { bisector } from 'd3'
 
-import type { ChartDimensions, PointClickData, ResolveValueFn, Series, TooltipContext, YAxisScale } from './types'
+import type {
+    ChartDimensions,
+    PointClickData,
+    ResolvedSeries,
+    ResolveValueFn,
+    TooltipContext,
+    YAxisScale,
+} from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
 
 export interface LabelPosition {
@@ -54,7 +61,7 @@ export function isInPlotArea(mouseX: number, mouseY: number, dimensions: ChartDi
 
 export function buildTooltipContext<Meta = unknown>(
     dataIndex: number,
-    series: Series<Meta>[],
+    series: ResolvedSeries<Meta>[],
     labels: string[],
     xScale: (label: string) => number | undefined,
     yScale: (value: number) => number,
@@ -103,7 +110,7 @@ export function buildTooltipContext<Meta = unknown>(
 
 export function buildPointClickData<Meta = unknown>(
     dataIndex: number,
-    series: Series<Meta>[],
+    series: ResolvedSeries<Meta>[],
     labels: string[],
     resolveValue: ResolveValueFn
 ): PointClickData<Meta> | null {

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -4,6 +4,12 @@ export type { ChartTheme }
 /** Default axis id used when a series doesn't specify one. */
 export const DEFAULT_Y_AXIS_ID = 'left'
 
+/** Series shape after the chart has applied its color fallback from `theme.colors`.
+ *  This is the type seen by overlays, draw functions, and interaction code — by the time
+ *  those run, `color` is guaranteed to be set. Public consumers should write {@link Series}
+ *  with color either supplied or omitted (chart picks one) and let the chart resolve it. */
+export type ResolvedSeries<Meta = unknown> = Series<Meta> & { color: string }
+
 export interface Series<Meta = unknown> {
     /** Unique identifier used to key React elements and look up stacked data. */
     key: string
@@ -11,8 +17,9 @@ export interface Series<Meta = unknown> {
     label: string
     /** Numeric values for each x-axis label. Must be the same length as the labels array. */
     data: number[]
-    /** CSS color string (hex, rgb, var(--…), etc.) for the line and associated fill/points. */
-    color: string
+    /** CSS color string (hex, rgb, var(--…), etc.) for the line and associated fill/points.
+     *  When omitted (or empty), the chart picks a color from `theme.colors` by series index. */
+    color?: string
     /** Which y-axis this series is scaled against. Defaults to {@link DEFAULT_Y_AXIS_ID}. */
     yAxisId?: string
     /** Arbitrary consumer data attached to this series. Flows through to TooltipContext
@@ -172,7 +179,7 @@ export interface ChartDrawArgs {
     /** Scale functions for mapping data to pixel coordinates. */
     scales: ChartScales
     /** Series with fallback colors already applied. */
-    series: Series[]
+    series: ResolvedSeries[]
     /** X-axis labels. */
     labels: string[]
     /** Index of the currently hovered data point, or -1. */
@@ -185,7 +192,7 @@ export interface ChartDrawArgs {
 export type ResolveValueFn = (series: Series, dataIndex: number) => number
 
 /** Factory function that chart types provide to create their scales from dimensions and data. */
-export type CreateScalesFn = (series: Series[], labels: string[], dimensions: ChartDimensions) => ChartScales
+export type CreateScalesFn = (series: ResolvedSeries[], labels: string[], dimensions: ChartDimensions) => ChartScales
 
 /** Per-axis scale: a mapping function and its tick values. */
 export interface YAxisScale {
@@ -208,4 +215,9 @@ export interface ChartScales {
     /** Per-axis y scales keyed by axis id. Present when dual axes are active.
      *  When absent, all series use `y` / `yTicks`. */
     yAxes?: Record<string, YAxisScale>
+    /** Chart-type-private slot. Library code MUST NOT read this — it is populated by
+     *  individual chart implementations (e.g. LineChart stashes raw d3 scales here so
+     *  its `drawStatic` can use them) and is opaque to the base Chart and overlays.
+     *  Typed as `unknown` so d3-style types don't leak through the public surface. */
+    _private?: unknown
 }

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -21,6 +21,7 @@ export type {
     CreateScalesFn,
     LineChartConfig,
     PointClickData,
+    ResolvedSeries,
     ResolveValueFn,
     Series,
     TooltipContext,

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -9,6 +9,8 @@ interface TooltipProps<Meta> {
     placement?: 'follow-data' | 'top'
 }
 
+const TOOLTIP_MIDDLEWARE = [offset(12), flip(), shift({ padding: 8 })]
+
 export function Tooltip<Meta = unknown>({
     context,
     renderTooltip,
@@ -31,13 +33,13 @@ export function Tooltip<Meta = unknown>({
                 }
             },
         }),
-        [context.position.x, placement === 'follow-data' ? context.position.y : null, context.canvasBounds, placement]
+        [context.position.x, context.position.y, context.canvasBounds, placement]
     )
 
     const { refs, floatingStyles } = useFloating({
         placement: placement === 'top' ? 'right-start' : 'right',
         strategy: 'fixed',
-        middleware: [offset(12), flip(), shift({ padding: 8 })],
+        middleware: TOOLTIP_MIDDLEWARE,
     })
 
     useLayoutEffect(() => {

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -16,11 +16,15 @@ export function Tooltip<Meta = unknown>({
     renderTooltip,
     placement = 'follow-data',
 }: TooltipProps<Meta>): React.ReactElement {
+    // In `top` placement the y position is anchored to the canvas top and `position.y` is
+    // unused, so we depend on the resolved y rather than `position.y` directly — otherwise
+    // mousemove rebuilds the virtual reference and triggers a Floating-UI reposition pass
+    // for nothing.
+    const y = placement === 'top' ? context.canvasBounds.top : context.canvasBounds.top + context.position.y
     const virtualReference = useMemo<VirtualElement>(
         () => ({
             getBoundingClientRect() {
                 const x = context.canvasBounds.left + context.position.x
-                const y = placement === 'top' ? context.canvasBounds.top : context.canvasBounds.top + context.position.y
                 return {
                     x,
                     y,
@@ -33,7 +37,7 @@ export function Tooltip<Meta = unknown>({
                 }
             },
         }),
-        [context.position.x, context.position.y, context.canvasBounds, placement]
+        [context.position.x, y, context.canvasBounds]
     )
 
     const { refs, floatingStyles } = useFloating({

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import type { BaseChartContext, ChartLayoutContextValue } from '../core/chart-context'
 import { ChartHoverContext, ChartLayoutContext } from '../core/chart-context'
-import type { ChartTheme, ResolveValueFn, Series } from '../core/types'
+import type { ChartTheme, ResolvedSeries, ResolveValueFn } from '../core/types'
 import { ValueLabels } from './ValueLabels'
 
 const DIMENSIONS = {
@@ -25,7 +25,7 @@ const yScale = (v: number): number => 368 - (v / 100) * 352
 const DEFAULT_THEME: ChartTheme = { colors: ['#000'], backgroundColor: '#ffffff' }
 const DEFAULT_RESOLVE: ResolveValueFn = (s, i) => s.data[i] ?? 0
 
-function makeContext(series: Series[], overrides: Partial<BaseChartContext> = {}): BaseChartContext {
+function makeContext(series: ResolvedSeries[], overrides: Partial<BaseChartContext> = {}): BaseChartContext {
     return {
         dimensions: DIMENSIONS,
         labels: LABELS,
@@ -64,7 +64,7 @@ describe('ValueLabels', () => {
     afterEach(() => cleanup())
 
     it('renders one label per non-zero data point in a single series', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [10, 20, 30, 40, 50] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [10, 20, 30, 40, 50] }]
         const { container } = renderInChart(makeContext(series), <ValueLabels />)
         const divs = labelDivs(container)
         expect(divs).toHaveLength(5)
@@ -75,7 +75,7 @@ describe('ValueLabels', () => {
         ['no formatter → toLocaleString', undefined, [1234, 5678], [(1234).toLocaleString(), (5678).toLocaleString()]],
         ['custom formatter', (v) => `$${(v / 1000).toFixed(1)}k`, [1000, 2000], ['$1.0k', '$2.0k']],
     ])('formats labels: %s', (_name, formatter, data, expected) => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data }]
         const ctx = makeContext(series, { labels: ['Mon', 'Tue'] })
         const { container } = renderInChart(ctx, <ValueLabels valueFormatter={formatter} />)
         const divs = labelDivs(container)
@@ -83,19 +83,19 @@ describe('ValueLabels', () => {
     })
 
     it('skips zero values', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [10, 0, 30, 0, 50] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [10, 0, 30, 0, 50] }]
         const { container } = renderInChart(makeContext(series), <ValueLabels />)
         expect(labelDivs(container).map((d) => d.textContent)).toEqual(['10', '30', '50'])
     })
 
     it('skips non-finite values (NaN, Infinity)', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [10, NaN, 30, Infinity, 50] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [10, NaN, 30, Infinity, 50] }]
         const { container } = renderInChart(makeContext(series), <ValueLabels />)
         expect(labelDivs(container).map((d) => d.textContent)).toEqual(['10', '30', '50'])
     })
 
     it('skips series where visibility.excluded is true', () => {
-        const series: Series[] = [
+        const series: ResolvedSeries[] = [
             { key: 'a', label: 'A', color: '#f00', data: [10, 20, 30, 40, 50] },
             { key: 'b', label: 'B', color: '#0f0', data: [60, 70, 80, 90, 100], visibility: { excluded: true } },
         ]
@@ -106,7 +106,7 @@ describe('ValueLabels', () => {
     })
 
     it('positions negative values below the point and positive values above', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [50, -50, 25, -25, 75] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [50, -50, 25, -25, 75] }]
         const { container } = renderInChart(makeContext(series), <ValueLabels />)
         const divs = labelDivs(container)
         expect(divs).toHaveLength(5)
@@ -130,7 +130,7 @@ describe('ValueLabels', () => {
         longData.forEach((_, i) => {
             longXPositions[`L${i}`] = 60 + (i / (longData.length - 1)) * 640
         })
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: longData }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: longData }]
         const ctx = makeContext(series, {
             labels: longLabels,
             scales: {
@@ -145,7 +145,7 @@ describe('ValueLabels', () => {
 
     it('honours a custom maxPointsPerSeries override', () => {
         const data = Array.from({ length: 6 }, (_, i) => 10 + i * 10)
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data }]
         // default (100) renders all; override to 3 should render none
         const ctx = makeContext(series)
         const { container } = renderInChart(ctx, <ValueLabels maxPointsPerSeries={3} />)
@@ -154,7 +154,7 @@ describe('ValueLabels', () => {
 
     it('drops overlapping labels via greedy collision avoidance', () => {
         // Two points at the same x: only one should survive.
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [50, 50] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [50, 50] }]
         const ctx = makeContext(series, {
             labels: ['A', 'B'],
             scales: {
@@ -171,7 +171,7 @@ describe('ValueLabels', () => {
     it('uses the matching yAxes scale when a series has a yAxisId', () => {
         // Right axis maps 0-1000; left axis maps 0-100.
         const rightScale = (v: number): number => 368 - (v / 1000) * 352
-        const series: Series[] = [{ key: 'right', label: 'R', color: '#00f', data: [500], yAxisId: 'y1' }]
+        const series: ResolvedSeries[] = [{ key: 'right', label: 'R', color: '#00f', data: [500], yAxisId: 'y1' }]
         const ctx = makeContext(series, {
             labels: ['Mon'],
             scales: {
@@ -192,7 +192,7 @@ describe('ValueLabels', () => {
     })
 
     it('falls back to the primary y-scale when yAxisId is unknown', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [50], yAxisId: 'missing' }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [50], yAxisId: 'missing' }]
         const ctx = makeContext(series, { labels: ['Mon'] })
         const { container } = renderInChart(ctx, <ValueLabels />)
         const divs = labelDivs(container)
@@ -202,7 +202,7 @@ describe('ValueLabels', () => {
     })
 
     it('renders one label per series at the same x, each with its own color', () => {
-        const series: Series[] = [
+        const series: ResolvedSeries[] = [
             { key: 'a', label: 'A', color: '#112233', data: [10] },
             { key: 'b', label: 'B', color: '#445566', data: [20] },
         ]
@@ -216,7 +216,7 @@ describe('ValueLabels', () => {
     })
 
     it('renders null when nothing survives filtering', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [NaN, NaN, NaN] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [NaN, NaN, NaN] }]
         const ctx = makeContext(series, { labels: ['Mon', 'Tue', 'Wed'] })
         const { container } = renderInChart(ctx, <ValueLabels />)
         expect(labelDivs(container)).toHaveLength(0)
@@ -225,7 +225,7 @@ describe('ValueLabels', () => {
     it('positions labels at the resolved (e.g. stacked) y, not the raw series.data y', () => {
         // Raw value 25 sits at y=278 on the left axis; stacking lifts it to top-of-stack=75 → y=104.
         // The resolveValue closure mimics what LineChart provides for stacked series.
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [25] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [25] }]
         const stackedTops: Record<string, number[]> = { s: [75] }
         const resolveValue: ResolveValueFn = (s, i) => stackedTops[s.key]?.[i] ?? s.data[i] ?? 0
         const ctx = makeContext(series, { labels: ['Mon'], resolveValue })
@@ -239,7 +239,7 @@ describe('ValueLabels', () => {
     })
 
     it('uses theme.backgroundColor for the label border (dark-mode safe)', () => {
-        const series: Series[] = [{ key: 's', label: 'S', color: '#f00', data: [50] }]
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [50] }]
         const darkTheme: ChartTheme = { colors: ['#f00'], backgroundColor: '#222222' }
         const ctx = makeContext(series, { labels: ['Mon'], theme: darkTheme })
         const { container } = renderInChart(ctx, <ValueLabels />)

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
 import { DEFAULT_Y_AXIS_ID } from '../core/types'
-import type { ChartScales, ResolveValueFn, Series } from '../core/types'
+import type { ChartScales, ResolvedSeries, ResolveValueFn } from '../core/types'
 
 export interface ValueLabelsProps {
     /** Formats the value shown on each label. Defaults to `value.toLocaleString()`. */
@@ -39,13 +39,13 @@ interface Candidate {
     above: boolean
 }
 
-function resolveYScale(s: Series, scales: ChartScales): (value: number) => number {
+function resolveYScale(s: ResolvedSeries, scales: ChartScales): (value: number) => number {
     const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
     return scales.yAxes?.[axisId]?.scale ?? scales.y
 }
 
 function buildCandidates(
-    series: Series[],
+    series: ResolvedSeries[],
     labels: string[],
     scales: ChartScales,
     resolveValue: ResolveValueFn,

--- a/frontend/src/lib/hog-charts/test-helpers.ts
+++ b/frontend/src/lib/hog-charts/test-helpers.ts
@@ -1,7 +1,7 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 
 import { DEFAULT_MARGINS } from './core/Chart'
-import type { ChartDimensions, Series } from './core/types'
+import type { ChartDimensions, ResolvedSeries, Series } from './core/types'
 
 export const dimensions: ChartDimensions = {
     width: 800,
@@ -24,7 +24,7 @@ export const mockRect: DOMRect = {
     toJSON: () => ({}),
 }
 
-export function makeSeries(overrides: Partial<Series> & { key: string; data: number[] }): Series {
+export function makeSeries(overrides: Partial<Series> & { key: string; data: number[] }): ResolvedSeries {
     return { label: overrides.key, color: '#000', ...overrides }
 }
 

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 
 import { Chart } from 'lib/Chart'
 import { AnnotationsOverlay } from 'lib/components/AnnotationsOverlay'
-import { computeVisibleXLabels, useChart } from 'lib/hog-charts'
+import { computeVisibleXLabels, useChartLayout } from 'lib/hog-charts'
 
 interface AnnotationsLayerProps {
     /** Numeric insight id used by the annotations logic. Pass `'new'` for unsaved insights. */
@@ -31,7 +31,7 @@ export function AnnotationsLayer({
     dates,
     xTickFormatter,
 }: AnnotationsLayerProps): React.ReactElement | null {
-    const { scales, dimensions, labels } = useChart()
+    const { scales, dimensions, labels } = useChartLayout()
 
     const chartLike = useMemo(() => {
         const visibleXLabels = computeVisibleXLabels(labels, scales.x, xTickFormatter)

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnomalyPointsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnomalyPointsLayer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/forbid-dom-props -- dynamic pixel positions from d3 scales */
 import React from 'react'
 
-import { useChart } from 'lib/hog-charts'
+import { useChartLayout } from 'lib/hog-charts'
 
 import type { AnomalyMarker } from './anomalyPointsAdapter'
 
@@ -18,7 +18,7 @@ interface AnomalyPointsLayerProps {
  *  pipeline (a sibling Series<>` would force `drawLine` to stitch a connecting line through
  *  NaN values — `tracePath` doesn't reset on gaps, see `core/canvas-renderer.ts`). */
 export function AnomalyPointsLayer({ markers, radius = 3 }: AnomalyPointsLayerProps): React.ReactElement | null {
-    const { scales, dimensions, labels } = useChart()
+    const { scales, dimensions, labels } = useChartLayout()
     if (!markers.length) {
         return null
     }

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsTooltip.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useMemo } from 'react'
+
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import type { TooltipContext } from 'lib/hog-charts'
 import { formatAggregationAxisValue, formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -8,6 +10,8 @@ import { BreakdownFilter, CurrencyCode, DateRange, TrendsFilter } from '~/querie
 import { IntervalType } from '~/types'
 
 import type { TrendsSeriesMeta } from './trendsSeriesMeta'
+
+const NOOP = (): void => {}
 
 interface TrendsTooltipProps {
     context: TooltipContext<TrendsSeriesMeta>
@@ -43,39 +47,71 @@ export function TrendsTooltip({
     formatCompareLabel,
     onRowClick,
 }: TrendsTooltipProps): React.ReactElement {
-    // TODO: CI bands and moving-average datasets aren't yet built in the hog-charts path. When they
-    // are, the bridge (or TrendsLineChart) will need to mark them as non-tooltip rows — legacy
-    // Chart.js path used a `hideTooltip: true` flag on the dataset for this.
-    const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
-        const meta = entry.series.meta ?? {}
-        return {
-            id: idx,
-            dataIndex: context.dataIndex,
-            datasetIndex: idx,
-            order: meta.order ?? idx,
-            label: entry.series.label,
-            color: entry.color,
-            count: entry.value,
-            action: meta.action,
-            breakdown_value: meta.breakdown_value,
-            compare_label: meta.compare_label,
-            date_label: meta.days?.[context.dataIndex],
-            filter: meta.filter,
-        }
-    })
+    const seriesData = useMemo<SeriesDatum[]>(
+        () =>
+            context.seriesData.map((entry, idx) => {
+                const meta = entry.series.meta ?? {}
+                return {
+                    id: idx,
+                    dataIndex: context.dataIndex,
+                    datasetIndex: idx,
+                    order: meta.order ?? idx,
+                    label: entry.series.label,
+                    color: entry.color,
+                    count: entry.value,
+                    action: meta.action,
+                    breakdown_value: meta.breakdown_value,
+                    compare_label: meta.compare_label,
+                    date_label: meta.days?.[context.dataIndex],
+                    filter: meta.filter,
+                }
+            }),
+        [context.seriesData, context.dataIndex]
+    )
 
     const date = context.seriesData[0]?.series.meta?.days?.[context.dataIndex]
 
-    const renderCount = (value: number): string => {
-        if (showPercentView) {
-            // Stickiness percent view: value is already a percentage.
-            return `${value.toFixed(1)}%`
-        }
-        if (!isPercentStackView) {
-            return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
-        }
-        return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
-    }
+    const renderCount = useCallback(
+        (value: number): string => {
+            if (showPercentView) {
+                // Stickiness percent view: value is already a percentage.
+                return `${value.toFixed(1)}%`
+            }
+            if (!isPercentStackView) {
+                return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
+            }
+            return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
+        },
+        [showPercentView, isPercentStackView, trendsFilter, baseCurrency]
+    )
+
+    const hasMultipleSeries = seriesData.length > 1
+
+    const renderSeries = useCallback(
+        (value: React.ReactNode, datum: SeriesDatum): React.ReactElement => {
+            const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
+
+            if (hasBreakdown && !hasMultipleSeries) {
+                const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
+                return <div className="datum-label-column">{title}</div>
+            }
+
+            return (
+                <div className="datum-label-column">
+                    {!formula && (
+                        <SeriesLetter
+                            className="mr-2"
+                            hasBreakdown={hasBreakdown}
+                            seriesIndex={datum.action?.order ?? datum.id}
+                            seriesColor={datum.color}
+                        />
+                    )}
+                    {value}
+                </div>
+            )
+        },
+        [hasMultipleSeries, breakdownFilter, formatCompareLabel, formula]
+    )
 
     return (
         <InsightTooltip
@@ -87,30 +123,8 @@ export function TrendsTooltip({
             dateRange={dateRange}
             formatCompareLabel={formatCompareLabel}
             groupTypeLabel={groupTypeLabel}
-            onClose={context.onUnpin ?? (() => {})}
-            renderSeries={(value, datum) => {
-                const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
-                const hasMultipleSeries = seriesData.length > 1
-
-                if (hasBreakdown && !hasMultipleSeries) {
-                    const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
-                    return <div className="datum-label-column">{title}</div>
-                }
-
-                return (
-                    <div className="datum-label-column">
-                        {!formula && (
-                            <SeriesLetter
-                                className="mr-2"
-                                hasBreakdown={hasBreakdown}
-                                seriesIndex={datum.action?.order ?? datum.id}
-                                seriesColor={datum.color}
-                            />
-                        )}
-                        {value}
-                    </div>
-                )
-            }}
+            onClose={context.onUnpin ?? NOOP}
+            renderSeries={renderSeries}
             renderCount={renderCount}
             onRowClick={onRowClick}
             hideInspectActorsSection={!onRowClick}

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsTooltip.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useMemo } from 'react'
-
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import type { TooltipContext } from 'lib/hog-charts'
 import { formatAggregationAxisValue, formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -10,8 +8,6 @@ import { BreakdownFilter, CurrencyCode, DateRange, TrendsFilter } from '~/querie
 import { IntervalType } from '~/types'
 
 import type { TrendsSeriesMeta } from './trendsSeriesMeta'
-
-const NOOP = (): void => {}
 
 interface TrendsTooltipProps {
     context: TooltipContext<TrendsSeriesMeta>
@@ -47,71 +43,39 @@ export function TrendsTooltip({
     formatCompareLabel,
     onRowClick,
 }: TrendsTooltipProps): React.ReactElement {
-    const seriesData = useMemo<SeriesDatum[]>(
-        () =>
-            context.seriesData.map((entry, idx) => {
-                const meta = entry.series.meta ?? {}
-                return {
-                    id: idx,
-                    dataIndex: context.dataIndex,
-                    datasetIndex: idx,
-                    order: meta.order ?? idx,
-                    label: entry.series.label,
-                    color: entry.color,
-                    count: entry.value,
-                    action: meta.action,
-                    breakdown_value: meta.breakdown_value,
-                    compare_label: meta.compare_label,
-                    date_label: meta.days?.[context.dataIndex],
-                    filter: meta.filter,
-                }
-            }),
-        [context.seriesData, context.dataIndex]
-    )
+    // TODO: CI bands and moving-average datasets aren't yet built in the hog-charts path. When they
+    // are, the bridge (or TrendsLineChart) will need to mark them as non-tooltip rows — legacy
+    // Chart.js path used a `hideTooltip: true` flag on the dataset for this.
+    const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
+        const meta = entry.series.meta ?? {}
+        return {
+            id: idx,
+            dataIndex: context.dataIndex,
+            datasetIndex: idx,
+            order: meta.order ?? idx,
+            label: entry.series.label,
+            color: entry.color,
+            count: entry.value,
+            action: meta.action,
+            breakdown_value: meta.breakdown_value,
+            compare_label: meta.compare_label,
+            date_label: meta.days?.[context.dataIndex],
+            filter: meta.filter,
+        }
+    })
 
     const date = context.seriesData[0]?.series.meta?.days?.[context.dataIndex]
 
-    const renderCount = useCallback(
-        (value: number): string => {
-            if (showPercentView) {
-                // Stickiness percent view: value is already a percentage.
-                return `${value.toFixed(1)}%`
-            }
-            if (!isPercentStackView) {
-                return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
-            }
-            return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
-        },
-        [showPercentView, isPercentStackView, trendsFilter, baseCurrency]
-    )
-
-    const hasMultipleSeries = seriesData.length > 1
-
-    const renderSeries = useCallback(
-        (value: React.ReactNode, datum: SeriesDatum): React.ReactElement => {
-            const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
-
-            if (hasBreakdown && !hasMultipleSeries) {
-                const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
-                return <div className="datum-label-column">{title}</div>
-            }
-
-            return (
-                <div className="datum-label-column">
-                    {!formula && (
-                        <SeriesLetter
-                            className="mr-2"
-                            hasBreakdown={hasBreakdown}
-                            seriesIndex={datum.action?.order ?? datum.id}
-                            seriesColor={datum.color}
-                        />
-                    )}
-                    {value}
-                </div>
-            )
-        },
-        [hasMultipleSeries, breakdownFilter, formatCompareLabel, formula]
-    )
+    const renderCount = (value: number): string => {
+        if (showPercentView) {
+            // Stickiness percent view: value is already a percentage.
+            return `${value.toFixed(1)}%`
+        }
+        if (!isPercentStackView) {
+            return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
+        }
+        return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
+    }
 
     return (
         <InsightTooltip
@@ -123,8 +87,30 @@ export function TrendsTooltip({
             dateRange={dateRange}
             formatCompareLabel={formatCompareLabel}
             groupTypeLabel={groupTypeLabel}
-            onClose={context.onUnpin ?? NOOP}
-            renderSeries={renderSeries}
+            onClose={context.onUnpin ?? (() => {})}
+            renderSeries={(value, datum) => {
+                const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
+                const hasMultipleSeries = seriesData.length > 1
+
+                if (hasBreakdown && !hasMultipleSeries) {
+                    const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
+                    return <div className="datum-label-column">{title}</div>
+                }
+
+                return (
+                    <div className="datum-label-column">
+                        {!formula && (
+                            <SeriesLetter
+                                className="mr-2"
+                                hasBreakdown={hasBreakdown}
+                                seriesIndex={datum.action?.order ?? datum.id}
+                                seriesColor={datum.color}
+                            />
+                        )}
+                        {value}
+                    </div>
+                )
+            }}
             renderCount={renderCount}
             onRowClick={onRowClick}
             hideInspectActorsSection={!onRowClick}


### PR DESCRIPTION
## Problem

A code review and React-best-practices pass over the new `lib/hog-charts/` library and `TrendsLineChart` flagged six correctness issues and a handful of rerender hot paths. The criticals were concentrated in four files (`useChartCanvas.ts`, `useChartDraw.ts`, `useChartInteraction.ts`, `LineChart.tsx`); the perf items were spread across the overlays and the trends adapter. This PR addresses all of them.

## Changes

- **`useChartCanvas`**: ResizeObserver attaches once and reads margins via a ref; a small secondary effect recomputes dimensions from a cached rect when margins change. Closes the feedback-loop window where y-tick width measurement could ping-pong margins between two stable values.
- **`useChartDraw`**: tracks RAF ids in refs and cancels at the top of each effect run before scheduling a new frame, so rapid renders can't paint stale frames over current state.
- **`useChartInteraction`**: pinned-tooltip refresh now bails when the rebuilt context is value-equal to the previous one (label, position, per-series value/color/identity), breaking the rerender chain when the parent updates while the pin is held.
- **`LineChart`**: removed the `d3ScalesRef` side-channel. Raw d3 scales are stashed in a private opaque slot on `ChartScales` (`_private`) so each render is self-contained and immune to strict-mode / concurrent-render reordering.
- **`LineChart.drawHover`**: skips series with `visibility.fromStack` (moving averages, trend lines) — they don't participate in stacking and would otherwise draw highlight rings outside the plot in percent-stack mode.
- **`Series.color`** is now optional. Internal post-fallback paths use a new `ResolvedSeries<Meta> = Series<Meta> & { color: string }` type, threaded through `ChartLayoutContextValue`, `ChartDrawArgs`, draw functions, interaction, and overlays. Test fixtures updated.
- **Overlay context subscriptions**: `AnnotationsLayer` and `AnomalyPointsLayer` use `useChartLayout()` instead of `useChart()` so they don't rerender on every mousemove.
- **Tooltip middleware**: `[offset(12), flip(), shift(...)]` hoisted to module scope; `virtualReference` dep tuple simplified.
- **Chart wrapper styles**: hoisted to module-level constants; cursor swap selects between two pre-built style objects; `aria-label` memoized.
- **`TrendsTooltip`**: `renderCount`/`renderSeries` wrapped in `useCallback`, `seriesData` memoized, module-level `NOOP` for the `onClose` fallback.
- New `useLatest` hook for refs that are read only in event handlers — defers the write to `useEffect` so concurrent renders don't observably mutate the ref.

## How did you test this code?

I'm an agent — no manual testing. Verified via:
- `hogli test` on `frontend/src/lib/hog-charts` and `frontend/src/scenes/trends/viz/trends-line-chart`: 277 tests pass across 12 suites.
- Per-file typecheck (scoped tsconfig) over the changed area: clean.

## Publish to changelog?