### PR TITLE
fix(phai): reconnect instead of resending on stream drop

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -685,18 +685,20 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 // Cancel any next iteration
                 actions.setForAnotherAgenticIteration(false)
 
-                // Retry logic
-                async function retry(): Promise<void> {
+                // Reconnect to the existing in-progress stream without resubmitting the user's
+                // message. The stream replays all events from the beginning, so the next pass
+                // must rebuild the thread from scratch — `clearThreadOnReplay` defers that clear
+                // to the first real event so the user keeps seeing the loading indicator.
+                async function reconnect(): Promise<void> {
+                    cache.clearThreadOnReplay = true
                     await breakpoint(1000 * (generationAttempt + 1))
-                    // Need to decrement the active streaming threads here, as we exit early.
                     actions.decrActiveStreamingThreads()
                     actions.streamConversation(
                         {
-                            content: streamData.content,
+                            content: null,
                             conversation: streamData.conversation,
-                            contextual_tools: streamData.contextual_tools,
-                            ui_context: streamData.ui_context,
                             agent_mode: agentMode,
+                            is_sandbox: isSandbox || undefined,
                         },
                         generationAttempt + 1
                     )
@@ -733,7 +735,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             if (generationAttempt > 15) {
                                 relevantErrorMessage.content = offlineMessage
                             } else {
-                                await retry()
+                                // The server is still working on the original turn; reconnecting
+                                // (instead of resending streamData.content) avoids racing the
+                                // server's still-running turn into a 409 and prevents the user
+                                // from perceiving their message as auto-resent.
+                                await reconnect()
                                 return
                             }
                         } else {
@@ -758,23 +764,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                         // 409 means the conversation is already in progress.
                         // Reconnect to the existing stream instead of resending the message.
                         if (e.status === 409 && generationAttempt <= 5) {
-                            // Mark that the next stream replay should clear the thread on the
-                            // first real event. We defer the clear (rather than doing it now)
-                            // so the user keeps seeing the existing thread + loading indicator
-                            // while we reconnect. The stream replays all events from the
-                            // beginning so we must rebuild from scratch to avoid duplicates.
-                            cache.clearThreadOnReplay = true
-                            await breakpoint(1000 * (generationAttempt + 1))
-                            actions.decrActiveStreamingThreads()
-                            actions.streamConversation(
-                                {
-                                    content: null,
-                                    conversation: streamData.conversation,
-                                    agent_mode: agentMode,
-                                    is_sandbox: isSandbox || undefined,
-                                },
-                                generationAttempt + 1
-                            )
+                            await reconnect()
                             return
                         }
 


### PR DESCRIPTION
## Problem

When the SSE stream drops mid-turn with a network error (e.g. brief connectivity blip, browser sleep), the PostHog AI client was re-POSTing the user's original message text. Because the server's turn was still in progress, the resend raced into a 409 (`Cannot resume streaming with a new message`) and only then took the reconnect path. From the user's perspective, their message appeared to be **auto-resent** — and reviewers investigating the chat saw two consecutive identical user messages they did not send.

Observed in a real chat: a user reported that "i need to convert this query from postgres to clickhouse dialect" appeared twice in their thread, but they only sent it once. The trace showed:

1. `TypeError: network error` thrown from `fetch`/SSE reader
2. Client called `retry()`, which re-POSTed `streamData.content`
3. Backend rejected with 409 `Cannot resume streaming with a new message` (`ee/api/conversation.py:386`)
4. Client then correctly took the 409 → reconnect path with `content: null`

The user-visible duplicate came from step 2; steps 3-4 only recovered the connection.

## Changes

`frontend/src/scenes/max/maxThreadLogic.tsx`

- On a network error while the conversation is `InProgress`, reconnect to the existing stream (`content: null`) rather than resubmitting `streamData.content`. The server's turn is already running — the right move is to re-attach to it, not to send a second copy.
- Refactored the existing 409 branch's reconnect body into a shared `reconnect()` helper. The network-error and 409 branches now point at the same code path; previously the 409 path was correct and the network-error path was wrong.
- Removed the now-unused `retry()` inner function.

Net diff: +14 / -24 lines.

## How did you test this code?

I'm an agent (Claude Code). I did not run the UI manually. I:

- Verified the diff visually against `ee/api/conversation.py:386` (server-side 409 source) and the existing 409 reconnect branch.
- Confirmed `oxfmt` formatting is clean on the changed file.
- Did not run `pnpm typescript:check` because the local install reports a pre-existing unrelated `Cannot find type definition file for 'minimatch'` error — CI will run it on the PR.
- Did not add a regression test. The existing `maxThreadLogic.test.ts` does not cover the network-error retry branch (mocking a mid-stream `fetch` reject through the `breakpoint(1000 * (n+1))` wait is non-trivial). Worth a follow-up.

Recommended manual test: trigger a stream mid-turn (e.g. devtools "Offline" toggle once tokens start streaming, then "Online" again). Before this PR, the user's message would appear twice in the thread; after, the stream should reconnect with the original turn intact.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7) at the request of @cvolzer3, after investigating an LLM trace where a user reported a phantom duplicate message.
- Investigation: pulled the chat's `\$ai_generation` events, found the `TypeError: network error` → `Cannot resume streaming with a new message` exception pair, traced both sides (`maxThreadLogic.tsx` retry path and `ee/api/conversation.py:386` 409 source).
- Key decision: rather than tweak `retry()` to pass `null` conditionally, unified both branches on the existing (correct) 409 reconnect implementation. Reduces the surface area where the same bug could re-emerge.
- Not tested manually by the agent; needs human verification of the offline → online recovery UX before merging.