### PR TITLE
fix(signals): Reduce inbox report failures via retries and relay fix

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -161,13 +161,90 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM events
+     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_multiple_routes_and_users.2
@@ -292,6 +369,17 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.1
   '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
+  '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
@@ -310,7 +398,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -325,7 +421,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -335,8 +431,15 @@
                             and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
             quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
                             0) AS previous_avg_time_on_page
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.properties,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
      GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
   LEFT JOIN
     (SELECT breakdown_value AS breakdown_value,
@@ -347,7 +450,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -357,7 +466,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -206,13 +206,8 @@ class SignalReportSummaryWorkflow:
                     report_id=inputs.report_id,
                     signals=fetch_result.signals,
                 ),
-                start_to_close_timeout=timedelta(minutes=10),
-                retry_policy=RetryPolicy(
-                    maximum_attempts=3,
-                    initial_interval=timedelta(seconds=10),
-                    backoff_coefficient=2.0,
-                    maximum_interval=timedelta(minutes=1),
-                ),
+                start_to_close_timeout=timedelta(minutes=30),
+                retry_policy=RetryPolicy(maximum_attempts=1),
             )
             if repo_result.repository is None:
                 log.warning(
@@ -235,14 +230,9 @@ class SignalReportSummaryWorkflow:
                         signals=fetch_result.signals,
                         repo_selection=repo_result,
                     ),
-                    start_to_close_timeout=timedelta(minutes=20),
+                    start_to_close_timeout=timedelta(hours=4),
                     heartbeat_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(
-                        maximum_attempts=3,
-                        initial_interval=timedelta(seconds=30),
-                        backoff_coefficient=2.0,
-                        maximum_interval=timedelta(minutes=2),
-                    ),
+                    retry_policy=RetryPolicy(maximum_attempts=1),
                 )
                 decision = ReportDecision(
                     title=agentic_result.title,

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -206,8 +206,13 @@ class SignalReportSummaryWorkflow:
                     report_id=inputs.report_id,
                     signals=fetch_result.signals,
                 ),
-                start_to_close_timeout=timedelta(minutes=30),
-                retry_policy=RetryPolicy(maximum_attempts=1),
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=3,
+                    initial_interval=timedelta(seconds=10),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(minutes=1),
+                ),
             )
             if repo_result.repository is None:
                 log.warning(
@@ -230,9 +235,14 @@ class SignalReportSummaryWorkflow:
                         signals=fetch_result.signals,
                         repo_selection=repo_result,
                     ),
-                    start_to_close_timeout=timedelta(hours=4),
+                    start_to_close_timeout=timedelta(minutes=20),
                     heartbeat_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    retry_policy=RetryPolicy(
+                        maximum_attempts=3,
+                        initial_interval=timedelta(seconds=30),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(minutes=2),
+                    ),
                 )
                 decision = ReportDecision(
                     title=agentic_result.title,

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -208,6 +208,7 @@ async def _poll_for_turn(
             return await _drain_final_log(
                 task_run,
                 refreshed_status=refreshed.status,
+                error_message=refreshed.error_message,
                 skip_lines=skip_lines,
                 printed_lines=printed_lines,
                 verbose=verbose,
@@ -220,6 +221,7 @@ async def _drain_final_log(
     task_run,
     *,
     refreshed_status: str,
+    error_message: str | None = None,
     skip_lines: int,
     printed_lines: int,
     verbose: bool,
@@ -255,8 +257,9 @@ async def _drain_final_log(
     if final_message:
         return final_message, final_log, final_lines, printed_lines
     reason = "end_turn with empty response" if final_empty_end_turn else "no agent message"
+    cause = f" (cause: {error_message})" if error_message else ""
     raise RuntimeError(
-        f"custom_prompt - drain_final_log: TaskRun reached terminal status={refreshed_status} — {reason}"
+        f"custom_prompt - drain_final_log: TaskRun reached terminal status={refreshed_status}{cause} — {reason}"
     )
 
 

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -325,13 +325,16 @@ async def _relay_loop(
                     await redis_stream.mark_error("Sandbox is no longer reachable (404)")
                     return
                 # Retryable server errors (502, 503, etc.)
+                # Retryable server errors (502, 503, etc.)
                 reconnect_count += 1
                 logger.warning(
                     "relay_sandbox_events_http_error",
                     run_id=run_id,
                     status_code=e.response.status_code,
+                    error=str(e),
                     reconnect_count=reconnect_count,
                 )
+                await asyncio.sleep(min(reconnect_count * 2, 10))
                 await asyncio.sleep(min(reconnect_count * 2, 10))
 
             except (httpx.TransportError, httpx_sse.SSEError) as e:

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -315,26 +315,25 @@ async def _relay_loop(
                 await asyncio.sleep(min(reconnect_count * 2, 10))
 
             except httpx.HTTPStatusError as e:
-                if e.response.status_code == 404:
-                    # Sandbox container is gone — reconnection won't help
+                status = e.response.status_code
+                if status < 500:
+                    # 4xx errors are permanent — sandbox is gone or auth is invalid
                     logger.warning(
                         "relay_sandbox_events_sandbox_gone",
                         run_id=run_id,
-                        status_code=404,
+                        status_code=status,
                     )
-                    await redis_stream.mark_error("Sandbox is no longer reachable (404)")
+                    await redis_stream.mark_error(f"Sandbox returned HTTP {status}")
                     return
-                # Retryable server errors (502, 503, etc.)
-                # Retryable server errors (502, 503, etc.)
+                # 5xx — transient server error, worth retrying
                 reconnect_count += 1
                 logger.warning(
                     "relay_sandbox_events_http_error",
                     run_id=run_id,
-                    status_code=e.response.status_code,
+                    status_code=status,
                     error=str(e),
                     reconnect_count=reconnect_count,
                 )
-                await asyncio.sleep(min(reconnect_count * 2, 10))
                 await asyncio.sleep(min(reconnect_count * 2, 10))
 
             except (httpx.TransportError, httpx_sse.SSEError) as e:

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -314,6 +314,26 @@ async def _relay_loop(
                 )
                 await asyncio.sleep(min(reconnect_count * 2, 10))
 
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    # Sandbox container is gone — reconnection won't help
+                    logger.warning(
+                        "relay_sandbox_events_sandbox_gone",
+                        run_id=run_id,
+                        status_code=404,
+                    )
+                    await redis_stream.mark_error("Sandbox is no longer reachable (404)")
+                    return
+                # Retryable server errors (502, 503, etc.)
+                reconnect_count += 1
+                logger.warning(
+                    "relay_sandbox_events_http_error",
+                    run_id=run_id,
+                    status_code=e.response.status_code,
+                    reconnect_count=reconnect_count,
+                )
+                await asyncio.sleep(min(reconnect_count * 2, 10))
+
             except (httpx.TransportError, httpx_sse.SSEError) as e:
                 reconnect_count += 1
                 logger.warning(


### PR DESCRIPTION
## Problem

Users have been reporting that their Signals inbox goes empty shortly after enabling sources, and stays that way - showing "Inbox is warming up…". Others see reports briefly appear as "researching" then vanish with no retry. These reports fail, and one issue is we have been hiding these in the UI completely, which I'm fixing in https://github.com/PostHog/code/pull/1950. But, there's the core issue of failures too.

_Handing it over to Claude:_

Investigation of production data over the last 7 days shows **~70% of signal report research runs are failing**, with the failure rate climbing:

| Day | Failed | Ready | Fail % |
|-----|--------|-------|--------|
| Apr 24 | 1,585 | 610 | 71% |
| Apr 25 | 3,853 | 1,037 | 77% |
| Apr 27 | 1,285 | 758 | 58% |
| Apr 28 | 2,403 | 883 | 69% |
| Apr 29 | 1,524 | 264 | 81% |

*(Source: `signal_report_completed` events, grouped by `properties.result`)*

Session replay signals are hit hardest — 3,693 failed vs 448 ready (**89% failure rate**) over the last 48h, compared to ~50% for error_tracking reports. 68 unique orgs are affected by failures vs only 9 getting ready reports.

The dominant error across all failures is a single `RuntimeError`:
```
custom_prompt - drain_final_log: TaskRun reached terminal status=failed — no agent message
```
*(Seen on every error log from `temporal-worker-video-export` with `activity_type=run_agentic_report_activity`, e.g. report `019ddb56-9b63-7e72-9430-368da7915f10` for team 222600, report `019ddb62-d0f6-7bd5-bd38-66f177caa64b` for team 61853)*

Three compounding issues cause this:

### 1. The SSE relay crashes on sandbox 404s instead of handling them

When a Modal sandbox dies, its `/events` URL returns HTTP 404. The relay's reconnect loop in `relay_sandbox_events.py` catches `httpx.TransportError` and `httpx_sse.SSEError` — but `httpx.HTTPStatusError` is a sibling class (inherits from `HTTPError`, not `TransportError`), so **404s escape the reconnect loop entirely**.

This is confirmed by 2,333 `HTTPStatusError` occurrences in error tracking (issue `c95785db`) and production logs like:
```
HTTPStatusError: Client error '404 Not Found' for url
'https://a-ta-01kqdf3ydmj4f7bea0gs50stxf-ktj3ha6xovyx8j0dw8zdkkqiu.w.modal.host/events?_modal_connect_token=...'
```
*(From `temporal-worker-tasks-agent`, `activity_type=relay_sandbox_events`, e.g. run `a5256b26-4d64-45a8-be39-26af4805dbef` at 2026-04-29T22:33)*

Once the relay crashes, the workflow loses its heartbeat source and the 5-minute inactivity timer starts counting down silently.

### ~~2. Zero retries on sandbox activities~~

_Per @sortafreel, keeping no retries for now to avoid a thundering herd, particularly till repo selection is stable via other changes._

Both `select_repository_activity` and `run_agentic_report_activity` use `RetryPolicy(maximum_attempts=1)`. Any transient sandbox failure — Modal container eviction, image build timeout (`ExecutionError: Timed out waiting for image to be created`, 102 occurrences in error tracking issue `c3950dfd`), OOM — permanently kills the report with no retry.

### 3. Opaque error messages when sandbox runs fail

The `_drain_final_log` RuntimeError says only "no agent message" with no hint of the underlying cause. The `TaskRun.error_message` field (e.g. `"Run timed out due to inactivity"`, `"Follow-up delivery failed: ..."`) is available at the call site but not passed through, making triage harder than it needs to be.

## Changes

**Handle `httpx.HTTPStatusError` in the relay reconnect loop** (`relay_sandbox_events.py`):
- 404 → mark error and return cleanly (sandbox is gone, reconnect won't help)
- 5xx → reconnect with backoff (transient server errors), same treatment as transport errors

~~**Add retry policies to the two sandbox activities** (`summary.py`):~~
_Per @sortafreel, keeping no retries for now to avoid a thundering herd, particularly till repo selection is stable via other changes._
- `select_repository_activity`: 3 attempts, 10s initial backoff, 2x coefficient, 10min timeout per attempt (was 30min × 1 attempt)
- `run_agentic_report_activity`: 3 attempts, 30s initial backoff, 2x coefficient, 20min timeout per attempt (was 4h × 1 attempt)
- Non-retryable business errors (safety rejection, not actionable, requires human input) are handled by explicit conditionals that return early — they never reach the retry mechanism

**Surface the TaskRun cause in `_drain_final_log`** (`custom_prompt_runner.py`):
- Error now reads e.g. `"TaskRun reached terminal status=failed (cause: Run timed out due to inactivity) — no agent message"` instead of just `"no agent message"`

## How did you test this code?

I'm an agent. I ran `ruff check` on all 3 changed files (all passed) and verified there are no import or type errors. The relay 404 fix was validated by tracing the `httpx` class hierarchy (`HTTPStatusError` → `HTTPError`; `TransportError` → `RequestError` → `HTTPError`), confirming the existing catch blocks don't cover it.

The retry policy changes are to Temporal workflow configuration and don't have dedicated unit tests — they're verified by production behavior.

## Publish to changelog?

No.

## 🤖 Agent context

- **Agent**: Claude Code (Opus 4.6)
- **How the investigation was done**: Queried PostHog production analytics (`signal_report_completed` events grouped by `properties.result` and `properties.source_products`), searched `temporal-worker-video-export` and `temporal-worker-tasks-agent` logs via the logs MCP tool, read the full process-task workflow/relay/sandbox code path, and correlated error tracking issues (`c95785db` HTTPStatusError 2333 occ, `c3950dfd` ExecutionError 102 occ, `25a722fd` RuntimeError 956 occ).
- **Related context**: The inactivity timeout was reduced from 30min to 5min in commit `447fa2b453c` on Apr 22 — that's not reverted here (policy decision for the Tasks team), but the relay fix and retries should significantly reduce failures under the current timeout.
- **Companion change**: PostHog Code changes (default status filter including "failed", failed report UI) in the `code` repo — separate PR.