### PR TITLE
feat(integrations): add kind filter and exclude config from MCP responses

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -16,6 +16,7 @@ from django.utils.crypto import get_random_string
 import stripe
 import requests
 import structlog
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -581,6 +582,8 @@ class IntegrationViewSet(
     permission_classes = [TeamMemberStrictManagementPermission]
     queryset = defer_repository_cache_fields(Integration.objects.all())
     serializer_class = IntegrationSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["kind"]
 
     def dangerously_get_permissions(self):
         if self.action == "refresh_github_repos":

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1057,6 +1057,16 @@ class TestIntegrationAPIKeyAccess:
         assert "github" in kinds
         assert "twilio" in kinds
 
+    def test_list_integrations_filtered_by_kind(self, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.get(f"/api/environments/{self.team.pk}/integrations/?kind=twilio")
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["kind"] == "twilio"
+
 
 class TestGitHubIntegrationStateValidation:
     @pytest.fixture(autouse=True)

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -416,7 +416,8 @@ export type RoleExternalReferencesLookupRetrieveParams = {
 
 export type IntegrationsListParams = {
     /**
-     * * `azure-blob` - Azure Blob
+     * * `apns` - Apple Push
+     * `azure-blob` - Azure Blob
      * `bing-ads` - Bing Ads
      * `clickup` - Clickup
      * `customerio-app` - Customerio App
@@ -464,6 +465,7 @@ export type IntegrationsListParams = {
 export type IntegrationsListKind = (typeof IntegrationsListKind)[keyof typeof IntegrationsListKind]
 
 export const IntegrationsListKind = {
+    Apns: 'apns',
     AzureBlob: 'azure-blob',
     BingAds: 'bing-ads',
     Clickup: 'clickup',

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -416,6 +416,42 @@ export type RoleExternalReferencesLookupRetrieveParams = {
 
 export type IntegrationsListParams = {
     /**
+     * * `azure-blob` - Azure Blob
+     * `bing-ads` - Bing Ads
+     * `clickup` - Clickup
+     * `customerio-app` - Customerio App
+     * `customerio-track` - Customerio Track
+     * `customerio-webhook` - Customerio Webhook
+     * `databricks` - Databricks
+     * `email` - Email
+     * `firebase` - Firebase
+     * `github` - Github
+     * `gitlab` - Gitlab
+     * `google-ads` - Google Ads
+     * `google-cloud-service-account` - Google Cloud Service Account
+     * `google-cloud-storage` - Google Cloud Storage
+     * `google-pubsub` - Google Pubsub
+     * `google-sheets` - Google Sheets
+     * `hubspot` - Hubspot
+     * `intercom` - Intercom
+     * `jira` - Jira
+     * `linear` - Linear
+     * `linkedin-ads` - Linkedin Ads
+     * `meta-ads` - Meta Ads
+     * `pinterest-ads` - Pinterest Ads
+     * `postgresql` - Postgresql
+     * `reddit-ads` - Reddit Ads
+     * `salesforce` - Salesforce
+     * `slack` - Slack
+     * `slack-posthog-code` - Slack Posthog Code
+     * `snapchat` - Snapchat
+     * `stripe` - Stripe
+     * `tiktok-ads` - Tiktok Ads
+     * `twilio` - Twilio
+     * `vercel` - Vercel
+     */
+    kind?: IntegrationsListKind
+    /**
      * Number of results to return per page.
      */
     limit?: number
@@ -424,6 +460,44 @@ export type IntegrationsListParams = {
      */
     offset?: number
 }
+
+export type IntegrationsListKind = (typeof IntegrationsListKind)[keyof typeof IntegrationsListKind]
+
+export const IntegrationsListKind = {
+    AzureBlob: 'azure-blob',
+    BingAds: 'bing-ads',
+    Clickup: 'clickup',
+    CustomerioApp: 'customerio-app',
+    CustomerioTrack: 'customerio-track',
+    CustomerioWebhook: 'customerio-webhook',
+    Databricks: 'databricks',
+    Email: 'email',
+    Firebase: 'firebase',
+    Github: 'github',
+    Gitlab: 'gitlab',
+    GoogleAds: 'google-ads',
+    GoogleCloudServiceAccount: 'google-cloud-service-account',
+    GoogleCloudStorage: 'google-cloud-storage',
+    GooglePubsub: 'google-pubsub',
+    GoogleSheets: 'google-sheets',
+    Hubspot: 'hubspot',
+    Intercom: 'intercom',
+    Jira: 'jira',
+    Linear: 'linear',
+    LinkedinAds: 'linkedin-ads',
+    MetaAds: 'meta-ads',
+    PinterestAds: 'pinterest-ads',
+    Postgresql: 'postgresql',
+    RedditAds: 'reddit-ads',
+    Salesforce: 'salesforce',
+    Slack: 'slack',
+    SlackPosthogCode: 'slack-posthog-code',
+    Snapchat: 'snapchat',
+    Stripe: 'stripe',
+    TiktokAds: 'tiktok-ads',
+    Twilio: 'twilio',
+    Vercel: 'vercel',
+} as const
 
 export type IntegrationsGithubBranchesRetrieveParams = {
     /**

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -33,8 +33,8 @@ tools:
             idempotent: true
         title: Get integration
         description: >
-            Get a specific integration by ID. Returns full integration details including kind, display name,
-            error status, and creation metadata. Does not expose sensitive credentials or raw configuration.
+            Get a specific integration by ID. Returns full integration details including kind, display name, error
+            status, and creation metadata. Does not expose sensitive credentials or raw configuration.
         response:
             include:
                 - id

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -33,8 +33,16 @@ tools:
             idempotent: true
         title: Get integration
         description: >
-            Get a specific integration by ID. Returns the full integration details including kind, display name,
-            non-sensitive configuration, error status, and creation metadata. Does not expose sensitive credentials.
+            Get a specific integration by ID. Returns full integration details including kind, display name,
+            error status, and creation metadata. Does not expose sensitive credentials or raw configuration.
+        response:
+            include:
+                - id
+                - kind
+                - display_name
+                - errors
+                - created_at
+                - created_by
     integrations-authorize-retrieve:
         operation: integrations_authorize_retrieve
         enabled: false
@@ -132,6 +140,13 @@ tools:
             display name, non-sensitive configuration, error status, and creation metadata. Common kinds include slack,
             github, hubspot, salesforce, and various ad platforms. Sensitive credentials (access tokens, secrets) are
             never serialized.
+        response:
+            include:
+                - id
+                - kind
+                - display_name
+                - created_at
+                - created_by
     integrations-twilio-phone-numbers-retrieve:
         operation: integrations_twilio_phone_numbers_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2100,7 +2100,7 @@
         }
     },
     "integration-get": {
-        "description": "Get a specific integration by ID. Returns the full integration details including kind, display name, non-sensitive configuration, error status, and creation metadata. Does not expose sensitive credentials.",
+        "description": "Get a specific integration by ID. Returns full integration details including kind, display name, error status, and creation metadata. Does not expose sensitive credentials or raw configuration.",
         "category": "Integrations",
         "feature": "integrations",
         "summary": "Get integration",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2413,7 +2413,7 @@
         }
     },
     "integration-get": {
-        "description": "Get a specific integration by ID. Returns the full integration details including kind, display name, non-sensitive configuration, error status, and creation metadata. Does not expose sensitive credentials.",
+        "description": "Get a specific integration by ID. Returns full integration details including kind, display name, error status, and creation metadata. Does not expose sensitive credentials or raw configuration.",
         "category": "Integrations",
         "feature": "integrations",
         "summary": "Get integration",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39627,7 +39627,8 @@ export namespace Schemas {
 
     export type EnvironmentsIntegrationsListParams = {
     /**
-     * * `azure-blob` - Azure Blob
+     * * `apns` - Apple Push
+    * `azure-blob` - Azure Blob
     * `bing-ads` - Bing Ads
     * `clickup` - Clickup
     * `customerio-app` - Customerio App
@@ -39676,6 +39677,7 @@ export namespace Schemas {
 
 
     export const EnvironmentsIntegrationsListKind = {
+      Apns: 'apns',
       AzureBlob: 'azure-blob',
       BingAds: 'bing-ads',
       Clickup: 'clickup',
@@ -44159,7 +44161,8 @@ export namespace Schemas {
 
     export type IntegrationsListParams = {
     /**
-     * * `azure-blob` - Azure Blob
+     * * `apns` - Apple Push
+    * `azure-blob` - Azure Blob
     * `bing-ads` - Bing Ads
     * `clickup` - Clickup
     * `customerio-app` - Customerio App
@@ -44208,6 +44211,7 @@ export namespace Schemas {
 
 
     export const IntegrationsListKind = {
+      Apns: 'apns',
       AzureBlob: 'azure-blob',
       BingAds: 'bing-ads',
       Clickup: 'clickup',

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39627,6 +39627,42 @@ export namespace Schemas {
 
     export type EnvironmentsIntegrationsListParams = {
     /**
+     * * `azure-blob` - Azure Blob
+    * `bing-ads` - Bing Ads
+    * `clickup` - Clickup
+    * `customerio-app` - Customerio App
+    * `customerio-track` - Customerio Track
+    * `customerio-webhook` - Customerio Webhook
+    * `databricks` - Databricks
+    * `email` - Email
+    * `firebase` - Firebase
+    * `github` - Github
+    * `gitlab` - Gitlab
+    * `google-ads` - Google Ads
+    * `google-cloud-service-account` - Google Cloud Service Account
+    * `google-cloud-storage` - Google Cloud Storage
+    * `google-pubsub` - Google Pubsub
+    * `google-sheets` - Google Sheets
+    * `hubspot` - Hubspot
+    * `intercom` - Intercom
+    * `jira` - Jira
+    * `linear` - Linear
+    * `linkedin-ads` - Linkedin Ads
+    * `meta-ads` - Meta Ads
+    * `pinterest-ads` - Pinterest Ads
+    * `postgresql` - Postgresql
+    * `reddit-ads` - Reddit Ads
+    * `salesforce` - Salesforce
+    * `slack` - Slack
+    * `slack-posthog-code` - Slack Posthog Code
+    * `snapchat` - Snapchat
+    * `stripe` - Stripe
+    * `tiktok-ads` - Tiktok Ads
+    * `twilio` - Twilio
+    * `vercel` - Vercel
+     */
+    kind?: EnvironmentsIntegrationsListKind;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -39635,6 +39671,45 @@ export namespace Schemas {
      */
     offset?: number;
     };
+
+    export type EnvironmentsIntegrationsListKind = typeof EnvironmentsIntegrationsListKind[keyof typeof EnvironmentsIntegrationsListKind];
+
+
+    export const EnvironmentsIntegrationsListKind = {
+      AzureBlob: 'azure-blob',
+      BingAds: 'bing-ads',
+      Clickup: 'clickup',
+      CustomerioApp: 'customerio-app',
+      CustomerioTrack: 'customerio-track',
+      CustomerioWebhook: 'customerio-webhook',
+      Databricks: 'databricks',
+      Email: 'email',
+      Firebase: 'firebase',
+      Github: 'github',
+      Gitlab: 'gitlab',
+      GoogleAds: 'google-ads',
+      GoogleCloudServiceAccount: 'google-cloud-service-account',
+      GoogleCloudStorage: 'google-cloud-storage',
+      GooglePubsub: 'google-pubsub',
+      GoogleSheets: 'google-sheets',
+      Hubspot: 'hubspot',
+      Intercom: 'intercom',
+      Jira: 'jira',
+      Linear: 'linear',
+      LinkedinAds: 'linkedin-ads',
+      MetaAds: 'meta-ads',
+      PinterestAds: 'pinterest-ads',
+      Postgresql: 'postgresql',
+      RedditAds: 'reddit-ads',
+      Salesforce: 'salesforce',
+      Slack: 'slack',
+      SlackPosthogCode: 'slack-posthog-code',
+      Snapchat: 'snapchat',
+      Stripe: 'stripe',
+      TiktokAds: 'tiktok-ads',
+      Twilio: 'twilio',
+      Vercel: 'vercel',
+    } as const;
 
     export type EnvironmentsIntegrationsGithubBranchesRetrieveParams = {
     /**
@@ -44084,6 +44159,42 @@ export namespace Schemas {
 
     export type IntegrationsListParams = {
     /**
+     * * `azure-blob` - Azure Blob
+    * `bing-ads` - Bing Ads
+    * `clickup` - Clickup
+    * `customerio-app` - Customerio App
+    * `customerio-track` - Customerio Track
+    * `customerio-webhook` - Customerio Webhook
+    * `databricks` - Databricks
+    * `email` - Email
+    * `firebase` - Firebase
+    * `github` - Github
+    * `gitlab` - Gitlab
+    * `google-ads` - Google Ads
+    * `google-cloud-service-account` - Google Cloud Service Account
+    * `google-cloud-storage` - Google Cloud Storage
+    * `google-pubsub` - Google Pubsub
+    * `google-sheets` - Google Sheets
+    * `hubspot` - Hubspot
+    * `intercom` - Intercom
+    * `jira` - Jira
+    * `linear` - Linear
+    * `linkedin-ads` - Linkedin Ads
+    * `meta-ads` - Meta Ads
+    * `pinterest-ads` - Pinterest Ads
+    * `postgresql` - Postgresql
+    * `reddit-ads` - Reddit Ads
+    * `salesforce` - Salesforce
+    * `slack` - Slack
+    * `slack-posthog-code` - Slack Posthog Code
+    * `snapchat` - Snapchat
+    * `stripe` - Stripe
+    * `tiktok-ads` - Tiktok Ads
+    * `twilio` - Twilio
+    * `vercel` - Vercel
+     */
+    kind?: IntegrationsListKind;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -44092,6 +44203,45 @@ export namespace Schemas {
      */
     offset?: number;
     };
+
+    export type IntegrationsListKind = typeof IntegrationsListKind[keyof typeof IntegrationsListKind];
+
+
+    export const IntegrationsListKind = {
+      AzureBlob: 'azure-blob',
+      BingAds: 'bing-ads',
+      Clickup: 'clickup',
+      CustomerioApp: 'customerio-app',
+      CustomerioTrack: 'customerio-track',
+      CustomerioWebhook: 'customerio-webhook',
+      Databricks: 'databricks',
+      Email: 'email',
+      Firebase: 'firebase',
+      Github: 'github',
+      Gitlab: 'gitlab',
+      GoogleAds: 'google-ads',
+      GoogleCloudServiceAccount: 'google-cloud-service-account',
+      GoogleCloudStorage: 'google-cloud-storage',
+      GooglePubsub: 'google-pubsub',
+      GoogleSheets: 'google-sheets',
+      Hubspot: 'hubspot',
+      Intercom: 'intercom',
+      Jira: 'jira',
+      Linear: 'linear',
+      LinkedinAds: 'linkedin-ads',
+      MetaAds: 'meta-ads',
+      PinterestAds: 'pinterest-ads',
+      Postgresql: 'postgresql',
+      RedditAds: 'reddit-ads',
+      Salesforce: 'salesforce',
+      Slack: 'slack',
+      SlackPosthogCode: 'slack-posthog-code',
+      Snapchat: 'snapchat',
+      Stripe: 'stripe',
+      TiktokAds: 'tiktok-ads',
+      Twilio: 'twilio',
+      Vercel: 'vercel',
+    } as const;
 
     export type IntegrationsGithubBranchesRetrieveParams = {
     /**

--- a/services/mcp/src/generated/integrations/api.ts
+++ b/services/mcp/src/generated/integrations/api.ts
@@ -19,6 +19,7 @@ export const IntegrationsListParams = /* @__PURE__ */ zod.object({
 export const IntegrationsListQueryParams = /* @__PURE__ */ zod.object({
     kind: zod
         .enum([
+            'apns',
             'azure-blob',
             'bing-ads',
             'clickup',
@@ -55,7 +56,7 @@ export const IntegrationsListQueryParams = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            '* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+            '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
         ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),

--- a/services/mcp/src/generated/integrations/api.ts
+++ b/services/mcp/src/generated/integrations/api.ts
@@ -17,6 +17,46 @@ export const IntegrationsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const IntegrationsListQueryParams = /* @__PURE__ */ zod.object({
+    kind: zod
+        .enum([
+            'azure-blob',
+            'bing-ads',
+            'clickup',
+            'customerio-app',
+            'customerio-track',
+            'customerio-webhook',
+            'databricks',
+            'email',
+            'firebase',
+            'github',
+            'gitlab',
+            'google-ads',
+            'google-cloud-service-account',
+            'google-cloud-storage',
+            'google-pubsub',
+            'google-sheets',
+            'hubspot',
+            'intercom',
+            'jira',
+            'linear',
+            'linkedin-ads',
+            'meta-ads',
+            'pinterest-ads',
+            'postgresql',
+            'reddit-ads',
+            'salesforce',
+            'slack',
+            'slack-posthog-code',
+            'snapchat',
+            'stripe',
+            'tiktok-ads',
+            'twilio',
+            'vercel',
+        ])
+        .optional()
+        .describe(
+            '* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+        ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })

--- a/services/mcp/src/tools/generated/integrations.ts
+++ b/services/mcp/src/tools/generated/integrations.ts
@@ -73,6 +73,7 @@ const integrationsList = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/integrations/`,
             query: {
+                kind: params.kind,
                 limit: params.limit,
                 offset: params.offset,
             },

--- a/services/mcp/src/tools/generated/integrations.ts
+++ b/services/mcp/src/tools/generated/integrations.ts
@@ -8,7 +8,7 @@ import {
     IntegrationsListQueryParams,
     IntegrationsRetrieveParams,
 } from '@/generated/integrations/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IntegrationDeleteSchema = IntegrationsDestroyParams.omit({ project_id: true })
@@ -37,7 +37,15 @@ const integrationGet = (): ToolBase<typeof IntegrationGetSchema, Schemas.Integra
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/integrations/${encodeURIComponent(String(params.id))}/`,
         })
-        return result
+        const filtered = pickResponseFields(result, [
+            'id',
+            'kind',
+            'display_name',
+            'errors',
+            'created_at',
+            'created_by',
+        ]) as typeof result
+        return filtered
     },
 })
 
@@ -78,7 +86,13 @@ const integrationsList = (): ToolBase<
                 offset: params.offset,
             },
         })
-        return await withPostHogUrl(context, result, '/settings/integrations')
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, ['id', 'kind', 'display_name', 'created_at', 'created_by'])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/settings/integrations')
     },
 })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/integrations-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/integrations-list.json
@@ -1,6 +1,46 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "kind": {
+            "description": "* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel",
+            "enum": [
+                "apns",
+                "azure-blob",
+                "bing-ads",
+                "clickup",
+                "customerio-app",
+                "customerio-track",
+                "customerio-webhook",
+                "databricks",
+                "email",
+                "firebase",
+                "github",
+                "gitlab",
+                "google-ads",
+                "google-cloud-service-account",
+                "google-cloud-storage",
+                "google-pubsub",
+                "google-sheets",
+                "hubspot",
+                "intercom",
+                "jira",
+                "linear",
+                "linkedin-ads",
+                "meta-ads",
+                "pinterest-ads",
+                "postgresql",
+                "reddit-ads",
+                "salesforce",
+                "slack",
+                "slack-posthog-code",
+                "snapchat",
+                "stripe",
+                "tiktok-ads",
+                "twilio",
+                "vercel"
+            ],
+            "type": "string"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"


### PR DESCRIPTION
## Problem

Follow-up to #56996 by @MarconLP, which removed the GitHub-only restriction on the integrations list/retrieve endpoints for PAK/OAuth callers. That change unblocked the MCP `integrations-list` tool seeing all kinds, but two related improvements weren't part of it:

1. There's no server-side `kind` filter on the integrations list endpoint, so MCP tools and other API consumers have to fetch every integration and filter client-side.
2. The MCP `integrations-list` and `integration-get` tools still return the raw `config` blob, which is noisy infrastructure metadata (database hosts, account IDs, ssl_root_cert PEM, expiry timestamps) that doesn't belong in MCP responses.

## Changes

Stacks two small things on top of #56996:

- **`kind` query param** on the integrations list endpoint via `DjangoFilterBackend` + `filterset_fields = ["kind"]`. Enables `?kind=hubspot` etc. and flows through to the generated frontend types and MCP tool schema.
- **`response.include`** on `integrations-list` and `integration-get` in `products/integrations/mcp/tools.yaml`, narrowing MCP responses to `id`, `kind`, `display_name`, `created_at`, `created_by` (plus `errors` for get). Avoids leaking the raw `config` field through MCP.

## How did you test this code?

I'm an agent (Claude). Tests run:

- `hogli test posthog/api/test/test_integration.py` — 103 passed, including the new `test_list_integrations_filtered_by_kind`.
- `pnpm test tests/unit/tool-schema-snapshots.test.ts --update` in `services/mcp` — schema snapshot regenerates cleanly with the new `kind` parameter.

No manual testing.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code. Originally opened as a single PR doing all three things (remove GitHub-only filter, add kind filter, MCP response.include). Marcus's #56996 landed the first piece independently while this was in review — rebased down to just the two pieces still missing from master.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*