### PR TITLE
docs(hogli): refresh layout docs after tools/ extraction

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -189,7 +189,7 @@ jobs:
             - name: Run hogli extension tests
               shell: bash
               run: |
-                  pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-ext.xml
+                  pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
 
             - name: Upload test results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -198,7 +198,7 @@ jobs:
                   name: junit-results-hogli
                   path: |
                       junit-hogli.xml
-                      junit-hogli-ext.xml
+                      junit-hogli-commands.xml
 
             - name: Run dependency detection script tests
               shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Codebase Structure
 
 - Key entry points: `posthog/api/__init__.py` (URL routing), `posthog/settings/web.py` (Django settings, INSTALLED_APPS), `products/` (product apps)
-- [Monorepo layout](docs/internal/monorepo-layout.md) - high-level directory structure (products, services, common)
+- [Monorepo layout](docs/internal/monorepo-layout.md) - high-level directory structure (products, services, common, tools)
 - [Products README](products/README.md) - how to create and structure products
 - [Products architecture](products/architecture.md) - DTOs, facades, isolated testing
 

--- a/docs/internal/monorepo-layout.md
+++ b/docs/internal/monorepo-layout.md
@@ -27,10 +27,11 @@ services/              # Independent backend services
   stripe-app/          # Stripe integration app
 
 common/                # Shared code (transitional - prefer other locations for new code)
-  hogli/               # Developer CLI tooling
   hogql_parser/        # HogQL parser
 
 tools/                 # Developer/CI tooling, not imported by runtime code
+  hogli/               # Developer CLI framework (PyPI-publishable; uv workspace member)
+  hogli-commands/      # PostHog-specific hogli commands (consumed via hogli.yaml)
 
 devenv/                # Developer environment config (intent map, process model)
 
@@ -85,11 +86,11 @@ That destroys the "platform is foundational" property and makes boundaries britt
 
 ### Common
 
-Transitional bucket for shared code that exists today: `hogli` (developer CLI), `hogql_parser`, and other cross-cutting utilities. New code should prefer `platform/`, `tools/`, `products/`, or `services/` — `common/` should not become the default dumping ground. Items here will migrate to more specific locations over time.
+Transitional bucket for shared code that exists today: `hogql_parser` and other cross-cutting utilities. New code should prefer `platform/`, `tools/`, `products/`, or `services/` — `common/` should not become the default dumping ground. Items here will migrate to more specific locations over time.
 
 ### Tools
 
-Developer tooling: CLIs, linters, formatters, code generators, scaffolding scripts, CI automation. Not imported by runtime code — build-time, CI, or developer-workflow artifacts only.
+Developer tooling: CLIs (notably `hogli/` framework + `hogli-commands/`), linters, formatters, code generators, scaffolding scripts, CI automation. Not imported by runtime code — build-time, CI, or developer-workflow artifacts only.
 
 ### Dev environment
 

--- a/docs/published/handbook/engineering/project-structure.md
+++ b/docs/published/handbook/engineering/project-structure.md
@@ -11,7 +11,8 @@ showTitle: true
 ```text
 .
 ├── bin              # Shell scripts wrapped by hogli, the unified developer CLI
-├── common           # Shared code: hogli CLI, PostHog SQL parser, HogVM, shared UI packages
+├── common           # Shared code: PostHog SQL parser, HogVM, shared UI packages
+├── tools            # Developer/CI tooling (hogli framework, hogli-commands, openapi-codegen, ...)
 ├── ee               # Enterprise platform package features (separate license)
 ├── frontend         # React/TypeScript frontend application
 │   └── src
@@ -83,10 +84,18 @@ High-performance Rust services including:
 
 Shared code used across the codebase:
 
-- `hogli` – Unified developer CLI for building, testing, and running PostHog
 - `hogql_parser` – PostHog SQL parser (C++)
 - `hogvm` – Hog virtual machine
 - `tailwind` – Shared Tailwind configuration
+
+### `tools`
+
+Developer and CI tooling, not imported by runtime code:
+
+- `hogli` – Developer CLI framework (PyPI-publishable)
+- `hogli-commands` – PostHog-specific hogli commands
+- `openapi-codegen` – OpenAPI client/spec generation
+- (and others — see `tools/`)
 
 ### `ee`
 

--- a/tools/hogli/README.md
+++ b/tools/hogli/README.md
@@ -115,9 +115,30 @@ my:command:
 
 ## Python Commands
 
-For complex logic, create Python commands using Click. Create a `commands.py` (or `__init__.py`) in your commands directory:
+For complex logic, create Python commands using Click. Two layouts are supported — pick based on how many commands you have.
+
+### Minimal: single file (recommended for most repos)
+
+A handful of commands needs nothing more than one `commands.py`:
+
+```text
+your-repo/
+├── hogli.yaml
+└── tools/
+    └── hogli-ext/
+        └── commands.py
+```
+
+```yaml
+# hogli.yaml
+config:
+  commands_dir: tools/hogli-ext
+```
+
+The directory can live anywhere `hogli.yaml` can reference — `tools/hogli-ext/` fits a monorepo with a `tools/` convention, but a top-level `hogli-ext/` or any other path works equally well.
 
 ```python
+# tools/hogli-ext/commands.py
 import click
 from hogli.cli import cli
 
@@ -132,12 +153,30 @@ def db_migrate(dry_run: bool) -> None:
         pass
 ```
 
-Configure the location in `hogli.yaml`:
+> **Note:** `commands_dir` must not be named `hogli` — that shadows the installed framework package and your `commands.py` will be silently ignored.
+
+### Full: package with submodules (for larger surfaces)
+
+When commands grow past one file and need to import each other, promote to a package. Add an `__init__.py` and split commands into submodules; `commands.py` becomes the registration entry point that imports them for side-effects:
+
+```text
+your-repo/
+└── tools/
+    └── hogli-ext/
+        └── hogli_ext/        # underscored: this is the import name
+            ├── __init__.py
+            ├── commands.py    # `from . import build, db, deploy`
+            ├── build.py
+            ├── db.py
+            └── deploy.py
+```
 
 ```yaml
 config:
-  commands_dir: tools/cli # Defaults to hogli/ next to hogli.yaml
+  commands_dir: tools/hogli-ext/hogli_ext
 ```
+
+The dashed outer dir + underscored inner package is the standard Python convention (PEP 8: dashed project name, underscored import name).
 
 ## Extension Hooks
 

--- a/tools/hogli/README.md
+++ b/tools/hogli/README.md
@@ -117,6 +117,8 @@ my:command:
 
 For complex logic, create Python commands using Click. Two layouts are supported — pick based on how many commands you have.
 
+The directory name is yours to choose. PostHog uses `hogli-commands` (and the examples below follow that). One constraint: it **must not** be named `hogli`, since that shadows the installed framework and your commands will be silently ignored.
+
 ### Minimal: single file (recommended for most repos)
 
 A handful of commands needs nothing more than one `commands.py`:
@@ -125,20 +127,18 @@ A handful of commands needs nothing more than one `commands.py`:
 your-repo/
 ├── hogli.yaml
 └── tools/
-    └── hogli-ext/
+    └── hogli-commands/
         └── commands.py
 ```
 
 ```yaml
 # hogli.yaml
 config:
-  commands_dir: tools/hogli-ext
+  commands_dir: tools/hogli-commands
 ```
 
-The directory can live anywhere `hogli.yaml` can reference — `tools/hogli-ext/` fits a monorepo with a `tools/` convention, but a top-level `hogli-ext/` or any other path works equally well.
-
 ```python
-# tools/hogli-ext/commands.py
+# tools/hogli-commands/commands.py
 import click
 from hogli.cli import cli
 
@@ -153,18 +153,18 @@ def db_migrate(dry_run: bool) -> None:
         pass
 ```
 
-> **Note:** `commands_dir` must not be named `hogli` — that shadows the installed framework package and your `commands.py` will be silently ignored.
+The directory can live anywhere `hogli.yaml` can reference — `tools/hogli-commands/` fits a monorepo with a `tools/` convention, but a top-level `hogli-commands/` or any other path works equally well.
 
 ### Full: package with submodules (for larger surfaces)
 
-When commands grow past one file and need to import each other, promote to a package. Add an `__init__.py` and split commands into submodules; `commands.py` becomes the registration entry point that imports them for side-effects:
+When commands grow past one file and need to import each other, promote to a package. Add an inner `hogli_commands/` directory with `__init__.py` and split commands into submodules; `commands.py` becomes the registration entry point that imports them for side-effects:
 
 ```text
 your-repo/
 ├── hogli.yaml
 └── tools/
-    └── hogli-ext/
-        └── hogli_ext/        # underscored: this is the import name
+    └── hogli-commands/
+        └── hogli_commands/    # underscored: this is the import name
             ├── __init__.py
             ├── commands.py    # `from . import build, db, deploy`
             ├── build.py
@@ -175,10 +175,10 @@ your-repo/
 ```yaml
 # hogli.yaml
 config:
-  commands_dir: tools/hogli-ext/hogli_ext
+  commands_dir: tools/hogli-commands/hogli_commands
 ```
 
-The dashed outer dir + underscored inner package is the standard Python convention (PEP 8: dashed project name, underscored import name).
+The dashed outer dir + underscored inner package follows PEP 8 (dashed project name, underscored import name). This is the layout PostHog itself uses.
 
 ## Extension Hooks
 

--- a/tools/hogli/README.md
+++ b/tools/hogli/README.md
@@ -161,6 +161,7 @@ When commands grow past one file and need to import each other, promote to a pac
 
 ```text
 your-repo/
+├── hogli.yaml
 └── tools/
     └── hogli-ext/
         └── hogli_ext/        # underscored: this is the import name
@@ -172,6 +173,7 @@ your-repo/
 ```
 
 ```yaml
+# hogli.yaml
 config:
   commands_dir: tools/hogli-ext/hogli_ext
 ```


### PR DESCRIPTION
## Problem

#51686 moved hogli from `common/` to `tools/` but left layout docs stale. Also, `tools/hogli/README.md` only showed the package layout — misleading for consumer repos that just need one `commands.py`.

## Changes

- `AGENTS.md`, `docs/internal/monorepo-layout.md`, `docs/published/handbook/engineering/project-structure.md` — fix post-#51686 drift.
- `tools/hogli/README.md` — split `## Python Commands` into "Minimal" (`tools/hogli-ext/commands.py`) and "Full" (PostHog's package). Notes that `commands_dir` must not be named `hogli` (shadows the installed framework).

## How did you test this code?

Agent-authored, markdown-only. No tests run. Grepped for stale `common/hogli` refs — only the intentional migration-aid in `bin/hogli` remains.

## Docs update

This PR is the docs update.

## 🤖 Agent context

- Tool: Claude Code
- Kept PostHog's `tools/hogli-commands/hogli_commands/` shape (doubling is the standard dashed-project + underscored-import convention).
- Follow-up: loader patch to warn when `commands_dir.name == "hogli"` (currently fails silently).