### PR TITLE
chore(mcp): Add CODEOWNERS entry for MCP tools directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,3 +43,7 @@ rust/persons_migrations/** @PostHog/team-ingestion
 posthog/api/authentication.py @PostHog/team-security
 posthog/auth.py @PostHog/team-security
 ee/api/scim/auth.py @PostHog/team-security
+
+# MCP tools - owned by @PostHog/team-posthog-ai
+services/mcp/src/tools/ @PostHog/team-posthog-ai
+services/mcp/src/tools/generated/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,4 +45,5 @@ posthog/auth.py @PostHog/team-security
 ee/api/scim/auth.py @PostHog/team-security
 
 # MCP tools - owned by @PostHog/team-posthog-ai
-services/mcp/src/tools/posthog_ai/ @PostHog/team-posthog-ai
+services/mcp/src/tools/ @PostHog/team-posthog-ai
+services/mcp/src/tools/generated/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,5 +45,4 @@ posthog/auth.py @PostHog/team-security
 ee/api/scim/auth.py @PostHog/team-security
 
 # MCP tools - owned by @PostHog/team-posthog-ai
-services/mcp/src/tools/ @PostHog/team-posthog-ai
-services/mcp/src/tools/generated/
+services/mcp/src/tools/posthog_ai/ @PostHog/team-posthog-ai

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -174,7 +174,3 @@ posthog/management/commands/find_enum_collisions.py @PostHog/team-devex
 
 # Visual Review - owned by @PostHog/team-devex
 products/visual_review/** @PostHog/team-devex
-
-# MCP tools - owned by @PostHog/team-posthog-ai
-services/mcp/src/tools/ @PostHog/team-posthog-ai
-services/mcp/src/tools/generated/

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -174,3 +174,6 @@ posthog/management/commands/find_enum_collisions.py @PostHog/team-devex
 
 # Visual Review - owned by @PostHog/team-devex
 products/visual_review/** @PostHog/team-devex
+
+# MCP tools - owned by @PostHog/team-posthog-ai
+services/mcp/src/tools/ @PostHog/team-posthog-ai

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -177,3 +177,4 @@ products/visual_review/** @PostHog/team-devex
 
 # MCP tools - owned by @PostHog/team-posthog-ai
 services/mcp/src/tools/ @PostHog/team-posthog-ai
+services/mcp/src/tools/generated/


### PR DESCRIPTION
## Problem

Codeowners to catch sneaky teams that ship manually written tools👀 

## Changes

Added a CODEOWNERS entry for `services/mcp/src/tools/` to be owned by `@PostHog/team-posthog-ai`.

## How did you test this code?

No testing needed. This is a configuration change to the CODEOWNERS file that specifies code ownership.

## Publish to changelog?

No

https://claude.ai/code/session_01XY4mA9m26qzSsTxc8v93ew