### PR TITLE
feat(experiments): track previous refresh state on metrics refresh

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -7,6 +7,7 @@ import { now } from 'lib/dayjs'
 import { TimeToSeeDataPayload } from 'lib/internalMetrics'
 import { objectClean } from 'lib/utils'
 import { BillingUsageInteractionProps } from 'scenes/billing/types'
+import { LastRefreshSnapshot } from 'scenes/experiments/experimentLogic'
 import { SharedMetric } from 'scenes/experiments/SharedMetrics/sharedMetricLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { ProductTourEvent } from 'scenes/product-tours/constants'
@@ -601,6 +602,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 triggered_by: 'manual' | 'auto-refresh'
                 auto_refresh_enabled?: boolean
                 auto_refresh_interval?: number
+                previous_refresh?: LastRefreshSnapshot | null
             }
         ) => ({
             experiment,
@@ -1571,12 +1573,17 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             })
         },
         reportExperimentMetricsRefreshed: ({ experiment, forceRefresh, context }) => {
+            const previousRefresh = context?.previous_refresh ?? null
             posthog.capture('experiment metrics refreshed', {
                 ...getEventPropertiesForExperiment(experiment),
                 force_refresh: forceRefresh,
                 triggered_by: context?.triggered_by || 'manual',
                 auto_refresh_enabled: context?.auto_refresh_enabled,
                 auto_refresh_interval: context?.auto_refresh_interval,
+                previous_refresh_id: previousRefresh?.refresh_id ?? null,
+                previous_refresh_age_ms: previousRefresh ? Date.now() - previousRefresh.started_at : null,
+                previous_refresh_state: previousRefresh?.state ?? null,
+                previous_refresh_triggered_by: previousRefresh?.triggered_by ?? null,
             })
         },
         reportExperimentAutoRefreshToggled: ({ experiment, enabled, interval }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -7,7 +7,6 @@ import { now } from 'lib/dayjs'
 import { TimeToSeeDataPayload } from 'lib/internalMetrics'
 import { objectClean } from 'lib/utils'
 import { BillingUsageInteractionProps } from 'scenes/billing/types'
-import { LastRefreshSnapshot } from 'scenes/experiments/experimentLogic'
 import { SharedMetric } from 'scenes/experiments/SharedMetrics/sharedMetricLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { ProductTourEvent } from 'scenes/product-tours/constants'
@@ -602,7 +601,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 triggered_by: 'manual' | 'auto-refresh'
                 auto_refresh_enabled?: boolean
                 auto_refresh_interval?: number
-                previous_refresh?: LastRefreshSnapshot | null
+                previous_refresh_id?: string | null
+                previous_refresh_age_ms?: number | null
+                previous_refresh_state?: string | null
+                previous_refresh_triggered_by?: string | null
             }
         ) => ({
             experiment,
@@ -1573,19 +1575,16 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             })
         },
         reportExperimentMetricsRefreshed: ({ experiment, forceRefresh, context }) => {
-            const previousRefresh = context?.previous_refresh ?? null
             posthog.capture('experiment metrics refreshed', {
                 ...getEventPropertiesForExperiment(experiment),
                 force_refresh: forceRefresh,
                 triggered_by: context?.triggered_by || 'manual',
                 auto_refresh_enabled: context?.auto_refresh_enabled,
                 auto_refresh_interval: context?.auto_refresh_interval,
-                previous_refresh_id: previousRefresh?.refresh_id ?? null,
-                previous_refresh_age_ms: previousRefresh ? Date.now() - previousRefresh.started_at : null,
-                previous_refresh_state: previousRefresh?.state ?? null,
-                // Normalize to the same kebab-case convention as `triggered_by`
-                // (e.g. `auto_refresh` → `auto-refresh`) so the two fields are comparable.
-                previous_refresh_triggered_by: previousRefresh?.triggered_by.replace(/_/g, '-') ?? null,
+                previous_refresh_id: context?.previous_refresh_id ?? null,
+                previous_refresh_age_ms: context?.previous_refresh_age_ms ?? null,
+                previous_refresh_state: context?.previous_refresh_state ?? null,
+                previous_refresh_triggered_by: context?.previous_refresh_triggered_by ?? null,
             })
         },
         reportExperimentAutoRefreshToggled: ({ experiment, enabled, interval }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1583,7 +1583,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 previous_refresh_id: previousRefresh?.refresh_id ?? null,
                 previous_refresh_age_ms: previousRefresh ? Date.now() - previousRefresh.started_at : null,
                 previous_refresh_state: previousRefresh?.state ?? null,
-                previous_refresh_triggered_by: previousRefresh?.triggered_by ?? null,
+                // Normalize to the same kebab-case convention as `triggered_by`
+                // (e.g. `auto_refresh` → `auto-refresh`) so the two fields are comparable.
+                previous_refresh_triggered_by: previousRefresh?.triggered_by.replace(/_/g, '-') ?? null,
             })
         },
         reportExperimentAutoRefreshToggled: ({ experiment, enabled, interval }) => {

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -38,6 +38,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
         isSingleVariantShipped,
         shippedVariantKey,
         autoRefresh,
+        lastRefresh: lastRefreshSnapshot,
     } = useValues(experimentLogic)
     const { updateExperiment, refreshExperimentResults, reportExperimentMetricsRefreshed } = useActions(experimentLogic)
     const { openEditConclusionModal, openDescriptionModal, closeDescriptionModal, openRunningTimeConfigModal } =
@@ -222,6 +223,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                                             triggered_by: 'manual',
                                             auto_refresh_enabled: autoRefresh.enabled,
                                             auto_refresh_interval: autoRefresh.interval,
+                                            previous_refresh: lastRefreshSnapshot,
                                         })
                                         refreshExperimentResults(true, 'manual')
                                     }}

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -15,7 +15,7 @@ import { urls } from 'scenes/urls'
 import { ExperimentStatsMethod, ExperimentStatus } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
-import { experimentLogic } from '../experimentLogic'
+import { experimentLogic, previousRefreshAnalytics } from '../experimentLogic'
 import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
 import { getExperimentStatus, isExperimentPaused } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
@@ -38,7 +38,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
         isSingleVariantShipped,
         shippedVariantKey,
         autoRefresh,
-        lastRefresh: lastRefreshSnapshot,
+        currentRefresh,
     } = useValues(experimentLogic)
     const { updateExperiment, refreshExperimentResults, reportExperimentMetricsRefreshed } = useActions(experimentLogic)
     const { openEditConclusionModal, openDescriptionModal, closeDescriptionModal, openRunningTimeConfigModal } =
@@ -223,7 +223,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                                             triggered_by: 'manual',
                                             auto_refresh_enabled: autoRefresh.enabled,
                                             auto_refresh_interval: autoRefresh.interval,
-                                            previous_refresh: lastRefreshSnapshot,
+                                            ...previousRefreshAnalytics(currentRefresh),
                                         })
                                         refreshExperimentResults(true, 'manual')
                                     }}

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -307,8 +307,10 @@ describe('experimentLogic', () => {
         })
     })
 
-    describe('lastRefresh tracking', () => {
-        beforeEach(() => {
+    describe('currentRefresh tracking', () => {
+        it('marks the refresh as in_progress while running and completed when it succeeds', async () => {
+            logic.actions.setExperiment(experiment)
+
             useMocks({
                 post: {
                     '/api/environments/:team/query': () => [
@@ -323,39 +325,52 @@ describe('experimentLogic', () => {
                     '/api/environments/:team/query/:id': () => [200, experimentMetricResultsSuccessJson],
                 },
             })
-        })
-
-        it('marks the refresh as in_progress while running and completed when it succeeds', async () => {
-            logic.actions.setExperiment(experiment)
 
             const promise = logic.asyncActions.refreshExperimentResults(true, 'manual')
 
             await expectLogic(logic).toDispatchActions(['markRefreshStarted'])
-            expect(logic.values.lastRefresh).toMatchObject({
+            expect(logic.values.currentRefresh).toMatchObject({
                 state: 'in_progress',
                 triggered_by: 'manual',
             })
-            expect(logic.values.lastRefresh?.refresh_id).toEqual(expect.any(String))
+            expect(logic.values.currentRefresh?.refresh_id).toEqual(expect.any(String))
 
             await promise
 
-            expect(logic.values.lastRefresh).toMatchObject({
+            expect(logic.values.currentRefresh).toMatchObject({
                 state: 'completed',
                 triggered_by: 'manual',
             })
         })
 
-        it('keeps refresh_id stable across the start/complete transition', async () => {
-            logic.actions.setExperiment(experiment)
+        it.each(['completed', 'partial', 'errored'] as const)(
+            'transitions to %s when markRefreshFinished fires with that state',
+            (finalState) => {
+                logic.actions.markRefreshStarted('refresh-1', 'manual')
+                expect(logic.values.currentRefresh?.state).toBe('in_progress')
 
-            const promise = logic.asyncActions.refreshExperimentResults(true, 'manual')
-            await expectLogic(logic).toDispatchActions(['markRefreshStarted'])
-            const startedId = logic.values.lastRefresh?.refresh_id
+                logic.actions.markRefreshFinished('refresh-1', finalState)
 
-            await promise
+                expect(logic.values.currentRefresh).toMatchObject({
+                    refresh_id: 'refresh-1',
+                    state: finalState,
+                    triggered_by: 'manual',
+                })
+            }
+        )
 
-            expect(logic.values.lastRefresh?.refresh_id).toBe(startedId)
-            expect(logic.values.lastRefresh?.state).toBe('completed')
+        it('ignores markRefreshFinished for a stale refresh_id and preserves the in-flight snapshot', () => {
+            logic.actions.markRefreshStarted('refresh-1', 'manual')
+            logic.actions.markRefreshStarted('refresh-2', 'auto_refresh')
+
+            // Late completion from the previous refresh shouldn't clobber the new one.
+            logic.actions.markRefreshFinished('refresh-1', 'completed')
+
+            expect(logic.values.currentRefresh).toMatchObject({
+                refresh_id: 'refresh-2',
+                state: 'in_progress',
+                triggered_by: 'auto_refresh',
+            })
         })
     })
 

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -307,6 +307,58 @@ describe('experimentLogic', () => {
         })
     })
 
+    describe('lastRefresh tracking', () => {
+        beforeEach(() => {
+            useMocks({
+                post: {
+                    '/api/environments/:team/query': () => [
+                        200,
+                        {
+                            cache_key: 'cache_key',
+                            query_status: experimentMetricResultsSuccessJson.query_status,
+                        },
+                    ],
+                },
+                get: {
+                    '/api/environments/:team/query/:id': () => [200, experimentMetricResultsSuccessJson],
+                },
+            })
+        })
+
+        it('marks the refresh as in_progress while running and completed when it succeeds', async () => {
+            logic.actions.setExperiment(experiment)
+
+            const promise = logic.asyncActions.refreshExperimentResults(true, 'manual')
+
+            await expectLogic(logic).toDispatchActions(['markRefreshStarted'])
+            expect(logic.values.lastRefresh).toMatchObject({
+                state: 'in_progress',
+                triggered_by: 'manual',
+            })
+            expect(logic.values.lastRefresh?.refresh_id).toEqual(expect.any(String))
+
+            await promise
+
+            expect(logic.values.lastRefresh).toMatchObject({
+                state: 'completed',
+                triggered_by: 'manual',
+            })
+        })
+
+        it('keeps refresh_id stable across the start/complete transition', async () => {
+            logic.actions.setExperiment(experiment)
+
+            const promise = logic.asyncActions.refreshExperimentResults(true, 'manual')
+            await expectLogic(logic).toDispatchActions(['markRefreshStarted'])
+            const startedId = logic.values.lastRefresh?.refresh_id
+
+            await promise
+
+            expect(logic.values.lastRefresh?.refresh_id).toBe(startedId)
+            expect(logic.values.lastRefresh?.state).toBe('completed')
+        })
+    })
+
     describe('removeSharedMetricFromExperiment', () => {
         beforeEach(() => {
             jest.spyOn(api, 'update')

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -179,6 +179,15 @@ export interface ExperimentLogicProps {
 
 export type ExperimentTriggeredBy = 'page_load' | 'manual' | 'auto_refresh' | 'config_change'
 
+export type LastRefreshState = 'in_progress' | 'completed' | 'errored'
+
+export interface LastRefreshSnapshot {
+    refresh_id: string
+    triggered_by: ExperimentTriggeredBy
+    started_at: number
+    state: LastRefreshState
+}
+
 function generateRefreshId(): string {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
         return crypto.randomUUID()
@@ -694,6 +703,14 @@ export const experimentLogic = kea<experimentLogicType>([
             forceRefresh,
             triggeredBy: triggeredBy ?? 'manual',
         }),
+        markRefreshStarted: (refreshId: string, triggeredBy: ExperimentTriggeredBy) => ({
+            refreshId,
+            triggeredBy,
+        }),
+        markRefreshCompleted: (refreshId: string, hasErrors: boolean) => ({
+            refreshId,
+            hasErrors,
+        }),
         updateExperimentMetrics: true,
         updateExperimentCollectionGoal: true,
         updateExposureCriteria: true,
@@ -857,6 +874,23 @@ export const experimentLogic = kea<experimentLogicType>([
             false,
             {
                 toggleDebugPanel: (state) => !state,
+            },
+        ],
+        lastRefresh: [
+            null as LastRefreshSnapshot | null,
+            {
+                markRefreshStarted: (_, { refreshId, triggeredBy }) => ({
+                    refresh_id: refreshId,
+                    triggered_by: triggeredBy,
+                    started_at: Date.now(),
+                    state: 'in_progress',
+                }),
+                markRefreshCompleted: (state, { refreshId, hasErrors }) => {
+                    if (!state || state.refresh_id !== refreshId) {
+                        return state
+                    }
+                    return { ...state, state: hasErrors ? 'errored' : 'completed' }
+                },
             },
         ],
         experiment: [
@@ -1630,18 +1664,24 @@ export const experimentLogic = kea<experimentLogicType>([
             cache.refreshSummariesById = cache.refreshSummariesById ?? {}
             cache.refreshSummariesById[refreshId] = summaries
 
+            actions.markRefreshStarted(refreshId, triggeredBy)
+
             // Start 10s timer to offer browser notifications
             clearTimeout(cache.notificationOfferTimer)
             cache.notificationOfferTimer = setTimeout(() => {
                 actions.setShowNotificationOffer(true)
             }, 10_000)
 
+            let caughtError = false
             try {
                 await Promise.all([
                     asyncActions.loadPrimaryMetricsResults(forceRefresh, refreshId),
                     asyncActions.loadSecondaryMetricsResults(forceRefresh, refreshId),
                     asyncActions.loadExposures(forceRefresh),
                 ])
+            } catch (error) {
+                caughtError = true
+                throw error
             } finally {
                 const totalDurationMs = Math.round(performance.now() - refreshStart)
                 const refreshSummaries: MetricLoadingSummary[] = cache.refreshSummariesById?.[refreshId] ?? []
@@ -1686,6 +1726,8 @@ export const experimentLogic = kea<experimentLogicType>([
                         execution_mode: getExperimentExecutionMode(values.featureFlags),
                     }
                 )
+
+                actions.markRefreshCompleted(refreshId, caughtError || erroredCount > 0)
 
                 // Clear notification offer timer
                 clearTimeout(cache.notificationOfferTimer)
@@ -2334,6 +2376,7 @@ export const experimentLogic = kea<experimentLogicType>([
                             triggered_by: 'auto-refresh',
                             auto_refresh_enabled: values.autoRefresh.enabled,
                             auto_refresh_interval: values.autoRefresh.interval,
+                            previous_refresh: values.lastRefresh,
                         })
                         actions.refreshExperimentResults(true, 'auto_refresh')
                     }, values.autoRefresh.interval * 1000)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -179,13 +179,37 @@ export interface ExperimentLogicProps {
 
 export type ExperimentTriggeredBy = 'page_load' | 'manual' | 'auto_refresh' | 'config_change'
 
-export type LastRefreshState = 'in_progress' | 'completed' | 'errored'
+export type CurrentRefreshState = 'in_progress' | 'completed' | 'partial' | 'errored'
+export type FinishedRefreshState = Exclude<CurrentRefreshState, 'in_progress'>
 
-export interface LastRefreshSnapshot {
+export interface CurrentRefreshSnapshot {
     refresh_id: string
     triggered_by: ExperimentTriggeredBy
     started_at: number
-    state: LastRefreshState
+    state: CurrentRefreshState
+}
+
+export function previousRefreshAnalytics(snapshot: CurrentRefreshSnapshot | null): {
+    previous_refresh_id: string | null
+    previous_refresh_age_ms: number | null
+    previous_refresh_state: CurrentRefreshState | null
+    previous_refresh_triggered_by: string | null
+} {
+    if (!snapshot) {
+        return {
+            previous_refresh_id: null,
+            previous_refresh_age_ms: null,
+            previous_refresh_state: null,
+            previous_refresh_triggered_by: null,
+        }
+    }
+    return {
+        previous_refresh_id: snapshot.refresh_id,
+        previous_refresh_age_ms: Date.now() - snapshot.started_at,
+        previous_refresh_state: snapshot.state,
+        // Normalize to the same kebab-case convention `triggered_by` uses (e.g. `auto_refresh` → `auto-refresh`).
+        previous_refresh_triggered_by: snapshot.triggered_by.replace(/_/g, '-'),
+    }
 }
 
 function generateRefreshId(): string {
@@ -707,9 +731,9 @@ export const experimentLogic = kea<experimentLogicType>([
             refreshId,
             triggeredBy,
         }),
-        markRefreshCompleted: (refreshId: string, hasErrors: boolean) => ({
+        markRefreshFinished: (refreshId: string, finalState: FinishedRefreshState) => ({
             refreshId,
-            hasErrors,
+            finalState,
         }),
         updateExperimentMetrics: true,
         updateExperimentCollectionGoal: true,
@@ -876,8 +900,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 toggleDebugPanel: (state) => !state,
             },
         ],
-        lastRefresh: [
-            null as LastRefreshSnapshot | null,
+        currentRefresh: [
+            null as CurrentRefreshSnapshot | null,
             {
                 markRefreshStarted: (_, { refreshId, triggeredBy }) => ({
                     refresh_id: refreshId,
@@ -885,11 +909,12 @@ export const experimentLogic = kea<experimentLogicType>([
                     started_at: Date.now(),
                     state: 'in_progress',
                 }),
-                markRefreshCompleted: (state, { refreshId, hasErrors }) => {
+                markRefreshFinished: (state, { refreshId, finalState }) => {
+                    // Stale-id guard: a newer refresh may already be in flight; don't clobber it.
                     if (!state || state.refresh_id !== refreshId) {
                         return state
                     }
-                    return { ...state, state: hasErrors ? 'errored' : 'completed' }
+                    return { ...state, state: finalState }
                 },
             },
         ],
@@ -1727,7 +1752,12 @@ export const experimentLogic = kea<experimentLogicType>([
                     }
                 )
 
-                actions.markRefreshCompleted(refreshId, caughtError || erroredCount > 0)
+                const finalState: FinishedRefreshState = caughtError
+                    ? 'errored'
+                    : erroredCount > 0
+                      ? 'partial'
+                      : 'completed'
+                actions.markRefreshFinished(refreshId, finalState)
 
                 // Clear notification offer timer
                 clearTimeout(cache.notificationOfferTimer)
@@ -2376,7 +2406,7 @@ export const experimentLogic = kea<experimentLogicType>([
                             triggered_by: 'auto-refresh',
                             auto_refresh_enabled: values.autoRefresh.enabled,
                             auto_refresh_interval: values.autoRefresh.interval,
-                            previous_refresh: values.lastRefresh,
+                            ...previousRefreshAnalytics(values.currentRefresh),
                         })
                         actions.refreshExperimentResults(true, 'auto_refresh')
                     }, values.autoRefresh.interval * 1000)


### PR DESCRIPTION
## Problem

When users click Refresh on an experiment, we currently fire `experiment metrics refreshed` (start) and `experiment results refresh completed` (end), but we have no first-class signal for **refresh-while-loading** — i.e. the user clicking Refresh again before the previous refresh has completed. That's a useful frustration indicator: it tells us the user wasn't willing to wait for results, and is something we want to track alongside the existing `experiment metric error` (404 / cache-expired) data we've been investigating for slow funnel queries.

The signal is technically derivable today by joining `experiment metrics refreshed` to its prior `experiment results refresh completed` via `refresh_id`, but that's painful in product analytics. Putting the state on the start event makes the analysis trivial.

## Changes

Adds four properties to the `experiment metrics refreshed` event, populated from the most recent refresh in the same scene:

- `previous_refresh_id`
- `previous_refresh_age_ms`
- `previous_refresh_state` — `'in_progress' | 'completed' | 'errored' | null`
- `previous_refresh_triggered_by` — to distinguish e.g. "user clicked while a manual refresh was in flight" from "user clicked while auto-refresh was running"

Implementation:

- New `LastRefreshSnapshot` type and `lastRefresh` reducer on `experimentLogic` that tracks the latest refresh's lifecycle. Updated by two new internal actions (`markRefreshStarted` / `markRefreshCompleted`).
- `refreshExperimentResults` listener fires `markRefreshStarted` at the top and `markRefreshCompleted` in `finally`, with a `caughtError` flag so a thrown promise (network error before any metric reports back) still marks the snapshot as `errored`.
- Both call sites of `reportExperimentMetricsRefreshed` (manual click in `Info.tsx`, auto-refresh interval in `experimentLogic.tsx`) now pass `previous_refresh: values.lastRefresh`.
- `lastRefresh` covers all four trigger types (`page_load`, `manual`, `auto_refresh`, `config_change`) so it's useful as the "previous" regardless of how the inflight refresh was started, but the event itself is unchanged in when it fires (still only manual + auto-refresh).

## How did you test this code?

I'm an agent (Claude). I did not perform manual browser testing. Automated checks I ran locally:

- `pnpm typescript:check` — clean
- `pnpm jest src/scenes/experiments/experimentLogic.test.ts` — 93 tests pass (91 existing + 2 new tests covering the in_progress → completed transition and stable `refresh_id`)
- `pnpm format` — touched files clean

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Origin: started from analysis of `experiment metric error` events (mostly 404s on funnel metric refreshes) where existing tracking only catches the eventual-timeout case but misses users who give up and click Refresh while loading. This PR closes that observability gap on the click side; an unmount/abandonment event is a separate follow-up.
- Decision worth a second look: I added `previous_refresh_triggered_by` as a fourth field beyond what was strictly required — the data is already on the snapshot and it sharpens the analysis (manual-while-auto-refresh vs manual-while-manual). Easy to drop if you'd prefer a tighter event.