### PR TITLE
feat(error-tracking): add HTTP webhook sub-template for issue spiking

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -645,6 +645,12 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
     'error-tracking-issue-spiking': [
         {
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-spiking'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook on issue spiking',
+            description: 'Send a webhook when an issue is spiking',
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-spiking'],
             template_id: 'template-discord',
             name: 'Post to Discord on issue spiking',
             description: 'Posts a message to Discord when an issue is spiking',


### PR DESCRIPTION
## Problem

In Error tracking → Configuration → Alerting, the destination list is built by iterating each Hog function template across the three error tracking sub-template IDs (`issue created`, `issue reopened`, `issue spiking`). HTTP Webhook had sub-template entries for `issue created` and `issue reopened`, but not `issue spiking`, so customers could wire up webhook notifications for the first two triggers but not the third. Discord, Microsoft Teams, and Slack support all three.

Reported by a customer who wanted to forward issue-spiking events to a custom HTTP endpoint.

## Changes

Added a `template-webhook` entry to the `error-tracking-issue-spiking` array in [`frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts`](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts), mirroring the shape of the existing webhook entries for `issue created` and `issue reopened` (no `inputs` block needed, since the generic webhook template has no fixed payload to parameterize).

## How did you test this code?

I've confirmed this shows in the UI, but I've not tested the actual HTTP endpoint firing on issue spiking. 

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

Co-authored by Claude Opus 4.7 via Claude Code.