### PR TITLE
ci: drive rate-limit monitor by PR/push events

### DIFF
--- a/.github/workflows/monitor-github-rate-limit.yml
+++ b/.github/workflows/monitor-github-rate-limit.yml
@@ -4,12 +4,21 @@ name: Monitor GitHub Rate Limit
 # GITHUB_TOKEN bucket is observable as a time series — that bucket is the slice
 # of GitHub API usage that the org-level API Insights dashboard does not cover.
 #
+# Trigger strategy: ride real PR/master events for density (synchronize fires
+# on every PR push and is the dominant signal source on this repo), with a
+# 30-minute schedule as a quiet-time floor. A delayed scheduled tick is fine
+# here — events fill the gap.
+#
 # Alerting belongs downstream in PostHog (windowed thresholds, attribution by
 # repo) — not in the workflow itself. Keep this file focused on emission.
 
 on:
+    pull_request:
+        types: [opened, synchronize]
+    push:
+        branches: [master]
     schedule:
-        - cron: '*/5 * * * *'
+        - cron: '*/30 * * * *'
     workflow_dispatch:
 
 permissions:
@@ -19,6 +28,9 @@ jobs:
     poll:
         runs-on: ubuntu-latest
         timeout-minutes: 3
+        # Forks don't get secret access on pull_request, so the capture would
+        # no-op anyway — skip the run entirely to avoid noise.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:


### PR DESCRIPTION
## Problem

`*/5 * * * *` schedule was effectively running ~once an hour ([28 runs over the last 24h](https://github.com/PostHog/posthog/actions/workflows/monitor-github-rate-limit.yml), expected ~288). GitHub explicitly de-prioritizes scheduled workflows on busy repos and silently drops ticks during high-load windows. The result: very thin time series for the per-repo `GITHUB_TOKEN` bucket.

We want denser, more reliable rate-limit data feeding the DevEx PostHog project — both to debug bursts and to characterize steady-state usage.

## Changes

Switch triggers from `schedule`-only to event-driven:

- `pull_request: [opened, synchronize]` — fires on every PR push (the dominant signal source on this repo)
- `push: branches: [master]` — captures direct master pushes
- `schedule: */30 * * * *` — quiet-time floor; delayed ticks are fine because events fill the gap
- Job-level `if:` skips fork PRs (no secret access ⇒ would no-op anyway)

Sample sparse runs that motivated this: [13:40Z](https://github.com/PostHog/posthog/actions/runs/25168704841), [12:55Z](https://github.com/PostHog/posthog/actions/runs/25166558195), [12:15Z](https://github.com/PostHog/posthog/actions/runs/25164794932), [11:43Z](https://github.com/PostHog/posthog/actions/runs/25163457607), [11:02Z](https://github.com/PostHog/posthog/actions/runs/25161832101) — gaps of 16–40 min on a 5-min cron.

## How did you test this code?

Agent-authored. No automated tests in this repo for workflow scheduling. Verified the YAML parses by re-reading the diff; behavior validation will come from observing event volume in the DevEx PostHog project after merge.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored by Claude Code in collaboration with Raúl. Considered piggybacking response headers from `pr-resolve-outdated-bot-comments.yml` (per-call resource attribution) — left for a follow-up. Cron offset (`13,43`) was tried and rejected for readability; the quiet-time floor doesn't need to dodge :00/:30 because PR/push events provide density.