### PR TITLE
chore(ci): gate codeql advanced to manual dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,11 @@
 name: 'CodeQL Advanced'
 
+# Disabled: CodeQL Advanced runs are gated to manual dispatch while we evaluate
+# its impact on GITHUB_TOKEN usage. Re-add `push`, `pull_request`, and `schedule`
+# triggers to re-enable. Disabling via GitHub's UI alone is not sufficient for
+# Advanced workflows — the workflow file's triggers must also be removed.
 on:
-    push:
-        branches: ['master']
-    pull_request:
-        branches: ['master']
-    schedule:
-        - cron: '38 19 * * 1'
+    workflow_dispatch:
 
 # Cancel superseded PR runs; queue master/schedule so every commit gets scanned.
 concurrency:


### PR DESCRIPTION
## Problem

Evaluating impact of the CodeQL Advanced workflow on our `GITHUB_TOKEN` usage. The Advanced setup is driven entirely by this workflow file's triggers — toggling it off in the GitHub UI does not stop runs.

## Changes

- Replaced `push` (master), `pull_request` (master), and `schedule` triggers with `workflow_dispatch` only
- Job, permissions, and concurrency blocks left intact so re-enabling is a one-line revert

## How did you test this code?

Agent-authored. No automated tests run — workflow-trigger change. Verified via diff that auto triggers are removed and `workflow_dispatch` is the sole entrypoint.

## Publish to changelog?

no

## 🤖 Agent context

Authored via Claude Code at the user's direction to disable the CodeQL Advanced workflow without deleting it, so we can A/B the GITHUB_TOKEN usage delta and re-enable trivially.