### PR TITLE
fix: Reset configuration when switching destination types

### DIFF
--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -527,6 +527,80 @@ def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval, 
     assert args.get("invalid_key", None) is None
 
 
+def test_patch_different_type_resets_config(
+    client: HttpClient,
+    temporal,
+    organization,
+    team,
+    user,
+):
+    """Assert patching a config with a different type resets it.
+
+    We confirm no previous values are present in Temporal or in the database.
+    """
+    interval = "hour"
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "interval": interval,
+    }
+
+    client.force_login(user)
+
+    destination = BatchExportDestination(**destination_data)
+    batch_export = BatchExport(team=team, destination=destination, **batch_export_data)
+
+    sync_batch_export(batch_export, created=True)
+
+    destination.save()
+    batch_export.save()
+
+    new_destination_data = {
+        "type": "BigQuery",
+        "config": {
+            "table_id": "test",
+            "dataset_id": "test",
+            "project_id": "test",
+        },
+    }
+
+    new_batch_export_data = {
+        "name": "my-production-bigquery-destination",
+        "destination": new_destination_data,
+    }
+
+    response = patch_batch_export(client, team.pk, batch_export.id, new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    batch_export_data = get_batch_export_ok(client, team.pk, batch_export.id)
+    assert batch_export_data["interval"] == interval
+    assert batch_export_data["destination"]["config"].get("bucket_name") is None
+    assert batch_export_data["destination"]["config"].get("aws_secret_access_key") is None
+    assert batch_export_data["destination"]["config"]["dataset_id"] == "test"
+    assert batch_export_data["destination"]["config"]["project_id"] == "test"
+    assert batch_export_data["destination"]["config"]["table_id"] == "test"
+
+    # validate the underlying temporal schedule has been updated
+    codec = EncryptionCodec(settings=settings)
+    new_schedule = describe_schedule(temporal, batch_export_data["id"])
+    decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+    assert args["table_id"] == "test"
+    assert args.get("aws_access_key_id") is None
+    assert args.get("bucket_name") is None
+    assert args.get("aws_secret_access_key") is None
+
+
 def test_can_patch_hogql_query(client: HttpClient, temporal, organization, team, user):
     """Test we can patch a schema with a HogQL query."""
     destination_data = {

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -646,13 +646,19 @@ class BatchExportSerializer(serializers.ModelSerializer):
         config = destination_attrs["config"]
         view = self.context.get("view")
 
+        instance = None
         if self.instance is not None:
-            existing_config = self.instance.destination.config
+            instance = self.instance
+            existing_config = instance.destination.config
         elif view is not None and "pk" in view.kwargs:
             # Running validation for a `detail=True` action.
             instance = view.get_object()
             existing_config = instance.destination.config
         else:
+            existing_config = {}
+
+        if instance is not None and destination_type != instance.destination.type:
+            # Start fresh if this is changing the batch export type
             existing_config = {}
         merged_config = recursive_dict_merge(existing_config, config)
 
@@ -968,6 +974,10 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
         with transaction.atomic():
             if destination_data:
+                if destination_data.get("type", batch_export.destination.type) != batch_export.destination.type:
+                    # Start fresh if this is changing the destination type
+                    batch_export.destination.config = {}
+
                 batch_export.destination.type = destination_data.get("type", batch_export.destination.type)
                 batch_export.destination.config = recursive_dict_merge(
                     batch_export.destination.config,


### PR DESCRIPTION
## Problem

Previously, configuration was not reset when switching destination types, causing invalid values from a previous destination to persist in the configuration.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Now we reset the batch export configuration if the types don't match. Both when validating and when saving the configuration.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a new unit test.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

No
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
