### PR TITLE
feat(cdp): instrument backgroundTask legs to identify hang source

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-events.consumer.ts
@@ -74,10 +74,16 @@ export class CdpEventsConsumer<
         return {
             // This is all IO so we can set them off in the background and start processing the next batch
             backgroundTask: Promise.all([
-                this.cyclotronJobQueue.queueInvocations(invocationsToBeQueued),
-                this.hogFunctionMonitoringService.flush().catch((err) => {
-                    captureException(err)
-                    logger.error('🔴', 'Error producing queued messages for monitoring', { err })
+                instrumentFn({ key: 'cdp.background_task.queue_invocations', sendException: false }, () =>
+                    this.cyclotronJobQueue.queueInvocations(invocationsToBeQueued)
+                ),
+                instrumentFn({ key: 'cdp.background_task.monitoring_flush', sendException: false }, async () => {
+                    try {
+                        await this.hogFunctionMonitoringService.flush()
+                    } catch (err) {
+                        captureException(err)
+                        logger.error('🔴', 'Error producing queued messages for monitoring', { err })
+                    }
                 }),
             ]),
             invocations: invocationsToBeQueued,

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -1,6 +1,7 @@
 import { chunk } from 'lodash'
 import { Gauge } from 'prom-client'
 
+import { instrumentFn } from '~/common/tracing/tracing-utils'
 import { parseJSON } from '~/utils/json-parse'
 
 import { HealthCheckResult, HealthCheckResultError, HealthCheckResultOk } from '../../../types'
@@ -120,10 +121,28 @@ export class CyclotronJobQueuePostgresV2 {
         try {
             const chunked = chunk(jobs, this.config.CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE)
             if (this.config.CDP_CYCLOTRON_INSERT_PARALLEL_BATCHES) {
-                await Promise.all(chunked.map((batch) => this.manager!.bulkCreateJobs(batch)))
+                await Promise.all(
+                    chunked.map((batch) =>
+                        instrumentFn(
+                            {
+                                key: 'cyclotron_v2.bulk_create_jobs',
+                                sendException: false,
+                                getLoggingContext: () => ({ batchSize: batch.length, parallel: true }),
+                            },
+                            () => this.manager!.bulkCreateJobs(batch)
+                        )
+                    )
+                )
             } else {
                 for (const batch of chunked) {
-                    await this.manager.bulkCreateJobs(batch)
+                    await instrumentFn(
+                        {
+                            key: 'cyclotron_v2.bulk_create_jobs',
+                            sendException: false,
+                            getLoggingContext: () => ({ batchSize: batch.length, parallel: false }),
+                        },
+                        () => this.manager!.bulkCreateJobs(batch)
+                    )
                 }
             }
         } catch (e) {

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -6,6 +6,8 @@
 import { DateTime } from 'luxon'
 import { Counter, Gauge } from 'prom-client'
 
+import { instrumentFn } from '~/common/tracing/tracing-utils'
+
 import { buildIntegerMatcher } from '../../../config/config'
 import { HealthCheckResultError, ValueMatcher } from '../../../types'
 import { logger } from '../../../utils/logger'
@@ -265,9 +267,32 @@ export class CyclotronJobQueue {
         }
 
         await Promise.all([
-            this.jobQueuePostgres.queueInvocations(postgresInvocations),
-            this.jobQueuePostgresV2?.queueInvocations(postgresV2Invocations),
-            this.jobQueueKafka.queueInvocations(kafkaInvocations),
+            instrumentFn(
+                {
+                    key: 'cyclotron.queue_invocations.postgres_v1',
+                    sendException: false,
+                    getLoggingContext: () => ({ count: postgresInvocations.length }),
+                },
+                () => this.jobQueuePostgres.queueInvocations(postgresInvocations)
+            ),
+            this.jobQueuePostgresV2
+                ? instrumentFn(
+                      {
+                          key: 'cyclotron.queue_invocations.postgres_v2',
+                          sendException: false,
+                          getLoggingContext: () => ({ count: postgresV2Invocations.length }),
+                      },
+                      () => this.jobQueuePostgresV2!.queueInvocations(postgresV2Invocations)
+                  )
+                : Promise.resolve(),
+            instrumentFn(
+                {
+                    key: 'cyclotron.queue_invocations.kafka',
+                    sendException: false,
+                    getLoggingContext: () => ({ count: kafkaInvocations.length }),
+                },
+                () => this.jobQueueKafka.queueInvocations(kafkaInvocations)
+            ),
         ])
     }
 


### PR DESCRIPTION
## Problem

When a `cdp-events-consumer` `backgroundTask` does not resolve before the consumer rebalance timeout, librdkafka force-recovers and abandons in-flight offsets, leading to message replay. Today we only have one outer histogram covering the whole leg, so a hang doesn't tell us which sub-component is responsible.

## Changes

Wraps each leg of the backgroundTask `Promise.all` in `instrumentFn` so per-leg duration shows up on the existing `instrumented_function_duration_seconds{function}` histogram. New `function` label values:

- `cdp.background_task.queue_invocations`
- `cdp.background_task.monitoring_flush`
- `cyclotron.queue_invocations.postgres_v1`
- `cyclotron.queue_invocations.postgres_v2`
- `cyclotron.queue_invocations.kafka`
- `cyclotron_v2.bulk_create_jobs`

## How did you test this code?

Only instrumentation added

## Publish to changelog?

No
