### PR TITLE
chore(batch-exports): set timeout for backfill estimate query

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -158,7 +158,7 @@ class ClickHouseClientTimeoutError(ClickHouseError):
         super().__init__(f"Timed-out waiting for response running query '{query_id}'", query, query_id)
 
 
-class ClickHouseQueryTimeOutError(ClickHouseError):
+class ClickHouseQueryTimeoutError(ClickHouseError):
     """Exception raised when a query exceeds the server-side max execution time."""
 
     def __init__(self, error_message, query: str | None = None, query_id: str | None = None):
@@ -379,7 +379,7 @@ class ClickHouseClient:
             "MEMORY_LIMIT_EXCEEDED": ClickHouseMemoryLimitExceededError,
             "TOO_MANY_BYTES": ClickHouseTooManyBytesError,
             "TOO_MANY_SIMULTANEOUS_QUERIES": ClickHouseTooManySimultaneousQueriesError,
-            "TIMEOUT_EXCEEDED": ClickHouseQueryTimeOutError,
+            "TIMEOUT_EXCEEDED": ClickHouseQueryTimeoutError,
         }
         for error_code, exc_class in ERROR_CODE_TO_EXCEPTION.items():
             if error_code in error_message:

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -158,6 +158,13 @@ class ClickHouseClientTimeoutError(ClickHouseError):
         super().__init__(f"Timed-out waiting for response running query '{query_id}'", query, query_id)
 
 
+class ClickHouseQueryTimeOutError(ClickHouseError):
+    """Exception raised when a query exceeds the server-side max execution time."""
+
+    def __init__(self, error_message, query: str | None = None, query_id: str | None = None):
+        super().__init__(error_message, query, query_id)
+
+
 class ClickHouseQueryNotFound(ClickHouseError):
     """Exception raised when a query with a given ID is not found."""
 
@@ -372,6 +379,7 @@ class ClickHouseClient:
             "MEMORY_LIMIT_EXCEEDED": ClickHouseMemoryLimitExceededError,
             "TOO_MANY_BYTES": ClickHouseTooManyBytesError,
             "TOO_MANY_SIMULTANEOUS_QUERIES": ClickHouseTooManySimultaneousQueriesError,
+            "TIMEOUT_EXCEEDED": ClickHouseQueryTimeOutError,
         }
         for error_code, exc_class in ERROR_CODE_TO_EXCEPTION.items():
             if error_code in error_message:

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -8,12 +8,14 @@ from unittest.mock import MagicMock, patch
 
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
+    ClickHouseAllReplicasAreStaleError,
     ClickHouseCheckQueryStatusError,
     ClickHouseClient,
     ClickHouseError,
     ClickHouseMemoryLimitExceededError,
     ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
+    ClickHouseQueryTimeOutError,
     ClickHouseTooManyBytesError,
     ClickHouseTooManySimultaneousQueriesError,
     add_log_comment_param,
@@ -154,36 +156,43 @@ def _mock_internal_session_post(return_value):
     return patch("posthog.temporal.common.clickhouse.internal_requests_session", mock_factory)
 
 
-def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
-    """Simulate a ClickHouse memory limit exceeded error and verify that the correct error is raised."""
-    mock_response = MagicMock(
-        status_code=500,
-        text="Code: 241. DB::Exception: (total) memory limit exceeded: would use 99.97 GiB (attempt to allocate chunk of 12.26 MiB bytes), current RSS: 111.22 GiB, maximum: 111.19 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing MergeSortingTransform. (MEMORY_LIMIT_EXCEEDED) (version x.x.x.x (official build))",
-    )
+@pytest.mark.parametrize(
+    "error_text,expected_exception",
+    [
+        (
+            "Code: 241. DB::Exception: (total) memory limit exceeded: would use 99.97 GiB (attempt to allocate chunk of 12.26 MiB bytes), current RSS: 111.22 GiB, maximum: 111.19 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing MergeSortingTransform. (MEMORY_LIMIT_EXCEEDED) (version x.x.x.x (official build))",
+            ClickHouseMemoryLimitExceededError,
+        ),
+        (
+            "Code: 307. DB::Exception: Limit for rows or bytes to read exceeded, max bytes: 50.00 TiB, current bytes: 50.00 TiB: While executing MergeTreeSelect(pool: ReadPool, algorithm: Thread). (TOO_MANY_BYTES) (version x.x.x.x (official build))",
+            ClickHouseTooManyBytesError,
+        ),
+        (
+            "Code: 202. DB::Exception: Received from dummy-ch-node.internal. DB::Exception: Too many simultaneous queries for all users. Current: 100, maximum: 100. (TOO_MANY_SIMULTANEOUS_QUERIES) (version x.x.x.x (official build))",
+            ClickHouseTooManySimultaneousQueriesError,
+        ),
+        (
+            "Code: 159. DB::Exception: Estimated query execution time (300.5 seconds) is too long. Maximum: 300. (TIMEOUT_EXCEEDED) (version x.x.x.x (official build))",
+            ClickHouseQueryTimeOutError,
+        ),
+        (
+            "Code: 279. DB::Exception: All replicas are stale: While executing Remote. (ALL_REPLICAS_ARE_STALE) (version x.x.x.x (official build))",
+            ClickHouseAllReplicasAreStaleError,
+        ),
+    ],
+    ids=[
+        "MEMORY_LIMIT_EXCEEDED",
+        "TOO_MANY_BYTES",
+        "TOO_MANY_SIMULTANEOUS_QUERIES",
+        "TIMEOUT_EXCEEDED",
+        "ALL_REPLICAS_ARE_STALE",
+    ],
+)
+def test_clickhouse_error_code_maps_to_exception(clickhouse_client, error_text, expected_exception):
+    """Server-side ClickHouse error codes map to the matching client exception class."""
+    mock_response = MagicMock(status_code=500, text=error_text)
     with _mock_internal_session_post(mock_response):
-        with pytest.raises(ClickHouseMemoryLimitExceededError):
-            with clickhouse_client.post_query("SELECT 1", query_parameters={}, query_id=None):
-                pass
-
-
-def test_clickhouse_too_many_bytes_error(clickhouse_client):
-    mock_response = MagicMock(
-        status_code=500,
-        text="Code: 307. DB::Exception: Limit for rows or bytes to read exceeded, max bytes: 50.00 TiB, current bytes: 50.00 TiB: While executing MergeTreeSelect(pool: ReadPool, algorithm: Thread). (TOO_MANY_BYTES) (version x.x.x.x (official build))",
-    )
-    with _mock_internal_session_post(mock_response):
-        with pytest.raises(ClickHouseTooManyBytesError):
-            with clickhouse_client.post_query("SELECT 1", query_parameters={}, query_id=None):
-                pass
-
-
-def test_clickhouse_too_many_simultaneous_queries_error(clickhouse_client):
-    mock_response = MagicMock(
-        status_code=500,
-        text="Code: 202. DB::Exception: Received from dummy-ch-node.internal. DB::Exception: Too many simultaneous queries for all users. Current: 100, maximum: 100. (TOO_MANY_SIMULTANEOUS_QUERIES) (version x.x.x.x (official build))",
-    )
-    with _mock_internal_session_post(mock_response):
-        with pytest.raises(ClickHouseTooManySimultaneousQueriesError):
+        with pytest.raises(expected_exception):
             with clickhouse_client.post_query("SELECT 1", query_parameters={}, query_id=None):
                 pass
 

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -15,7 +15,7 @@ from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
     ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
-    ClickHouseQueryTimeOutError,
+    ClickHouseQueryTimeoutError,
     ClickHouseTooManyBytesError,
     ClickHouseTooManySimultaneousQueriesError,
     add_log_comment_param,
@@ -173,7 +173,7 @@ def _mock_internal_session_post(return_value):
         ),
         (
             "Code: 159. DB::Exception: Estimated query execution time (300.5 seconds) is too long. Maximum: 300. (TIMEOUT_EXCEEDED) (version x.x.x.x (official build))",
-            ClickHouseQueryTimeOutError,
+            ClickHouseQueryTimeoutError,
         ),
         (
             "Code: 279. DB::Exception: All replicas are stale: While executing Remote. (ALL_REPLICAS_ARE_STALE) (version x.x.x.x (official build))",

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -551,23 +551,32 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
                 total_records_count=None,
                 interval_seconds=interval_seconds,
             )
-    except (ClickHouseQueryTimeoutError, ClickHouseMemoryLimitExceededError, ClickHouseTooManyBytesError) as e:
-        if isinstance(e, ClickHouseQueryTimeoutError):
-            logger.warning(
-                "Backfill estimation query timed out, proceeding without estimate",
-                model=model,
-                timeout_seconds=BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
-            )
-        elif isinstance(e, ClickHouseMemoryLimitExceededError):
-            logger.warning(
-                "Backfill estimation query exceeded memory limit, proceeding without estimate",
-                model=model,
-            )
-        else:
-            logger.warning(
-                "Backfill estimation query exceeded bytes-read limit, proceeding without estimate",
-                model=model,
-            )
+    except ClickHouseQueryTimeoutError:
+        logger.warning(
+            "Backfill estimation query timed out, proceeding without estimate",
+            model=model,
+            timeout_seconds=BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
+        )
+        return GetBackfillInfoOutputs(
+            adjusted_start_at=inputs.start_at,
+            total_records_count=None,
+            interval_seconds=interval_seconds,
+        )
+    except ClickHouseMemoryLimitExceededError:
+        logger.warning(
+            "Backfill estimation query exceeded memory limit, proceeding without estimate",
+            model=model,
+        )
+        return GetBackfillInfoOutputs(
+            adjusted_start_at=inputs.start_at,
+            total_records_count=None,
+            interval_seconds=interval_seconds,
+        )
+    except ClickHouseTooManyBytesError:
+        logger.warning(
+            "Backfill estimation query exceeded bytes-read limit, proceeding without estimate",
+            model=model,
+        )
         return GetBackfillInfoOutputs(
             adjusted_start_at=inputs.start_at,
             total_records_count=None,

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -26,7 +26,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
-    ClickHouseQueryTimeOutError,
+    ClickHouseQueryTimeoutError,
     ClickHouseTooManyBytesError,
     get_client,
 )
@@ -551,8 +551,8 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
                 total_records_count=None,
                 interval_seconds=interval_seconds,
             )
-    except (ClickHouseQueryTimeOutError, ClickHouseMemoryLimitExceededError, ClickHouseTooManyBytesError) as e:
-        if isinstance(e, ClickHouseQueryTimeOutError):
+    except (ClickHouseQueryTimeoutError, ClickHouseMemoryLimitExceededError, ClickHouseTooManyBytesError) as e:
+        if isinstance(e, ClickHouseQueryTimeoutError):
             logger.warning(
                 "Backfill estimation query timed out, proceeding without estimate",
                 model=model,

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -26,6 +26,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
+    ClickHouseQueryTimeOutError,
     ClickHouseTooManyBytesError,
     get_client,
 )
@@ -46,6 +47,11 @@ from products.batch_exports.backend.temporal.record_batch_model import SessionsR
 from products.batch_exports.backend.temporal.spmc import compose_filters_clause
 
 LOGGER = get_write_only_logger(__name__)
+
+# Cap individual backfill estimation queries so a slow query cannot hold a
+# ClickHouse slot for hours. The estimate is advisory: when the timeout fires
+# we proceed with the backfill without a record-count estimate.
+BACKFILL_INFO_QUERY_TIMEOUT_SECONDS = 300
 
 
 class TemporalScheduleNotFoundError(Exception):
@@ -252,7 +258,7 @@ async def _get_backfill_info_for_events(
         {filters_str}
         {date_conditions}
         FORMAT JSONEachRow
-        SETTINGS log_comment=%(log_comment)s
+        SETTINGS max_execution_time=%(max_execution_time)s, log_comment=%(log_comment)s
     """
 
     query_parameters = {
@@ -260,6 +266,7 @@ async def _get_backfill_info_for_events(
         "include_events": include_events,
         "exclude_events": exclude_events,
         "log_comment": log_comment,
+        "max_execution_time": BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
         **extra_query_parameters,
     }
 
@@ -313,7 +320,11 @@ async def _get_backfill_info_for_persons(
     lower_bound_condition = ""
     date_conditions = ""
     having_date_conditions = ""
-    query_parameters: dict[str, typing.Any] = {"team_id": team_id, "log_comment": log_comment}
+    query_parameters: dict[str, typing.Any] = {
+        "team_id": team_id,
+        "log_comment": log_comment,
+        "max_execution_time": BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
+    }
 
     if start_at is not None:
         lower_bound_condition = "AND _timestamp >= %(start_at)s "
@@ -340,7 +351,7 @@ async def _get_backfill_info_for_persons(
         AND _timestamp > '2000-01-01'
         {date_conditions}
         FORMAT JSONEachRow
-        SETTINGS log_comment=%(log_comment)s
+        SETTINGS max_execution_time=%(max_execution_time)s, log_comment=%(log_comment)s
     """
 
     min_timestamp_query_id = str(uuid.uuid4())
@@ -408,7 +419,7 @@ async def _get_backfill_info_for_persons(
         SELECT uniq(distinct_id) AS record_count
         FROM distinct_ids
         FORMAT JSONEachRow
-        SETTINGS optimize_uniq_to_count = 0, log_comment=%(log_comment)s
+        SETTINGS optimize_uniq_to_count = 0, max_execution_time=%(max_execution_time)s, log_comment=%(log_comment)s
     """
 
     count_query_id = str(uuid.uuid4())
@@ -444,7 +455,12 @@ async def _get_backfill_info_for_sessions(
     """
 
     model = SessionsRecordBatchModel(team_id=batch_export.team_id, batch_export_id=str(batch_export.id))
-    min_timestamp, record_count = await model.get_backfill_info(start_at, end_at, log_comment=log_comment)
+    min_timestamp, record_count = await model.get_backfill_info(
+        start_at,
+        end_at,
+        log_comment=log_comment,
+        max_execution_time_seconds=BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
+    )
 
     if min_timestamp is None:
         return None, 0
@@ -535,11 +551,23 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
                 total_records_count=None,
                 interval_seconds=interval_seconds,
             )
-    except (ClickHouseMemoryLimitExceededError, ClickHouseTooManyBytesError):
-        logger.warning(
-            "Backfill estimation query exceeded resource limits, proceeding without estimate",
-            model=model,
-        )
+    except (ClickHouseQueryTimeOutError, ClickHouseMemoryLimitExceededError, ClickHouseTooManyBytesError) as e:
+        if isinstance(e, ClickHouseQueryTimeOutError):
+            logger.warning(
+                "Backfill estimation query timed out, proceeding without estimate",
+                model=model,
+                timeout_seconds=BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
+            )
+        elif isinstance(e, ClickHouseMemoryLimitExceededError):
+            logger.warning(
+                "Backfill estimation query exceeded memory limit, proceeding without estimate",
+                model=model,
+            )
+        else:
+            logger.warning(
+                "Backfill estimation query exceeded bytes-read limit, proceeding without estimate",
+                model=model,
+            )
         return GetBackfillInfoOutputs(
             adjusted_start_at=inputs.start_at,
             total_records_count=None,

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -243,7 +243,11 @@ INSERT INTO FUNCTION {s3_function}
         )
 
     async def get_backfill_info(
-        self, start_at: dt.datetime | None, end_at: dt.datetime | None, log_comment: str
+        self,
+        start_at: dt.datetime | None,
+        end_at: dt.datetime | None,
+        log_comment: str,
+        max_execution_time_seconds: int,
     ) -> tuple[dt.datetime | None, int | None]:
         """Estimate record count and earliest timestamp for a backfill.
 
@@ -255,6 +259,7 @@ INSERT INTO FUNCTION {s3_function}
         context = await self.get_hogql_context()
 
         context.values["log_comment"] = log_comment
+        context.values["max_execution_time_seconds"] = max_execution_time_seconds
 
         prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
             hogql_query, context=context, dialect="clickhouse", stack=[]
@@ -268,10 +273,11 @@ INSERT INTO FUNCTION {s3_function}
             stack=[],
         )
 
+        query_settings = "max_execution_time={max_execution_time_seconds}, log_comment={log_comment}"
         if "settings" not in printed.lower():
-            printed += " SETTINGS log_comment={log_comment}"
+            printed += f" SETTINGS {query_settings}"
         else:
-            printed += ", log_comment={log_comment}"
+            printed += f", {query_settings}"
 
         query_id = str(uuid.uuid4())
         logger = LOGGER.bind(query_id=query_id)

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -9,7 +9,7 @@ from temporalio.testing import ActivityEnvironment
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination
 from posthog.models.utils import uuid7
-from posthog.temporal.common.clickhouse import ClickHouseQueryTimeOutError
+from posthog.temporal.common.clickhouse import ClickHouseQueryTimeoutError
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, insert_sessions_in_clickhouse
 
 from products.batch_exports.backend.temporal.backfill_batch_export import (
@@ -263,7 +263,7 @@ class TestGetBackfillInfoForEvents:
         self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
     ):
         mock_clickhouse_client.mock_client.read_query_as_jsonl = AsyncMock(
-            side_effect=ClickHouseQueryTimeOutError("Code: 159. TIMEOUT_EXCEEDED")
+            side_effect=ClickHouseQueryTimeoutError("Code: 159. TIMEOUT_EXCEEDED")
         )
 
         batch_export = await create_batch_export()
@@ -671,7 +671,7 @@ class TestGetBackfillInfoForPersons:
         self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
     ):
         mock_clickhouse_client.mock_client.read_query_as_jsonl = AsyncMock(
-            side_effect=ClickHouseQueryTimeOutError("Code: 159. TIMEOUT_EXCEEDED")
+            side_effect=ClickHouseQueryTimeoutError("Code: 159. TIMEOUT_EXCEEDED")
         )
 
         batch_export = await create_batch_export()
@@ -876,7 +876,7 @@ class TestGetBackfillInfoForSessions:
         self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
     ):
         mock_clickhouse_client.mock_client.read_query_as_jsonl = AsyncMock(
-            side_effect=ClickHouseQueryTimeOutError("Code: 159. TIMEOUT_EXCEEDED")
+            side_effect=ClickHouseQueryTimeoutError("Code: 159. TIMEOUT_EXCEEDED")
         )
 
         batch_export = await create_batch_export()

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -3,15 +3,20 @@ import typing as t
 import datetime as dt
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from temporalio.testing import ActivityEnvironment
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination
 from posthog.models.utils import uuid7
+from posthog.temporal.common.clickhouse import ClickHouseQueryTimeOutError
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, insert_sessions_in_clickhouse
 
-from products.batch_exports.backend.temporal.backfill_batch_export import GetBackfillInfoInputs, get_backfill_info
+from products.batch_exports.backend.temporal.backfill_batch_export import (
+    BACKFILL_INFO_QUERY_TIMEOUT_SECONDS,
+    GetBackfillInfoInputs,
+    get_backfill_info,
+)
 from products.batch_exports.backend.tests.temporal.utils.clickhouse import (
     truncate_events,
     truncate_persons,
@@ -238,6 +243,38 @@ class TestGetBackfillInfoForEvents:
                 "query_type": "backfill_estimate",
             }
         )
+
+    async def test_query_caps_max_execution_time(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
+    ):
+        batch_export = await create_batch_export()
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        captured = mock_clickhouse_client.calls[0]
+        assert captured.query_parameters is not None
+        assert captured.query_parameters["max_execution_time"] == BACKFILL_INFO_QUERY_TIMEOUT_SECONDS
+        assert "max_execution_time" in captured.query.lower()
+
+    async def test_returns_no_estimate_on_timeout(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
+    ):
+        mock_clickhouse_client.mock_client.read_query_as_jsonl = AsyncMock(
+            side_effect=ClickHouseQueryTimeOutError("Code: 159. TIMEOUT_EXCEEDED")
+        )
+
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        assert result.total_records_count is None
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat()
 
 
 class TestGetBackfillInfoForPersons:
@@ -610,6 +647,43 @@ class TestGetBackfillInfoForPersons:
         mock_clickhouse_client.expect_unique_query_ids()
         mock_clickhouse_client.expect_properties_in_log_comment({"query_type": "backfill_estimate"})
 
+    async def test_query_caps_max_execution_time(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
+    ):
+        batch_export = await create_batch_export()
+        mock_clickhouse_client.read_query_as_jsonl_responses = [
+            [{"min_timestamp": "2021-01-15 10:30:00"}, {"min_timestamp": "2021-01-15 10:30:00"}],
+            [{"record_count": "42"}],
+        ]
+
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        for call in mock_clickhouse_client.calls:
+            assert call.query_parameters is not None
+            assert call.query_parameters["max_execution_time"] == BACKFILL_INFO_QUERY_TIMEOUT_SECONDS
+            assert "max_execution_time" in call.query.lower()
+
+    async def test_returns_no_estimate_on_timeout(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
+    ):
+        mock_clickhouse_client.mock_client.read_query_as_jsonl = AsyncMock(
+            side_effect=ClickHouseQueryTimeOutError("Code: 159. TIMEOUT_EXCEEDED")
+        )
+
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        assert result.total_records_count is None
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat()
+
 
 class TestGetBackfillInfoForSessions:
     @pytest.fixture(autouse=True)
@@ -780,3 +854,37 @@ class TestGetBackfillInfoForSessions:
                 "query_type": "backfill_estimate",
             }
         )
+
+    async def test_query_caps_max_execution_time(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
+    ):
+        batch_export = await create_batch_export()
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        captured = mock_clickhouse_client.calls[0]
+        # The sessions path uses HogQL placeholders (`{name}`); the printed
+        # query carries the placeholder, while context.values carries the value.
+        assert "max_execution_time" in captured.query.lower()
+        assert captured.query_parameters is not None
+        assert captured.query_parameters["max_execution_time_seconds"] == BACKFILL_INFO_QUERY_TIMEOUT_SECONDS
+
+    async def test_returns_no_estimate_on_timeout(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export
+    ):
+        mock_clickhouse_client.mock_client.read_query_as_jsonl = AsyncMock(
+            side_effect=ClickHouseQueryTimeOutError("Code: 159. TIMEOUT_EXCEEDED")
+        )
+
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        assert result.total_records_count is None
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat()


### PR DESCRIPTION
## Problem

Backfill estimation queries run to compute the earliest timestamp and total record count for the requested range. They are advisory — the backfill itself does not depend on the estimate — but on large ranges or exports with complex filters they can run for a significant amount of time.

We already catch `MEMORY_LIMIT_EXCEEDED` and `TOO_MANY_BYTES` and proceed without an estimate. Long-running queries that never trip those limits had no escape hatch.

## Changes

- Add `ClickHouseQueryTimeOutError` and map it from the `TIMEOUT_EXCEEDED` server error code in `posthog/temporal/common/clickhouse.py`.
- Set `max_execution_time = 300` on every backfill estimation query in `products/batch_exports/backend/temporal/backfill_batch_export.py` (events, persons, sessions paths) and on the sessions HogQL query in `record_batch_model.py`.
- Treat `ClickHouseQueryTimeOutError` the same as the existing resource-limit errors in `get_backfill_info`: log a warning and return no estimate so the backfill can proceed.

## How did you test this code?

Automated tests:

- `posthog/temporal/tests/test_clickhouse.py::test_clickhouse_error_code_maps_to_exception`
  (parameterized — covers the new `TIMEOUT_EXCEEDED` mapping plus the
  existing cases).
- `products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py`
  for events / persons / sessions, including the new `test_query_caps_max_execution_time` and `test_returns_no_estimate_on_timeout` cases.

Also tested using the local stack by setting the timeout to a very low value (0.01s) and verifying the timeout was raised.

## Publish to changelog?

no

## Docs update

No docs change required.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7)