### PR TITLE
fix(insights): isolate annotation hovers and report chart render errors

### DIFF
--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from '../core/canvas-renderer'
 import type { DrawContext } from '../core/canvas-renderer'
 import { Chart } from '../core/Chart'
+import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
 import {
     computePercentStackData,
     computeStackData,
@@ -40,9 +41,18 @@ export interface LineChartProps<Meta = unknown> {
     onPointClick?: (data: PointClickData<Meta>) => void
     className?: string
     children?: React.ReactNode
+    onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
-export function LineChart<Meta = unknown>({
+export function LineChart<Meta = unknown>(props: LineChartProps<Meta>): React.ReactElement {
+    return (
+        <ChartErrorBoundary onError={props.onError}>
+            <LineChartInner {...props} />
+        </ChartErrorBoundary>
+    )
+}
+
+function LineChartInner<Meta = unknown>({
     series,
     labels,
     config,

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -44,10 +44,10 @@ export interface LineChartProps<Meta = unknown> {
     onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
-export function LineChart<Meta = unknown>(props: LineChartProps<Meta>): React.ReactElement {
+export function LineChart<Meta = unknown>({ onError, ...rest }: LineChartProps<Meta>): React.ReactElement {
     return (
-        <ChartErrorBoundary onError={props.onError}>
-            <LineChartInner {...props} />
+        <ChartErrorBoundary onError={onError}>
+            <LineChartInner {...rest} />
         </ChartErrorBoundary>
     )
 }

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -7,7 +7,6 @@ import { Tooltip } from '../overlays/Tooltip'
 import { drawCrosshair } from './canvas-renderer'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
 import type { ChartHoverContextValue, ChartLayoutContextValue } from './chart-context'
-import { ChartErrorBoundary } from './ChartErrorBoundary'
 import { useChartCanvas } from './hooks/useChartCanvas'
 import { useChartDraw } from './hooks/useChartDraw'
 import { useChartInteraction } from './hooks/useChartInteraction'
@@ -314,45 +313,43 @@ export function Chart<Meta = unknown>({
     const hoverValue = useMemo<ChartHoverContextValue>(() => ({ hoverIndex }), [hoverIndex])
 
     return (
-        <ChartErrorBoundary>
-            <ChartLayoutContext.Provider value={layoutValue}>
-                <ChartHoverContext.Provider value={hoverValue}>
-                    <div
-                        ref={wrapperRef}
-                        className={className}
-                        style={wrapperStyle}
-                        onMouseMove={handlers.onMouseMove}
-                        onMouseLeave={handlers.onMouseLeave}
-                        onClick={handlers.onClick}
-                    >
-                        <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
-                        <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
+        <ChartLayoutContext.Provider value={layoutValue}>
+            <ChartHoverContext.Provider value={hoverValue}>
+                <div
+                    ref={wrapperRef}
+                    className={className}
+                    style={wrapperStyle}
+                    onMouseMove={handlers.onMouseMove}
+                    onMouseLeave={handlers.onMouseLeave}
+                    onClick={handlers.onClick}
+                >
+                    <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
+                    <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
 
-                        {dimensions && scales && (
-                            <OverlayLayer>
-                                <AxisLabels
-                                    xTickFormatter={xTickFormatter}
-                                    yTickFormatter={resolvedYFormatter}
-                                    yRightTickFormatter={resolvedYRightFormatter}
-                                    hideXAxis={hideXAxis}
-                                    hideYAxis={hideYAxis}
-                                    axisColor={theme.axisColor}
+                    {dimensions && scales && (
+                        <OverlayLayer>
+                            <AxisLabels
+                                xTickFormatter={xTickFormatter}
+                                yTickFormatter={resolvedYFormatter}
+                                yRightTickFormatter={resolvedYRightFormatter}
+                                hideXAxis={hideXAxis}
+                                hideYAxis={hideYAxis}
+                                axisColor={theme.axisColor}
+                            />
+
+                            {children}
+
+                            {tooltipCtx && showTooltip && (
+                                <Tooltip
+                                    context={tooltipCtx}
+                                    renderTooltip={renderTooltip}
+                                    placement={tooltipPlacement}
                                 />
-
-                                {children}
-
-                                {tooltipCtx && showTooltip && (
-                                    <Tooltip
-                                        context={tooltipCtx}
-                                        renderTooltip={renderTooltip}
-                                        placement={tooltipPlacement}
-                                    />
-                                )}
-                            </OverlayLayer>
-                        )}
-                    </div>
-                </ChartHoverContext.Provider>
-            </ChartLayoutContext.Provider>
-        </ChartErrorBoundary>
+                            )}
+                        </OverlayLayer>
+                    )}
+                </div>
+            </ChartHoverContext.Provider>
+        </ChartLayoutContext.Provider>
     )
 }

--- a/frontend/src/lib/hog-charts/core/ChartErrorBoundary.tsx
+++ b/frontend/src/lib/hog-charts/core/ChartErrorBoundary.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 interface ChartErrorBoundaryProps {
     children: React.ReactNode
     fallback?: React.ReactNode
+    onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
 interface ChartErrorBoundaryState {
@@ -29,6 +30,7 @@ export class ChartErrorBoundary extends React.Component<ChartErrorBoundaryProps,
 
     override componentDidCatch(error: Error, info: React.ErrorInfo): void {
         console.error('[hog-charts] render error:', error, info.componentStack)
+        this.props.onError?.(error, info)
     }
 
     override render(): React.ReactNode {

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -20,9 +20,10 @@ const WRAPPER_STYLE: React.CSSProperties = {
     pointerEvents: 'auto',
 }
 
-// Stop badge clicks from bubbling to the chart wrapper, which would otherwise
-// fire the chart's onPointClick (e.g. opening the persons modal).
-const stopClickPropagation = (e: React.MouseEvent<HTMLDivElement>): void => {
+// Stop pointer events from bubbling to the chart wrapper. Without this the chart's
+// onMouseMove tracks the cursor and moves the crosshair while the user is interacting
+// with annotation badges, and onClick fires onPointClick (e.g. opening the persons modal).
+const stopPointerPropagation = (e: React.MouseEvent<HTMLDivElement>): void => {
     e.stopPropagation()
 }
 
@@ -54,7 +55,13 @@ export function AnnotationsLayer({
     }
 
     return (
-        <div className="HogChartsAnnotationsLayer" style={WRAPPER_STYLE} onClick={stopClickPropagation}>
+        <div
+            className="HogChartsAnnotationsLayer"
+            style={WRAPPER_STYLE}
+            onClick={stopPointerPropagation}
+            onMouseMove={stopPointerPropagation}
+            onMouseDown={stopPointerPropagation}
+        >
             <AnnotationsOverlay
                 chart={chartLike as unknown as Chart}
                 dates={dates}

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -20,9 +20,7 @@ const WRAPPER_STYLE: React.CSSProperties = {
     pointerEvents: 'auto',
 }
 
-// Stop pointer events from bubbling to the chart wrapper. Without this the chart's
-// onMouseMove tracks the cursor and moves the crosshair while the user is interacting
-// with annotation badges, and onClick fires onPointClick (e.g. opening the persons modal).
+// Annotation badges must not drive the chart's crosshair or onPointClick.
 const stopPointerPropagation = (e: React.MouseEvent<HTMLDivElement>): void => {
     e.stopPropagation()
 }

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -1,4 +1,5 @@
 import { useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useCallback, useMemo } from 'react'
 
 import { createXAxisTickCallback } from 'lib/charts/utils/dates'
@@ -90,7 +91,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
     // Dash the in-progress tail (mirrors LineGraph.tsx). Stickiness indices aren't dates.
     const isInProgress = !isStickiness && incompletenessOffsetFromEnd < 0
 
-    const hogSeries: Series<TrendsSeriesMeta>[] = useMemo(
+    const series: Series<TrendsSeriesMeta>[] = useMemo(
         () =>
             (indexedResults ?? []).flatMap((r: IndexedTrendResult, index: number) => {
                 const isActiveSeries = !r.compare || r.compare_label !== 'previous'
@@ -223,7 +224,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         [yAxisScaleType, isPercentStackView, xTickFormatter, yTickFormatter]
     )
 
-    const referenceLines = useMemo(() => goalLinesToReferenceLines(goalLines, hogSeries), [goalLines, hogSeries])
+    const referenceLines = useMemo(() => goalLinesToReferenceLines(goalLines, series), [goalLines, series])
 
     const getYAxisId = useCallback(
         (r: IndexedTrendResult) => {
@@ -324,13 +325,14 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
 
     return (
         <LineChart
-            series={hogSeries}
+            series={series}
             labels={labels}
             config={chartConfig}
             theme={theme}
             tooltip={renderTooltip}
             onPointClick={canHandleClick ? onPointClick : undefined}
             className="LineGraph"
+            onError={(error) => posthog.captureException(error, { feature: 'trends-line-chart' })}
         >
             <ReferenceLines lines={referenceLines} />
             {insight.id ? (

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -36,6 +36,10 @@ interface TrendsLineChartProps {
     inSharedMode?: boolean
 }
 
+const handleChartError = (error: Error): void => {
+    posthog.captureException(error, { feature: 'trends-line-chart' })
+}
+
 export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineChartProps): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
@@ -332,7 +336,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             tooltip={renderTooltip}
             onPointClick={canHandleClick ? onPointClick : undefined}
             className="LineGraph"
-            onError={(error) => posthog.captureException(error, { feature: 'trends-line-chart' })}
+            onError={handleChartError}
         >
             <ReferenceLines lines={referenceLines} />
             {insight.id ? (

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, type ErrorInfo } from 'react'
 
 import { createXAxisTickCallback } from 'lib/charts/utils/dates'
 import { buildTheme } from 'lib/charts/utils/theme'
@@ -36,8 +36,11 @@ interface TrendsLineChartProps {
     inSharedMode?: boolean
 }
 
-const handleChartError = (error: Error): void => {
-    posthog.captureException(error, { feature: 'trends-line-chart' })
+const handleChartError = (error: Error, info: ErrorInfo): void => {
+    posthog.captureException(error, {
+        feature: 'trends-line-chart',
+        componentStack: info.componentStack ?? undefined,
+    })
 }
 
 export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineChartProps): JSX.Element | null {


### PR DESCRIPTION
## Problem

Two follow-ups on the new hog-charts line chart:

- Hovering an annotation badge bubbled `mousemove` to the chart wrapper, so the crosshair kept tracking under the cursor while the user was interacting with annotations. The legacy chart.js implementation attached events to the canvas itself, which is why annotation hovers never reached the chart there.
- The chart's existing `ChartErrorBoundary` only `console.error`'d render failures — they never reached PostHog's exception capture.

## Changes

- `AnnotationsLayer` now stops `mousemove` and `mousedown` propagation on its wrapper (it already stopped `click`), so cursor activity over the annotations area no longer drives the chart's hover state.
- `ChartErrorBoundary` accepts an optional `onError(error, info)` callback alongside its existing `console.error`.
- `LineChart` now wraps its body with `ChartErrorBoundary` at the top level via a `LineChartInner` split, and exposes an `onError` prop that forwards to the boundary. This catches render failures in `LineChart`'s own hooks as well as everything inside `Chart` (boundaries only see descendants, so the previous boundary inside `Chart`'s return missed `Chart`'s own render-phase errors).
- `Chart` no longer wraps itself with the boundary, since the new top-level boundary in `LineChart` covers its descendants.
- `TrendsLineChart` passes `onError={(error) => posthog.captureException(error, { feature: 'trends-line-chart' })}` so chart render failures show up in error tracking.

## How did you test this code?

I'm an agent — no manual testing. No new automated tests; existing unit tests for `Chart`/`LineChart`/`useChartInteraction` should cover the structural refactor.

## Publish to changelog?

## 🤖 Agent context

Co-authored with Claude Code (Opus 4.7). Sam noticed the crosshair tracking behavior while QAing the new line chart and asked about error capture. The error-boundary placement question prompted moving the boundary up to the public `LineChart` so it covers `LineChart`'s and `Chart`'s render-phase errors, not just descendant overlays.