### PR TITLE
chore(hog-charts): colocate tests and stories with components

### DIFF
--- a/common/storybook/storybook-timings.json
+++ b/common/storybook/storybook-timings.json
@@ -268,7 +268,7 @@
         "chromium": 2.181,
         "webkit": 2.152
     },
-    "frontend/src/lib/hog-charts/ReferenceLine.stories.tsx": {
+    "frontend/src/lib/hog-charts/overlays/ReferenceLine.stories.tsx": {
         "chromium": 20.109,
         "webkit": 3.433
     },

--- a/frontend/src/lib/hog-charts/charts/ConfidenceIntervals.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/ConfidenceIntervals.stories.tsx
@@ -4,7 +4,7 @@ import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import { ciRanges } from 'lib/statistics'
 
-import { Stage, useReactiveTheme } from './story-helpers'
+import { Stage, useReactiveTheme } from '../story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 

--- a/frontend/src/lib/hog-charts/charts/LineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.stories.tsx
@@ -4,7 +4,7 @@ import { LineChart, ReferenceLine, ValueLabels } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import { ciRanges, trendLine } from 'lib/statistics'
 
-import { playHoverAtFraction, Stage, useReactiveTheme } from './story-helpers'
+import { playHoverAtFraction, Stage, useReactiveTheme } from '../story-helpers'
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 const BASIC: LineChartConfig = { showGrid: true }

--- a/frontend/src/lib/hog-charts/charts/TrendLines.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TrendLines.stories.tsx
@@ -4,7 +4,7 @@ import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import { trendLine } from 'lib/statistics'
 
-import { Stage, useReactiveTheme } from './story-helpers'
+import { Stage, useReactiveTheme } from '../story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3'
 
-import { drawArea, drawGrid, drawLine, type DrawContext } from '../core/canvas-renderer'
-import type { ChartDimensions, Series } from '../core/types'
+import { drawArea, drawGrid, drawLine, type DrawContext } from './canvas-renderer'
+import type { ChartDimensions, Series } from './types'
 
 const dimensions: ChartDimensions = {
     width: 800,

--- a/frontend/src/lib/hog-charts/core/chart-context.test.tsx
+++ b/frontend/src/lib/hog-charts/core/chart-context.test.tsx
@@ -1,9 +1,9 @@
 import { act, cleanup, render } from '@testing-library/react'
 import React, { useState } from 'react'
 
-import { ChartHoverContext, ChartLayoutContext, useChart, useChartHover, useChartLayout } from '../chart-context'
-import type { ChartLayoutContextValue } from '../chart-context'
-import type { ChartTheme } from '../types'
+import { ChartHoverContext, ChartLayoutContext, useChart, useChartHover, useChartLayout } from './chart-context'
+import type { ChartLayoutContextValue } from './chart-context'
+import type { ChartTheme } from './types'
 
 const THEME: ChartTheme = { colors: ['#000'], backgroundColor: '#ffffff' }
 

--- a/frontend/src/lib/hog-charts/core/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.test.ts
@@ -1,6 +1,6 @@
+import { dimensions, makeSeries } from '../test-helpers'
 import { buildPointClickData, buildTooltipContext, findNearestIndex, isInPlotArea } from './interaction'
 import type { ResolveValueFn } from './types'
-import { dimensions, makeSeries } from '../test-helpers'
 
 const defaultResolveValue: ResolveValueFn = (s, i) => s.data[i]
 

--- a/frontend/src/lib/hog-charts/core/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.test.ts
@@ -1,5 +1,5 @@
-import { buildPointClickData, buildTooltipContext, findNearestIndex, isInPlotArea } from '../core/interaction'
-import type { ResolveValueFn } from '../core/types'
+import { buildPointClickData, buildTooltipContext, findNearestIndex, isInPlotArea } from './interaction'
+import type { ResolveValueFn } from './types'
 import { dimensions, makeSeries } from '../test-helpers'
 
 const defaultResolveValue: ResolveValueFn = (s, i) => s.data[i]

--- a/frontend/src/lib/hog-charts/core/scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/scales.test.ts
@@ -6,8 +6,8 @@ import {
     createXScale,
     createYScale,
     yTickCountForHeight,
-} from '../core/scales'
-import { DEFAULT_Y_AXIS_ID } from '../core/types'
+} from './scales'
+import { DEFAULT_Y_AXIS_ID } from './types'
 import { dimensions, makeSeries } from '../test-helpers'
 
 describe('hog-charts scales', () => {

--- a/frontend/src/lib/hog-charts/core/scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/scales.test.ts
@@ -1,3 +1,4 @@
+import { dimensions, makeSeries } from '../test-helpers'
 import {
     autoFormatYTick,
     computePercentStackData,
@@ -8,7 +9,6 @@ import {
     yTickCountForHeight,
 } from './scales'
 import { DEFAULT_Y_AXIS_ID } from './types'
-import { dimensions, makeSeries } from '../test-helpers'
 
 describe('hog-charts scales', () => {
     describe('createXScale', () => {

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.stories.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { LineChart, ReferenceLine } from 'lib/hog-charts'
 import type { LineChartConfig, ReferenceLineFillSide, ReferenceLineVariant, Series } from 'lib/hog-charts'
 
-import { Stage, useReactiveTheme } from './story-helpers'
+import { Stage, useReactiveTheme } from '../story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.stories.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { LineChart, ValueLabels } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 
-import { Stage, useReactiveTheme } from './story-helpers'
+import { Stage, useReactiveTheme } from '../story-helpers'
 
 const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 


### PR DESCRIPTION
## Problem

Tests and stories in `frontend/src/lib/hog-charts/` were split between `__tests__/` folders and the package root, away from the components they cover. This makes them harder to discover and maintain.

## Changes

Moves test files out of `__tests__/` folders and stories from the package root next to the components they cover.

- Tests:
  - `__tests__/canvas-renderer.test.ts` → `core/canvas-renderer.test.ts`
  - `__tests__/interaction.test.ts` → `core/interaction.test.ts`
  - `__tests__/scales.test.ts` → `core/scales.test.ts`
  - `core/__tests__/chart-context.test.tsx` → `core/chart-context.test.tsx`
- Stories:
  - `LineChart.stories.tsx`, `ConfidenceIntervals.stories.tsx`, `TrendLines.stories.tsx` → `charts/`
  - `ReferenceLine.stories.tsx`, `ValueLabels.stories.tsx` → `overlays/`
- Both `__tests__/` directories removed.
- Shared `story-helpers.tsx` and `test-helpers.ts` stay at the package root — they are utility modules, and `test-helpers.ts` is imported from outside `hog-charts`.
- Relative imports updated accordingly.

`ConfidenceIntervals` and `TrendLines` stories don't have a 1:1 component — they demo `LineChart` features, so they sit next to `LineChart.tsx` in `charts/`.

## How did you test this code?

I'm an agent. I did not run jest in this environment (`node_modules` weren't installed). Verified statically that all relative imports resolve to existing files. Recommend running `pnpm jest -- --testPathPattern='lib/hog-charts'` and Storybook locally before merging.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code (Task-Id: 88c6d789-3c6c-40cc-9fe7-a27cd2e41ffd). Pure file-move refactor — no behavior changes. No manual testing performed.