### PR TITLE
fix(notebooks): cleaner sql output panel if no editor

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -527,9 +527,10 @@ function OutputActions({
 
 interface OutputPaneProps {
     tabId: string
+    showToolbar?: boolean
 }
 
-export function OutputPane({ tabId }: OutputPaneProps): JSX.Element {
+export function OutputPane({ tabId, showToolbar = true }: OutputPaneProps): JSX.Element {
     const { activeTab } = useValues(outputPaneLogic)
     const { setActiveTab } = useActions(outputPaneLogic)
 
@@ -739,7 +740,7 @@ export function OutputPane({ tabId }: OutputPaneProps): JSX.Element {
         pollResponse,
         setProgress,
         progress: queryId ? progressCache[queryId] : undefined,
-        showVisualizationSettings: isChartSettingsPanelOpen,
+        showVisualizationSettings: showToolbar && isChartSettingsPanelOpen,
     }
     const sharedActionsProps = {
         response,
@@ -761,29 +762,33 @@ export function OutputPane({ tabId }: OutputPaneProps): JSX.Element {
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{ width: splitPaneWidth, maxWidth: 'calc(100% - 16rem)' }}
             >
-                <div className="flex flex-row justify-between align-center w-full min-h-[41px] overflow-y-auto border-r">
-                    <div className="flex min-h-[41px] gap-2 ml-4">
-                        {splitToggle}
-                        <OutputTabLabel tab={outputTabs[0]} active />
+                {showToolbar ? (
+                    <div className="flex flex-row justify-between align-center w-full min-h-[41px] overflow-y-auto border-r">
+                        <div className="flex min-h-[41px] gap-2 ml-4">
+                            {splitToggle}
+                            <OutputTabLabel tab={outputTabs[0]} active />
+                        </div>
+                        <div className="flex gap-2 py-1 px-4 flex-shrink-0">
+                            <OutputActions activeTab={OutputTab.Results} {...sharedActionsProps} />
+                        </div>
                     </div>
-                    <div className="flex gap-2 py-1 px-4 flex-shrink-0">
-                        <OutputActions activeTab={OutputTab.Results} {...sharedActionsProps} />
-                    </div>
-                </div>
+                ) : null}
                 <div className="flex flex-1 min-h-0 relative bg-dark border-r">
                     <Content activeTab={OutputTab.Results} {...sharedContentProps} />
                 </div>
                 <Resizer {...splitResizerProps} />
             </div>
             <div className="flex min-w-0 flex-1 flex-col bg-white dark:bg-black">
-                <div className="flex flex-row justify-between align-center w-full min-h-[41px] overflow-y-auto">
-                    <div className="flex min-h-[41px] gap-2 ml-4">
-                        <OutputTabLabel tab={outputTabs[1]} active />
+                {showToolbar ? (
+                    <div className="flex flex-row justify-between align-center w-full min-h-[41px] overflow-y-auto">
+                        <div className="flex min-h-[41px] gap-2 ml-4">
+                            <OutputTabLabel tab={outputTabs[1]} active />
+                        </div>
+                        <div className="flex gap-2 py-1 px-4 flex-shrink-0">
+                            <OutputActions activeTab={OutputTab.Visualization} {...sharedActionsProps} />
+                        </div>
                     </div>
-                    <div className="flex gap-2 py-1 px-4 flex-shrink-0">
-                        <OutputActions activeTab={OutputTab.Visualization} {...sharedActionsProps} />
-                    </div>
-                </div>
+                ) : null}
                 <div className="flex flex-1 min-h-0 relative bg-dark">
                     <Content activeTab={OutputTab.Visualization} {...sharedContentProps} />
                 </div>
@@ -791,22 +796,24 @@ export function OutputPane({ tabId }: OutputPaneProps): JSX.Element {
         </div>
     ) : (
         <>
-            <div className="flex flex-row justify-between align-center w-full min-h-[41px] overflow-y-auto">
-                <div className="flex min-h-[41px] gap-2 ml-4">
-                    {splitToggle}
-                    {outputTabs.map((tab) => (
-                        <OutputTabLabel
-                            key={tab.key}
-                            tab={tab}
-                            active={tab.key === activeTab}
-                            onClick={() => setActiveTab(tab.key)}
-                        />
-                    ))}
+            {showToolbar ? (
+                <div className="flex flex-row justify-between align-center w-full min-h-[41px] overflow-y-auto">
+                    <div className="flex min-h-[41px] gap-2 ml-4">
+                        {splitToggle}
+                        {outputTabs.map((tab) => (
+                            <OutputTabLabel
+                                key={tab.key}
+                                tab={tab}
+                                active={tab.key === activeTab}
+                                onClick={() => setActiveTab(tab.key)}
+                            />
+                        ))}
+                    </div>
+                    <div className="flex gap-2 py-1 px-4 flex-shrink-0">
+                        <OutputActions activeTab={activeTab} {...sharedActionsProps} />
+                    </div>
                 </div>
-                <div className="flex gap-2 py-1 px-4 flex-shrink-0">
-                    <OutputActions activeTab={activeTab} {...sharedActionsProps} />
-                </div>
-            </div>
+            ) : null}
             <div className="flex flex-1 min-h-0 relative bg-dark">
                 <Content activeTab={activeTab} {...sharedContentProps} />
             </div>

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -51,6 +51,7 @@ interface SQLEditorProps {
     showDatabaseTree?: boolean
     defaultShowDatabaseTree?: boolean
     panel?: SQLEditorPanel
+    showOutputToolbar?: boolean
 }
 
 export function SQLEditor({
@@ -59,6 +60,7 @@ export function SQLEditor({
     showDatabaseTree,
     defaultShowDatabaseTree = true,
     panel = SQLEditorPanel.Full,
+    showOutputToolbar = true,
 }: SQLEditorProps): JSX.Element {
     const ref = useRef(null)
     const navigatorRef = useRef(null)
@@ -187,7 +189,7 @@ export function SQLEditor({
                                     <VariablesQuerySync />
                                     {panel === SQLEditorPanel.Output ? (
                                         <div className="flex h-full min-h-0 flex-col overflow-hidden">
-                                            <OutputPane tabId={tabId || ''} />
+                                            <OutputPane tabId={tabId || ''} showToolbar={showOutputToolbar} />
                                         </div>
                                     ) : (
                                         <BindLogic logic={editorSizingLogic} props={editorSizingLogicProps}>

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -299,7 +299,12 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
 
                                             <div className="flex deprecated-space-x-1">
                                                 {parsedHref && (
-                                                    <LemonButton size="small" icon={<IconLink />} to={parsedHref} />
+                                                    <LemonButton
+                                                        size="small"
+                                                        icon={<IconLink />}
+                                                        to={parsedHref}
+                                                        tooltip="Open linked resource"
+                                                    />
                                                 )}
 
                                                 {isPythonNode ? (
@@ -340,6 +345,11 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                                         size="small"
                                                         icon={<IconPencil />}
                                                         active={editingNodeIds[nodeId]}
+                                                        tooltip={
+                                                            editingNodeIds[nodeId]
+                                                                ? 'Hide editor'
+                                                                : 'Show editor and settings'
+                                                        }
                                                         data-attr="notebook-node-edit-settings"
                                                     />
                                                 ) : null}
@@ -349,12 +359,17 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                                         onClick={() => setExpanded(!expanded)}
                                                         size="small"
                                                         icon={expanded ? <IconCollapse /> : <IconExpand />}
+                                                        tooltip={expanded ? 'Hide output' : 'Show output'}
                                                     />
                                                 )}
 
                                                 {hasMenu ? (
                                                     <LemonMenu items={menuItems} placement="bottom-end">
-                                                        <LemonButton icon={<IconEllipsis />} size="small" />
+                                                        <LemonButton
+                                                            icon={<IconEllipsis />}
+                                                            size="small"
+                                                            tooltip="More actions"
+                                                        />
                                                     </LemonMenu>
                                                 ) : null}
                                             </div>
@@ -413,6 +428,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                             size="xsmall"
                                             type="secondary"
                                             icon={<IconPlus />}
+                                            tooltip="Add block"
                                             onClick={(e) => {
                                                 e.stopPropagation()
                                                 setSlashCommandsPopoverVisible(true)
@@ -425,6 +441,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                             size="xsmall"
                                             type="secondary"
                                             icon={x.icon ?? <IconPlus />}
+                                            tooltip={x.text}
                                             onClick={(e) => {
                                                 e.stopPropagation()
                                                 x.onClick()

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -126,7 +126,8 @@ function useNotebookSQLEditorSync({
 function NotebookSQLEditorOutput({
     attributes,
     updateAttributes,
-}: NotebookNodeProps<NotebookNodeQueryAttributes>): JSX.Element | null {
+    showOutputToolbar,
+}: NotebookNodeProps<NotebookNodeQueryAttributes> & { showOutputToolbar: boolean }): JSX.Element | null {
     const tabId = useMemo(() => getNotebookSqlEditorTabId(attributes.nodeId), [attributes.nodeId])
     const editorSourceQuery = useNotebookSQLEditorSync({ attributes, updateAttributes, tabId })
 
@@ -145,6 +146,7 @@ function NotebookSQLEditorOutput({
                 mode={SQLEditorMode.Embedded}
                 panel={SQLEditorPanel.Output}
                 defaultShowDatabaseTree={false}
+                showOutputToolbar={showOutputToolbar}
             />
         </div>
     )
@@ -187,7 +189,8 @@ const Component = ({
 }: NotebookNodeProps<NotebookNodeQueryAttributes>): JSX.Element | null => {
     const { query, nodeId } = attributes
     const nodeLogic = useMountedLogic(notebookNodeLogic)
-    const { expanded, notebookLogic } = useValues(nodeLogic)
+    const { expanded, nodeId: resolvedNodeId, notebookLogic } = useValues(nodeLogic)
+    const { editingNodeIds } = useValues(notebookLogic)
     const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
     const { canvasFiltersOverride } = useValues(notebookLogic)
@@ -264,7 +267,11 @@ const Component = ({
     if (isNotebookSqlEditorEnabled && getSqlEditorSourceQuery(query)) {
         return (
             <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
-                <NotebookSQLEditorOutput attributes={attributes} updateAttributes={updateAttributes} />
+                <NotebookSQLEditorOutput
+                    attributes={attributes}
+                    updateAttributes={updateAttributes}
+                    showOutputToolbar={!!editingNodeIds[resolvedNodeId]}
+                />
             </div>
         )
     }


### PR DESCRIPTION
## Problem

The new SQL editor in notebooks works well, however when the editor is closed, we should also hide the chart editing controls:

<img width="1892" height="1423" alt="2026-04-30 12 08 11" src="https://github.com/user-attachments/assets/c6f64a72-9d2e-4838-ac31-d5754100c3fa" />

## Changes

Now with just the output open, the view is cleaner:

<img width="1892" height="1423" alt="2026-04-30 12 40 46" src="https://github.com/user-attachments/assets/80be335c-4521-404e-9074-da8406a8f0ef" />


## How did you test this code?

👀 