### PR TITLE
fix(experiments): Expose query parameters for list endpoint (API, MCP)

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -470,6 +470,59 @@ class CopyExperimentToProjectSerializer(serializers.Serializer):
     # GET /experiments/ — DRF mixin, filtering via ExperimentService.filter_experiments_queryset
     list=extend_schema(
         description="List experiments for the current project. Supports filtering by status and archival state.",
+        parameters=[
+            OpenApiParameter(
+                name="status",
+                location=OpenApiParameter.QUERY,
+                type=str,
+                enum=["draft", "running", "paused", "stopped", "complete", "all"],
+                description=(
+                    'Filter by experiment status. "running" and "paused" are mutually exclusive: "running" returns '
+                    'launched experiments with an active feature flag, "paused" returns launched experiments whose '
+                    'feature flag is deactivated. "complete" is an alias for "stopped". "all" disables status '
+                    "filtering."
+                ),
+                required=False,
+            ),
+            OpenApiParameter(
+                name="archived",
+                location=OpenApiParameter.QUERY,
+                type=bool,
+                description="Filter by archived state. Defaults to non-archived experiments only.",
+                required=False,
+            ),
+            OpenApiParameter(
+                name="feature_flag_id",
+                location=OpenApiParameter.QUERY,
+                type=int,
+                description="Filter to experiments linked to the given feature flag ID.",
+                required=False,
+            ),
+            OpenApiParameter(
+                name="created_by_id",
+                location=OpenApiParameter.QUERY,
+                type=int,
+                description="Filter to experiments created by the given user ID.",
+                required=False,
+            ),
+            OpenApiParameter(
+                name="search",
+                location=OpenApiParameter.QUERY,
+                type=str,
+                description="Free-text search applied to the experiment name (case-insensitive).",
+                required=False,
+            ),
+            OpenApiParameter(
+                name="order",
+                location=OpenApiParameter.QUERY,
+                type=str,
+                description=(
+                    "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, "
+                    "created_at, updated_at, start_date, end_date, duration, and status."
+                ),
+                required=False,
+            ),
+        ],
     ),
     # DELETE /experiments/{id}/
     # Logic and API docs defined in posthog/api/forbid_destroy_model.py (hard delete not allowed)

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -753,6 +753,18 @@ export type ExperimentSavedMetricsListParams = {
 
 export type ExperimentsListParams = {
     /**
+     * Filter by archived state. Defaults to non-archived experiments only.
+     */
+    archived?: boolean
+    /**
+     * Filter to experiments created by the given user ID.
+     */
+    created_by_id?: number
+    /**
+     * Filter to experiments linked to the given feature flag ID.
+     */
+    feature_flag_id?: number
+    /**
      * Number of results to return per page.
      */
     limit?: number
@@ -760,7 +772,30 @@ export type ExperimentsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+    /**
+     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.
+     */
+    order?: string
+    /**
+     * Free-text search applied to the experiment name (case-insensitive).
+     */
+    search?: string
+    /**
+     * Filter by experiment status. "running" and "paused" are mutually exclusive: "running" returns launched experiments with an active feature flag, "paused" returns launched experiments whose feature flag is deactivated. "complete" is an alias for "stopped". "all" disables status filtering.
+     */
+    status?: ExperimentsListStatus
 }
+
+export type ExperimentsListStatus = (typeof ExperimentsListStatus)[keyof typeof ExperimentsListStatus]
+
+export const ExperimentsListStatus = {
+    All: 'all',
+    Complete: 'complete',
+    Draft: 'draft',
+    Paused: 'paused',
+    Running: 'running',
+    Stopped: 'stopped',
+} as const
 
 export type ExperimentsTimeseriesResultsRetrieveParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -42185,6 +42185,18 @@ export namespace Schemas {
 
     export type ExperimentsListParams = {
     /**
+     * Filter by archived state. Defaults to non-archived experiments only.
+     */
+    archived?: boolean;
+    /**
+     * Filter to experiments created by the given user ID.
+     */
+    created_by_id?: number;
+    /**
+     * Filter to experiments linked to the given feature flag ID.
+     */
+    feature_flag_id?: number;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -42192,7 +42204,31 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.
+     */
+    order?: string;
+    /**
+     * Free-text search applied to the experiment name (case-insensitive).
+     */
+    search?: string;
+    /**
+     * Filter by experiment status. "running" and "paused" are mutually exclusive: "running" returns launched experiments with an active feature flag, "paused" returns launched experiments whose feature flag is deactivated. "complete" is an alias for "stopped". "all" disables status filtering.
+     */
+    status?: ExperimentsListStatus;
     };
+
+    export type ExperimentsListStatus = typeof ExperimentsListStatus[keyof typeof ExperimentsListStatus];
+
+
+    export const ExperimentsListStatus = {
+      All: 'all',
+      Complete: 'complete',
+      Draft: 'draft',
+      Paused: 'paused',
+      Running: 'running',
+      Stopped: 'stopped',
+    } as const;
 
     export type ExperimentsTimeseriesResultsRetrieveParams = {
     /**

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -20,8 +20,24 @@ export const ExperimentsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const ExperimentsListQueryParams = /* @__PURE__ */ zod.object({
+    archived: zod.boolean().optional().describe('Filter by archived state. Defaults to non-archived experiments only.'),
+    created_by_id: zod.number().optional().describe('Filter to experiments created by the given user ID.'),
+    feature_flag_id: zod.number().optional().describe('Filter to experiments linked to the given feature flag ID.'),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order: zod
+        .string()
+        .optional()
+        .describe(
+            "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status."
+        ),
+    search: zod.string().optional().describe('Free-text search applied to the experiment name (case-insensitive).'),
+    status: zod
+        .enum(['all', 'complete', 'draft', 'paused', 'running', 'stopped'])
+        .optional()
+        .describe(
+            'Filter by experiment status. "running" and "paused" are mutually exclusive: "running" returns launched experiments with an active feature flag, "paused" returns launched experiments whose feature flag is deactivated. "complete" is an alias for "stopped". "all" disables status filtering.'
+        ),
 })
 
 /**

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -276,7 +276,11 @@ const experimentLaunch = (): ToolBase<typeof ExperimentLaunchSchema, WithPostHog
         },
     })
 
-const ExperimentListSchema = ExperimentsListQueryParams
+const ExperimentListSchema = ExperimentsListQueryParams.extend({
+    status: ExperimentsListQueryParams.shape['status'].describe(
+        'Filter by experiment status. Values: "draft" (not yet launched), "running" (launched, flag active), "paused" (launched, flag deactivated — mutually exclusive with running), "stopped" or "complete" (both mean ended), "all" (no filter). Defaults to all non-archived experiments.'
+    ),
+})
 
 const experimentList = (): ToolBase<typeof ExperimentListSchema, WithPostHogUrl<Schemas.PaginatedExperimentList>> =>
     withUiApp('experiment-list', {
@@ -288,8 +292,14 @@ const experimentList = (): ToolBase<typeof ExperimentListSchema, WithPostHogUrl<
                 method: 'GET',
                 path: `/api/projects/${encodeURIComponent(String(projectId))}/experiments/`,
                 query: {
+                    archived: params.archived,
+                    created_by_id: params.created_by_id,
+                    feature_flag_id: params.feature_flag_id,
                     limit: params.limit,
                     offset: params.offset,
+                    order: params.order,
+                    search: params.search,
+                    status: params.status,
                 },
             })
             const filtered = {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-get-all.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-get-all.json
@@ -1,6 +1,18 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "archived": {
+            "description": "Filter by archived state. Defaults to non-archived experiments only.",
+            "type": "boolean"
+        },
+        "created_by_id": {
+            "description": "Filter to experiments created by the given user ID.",
+            "type": "number"
+        },
+        "feature_flag_id": {
+            "description": "Filter to experiments linked to the given feature flag ID.",
+            "type": "number"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"
@@ -8,6 +20,19 @@
         "offset": {
             "description": "The initial index from which to return the results.",
             "type": "number"
+        },
+        "order": {
+            "description": "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.",
+            "type": "string"
+        },
+        "search": {
+            "description": "Free-text search applied to the experiment name (case-insensitive).",
+            "type": "string"
+        },
+        "status": {
+            "description": "Filter by experiment status. Values: \"draft\" (not yet launched), \"running\" (launched, flag active), \"paused\" (launched, flag deactivated — mutually exclusive with running), \"stopped\" or \"complete\" (both mean ended), \"all\" (no filter). Defaults to all non-archived experiments.",
+            "enum": ["all", "complete", "draft", "paused", "running", "stopped"],
+            "type": "string"
         }
     },
     "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-list.json
@@ -1,6 +1,18 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "archived": {
+            "description": "Filter by archived state. Defaults to non-archived experiments only.",
+            "type": "boolean"
+        },
+        "created_by_id": {
+            "description": "Filter to experiments created by the given user ID.",
+            "type": "number"
+        },
+        "feature_flag_id": {
+            "description": "Filter to experiments linked to the given feature flag ID.",
+            "type": "number"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"
@@ -8,6 +20,19 @@
         "offset": {
             "description": "The initial index from which to return the results.",
             "type": "number"
+        },
+        "order": {
+            "description": "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.",
+            "type": "string"
+        },
+        "search": {
+            "description": "Free-text search applied to the experiment name (case-insensitive).",
+            "type": "string"
+        },
+        "status": {
+            "description": "Filter by experiment status. Values: \"draft\" (not yet launched), \"running\" (launched, flag active), \"paused\" (launched, flag deactivated — mutually exclusive with running), \"stopped\" or \"complete\" (both mean ended), \"all\" (no filter). Defaults to all non-archived experiments.",
+            "enum": ["all", "complete", "draft", "paused", "running", "stopped"],
+            "type": "string"
         }
     },
     "type": "object"


### PR DESCRIPTION
## Problem

The experiments list endpoint accepts query params (`status`, `archived`, `feature_flag_id`, `created_by_id`, `search`, `order`) but never declared them in OpenAPI. The MCP `experiment-list` tool's input schema only exposed `limit`/`offset`, so agents couldn't filter, even though tool descriptions claimed they could.

(It was of course possible to filter client-side, so this is just a hygiene fix)

## Changes

- Added params to schema

## How did you test this code?

- Tested with local MCP, does use new params

## Publish to changelog?

no