### PR TITLE
chore(mcp): redirect /sse to /mcp

### DIFF
--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -26,7 +26,7 @@ npx @posthog/wizard@latest mcp add
       "args": [
         "-y",
         "mcp-remote@latest",
-        "https://mcp.posthog.com/mcp", // You can replace this with https://mcp.posthog.com/sse if your client does not support Streamable HTTP
+        "https://mcp.posthog.com/mcp",
         "--header",
         "Authorization:${POSTHOG_AUTH_HEADER}"
       ],

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -196,13 +196,26 @@ const handleRequest = async (
         return Response.redirect(redirectTo, redirect.status)
     }
 
+    // The legacy SSE transport (`/sse`) is deprecated in favor of `/mcp`
+    // (Streamable HTTP). Permanently redirect `/sse*` to the equivalent `/mcp*`.
+    // We tag the redirect Location with `_deprecated=sse` so the followup
+    // request on /mcp carries the marker — that lets us correlate
+    // success/failure on /mcp back to clients that came in via the deprecated
+    // path, even after the protocol-level handoff.
+    if (url.pathname === '/sse' || url.pathname.startsWith('/sse/')) {
+        const target = getPublicUrl(request)
+        target.pathname = '/mcp' + url.pathname.slice('/sse'.length)
+        target.searchParams.set('_deprecated', 'sse')
+        log.extend({ deprecation: 'sse', redirectTo: target.toString() })
+        return Response.redirect(target.toString(), 308)
+    }
+
     // OAuth Protected Resource Metadata (RFC 9728)
     // This endpoint tells MCP clients where to authenticate to get tokens.
     //
     // Per RFC 9728, the well-known URL is constructed by inserting /.well-known/oauth-protected-resource
     // between the host and the path. For example:
     // - Resource: https://mcp.posthog.com/mcp → Well-known: https://mcp.posthog.com/.well-known/oauth-protected-resource/mcp
-    // - Resource: https://mcp.posthog.com/sse → Well-known: https://mcp.posthog.com/.well-known/oauth-protected-resource/sse
     //
     // OAuth flow for MCP:
     // 1. Client connects to MCP server without a token
@@ -248,7 +261,6 @@ const handleRequest = async (
         // Per RFC 9728, the well-known URL is constructed by inserting the well-known path
         // between the host and the resource path:
         // - Resource /mcp → metadata at /.well-known/oauth-protected-resource/mcp
-        // - Resource /sse → metadata at /.well-known/oauth-protected-resource/sse
         const metadataUrl = getPublicUrl(request)
         metadataUrl.pathname = `/.well-known/oauth-protected-resource${url.pathname}`
         metadataUrl.search = ''
@@ -347,13 +359,20 @@ const handleRequest = async (
         log.extend({ mcpClientName: clientInfo.clientName })
     }
 
+    // Marker set by the /sse → /mcp redirect handler above. Lets us correlate
+    // success/failure on this /mcp request back to clients that originated on
+    // the deprecated /sse path — both in worker logs and in the `mcp init`
+    // analytics event (via `RequestProperties.viaSseRedirect`).
+    const viaSseRedirect = url.searchParams.get('_deprecated') === 'sse'
+    if (viaSseRedirect) {
+        log.extend({ via: 'sse_redirect' })
+        Object.assign(ctx.props, { viaSseRedirect: true })
+    }
+
     let server: Promise<Response> | null = null
     if (url.pathname.startsWith('/mcp')) {
         Object.assign(ctx.props, { transport: 'streamable-http' })
         server = MCP.serve('/mcp').fetch(request, env, ctx)
-    } else if (url.pathname.startsWith('/sse')) {
-        Object.assign(ctx.props, { transport: 'sse' })
-        server = MCP.serveSSE('/sse').fetch(request, env, ctx)
     }
 
     if (server !== null) {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -62,6 +62,7 @@ export type RequestProperties = {
     readOnly?: boolean
     mode?: McpMode
     transport?: 'streamable-http' | 'sse'
+    viaSseRedirect?: boolean
     requestStartTime?: number
 }
 
@@ -749,6 +750,7 @@ export class MCP extends McpAgent<Env> {
                     has_organization_id: !!organizationId,
                     has_project_id: !!projectId,
                     read_only: !!readOnly,
+                    via_sse_redirect: !!this.requestProperties.viaSseRedirect,
                     ...(mode ? { mcp_mode_explicit: mode } : {}),
                     ...(initDurationMs !== undefined ? { init_duration_ms: initDurationMs } : {}),
                 },

--- a/services/mcp/tests/unit/oauth-region.test.ts
+++ b/services/mcp/tests/unit/oauth-region.test.ts
@@ -40,6 +40,8 @@ describe('OAuth Region Routing', () => {
         // between the host and the resource path:
         // - Resource /mcp → metadata at /.well-known/oauth-protected-resource/mcp
         // - Resource /sse → metadata at /.well-known/oauth-protected-resource/sse
+        //   (the /sse endpoint itself is deprecated and redirects to /mcp, but the
+        //   metadata generator stays generic so cached metadata for /sse remains valid)
         const testCases = [
             {
                 name: 'includes region param and resource path /mcp in metadata URL',
@@ -52,7 +54,7 @@ describe('OAuth Region Routing', () => {
                 expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource/mcp',
             },
             {
-                name: 'includes resource path /sse for SSE endpoint',
+                name: 'includes resource path /sse for legacy SSE endpoint',
                 requestUrl: 'https://mcp.posthog.com/sse',
                 expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource/sse',
             },

--- a/services/mcp/tests/workers/sse-redirect.test.ts
+++ b/services/mcp/tests/workers/sse-redirect.test.ts
@@ -1,0 +1,31 @@
+import { SELF } from 'cloudflare:test'
+import { describe, expect, it } from 'vitest'
+
+describe('SSE to MCP redirect', () => {
+    it.each([
+        { from: 'https://mcp.posthog.com/sse', toPath: '/mcp' },
+        { from: 'https://mcp.posthog.com/sse/', toPath: '/mcp/' },
+        { from: 'https://mcp.posthog.com/sse/message', toPath: '/mcp/message' },
+        { from: 'https://mcp.posthog.com/sse?features=flags', toPath: '/mcp' },
+        { from: 'https://mcp.posthog.com/sse?features=flags&region=eu', toPath: '/mcp' },
+    ])('redirects $from to $toPath with 308 and tracking marker', async ({ from, toPath }) => {
+        const response = await SELF.fetch(from, { redirect: 'manual' })
+
+        expect(response.status).toBe(308)
+        const location = new URL(response.headers.get('location')!)
+        expect(location.pathname).toBe(toPath)
+        // Tracking marker so /mcp can identify clients that came in via /sse.
+        expect(location.searchParams.get('_deprecated')).toBe('sse')
+        // Original query params are preserved.
+        const originalParams = new URL(from).searchParams
+        for (const [key, value] of originalParams) {
+            expect(location.searchParams.get(key)).toBe(value)
+        }
+    })
+
+    it('does not affect /mcp requests', async () => {
+        const response = await SELF.fetch('https://mcp.posthog.com/mcp', { redirect: 'manual' })
+
+        expect(response.status).not.toBe(308)
+    })
+})


### PR DESCRIPTION
We are deprecating support for SSE in the MCP server, but a number of clients that support Streamable HTTP are still connecting via the /sse endpoint. Let’s add a redirect.