### PR TITLE
fix(retention): keep first-ever cohort intact when applying a breakdown

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -48,6 +48,13 @@ class RetentionBaseQueryBuilder(ABC):
         return self.runner.start_entity_expr
 
     @property
+    def start_entity_expr_no_props(self) -> ast.Expr:
+        # Start-event matcher with property filters stripped — used to anchor "first ever" against the unfiltered stream.
+        clean_start_event = self.start_event.model_copy(deep=True)
+        clean_start_event.properties = []
+        return entity_to_expr(clean_start_event, self.team)
+
+    @property
     def return_entity_expr(self) -> ast.Expr:
         return self.runner.return_entity_expr
 
@@ -128,7 +135,24 @@ class RetentionBaseQueryBuilder(ABC):
                 self.query.breakdownFilter.breakdown_group_type_index,
             )
 
-        if breakdown_expr:
+        if breakdown_expr is None:
+            return
+
+        if self.is_first_ever_occurrence:
+            # Bucket each user by the breakdown value on their absolute-first
+            # start event. Adding breakdown_value to GROUP BY (the else branch)
+            # would split each user into one partition per breakdown value they
+            # ever had, and the per-partition "first ever" check would silently
+            # become "first ever with this value" — letting one user populate
+            # multiple buckets. argMinIf reads the breakdown property off the
+            # user's earliest start-event row; missing values fall into the
+            # empty-string bucket via breakdown_extract_expr's ifNull wrap.
+            breakdown_value_expr: ast.Expr = parse_expr(
+                "argMinIf({breakdown}, events.timestamp, {entity})",
+                {"breakdown": breakdown_expr, "entity": self.start_entity_expr_no_props},
+            )
+            base_query.select.append(ast.Alias(alias="breakdown_value", expr=breakdown_value_expr))
+        else:
             base_query.select.append(ast.Alias(alias="breakdown_value", expr=breakdown_expr))
             cast(list[ast.Expr], base_query.group_by).append(ast.Field(chain=["breakdown_value"]))
 
@@ -140,15 +164,10 @@ class RetentionBaseQueryBuilder(ABC):
             start_entity_with_properties_expr = entity_to_expr(self.start_event, self.team)
 
             if self.is_first_ever_occurrence:
-                # Create a clean entity without properties to find the true first-ever event
-                clean_start_event = self.start_event.model_copy(deep=True)
-                clean_start_event.properties = []
-                start_entity_expr_no_props = entity_to_expr(clean_start_event, self.team)
-
                 # First-ever occurrence of the target event, then check filters.
                 # We find the timestamp of the first event of this type, and the first event of this type that also matches properties.
                 # If they are the same, this is the user's cohorting event.
-                min_ts_expr = parse_expr("minIf(events.timestamp, {expr})", {"expr": start_entity_expr_no_props})
+                min_ts_expr = parse_expr("minIf(events.timestamp, {expr})", {"expr": self.start_entity_expr_no_props})
                 min_ts_with_props_expr = parse_expr(
                     "minIf(events.timestamp, {expr})", {"expr": start_entity_with_properties_expr}
                 )

--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import cached_property
 from typing import TYPE_CHECKING, Optional, cast
 
 from posthog.hogql import ast
@@ -47,7 +48,7 @@ class RetentionBaseQueryBuilder(ABC):
     def start_entity_expr(self) -> ast.Expr:
         return self.runner.start_entity_expr
 
-    @property
+    @cached_property
     def start_entity_expr_no_props(self) -> ast.Expr:
         # Start-event matcher with property filters stripped — used to anchor "first ever" against the unfiltered stream.
         clean_start_event = self.start_event.model_copy(deep=True)

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -2888,6 +2888,86 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
+    def test_retention_first_time_ever_breakdown_does_not_inflate_buckets(self):
+        # First-ever retention with a breakdown by an event property that was
+        # captured later than the user's first event (e.g. a flag rolled out
+        # after they first opened the app). Each user must land in exactly one
+        # bucket — the breakdown value on their absolute-first start event.
+        # old_user must land only in the empty bucket on day 0; their later
+        # control-tagged event must not pull them into the control bucket.
+        _create_person(team_id=self.team.pk, distinct_ids=["old_user"])
+        _create_person(team_id=self.team.pk, distinct_ids=["new_user"])
+
+        # old_user: first app_opened on day 0 (pre-flag), again on day 2 tagged control, insight_viewed day 3.
+        _create_events(self.team, [("old_user", _date(0))], "app_opened")
+        _create_events(self.team, [("old_user", _date(2), {"$feature/new_design": "control"})], "app_opened")
+        _create_events(self.team, [("old_user", _date(3), {"$feature/new_design": "control"})], "insight_viewed")
+
+        # new_user: first app_opened on day 2 tagged variant_a, insight_viewed day 3.
+        _create_events(self.team, [("new_user", _date(2), {"$feature/new_design": "variant_a"})], "app_opened")
+        _create_events(self.team, [("new_user", _date(3), {"$feature/new_design": "variant_a"})], "insight_viewed")
+
+        flush_persons_and_events()
+
+        base_query: dict[str, Any] = {
+            "dateRange": {"date_from": _date(0), "date_to": _date(4)},
+            "retentionFilter": {
+                "period": "Day",
+                "totalIntervals": 4,
+                "retentionType": RETENTION_FIRST_EVER_OCCURRENCE,
+                "targetEntity": {"id": "app_opened", "name": "app_opened", "type": TREND_FILTER_TYPE_EVENTS},
+                "returningEntity": {"id": "insight_viewed", "name": "insight_viewed", "type": "events"},
+            },
+        }
+
+        unbroken = self.run_query(query=base_query)
+        unbroken_cohort_sizes = [row["values"][0]["count"] for row in unbroken]
+
+        broken_down = self.run_query(
+            query={
+                **base_query,
+                "breakdownFilter": {"breakdown": "$feature/new_design", "breakdown_type": "event"},
+            }
+        )
+
+        # Per-day, breakdown buckets must sum to the unbroken total.
+        per_date_totals: dict[Any, int] = {}
+        for row in broken_down:
+            per_date_totals[row["date"]] = per_date_totals.get(row["date"], 0) + row["values"][0]["count"]
+
+        for unbroken_row, total in zip(unbroken, unbroken_cohort_sizes):
+            self.assertEqual(
+                per_date_totals.get(unbroken_row["date"], 0),
+                total,
+                f"breakdown bucket sum should equal unbroken total on {unbroken_row['date']}",
+            )
+
+        def cohort_count(breakdown_value: str, day_index: int) -> int:
+            target_date = unbroken[day_index]["date"]
+            return sum(
+                row["values"][0]["count"]
+                for row in broken_down
+                if row.get("breakdown_value") == breakdown_value and row["date"] == target_date
+            )
+
+        self.assertEqual(cohort_count("", 0), 1)  # old_user, first event had no flag
+        self.assertEqual(cohort_count("variant_a", 2), 1)  # new_user
+        self.assertEqual(cohort_count("control", 2), 0)  # old_user must not leak here
+
+        # Pin down person identities per bucket — same data the cohort modal shows.
+        actors_query = {
+            **base_query,
+            "breakdownFilter": {"breakdown": "$feature/new_design", "breakdown_type": "event"},
+        }
+
+        def actor_distinct_ids(interval: int, breakdown_value: str) -> list[str]:
+            rows = self.run_actors_query(interval=interval, query=actors_query, breakdown=[breakdown_value])
+            return sorted(distinct_id for row in rows for distinct_id in row[0]["distinct_ids"])
+
+        self.assertEqual(actor_distinct_ids(0, ""), ["old_user"])
+        self.assertEqual(actor_distinct_ids(2, "variant_a"), ["new_user"])
+        self.assertEqual(actor_distinct_ids(2, "control"), [])
+
     def test_retention_first_time_ever_with_cohort_breakdown(self):
         """Test first time ever retention with cohort breakdown"""
         # Create cohorts

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -2921,8 +2921,6 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
         }
 
         unbroken = self.run_query(query=base_query)
-        unbroken_cohort_sizes = [row["values"][0]["count"] for row in unbroken]
-
         broken_down = self.run_query(
             query={
                 **base_query,
@@ -2935,10 +2933,10 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
         for row in broken_down:
             per_date_totals[row["date"]] = per_date_totals.get(row["date"], 0) + row["values"][0]["count"]
 
-        for unbroken_row, total in zip(unbroken, unbroken_cohort_sizes):
+        for unbroken_row in unbroken:
             self.assertEqual(
                 per_date_totals.get(unbroken_row["date"], 0),
-                total,
+                unbroken_row["values"][0]["count"],
                 f"breakdown bucket sum should equal unbroken total on {unbroken_row['date']}",
             )
 


### PR DESCRIPTION
## Problem

Retention insights using **First time ever** plus a **breakdown** can produce per-bucket cohort sums that exceed the unbroken total. A user whose absolute-first start event predates the breakdown property (e.g. an event captured before a feature flag rolled out) ends up double-counted: once in the empty-string bucket on their true first-event day, and again in a tagged bucket on the day their first flag-tagged event landed.

https://posthoghelp.zendesk.com/agent/tickets/57068 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/58028)

## Changes

Inside `apply_breakdown`, the first-ever path no longer adds `breakdown_value` to `GROUP BY`. Instead it computes the breakdown value via `argMinIf(breakdown_expr, events.timestamp, start_entity_no_props)` — reading the property off the user's earliest start-event row. Recurring and `first_occurrence_matching_filters` paths are unchanged.

Why: with `breakdown_value` in `GROUP BY`, each user is split into one partition per breakdown value they ever had, and the per-partition first-ever check silently becomes "first ever **with this value**" — letting one user populate multiple buckets.

Side-effect: a small helper `start_entity_expr_no_props` is now a property and shared with `get_first_time_anchor_expr`.

No frontend changes.

## How did you test this code?

- **Manually verified end-to-end in a local instance.** Seeded a two-user scenario (`old_user` with a pre-flag first event, `new_user` with a flag-tagged first event), built the retention insight (target = `app_opened`, breakdown = `$feature/new_design`, type = First time ever) and compared bucket counts before/after the fix. Pre-fix: `control = 2, '' = 1` (sum 3, but only 2 users). Post-fix: `control = 1, '' = 1` (sum 2, matches user count). Confirmed `old_user` no longer leaks into the day-2 control bucket via the cohort modal.
- **Added a focused automated test** `test_retention_first_time_ever_breakdown_does_not_inflate_buckets` covering the same scenario, with both per-day "buckets sum to unbroken total" and per-bucket actor-identity assertions via the actors query.

## Publish to changelog?

no

## Docs update

Not needed — this is a correctness fix, not a feature. Behavior change only affects first-ever retention with a breakdown.

## 🤖 Agent context

Co-authored with Claude (Claude Code, Opus 4.7 1M-context) to fix a customer-reported case where retention bucket sums exceeded the unbroken total. Fix is scoped to `is_first_ever_occurrence`.