### PR TITLE
chore(flags): rust-jumphost claim-from-pool shim over toolbox.py

### DIFF
--- a/bin/rust-jumphost
+++ b/bin/rust-jumphost
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 #
-# Shell into the flags-cache-jumphost pod. The jumphost is a long-lived
-# `sleep infinity` deployment that ships the warm-flags-cache binary on
-# PATH so ops can run it ad-hoc against an environment's Postgres / Redis
-# / S3.
+# Claim a flags-cache-jumphost pod from the dev pool, drop into bash, and
+# auto-delete the pod on exit. Thin shim that delegates to
+# tools/infra-scripts/clitools/toolbox.py with --pool flags-cache-jumphost
+# and --auto-delete; all the orphan-relabel-claim logic lives there.
 #
 # Prerequisites:
-#   - kubectl context already pointed at the target cluster (e.g.
-#     `kubectl config use-context posthog-dev`).
-#   - The flags-cache-jumphost deployment exists in $KUBE_NAMESPACE.
+#   - kubectl context pointing at the target cluster, or pass
+#     KUBE_CONTEXT=… (e.g. KUBE_CONTEXT=posthog-dev).
 #
 # Usage:
-#   bin/rust-jumphost                  # drops into bash
-#   KUBE_NAMESPACE=posthog bin/rust-jumphost
+#   bin/rust-jumphost                       # claim + connect
+#   KUBE_CONTEXT=posthog-dev bin/rust-jumphost
+#   KUBE_NAMESPACE=posthog   bin/rust-jumphost
+#   bin/rust-jumphost --claim-duration 4    # 4h claim window
 #
 # Inside the pod:
 #   warm-flags-cache --help
@@ -20,6 +21,13 @@
 
 set -euo pipefail
 
-NAMESPACE="${KUBE_NAMESPACE:-posthog}"
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo "Error: kubectl not found on PATH."
+    exit 1
+fi
 
-exec kubectl exec -it "deploy/flags-cache-jumphost" -n "$NAMESPACE" -- bash
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec "$REPO_ROOT/tools/infra-scripts/clitools/toolbox.py" \
+    --pool flags-cache-jumphost \
+    --auto-delete \
+    "$@"

--- a/rust/feature-flags/src/bin/warm-flags-cache.rs
+++ b/rust/feature-flags/src/bin/warm-flags-cache.rs
@@ -277,7 +277,10 @@ async fn run_warm(
         join_set.spawn(async move {
             warm_team(pg, &writer, team_id, ttl_seconds)
                 .await
-                .map_err(|e| (team_id, e.to_string()))
+                // Debug format walks Box<dyn Error>'s nested chain so SDK errors
+                // (e.g. an S3 PutObject 403) surface their code + message instead
+                // of being collapsed to a top-level "service error" string.
+                .map_err(|e| (team_id, format!("{e:?}")))
         });
     }
 

--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -926,6 +926,85 @@ class TestToolbox(unittest.TestCase):
         mock_input.assert_called_once()
         mock_run.assert_not_called()
 
+    @patch("subprocess.run")
+    def test_delete_pod_skips_when_label_does_not_match(self, mock_run):
+        """When expected_label_* are passed (atexit path) and the label doesn't match,
+        the kubectl delete is skipped to protect against deleting an unclaimed pool pod
+        when claim_pod() failed before any label was written.
+        """
+        # kubectl get returns an empty label value (pod was never claimed).
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        delete_pod(
+            "toolbox-pod-1",
+            namespace="posthog",
+            auto_yes=True,
+            expected_label_key="toolbox-claimed",
+            expected_label_value="user_at_posthog.com",
+        )
+
+        # Exactly one kubectl call: the verification get. No delete was issued.
+        self.assertEqual(mock_run.call_count, 1)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("get", cmd)
+        self.assertNotIn("delete", cmd)
+
+    @patch("subprocess.run")
+    def test_delete_pod_proceeds_when_label_matches(self, mock_run):
+        """When the label check confirms our claim, delete_pod proceeds with the kubectl delete."""
+        # First call (get) returns the matching label value; second call (delete) succeeds.
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="user_at_posthog.com", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        delete_pod(
+            "toolbox-pod-1",
+            namespace="posthog",
+            auto_yes=True,
+            expected_label_key="toolbox-claimed",
+            expected_label_value="user_at_posthog.com",
+        )
+
+        self.assertEqual(mock_run.call_count, 2)
+        delete_cmd = mock_run.call_args_list[1][0][0]
+        self.assertIn("delete", delete_cmd)
+        self.assertIn("toolbox-pod-1", delete_cmd)
+
+    @patch("subprocess.run")
+    def test_delete_pod_skips_when_label_check_errors(self, mock_run):
+        """If the label-verification kubectl get errors out, default to NOT deleting.
+
+        Leaving an orphan to be reaped is preferable to silently shrinking the pool.
+        """
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["kubectl", "get"],
+            stderr="forbidden",
+        )
+
+        delete_pod(
+            "toolbox-pod-1",
+            namespace="posthog",
+            auto_yes=True,
+            expected_label_key="toolbox-claimed",
+            expected_label_value="user_at_posthog.com",
+        )
+
+        # Only the failing get call; no delete attempted.
+        self.assertEqual(mock_run.call_count, 1)
+
+    @patch("subprocess.run")
+    def test_delete_pod_without_expected_label_skips_verification(self, mock_run):
+        """Without expected_label_*, no extra kubectl get is issued (interactive 'y' path)."""
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        delete_pod("toolbox-pod-1", namespace="posthog", auto_yes=True)
+
+        self.assertEqual(mock_run.call_count, 1)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("delete", cmd)
+
     @patch("builtins.print", side_effect=BrokenPipeError("hung-up PTY"))
     @patch("subprocess.run")
     def test_delete_pod_swallows_kubectl_failure_when_stdout_broken(self, mock_run, mock_print):
@@ -1214,9 +1293,16 @@ class TestToolbox(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 toolbox_script.main()
 
-        # atexit cleanup is registered with auto_yes=True and the resolved context.
+        # atexit cleanup is registered with auto_yes=True, resolved context, and the
+        # claim label so delete_pod can verify before deleting an unclaimed pool pod.
         m_atexit.assert_called_once_with(
-            m_delete, "toolbox-pod-1", namespace="posthog", context="posthog-dev", auto_yes=True
+            m_delete,
+            "toolbox-pod-1",
+            namespace="posthog",
+            context="posthog-dev",
+            auto_yes=True,
+            expected_label_key="toolbox-claimed",
+            expected_label_value="user_at_posthog.com",
         )
         # Both SIGTERM and SIGHUP route to _exit_for_signal.
         signal_calls = {c.args[0]: c.args[1] for c in m_signal.call_args_list}
@@ -1274,7 +1360,13 @@ class TestToolbox(unittest.TestCase):
                 toolbox_script.main()
 
         m_atexit.assert_called_once_with(
-            m_delete, "toolbox-pod-1", namespace="posthog", context="posthog-dev", auto_yes=True
+            m_delete,
+            "toolbox-pod-1",
+            namespace="posthog",
+            context="posthog-dev",
+            auto_yes=True,
+            expected_label_key="toolbox-claimed",
+            expected_label_value="user_at_posthog.com",
         )
         # update-claim path passes resource_version=None because we already own the pod.
         self.assertEqual(m_claim.call_args.kwargs["resource_version"], None)
@@ -1348,7 +1440,13 @@ class TestToolbox(unittest.TestCase):
         m_unregister.assert_called_with(m_delete)
 
     def test_main_gives_up_after_max_claim_retries(self):
-        """If every attempt races, main() exits 1 rather than looping forever."""
+        """If every attempt races, main() exits 1 rather than looping forever.
+
+        Also asserts that the stale atexit registration is cleared before the
+        terminal exit — otherwise atexit would fire delete_pod against an
+        unclaimed candidate pod and silently shrink the pool on every
+        retry-exhaustion.
+        """
         max_retries = toolbox_script.MAX_CLAIM_RETRIES
         patches = self._patch_main_collaborators()
         patches["get_toolbox_pod"] = patch.object(
@@ -1365,11 +1463,11 @@ class TestToolbox(unittest.TestCase):
             patches["get_toolbox_pod"],
             patches["claim_pod"] as m_claim,
             patches["connect_to_pod"],
-            patches["delete_pod"],
+            patches["delete_pod"] as m_delete,
             patches["select_context"],
             patches["validate_context"],
-            patch.object(toolbox_script.atexit, "register"),
-            patch.object(toolbox_script.atexit, "unregister"),
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.atexit, "unregister") as m_unregister,
             patch.object(toolbox_script.signal, "signal"),
             patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
             patch.dict(os.environ, {}, clear=False),
@@ -1380,6 +1478,13 @@ class TestToolbox(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertEqual(m_claim.call_count, max_retries)
+        # One register for the initial pre-claim arming, one per candidate after
+        # each lost race (max_retries - 1 in-loop + 1 final dead candidate when
+        # the final claim races) — and one matching unregister per register,
+        # including the final one before sys.exit(1).
+        self.assertEqual(m_atexit.call_count, m_unregister.call_count)
+        self.assertGreaterEqual(m_unregister.call_count, max_retries)
+        m_unregister.assert_called_with(m_delete)
 
     def test_main_race_resolves_to_already_claimed_skips_auto_delete(self):
         """If, after losing a race, the next get_toolbox_pod finds a pod already claimed by us,

--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -1,18 +1,50 @@
 #!/usr/bin/env python3
 
+import os
 import json
 import time
+import signal
 import subprocess
+import importlib.util
 
 import unittest
 from unittest.mock import MagicMock, patch
 
-from toolbox.kubernetes import get_available_contexts, get_current_context, select_context, switch_context
-from toolbox.pod import claim_pod, get_toolbox_pod
+from toolbox.kubernetes import (
+    get_available_contexts,
+    get_current_context,
+    kubectl_cmd,
+    select_context,
+    switch_context,
+    validate_context,
+)
+from toolbox.pod import ClaimRaceError, claim_pod, delete_pod, get_toolbox_pod
 from toolbox.user import get_current_user, parse_arn, sanitize_label
+
+# Load toolbox.py (the script with main() and POOLS) by file path, since the
+# `toolbox` package shadows it in normal import resolution.
+_TOOLBOX_SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "toolbox.py")
+_spec = importlib.util.spec_from_file_location("_toolbox_script", _TOOLBOX_SCRIPT_PATH)
+toolbox_script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(toolbox_script)
 
 
 class TestToolbox(unittest.TestCase):
+    def test_kubectl_cmd_without_context(self):
+        """kubectl_cmd with context=None returns the same shape as a bare kubectl call."""
+        self.assertEqual(kubectl_cmd("get", "pods"), ["kubectl", "get", "pods"])
+
+    def test_kubectl_cmd_with_context(self):
+        """kubectl_cmd injects --context= so we can scope to a cluster without mutating kubeconfig."""
+        self.assertEqual(
+            kubectl_cmd("get", "pods", context="posthog-dev"),
+            ["kubectl", "--context=posthog-dev", "get", "pods"],
+        )
+
+    def test_kubectl_cmd_empty_context_is_treated_as_unset(self):
+        """An empty string for context means 'no override', matching get_current_context() returning ''."""
+        self.assertEqual(kubectl_cmd("get", "pods", context=""), ["kubectl", "get", "pods"])
+
     def test_sanitize_label(self):
         """Test label sanitization function."""
         # Test basic email sanitization
@@ -40,19 +72,29 @@ class TestToolbox(unittest.TestCase):
         """Test parsing valid AWS STS ARN."""
         arn = "arn:aws:sts::169684386827:assumed-role/AWSReservedSSO_developers_0847e649a00cc5e7/michael.k@posthog.com"
         expected = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "developers", "assumed-role": "true"}
-        self.assertEqual(parse_arn(arn), expected)
+        self.assertEqual(parse_arn(arn, claimed_label_key="toolbox-claimed"), expected)
 
     def test_parse_arn_different_role(self):
         """Test parsing ARN with different role."""
         arn = "arn:aws:sts::169684386827:assumed-role/AWSReservedSSO_admins_0847e649a00cc5e7/michael.k@posthog.com"
         expected = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "admins", "assumed-role": "true"}
-        self.assertEqual(parse_arn(arn), expected)
+        self.assertEqual(parse_arn(arn, claimed_label_key="toolbox-claimed"), expected)
 
     def test_parse_arn_unexpected_format(self):
         """Test parsing ARN with unexpected role format."""
         arn = "arn:aws:sts::169684386827:assumed-role/custom-role-name/michael.k@posthog.com"
         expected = {"toolbox-claimed": "arn_aws_sts__169684386827_assum_e-name_michael.k_at_posthog.com"}
-        self.assertEqual(parse_arn(arn), expected)
+        self.assertEqual(parse_arn(arn, claimed_label_key="toolbox-claimed"), expected)
+
+    def test_parse_arn_jumphost_label_key(self):
+        """Pool-specific claimed_label_key reaches every return path of parse_arn."""
+        arn = "arn:aws:sts::169684386827:assumed-role/AWSReservedSSO_developers_0847e649a00cc5e7/michael.k@posthog.com"
+        expected = {
+            "flags-jumphost-claimed": "michael.k_at_posthog.com",
+            "role-name": "developers",
+            "assumed-role": "true",
+        }
+        self.assertEqual(parse_arn(arn, claimed_label_key="flags-jumphost-claimed"), expected)
 
     @patch("subprocess.run")
     def test_get_current_user(self, mock_run):
@@ -76,11 +118,39 @@ class TestToolbox(unittest.TestCase):
         )
         mock_run.return_value = mock_response
 
-        user_labels = get_current_user()
+        user_labels = get_current_user(claimed_label_key="toolbox-claimed")
         expected = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "developers", "assumed-role": "true"}
         self.assertEqual(user_labels, expected)
         mock_run.assert_called_once_with(
             ["kubectl", "auth", "whoami", "-o", "json"], capture_output=True, text=True, check=True
+        )
+
+    @patch("subprocess.run")
+    def test_get_current_user_with_context(self, mock_run):
+        """get_current_user with context= scopes the whoami call to that context."""
+        mock_response = MagicMock()
+        mock_response.stdout = json.dumps(
+            {
+                "status": {
+                    "userInfo": {
+                        "username": "sso-developers",
+                        "extra": {
+                            "arn": [
+                                "arn:aws:sts::169684386827:assumed-role/AWSReservedSSO_developers_0847e649a00cc5e7/michael.k@posthog.com"
+                            ],
+                        },
+                    }
+                }
+            }
+        )
+        mock_run.return_value = mock_response
+
+        get_current_user(claimed_label_key="toolbox-claimed", context="posthog-dev")
+        mock_run.assert_called_once_with(
+            ["kubectl", "--context=posthog-dev", "auth", "whoami", "-o", "json"],
+            capture_output=True,
+            text=True,
+            check=True,
         )
 
     @patch("sys.exit")
@@ -96,7 +166,7 @@ class TestToolbox(unittest.TestCase):
         )
         mock_run.side_effect = error
 
-        get_current_user()
+        get_current_user(claimed_label_key="toolbox-claimed")
 
         mock_run.assert_called_once_with(
             ["kubectl", "auth", "whoami", "-o", "json"], capture_output=True, text=True, check=True
@@ -108,8 +178,7 @@ class TestToolbox(unittest.TestCase):
 
     @patch("subprocess.run")
     def test_get_toolbox_pod(self, mock_run):
-        """Test getting available toolbox pod."""
-        # Mock kubectl get pods response
+        """get_toolbox_pod returns (name, claimed, resource_version) for a fresh unclaimed pod."""
         mock_response = MagicMock()
         mock_response.stdout = json.dumps(
             {
@@ -117,6 +186,7 @@ class TestToolbox(unittest.TestCase):
                     {
                         "metadata": {
                             "name": "toolbox-pod-1",
+                            "resourceVersion": "12345",
                             "labels": {
                                 "app.kubernetes.io/name": "posthog-toolbox-django",
                                 "pod-template-hash": "749c5d8db",
@@ -133,9 +203,15 @@ class TestToolbox(unittest.TestCase):
         )
         mock_run.return_value = mock_response
 
-        pod_name, is_claimed = get_toolbox_pod("michael.k_at_posthog.com")
+        pod_name, is_claimed, resource_version = get_toolbox_pod(
+            "michael.k_at_posthog.com",
+            app_label="posthog-toolbox-django",
+            claimed_label_key="toolbox-claimed",
+            namespace="posthog",
+        )
         self.assertEqual(pod_name, "toolbox-pod-1")
         self.assertFalse(is_claimed)
+        self.assertEqual(resource_version, "12345")
         mock_run.assert_called_once_with(
             [
                 "kubectl",
@@ -152,6 +228,86 @@ class TestToolbox(unittest.TestCase):
             text=True,
             check=True,
         )
+
+    @patch("subprocess.run")
+    def test_get_toolbox_pod_with_context(self, mock_run):
+        """get_toolbox_pod with context= passes --context to kubectl get pods."""
+        mock_response = MagicMock()
+        mock_response.stdout = json.dumps(
+            {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "toolbox-pod-1",
+                            "resourceVersion": "12345",
+                            "labels": {"app.kubernetes.io/name": "posthog-toolbox-django"},
+                            "deletionTimestamp": None,
+                        },
+                        "status": {"phase": "Running"},
+                    }
+                ]
+            }
+        )
+        mock_run.return_value = mock_response
+
+        get_toolbox_pod(
+            "michael.k_at_posthog.com",
+            app_label="posthog-toolbox-django",
+            claimed_label_key="toolbox-claimed",
+            namespace="posthog",
+            context="posthog-dev",
+        )
+        mock_run.assert_called_once_with(
+            [
+                "kubectl",
+                "--context=posthog-dev",
+                "get",
+                "pods",
+                "-n",
+                "posthog",
+                "-l",
+                "app.kubernetes.io/name=posthog-toolbox-django",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_get_toolbox_pod_returns_existing_claim_with_rv(self, mock_run):
+        """An already-claimed pod returns is_claimed=True and the observed resourceVersion."""
+        mock_response = MagicMock()
+        mock_response.stdout = json.dumps(
+            {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "toolbox-pod-1",
+                            "resourceVersion": "55555",
+                            "labels": {
+                                "app.kubernetes.io/name": "posthog-toolbox-django",
+                                "toolbox-claimed": "michael.k_at_posthog.com",
+                            },
+                            "deletionTimestamp": None,
+                        },
+                        "status": {"phase": "Running"},
+                    }
+                ]
+            }
+        )
+        mock_run.return_value = mock_response
+
+        pod_name, is_claimed, rv = get_toolbox_pod(
+            "michael.k_at_posthog.com",
+            app_label="posthog-toolbox-django",
+            claimed_label_key="toolbox-claimed",
+            namespace="posthog",
+        )
+        self.assertEqual(pod_name, "toolbox-pod-1")
+        self.assertTrue(is_claimed)
+        self.assertEqual(rv, "55555")
 
     @patch("subprocess.run")
     def test_claim_pod(self, mock_run):
@@ -173,7 +329,7 @@ class TestToolbox(unittest.TestCase):
         ]
 
         user_labels = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "developers", "assumed-role": "true"}
-        claim_pod("toolbox-pod-1", user_labels, 1234567890)
+        claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog")
 
         # Verify kubectl commands were called correctly
         self.assertEqual(mock_run.call_count, 4)
@@ -248,7 +404,7 @@ class TestToolbox(unittest.TestCase):
         future_timestamp = int(time.time()) + (4 * 60 * 60)
 
         user_labels = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "developers", "assumed-role": "true"}
-        claim_pod("toolbox-pod-1", user_labels, future_timestamp)
+        claim_pod("toolbox-pod-1", user_labels, future_timestamp, namespace="posthog")
 
         # Verify kubectl commands were called correctly
         self.assertEqual(mock_run.call_count, 4)
@@ -295,10 +451,7 @@ class TestToolbox(unittest.TestCase):
         # Set up the side effect to handle all kubectl calls
         mock_run.side_effect = [
             mock_get_response,  # get pod labels
-            mock_label_response,  # remove toolbox-claimed
-            mock_label_response,  # remove role-name
-            mock_label_response,  # remove assumed-role
-            mock_label_response,  # remove terminate-after
+            mock_label_response,  # batch-remove existing labels
             mock_annotate_response,  # add annotation
             mock_label_response,  # add new labels
             mock_label_response,  # wait for pod
@@ -308,10 +461,10 @@ class TestToolbox(unittest.TestCase):
         future_timestamp = int(time.time()) + (24 * 60 * 60)
 
         user_labels = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "developers", "assumed-role": "true"}
-        claim_pod("toolbox-pod-1", user_labels, future_timestamp)
+        claim_pod("toolbox-pod-1", user_labels, future_timestamp, namespace="posthog")
 
         # Verify kubectl commands were called correctly
-        self.assertEqual(mock_run.call_count, 8)
+        self.assertEqual(mock_run.call_count, 5)
 
         # Get all calls made to kubectl
         calls = mock_run.call_args_list
@@ -322,19 +475,26 @@ class TestToolbox(unittest.TestCase):
             ["kubectl", "get", "pod", "-n", "posthog", "toolbox-pod-1", "-o", "jsonpath={.metadata.labels}"],
         )
 
-        # Verify the label removal calls
+        # Verify the batched label-removal call (single kubectl invocation)
         self.assertEqual(
-            calls[1][0][0], ["kubectl", "label", "pod", "-n", "posthog", "toolbox-pod-1", "toolbox-claimed-"]
-        )
-        self.assertEqual(calls[2][0][0], ["kubectl", "label", "pod", "-n", "posthog", "toolbox-pod-1", "role-name-"])
-        self.assertEqual(calls[3][0][0], ["kubectl", "label", "pod", "-n", "posthog", "toolbox-pod-1", "assumed-role-"])
-        self.assertEqual(
-            calls[4][0][0], ["kubectl", "label", "pod", "-n", "posthog", "toolbox-pod-1", "terminate-after-"]
+            calls[1][0][0],
+            [
+                "kubectl",
+                "label",
+                "pod",
+                "-n",
+                "posthog",
+                "toolbox-pod-1",
+                "toolbox-claimed-",
+                "role-name-",
+                "assumed-role-",
+                "terminate-after-",
+            ],
         )
 
         # Verify the annotation call
         self.assertEqual(
-            calls[5][0][0],
+            calls[2][0][0],
             [
                 "kubectl",
                 "annotate",
@@ -349,7 +509,7 @@ class TestToolbox(unittest.TestCase):
 
         # Verify the label call
         self.assertEqual(
-            calls[6][0][0],
+            calls[3][0][0],
             [
                 "kubectl",
                 "label",
@@ -366,9 +526,119 @@ class TestToolbox(unittest.TestCase):
 
         # Verify the wait call
         self.assertEqual(
-            calls[7][0][0],
+            calls[4][0][0],
             ["kubectl", "wait", "--for=condition=Ready", "--timeout=5m", "-n", "posthog", "pod", "toolbox-pod-1"],
         )
+
+    @patch("subprocess.run")
+    def test_claim_pod_with_resource_version_passes_flag_on_first_mutation(self, mock_run):
+        """When resource_version is set, the FIRST mutating kubectl call carries --resource-version=<rv>.
+
+        Subsequent calls drop the flag because the resourceVersion advances after every
+        successful write; carrying the original rv on later calls would 409 against
+        ourselves.
+        """
+        mock_get_response = MagicMock()
+        mock_get_response.stdout = json.dumps({"app.kubernetes.io/name": "posthog-toolbox-django"})
+        # No labels_to_remove → annotate is the first mutation, so it carries the rv flag.
+        mock_run.side_effect = [
+            mock_get_response,  # kubectl get pod labels
+            MagicMock(),  # annotate (first mutation, with --resource-version)
+            MagicMock(),  # label add (no rv flag)
+            MagicMock(),  # wait
+        ]
+
+        user_labels = {"toolbox-claimed": "u_at_posthog.com"}
+        claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog", resource_version="42")
+
+        annotate_args = mock_run.call_args_list[1][0][0]
+        label_args = mock_run.call_args_list[2][0][0]
+        self.assertIn("--resource-version=42", annotate_args)
+        self.assertNotIn("--resource-version=42", label_args)
+
+    @patch("subprocess.run")
+    def test_claim_pod_with_resource_version_attaches_to_label_strip_when_present(self, mock_run):
+        """If existing labels need stripping, the strip step (not annotate) is the first mutation."""
+        mock_get_response = MagicMock()
+        mock_get_response.stdout = json.dumps(
+            {
+                "app.kubernetes.io/name": "posthog-toolbox-django",
+                "pod-template-hash": "abc123",
+            }
+        )
+        mock_run.side_effect = [
+            mock_get_response,  # kubectl get pod labels
+            MagicMock(),  # label-strip (first mutation, with rv flag)
+            MagicMock(),  # annotate (no rv flag)
+            MagicMock(),  # label add (no rv flag)
+            MagicMock(),  # wait
+        ]
+
+        user_labels = {"toolbox-claimed": "u_at_posthog.com"}
+        claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog", resource_version="42")
+
+        strip_args = mock_run.call_args_list[1][0][0]
+        annotate_args = mock_run.call_args_list[2][0][0]
+        self.assertIn("--resource-version=42", strip_args)
+        self.assertNotIn("--resource-version=42", annotate_args)
+
+    @patch("subprocess.run")
+    def test_claim_pod_raises_claim_race_error_on_conflict(self, mock_run):
+        """A 409 Conflict on the first mutation surfaces as ClaimRaceError so the caller can retry."""
+        mock_get_response = MagicMock()
+        mock_get_response.stdout = json.dumps({"app.kubernetes.io/name": "posthog-toolbox-django"})
+        conflict = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["kubectl", "annotate", "pod"],
+            stderr="Error from server (Conflict): the object has been modified",
+        )
+        mock_run.side_effect = [
+            mock_get_response,  # kubectl get pod labels
+            conflict,  # annotate (first mutation) loses the race
+        ]
+
+        user_labels = {"toolbox-claimed": "u_at_posthog.com"}
+        with self.assertRaises(ClaimRaceError):
+            claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog", resource_version="42")
+
+    @patch("subprocess.run")
+    def test_claim_pod_non_conflict_error_does_not_raise_race(self, mock_run):
+        """A non-409 kubectl failure on the first mutation is not a race; the original error path applies."""
+        mock_get_response = MagicMock()
+        mock_get_response.stdout = json.dumps({"app.kubernetes.io/name": "posthog-toolbox-django"})
+        non_conflict = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["kubectl", "annotate", "pod"],
+            stderr="Error from server (Forbidden): user cannot annotate pods",
+        )
+        mock_run.side_effect = [
+            mock_get_response,  # kubectl get pod labels
+            non_conflict,  # annotate fails with a non-409 error
+        ]
+
+        user_labels = {"toolbox-claimed": "u_at_posthog.com"}
+        with self.assertRaises(SystemExit):
+            claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog", resource_version="42")
+
+    @patch("subprocess.run")
+    def test_claim_pod_with_context(self, mock_run):
+        """claim_pod with context= passes --context to every kubectl invocation."""
+        mock_get_response = MagicMock()
+        mock_get_response.stdout = json.dumps({"app.kubernetes.io/name": "posthog-toolbox-django"})
+        mock_run.side_effect = [
+            mock_get_response,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        ]
+
+        user_labels = {"toolbox-claimed": "u_at_posthog.com"}
+        claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog", context="posthog-dev")
+
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            self.assertEqual(cmd[0], "kubectl")
+            self.assertEqual(cmd[1], "--context=posthog-dev")
 
     # New tests for Kubernetes context functions
     @patch("subprocess.run")
@@ -452,6 +722,18 @@ class TestToolbox(unittest.TestCase):
         mock_run.assert_called_once()
 
     @patch("toolbox.kubernetes.get_available_contexts")
+    def test_validate_context_known(self, mock_get):
+        """validate_context returns True for a context that's in the available list."""
+        mock_get.return_value = ["posthog-dev", "posthog-prod"]
+        self.assertTrue(validate_context("posthog-dev"))
+
+    @patch("toolbox.kubernetes.get_available_contexts")
+    def test_validate_context_unknown(self, mock_get):
+        """validate_context returns False for a context that isn't known."""
+        mock_get.return_value = ["posthog-dev", "posthog-prod"]
+        self.assertFalse(validate_context("posthog-bogus"))
+
+    @patch("toolbox.kubernetes.get_available_contexts")
     @patch("toolbox.kubernetes.get_current_context")
     @patch("builtins.input")
     def test_select_context(self, mock_input, mock_get_current, mock_get_available):
@@ -469,6 +751,21 @@ class TestToolbox(unittest.TestCase):
         mock_get_available.assert_called_once()
         mock_get_current.assert_called_once()
         mock_input.assert_called_once()
+
+    @patch("toolbox.kubernetes.get_available_contexts")
+    @patch("toolbox.kubernetes.get_current_context")
+    @patch("builtins.input")
+    def test_select_context_picks_index_without_switching(self, mock_input, mock_get_current, mock_get_available):
+        """Picking a context returns the chosen name without calling kubectl config use-context."""
+        mock_get_available.return_value = ["context1", "context2", "context3"]
+        mock_get_current.return_value = "context1"
+        mock_input.return_value = "2"
+
+        with patch("toolbox.kubernetes.switch_context") as mock_switch:
+            result = select_context()
+
+        self.assertEqual(result, "context2")
+        mock_switch.assert_not_called()
 
     @patch("toolbox.kubernetes.get_available_contexts")
     @patch("toolbox.kubernetes.get_current_context")
@@ -504,7 +801,630 @@ class TestToolbox(unittest.TestCase):
         mock_run.side_effect = side_effect
         user_labels = {"toolbox-claimed": "michael.k_at_posthog.com", "role-name": "developers", "assumed-role": "true"}
         with self.assertRaises(SystemExit):
-            claim_pod("toolbox-pod-1", user_labels, 1234567890)
+            claim_pod("toolbox-pod-1", user_labels, 1234567890, namespace="posthog")
+
+    def test_pools_definition(self):
+        """POOLS contains both pools with the expected app and claim labels."""
+        self.assertEqual(
+            toolbox_script.POOLS["toolbox-django"],
+            {"app_label": "posthog-toolbox-django", "claimed_label_key": "toolbox-claimed"},
+        )
+        self.assertEqual(
+            toolbox_script.POOLS["flags-cache-jumphost"],
+            {"app_label": "flags-cache-jumphost", "claimed_label_key": "flags-jumphost-claimed"},
+        )
+
+    def test_exit_for_signal_raises_systemexit_for_sigterm(self):
+        """SIGTERM handler routes through sys.exit so atexit-registered cleanup fires."""
+        with self.assertRaises(SystemExit) as ctx:
+            toolbox_script._exit_for_signal(signal.SIGTERM, None)
+        self.assertEqual(ctx.exception.code, 128 + int(signal.SIGTERM))
+
+    def test_exit_for_signal_raises_systemexit_for_sighup(self):
+        """SIGHUP handler routes through sys.exit so atexit-registered cleanup fires.
+
+        SIGHUP fires on terminal close (closing iTerm, SSH disconnect, killing a tmux
+        pane); without this routing the claimed pod would leak.
+        """
+        with self.assertRaises(SystemExit) as ctx:
+            toolbox_script._exit_for_signal(signal.SIGHUP, None)
+        self.assertEqual(ctx.exception.code, 128 + int(signal.SIGHUP))
+
+    @patch("builtins.input")
+    @patch("subprocess.run")
+    def test_delete_pod_auto_yes_skips_prompt(self, mock_run, mock_input):
+        """delete_pod(auto_yes=True) does not call input() and uses --ignore-not-found."""
+        delete_pod("toolbox-pod-1", namespace="posthog", auto_yes=True)
+
+        mock_input.assert_not_called()
+        mock_run.assert_called_once_with(
+            [
+                "kubectl",
+                "delete",
+                "pod",
+                "-n",
+                "posthog",
+                "toolbox-pod-1",
+                "--ignore-not-found",
+                "--wait=false",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("builtins.input")
+    @patch("subprocess.run")
+    def test_delete_pod_with_context_passes_flag(self, mock_run, mock_input):
+        """delete_pod with context= scopes the kubectl delete to that context."""
+        delete_pod("toolbox-pod-1", namespace="posthog", context="posthog-dev", auto_yes=True)
+
+        mock_input.assert_not_called()
+        mock_run.assert_called_once_with(
+            [
+                "kubectl",
+                "--context=posthog-dev",
+                "delete",
+                "pod",
+                "-n",
+                "posthog",
+                "toolbox-pod-1",
+                "--ignore-not-found",
+                "--wait=false",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("builtins.input", return_value="y")
+    @patch("subprocess.run")
+    def test_delete_pod_prompt_yes_invokes_kubectl(self, mock_run, mock_input):
+        """delete_pod(auto_yes=False) with a 'y' response invokes kubectl delete."""
+        delete_pod("toolbox-pod-1", namespace="posthog")
+
+        mock_input.assert_called_once()
+        mock_run.assert_called_once()
+
+    @patch("builtins.input", return_value="n")
+    @patch("subprocess.run")
+    def test_delete_pod_prompt_no_skips_kubectl(self, mock_run, mock_input):
+        """delete_pod(auto_yes=False) with a non-'y' response does not call kubectl."""
+        delete_pod("toolbox-pod-1", namespace="posthog")
+
+        mock_input.assert_called_once()
+        mock_run.assert_not_called()
+
+    @patch("builtins.print", side_effect=BrokenPipeError("hung-up PTY"))
+    @patch("subprocess.run")
+    def test_delete_pod_runs_kubectl_when_stdout_is_broken(self, mock_run, mock_print):
+        """delete_pod must still run kubectl delete when stdout is hung up.
+
+        Reproduces the SIGHUP-cleanup leak: when the user closes their terminal
+        tab, atexit fires delete_pod *after* the controlling PTY is gone.
+        Pre-fix, the very first ``print('🗑️  Deleting pod...')`` raised
+        BrokenPipeError before kubectl was reached, leaking a claimed pod.
+        """
+        delete_pod("toolbox-pod-1", namespace="posthog", auto_yes=True)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        self.assertEqual(cmd[0], "kubectl")
+        self.assertIn("delete", cmd)
+        self.assertIn("toolbox-pod-1", cmd)
+
+    @patch("builtins.input", side_effect=BrokenPipeError("hung-up PTY"))
+    @patch("subprocess.run")
+    def test_delete_pod_prompt_path_with_broken_input_skips_delete(self, mock_run, mock_input):
+        """When input() can't read (no TTY / hung-up), default to NOT deleting.
+
+        Matches the safety semantics of an explicit user 'n' so we never delete
+        a non-auto-delete pod without explicit consent.
+        """
+        delete_pod("toolbox-pod-1", namespace="posthog", auto_yes=False)
+
+        mock_input.assert_called_once()
+        mock_run.assert_not_called()
+
+    @patch("builtins.print", side_effect=BrokenPipeError("hung-up PTY"))
+    @patch("subprocess.run")
+    def test_delete_pod_swallows_kubectl_failure_when_stdout_broken(self, mock_run, mock_print):
+        """If kubectl delete fails AND stdout is broken, delete_pod must not raise.
+
+        Otherwise a transient kubectl failure during atexit would propagate and
+        skip any subsequent atexit handlers.
+        """
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["kubectl", "delete"],
+            stderr="some error",
+        )
+
+        # Should not raise:
+        delete_pod("toolbox-pod-1", namespace="posthog", auto_yes=True)
+
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_connect_to_pod_returns_zero_on_success(self, mock_run):
+        """connect_to_pod returns 0 when kubectl exec exits cleanly."""
+        from toolbox.pod import connect_to_pod
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        rc = connect_to_pod("toolbox-pod-1", namespace="posthog")
+        self.assertEqual(rc, 0)
+
+    @patch("subprocess.run")
+    def test_connect_to_pod_returns_nonzero_on_failure(self, mock_run):
+        """connect_to_pod surfaces a non-zero exit code from kubectl exec.
+
+        The original code used subprocess.run without checking returncode, so RBAC
+        denials, missing pods, and network failures silently looked successful and
+        triggered downstream cleanup of a session that never opened.
+        """
+        from toolbox.pod import connect_to_pod
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_run.return_value = mock_result
+
+        rc = connect_to_pod("toolbox-pod-1", namespace="posthog")
+        self.assertEqual(rc, 1)
+
+    @patch("subprocess.run")
+    def test_connect_to_pod_with_context(self, mock_run):
+        """connect_to_pod with context= passes --context to kubectl exec."""
+        from toolbox.pod import connect_to_pod
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        connect_to_pod("toolbox-pod-1", namespace="posthog", context="posthog-dev")
+        mock_run.assert_called_once_with(
+            [
+                "kubectl",
+                "--context=posthog-dev",
+                "exec",
+                "-it",
+                "-n",
+                "posthog",
+                "toolbox-pod-1",
+                "--",
+                "bash",
+            ]
+        )
+
+    def _patch_main_collaborators(self, *, get_pod_returns=("toolbox-pod-1", False, "12345")):
+        """Common patch stack for main() integration tests.
+
+        Patches everything main() depends on so the test exercises only the dispatch
+        wiring (POOLS lookup, KUBE_CONTEXT branch, kwargs threading, race-retry, etc.).
+        """
+        connect_mock = MagicMock(return_value=0)
+        return {
+            "get_current_user": patch.object(
+                toolbox_script,
+                "get_current_user",
+                return_value={"toolbox-claimed": "user_at_posthog.com"},
+            ),
+            "get_toolbox_pod": patch.object(toolbox_script, "get_toolbox_pod", return_value=get_pod_returns),
+            "claim_pod": patch.object(toolbox_script, "claim_pod"),
+            "connect_to_pod": patch.object(toolbox_script, "connect_to_pod", new=connect_mock),
+            "delete_pod": patch.object(toolbox_script, "delete_pod"),
+            "select_context": patch.object(toolbox_script, "select_context", return_value="posthog-dev"),
+            "validate_context": patch.object(toolbox_script, "validate_context", return_value=True),
+        }
+
+    def _clean_env(self):
+        os.environ.pop("KUBE_CONTEXT", None)
+        os.environ.pop("KUBE_NAMESPACE", None)
+        os.environ.pop("FLOX_ENV", None)
+
+    def test_main_jumphost_pool_dispatches_correct_kwargs(self):
+        """--pool flags-cache-jumphost threads the jumphost app/claim labels into helpers."""
+        patches = self._patch_main_collaborators()
+        # Override get_current_user for the jumphost pool's claim key.
+        patches["get_current_user"] = patch.object(
+            toolbox_script,
+            "get_current_user",
+            return_value={"flags-jumphost-claimed": "user_at_posthog.com"},
+        )
+
+        with (
+            patches["get_current_user"] as m_user,
+            patches["get_toolbox_pod"] as m_get_pod,
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--pool", "flags-cache-jumphost"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit) as ctx:
+                toolbox_script.main()
+        self.assertEqual(ctx.exception.code, 0)
+
+        m_user.assert_called_once_with(claimed_label_key="flags-jumphost-claimed", context="posthog-dev")
+        m_get_pod.assert_called_once_with(
+            "user_at_posthog.com",
+            check_claimed=True,
+            app_label="flags-cache-jumphost",
+            claimed_label_key="flags-jumphost-claimed",
+            namespace="posthog",
+            context="posthog-dev",
+        )
+        # claim_pod gets namespace, context, and resource_version from get_toolbox_pod's return.
+        self.assertEqual(
+            m_claim.call_args.kwargs,
+            {"namespace": "posthog", "context": "posthog-dev", "resource_version": "12345"},
+        )
+
+    def test_main_default_pool_dispatches_toolbox_django_kwargs(self):
+        """No --pool argument defaults to toolbox-django and threads its labels."""
+        patches = self._patch_main_collaborators()
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"] as m_get_pod,
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        m_get_pod.assert_called_once_with(
+            "user_at_posthog.com",
+            check_claimed=True,
+            app_label="posthog-toolbox-django",
+            claimed_label_key="toolbox-claimed",
+            namespace="posthog",
+            context="posthog-dev",
+        )
+
+    def test_main_kube_context_env_validates_without_switching(self):
+        """When KUBE_CONTEXT is set, main() validates it and threads it as --context, never calling switch_context."""
+        patches = self._patch_main_collaborators()
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"] as m_get_pod,
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"] as m_select,
+            patches["validate_context"] as m_validate,
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
+            patch.dict(os.environ, {"KUBE_CONTEXT": "posthog-dev"}, clear=False),
+        ):
+            os.environ.pop("KUBE_NAMESPACE", None)
+            os.environ.pop("FLOX_ENV", None)
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        m_validate.assert_called_once_with("posthog-dev")
+        m_select.assert_not_called()
+        # And the resolved context is threaded into get_toolbox_pod.
+        self.assertEqual(m_get_pod.call_args.kwargs["context"], "posthog-dev")
+
+    def test_main_kube_context_unset_falls_back_to_select_context(self):
+        """When KUBE_CONTEXT is unset, main() prompts via select_context and uses its return as --context."""
+        patches = self._patch_main_collaborators()
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"] as m_get_pod,
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"] as m_select,
+            patches["validate_context"] as m_validate,
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        m_select.assert_called_once_with()
+        m_validate.assert_not_called()
+        self.assertEqual(m_get_pod.call_args.kwargs["context"], "posthog-dev")
+
+    def test_main_kube_context_validate_failure_exits(self):
+        """When validate_context returns False, main() exits with status 1."""
+        patches = self._patch_main_collaborators()
+        patches["validate_context"] = patch.object(toolbox_script, "validate_context", return_value=False)
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py"]),
+            patch.dict(os.environ, {"KUBE_CONTEXT": "bogus"}, clear=False),
+        ):
+            os.environ.pop("FLOX_ENV", None)
+            with self.assertRaises(SystemExit) as ctx:
+                toolbox_script.main()
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_main_auto_delete_arms_atexit_before_claim_pod(self):
+        """atexit.register must run BEFORE claim_pod() so a Ctrl-C during the up-to-5min Ready wait still cleans up."""
+        patches = self._patch_main_collaborators()
+
+        parent = MagicMock()
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.signal, "signal"),
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            parent.attach_mock(m_atexit, "atexit_register")
+            parent.attach_mock(m_claim, "claim_pod")
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        call_names = [name for name, _, _ in parent.mock_calls]
+        first_atexit = call_names.index("atexit_register")
+        first_claim = call_names.index("claim_pod")
+        self.assertLess(first_atexit, first_claim)
+
+    def test_main_auto_delete_registers_signal_handlers_and_atexit(self):
+        """--auto-delete registers atexit cleanup and SIGTERM/SIGHUP handlers when claiming a fresh pod."""
+        patches = self._patch_main_collaborators()
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"] as m_delete,
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.signal, "signal") as m_signal,
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        # atexit cleanup is registered with auto_yes=True and the resolved context.
+        m_atexit.assert_called_once_with(
+            m_delete, "toolbox-pod-1", namespace="posthog", context="posthog-dev", auto_yes=True
+        )
+        # Both SIGTERM and SIGHUP route to _exit_for_signal.
+        signal_calls = {c.args[0]: c.args[1] for c in m_signal.call_args_list}
+        self.assertIs(signal_calls[signal.SIGTERM], toolbox_script._exit_for_signal)
+        self.assertIs(signal_calls[signal.SIGHUP], toolbox_script._exit_for_signal)
+
+    def test_main_auto_delete_skipped_on_pure_reattach(self):
+        """When reattaching to an already-claimed pod (no --update-claim), --auto-delete must NOT register cleanup.
+
+        The pod may still be in active use by another shell of yours; deleting it
+        when this shell exits would kill that other session.
+        """
+        patches = self._patch_main_collaborators(get_pod_returns=("toolbox-pod-1", True, "55555"))
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.signal, "signal") as m_signal,
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        m_atexit.assert_not_called()
+        m_signal.assert_not_called()
+        m_claim.assert_not_called()  # Pure reattach: no claim mutation either.
+
+    def test_main_auto_delete_armed_when_extending_own_claim(self):
+        """--auto-delete WITH --update-claim DOES register cleanup because we are actively (re-)claiming."""
+        patches = self._patch_main_collaborators(get_pod_returns=("toolbox-pod-1", True, "55555"))
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"],
+            patches["delete_pod"] as m_delete,
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.signal, "signal"),
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete", "--update-claim"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        m_atexit.assert_called_once_with(
+            m_delete, "toolbox-pod-1", namespace="posthog", context="posthog-dev", auto_yes=True
+        )
+        # update-claim path passes resource_version=None because we already own the pod.
+        self.assertEqual(m_claim.call_args.kwargs["resource_version"], None)
+
+    def test_main_propagates_connect_to_pod_exit_code(self):
+        """When kubectl exec returns non-zero, main() exits with the same code."""
+        patches = self._patch_main_collaborators()
+        patches["connect_to_pod"] = patch.object(toolbox_script, "connect_to_pod", return_value=42)
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"],
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit) as ctx:
+                toolbox_script.main()
+
+        self.assertEqual(ctx.exception.code, 42)
+
+    def test_main_retries_on_claim_race_and_picks_new_pod(self):
+        """A ClaimRaceError on the first attempt triggers a re-fetch and retry against the next available pod."""
+        patches = self._patch_main_collaborators()
+        # Simulate: first get returns pod-A; first claim races; second get returns pod-B; second claim succeeds.
+        patches["get_toolbox_pod"] = patch.object(
+            toolbox_script,
+            "get_toolbox_pod",
+            side_effect=[
+                ("toolbox-pod-A", False, "1"),
+                ("toolbox-pod-B", False, "2"),
+            ],
+        )
+        patches["claim_pod"] = patch.object(
+            toolbox_script,
+            "claim_pod",
+            side_effect=[ClaimRaceError("racing"), None],
+        )
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"] as m_get_pod,
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"] as m_connect,
+            patches["delete_pod"] as m_delete,
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.atexit, "unregister") as m_unregister,
+            patch.object(toolbox_script.signal, "signal"),
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        self.assertEqual(m_get_pod.call_count, 2)
+        self.assertEqual(m_claim.call_count, 2)
+        # We connected to the pod we won, not the one we lost.
+        m_connect.assert_called_once_with("toolbox-pod-B", namespace="posthog", context="posthog-dev")
+        # atexit was registered twice (once per candidate pod) and unregistered once
+        # to clear the stale registration after the race.
+        self.assertEqual(m_atexit.call_count, 2)
+        self.assertEqual(m_unregister.call_count, 1)
+        m_unregister.assert_called_with(m_delete)
+
+    def test_main_gives_up_after_max_claim_retries(self):
+        """If every attempt races, main() exits 1 rather than looping forever."""
+        max_retries = toolbox_script.MAX_CLAIM_RETRIES
+        patches = self._patch_main_collaborators()
+        patches["get_toolbox_pod"] = patch.object(
+            toolbox_script,
+            "get_toolbox_pod",
+            side_effect=[(f"pod-{i}", False, str(i)) for i in range(max_retries + 2)],
+        )
+        patches["claim_pod"] = patch.object(
+            toolbox_script, "claim_pod", side_effect=[ClaimRaceError("racing")] * (max_retries + 1)
+        )
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"],
+            patches["delete_pod"],
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register"),
+            patch.object(toolbox_script.atexit, "unregister"),
+            patch.object(toolbox_script.signal, "signal"),
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit) as ctx:
+                toolbox_script.main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(m_claim.call_count, max_retries)
+
+    def test_main_race_resolves_to_already_claimed_skips_auto_delete(self):
+        """If, after losing a race, the next get_toolbox_pod finds a pod already claimed by us,
+        we attach but DO NOT register cleanup against it (it could be another shell's claim)."""
+        patches = self._patch_main_collaborators()
+        patches["get_toolbox_pod"] = patch.object(
+            toolbox_script,
+            "get_toolbox_pod",
+            side_effect=[
+                ("toolbox-pod-A", False, "1"),
+                ("toolbox-pod-mine", True, "9"),
+            ],
+        )
+        patches["claim_pod"] = patch.object(
+            toolbox_script,
+            "claim_pod",
+            side_effect=[ClaimRaceError("racing")],
+        )
+
+        with (
+            patches["get_current_user"],
+            patches["get_toolbox_pod"],
+            patches["claim_pod"] as m_claim,
+            patches["connect_to_pod"] as m_connect,
+            patches["delete_pod"] as m_delete,
+            patches["select_context"],
+            patches["validate_context"],
+            patch.object(toolbox_script.atexit, "register") as m_atexit,
+            patch.object(toolbox_script.atexit, "unregister") as m_unregister,
+            patch.object(toolbox_script.signal, "signal"),
+            patch.object(toolbox_script.sys, "argv", ["toolbox.py", "--auto-delete"]),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            self._clean_env()
+            with self.assertRaises(SystemExit):
+                toolbox_script.main()
+
+        m_connect.assert_called_once_with("toolbox-pod-mine", namespace="posthog", context="posthog-dev")
+        # claim_pod was called once (the racing one) and not retried since we found our own pod.
+        self.assertEqual(m_claim.call_count, 1)
+        # First atexit register armed cleanup for pod-A; on the race we unregistered;
+        # we did NOT re-register for pod-mine.
+        self.assertEqual(m_atexit.call_count, 1)
+        self.assertEqual(m_unregister.call_count, 1)
+        m_unregister.assert_called_with(m_delete)
 
 
 if __name__ == "__main__":

--- a/tools/infra-scripts/clitools/toolbox.py
+++ b/tools/infra-scripts/clitools/toolbox.py
@@ -127,7 +127,19 @@ def main():
         # prevents this shell from deleting a pod that another shell of yours
         # may still be using.
         if args.auto_delete and will_claim:
-            atexit.register(delete_pod, pod_name, namespace=namespace, context=selected_context, auto_yes=True)
+            # expected_label_key/value gate the delete on the pod still carrying our claim
+            # label, so a claim_pod() failure before any label was written (transient
+            # kubectl get/RBAC error, pod gone) doesn't shrink the pool by deleting an
+            # unclaimed pool pod from atexit.
+            atexit.register(
+                delete_pod,
+                pod_name,
+                namespace=namespace,
+                context=selected_context,
+                auto_yes=True,
+                expected_label_key=claimed_label_key,
+                expected_label_value=user_labels[claimed_label_key],
+            )
             # SIGTERM and SIGHUP bypass atexit by default; _exit_for_signal routes them
             # through sys.exit so the registered cleanup runs. SIGHUP fires on terminal
             # close (closing iTerm, SSH disconnect, killing a tmux pane). SIGINT raises
@@ -180,8 +192,16 @@ def main():
                             namespace=namespace,
                             context=selected_context,
                             auto_yes=True,
+                            expected_label_key=claimed_label_key,
+                            expected_label_value=user_labels[claimed_label_key],
                         )
             else:
+                # Drop the stale registration first. The except branch above
+                # registers cleanup for the *next* candidate before retrying;
+                # if we exhaust retries, that candidate was never claimed by us
+                # and atexit would otherwise delete a healthy unclaimed pool pod.
+                if args.auto_delete:
+                    atexit.unregister(delete_pod)
                 print(f"❌ Could not claim a pod after {MAX_CLAIM_RETRIES} race retries.")  # noqa: T201
                 sys.exit(1)
             if will_claim:
@@ -213,7 +233,10 @@ def main():
         sys.exit(rc)
     except KeyboardInterrupt:
         print("\n👋 Goodbye! \n \n Did something not work as expected? Ask in #team-infrastructure")  # noqa: T201
-        sys.exit(0)
+        # POSIX convention: SIGINT exits 128 + signum (130). sys.exit(0) here
+        # would mask Ctrl-C as a clean success to any wrapper checking $?, and
+        # is inconsistent with the SIGTERM/SIGHUP handlers which already use 128 + signum.
+        sys.exit(128 + signal.SIGINT)
 
 
 if __name__ == "__main__":

--- a/tools/infra-scripts/clitools/toolbox.py
+++ b/tools/infra-scripts/clitools/toolbox.py
@@ -5,6 +5,8 @@ Toolbox command for connecting to PostHog toolbox pods in a Kubernetes environme
 
 import os
 import sys
+import atexit
+import signal
 import argparse
 from datetime import datetime, timedelta
 
@@ -12,9 +14,32 @@ from datetime import datetime, timedelta
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import functions from the modular package
-from toolbox.kubernetes import select_context
-from toolbox.pod import claim_pod, connect_to_pod, delete_pod, get_toolbox_pod
+from toolbox.kubernetes import select_context, validate_context
+from toolbox.pod import ClaimRaceError, claim_pod, connect_to_pod, delete_pod, get_toolbox_pod
 from toolbox.user import get_current_user
+
+POOLS = {
+    "toolbox-django": {
+        "app_label": "posthog-toolbox-django",
+        "claimed_label_key": "toolbox-claimed",
+    },
+    "flags-cache-jumphost": {
+        "app_label": "flags-cache-jumphost",
+        "claimed_label_key": "flags-jumphost-claimed",
+    },
+}
+
+# Bound the claim-race retry budget so a permanently-contended pool can't loop forever.
+MAX_CLAIM_RETRIES = 3
+
+
+def _exit_for_signal(signum, _frame):
+    """SIGTERM/SIGHUP handler that routes through sys.exit so atexit-registered cleanup runs.
+
+    Default Python behavior on SIGTERM/SIGHUP is to terminate without running atexit; raising
+    SystemExit via sys.exit makes the registered cleanup fire.
+    """
+    sys.exit(128 + signum)
 
 
 def main():
@@ -41,20 +66,51 @@ def main():
             action="store_true",
             help="Update the termination time of your existing claimed pod instead of claiming a new one.",
         )
+        parser.add_argument(
+            "--pool",
+            choices=sorted(POOLS.keys()),
+            default="toolbox-django",
+            help="Which pool to claim from. Defaults to toolbox-django (the original posthog-toolbox-django pool).",
+        )
+        parser.add_argument(
+            "--auto-delete",
+            action="store_true",
+            help="Skip the [y/N] prompt on exit and unconditionally delete the claimed pod on normal exit, Ctrl-C, or terminal close.",
+        )
         args = parser.parse_args()
 
-        print("🛠️  Connecting to toolbox pod...")  # noqa: T201
+        pool = POOLS[args.pool]
+        app_label = pool["app_label"]
+        claimed_label_key = pool["claimed_label_key"]
+        namespace = os.environ.get("KUBE_NAMESPACE", "posthog")
 
-        # Let user select kubernetes context
-        selected_context = select_context()
+        print(f"🛠️  Connecting to {args.pool} pool in namespace {namespace}...")  # noqa: T201
+
+        # Resolve which kubernetes context to use without ever calling
+        # `kubectl config use-context`. Switching kubeconfig globally would persist past
+        # this script and silently redirect later operational commands.
+        if kube_context := os.environ.get("KUBE_CONTEXT"):
+            if not validate_context(kube_context):
+                print(f"❌ KUBE_CONTEXT='{kube_context}' is not a known kubernetes context.")  # noqa: T201
+                sys.exit(1)
+            selected_context = kube_context
+        else:
+            selected_context = select_context()
         print(f"🔄 Using kubernetes context: {selected_context}")  # noqa: T201
 
         # Get current user labels
-        user_labels = get_current_user()
+        user_labels = get_current_user(claimed_label_key=claimed_label_key, context=selected_context)
         print(f"👤 Current user labels: {user_labels}")  # noqa: T201
 
         # Get available pod
-        pod_name, is_already_claimed = get_toolbox_pod(user_labels["toolbox-claimed"], check_claimed=True)
+        pod_name, is_already_claimed, resource_version = get_toolbox_pod(
+            user_labels[claimed_label_key],
+            check_claimed=True,
+            app_label=app_label,
+            claimed_label_key=claimed_label_key,
+            namespace=namespace,
+            context=selected_context,
+        )
         print(f"🎯 Found pod: {pod_name}")  # noqa: T201
 
         # Calculate duration
@@ -62,18 +118,99 @@ def main():
         timestamp = int(future_time.timestamp())
         human_readable = future_time.strftime("%Y-%m-%d %H:%M:%S")
 
-        # Claim or update pod
-        if not is_already_claimed or args.update_claim:
-            print(f"⏰ {'Updating' if is_already_claimed else 'Setting'} pod termination time to: {human_readable}")  # noqa: T201
-            claim_pod(pod_name, user_labels, timestamp)
-            print(f"✅ Successfully {'updated' if is_already_claimed else 'claimed'} pod: {pod_name}")  # noqa: T201
+        will_claim = (not is_already_claimed) or args.update_claim
+
+        # Arm cleanup BEFORE the claim. claim_pod() can block for up to 5 minutes
+        # waiting for the pod to become Ready, so a Ctrl-C / SIGHUP / SIGTERM during
+        # that wait must still clean up the pod we already labelled. Skipping
+        # registration when we're just reattaching to an already-claimed pod
+        # prevents this shell from deleting a pod that another shell of yours
+        # may still be using.
+        if args.auto_delete and will_claim:
+            atexit.register(delete_pod, pod_name, namespace=namespace, context=selected_context, auto_yes=True)
+            # SIGTERM and SIGHUP bypass atexit by default; _exit_for_signal routes them
+            # through sys.exit so the registered cleanup runs. SIGHUP fires on terminal
+            # close (closing iTerm, SSH disconnect, killing a tmux pane). SIGINT raises
+            # KeyboardInterrupt, which the outer except handles, and atexit fires from there.
+            signal.signal(signal.SIGTERM, _exit_for_signal)
+            signal.signal(signal.SIGHUP, _exit_for_signal)
+
+        if not is_already_claimed:
+            # Fresh claim: protect against concurrent claimers via resourceVersion. If we
+            # lose the race (409 Conflict), retry against a different pod up to
+            # MAX_CLAIM_RETRIES times.
+            print(f"⏰ Setting pod termination time to: {human_readable}")  # noqa: T201
+            for attempt in range(1, MAX_CLAIM_RETRIES + 1):
+                try:
+                    claim_pod(
+                        pod_name,
+                        user_labels,
+                        timestamp,
+                        namespace=namespace,
+                        context=selected_context,
+                        resource_version=resource_version,
+                    )
+                    break
+                except ClaimRaceError as race:
+                    print(f"⚠️  Claim race on {pod_name} (attempt {attempt}/{MAX_CLAIM_RETRIES}): {race}")  # noqa: T201
+                    if args.auto_delete and will_claim:
+                        # Stale registration points at the pod we lost; remove it before
+                        # picking another. atexit.unregister removes all registrations of
+                        # delete_pod, which is fine because we register at most one.
+                        atexit.unregister(delete_pod)
+                    pod_name, is_already_claimed, resource_version = get_toolbox_pod(
+                        user_labels[claimed_label_key],
+                        check_claimed=True,
+                        app_label=app_label,
+                        claimed_label_key=claimed_label_key,
+                        namespace=namespace,
+                        context=selected_context,
+                    )
+                    if is_already_claimed:
+                        # Either we won an earlier race attempt (whose ack we missed) or
+                        # another shell of ours holds a claim — either way, don't auto-delete.
+                        print(f"🎯 Found pod already claimed by you: {pod_name}")  # noqa: T201
+                        will_claim = False
+                        break
+                    print(f"🎯 Trying pod: {pod_name}")  # noqa: T201
+                    if args.auto_delete:
+                        atexit.register(
+                            delete_pod,
+                            pod_name,
+                            namespace=namespace,
+                            context=selected_context,
+                            auto_yes=True,
+                        )
+            else:
+                print(f"❌ Could not claim a pod after {MAX_CLAIM_RETRIES} race retries.")  # noqa: T201
+                sys.exit(1)
+            if will_claim:
+                print(f"✅ Successfully claimed pod: {pod_name}")  # noqa: T201
+        elif args.update_claim:
+            # Extending an existing claim of ours; no race possible because nobody
+            # else is competing for a pod we already own.
+            print(f"⏰ Updating pod termination time to: {human_readable}")  # noqa: T201
+            claim_pod(
+                pod_name,
+                user_labels,
+                timestamp,
+                namespace=namespace,
+                context=selected_context,
+                resource_version=None,
+            )
+            print(f"✅ Successfully updated pod: {pod_name}")  # noqa: T201
         else:
             print("✅ Connecting to your existing pod (use --update-claim to extend the duration)")  # noqa: T201
 
-        try:
-            connect_to_pod(pod_name)
-        finally:
-            delete_pod(pod_name)
+        if args.auto_delete:
+            rc = connect_to_pod(pod_name, namespace=namespace, context=selected_context)
+        else:
+            try:
+                rc = connect_to_pod(pod_name, namespace=namespace, context=selected_context)
+            finally:
+                if will_claim:
+                    delete_pod(pod_name, namespace=namespace, context=selected_context)
+        sys.exit(rc)
     except KeyboardInterrupt:
         print("\n👋 Goodbye! \n \n Did something not work as expected? Ask in #team-infrastructure")  # noqa: T201
         sys.exit(0)

--- a/tools/infra-scripts/clitools/toolbox/kubernetes.py
+++ b/tools/infra-scripts/clitools/toolbox/kubernetes.py
@@ -5,6 +5,22 @@ import sys
 import subprocess
 
 
+def kubectl_cmd(*args: str, context: str | None = None) -> list[str]:
+    """Build a kubectl command with --context if `context` is set.
+
+    Threading the context through every kubectl invocation lets us scope all
+    operations to one cluster without ever mutating the user's global kubeconfig
+    via `kubectl config use-context`. That matters because a wrapper that
+    silently flips the default context can redirect later operational commands
+    (kubectl delete, helm upgrade, …) to the wrong cluster.
+    """
+    cmd = ["kubectl"]
+    if context:
+        cmd.append(f"--context={context}")
+    cmd.extend(args)
+    return cmd
+
+
 def get_available_contexts() -> list:
     """Get available kubernetes contexts."""
     try:
@@ -29,7 +45,12 @@ def get_current_context() -> str | None:
 
 
 def switch_context(context: str) -> bool:
-    """Switch to specified kubernetes context."""
+    """Switch to specified kubernetes context.
+
+    Mutates kubeconfig globally. Prefer ``validate_context`` plus passing
+    ``--context`` per invocation via ``kubectl_cmd``; this function is kept
+    for callers that explicitly want a persistent switch.
+    """
     try:
         subprocess.run(["kubectl", "config", "use-context", context], check=True)
         print(f"✅ Switched to context: {context}")  # noqa: T201
@@ -39,8 +60,22 @@ def switch_context(context: str) -> bool:
         return False
 
 
-def select_context():
-    """List available contexts and let user select one."""
+def validate_context(context: str) -> bool:
+    """Return True if ``context`` is a known kubernetes context.
+
+    Use this when you want to scope a single invocation to a context without
+    mutating kubeconfig via ``switch_context``.
+    """
+    return context in get_available_contexts()
+
+
+def select_context() -> str:
+    """List available contexts and let the user pick one. Returns the chosen name.
+
+    Does **not** call ``kubectl config use-context``; the caller is expected to
+    pass the returned name as ``--context`` to subsequent kubectl invocations
+    via ``kubectl_cmd``. Pressing Enter keeps the current context.
+    """
     contexts = get_available_contexts()
     current = get_current_context()
     if current is None:
@@ -61,20 +96,17 @@ def select_context():
     print(f"\nCurrently using: {current}")  # noqa: T201
     response = input("Enter context number to switch or press Enter to continue with current context: ").strip()
 
-    if response:
-        try:
-            index = int(response) - 1
-            if 0 <= index < len(contexts):
-                if switch_context(contexts[index]):
-                    return contexts[index]
-                else:
-                    print("⚠️ Failed to switch context, continuing with current context.")  # noqa: T201
-                    return current
-            else:
-                print("⚠️ Invalid selection, continuing with current context.")  # noqa: T201
-                return current
-        except ValueError:
-            print("⚠️ Invalid input, continuing with current context.")  # noqa: T201
-            return current
+    if not response:
+        return current
 
+    try:
+        index = int(response) - 1
+    except ValueError:
+        print("⚠️ Invalid input, continuing with current context.")  # noqa: T201
+        return current
+
+    if 0 <= index < len(contexts):
+        return contexts[index]
+
+    print("⚠️ Invalid selection, continuing with current context.")  # noqa: T201
     return current

--- a/tools/infra-scripts/clitools/toolbox/pod.py
+++ b/tools/infra-scripts/clitools/toolbox/pod.py
@@ -264,18 +264,63 @@ def _safe_print(msg: str) -> None:
         pass
 
 
-def delete_pod(pod_name: str, *, namespace: str, context: str | None = None, auto_yes: bool = False):
+def delete_pod(
+    pod_name: str,
+    *,
+    namespace: str,
+    context: str | None = None,
+    auto_yes: bool = False,
+    expected_label_key: str | None = None,
+    expected_label_value: str | None = None,
+):
     """Delete the specified pod.
 
     With auto_yes=True, skip the [y/N] prompt and unconditionally delete.
     Uses --ignore-not-found so it is safe to call on a pod whose claim labels
     were never written or that has already been deleted.
 
+    When ``expected_label_key`` and ``expected_label_value`` are supplied, the
+    pod's current ``<key>`` label is checked first; if it does not match, the
+    delete is skipped. This guards the atexit path from deleting a healthy
+    unclaimed pool pod when ``claim_pod()`` failed before writing the claim
+    label (e.g. a transient kubectl/get failure on the very first call). If
+    the label check itself errors, the safe default is to skip the delete —
+    leaving an orphan to be reaped is preferable to silently shrinking the pool.
+
     Robust to a closed/hung-up controlling terminal: progress prints can fail
     silently, and kubectl's own stdout/stderr are captured so they can't trip
     on the same broken FDs. The kubectl delete is the load-bearing operation
     and runs even when the user's terminal is gone.
     """
+    if expected_label_key is not None and expected_label_value is not None:
+        try:
+            result = subprocess.run(
+                kubectl_cmd(
+                    "get",
+                    "pod",
+                    "-n",
+                    namespace,
+                    pod_name,
+                    "-o",
+                    f"jsonpath={{.metadata.labels.{expected_label_key}}}",
+                    "--ignore-not-found",
+                    context=context,
+                ),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            _safe_print(f"⚠️  Skipping delete of {pod_name}: could not verify claim label ({e.stderr or e})")
+            return
+        observed = result.stdout.strip()
+        if observed != expected_label_value:
+            _safe_print(
+                f"⚠️  Skipping delete of {pod_name}: "
+                f"{expected_label_key}='{observed}' (expected '{expected_label_value}')"
+            )
+            return
+
     if not auto_yes:
         try:
             response = input("\n❓ Would you like to delete this pod now? [y/N]: ").lower().strip()

--- a/tools/infra-scripts/clitools/toolbox/pod.py
+++ b/tools/infra-scripts/clitools/toolbox/pod.py
@@ -7,16 +7,47 @@ import time
 import subprocess
 from datetime import datetime, timedelta
 
+from toolbox.kubernetes import kubectl_cmd
 
-def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
-    """Get an available toolbox pod name.
+
+class ClaimRaceError(Exception):
+    """Raised when a claim attempt loses an optimistic-concurrency race.
+
+    The Kubernetes API rejects label/annotate writes whose ``--resource-version``
+    does not match the current value, returning a 409 Conflict. ``claim_pod``
+    surfaces that as ``ClaimRaceError`` so the caller can retry against a
+    different pod (or bail) instead of silently overwriting another writer.
+    """
+
+
+def _is_conflict(stderr: str) -> bool:
+    """Heuristic detection of a 409 Conflict in kubectl stderr."""
+    return "Conflict" in stderr or "the object has been modified" in stderr
+
+
+def get_toolbox_pod(
+    user: str,
+    check_claimed: bool = True,
+    *,
+    app_label: str,
+    claimed_label_key: str,
+    namespace: str,
+    context: str | None = None,
+) -> tuple[str, bool, str]:
+    """Get an available toolbox pod name and the resourceVersion observed.
 
     Args:
         user: Current user ARN
         check_claimed: If True, first look for pods already claimed by the user
+        app_label: Value of the app.kubernetes.io/name label that identifies the pool.
+        claimed_label_key: Label key the wrapper sets on a claimed pod.
+        namespace: Kubernetes namespace the pool lives in.
+        context: Optional kubernetes context to scope the kubectl call to.
 
     Returns:
-        Tuple of (pod_name, is_already_claimed)
+        Tuple of (pod_name, is_already_claimed, resource_version). The
+        resource_version reflects the pod state at observation time and is
+        used by ``claim_pod`` for optimistic concurrency control.
     """
     wait_start = datetime.now()
     max_wait = timedelta(minutes=5)
@@ -26,17 +57,17 @@ def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
     while True:
         try:
             result = subprocess.run(
-                [
-                    "kubectl",
+                kubectl_cmd(
                     "get",
                     "pods",
                     "-n",
-                    "posthog",
+                    namespace,
                     "-l",
-                    "app.kubernetes.io/name=posthog-toolbox-django",
+                    f"app.kubernetes.io/name={app_label}",
                     "-o",
                     "json",
-                ],
+                    context=context,
+                ),
                 capture_output=True,
                 text=True,
                 check=True,
@@ -48,30 +79,30 @@ def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
                 user_id = sanitize_label(user.split("/")[-1] if "/" in user else user)
                 # First look for pods already claimed by this user
                 claimed_pods = [
-                    pod["metadata"]["name"]
+                    (pod["metadata"]["name"], pod["metadata"].get("resourceVersion", ""))
                     for pod in pods
                     if pod["status"]["phase"] == "Running"
-                    and pod.get("metadata", {}).get("labels", {}).get("toolbox-claimed") == user_id
+                    and pod.get("metadata", {}).get("labels", {}).get(claimed_label_key) == user_id
                     and not pod.get("metadata", {}).get("deletionTimestamp")
                 ]
 
                 if claimed_pods:
                     print("⚠️  Found pod already claimed by you")  # noqa: T201
-                    return claimed_pods[0], True
+                    return claimed_pods[0][0], True, claimed_pods[0][1]
                 print("No pods currently claimed by you, looking for available pods...")  # noqa: T201
 
             # Look for unclaimed pods
             available_pods = [
-                pod["metadata"]["name"]
+                (pod["metadata"]["name"], pod["metadata"].get("resourceVersion", ""))
                 for pod in pods
                 if pod["status"]["phase"] in ("Running", "Pending")
-                and "toolbox-claimed" not in pod.get("metadata", {}).get("labels", {})
+                and claimed_label_key not in pod.get("metadata", {}).get("labels", {})
                 and "terminate-after" not in pod.get("metadata", {}).get("labels", {})
                 and not pod.get("metadata", {}).get("deletionTimestamp")
             ]
 
             if available_pods:
-                return available_pods[0], False
+                return available_pods[0][0], False, available_pods[0][1]
 
             # No pods available, check if we should wait or timeout
             current_time = datetime.now()
@@ -97,15 +128,35 @@ def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
             sys.exit(1)
 
 
-def claim_pod(pod_name: str, user_labels: dict, timestamp: int):
-    """Claim the pod by updating its labels."""
+def claim_pod(
+    pod_name: str,
+    user_labels: dict,
+    timestamp: int,
+    *,
+    namespace: str,
+    context: str | None = None,
+    resource_version: str | None = None,
+):
+    """Claim the pod by updating its labels.
 
+    When ``resource_version`` is supplied, the first kubectl call that mutates
+    the pod attaches ``--resource-version=<rv>`` so the API rejects the write
+    if another user has already modified the pod since we observed it. On
+    rejection, ``ClaimRaceError`` is raised so the caller can retry against a
+    different pod. Subsequent kubectl calls in the same claim sequence do not
+    pass --resource-version because the resource version advances after every
+    successful write; once the first mutation has won, no other writer can
+    sneak in mid-claim.
+
+    Strips every label except app.kubernetes.io/name (which orphans the pod from
+    its ReplicaSet by removing pod-template-hash), annotates karpenter to skip
+    disruption, then applies user_labels + a terminate-after timestamp.
+    """
     human_readable = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S %Z")
-    print(f"Claiming pod {pod_name} for user {user_labels.get('toolbox-claimed', 'unknown')} until {human_readable}")  # noqa: T201
+    print(f"Claiming pod {pod_name} until {human_readable}")  # noqa: T201
     try:
-        # Get current labels
         result = subprocess.run(
-            ["kubectl", "get", "pod", "-n", "posthog", pod_name, "-o", "jsonpath={.metadata.labels}"],
+            kubectl_cmd("get", "pod", "-n", namespace, pod_name, "-o", "jsonpath={.metadata.labels}", context=context),
             capture_output=True,
             text=True,
             check=True,
@@ -113,89 +164,149 @@ def claim_pod(pod_name: str, user_labels: dict, timestamp: int):
 
         current_labels = json.loads(result.stdout)
 
-        # Remove all labels except app.kubernetes.io/name
-        for label_name in current_labels.keys():
-            if label_name != "app.kubernetes.io/name":
-                subprocess.run(
-                    ["kubectl", "label", "pod", "-n", "posthog", pod_name, f"{label_name}-"],
-                    check=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
+        labels_to_remove = [name for name in current_labels.keys() if name != "app.kubernetes.io/name"]
+        # Attach the optimistic-concurrency guard to whichever kubectl invocation is the first
+        # actual write; once it succeeds, the resourceVersion advances and subsequent calls
+        # don't need (and can't pass) the same value.
+        rv_guard_pending = bool(resource_version)
 
-        # Add karpenter.sh/do-not-disrupt annotation
+        if labels_to_remove:
+            args = [f"{name}-" for name in labels_to_remove]
+            if rv_guard_pending:
+                args.append(f"--resource-version={resource_version}")
+                rv_guard_pending = False
+            try:
+                subprocess.run(
+                    kubectl_cmd("label", "pod", "-n", namespace, pod_name, *args, context=context),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                if _is_conflict(e.stderr or ""):
+                    raise ClaimRaceError(f"Pod {pod_name} was claimed by another writer") from e
+                print(f"Error stripping labels: {e.stderr or e}")  # noqa: T201
+                raise
+
+        annotate_args = ["karpenter.sh/do-not-disrupt=true", "--overwrite=true"]
+        if rv_guard_pending:
+            annotate_args.append(f"--resource-version={resource_version}")
+            rv_guard_pending = False
+        try:
+            subprocess.run(
+                kubectl_cmd("annotate", "pod", "-n", namespace, pod_name, *annotate_args, context=context),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            if _is_conflict(e.stderr or ""):
+                raise ClaimRaceError(f"Pod {pod_name} was claimed by another writer") from e
+            print(f"Error annotating pod: {e.stderr or e}")  # noqa: T201
+            raise
+
+        label_args = [f"{key}={value}" for key, value in {**user_labels, "terminate-after": str(timestamp)}.items()]
         subprocess.run(
-            [
-                "kubectl",
-                "annotate",
-                "pod",
-                "-n",
-                "posthog",
-                pod_name,
-                "karpenter.sh/do-not-disrupt=true",
-                "--overwrite=true",
-            ],
+            kubectl_cmd("label", "pod", "-n", namespace, pod_name, *label_args, context=context),
             check=True,
         )
 
-        # Build label arguments
-        label_args = [f"{key}={value}" for key, value in {**user_labels, "terminate-after": str(timestamp)}.items()]
-
-        # Add new labels
-        subprocess.run(["kubectl", "label", "pod", "-n", "posthog", pod_name, *label_args], check=True)
-
-        # Wait for pod to be ready
         print("⏳ Waiting for pod to be ready")  # noqa: T201
         try:
             subprocess.run(
-                ["kubectl", "wait", "--for=condition=Ready", "--timeout=5m", "-n", "posthog", "pod", pod_name],
+                kubectl_cmd(
+                    "wait",
+                    "--for=condition=Ready",
+                    "--timeout=5m",
+                    "-n",
+                    namespace,
+                    "pod",
+                    pod_name,
+                    context=context,
+                ),
                 check=True,
             )
         except subprocess.CalledProcessError:
             print(f"❌ Pod {pod_name} did not become ready within 5 minutes.")  # noqa: T201
             sys.exit(1)
+    except ClaimRaceError:
+        raise
     except Exception as e:
         print(f"Error claiming pod: {e}")  # noqa: T201
         sys.exit(1)
 
 
-def connect_to_pod(pod_name: str):
-    """Connect to the specified pod using kubectl exec.
+def connect_to_pod(pod_name: str, *, namespace: str, context: str | None = None) -> int:
+    """Connect to the specified pod using kubectl exec, returning the exec exit code.
 
-    Args:
-        pod_name: Name of the pod to connect to
+    The caller is responsible for surfacing a non-zero return as a non-zero
+    process exit so failures (RBAC denied, pod gone, network) don't get masked
+    as success and trigger downstream cleanup of a session that never opened.
     """
-    print(f"🚀 Connecting to pod {pod_name}...")  # noqa: T201
-    subprocess.run(["kubectl", "exec", "-it", "-n", "posthog", pod_name, "--", "bash"])
+    _safe_print(f"🚀 Connecting to pod {pod_name}...")
+    result = subprocess.run(kubectl_cmd("exec", "-it", "-n", namespace, pod_name, "--", "bash", context=context))
+    return result.returncode
 
 
-def delete_pod(pod_name: str):
+def _safe_print(msg: str) -> None:
+    """print() that swallows IOErrors raised by writing to a hung-up terminal.
+
+    When the user closes their terminal tab, the wrapper receives SIGHUP and
+    runs cleanup via atexit *after* the controlling PTY is gone. A naked
+    ``print()`` in that path raises ``BrokenPipeError``/``OSError`` and aborts
+    the cleanup mid-flight — leaking the very pod we're trying to delete. The
+    actual cluster-side work (kubectl delete) is the load-bearing call;
+    progress messages are best-effort.
+    """
+    try:
+        print(msg)  # noqa: T201
+    except (BrokenPipeError, OSError):
+        pass
+
+
+def delete_pod(pod_name: str, *, namespace: str, context: str | None = None, auto_yes: bool = False):
     """Delete the specified pod.
 
-    Args:
-        pod_name: Name of the pod to delete
+    With auto_yes=True, skip the [y/N] prompt and unconditionally delete.
+    Uses --ignore-not-found so it is safe to call on a pod whose claim labels
+    were never written or that has already been deleted.
+
+    Robust to a closed/hung-up controlling terminal: progress prints can fail
+    silently, and kubectl's own stdout/stderr are captured so they can't trip
+    on the same broken FDs. The kubectl delete is the load-bearing operation
+    and runs even when the user's terminal is gone.
     """
-    response = input("\n❓ Would you like to delete this pod now? [y/N]: ").lower().strip()
-    if response == "y":
-        print("🗑️  Deleting pod...")  # noqa: T201
+    if not auto_yes:
         try:
-            subprocess.run(
-                [
-                    "kubectl",
-                    "delete",
-                    "pod",
-                    "-n",
-                    "posthog",
-                    pod_name,
-                    "--wait=false",  # Don't wait for pod deletion to complete
-                ],
-                check=True,
-            )
-            print("✅ Pod scheduled for deletion")  # noqa: T201
-        except subprocess.CalledProcessError as e:
-            print(f"❌ Failed to delete pod: {e}")  # noqa: T201
-    else:
-        print("👋 Pod will remain running until its scheduled termination time")  # noqa: T201
+            response = input("\n❓ Would you like to delete this pod now? [y/N]: ").lower().strip()
+        except (BrokenPipeError, OSError, EOFError):
+            # No usable TTY — default to "don't delete" so we never delete without consent.
+            _safe_print("👋 Pod will remain running until its scheduled termination time")
+            return
+        if response != "y":
+            _safe_print("👋 Pod will remain running until its scheduled termination time")
+            return
+
+    _safe_print("🗑️  Deleting pod...")
+    try:
+        subprocess.run(
+            kubectl_cmd(
+                "delete",
+                "pod",
+                "-n",
+                namespace,
+                pod_name,
+                "--ignore-not-found",
+                "--wait=false",
+                context=context,
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _safe_print("✅ Pod scheduled for deletion")
+    except subprocess.CalledProcessError as e:
+        _safe_print(f"❌ Failed to delete pod: {e.stderr or e}")
 
 
 def sanitize_label(value: str) -> str:

--- a/tools/infra-scripts/clitools/toolbox/user.py
+++ b/tools/infra-scripts/clitools/toolbox/user.py
@@ -6,26 +6,42 @@ import sys
 import json
 import subprocess
 
+from toolbox.kubernetes import kubectl_cmd
 
-def get_current_user() -> dict:
-    """Get user identity from kubectl auth and parse it into labels."""
+
+def get_current_user(*, claimed_label_key: str, context: str | None = None) -> dict:
+    """Get user identity from kubectl auth and parse it into labels.
+
+    Args:
+        claimed_label_key: Label key under which the sanitized session name is
+            placed in the returned dict. Pool-specific (e.g. ``toolbox-claimed``
+            for the toolbox-django pool, ``flags-jumphost-claimed`` for the
+            flags-cache-jumphost pool); see ``POOLS`` in ``toolbox.py``.
+        context: Optional kubernetes context to scope the whoami call to,
+            instead of relying on the default kubeconfig context.
+    """
     try:
         print("Attempting to get user identity...")  # noqa: T201
-        whoami = subprocess.run(["kubectl", "auth", "whoami", "-o", "json"], capture_output=True, text=True, check=True)
+        whoami = subprocess.run(
+            kubectl_cmd("auth", "whoami", "-o", "json", context=context),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
 
         user_info = json.loads(whoami.stdout)
         user_info = user_info["status"]["userInfo"]  # Navigate to the correct nesting level
 
         # First try to get the ARN from the extra info
         if "extra" in user_info and "arn" in user_info["extra"]:
-            return parse_arn(user_info["extra"]["arn"][0])  # The ARN is in a list
+            return parse_arn(user_info["extra"]["arn"][0], claimed_label_key=claimed_label_key)  # ARN is in a list
 
         # Fallback to sessionName if available
         if "extra" in user_info and "sessionName" in user_info["extra"]:
-            return {"toolbox-claimed": sanitize_label(user_info["extra"]["sessionName"][0])}
+            return {claimed_label_key: sanitize_label(user_info["extra"]["sessionName"][0])}
 
         # Final fallback to username
-        return {"toolbox-claimed": sanitize_label(f"k8s-user/{user_info['username']}")}
+        return {claimed_label_key: sanitize_label(f"k8s-user/{user_info['username']}")}
 
     except subprocess.CalledProcessError as e:
         print(f"Command failed with return code {e.returncode}")  # noqa: T201
@@ -44,19 +60,19 @@ def get_current_user() -> dict:
         sys.exit(1)
 
 
-def parse_arn(arn: str) -> dict:
+def parse_arn(arn: str, *, claimed_label_key: str) -> dict:
     """Parse AWS ARN into components."""
     try:
         # Handle AWS STS assumed-role ARN format
         # Format: arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_developers_0847e649a00cc5e7/michael.k@posthog.com
         parts = arn.split(":")
         if len(parts) != 6 or "assumed-role" not in parts[5]:
-            return {"toolbox-claimed": sanitize_label(arn)}  # fallback for unexpected format
+            return {claimed_label_key: sanitize_label(arn)}  # fallback for unexpected format
 
         # Extract role path and session name
         role_and_session = parts[5].split("/")
         if len(role_and_session) < 3:
-            return {"toolbox-claimed": sanitize_label(arn)}
+            return {claimed_label_key: sanitize_label(arn)}
 
         role_path = role_and_session[1]  # The full role path (e.g. AWSReservedSSO_developers_0847e649a00cc5e7)
         session_name = role_and_session[2]  # The session name (email)
@@ -64,7 +80,7 @@ def parse_arn(arn: str) -> dict:
         # Extract role name from the role path (e.g. "developers" from "AWSReservedSSO_developers_0847e649a00cc5e7")
         role_parts = role_path.split("_")
         if len(role_parts) < 2:
-            return {"toolbox-claimed": sanitize_label(arn)}  # fallback for unexpected format
+            return {claimed_label_key: sanitize_label(arn)}  # fallback for unexpected format
         role_name = role_parts[1]  # For AWSReservedSSO_* format
 
         # Sanitize values for kubernetes labels
@@ -74,13 +90,13 @@ def parse_arn(arn: str) -> dict:
         print(f"Parsed ARN: session_name={session_name}, role_name={role_name}")  # noqa: T201
 
         return {
-            "toolbox-claimed": session_name,  # The sanitized email address
+            claimed_label_key: session_name,  # The sanitized email address
             "role-name": role_name,  # The role name (e.g. "developers")
             "assumed-role": "true",
         }
     except Exception as e:
         print(f"Warning: Failed to parse ARN ({e}), using fallback format")  # noqa: T201
-        return {"toolbox-claimed": sanitize_label(arn)}  # fallback for any parsing errors
+        return {claimed_label_key: sanitize_label(arn)}  # fallback for any parsing errors
 
 
 def sanitize_label(value: str) -> str:


### PR DESCRIPTION
## Problem

`bin/rust-jumphost` ran `kubectl exec -it deploy/flags-cache-jumphost ... bash`, which dropped every operator into the same long-lived deployment pod. Sessions shared state, the pod never recycled, and there was no claim contract or termination guarantee. We already had a claim-from-pool model in `tools/infra-scripts/clitools/toolbox.py` for `posthog-toolbox-django`. This PR generalizes that machinery to support multiple pools and uses it for the rust jumphost.

## Changes

`bin/rust-jumphost` is now a thin shim that delegates to `toolbox.py --pool flags-cache-jumphost --auto-delete`.

`toolbox.py` gains a `POOLS` registry (`toolbox-django` plus `flags-cache-jumphost`), a `--pool` flag, a `--auto-delete` flag, and `KUBE_CONTEXT` / `KUBE_NAMESPACE` env support.

A new `kubectl_cmd(*args, context=)` helper in `toolbox/kubernetes.py` threads `--context=<name>` into every kubectl invocation, so `KUBE_CONTEXT` no longer mutates the user's global kubeconfig via `kubectl config use-context`. `select_context()` was reworked to return the chosen name without switching.

Pod claims are now atomic. `get_toolbox_pod` returns the observed `resourceVersion`, and `claim_pod` attaches `--resource-version=<rv>` to the first kubectl mutation. A 409 conflict surfaces as `ClaimRaceError`, and `main()` retries against a fresh pod up to `MAX_CLAIM_RETRIES=3`.

`atexit` cleanup and SIGTERM/SIGHUP handlers are armed before `claim_pod()`, so a Ctrl-C during the up-to-5min Ready wait still cleans up. Registration is gated on this invocation actually claiming the pod, so a pure reattach skips it and a second shell of yours doesn't delete a pod the first shell is still using.

`connect_to_pod` returns the `kubectl exec` exit code, and `main()` propagates it via `sys.exit(rc)`.

`delete_pod` now survives a hung-up controlling terminal. The first `print('🗑️  Deleting pod…')` would previously raise `BrokenPipeError` on the dead PTY before kubectl was reached, leaking the pod the cleanup was supposed to delete. Progress prints now use a `_safe_print` helper that swallows `BrokenPipeError` / `OSError`, the prompt path defaults to "don't delete" if `input()` is unusable, and kubectl's stdout/stderr are captured so the subprocess can't trip on the same broken FDs.

An unrelated small fix in `warm-flags-cache.rs` switches the per-team error formatter from `Display` to `Debug`, so SDK errors (for example an S3 PutObject 403) surface the actual error code instead of collapsing to "service error".

The chart-side pool, spawn-template removal, and `terminate-after` reaper all landed in PostHog/charts PR #10721. Pool size is `minPods/maxPods=2`, reaper runs every 5 minutes scoped to `flags-jumphost-claimed`.

## How did you test this code?

62 unit tests cover all of the above: kubectl-command shape, context threading, atomic claim with resource-version, `ClaimRaceError`, exec exit-code propagation, atexit-before-claim ordering, reattach-skips-cleanup, race retries, broken-stdout robustness in `delete_pod`, and pool dispatch. Lint clean (`ruff check`, `ruff format --check`, `cargo fmt --check`, `cargo clippy --features warm-flags-cache -- -D warnings`).

I also exercised every behavioral path against `posthog-dev` from a Ghostty session.

- Happy path: claim, exec, exit, pod auto-deleted, ReplicaSet replaced.
- Ctrl-C during `claim_pod()`'s Ready wait: pod fully deleted on exit.
- Closing the terminal tab (SIGHUP): pod deleted (this surfaced and was fixed during testing in this PR).
- Reattach safety: a second shell that finds an already-claimed pod skips cleanup, and exiting it leaves the first shell's session unharmed.
- Exit code propagation: typing `exit 42` inside the pod made the wrapper exit 42 on the host.
- Kubeconfig stays put: `kubectl config current-context` matches before and after every wrapper run, regardless of `KUBE_CONTEXT`.
- Reaper observation: the chart-side cron runs on schedule (208 successful runs over 17h on the dev cluster).

## Publish to changelog?

no

## Docs update