### PR TITLE
chore(devex): scaffold product logic as a package by default

### DIFF
--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -321,19 +321,29 @@ class FileFolderConflictsCheck(ProductCheck):
         if not ctx.backend_dir.exists():
             return CheckResult(skip=True)
 
-        conflicts = []
+        # Collect "<name>" stems that may be expressed as either a file or a
+        # package, from two structure shapes:
+        #   - "<name>.py" with `can_be_folder: true` (e.g. models.py)
+        #   - "<name>/__init__.py"                   (e.g. logic/__init__.py)
+        # Any package init file in the canonical structure (facade, presentation,
+        # tasks, tests, ...) qualifies; this also catches a stray `tasks.py`
+        # next to `tasks/`, which is always a mistake.
+        stems: set[str] = set()
         for path, config in flatten_structure(ctx.structure.get("backend_files", {})).items():
-            # Pattern A: structure declares "logic.py" with can_be_folder — twin is "logic/"
             if config.get("can_be_folder", False) and path.endswith(".py"):
-                folder_form = path[: -len(".py")]
-                if (ctx.backend_dir / path).exists() and (ctx.backend_dir / folder_form).exists():
-                    conflicts.append(f"Both 'backend/{path}' and 'backend/{folder_form}/' exist — pick one")
-            # Pattern B: structure declares "logic/__init__.py" (package) — twin is "logic.py"
+                stems.add(path[: -len(".py")])
             elif path.endswith("/__init__.py"):
-                folder_form = path[: -len("/__init__.py")]
-                file_twin = folder_form + ".py"
-                if (ctx.backend_dir / path).exists() and (ctx.backend_dir / file_twin).exists():
-                    conflicts.append(f"Both 'backend/{file_twin}' and 'backend/{folder_form}/' exist — pick one")
+                stems.add(path[: -len("/__init__.py")])
+
+        # Conflict if both `<stem>.py` and `<stem>/` directory exist on disk.
+        # Check the directory itself (not `__init__.py`) so a half-migrated state
+        # without `__init__.py` is still flagged.
+        conflicts = []
+        for stem in sorted(stems):
+            file_form = ctx.backend_dir / f"{stem}.py"
+            dir_form = ctx.backend_dir / stem
+            if file_form.is_file() and dir_form.is_dir():
+                conflicts.append(f"Both 'backend/{stem}.py' and 'backend/{stem}/' exist — pick one")
 
         if conflicts:
             return CheckResult(

--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -323,10 +323,17 @@ class FileFolderConflictsCheck(ProductCheck):
 
         conflicts = []
         for path, config in flatten_structure(ctx.structure.get("backend_files", {})).items():
-            if not config.get("can_be_folder", False):
-                continue
-            if (ctx.backend_dir / path).exists() and (ctx.backend_dir / path.replace(".py", "")).exists():
-                conflicts.append(f"Both 'backend/{path}' and 'backend/{path.replace('.py', '/')}' exist — pick one")
+            # Pattern A: structure declares "logic.py" with can_be_folder — twin is "logic/"
+            if config.get("can_be_folder", False) and path.endswith(".py"):
+                folder_form = path[: -len(".py")]
+                if (ctx.backend_dir / path).exists() and (ctx.backend_dir / folder_form).exists():
+                    conflicts.append(f"Both 'backend/{path}' and 'backend/{folder_form}/' exist — pick one")
+            # Pattern B: structure declares "logic/__init__.py" (package) — twin is "logic.py"
+            elif path.endswith("/__init__.py"):
+                folder_form = path[: -len("/__init__.py")]
+                file_twin = folder_form + ".py"
+                if (ctx.backend_dir / path).exists() and (ctx.backend_dir / file_twin).exists():
+                    conflicts.append(f"Both 'backend/{file_twin}' and 'backend/{folder_form}/' exist — pick one")
 
         if conflicts:
             return CheckResult(

--- a/tools/hogli-commands/hogli_commands/product_structure.yaml
+++ b/tools/hogli-commands/hogli_commands/product_structure.yaml
@@ -117,16 +117,23 @@ backend_files:
             # - Do not use ForeignKeys to models outside this app unless allowed, as you will make implicit dependencies.
             # - If you make a ForeignKey to a common model, disallow reverse relations with related_name='+'
 
-    logic.py:
-        required: false
-        can_be_folder: true
-        template: |
-            """
-            Business logic for {product}.
+    logic/:
+        # Scaffolded as a package because business logic tends to grow fast and
+        # splitting a single logic.py later is more churn than starting with a
+        # package. Single-file logic.py is still allowed (see can_be_folder
+        # handling in FileFolderConflictsCheck) for legacy products.
+        __init__.py:
+            required: false
+            template: |
+                """
+                Business logic for {product}.
 
-            Validation, calculations, business rules, ORM queries.
-            Called by facade/api.py.
-            """
+                Validation, calculations, business rules, ORM queries.
+                Called by facade/api.py.
+
+                Split into submodules (e.g. logic/queries.py, logic/rules.py)
+                as this grows.
+                """
 
     tasks/:
         __init__.py:

--- a/tools/hogli-commands/hogli_commands/product_structure.yaml
+++ b/tools/hogli-commands/hogli_commands/product_structure.yaml
@@ -120,8 +120,9 @@ backend_files:
     logic/:
         # Scaffolded as a package because business logic tends to grow fast and
         # splitting a single logic.py later is more churn than starting with a
-        # package. Single-file logic.py is still allowed (see can_be_folder
-        # handling in FileFolderConflictsCheck) for legacy products.
+        # package. Legacy products with a flat logic.py are still fine — it's
+        # not a required file. FileFolderConflictsCheck only complains if
+        # logic.py and logic/ both exist in the same product.
         __init__.py:
             required: false
             template: |

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -10,6 +10,7 @@ import pytest
 from hogli_commands.product import gh as gh_module
 from hogli_commands.product.checks import (
     CheckContext,
+    FileFolderConflictsCheck,
     PackageJsonScriptsCheck,
     ProductYamlCheck,
     ProductYamlOwnersCheck,
@@ -577,3 +578,87 @@ class TestProductYamlOwnersCheck:
         monkeypatch.setattr(gh_module, "_fetch_err", "gh CLI not found")
         result = owners_check.run(ctx)
         assert not result.issues
+
+
+# ---------------------------------------------------------------------------
+# FileFolderConflictsCheck — file vs package twin detection
+# ---------------------------------------------------------------------------
+
+# Structure mirrors product_structure.yaml: logic is a package, models can be
+# either a file or folder. Tests exercise both shapes plus a stray-twin case.
+_CONFLICT_STRUCTURE = {
+    "backend_files": {
+        "models.py": {"can_be_folder": True},
+        "logic/": {"__init__.py": {}},
+        "tasks/": {"__init__.py": {}},
+    },
+}
+
+conflict_check = FileFolderConflictsCheck()
+
+
+def _make_backend(tmp_path: Path, files: list[str]) -> CheckContext:
+    """Create a product with the given files/dirs under backend/. Trailing '/' = directory."""
+    product_dir = tmp_path / "p"
+    backend = product_dir / "backend"
+    backend.mkdir(parents=True)
+    for f in files:
+        target = backend / f.rstrip("/")
+        if f.endswith("/"):
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("")
+    return CheckContext(
+        name="p",
+        product_dir=product_dir,
+        backend_dir=backend,
+        is_isolated=False,
+        structure=_CONFLICT_STRUCTURE,
+        detailed=False,
+    )
+
+
+class TestFileFolderConflictsCheck:
+    def test_skip_when_no_backend(self, tmp_path: Path) -> None:
+        product_dir = tmp_path / "p"
+        product_dir.mkdir()
+        ctx = CheckContext(
+            name="p",
+            product_dir=product_dir,
+            backend_dir=product_dir / "backend",
+            is_isolated=False,
+            structure=_CONFLICT_STRUCTURE,
+            detailed=False,
+        )
+        assert conflict_check.run(ctx).skip is True
+
+    @pytest.mark.parametrize(
+        "files, expect_conflicts",
+        [
+            # Pattern A (can_be_folder): models.py only / models/ only — both fine
+            (["models.py"], []),
+            (["models/"], []),
+            (["models.py", "models/"], ["models.py"]),
+            # Pattern B (package init): logic.py only / logic/ only — both fine
+            (["logic/__init__.py"], []),
+            (["logic.py"], []),
+            (["logic/"], []),  # half-migrated package without __init__.py
+            (["logic.py", "logic/__init__.py"], ["logic.py"]),
+            (["logic.py", "logic/"], ["logic.py"]),  # __init__.py absent — still flagged
+            # Pattern B also covers other canonical packages — stray tasks.py is a mistake
+            (["tasks/__init__.py"], []),
+            (["tasks.py", "tasks/__init__.py"], ["tasks.py"]),
+            # Multiple conflicts at once
+            (["logic.py", "logic/", "models.py", "models/"], ["logic.py", "models.py"]),
+        ],
+    )
+    def test_conflict_detection(self, tmp_path: Path, files: list[str], expect_conflicts: list[str]) -> None:
+        ctx = _make_backend(tmp_path, files)
+        result = conflict_check.run(ctx)
+        if not expect_conflicts:
+            assert not result.issues, f"unexpected conflicts: {result.issues}"
+            return
+        assert len(result.issues) == len(expect_conflicts)
+        for stem in expect_conflicts:
+            assert any(f"backend/{stem}" in i and f"backend/{stem[:-3]}/" in i for i in result.issues), result.issues


### PR DESCRIPTION
## Problem

`hogli product:bootstrap` scaffolds `backend/logic.py` as a single file. Logic tends to grow fast (see `legal_documents/backend/logic/` which already split into `pandadoc.py`, `slack.py`, etc.), and going from a single file to a package later is more churn than starting as a package.

## Changes

- Scaffold `backend/logic/__init__.py` (package) instead of `backend/logic.py`. Same docstring template, plus a hint to split into submodules as it grows.
- `FileFolderConflictsCheck` now handles both shapes — declared as `logic.py` with `can_be_folder` (legacy) or as `logic/__init__.py` (new). Lint still flags a stray `logic.py` left next to a `logic/` package.
- tach is unaffected — module paths cover both file and package forms. `MisplacedFilesCheck._KNOWN_DIRS` already lists `logic`.

## How did you test this code?

I'm an agent. Ran the existing hogli check tests (61 passed) and dry-ran `hogli product:bootstrap test_logic_pkg --dry-run` to verify `backend/logic/__init__.py` is created. Also ran `hogli product:lint legal_documents` (uses `logic/` package) and `hogli product:lint surveys` (uses `logic.py`) — both pass. No manual end-to-end product creation tested.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) at the user's request. Reviewer should sanity-check the conflict-check edit covers both shape variants and that the docstring template still reads well as a package `__init__.py`.