### PR TITLE
chore(data-warehouse): Log the url in the body

### DIFF
--- a/posthog/temporal/data_imports/sources/common/http/observer.py
+++ b/posthog/temporal/data_imports/sources/common/http/observer.py
@@ -138,11 +138,11 @@ def _emit_log(
         fields.update(ctx.as_log_fields())
 
     if record.error_class is not None:
-        logger.warning("data_imports.http.request", **fields)
+        logger.warning(f"data_imports.http.request {record.url}", **fields)
     elif record.status_code is not None and record.status_code >= 400:
-        logger.warning("data_imports.http.request", **fields)
+        logger.warning(f"data_imports.http.request {record.url}", **fields)
     else:
-        logger.debug("data_imports.http.request", **fields)
+        logger.debug(f"data_imports.http.request: {record.url}", **fields)
 
 
 def _emit_metrics(record: RequestRecord, *, host: str, ctx: JobContext | None) -> None:

--- a/posthog/temporal/data_imports/sources/common/http/observer.py
+++ b/posthog/temporal/data_imports/sources/common/http/observer.py
@@ -142,7 +142,7 @@ def _emit_log(
     elif record.status_code is not None and record.status_code >= 400:
         logger.warning(f"data_imports.http.request {record.url}", **fields)
     else:
-        logger.debug(f"data_imports.http.request: {record.url}", **fields)
+        logger.debug(f"data_imports.http.request {record.url}", **fields)
 
 
 def _emit_metrics(record: RequestRecord, *, host: str, ctx: JobContext | None) -> None:

--- a/posthog/temporal/data_imports/sources/common/test/test_http_observer.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_http_observer.py
@@ -48,7 +48,7 @@ def captured_logs():
 
 
 def _entries(logs: list[dict]) -> list[dict]:
-    return [entry for entry in logs if entry.get("event") == "data_imports.http.request"]
+    return [entry for entry in logs if entry.get("event", "").startswith("data_imports.http.request")]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem
The extra log fields dont get rendered in the job logs view:

<img width="747" height="269" alt="image" src="https://github.com/user-attachments/assets/e340b419-50a9-4890-bae6-3524e40c7f9a" />


## Changes
Just include the request URL in the body of the request log (its pre-scrubbed) 
