### PR TITLE
fix(surveys): preserve AI survey targeting conditions

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -369,13 +369,90 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
+         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
+            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
+                            0) AS previous_avg_time_on_page
+     FROM events
+     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  WHERE isNotNull(counts.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
@@ -725,7 +802,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -740,7 +825,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -753,7 +838,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -763,7 +854,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -797,80 +888,13 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
   '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.2
@@ -1853,13 +1877,54 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         tuple(avg(is_bounce), NULL) AS `context.columns.bounce_rate`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_pathname` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  HAVING isNotNull(`context.columns.breakdown_value`)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.2

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -802,15 +802,7 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -825,7 +817,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -838,13 +830,7 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -854,7 +840,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
@@ -916,7 +902,15 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.person_id,
+                  events.properties,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -931,7 +925,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -944,7 +938,13 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM events
+        FROM
+          (SELECT events.`$session_id_uuid`,
+                  events.distinct_id,
+                  events.event,
+                  events.timestamp
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -954,7 +954,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
+        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)

--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -117,8 +117,6 @@ URL_MATCH_ALIASES: dict[str, str] = {
     "regex": "regex",
 }
 
-TOOL_MANAGED_CONDITION_KEYS = {"url", "urlMatchType", "linkedFlagVariant", "seenSurveyWaitPeriodInDays"}
-
 
 def _build_targeting_conditions(
     target_url: str | None,
@@ -325,6 +323,12 @@ SURVEY_EDIT_TOOL_DESCRIPTION = dedent("""
     - Set stop=true to stop collecting responses
     - Set archive=true to archive the survey
 
+    # Removing targeting
+    - Set remove_url_targeting=true to remove URL targeting
+    - Set remove_linked_flag=true to remove linked feature flag targeting
+    - Set remove_linked_flag_variant=true to remove only feature flag variant targeting
+    - Set remove_wait_period=true to remove the survey wait period
+
     # Question identity
     - When updating questions, use read_data(kind="survey") first to see the current questions
     - Each question is shown with a number (1, 2, 3, ...) — pass that number as the question's `id` to preserve its identity and historical response data
@@ -332,6 +336,7 @@ SURVEY_EDIT_TOOL_DESCRIPTION = dedent("""
 
     # Important
     - Only include fields you want to change
+    - Omitted targeting fields are preserved. Use the remove_* fields when the user explicitly asks to remove targeting.
     - When updating questions, provide the complete list (it replaces existing)
     """).strip()
 
@@ -352,6 +357,12 @@ class EditSurveyToolArgs(BaseModel):
     wait_period_days: int | None = Field(
         default=None, description="Minimum days before showing this survey again to a user who has seen any survey"
     )
+    remove_url_targeting: bool = Field(default=False, description="Remove URL targeting from the survey")
+    remove_linked_flag: bool = Field(default=False, description="Remove linked feature flag targeting from the survey")
+    remove_linked_flag_variant: bool = Field(
+        default=False, description="Remove feature flag variant targeting from the survey"
+    )
+    remove_wait_period: bool = Field(default=False, description="Remove the survey wait period")
     responses_limit: int | None = Field(default=None, description="Maximum number of responses")
     launch: bool | None = Field(default=None, description="Set to true to launch the survey")
     stop: bool | None = Field(default=None, description="Set to true to stop the survey")
@@ -372,9 +383,21 @@ class EditSurveyTool(MaxTool):
         launch: bool | None = None,
         stop: bool | None = None,
         archive: bool | None = None,
+        remove_url_targeting: bool = False,
+        remove_linked_flag: bool = False,
+        remove_linked_flag_variant: bool = False,
+        remove_wait_period: bool = False,
         **kwargs,
     ) -> bool:
-        return launch is True or stop is True or archive is True
+        return (
+            launch is True
+            or stop is True
+            or archive is True
+            or remove_url_targeting is True
+            or remove_linked_flag is True
+            or remove_linked_flag_variant is True
+            or remove_wait_period is True
+        )
 
     async def format_dangerous_operation_preview(
         self,
@@ -382,6 +405,10 @@ class EditSurveyTool(MaxTool):
         launch: bool | None = None,
         stop: bool | None = None,
         archive: bool | None = None,
+        remove_url_targeting: bool = False,
+        remove_linked_flag: bool = False,
+        remove_linked_flag_variant: bool = False,
+        remove_wait_period: bool = False,
         **kwargs,
     ) -> str:
         survey_name = survey_id
@@ -398,6 +425,14 @@ class EditSurveyTool(MaxTool):
             actions.append("**Stop** the survey (it will stop collecting responses)")
         if archive is True:
             actions.append("**Archive** the survey")
+        if remove_url_targeting is True:
+            actions.append("**Remove URL targeting** from the survey")
+        if remove_linked_flag is True:
+            actions.append("**Remove linked feature flag targeting** from the survey")
+        if remove_linked_flag_variant is True:
+            actions.append("**Remove feature flag variant targeting** from the survey")
+        if remove_wait_period is True:
+            actions.append("**Remove the survey wait period**")
 
         if len(actions) == 1:
             return f"{actions[0]} {survey_name}"
@@ -416,6 +451,10 @@ class EditSurveyTool(MaxTool):
         linked_flag_id: int | None = None,
         linked_flag_variant: str | None = None,
         wait_period_days: int | None = None,
+        remove_url_targeting: bool = False,
+        remove_linked_flag: bool = False,
+        remove_linked_flag_variant: bool = False,
+        remove_wait_period: bool = False,
         responses_limit: int | None = None,
         launch: bool | None = None,
         stop: bool | None = None,
@@ -453,20 +492,28 @@ class EditSurveyTool(MaxTool):
                 update_data["questions"] = _validate_and_sanitize_questions(new_questions)
             if linked_flag_id is not None:
                 update_data["linked_flag_id"] = linked_flag_id
+            elif remove_linked_flag:
+                update_data["linked_flag_id"] = None
             if responses_limit is not None:
                 update_data["responses_limit"] = responses_limit
 
-            # When any targeting field is provided, strip all tool-managed keys
-            # from existing conditions first, then apply new values. This prevents
-            # stale targeting from accumulating across edits.
+            existing_conditions = dict(survey.conditions or {})
+            updated_conditions = dict(existing_conditions)
+            if remove_url_targeting:
+                updated_conditions.pop("url", None)
+                updated_conditions.pop("urlMatchType", None)
+            if remove_linked_flag or remove_linked_flag_variant:
+                updated_conditions.pop("linkedFlagVariant", None)
+            if remove_wait_period:
+                updated_conditions.pop("seenSurveyWaitPeriodInDays", None)
+
             conditions = _build_targeting_conditions(
                 target_url, target_url_match, linked_flag_variant, wait_period_days
             )
             if conditions:
-                existing_conditions = {
-                    k: v for k, v in (survey.conditions or {}).items() if k not in TOOL_MANAGED_CONDITION_KEYS
-                }
-                update_data["conditions"] = {**existing_conditions, **conditions}
+                updated_conditions.update(conditions)
+            if updated_conditions != existing_conditions:
+                update_data["conditions"] = updated_conditions
 
             # Lifecycle bools
             lifecycle_actions = []

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -9,6 +9,7 @@ from posthog.test.base import BaseTest
 
 from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
+from parameterized import parameterized
 
 from posthog.models import FeatureFlag, Insight
 
@@ -733,7 +734,52 @@ class TestEditSurveyTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_edit_survey_linked_flag_variant_preserves_url_targeting(self):
+    @parameterized.expand(
+        [
+            (
+                "flag_variant_preserves_url",
+                False,
+                {
+                    "url": "app.heygen.com/(home|projects|voices|templates|labs)",
+                    "urlMatchType": "regex",
+                    "seenSurveyWaitPeriodInDays": 7,
+                },
+                {"linked_flag_variant": "control"},
+                {
+                    "url": "app.heygen.com/(home|projects|voices|templates|labs)",
+                    "urlMatchType": "regex",
+                    "seenSurveyWaitPeriodInDays": 7,
+                    "linkedFlagVariant": "control",
+                },
+            ),
+            (
+                "url_preserves_flag_variant",
+                True,
+                {
+                    "seenSurveyWaitPeriodInDays": 7,
+                    "linkedFlagVariant": "control",
+                },
+                {
+                    "target_url": "app.heygen.com/(home|projects|voices|templates|labs)",
+                    "target_url_match": "regex",
+                },
+                {
+                    "url": "app.heygen.com/(home|projects|voices|templates|labs)",
+                    "urlMatchType": "regex",
+                    "seenSurveyWaitPeriodInDays": 7,
+                    "linkedFlagVariant": "control",
+                },
+            ),
+        ]
+    )
+    async def test_edit_survey_targeting_updates_preserve_existing_conditions(
+        self,
+        _case_name,
+        initial_linked_flag,
+        initial_conditions,
+        tool_kwargs,
+        expected_conditions,
+    ):
         tool = self._setup_tool()
         flag = await sync_to_async(FeatureFlag.objects.create)(
             team=self.team,
@@ -741,28 +787,22 @@ class TestEditSurveyTool(BaseTest):
             created_by=self.user,
             filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
         )
+        if "linked_flag_variant" in tool_kwargs:
+            tool_kwargs = {**tool_kwargs, "linked_flag_id": flag.id}
+
         survey = await self._create_test_survey(
-            conditions={
-                "url": "app.heygen.com/(home|projects|voices|templates|labs)",
-                "urlMatchType": "regex",
-                "seenSurveyWaitPeriodInDays": 7,
-            }
+            linked_flag=flag if initial_linked_flag else None,
+            conditions=initial_conditions,
         )
 
-        content, artifact = await tool._arun_impl(
-            survey_id=str(survey.id), linked_flag_id=flag.id, linked_flag_variant="control"
-        )
+        content, artifact = await tool._arun_impl(survey_id=str(survey.id), **tool_kwargs)
 
         assert "updated successfully" in content
-        assert "linked_flag_id" in artifact["updated_fields"]
         assert "conditions" in artifact["updated_fields"]
         updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
-        assert updated_survey.linked_flag_id == flag.id
-        assert updated_survey.conditions is not None
-        assert updated_survey.conditions["url"] == "app.heygen.com/(home|projects|voices|templates|labs)"
-        assert updated_survey.conditions["urlMatchType"] == "regex"
-        assert updated_survey.conditions["seenSurveyWaitPeriodInDays"] == 7
-        assert updated_survey.conditions["linkedFlagVariant"] == "control"
+        if "linked_flag_id" in tool_kwargs or initial_linked_flag:
+            assert updated_survey.linked_flag_id == flag.id
+        assert updated_survey.conditions == expected_conditions
 
     @pytest.mark.django_db
     @pytest.mark.asyncio

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -733,21 +733,85 @@ class TestEditSurveyTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_edit_survey_targeting_clears_stale_keys(self):
+    async def test_edit_survey_linked_flag_variant_preserves_url_targeting(self):
         tool = self._setup_tool()
+        flag = await sync_to_async(FeatureFlag.objects.create)(
+            team=self.team,
+            key="survey-targeting-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
         survey = await self._create_test_survey(
-            conditions={"url": "/old-page", "urlMatchType": "icontains", "seenSurveyWaitPeriodInDays": 7}
+            conditions={
+                "url": "app.heygen.com/(home|projects|voices|templates|labs)",
+                "urlMatchType": "regex",
+                "seenSurveyWaitPeriodInDays": 7,
+            }
         )
 
-        content, artifact = await tool._arun_impl(survey_id=str(survey.id), linked_flag_variant="control")
+        content, artifact = await tool._arun_impl(
+            survey_id=str(survey.id), linked_flag_id=flag.id, linked_flag_variant="control"
+        )
 
         assert "updated successfully" in content
+        assert "linked_flag_id" in artifact["updated_fields"]
+        assert "conditions" in artifact["updated_fields"]
         updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.linked_flag_id == flag.id
         assert updated_survey.conditions is not None
-        assert "url" not in updated_survey.conditions
-        assert "urlMatchType" not in updated_survey.conditions
-        assert "seenSurveyWaitPeriodInDays" not in updated_survey.conditions
+        assert updated_survey.conditions["url"] == "app.heygen.com/(home|projects|voices|templates|labs)"
+        assert updated_survey.conditions["urlMatchType"] == "regex"
+        assert updated_survey.conditions["seenSurveyWaitPeriodInDays"] == 7
         assert updated_survey.conditions["linkedFlagVariant"] == "control"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_can_explicitly_remove_targeting(self):
+        tool = self._setup_tool()
+        flag = await sync_to_async(FeatureFlag.objects.create)(
+            team=self.team,
+            key="survey-targeting-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        survey = await self._create_test_survey(
+            linked_flag=flag,
+            conditions={
+                "url": "/old-page",
+                "urlMatchType": "icontains",
+                "seenSurveyWaitPeriodInDays": 7,
+                "linkedFlagVariant": "control",
+            },
+        )
+
+        content, artifact = await tool._arun_impl(
+            survey_id=str(survey.id),
+            remove_url_targeting=True,
+            remove_linked_flag=True,
+            remove_wait_period=True,
+        )
+
+        assert "updated successfully" in content
+        assert "linked_flag_id" in artifact["updated_fields"]
+        assert "conditions" in artifact["updated_fields"]
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.linked_flag_id is None
+        assert updated_survey.conditions == {}
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_remove_targeting_is_dangerous(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey()
+
+        is_dangerous = await tool.is_dangerous_operation(survey_id=str(survey.id), remove_url_targeting=True)
+        preview = await tool.format_dangerous_operation_preview(
+            survey_id=str(survey.id), remove_url_targeting=True, remove_linked_flag=True
+        )
+
+        assert is_dangerous is True
+        assert "Remove URL targeting" in preview
+        assert "Remove linked feature flag targeting" in preview
 
     @pytest.mark.django_db
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

PostHog AI survey edits can attach or adjust feature flag targeting independently from URL and wait-period targeting. The edit tool previously rebuilt survey `conditions` by first removing all tool-managed condition keys, so a narrow feature-flag edit could unintentionally clear existing URL targeting.

The tool also did not have a clean way to distinguish omitted targeting fields from an explicit request to remove targeting.

## Changes

Keep existing survey `conditions` when applying AI edit-tool targeting updates, and overwrite only the condition keys explicitly provided by the tool call.

Add explicit removal arguments for intentional targeting removal:

- `remove_url_targeting`
- `remove_linked_flag`
- `remove_linked_flag_variant`
- `remove_wait_period`

Classify targeting removal as a dangerous operation so broadening survey eligibility requires confirmation.

Add regression coverage for attaching a linked feature flag and variant while preserving existing regex URL targeting and wait-period conditions, plus coverage for explicit removal behavior.

## How did you test this code?

Agent-tested with:

- `hogli test products/surveys/backend/test_max_tools.py::TestEditSurveyTool::test_edit_survey_linked_flag_variant_preserves_url_targeting`
- `hogli test products/surveys/backend/test_max_tools.py::TestEditSurveyTool`
- `ruff check products/surveys/backend/max_tools.py products/surveys/backend/test_max_tools.py`

Pre-commit also ran:

- `bin/hogli lint:python:fix`
- `bin/hogli format:python`
- `uv run ty check`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

Codex authored this PR in the local development workspace. The key decision was to make `edit_survey` condition updates additive at the field level, preserving unrelated targeting conditions unless a tool argument explicitly overwrites or removes them. Explicit removal arguments were added so PostHog AI can still remove targeting intentionally without relying on destructive partial-update behavior. Human review is required before merge.
