### PR TITLE
feat(insights): capture hog chart rendered for rollout dashboard

### DIFF
--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useCallback, useMemo, type ErrorInfo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, type ErrorInfo } from 'react'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { createXAxisTickCallback, DEFAULT_Y_AXIS_ID, LineChart, ReferenceLines, ValueLabels } from 'lib/hog-charts'
@@ -14,6 +14,7 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import { ChartDisplayType } from '~/types'
 
 import { InsightEmptyState } from '../../../insights/EmptyStates'
 import { openPersonsModal } from '../../persons-modal/PersonsModal'
@@ -75,6 +76,23 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
     } = useValues(trendsDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
+
+    const capturedRef = useRef(false)
+    useEffect(() => {
+        if (capturedRef.current) {
+            return
+        }
+        capturedRef.current = true
+        posthog.capture('hog chart rendered', {
+            chart_type: display ?? ChartDisplayType.ActionsLineGraph,
+            has_breakdown: !!breakdownFilter?.breakdown,
+            series_count: indexedResults?.length ?? 0,
+            insight_short_id: insight?.short_id,
+            dashboard_id: insightProps?.dashboardId,
+            in_shared_mode: inSharedMode,
+        })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     const isPercentStackView = !!showPercentStackView && !!supportsPercentStackView
     const resolvedGroupTypeLabel =


### PR DESCRIPTION
## Problem

We're rolling out the new \`TrendsLineChart\` (powered by hog-charts) behind the \`product-analytics-hog-charts\` feature flag. To measure rollout health (errors, frustration signals, performance) per variant we need a clean exposure metric — pageviews on \`/insights\` and \`/dashboard\` are too noisy because not every page renders the new chart (e.g. funnels, lifecycle, stickiness all stay on the legacy chart).

## Changes

\`TrendsLineChart\` now fires a \`hog chart rendered\` event once per mount with:

- \`chart_type\` (line / area / cumulative)
- \`has_breakdown\`, \`series_count\`
- \`insight_short_id\`, \`dashboard_id\`, \`in_shared_mode\`

A \`useRef\` guard prevents re-fires inside the same mount as data refreshes — so this measures impressions of the new chart, not re-renders.

The event drives the [Hog charts rollout dashboard](https://us.posthog.com/project/2/dashboard/1528179) (impressions + DAU broken down by variant). Other tiles (exceptions, dead/rage clicks, load time) already filter by \`\$feature/product-analytics-hog-charts\` and are now on log-scale Y axes so the test variant is visible alongside the much larger control variant.

## How did you test this code?

I'm an agent — no manual testing performed. Verified that the file compiles in isolation; existing unit tests for \`TrendsLineChart\` still pass on CI.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Agent-authored via PostHog Code. Key decisions:

- Used \`useRef\` + empty-deps \`useEffect\` so each mount fires exactly one capture, regardless of how many times \`indexedResults\` updates as data loads. The eslint-disable comment is intentional — adding deps would re-fire on every data refresh.
- Did *not* add a URL filter to the dashboard's exposure tile — the event itself only fires when the chart actually renders, so URL filtering is redundant and would just exclude valid impressions on shared/embedded pages.
- Did *not* gate the capture on \`hasData\` — failed loads are still meaningful "user was exposed to this code path" signal for error metrics.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*