### PR TITLE
feat(visual-review): Add Co-authored-by trailer when approver has personal GitHub integration

### DIFF
--- a/posthog/models/user_integration.py
+++ b/posthog/models/user_integration.py
@@ -138,6 +138,19 @@ class UserGitHubIntegration(GitHubIntegrationBase):
             return int(gh_id) if gh_id is not None else None
         return None
 
+    @property
+    def coauthor_trailer(self) -> str | None:
+        """`Co-authored-by` trailer for git commits attributed to this GitHub user.
+
+        Uses GitHub's `<id>+<login>@users.noreply.github.com` format so attribution
+        works regardless of the user's email privacy settings.
+        """
+        login = self.github_login
+        gh_id = self.github_id
+        if not login or gh_id is None:
+            return None
+        return f"Co-authored-by: {login} <{gh_id}+{login}@users.noreply.github.com>"
+
     # --- User-to-server token ---
 
     @property

--- a/posthog/models/user_integration.py
+++ b/posthog/models/user_integration.py
@@ -143,10 +143,17 @@ class UserGitHubIntegration(GitHubIntegrationBase):
         """`Co-authored-by` trailer for git commits attributed to this GitHub user.
 
         Uses GitHub's `<id>+<login>@users.noreply.github.com` format so attribution
-        works regardless of the user's email privacy settings.
+        works regardless of the user's email privacy settings. Returns None if the
+        stored identity is incomplete or malformed — co-author attribution is
+        optional and must not abort the caller.
         """
         login = self.github_login
-        gh_id = self.github_id
+        github_user = self.integration.config.get("github_user")
+        raw_id = github_user.get("id") if isinstance(github_user, dict) else None
+        try:
+            gh_id = int(raw_id) if raw_id is not None else None
+        except (TypeError, ValueError):
+            return None
         if not login or gh_id is None:
             return None
         return f"Co-authored-by: {login} <{gh_id}+{login}@users.noreply.github.com>"

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1382,7 +1382,25 @@ def _post_commit_status(
         logger.warning("visual_review.status_check_error", run_id=str(run.id), exc_info=True)
 
 
-def _commit_baseline_to_github(run: Run, repo: Repo, approved_snapshots: list[dict]) -> dict:
+def _get_coauthor_trailer(user_id: int, installation_id: str) -> str | None:
+    """Return a `Co-authored-by` trailer for the approver, if they have a personal
+    GitHub integration for the same installation. Returns None when no match exists.
+    """
+    from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
+
+    user_integration = UserIntegration.objects.filter(
+        user_id=user_id,
+        kind=UserIntegration.IntegrationKind.GITHUB,
+        integration_id=installation_id,
+    ).first()
+    if user_integration is None:
+        return None
+    return UserGitHubIntegration(user_integration).coauthor_trailer
+
+
+def _commit_baseline_to_github(
+    run: Run, repo: Repo, approved_snapshots: list[dict], approver_user_id: int | None = None
+) -> dict:
     """
     Commit updated baseline file to GitHub.
 
@@ -1435,6 +1453,12 @@ def _commit_baseline_to_github(run: Run, repo: Repo, approved_snapshots: list[di
         parts.append(f"{removed_count} removed")
     summary = ", ".join(parts)
     commit_message = f"chore(visual): update {run.run_type} baselines\n\n{summary}\nRun: {run.id}"
+
+    installation_id = github.integration.integration_id
+    if approver_user_id is not None and isinstance(installation_id, str) and installation_id:
+        trailer = _get_coauthor_trailer(approver_user_id, installation_id)
+        if trailer:
+            commit_message = f"{commit_message}\n\n{trailer}"
 
     result = github.update_file(
         repository=repo_name,
@@ -1684,7 +1708,7 @@ def approve_run(
 
     # Commit to GitHub first — do this before DB changes so we can fail cleanly
     if commit_to_github and run.pr_number and repo.repo_full_name:
-        _commit_baseline_to_github(run, repo, approved_snapshots)
+        _commit_baseline_to_github(run, repo, approved_snapshots, approver_user_id=user_id)
 
     # Mark approved snapshots
     now = timezone.now()

--- a/products/visual_review/backend/tests/test_github_integration.py
+++ b/products/visual_review/backend/tests/test_github_integration.py
@@ -484,6 +484,79 @@ class TestGitHubCommitOnApprove:
 
         assert "newer commits" in str(exc_info.value)
 
+    def test_approve_adds_coauthor_trailer_when_user_has_personal_integration(
+        self,
+        local_git_repo,
+        mock_github_api,
+        mock_github_integration,
+        vr_project_with_github,
+        run_with_changes,
+        user,
+    ):
+        """Approver's personal GitHub integration should be added as Co-authored-by on the bot commit."""
+        from posthog.models.user_integration import UserIntegration
+
+        # Pin the team integration's installation_id so UserIntegration lookup matches
+        mock_github_integration.integration_id = "12345"
+
+        UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+            integration_id="12345",
+            config={"github_user": {"login": "octocat", "id": 583231}},
+            sensitive_config={"user_access_token": "ghu_fake"},
+        )
+
+        run = run_with_changes
+        approved = [{"identifier": "button--primary", "new_hash": "abc123hash"}]
+
+        logic.approve_run(
+            run_id=run.id,
+            user_id=user.id,
+            approved_snapshots=approved,
+            commit_to_github=True,
+        )
+
+        log_result = subprocess.run(
+            ["git", "log", "--format=%B", "-1"],
+            cwd=local_git_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "Co-authored-by: octocat <583231+octocat@users.noreply.github.com>" in log_result.stdout
+
+    def test_approve_without_personal_integration_omits_trailer(
+        self,
+        local_git_repo,
+        mock_github_api,
+        mock_github_integration,
+        vr_project_with_github,
+        run_with_changes,
+        user,
+    ):
+        """If the approver has no personal GitHub integration, no trailer is added."""
+        mock_github_integration.integration_id = "12345"
+
+        run = run_with_changes
+        approved = [{"identifier": "button--primary", "new_hash": "abc123hash"}]
+
+        logic.approve_run(
+            run_id=run.id,
+            user_id=user.id,
+            approved_snapshots=approved,
+            commit_to_github=True,
+        )
+
+        log_result = subprocess.run(
+            ["git", "log", "--format=%B", "-1"],
+            cwd=local_git_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "Co-authored-by:" not in log_result.stdout
+
     def test_approve_without_github_skips_commit(
         self,
         vr_project_with_github,

--- a/products/visual_review/backend/tests/test_github_integration.py
+++ b/products/visual_review/backend/tests/test_github_integration.py
@@ -484,7 +484,14 @@ class TestGitHubCommitOnApprove:
 
         assert "newer commits" in str(exc_info.value)
 
-    def test_approve_adds_coauthor_trailer_when_user_has_personal_integration(
+    @pytest.mark.parametrize(
+        "create_user_integration,expected_trailer",
+        [
+            (True, "Co-authored-by: octocat <583231+octocat@users.noreply.github.com>"),
+            (False, None),
+        ],
+    )
+    def test_approve_coauthor_trailer(
         self,
         local_git_repo,
         mock_github_api,
@@ -492,70 +499,42 @@ class TestGitHubCommitOnApprove:
         vr_project_with_github,
         run_with_changes,
         user,
+        create_user_integration,
+        expected_trailer,
     ):
-        """Approver's personal GitHub integration should be added as Co-authored-by on the bot commit."""
+        """Bot commit gets a Co-authored-by trailer iff the approver has a matching personal integration."""
         from posthog.models.user_integration import UserIntegration
 
-        # Pin the team integration's installation_id so UserIntegration lookup matches
+        # Pin the team integration's installation_id so UserIntegration lookup can match
         mock_github_integration.integration_id = "12345"
 
-        UserIntegration.objects.create(
-            user=user,
-            kind=UserIntegration.IntegrationKind.GITHUB,
-            integration_id="12345",
-            config={"github_user": {"login": "octocat", "id": 583231}},
-            sensitive_config={"user_access_token": "ghu_fake"},
-        )
-
-        run = run_with_changes
-        approved = [{"identifier": "button--primary", "new_hash": "abc123hash"}]
+        if create_user_integration:
+            UserIntegration.objects.create(
+                user=user,
+                kind=UserIntegration.IntegrationKind.GITHUB,
+                integration_id="12345",
+                config={"github_user": {"login": "octocat", "id": 583231}},
+                sensitive_config={"user_access_token": "ghu_fake"},
+            )
 
         logic.approve_run(
-            run_id=run.id,
+            run_id=run_with_changes.id,
             user_id=user.id,
-            approved_snapshots=approved,
+            approved_snapshots=[{"identifier": "button--primary", "new_hash": "abc123hash"}],
             commit_to_github=True,
         )
 
-        log_result = subprocess.run(
+        log = subprocess.run(
             ["git", "log", "--format=%B", "-1"],
             cwd=local_git_repo,
             capture_output=True,
             text=True,
             check=True,
-        )
-        assert "Co-authored-by: octocat <583231+octocat@users.noreply.github.com>" in log_result.stdout
-
-    def test_approve_without_personal_integration_omits_trailer(
-        self,
-        local_git_repo,
-        mock_github_api,
-        mock_github_integration,
-        vr_project_with_github,
-        run_with_changes,
-        user,
-    ):
-        """If the approver has no personal GitHub integration, no trailer is added."""
-        mock_github_integration.integration_id = "12345"
-
-        run = run_with_changes
-        approved = [{"identifier": "button--primary", "new_hash": "abc123hash"}]
-
-        logic.approve_run(
-            run_id=run.id,
-            user_id=user.id,
-            approved_snapshots=approved,
-            commit_to_github=True,
-        )
-
-        log_result = subprocess.run(
-            ["git", "log", "--format=%B", "-1"],
-            cwd=local_git_repo,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        assert "Co-authored-by:" not in log_result.stdout
+        ).stdout
+        if expected_trailer:
+            assert expected_trailer in log
+        else:
+            assert "Co-authored-by:" not in log
 
     def test_approve_without_github_skips_commit(
         self,


### PR DESCRIPTION
## Problem

When a user approves visual review changes and commits them to GitHub, the commit should attribute the approver as a co-author if they have a personal GitHub integration configured for the same installation. This provides proper attribution in the git history.

## Changes

- Added `_get_coauthor_trailer()` function in `logic.py` that looks up a user's personal GitHub integration and generates a `Co-authored-by` trailer in GitHub's standard format (`<id>+<login>@users.noreply.github.com`)
- Added `coauthor_trailer` property to `UserGitHubIntegration` class that formats the trailer string using the user's GitHub login and ID
- Modified `_commit_baseline_to_github()` to accept an optional `approver_user_id` parameter and append the co-author trailer to the commit message when available
- Updated `approve_run()` to pass the user ID when committing to GitHub
- Added comprehensive test coverage:
  - `test_approve_adds_coauthor_trailer_when_user_has_personal_integration`: Verifies the trailer is added when a personal integration exists
  - `test_approve_without_personal_integration_omits_trailer`: Verifies no trailer is added when no personal integration exists

## How did you test this code?

Added two new test cases that verify:
1. When an approver has a personal GitHub integration for the same installation, the `Co-authored-by` trailer is correctly appended to the commit message
2. When an approver has no personal GitHub integration, no trailer is added to the commit message

Both tests verify the actual git commit message using `git log`, ensuring the implementation works end-to-end.

## Publish to changelog?

no

https://claude.ai/code/session_015pcP7Qsoo6njEhYSQa6f7s