### PR TITLE
fix(phai): tag query_tagging feature for PostHog AI and MCP queries

### DIFF
--- a/ee/hogai/chat_agent/query_planner/toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/toolkit.py
@@ -14,7 +14,7 @@ from posthog.schema import (
 
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
@@ -213,7 +213,12 @@ class TaxonomyAgentToolkit:
             query = EventTaxonomyQuery(actionId=event_name_or_action_id, maxPropertyValues=25)
             verbose_name = f"action with ID {event_name_or_action_id}"
         runner = EventTaxonomyQueryRunner(query, self._team)
-        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+        with tags_context(
+            product=Product.MAX_AI,
+            feature=Feature.POSTHOG_AI,
+            team_id=self._team.pk,
+            org_id=self._team.organization_id,
+        ):
             response = runner.run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
                 analytics_props={"source": EventSource.POSTHOG_AI},
@@ -372,7 +377,12 @@ class TaxonomyAgentToolkit:
         except PropertyDefinition.DoesNotExist:
             return f"The property {property_name} does not exist in the taxonomy for the entity {entity}."
 
-        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+        with tags_context(
+            product=Product.MAX_AI,
+            feature=Feature.POSTHOG_AI,
+            team_id=self._team.pk,
+            org_id=self._team.organization_id,
+        ):
             response = ActorsPropertyTaxonomyQueryRunner(query, self._team).run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
                 analytics_props={"source": EventSource.POSTHOG_AI},

--- a/ee/hogai/chat_agent/rag/nodes.py
+++ b/ee/hogai/chat_agent/rag/nodes.py
@@ -12,7 +12,7 @@ from prometheus_client import Histogram
 
 from posthog.schema import CachedVectorSearchQueryResponse, MaxActionContext, TeamTaxonomyQuery, VectorSearchQuery
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
 from posthog.hogql_queries.ai.vector_search_query_runner import (
@@ -124,7 +124,12 @@ class InsightRagContextNode(AssistantNode):
                     team=self._team,
                     query=VectorSearchQuery(embedding=embedding, embeddingVersion=LATEST_ACTIONS_EMBEDDING_VERSION),
                 )
-                with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+                with tags_context(
+                    product=Product.MAX_AI,
+                    feature=Feature.POSTHOG_AI,
+                    team_id=self._team.pk,
+                    org_id=self._team.organization_id,
+                ):
                     response = runner.run(
                         ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                         analytics_props={"source": EventSource.POSTHOG_AI},

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/queries.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/queries.py
@@ -6,7 +6,7 @@ import posthoganalytics
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.tasks.usage_report import (
     AI_BILLING_EXCLUDED_TOOLS,
     AI_COST_MARKUP_PERCENT,
@@ -143,7 +143,12 @@ def get_ai_credits(
 
     usage_report_kind = "posthog_ai_credits_for_conversation" if conversation_id else "posthog_ai_credits_for_team"
 
-    with tags_context(product=Product.MAX_AI, usage_report=usage_report_kind, kind=usage_report_kind):
+    with tags_context(
+        product=Product.MAX_AI,
+        feature=Feature.POSTHOG_AI,
+        usage_report=usage_report_kind,
+        kind=usage_report_kind,
+    ):
         query = f"""
         WITH trace_analysis AS (
             WITH %(excluded_tools)s AS excluded_tools

--- a/ee/hogai/chat_agent/taxonomy/toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/toolkit.py
@@ -23,7 +23,7 @@ from posthog.schema import (
 
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
@@ -238,7 +238,12 @@ class TaxonomyAgentToolkit:
             query = EventTaxonomyQuery(actionId=action_id, maxPropertyValues=25, properties=properties)
             verbose_name = f"action with ID {action_id}"
         runner = EventTaxonomyQueryRunner(query, self._team)
-        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+        with tags_context(
+            product=Product.MAX_AI,
+            feature=Feature.POSTHOG_AI,
+            team_id=self._team.pk,
+            org_id=self._team.organization_id,
+        ):
             # Use cache-first execution mode for optimal performance
             response = runner.run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
@@ -628,7 +633,12 @@ class TaxonomyAgentToolkit:
     def _run_actors_taxonomy_query(
         self, query
     ) -> CachedActorsPropertyTaxonomyQueryResponse | CacheMissResponse | QueryStatusResponse:
-        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+        with tags_context(
+            product=Product.MAX_AI,
+            feature=Feature.POSTHOG_AI,
+            team_id=self._team.pk,
+            org_id=self._team.organization_id,
+        ):
             return ActorsPropertyTaxonomyQueryRunner(query, self._team).run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
                 analytics_props={"source": EventSource.POSTHOG_AI},

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 import structlog
 from asgiref.sync import async_to_sync
 from posthoganalytics import capture_exception
+from pydantic import BaseModel
 from rest_framework.exceptions import APIException
 
 from posthog.schema import (
@@ -45,7 +46,7 @@ from posthog.hogql.errors import (
 
 from posthog.api.services.query import process_query_dict
 from posthog.clickhouse.client.execute_async import get_query_status
-from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags, tag_queries, tags_context
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql_queries.query_runner import BLOCKING_EXECUTION_MODES, ExecutionMode
 from posthog.models import Team
@@ -182,7 +183,13 @@ class AssistantQueryExecutor:
             logger.warning(f"{TIMING_LOG_PREFIX} Starting arun_and_format_query for {query_type}")
 
         try:
-            with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+            active_tags = get_query_tags()
+            with tags_context(
+                product=Product.MAX_AI,
+                feature=active_tags.feature or Feature.POSTHOG_AI,
+                team_id=self._team.pk,
+                org_id=self._team.organization_id,
+            ):
                 if insight_id:
                     # Including insight ID for insight search
                     tag_queries(insight_id=insight_id)
@@ -315,17 +322,30 @@ class AssistantQueryExecutor:
             if debug_timing:
                 logger.warning(f"{TIMING_LOG_PREFIX} Calling process_query_dict")
 
+            # Snapshot the caller's query tags from the async context so we can replay them inside
+            # the threaded sync function — `database_sync_to_async` crosses a thread boundary and
+            # downstream code (e.g. `enqueue_process_query_task`) reads `get_query_tags()` from the
+            # executing thread to forward to Celery, where contextvars do not propagate.
+            parent_tag_kwargs = get_query_tags().model_dump(exclude_none=True)
+            team = self._team
+            user = self._user
+            query_dict = query.model_dump(mode="json")
+
+            def process_query_dict_with_tags() -> dict | BaseModel:
+                with tags_context(**parent_tag_kwargs):
+                    return process_query_dict(
+                        team,
+                        query_dict,
+                        execution_mode=execution_mode,
+                        limit_context=LimitContext.POSTHOG_AI,
+                        user=user,
+                    )
+
             # If the query has a blocking execution, execute on a separate thread. Otherwise, use the main thread
             # as it only does lightweight ORM retrievals and Redis calls. If we run in tests, do not spawn another thread.
             results_response = await database_sync_to_async(
-                process_query_dict, thread_sensitive=execution_mode not in BLOCKING_EXECUTION_MODES
-            )(
-                self._team,
-                query.model_dump(mode="json"),
-                execution_mode=execution_mode,
-                limit_context=LimitContext.POSTHOG_AI,
-                user=self._user,
-            )
+                process_query_dict_with_tags, thread_sensitive=execution_mode not in BLOCKING_EXECUTION_MODES
+            )()
 
             process_elapsed = time.time() - process_start
             if debug_timing:

--- a/ee/hogai/context/insight/test/test_query_executor.py
+++ b/ee/hogai/context/insight/test/test_query_executor.py
@@ -45,6 +45,7 @@ from posthog.schema import (
 from posthog.hogql.constants import DEFAULT_POSTHOG_AI_RETURNED_ROWS
 from posthog.hogql.errors import ExposedHogQLError
 
+from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags, tags_context
 from posthog.errors import ExposedCHQueryError
 
 from ee.hogai.context.insight.query_executor import (
@@ -695,6 +696,50 @@ class TestAssistantQueryExecutor(NonAtomicBaseTest):
 
         result, used_fallback = await self.query_runner.arun_and_format_query(query)
         self.assertIn("Date|test2", result)
+
+    @patch("ee.hogai.context.insight.query_executor.process_query_dict")
+    async def test_outer_tags_propagate_across_sync_boundary(self, mock_process_query):
+        """Outer-context query tags must survive the database_sync_to_async thread switch."""
+        captured_tags: dict[str, Any] = {}
+
+        def fake_process_query_dict(*args, **kwargs):
+            # Captured from inside the threaded sync function — i.e. across the async-to-sync boundary
+            captured_tags.update(get_query_tags().model_dump(exclude_none=True))
+            return {"results": []}
+
+        mock_process_query.side_effect = fake_process_query_dict
+
+        query = AssistantTrendsQuery(series=[])
+
+        # Tags set in the outer async context — these would be lost without the snapshot/replay logic
+        with tags_context(feature=Feature.MCP, scene="my-scene"):
+            await self.query_runner.arun_and_format_query(query, insight_id=42)
+
+        # Outer-context tags propagated through the sync boundary
+        self.assertEqual(captured_tags.get("scene"), "my-scene")
+        # Outer feature wins over the default POSTHOG_AI fallback in arun_and_format_query
+        self.assertEqual(captured_tags.get("feature"), Feature.MCP.value)
+        # Tags applied by arun_and_format_query also propagate
+        self.assertEqual(captured_tags.get("product"), Product.MAX_AI.value)
+        self.assertEqual(captured_tags.get("team_id"), self.team.pk)
+        self.assertEqual(captured_tags.get("insight_id"), 42)
+
+    @patch("ee.hogai.context.insight.query_executor.process_query_dict")
+    async def test_default_feature_when_no_outer_feature(self, mock_process_query):
+        """When no outer feature is set, arun_and_format_query falls back to POSTHOG_AI."""
+        captured_tags: dict[str, Any] = {}
+
+        def fake_process_query_dict(*args, **kwargs):
+            captured_tags.update(get_query_tags().model_dump(exclude_none=True))
+            return {"results": []}
+
+        mock_process_query.side_effect = fake_process_query_dict
+
+        query = AssistantTrendsQuery(series=[])
+        await self.query_runner.arun_and_format_query(query)
+
+        self.assertEqual(captured_tags.get("feature"), Feature.POSTHOG_AI.value)
+        self.assertEqual(captured_tags.get("product"), Product.MAX_AI.value)
 
 
 class TestAssistantQueryExecutorAsync(NonAtomicBaseTest):

--- a/ee/hogai/tools/manage_memories.py
+++ b/ee/hogai/tools/manage_memories.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.sync import database_sync_to_async
 
 from products.posthog_ai.backend.models import AgentMemory
@@ -181,7 +181,12 @@ class ManageMemoriesTool(MaxTool):
 
         @database_sync_to_async(thread_sensitive=False)
         def run_query():
-            with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+            with tags_context(
+                product=Product.MAX_AI,
+                feature=Feature.POSTHOG_AI,
+                team_id=self._team.pk,
+                org_id=self._team.organization_id,
+            ):
                 return execute_hogql_query(
                     query_type="ManageMemoriesTool",
                     query=query,

--- a/ee/hogai/tools/replay/filter_session_recordings.py
+++ b/ee/hogai/tools/replay/filter_session_recordings.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import MaxRecordingUniversalFilters, RecordingsQuery
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.session_recordings.queries.utils import SessionRecordingQueryResult
 from posthog.sync import database_sync_to_async
@@ -190,7 +190,12 @@ class FilterSessionRecordingsTool(MaxTool):
 
     def _get_recordings_with_filters(self, recordings_query: RecordingsQuery) -> SessionRecordingQueryResult:
         """Get recordings from DB with filters"""
-        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+        with tags_context(
+            product=Product.MAX_AI,
+            feature=Feature.POSTHOG_AI,
+            team_id=self._team.pk,
+            org_id=self._team.organization_id,
+        ):
             query_runner = SessionRecordingListFromQuery(
                 team=self._team, query=recordings_query, hogql_query_modifiers=None
             )

--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import MaxRecordingUniversalFilters, RecordingsQuery
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.session_replay.count_playlist_items import convert_filters_to_recordings_query
@@ -254,7 +254,12 @@ class SummarizeSessionsTool(MaxTool):
 
         # Execute the query to get session IDs
         try:
-            with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+            with tags_context(
+                product=Product.MAX_AI,
+                feature=Feature.POSTHOG_AI,
+                team_id=self._team.pk,
+                org_id=self._team.organization_id,
+            ):
                 query_runner = SessionRecordingListFromQuery(
                     team=self._team, query=replay_filters, hogql_query_modifiers=None
                 )

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -94,6 +94,8 @@ class Feature(StrEnum):
     ENDPOINT_EXECUTION = "endpoint_execution"  # external API callers (personal_api_key or oauth)
     ENDPOINT_PLAYGROUND = "endpoint_playground"  # frontend Playground tab (browser session auth)
     ENDPOINT_LAST_EXECUTION = "endpoint_last_execution"  # Usage tab query_log lookup
+    POSTHOG_AI = "posthog_ai"
+    MCP = "mcp"
 
 
 class TemporalTags(BaseModel):

--- a/products/posthog_ai/backend/api/mcp_tools.py
+++ b/products/posthog_ai/backend/api/mcp_tools.py
@@ -16,6 +16,7 @@ from structlog import get_logger
 
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.clickhouse.query_tagging import Feature, tags_context
 from posthog.models.user import User
 from posthog.renderers import SafeJSONRenderer
 
@@ -77,7 +78,12 @@ class MCPToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             )
 
         try:
-            content = async_to_sync(tool.execute)(validated_args)
+
+            async def execute_tool() -> str:
+                with tags_context(feature=Feature.MCP, team_id=self.team.pk, org_id=self.team.organization_id):
+                    return await tool.execute(validated_args)
+
+            content = async_to_sync(execute_tool)()
         except MaxToolError as e:
             return Response(
                 {


### PR DESCRIPTION
## Problem

ClickHouse query tags coming out of the PostHog AI pipeline and the MCP tools API were not attributing queries to a specific feature, making it hard to slice query-log analyses by surface (PostHog AI, MCP, etc.).

## Changes

- Add `POSTHOG_AI` and `MCP` entries to the `Feature` enum in `posthog/clickhouse/query_tagging.py`.
- Propagate `feature=Feature.POSTHOG_AI` through every `tags_context` call in `ee/hogai` so queries originating from Max are attributed correctly.
- In `query_executor.py`, preserve an outer-context feature when one is already set (`active_tags.feature or Feature.POSTHOG_AI`) so calls coming in through other surfaces (e.g. MCP) keep their original feature attribution.
- Snapshot caller tags in `query_executor.aexecute_query` before the `database_sync_to_async` thread switch so downstream Celery enqueues keep the parent feature/product tags.
- Tag MCP tool execution in `products/posthog_ai/backend/api/mcp_tools.py` with `feature=Feature.MCP`.

## How did you test this code?

Agent-authored PR. Ran `ruff check` over the touched files (clean) and added a unit test (`test_outer_tags_propagate_across_sync_boundary`) that asserts outer-context query tags survive the async/sync boundary inside `aexecute_query`. No manual UI testing was performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Key decision: keep the outer-context feature override only in `query_executor.py` — every other `tags_context` call site in `ee/hogai` is reached only from Max-originating flows, so hardcoding `Feature.POSTHOG_AI` is safe and avoids unnecessary `get_query_tags()` reads.