### PR TITLE
chore(tasks): update generated integration types

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -754,6 +754,10 @@ def create_posthog_code_task_for_repo_activity(
     except Exception:
         log.warning("posthog_code_slack_permalink_failed", channel=channel, thread_ts=thread_ts)
 
+    # Slack tasks can intentionally start without an attached repository. Keep
+    # PR tooling enabled so an explicit follow-up can clone a repo and publish.
+    allow_pr_creation = True
+
     # 1. Create task + run WITHOUT starting the workflow
     try:
         task = Task.create_and_run(
@@ -763,7 +767,7 @@ def create_posthog_code_task_for_repo_activity(
             origin_product=Task.OriginProduct.SLACK,
             user_id=user_id,
             repository=repository,
-            create_pr=repository is not None,
+            create_pr=allow_pr_creation,
             mode="interactive",
             slack_thread_context=slack_thread_context,
             slack_thread_url=slack_thread_url,
@@ -821,7 +825,7 @@ def create_posthog_code_task_for_repo_activity(
             run_id=str(task_run.id),
             team_id=task.team.id,
             user_id=user_id,
-            create_pr=repository is not None,
+            create_pr=allow_pr_creation,
             slack_thread_context=slack_thread_context,
             posthog_mcp_scopes="full",
         )
@@ -1123,7 +1127,7 @@ def _resume_task_with_new_run(
             run_id=str(new_run.id),
             team_id=mapping.task.team_id,
             user_id=created_by.id,
-            create_pr=mapping.task.repository is not None,
+            create_pr=True,
             slack_thread_context=slack_thread_context,
             posthog_mcp_scopes="full",
         )

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -9,8 +9,10 @@ from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
 from posthog.temporal.ai.posthog_code_slack_mention import (
     PostHogCodeSlackMentionWorkflowInputs,
+    create_posthog_code_task_for_repo_activity,
     forward_posthog_code_followup_activity,
 )
 
@@ -129,6 +131,124 @@ class TestSlackThreadTaskMapping(TestCase):
             )
 
 
+class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
+    def setUp(self):
+        self.Task = apps.get_model("tasks", "Task")
+        self.TaskRun = apps.get_model("tasks", "TaskRun")
+        self.org = Organization.objects.create(name="TestOrg")
+        self.team = Team.objects.create(organization=self.org, name="TestTeam")
+        self.user = User.objects.create(email="alice@test.com", distinct_id="user-1")
+        self.integration = Integration.objects.create(
+            team=self.team, kind="slack-posthog-code", integration_id="T_SLACK", config={}
+        )
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_no_repo_task_starts_with_pr_creation_enabled(self, mock_slack_cls, mock_execute_workflow):
+        mock_slack_instance = MagicMock()
+        mock_slack_instance.client.chat_getPermalink.return_value = {
+            "ok": True,
+            "permalink": "https://slack.example.com/thread",
+        }
+        mock_slack_cls.return_value = mock_slack_instance
+
+        inputs = _make_inputs(self.integration.id)
+        create_posthog_code_task_for_repo_activity(
+            inputs,
+            "C123",
+            "1234.5678",
+            "U_ALICE",
+            self.user.id,
+            inputs.event,
+            [{"user": "U_ALICE", "text": "run without repo"}],
+            None,
+        )
+
+        task = self.Task.objects.get(team=self.team)
+        assert task.repository is None
+        assert task.origin_product == self.Task.OriginProduct.SLACK
+        assert task.latest_run.state["interaction_origin"] == "slack"
+        assert task.latest_run.state["pr_authorship_mode"] == "bot"
+
+        mock_execute_workflow.assert_called_once()
+        call_kwargs = mock_execute_workflow.call_args.kwargs
+        assert call_kwargs["task_id"] == str(task.id)
+        assert call_kwargs["run_id"] == str(task.latest_run.id)
+        assert call_kwargs["create_pr"] is True
+        assert call_kwargs["posthog_mcp_scopes"] == "full"
+
+        mapping = SlackThreadTaskMapping.objects.get(
+            integration=self.integration, channel="C123", thread_ts="1234.5678"
+        )
+        assert mapping.task_id == task.id
+        assert mapping.task_run_id == task.latest_run.id
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_no_repo_task_falls_back_to_team_github_integration(self, mock_slack_cls, mock_execute_workflow):
+        Integration.objects.create(team=self.team, kind="github", integration_id="12345", config={})
+        mock_slack_instance = MagicMock()
+        mock_slack_instance.client.chat_getPermalink.return_value = {
+            "ok": True,
+            "permalink": "https://slack.example.com/thread",
+        }
+        mock_slack_cls.return_value = mock_slack_instance
+
+        inputs = _make_inputs(self.integration.id)
+        create_posthog_code_task_for_repo_activity(
+            inputs,
+            "C123",
+            "1234.5678",
+            "U_ALICE",
+            self.user.id,
+            inputs.event,
+            [{"user": "U_ALICE", "text": "clone a repo later"}],
+            None,
+        )
+
+        task = self.Task.objects.get(team=self.team)
+        assert task.repository is None
+        assert task.github_integration is not None
+        assert task.github_user_integration is None
+        assert task.latest_run.state["pr_authorship_mode"] == "bot"
+        mock_execute_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_no_repo_task_prefers_user_github_integration(self, mock_slack_cls, mock_execute_workflow):
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="github",
+            integration_id="12345",
+            config={"installation_id": "12345"},
+            sensitive_config={"user_access_token": "gho_user", "user_refresh_token": "ghr_user"},
+        )
+        mock_slack_instance = MagicMock()
+        mock_slack_instance.client.chat_getPermalink.return_value = {
+            "ok": True,
+            "permalink": "https://slack.example.com/thread",
+        }
+        mock_slack_cls.return_value = mock_slack_instance
+
+        inputs = _make_inputs(self.integration.id)
+        create_posthog_code_task_for_repo_activity(
+            inputs,
+            "C123",
+            "1234.5678",
+            "U_ALICE",
+            self.user.id,
+            inputs.event,
+            [{"user": "U_ALICE", "text": "clone a repo later"}],
+            None,
+        )
+
+        task = self.Task.objects.get(team=self.team)
+        assert task.repository is None
+        assert task.github_user_integration is not None
+        assert task.latest_run.state["pr_authorship_mode"] == "user"
+        mock_execute_workflow.assert_called_once()
+
+
 class TestForwardPostHogCodeFollowupActivity(TestCase):
     def setUp(self):
         self.Task = apps.get_model("tasks", "Task")
@@ -213,6 +333,25 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
             channel="C123", timestamp="1234.5679", name="eyes"
         )
         mock_slack_instance.client.chat_postMessage.assert_not_called()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_terminal_no_repo_run_resumes_with_pr_creation_enabled(self, mock_slack_cls, mock_execute_workflow):
+        self.task.repository = None
+        self.task.save()
+        self.task_run.status = self.TaskRun.Status.COMPLETED
+        self.task_run.save()
+        self._create_mapping()
+        mock_slack_cls.return_value = MagicMock()
+
+        inputs = _make_inputs(self.integration.id)
+        result = forward_posthog_code_followup_activity(
+            inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> clone org/repo and open PR", "1234.5679"
+        )
+
+        assert result is True
+        mock_execute_workflow.assert_called_once()
+        assert mock_execute_workflow.call_args.kwargs["create_pr"] is True
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -215,6 +215,45 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")
+    def test_no_repo_task_falls_back_to_team_github_integration_when_user_token_unusable(
+        self, mock_slack_cls, mock_execute_workflow
+    ):
+        Integration.objects.create(team=self.team, kind="github", integration_id="12345", config={})
+        UserIntegration.objects.create(
+            user=self.user,
+            kind="github",
+            integration_id="12345",
+            config={"installation_id": "12345"},
+            sensitive_config={},
+        )
+        mock_slack_instance = MagicMock()
+        mock_slack_instance.client.chat_getPermalink.return_value = {
+            "ok": True,
+            "permalink": "https://slack.example.com/thread",
+        }
+        mock_slack_cls.return_value = mock_slack_instance
+
+        inputs = _make_inputs(self.integration.id)
+        create_posthog_code_task_for_repo_activity(
+            inputs,
+            "C123",
+            "1234.5678",
+            "U_ALICE",
+            self.user.id,
+            inputs.event,
+            [{"user": "U_ALICE", "text": "clone a repo later"}],
+            None,
+        )
+
+        task = self.Task.objects.get(team=self.team)
+        assert task.repository is None
+        assert task.github_integration is not None
+        assert task.github_user_integration is None
+        assert task.latest_run.state["pr_authorship_mode"] == "bot"
+        mock_execute_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("posthog.models.integration.SlackIntegration")
     def test_no_repo_task_prefers_user_github_integration(self, mock_slack_cls, mock_execute_workflow):
         UserIntegration.objects.create(
             user=self.user,

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -31,6 +31,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.event_usage import groups
+from posthog.models.integration import Integration
 from posthog.permissions import APIScopePermission
 from posthog.rate_limit import CodeInviteThrottle
 from posthog.renderers import ServerSentEventRenderer
@@ -133,9 +134,31 @@ TASK_RUN_STREAM_KEEPALIVE_PAYLOAD = {"type": "keepalive"}
 TASK_RUN_ARTIFACT_UPLOAD_EXPIRATION_SECONDS = 60 * 60
 
 
-def _validate_user_authored_task_github_access(task: Task, *, request_user_id: int | None) -> Response | None:
+def _ensure_task_team_github_integration(task: Task) -> bool:
+    if task.github_integration_id is not None:
+        return True
+
+    github_integration = Integration.objects.filter(team_id=task.team_id, kind="github").first()
+    if github_integration is None:
+        return False
+
+    task.github_integration = github_integration
+    task.save(update_fields=["github_integration", "updated_at"])
+    return True
+
+
+def _resolve_cloud_pr_authorship_mode(
+    task: Task,
+    *,
+    pr_authorship_mode: PrAuthorshipMode | str | None,
+    request_user_id: int | None,
+    github_user_token: str | None,
+) -> tuple[PrAuthorshipMode | str | None, Response | None]:
+    if pr_authorship_mode != PrAuthorshipMode.USER or github_user_token:
+        return pr_authorship_mode, None
+
     if task.created_by_id != request_user_id:
-        return Response(
+        return None, Response(
             {
                 "type": "validation_error",
                 "code": "github_authorization_required",
@@ -146,22 +169,24 @@ def _validate_user_authored_task_github_access(task: Task, *, request_user_id: i
         )
 
     user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
-    if user_github_integration is None or not user_github_integration_is_usable(user_github_integration):
-        return Response(
-            {
-                "type": "validation_error",
-                "code": "github_authorization_required",
-                "detail": ("Link a GitHub account with repo access before running user-authored cloud tasks."),
-                "attr": "pr_authorship_mode",
-            },
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+    if user_github_integration is not None and user_github_integration_is_usable(user_github_integration):
+        if task.github_user_integration_id != user_github_integration.integration.id:
+            task.github_user_integration = user_github_integration.integration
+            task.save(update_fields=["github_user_integration", "updated_at"])
+        return PrAuthorshipMode.USER, None
 
-    if task.github_user_integration_id != user_github_integration.integration.id:
-        task.github_user_integration = user_github_integration.integration
-        task.save(update_fields=["github_user_integration", "updated_at"])
+    if _ensure_task_team_github_integration(task):
+        return PrAuthorshipMode.BOT, None
 
-    return None
+    return None, Response(
+        {
+            "type": "validation_error",
+            "code": "github_authorization_required",
+            "detail": ("Link a GitHub account with repo access before running user-authored cloud tasks."),
+            "attr": "pr_authorship_mode",
+        },
+        status=status.HTTP_400_BAD_REQUEST,
+    )
 
 
 TASK_RUN_ARTIFACT_UPLOAD_FORM_OVERHEAD_BYTES = 64 * 1024
@@ -655,16 +680,19 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 status=400,
             )
 
-        # User-authored cloud runs need *some* GitHub credential: either the caller
-        # ships its own token in ``github_user_token`` (backward compatibility), or
-        # the task creator has linked GitHub so the server has user-to-server tokens.
-        if pr_authorship_mode == PrAuthorshipMode.USER and not github_user_token:
-            validation_response = _validate_user_authored_task_github_access(
-                task,
-                request_user_id=getattr(request.user, "id", None),
+        pr_authorship_mode, validation_response = _resolve_cloud_pr_authorship_mode(
+            task,
+            pr_authorship_mode=pr_authorship_mode,
+            request_user_id=getattr(request.user, "id", None),
+            github_user_token=github_user_token,
+        )
+        if validation_response is not None:
+            return validation_response
+        if pr_authorship_mode is not None:
+            extra_state = extra_state or {}
+            extra_state["pr_authorship_mode"] = (
+                pr_authorship_mode.value if hasattr(pr_authorship_mode, "value") else pr_authorship_mode
             )
-            if validation_response is not None:
-                return validation_response
 
         if sandbox_environment_id is not None:
             sandbox_environment = SandboxEnvironment.get_accessible_for_task(
@@ -877,13 +905,19 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if pr_authorship_mode == PrAuthorshipMode.USER and not github_user_token:
-            validation_response = _validate_user_authored_task_github_access(
-                task,
-                request_user_id=getattr(request.user, "id", None),
+        pr_authorship_mode, validation_response = _resolve_cloud_pr_authorship_mode(
+            task,
+            pr_authorship_mode=pr_authorship_mode,
+            request_user_id=getattr(request.user, "id", None),
+            github_user_token=github_user_token,
+        )
+        if validation_response is not None:
+            return validation_response
+        if pr_authorship_mode is not None:
+            extra_state = extra_state or {}
+            extra_state["pr_authorship_mode"] = (
+                pr_authorship_mode.value if hasattr(pr_authorship_mode, "value") else pr_authorship_mode
             )
-            if validation_response is not None:
-                return validation_response
 
         if sandbox_environment_id is not None:
             sandbox_environment = SandboxEnvironment.get_accessible_for_task(
@@ -2127,12 +2161,21 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 )
 
             if get_pr_authorship_mode(task_run.task, task_run.state) == PrAuthorshipMode.USER:
-                validation_response = _validate_user_authored_task_github_access(
+                pr_authorship_mode, validation_response = _resolve_cloud_pr_authorship_mode(
                     task_run.task,
+                    pr_authorship_mode=PrAuthorshipMode.USER,
                     request_user_id=getattr(request.user, "id", None),
+                    github_user_token=None,
                 )
                 if validation_response is not None:
                     return validation_response
+                if pr_authorship_mode is not None:
+                    task_run.state = {
+                        **(task_run.state or {}),
+                        "pr_authorship_mode": (
+                            pr_authorship_mode.value if hasattr(pr_authorship_mode, "value") else pr_authorship_mode
+                        ),
+                    }
 
             prior_status = task_run.status
             prior_environment = task_run.environment

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -296,31 +296,30 @@ class Task(DeletedMetaFields, models.Model):
             resolve_user_github_integration_for_task,
         )
 
-        github_integration = None
+        github_integration = Integration.objects.filter(team=team, kind="github").first()
         github_user_integration = None
-        if repository:
-            github_integration = Integration.objects.filter(team=team, kind="github").first()
-            task_stub = Task(
-                team=team,
-                origin_product=origin_product,
-                created_by=created_by,
-                repository=repository,
-                github_integration=github_integration,
-            )
-            authorship_mode = get_pr_authorship_mode(
+        task_stub = Task(
+            team=team,
+            origin_product=origin_product,
+            created_by=created_by,
+            repository=repository,
+            github_integration=github_integration,
+        )
+        authorship_mode = get_pr_authorship_mode(
+            task_stub,
+            {"run_source": RunSource.SIGNAL_REPORT.value}
+            if origin_product == Task.OriginProduct.SIGNAL_REPORT
+            else None,
+        )
+        if authorship_mode == PrAuthorshipMode.USER:
+            user_github_integration = resolve_user_github_integration_for_task(
                 task_stub,
-                {"run_source": RunSource.SIGNAL_REPORT.value}
-                if origin_product == Task.OriginProduct.SIGNAL_REPORT
-                else None,
+                repository=repository,
+                allow_refresh=True,
             )
-            if authorship_mode == PrAuthorshipMode.USER:
-                user_github_integration = resolve_user_github_integration_for_task(
-                    task_stub,
-                    repository=repository,
-                    allow_refresh=True,
-                )
-                github_user_integration = user_github_integration.integration if user_github_integration else None
+            github_user_integration = user_github_integration.integration if user_github_integration else None
 
+        if repository:
             if not github_integration and github_user_integration is None and not is_public_sandbox_repo(repository):
                 raise ValueError(f"Team {team.id} does not have a GitHub integration")
 
@@ -359,7 +358,9 @@ class Task(DeletedMetaFields, models.Model):
             extra_state["run_source"] = RunSource.SIGNAL_REPORT.value
             extra_state["pr_authorship_mode"] = PrAuthorshipMode.BOT.value
         elif origin_product in (Task.OriginProduct.USER_CREATED, Task.OriginProduct.SLACK):
-            extra_state["pr_authorship_mode"] = PrAuthorshipMode.USER.value
+            extra_state["pr_authorship_mode"] = (
+                PrAuthorshipMode.USER.value if github_user_integration is not None else PrAuthorshipMode.BOT.value
+            )
 
         if sandbox_env is not None:
             extra_state["sandbox_environment_id"] = str(sandbox_env.id)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -294,6 +294,7 @@ class Task(DeletedMetaFields, models.Model):
             RunSource,
             get_pr_authorship_mode,
             resolve_user_github_integration_for_task,
+            user_github_integration_is_usable,
         )
 
         github_integration = Integration.objects.filter(team=team, kind="github").first()
@@ -317,7 +318,8 @@ class Task(DeletedMetaFields, models.Model):
                 repository=repository,
                 allow_refresh=True,
             )
-            github_user_integration = user_github_integration.integration if user_github_integration else None
+            if user_github_integration_is_usable(user_github_integration):
+                github_user_integration = user_github_integration.integration if user_github_integration else None
 
         if repository:
             if not github_integration and github_user_integration is None and not is_public_sandbox_repo(repository):

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -140,7 +140,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
 
         github_token = ""
         should_inject_github_token = ctx.has_github_credentials and (
-            has_repo or ctx.github_user_integration_id is not None
+            has_repo or ctx.github_user_integration_id is not None or ctx.github_integration_id is not None
         )
         if should_inject_github_token:
             try:

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -231,7 +231,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
 
         github_token = ""
         should_inject_github_token = ctx.has_github_credentials and (
-            has_repo or ctx.github_user_integration_id is not None
+            has_repo or ctx.github_user_integration_id is not None or ctx.github_integration_id is not None
         )
         if should_inject_github_token:
             try:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -127,6 +127,30 @@ class TestGetTaskProcessingContextActivity:
         assert result.has_github_credentials is True
 
     @pytest.mark.django_db
+    def test_get_task_processing_context_uses_team_integration_without_repository(
+        self, activity_environment, team, user, github_integration
+    ):
+        task = Task.objects.create(
+            team=team,
+            created_by=user,
+            title="Slack task without repository",
+            description="Clone a repo later from chat",
+            origin_product=Task.OriginProduct.SLACK,
+            github_integration=github_integration,
+        )
+        task_run = task.create_run(extra_state={"interaction_origin": "slack", "pr_authorship_mode": "bot"})
+
+        result = async_to_sync(activity_environment.run)(
+            get_task_processing_context,
+            GetTaskProcessingContextInput(run_id=str(task_run.id)),
+        )
+
+        assert result.repository is None
+        assert result.github_integration_id == github_integration.id
+        assert result.github_user_integration_id is None
+        assert result.has_github_credentials is True
+
+    @pytest.mark.django_db
     def test_get_task_processing_context_resolves_allowed_domains(self, activity_environment, test_task):
         sandbox_environment = SandboxEnvironment.objects.create(
             team=test_task.team,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_inject_fresh_tokens_on_resume.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_inject_fresh_tokens_on_resume.py
@@ -184,6 +184,57 @@ class TestInjectFreshTokensOnResumeActivity:
         assert prepared.environment_variables["GH_TOKEN"] == "gho_user"
         assert prepared.environment_variables["POSTHOG_PERSONAL_API_KEY"] == "oauth_new"
 
+    def test_prepare_sandbox_injects_team_github_token_without_repository(
+        self, activity_environment, team, user, github_integration
+    ):
+        from products.tasks.backend.models import Task
+
+        task = Task.objects.create(
+            team=team,
+            created_by=user,
+            title="Repo-less Slack task",
+            description="Clone later from chat",
+            origin_product=Task.OriginProduct.SLACK,
+            github_integration=github_integration,
+        )
+        task_run = task.create_run(extra_state={"interaction_origin": "slack", "pr_authorship_mode": "bot"})
+        context = TaskProcessingContext(
+            task_id=str(task.id),
+            run_id=str(task_run.id),
+            team_id=task.team_id,
+            team_uuid=str(task.team.uuid),
+            organization_id=str(task.team.organization_id),
+            github_integration_id=github_integration.id,
+            github_user_integration_id=None,
+            repository=None,
+            distinct_id=user.distinct_id or "test-distinct-id",
+            task_created_by_id=user.id,
+            state=task_run.state,
+        )
+
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.provision_sandbox.get_sandbox_github_token",
+                return_value="ghs_team",
+            ) as get_sandbox_github_token_mock,
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.provision_sandbox.create_oauth_access_token",
+                return_value="oauth_new",
+            ),
+        ):
+            prepared = async_to_sync(activity_environment.run)(
+                prepare_sandbox_for_repository,
+                PrepareSandboxForRepositoryInput(context=context),
+            )
+
+        get_sandbox_github_token_mock.assert_called_once()
+        assert get_sandbox_github_token_mock.call_args.kwargs["repository"] is None
+        assert prepared.repository is None
+        assert prepared.github_token == "ghs_team"
+        assert prepared.environment_variables["GITHUB_TOKEN"] == "ghs_team"
+        assert prepared.environment_variables["GH_TOKEN"] == "ghs_team"
+        assert prepared.environment_variables["POSTHOG_PERSONAL_API_KEY"] == "oauth_new"
+
     def test_build_environment_variables_ignores_other_users_private_sandbox_environment(
         self, task_context, test_task, test_task_run
     ):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -784,6 +784,29 @@ class TestTaskAPI(BaseTaskAPITest):
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_create_run_endpoint_falls_back_to_team_integration_when_no_user_integration(self, mock_workflow):
+        integration = Integration.objects.create(team=self.team, kind="github", config={"access_token": "token"})
+        task = self.create_task(created_by=self.user)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {
+                "environment": "cloud",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task.refresh_from_db()
+        task_run = TaskRun.objects.get(id=response.json()["id"])
+        self.assertEqual(task.github_integration_id, integration.id)
+        self.assertIsNone(task.github_user_integration_id)
+        self.assertEqual(task_run.state["pr_authorship_mode"], "bot")
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_start_run_endpoint_triggers_workflow_for_existing_cloud_run(self, mock_workflow):
         task = self.create_task()
         task_run = task.create_run(environment=TaskRun.Environment.CLOUD)
@@ -1379,6 +1402,30 @@ class TestTaskAPI(BaseTaskAPITest):
         assert response.status_code == status.HTTP_200_OK
         task.refresh_from_db()
         assert task.github_user_integration_id == user_integration.id
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_falls_back_to_team_integration_when_no_user_integration(self, mock_workflow):
+        integration = Integration.objects.create(team=self.team, kind="github", config={"access_token": "token"})
+        task = self.create_task(created_by=self.user)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task.refresh_from_db()
+        task_run = task.latest_run
+        assert task_run is not None
+        assert task.github_integration_id == integration.id
+        assert task.github_user_integration_id is None
+        assert task_run.state["pr_authorship_mode"] == "bot"
         mock_workflow.assert_called_once()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
@@ -2265,6 +2312,30 @@ class TestTaskRunAPI(BaseTaskAPITest):
         task.refresh_from_db()
         run.refresh_from_db()
         self.assertEqual(task.github_user_integration_id, user_integration.id)
+        self.assertEqual(run.environment, TaskRun.Environment.CLOUD)
+        self.assertEqual(run.status, TaskRun.Status.QUEUED)
+        mock_resume.assert_called_once_with(str(run.id), run.workflow_id)
+
+    @patch("products.tasks.backend.api.resume_task_in_cloud_workflow")
+    def test_resume_in_cloud_falls_back_to_team_integration_when_no_user_integration(self, mock_resume):
+        integration = Integration.objects.create(team=self.team, kind="github", config={"access_token": "token"})
+        task = self.create_task(created_by=self.user)
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            environment=TaskRun.Environment.LOCAL,
+            status=TaskRun.Status.COMPLETED,
+            state={"pr_authorship_mode": "user"},
+        )
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/resume_in_cloud/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        task.refresh_from_db()
+        run.refresh_from_db()
+        self.assertEqual(task.github_integration_id, integration.id)
+        self.assertIsNone(task.github_user_integration_id)
+        self.assertEqual(run.state["pr_authorship_mode"], "bot")
         self.assertEqual(run.environment, TaskRun.Environment.CLOUD)
         self.assertEqual(run.status, TaskRun.Status.QUEUED)
         mock_resume.assert_called_once_with(str(run.id), run.workflow_id)


### PR DESCRIPTION
## Problem

The backend PR changes task and integration API shapes, ggenerated frontend and MCP definitions need to match those serializers and OpenAPI changes

**Before**:
<img width="396" height="385" alt="gh_authorship_sad" src="https://github.com/user-attachments/assets/e85d1d85-9f20-4de9-9a3c-46a10256be0c" />

**After**:
<img width="397" height="409" alt="gh_authorship_happy" src="https://github.com/user-attachments/assets/fef3f1a7-c8de-4578-b21a-e56ebbdb1df9" />
