### PR TITLE
chore(devex): seed Postgres schema cache from master CI runs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -870,7 +870,7 @@ jobs:
               # wins; LRU eviction handles cleanup. No PR-side consumer yet —
               # this just establishes the cache so the follow-up lands hot.
               if: github.event_name == 'push'
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                   path: schema.sql.gz
                   key: posthog-schema-master-${{ github.sha }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -863,6 +863,18 @@ jobs:
                   path: schema.sql.gz
                   retention-days: 90
 
+            - name: Save schema to Actions cache for PR shards
+              # Seeds a Postgres schema cache that PR test jobs will read in a
+              # follow-up change to skip the full Django migrate. SHA-suffixed
+              # key + restore-keys prefix means the newest master cache always
+              # wins; LRU eviction handles cleanup. No PR-side consumer yet —
+              # this just establishes the cache so the follow-up lands hot.
+              if: github.event_name == 'push'
+              uses: actions/cache/save@v4
+              with:
+                  path: schema.sql.gz
+                  key: posthog-schema-master-${{ github.sha }}
+
             - name: Check migrations
               # Skip migration safety check on master push (no migration_files from path filter)
               if: github.event_name != 'push'


### PR DESCRIPTION
## Problem

Every PR currently has ~57 backend + dagster shards hitting `gh api` + `gh run download` to fetch the `migrated-schema` artifact for `pytest --reuse-db`. That eats into the 1k/hour `GITHUB_TOKEN` rate limit and adds avoidable network cost per shard.

## Changes

Adds a single `actions/cache/save@v4` step in the migration-check job (master push only) that caches `schema.sql.gz` under `posthog-schema-master-${{ github.sha }}`.

No consumer in this PR — that's deliberate. Landing the producer first means the cache is already populated by the time the consumer follow-up merges, so the first PR after that doesn't see a cold cache.

The follow-up (separate PR) will replace the `gh-api`-based prime step in PR test jobs with `actions/cache/restore@v4` + `restore-keys: posthog-schema-master-` (newest master cache wins, LRU eviction handles cleanup, no explicit invalidation).

## How did you test this code?

Agent-run, no manual testing. The change is a single additive workflow step gated to `github.event_name == 'push'` — has zero effect on PR runs and only does extra work on master push (cache write is async / very cheap).

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Co-authored with Claude (Opus 4.7). Extracted from #54292 so the cache producer can land independently of the consumer changes that touch ci-backend, ci-dagster, and hogli.yaml. Sequencing this way removes the cold-start penalty when the follow-up merges.