### PR TITLE
feat(observability): add per-request pg/ch query count and max to Server-Timing

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -358,12 +358,21 @@ def reset_query_tags():
 
 
 class QueryCounter:
+    SLOW_QUERY_THRESHOLD_S = 0.05
+
     def __init__(self):
         self.total_query_time = 0.0
+        self.count = 0
+        self.max_query_time = 0.0
+        self.slow_count = 0
 
     @property
     def query_time_ms(self):
         return self.total_query_time * 1000
+
+    @property
+    def max_query_time_ms(self):
+        return self.max_query_time * 1000
 
     def __call__(self, execute, *args, **kwargs):
         import time
@@ -373,7 +382,13 @@ class QueryCounter:
         try:
             return execute(*args, **kwargs)
         finally:
-            self.total_query_time += time.perf_counter() - start_time
+            elapsed = time.perf_counter() - start_time
+            self.total_query_time += elapsed
+            self.count += 1
+            if elapsed > self.max_query_time:
+                self.max_query_time = elapsed
+            if elapsed > self.SLOW_QUERY_THRESHOLD_S:
+                self.slow_count += 1
 
 
 @contextmanager

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -447,20 +447,26 @@ class QueryTimeCountingMiddleware:
             response: HttpResponse = self.get_response(request)
 
         response.headers["Server-Timing"] = self._construct_header(
-            django=time.perf_counter() - start_time,
-            pg=pg_query_counter.query_time_ms,
-            pg_count=pg_query_counter.count,
-            pg_max=pg_query_counter.max_query_time_ms,
-            pg_slow=pg_query_counter.slow_count,
-            ch=ch_query_counter.query_time_ms,
-            ch_count=ch_query_counter.count,
-            ch_max=ch_query_counter.max_query_time_ms,
-            ch_slow=ch_query_counter.slow_count,
+            durations={
+                "django": time.perf_counter() - start_time,
+                "pg": pg_query_counter.query_time_ms,
+                "pg_max": pg_query_counter.max_query_time_ms,
+                "ch": ch_query_counter.query_time_ms,
+                "ch_max": ch_query_counter.max_query_time_ms,
+            },
+            counts={
+                "pg_count": pg_query_counter.count,
+                "pg_slow": pg_query_counter.slow_count,
+                "ch_count": ch_query_counter.count,
+                "ch_slow": ch_query_counter.slow_count,
+            },
         )
         return response
 
-    def _construct_header(self, **kwargs):
-        return ", ".join(f"{key};dur={round(duration)}" for key, duration in kwargs.items())
+    def _construct_header(self, durations: dict[str, float], counts: dict[str, int]) -> str:
+        parts = [f"{key};dur={round(value)}" for key, value in durations.items()]
+        parts += [f'{key};desc="{value}"' for key, value in counts.items()]
+        return ", ".join(parts)
 
 
 def shortcircuitmiddleware(f):

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -449,7 +449,13 @@ class QueryTimeCountingMiddleware:
         response.headers["Server-Timing"] = self._construct_header(
             django=time.perf_counter() - start_time,
             pg=pg_query_counter.query_time_ms,
+            pg_count=pg_query_counter.count,
+            pg_max=pg_query_counter.max_query_time_ms,
+            pg_slow=pg_query_counter.slow_count,
             ch=ch_query_counter.query_time_ms,
+            ch_count=ch_query_counter.count,
+            ch_max=ch_query_counter.max_query_time_ms,
+            ch_slow=ch_query_counter.slow_count,
         )
         return response
 


### PR DESCRIPTION
## Problem

The `Server-Timing` header on api responses already includes `pg=<ms>` for total `cursor.execute()` wall-clock on a request. That single number can't disambiguate between:

- **N+1 chain** — many small queries each paying a pgbouncer round-trip
- **One fat query** — a single SELECT taking seconds
- **Pool exhaustion** — many fast queries waiting on transaction-pool checkout

You see them all as 'pg=4000' and have to guess.

## Changes

`QueryCounter` now also tracks per-request:
- `count` — number of `execute()` calls
- `max_query_time` — slowest single execution
- `slow_count` — executions over 50 ms

The middleware emits these alongside the existing fields. Same fields are emitted for both postgres (`pg_*`) and clickhouse (`ch_*`) since the same `QueryCounter` class backs both.

In the browser DevTools Network panel, a slow request now reads like one of:

- `pg=4000 pg_count=47 pg_max=180 pg_slow=2` — N+1
- `pg=4000 pg_count=8 pg_max=3500 pg_slow=1` — one fat query
- `pg=4000 pg_count=12 pg_max=80 pg_slow=0` — pool/network wait

Three different fixes, identifiable in one page reload.

## 🤖 Agent context

Pure observability, no behavior change. Wraps existing `connection.execute_wrapper` so the per-call overhead is two `time.perf_counter()` reads and a few comparisons — negligible.

The `QueryTimeCountingMiddleware` only runs when `CAPTURE_TIME_TO_SEE_DATA` is enabled and the request matches the existing allow-list (`dashboard`, `insight`, `property_definitions`, `properties`, `person`), so this doesn't regress any other endpoint's response shape.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*