### PR TITLE
feat(mcp): exec tool for lovable and replit

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -18,6 +18,13 @@
  * - `isPostHogCodeConsumer()` matches the `x-posthog-mcp-consumer` header
  *   sent by the PostHog Code Tasks wrapper.
  *
+ * - `isVibeCodingClient()` matches the OAuth application name (returned by
+ *   token introspection — see `StateManager._fetchApiKey`). Vibe-coding
+ *   platforms like Lovable and Replit connect through their own OAuth app
+ *   while reporting a generic `clientInfo.name`, so the OAuth name is the
+ *   reliable identifier. Used to force single-exec mode regardless of the
+ *   self-reported MCP client name.
+ *
  * - `capabilities` is a feature-flag-style object describing protocol
  *   features the client actually implements (e.g. `supportsInstructions` —
  *   Codex ignores the `instructions` field returned from `initialize`).
@@ -61,6 +68,15 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
 // emission in single-exec mode. Slack-launched runs send `"slack"` instead.
 export const POSTHOG_CODE_CONSUMER = 'posthog-code'
 
+// OAuth application names (from token introspection) for vibe-coding platforms
+// that should default to single-exec mode. These match against the OAuth
+// `client_name` (the registered OAuth app name in PostHog), not the MCP
+// `clientInfo.name` self-report — those platforms typically connect through a
+// generic MCP client wrapper, so the OAuth name is what reliably identifies
+// the upstream tool. Substring match is case-insensitive and separator-agnostic
+// so "Lovable", "Lovable.dev", "Replit", and "Replit Agent" all resolve.
+export const VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS = ['lovable', 'replit'] as const
+
 export type ClientCapabilities = {
     // MCP `initialize` response includes an `instructions` field that most
     // clients inject into the model's system prompt. Codex discards it, so
@@ -88,12 +104,14 @@ type MCPClientProfileInput = {
     clientName?: string | undefined
     clientVersion?: string | undefined
     consumer?: string | undefined
+    oauthClientName?: string | undefined
 }
 
 export class MCPClientProfile {
     readonly clientName: string | undefined
     readonly clientVersion: string | undefined
     readonly consumer: string | undefined
+    readonly oauthClientName: string | undefined
 
     private _capabilities: ClientCapabilities | undefined
 
@@ -101,6 +119,7 @@ export class MCPClientProfile {
         this.clientName = input.clientName
         this.clientVersion = input.clientVersion
         this.consumer = input.consumer
+        this.oauthClientName = input.oauthClientName
     }
 
     isCodingAgent(): boolean {
@@ -109,6 +128,10 @@ export class MCPClientProfile {
 
     isPostHogCodeConsumer(): boolean {
         return this.consumer === POSTHOG_CODE_CONSUMER
+    }
+
+    isVibeCodingClient(): boolean {
+        return matchesAnyFragment(this.oauthClientName, VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS)
     }
 
     get capabilities(): ClientCapabilities {
@@ -135,4 +158,8 @@ export function isCodingAgentClient(clientName: string | undefined): boolean {
 
 export function isPostHogCodeConsumer(mcpConsumer: string | undefined): boolean {
     return new MCPClientProfile({ consumer: mcpConsumer }).isPostHogCodeConsumer()
+}
+
+export function isVibeCodingClient(oauthClientName: string | undefined): boolean {
+    return new MCPClientProfile({ oauthClientName }).isVibeCodingClient()
 }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -514,22 +514,16 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
-        // Trigger OAuth introspection so the OAuth client name is cached before
-        // the useSingleExec decision below. Lovable / Replit-style vibe-coding
-        // platforms are detected by their OAuth application name, and we want
-        // that signal even when the caller pinned a project via header (which
-        // skips `setDefaultOrganizationAndProject`'s own getApiKey call).
-        // `getApiKey()` caches its result, so this is a no-op if it already ran.
-        const apiKeyPromise = context.stateManager.getApiKey().catch(() => undefined)
-
         const [flagVersion, toolFeatureFlags, singleExecFlagOn] = await Promise.all([
             flagPromise,
             toolFlagsPromise,
             singleExecPromise,
-            apiKeyPromise,
+            // Trigger OAuth introspection so the OAuth client name is cached before the useSingleExec decision below
+            context.stateManager.getApiKey(),
         ])
 
         const oauthClientName = (await this.cache.get('clientName')) || undefined
+
         const clientProfile = new MCPClientProfile({
             clientName: this.mcpClientName,
             clientVersion: this.mcpClientVersion,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -482,12 +482,6 @@ export class MCP extends McpAgent<Env> {
         // `resolveClientInfo` is only reachable post-init.
         await this.resolveClientInfo()
 
-        const clientProfile = new MCPClientProfile({
-            clientName: this.mcpClientName,
-            clientVersion: this.mcpClientVersion,
-            consumer: this.requestProperties.mcpConsumer,
-        })
-
         // Start feature flag resolution in parallel with cache seeding
         const flagPromise = this.resolveVersionFlag()
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
@@ -520,25 +514,46 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
+        // Trigger OAuth introspection so the OAuth client name is cached before
+        // the useSingleExec decision below. Lovable / Replit-style vibe-coding
+        // platforms are detected by their OAuth application name, and we want
+        // that signal even when the caller pinned a project via header (which
+        // skips `setDefaultOrganizationAndProject`'s own getApiKey call).
+        // `getApiKey()` caches its result, so this is a no-op if it already ran.
+        const apiKeyPromise = context.stateManager.getApiKey().catch(() => undefined)
+
         const [flagVersion, toolFeatureFlags, singleExecFlagOn] = await Promise.all([
             flagPromise,
             toolFlagsPromise,
             singleExecPromise,
+            apiKeyPromise,
         ])
+
+        const oauthClientName = (await this.cache.get('clientName')) || undefined
+        const clientProfile = new MCPClientProfile({
+            clientName: this.mcpClientName,
+            clientVersion: this.mcpClientVersion,
+            consumer: this.requestProperties.mcpConsumer,
+            oauthClientName,
+        })
 
         // Restrict single-exec mode to coding agents only — Cursor and other clients that
         // render `structuredContent` in their UI need the full per-tool roster, not the
         // wrapped CLI. `resolveClientInfo` is awaited at the top of `init()` so this
         // decision sees the real value on first-connect. PostHog's agent wrapper
         // self-identifies via the `x-posthog-mcp-consumer` header and forces
-        // single-exec regardless of the wrapped client's reported name.
+        // single-exec regardless of the wrapped client's reported name. Vibe-coding
+        // platforms (Lovable, Replit) are detected by OAuth client name since they
+        // typically connect through a generic MCP client wrapper.
         // An explicit `mode` from the caller (header `x-posthog-mcp-mode` or query
         // param `mode`) wins over the flag + client-profile heuristic.
         const useSingleExec =
             mode === 'cli' ||
             (mode !== 'tools' &&
                 singleExecFlagOn &&
-                (clientProfile.isCodingAgent() || clientProfile.isPostHogCodeConsumer()))
+                (clientProfile.isCodingAgent() ||
+                    clientProfile.isPostHogCodeConsumer() ||
+                    clientProfile.isVibeCodingClient()))
         const version = useSingleExec ? 2 : (flagVersion ?? clientVersion ?? 1)
 
         // Fetch group types and metadata in parallel (cache is now seeded)
@@ -576,9 +591,9 @@ export class MCP extends McpAgent<Env> {
             featureFlags: toolFeatureFlags,
         })
 
-        // OAuth introspection has now run (triggered by getToolsFromContext → getApiKey),
-        // so update the ApiClient with the verified OAuth client name for header forwarding.
-        const oauthClientName = (await this.cache.get('clientName')) || undefined
+        // OAuth introspection ran above (we awaited `getApiKey()` before constructing
+        // `clientProfile`), so update the ApiClient with the verified OAuth client
+        // name for header forwarding.
         if (oauthClientName && this._api) {
             this._api.config.oauthClientName = oauthClientName
         }

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -5,8 +5,10 @@ import {
     DEFAULT_CLIENT_CAPABILITIES,
     MCPClientProfile,
     POSTHOG_CODE_CONSUMER,
+    VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS,
     isCodingAgentClient,
     isPostHogCodeConsumer,
+    isVibeCodingClient,
 } from '@/lib/client-detection'
 
 describe('isCodingAgentClient', () => {
@@ -110,6 +112,41 @@ describe('isPostHogCodeConsumer', () => {
     })
 })
 
+describe('isVibeCodingClient', () => {
+    it.each([
+        ['Lovable'],
+        ['lovable'],
+        ['LOVABLE'],
+        ['Lovable.dev'],
+        ['lovable-app'],
+        ['Replit'],
+        ['replit'],
+        ['Replit Agent'],
+        ['replit-ai'],
+    ])('returns true for OAuth client name %s', (oauthClientName) => {
+        expect(isVibeCodingClient(oauthClientName)).toBe(true)
+    })
+
+    it.each([['Claude Code (posthog)'], ['Cursor'], ['some-random-app'], ['']])(
+        'returns false for OAuth client name %s',
+        (oauthClientName) => {
+            expect(isVibeCodingClient(oauthClientName)).toBe(false)
+        }
+    )
+
+    it('returns false for undefined', () => {
+        expect(isVibeCodingClient(undefined)).toBe(false)
+    })
+
+    it('keeps the fragment list non-empty and lowercased', () => {
+        expect(VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS.length).toBeGreaterThan(0)
+        for (const fragment of VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS) {
+            expect(fragment).toBe(fragment.toLowerCase())
+            expect(fragment.length).toBeGreaterThan(0)
+        }
+    })
+})
+
 describe('MCPClientProfile', () => {
     describe('isCodingAgent()', () => {
         it.each([['claude-code'], ['Codex CLI'], ['cline'], ['zed-editor'], ['GitHub Copilot Chat']])(
@@ -142,6 +179,38 @@ describe('MCPClientProfile', () => {
 
         it('returns false when consumer is undefined', () => {
             expect(new MCPClientProfile({}).isPostHogCodeConsumer()).toBe(false)
+        })
+    })
+
+    describe('isVibeCodingClient()', () => {
+        it.each([['Lovable'], ['lovable.dev'], ['Replit'], ['Replit Agent']])(
+            'returns true for OAuth client name %s',
+            (oauthClientName) => {
+                expect(new MCPClientProfile({ oauthClientName }).isVibeCodingClient()).toBe(true)
+            }
+        )
+
+        it.each([['Claude Code (posthog)'], ['Cursor'], [''], ['   ']])(
+            'returns false for OAuth client name %s',
+            (oauthClientName) => {
+                expect(new MCPClientProfile({ oauthClientName }).isVibeCodingClient()).toBe(false)
+            }
+        )
+
+        it('returns false when oauthClientName is undefined', () => {
+            expect(new MCPClientProfile({}).isVibeCodingClient()).toBe(false)
+        })
+
+        it('uses oauthClientName, not the MCP clientName', () => {
+            // A generic MCP client name should not trigger a match — only the
+            // OAuth application name does, since vibe-coding platforms typically
+            // wrap a generic MCP client.
+            expect(
+                new MCPClientProfile({ clientName: 'lovable', oauthClientName: 'Cursor' }).isVibeCodingClient()
+            ).toBe(false)
+            expect(
+                new MCPClientProfile({ clientName: 'mcp-inspector', oauthClientName: 'Lovable' }).isVibeCodingClient()
+            ).toBe(true)
         })
     })
 
@@ -181,10 +250,12 @@ describe('MCPClientProfile', () => {
             clientName: 'claude-code',
             clientVersion: '1.2.3',
             consumer: POSTHOG_CODE_CONSUMER,
+            oauthClientName: 'Lovable',
         })
         expect(profile.clientName).toBe('claude-code')
         expect(profile.clientVersion).toBe('1.2.3')
         expect(profile.consumer).toBe(POSTHOG_CODE_CONSUMER)
+        expect(profile.oauthClientName).toBe('Lovable')
     })
 })
 


### PR DESCRIPTION
## Problem

Lovable and Replit are vibe-coding platforms that connect to Claude through their own OAuth applications but report generic MCP client names. We need to detect these platforms by their OAuth application name (from token introspection) rather than their self-reported MCP client name, so they can be routed to single-exec mode like other coding agents.

## Changes

- Added `VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS` constant with OAuth client name fragments for Lovable and Replit
- Added `isVibeCodingClient()` function and method to `MCPClientProfile` to detect vibe-coding platforms by OAuth client name
- Updated `MCPClientProfile` to accept and store `oauthClientName` from token introspection
- Modified `MCP.init()` to:
  - Trigger OAuth introspection earlier (before single-exec decision) to cache the OAuth client name
  - Include vibe-coding client detection in the single-exec mode heuristic alongside coding agents and PostHog consumers
  - Pass the OAuth client name to `MCPClientProfile` constructor
- Added comprehensive unit tests covering:
  - Various OAuth client name formats (case-insensitive, with separators)
  - Negative cases (non-matching names, undefined values)
  - Fragment list validation (non-empty, lowercased)
  - `MCPClientProfile.isVibeCodingClient()` method behavior
  - Verification that OAuth client name takes precedence over MCP client name

## How did you test this code?

Added comprehensive unit tests in `client-detection.test.ts`:
- `isVibeCodingClient()` function tests with various OAuth client name formats
- `MCPClientProfile.isVibeCodingClient()` method tests
- Tests verifying OAuth client name precedence over MCP client name
- Fragment list validation tests

All tests pass and cover the detection logic for both Lovable and Replit platforms across different naming conventions.

## Publish to changelog?

Yes - this enables proper routing of Lovable and Replit users to single-exec mode.

https://claude.ai/code/session_01ELKP6rVXiKXxZyUhufQCcP