### PR TITLE
chore(insights): trace insight list endpoint with fixed span name

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1230,13 +1230,14 @@ class InsightViewSet(
     def _is_basic_request(self) -> bool:
         return self.action in ("list", "retrieve") and str_to_bool(self.request.query_params.get("basic", "0"))
 
+    @tracer.start_as_current_span("insight_api_list")
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        with tracer.start_as_current_span("insight_api_list") as span:
-            span.set_attribute("posthog.team_id", self.team_id)
-            span.set_attribute("posthog.basic", self._is_basic_request())
-            span.set_attribute("posthog.saved", request.query_params.get("saved", ""))
-            span.set_attribute("posthog.order", request.query_params.get("order", ""))
-            return super().list(request, *args, **kwargs)
+        span = trace.get_current_span()
+        span.set_attribute("posthog.team_id", self.team_id)
+        span.set_attribute("posthog.basic", self._is_basic_request())
+        span.set_attribute("posthog.saved", request.query_params.get("saved", ""))
+        span.set_attribute("posthog.order", request.query_params.get("order", ""))
+        return super().list(request, *args, **kwargs)
 
     def get_serializer_class(self) -> type[serializers.BaseSerializer]:
         if self._is_basic_request():

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1573,7 +1573,7 @@ class InsightViewSet(
             INSIGHT_ID_PATH_PARAMETER,
             OpenApiParameter(
                 name="refresh",
-                enum=list(ExecutionMode),
+                enum=[*ExecutionMode],
                 default=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                 # Sync the `refresh` description here with the other one in this file, and with frontend/src/queries/schema.ts
                 description="""

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1235,7 +1235,7 @@ class InsightViewSet(
         span = trace.get_current_span()
         span.set_attribute("posthog.team_id", self.team_id)
         span.set_attribute("posthog.basic", self._is_basic_request())
-        span.set_attribute("posthog.saved", request.query_params.get("saved", ""))
+        span.set_attribute("posthog.saved", str_to_bool(request.query_params.get("saved", "0")))
         span.set_attribute("posthog.order", request.query_params.get("order", ""))
         return super().list(request, *args, **kwargs)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -17,6 +17,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema_view
 from loginas.utils import is_impersonated_session
+from opentelemetry import trace
 from prometheus_client import Counter
 from pydantic import (
     BaseModel,
@@ -121,6 +122,7 @@ from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from common.hogvm.python.utils import HogVMException
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 LEGACY_INSIGHT_ENDPOINTS_BLOCKED_FLAG = "legacy-insight-endpoints-disabled"
 LEGACY_INSIGHT_FILTERS_BLOCKED_FLAG = "legacy-insight-filters-disabled"
@@ -1227,6 +1229,14 @@ class InsightViewSet(
 
     def _is_basic_request(self) -> bool:
         return self.action in ("list", "retrieve") and str_to_bool(self.request.query_params.get("basic", "0"))
+
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        with tracer.start_as_current_span("insight_api_list") as span:
+            span.set_attribute("posthog.team_id", self.team_id)
+            span.set_attribute("posthog.basic", self._is_basic_request())
+            span.set_attribute("posthog.saved", request.query_params.get("saved", ""))
+            span.set_attribute("posthog.order", request.query_params.get("order", ""))
+            return super().list(request, *args, **kwargs)
 
     def get_serializer_class(self) -> type[serializers.BaseSerializer]:
         if self._is_basic_request():


### PR DESCRIPTION
## Problem

The insights list endpoint (`GET /api/environments/:id/insights/?basic=true`) is the dominant page-load API call but Jaeger only surfaces it under the resolved Django URL pattern, which is shared with every other action on the viewset. Filtering for *just* the list call (and even better, the basic / saved variants) is awkward.

## Changes

Adds an OpenTelemetry span around `InsightViewSet.list` named `insight_api_list` with attributes for `team_id`, `basic`, `saved`, and `order`. Same pattern already used in `posthog/api/session.py` and `posthog/hogql/query.py`.

In Jaeger this lets you filter:
- **Operation:** `insight_api_list`
- **Tags:** `posthog.basic=true`, `posthog.saved=true`, `posthog.order=-last_modified_at`

Once we know which variant we are looking at, child spans (DB queries, RBAC subquery, etc.) are easy to drill into.

## 🤖 Agent context

Follow-up to #57032 and #57055. No behavior change — span is observability only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*