### PR TITLE
feat(mcp): add synthetic git endpoints for per-skill plugin distribution

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -10,6 +10,7 @@ import { RequestLogger, withLogging } from '@/lib/logging'
 import { extractClientInfoFromBody } from '@/lib/mcp-client-info'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
 import { hash, parseMcpMode, sanitizeHeaderValue } from '@/lib/utils'
+import { handleGitRequest } from '@/routes/git'
 import type { CloudRegion } from '@/tools/types'
 
 import { MCP, RequestProperties } from './mcp'
@@ -174,6 +175,15 @@ const handleRequest = async (
                 'Cache-Control': 'no-store',
             },
         })
+    }
+
+    // Synthetic git plugin distribution — unauthenticated, public endpoints.
+    // Must be checked before the token requirement below.
+    if (url.pathname === '/marketplace.json' || url.pathname.startsWith('/git/')) {
+        const gitResponse = await handleGitRequest(request, url, ctx, log)
+        if (gitResponse) {
+            return gitResponse
+        }
     }
 
     // Detect region from hostname (mcp-eu.posthog.com) or query param (?region=eu)

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -10,6 +10,7 @@ import { RequestLogger, withLogging } from '@/lib/logging'
 import { extractClientInfoFromBody } from '@/lib/mcp-client-info'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
 import { hash, parseMcpMode, sanitizeHeaderValue } from '@/lib/utils'
+import { handleGitRequest } from '@/routes/git'
 import type { CloudRegion } from '@/tools/types'
 
 import { MCP, RequestProperties } from './mcp'
@@ -153,6 +154,14 @@ const handleRequest = async (
     log.extend({ route: url.pathname })
 
     if (url.pathname === '/') {
+        const accept = request.headers.get('Accept') || ''
+        if (!accept.includes('text/html')) {
+            // Non-browser clients (Claude Code marketplace fetcher) get the marketplace JSON
+            const gitResponse = await handleGitRequest(request, new URL(`${url.origin}/git/marketplace`), ctx, log)
+            if (gitResponse) {
+                return gitResponse
+            }
+        }
         return new Response(PARSED_LANDING_HTML, {
             headers: { 'content-type': 'text/html; charset=utf-8' },
         })
@@ -174,6 +183,25 @@ const handleRequest = async (
                 'Cache-Control': 'no-store',
             },
         })
+    }
+
+    // Synthetic git plugin distribution — unauthenticated, public endpoints.
+    // Must be checked before the token requirement below.
+    // Root-level /info/refs and /git-upload-pack serve the marketplace repo,
+    // so `git clone https://mcp.posthog.com` works directly.
+    if (url.pathname === '/marketplace.json' || url.pathname.startsWith('/git/')) {
+        const gitResponse = await handleGitRequest(request, url, ctx, log)
+        if (gitResponse) {
+            return gitResponse
+        }
+    }
+    if (url.pathname === '/info/refs' || url.pathname === '/git-upload-pack') {
+        const rewritten = new URL(url)
+        rewritten.pathname = `/git/marketplace${url.pathname}`
+        const gitResponse = await handleGitRequest(request, rewritten, ctx, log)
+        if (gitResponse) {
+            return gitResponse
+        }
     }
 
     // Detect region from hostname (mcp-eu.posthog.com) or query param (?region=eu)

--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -8,6 +8,8 @@ export enum AnalyticsEvent {
     MCP_PROJECT_SWITCHED = 'mcp project switched',
     MCP_ORGANIZATION_SWITCHED = 'mcp organization switched',
     MCP_TOOL_CALLED = 'mcp_tool_called', // matching mcpcat
+    SKILL_FETCHED = 'skill_fetched',
+    MARKETPLACE_VIEWED = 'marketplace_viewed',
 }
 
 export type MCPAnalyticsContext = {

--- a/services/mcp/src/lib/git.ts
+++ b/services/mcp/src/lib/git.ts
@@ -1,0 +1,282 @@
+/**
+ * Synthetic git smart HTTP for read-only plugin distribution.
+ *
+ * Synthesizes a virtual git repo from a file tree (path → content).
+ * Implements just enough of the git smart HTTP protocol for `git clone`.
+ * No actual git repo on disk. No push support. No delta compression.
+ */
+
+import { createHash } from 'node:crypto'
+
+import { zlibSync } from 'fflate'
+
+const OBJ_COMMIT = 1
+const OBJ_TREE = 2
+const OBJ_BLOB = 3
+
+interface GitObject {
+    type: number
+    data: Uint8Array
+    sha: string
+}
+
+interface TreeEntry {
+    mode: string
+    name: string
+    sha: string
+}
+
+interface DirNode {
+    files: Map<string, string>
+    dirs: Map<string, DirNode>
+}
+
+export interface FileTree {
+    [path: string]: string
+}
+
+// --- Git object creation ---
+
+function enc(s: string): Uint8Array {
+    return new TextEncoder().encode(s)
+}
+
+function hexToBytes(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2)
+    for (let i = 0; i < hex.length; i += 2) {
+        bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+    }
+    return bytes
+}
+
+function concat(arrays: Uint8Array[]): Uint8Array {
+    let len = 0
+    for (const a of arrays) len += a.length
+    const result = new Uint8Array(len)
+    let offset = 0
+    for (const a of arrays) {
+        result.set(a, offset)
+        offset += a.length
+    }
+    return result
+}
+
+function u32be(buf: Uint8Array, offset: number, value: number): void {
+    buf[offset] = (value >>> 24) & 0xff
+    buf[offset + 1] = (value >>> 16) & 0xff
+    buf[offset + 2] = (value >>> 8) & 0xff
+    buf[offset + 3] = value & 0xff
+}
+
+function gitHash(type: string, data: Uint8Array): string {
+    const header = enc(`${type} ${data.length}\0`)
+    return createHash('sha1').update(header).update(data).digest('hex')
+}
+
+function createBlob(content: string): GitObject {
+    const data = enc(content)
+    return { type: OBJ_BLOB, data, sha: gitHash('blob', data) }
+}
+
+function createTree(entries: TreeEntry[]): GitObject {
+    const sorted = [...entries].sort((a, b) => {
+        const aKey = a.mode.startsWith('40') ? a.name + '/' : a.name
+        const bKey = b.mode.startsWith('40') ? b.name + '/' : b.name
+        return aKey < bKey ? -1 : aKey > bKey ? 1 : 0
+    })
+
+    const parts: Uint8Array[] = []
+    for (const entry of sorted) {
+        parts.push(enc(`${entry.mode} ${entry.name}\0`))
+        parts.push(hexToBytes(entry.sha))
+    }
+
+    const data = concat(parts)
+    return { type: OBJ_TREE, data, sha: gitHash('tree', data) }
+}
+
+function createCommit(treeSha: string, message: string): GitObject {
+    const ts = '1700000000 +0000'
+    const text = `tree ${treeSha}\nauthor PostHog <mcp@posthog.com> ${ts}\ncommitter PostHog <mcp@posthog.com> ${ts}\n\n${message}\n`
+    const data = enc(text)
+    return { type: OBJ_COMMIT, data, sha: gitHash('commit', data) }
+}
+
+// --- File tree → git objects ---
+
+export function synthesizeRepo(files: FileTree): { objects: GitObject[]; headSha: string } {
+    const objects: GitObject[] = []
+    const blobShas = new Map<string, string>()
+
+    for (const [path, content] of Object.entries(files)) {
+        const blob = createBlob(content)
+        objects.push(blob)
+        blobShas.set(path, blob.sha)
+    }
+
+    const root: DirNode = { files: new Map(), dirs: new Map() }
+
+    for (const path of Object.keys(files)) {
+        const parts = path.split('/')
+        const filename = parts.pop()!
+        let node = root
+        for (const dir of parts) {
+            if (!node.dirs.has(dir)) {
+                node.dirs.set(dir, { files: new Map(), dirs: new Map() })
+            }
+            node = node.dirs.get(dir)!
+        }
+        node.files.set(filename, blobShas.get(path)!)
+    }
+
+    function buildTree(node: DirNode): string {
+        const entries: TreeEntry[] = []
+        for (const [name, sha] of node.files) {
+            entries.push({ mode: '100644', name, sha })
+        }
+        for (const [name, child] of node.dirs) {
+            entries.push({ mode: '40000', name, sha: buildTree(child) })
+        }
+        const tree = createTree(entries)
+        objects.push(tree)
+        return tree.sha
+    }
+
+    const rootSha = buildTree(root)
+    const commit = createCommit(rootSha, 'PostHog plugin')
+    objects.push(commit)
+
+    return { objects, headSha: commit.sha }
+}
+
+// --- Packfile ---
+
+function encodeObjHeader(type: number, size: number): Uint8Array {
+    const bytes: number[] = []
+    let b = (type << 4) | (size & 0x0f)
+    size >>= 4
+    if (size > 0) b |= 0x80
+    bytes.push(b)
+    while (size > 0) {
+        b = size & 0x7f
+        size >>= 7
+        if (size > 0) b |= 0x80
+        bytes.push(b)
+    }
+    return new Uint8Array(bytes)
+}
+
+function buildPackfile(objects: GitObject[]): Uint8Array {
+    const parts: Uint8Array[] = []
+
+    const header = new Uint8Array(12)
+    header.set(enc('PACK'))
+    u32be(header, 4, 2)
+    u32be(header, 8, objects.length)
+    parts.push(header)
+
+    for (const obj of objects) {
+        parts.push(encodeObjHeader(obj.type, obj.data.length))
+        parts.push(new Uint8Array(zlibSync(obj.data)))
+    }
+
+    const body = concat(parts)
+    const checksum = createHash('sha1').update(body).digest()
+    return concat([body, new Uint8Array(checksum)])
+}
+
+// --- Pkt-line encoding ---
+
+function pktLine(data: string): string {
+    const len = data.length + 4
+    return len.toString(16).padStart(4, '0') + data
+}
+
+function sideBandChunks(band: number, data: Uint8Array): Uint8Array[] {
+    const MAX_CHUNK = 65515 // 65520 - 4 (length) - 1 (band)
+    const chunks: Uint8Array[] = []
+    let offset = 0
+
+    while (offset < data.length) {
+        const slice = data.subarray(offset, offset + MAX_CHUNK)
+        const len = slice.length + 5
+        const line = new Uint8Array(len)
+        line.set(enc(len.toString(16).padStart(4, '0')))
+        line[4] = band
+        line.set(slice, 5)
+        chunks.push(line)
+        offset += slice.length
+    }
+
+    return chunks
+}
+
+// --- HTTP handlers ---
+
+export function handleInfoRefs(headSha: string): Response {
+    const caps = 'side-band-64k shallow symref=HEAD:refs/heads/main'
+    let body = ''
+    body += pktLine('# service=git-upload-pack\n')
+    body += '0000'
+    body += pktLine(`${headSha} HEAD\0${caps}\n`)
+    body += pktLine(`${headSha} refs/heads/main\n`)
+    body += '0000'
+
+    return new Response(body, {
+        headers: {
+            'Content-Type': 'application/x-git-upload-pack-advertisement',
+            'Cache-Control': 'no-cache',
+        },
+    })
+}
+
+export async function handleUploadPack(request: Request, objects: GitObject[], headSha: string): Promise<Response> {
+    const body = await request.text()
+    const isShallow = body.includes('deepen')
+    const isDone = body.includes('done')
+
+    const parts: Uint8Array[] = []
+
+    if (isShallow) {
+        parts.push(enc(pktLine(`shallow ${headSha}\n`)))
+        parts.push(enc('0000'))
+    }
+
+    if (isDone) {
+        parts.push(enc(pktLine('NAK\n')))
+        parts.push(...sideBandChunks(1, buildPackfile(objects)))
+        parts.push(enc('0000'))
+    }
+
+    const responseBytes = concat(parts)
+    return new Response(responseBytes as unknown as BodyInit, {
+        headers: {
+            'Content-Type': 'application/x-git-upload-pack-result',
+            'Cache-Control': 'no-cache',
+        },
+    })
+}
+
+// --- Repo cache ---
+
+export class GitRepoCache {
+    private cache = new Map<string, { objects: GitObject[]; headSha: string; contentHash: string }>()
+
+    getOrBuild(key: string, files: FileTree): { objects: GitObject[]; headSha: string; contentHash: string } {
+        const contentHash = createHash('sha256').update(JSON.stringify(files)).digest('hex')
+
+        const cached = this.cache.get(key)
+        if (cached && cached.contentHash === contentHash) {
+            return cached
+        }
+
+        const repo = synthesizeRepo(files)
+        const entry = { ...repo, contentHash }
+        this.cache.set(key, entry)
+        return entry
+    }
+
+    invalidateAll(): void {
+        this.cache.clear()
+    }
+}

--- a/services/mcp/src/lib/git.ts
+++ b/services/mcp/src/lib/git.ts
@@ -106,11 +106,19 @@ function createCommit(treeSha: string, message: string): GitObject {
 
 export function synthesizeRepo(files: FileTree): { objects: GitObject[]; headSha: string } {
     const objects: GitObject[] = []
+    const seen = new Set<string>()
     const blobShas = new Map<string, string>()
+
+    function addObject(obj: GitObject): void {
+        if (!seen.has(obj.sha)) {
+            seen.add(obj.sha)
+            objects.push(obj)
+        }
+    }
 
     for (const [path, content] of Object.entries(files)) {
         const blob = createBlob(content)
-        objects.push(blob)
+        addObject(blob)
         blobShas.set(path, blob.sha)
     }
 
@@ -138,13 +146,13 @@ export function synthesizeRepo(files: FileTree): { objects: GitObject[]; headSha
             entries.push({ mode: '40000', name, sha: buildTree(child) })
         }
         const tree = createTree(entries)
-        objects.push(tree)
+        addObject(tree)
         return tree.sha
     }
 
     const rootSha = buildTree(root)
     const commit = createCommit(rootSha, 'PostHog plugin')
-    objects.push(commit)
+    addObject(commit)
 
     return { objects, headSha: commit.sha }
 }

--- a/services/mcp/src/lib/plugin-content.ts
+++ b/services/mcp/src/lib/plugin-content.ts
@@ -136,10 +136,74 @@ export function extractBundlesFromArchive(archive: Unzipped): BundleEntry[] {
 }
 
 /**
- * Build the file tree for the core PostHog plugin.
- * Contains MCP server config and plugin metadata — no skills.
+ * Generate the recommend-skills SKILL.md content.
+ * Dynamically includes the current bundle catalog so the skill
+ * always recommends from the latest available bundles.
  */
-export function buildCorePluginFiles(version: string): FileTree {
+function buildRecommendSkillContent(bundles: BundleEntry[]): string {
+    const bundleList = bundles
+        .map((b) => `- **posthog-${b.name}**: ${b.description} (keywords: ${b.keywords.join(', ')})`)
+        .join('\n')
+
+    return `---
+name: recommend-posthog-skills
+description: >
+  Detect the user's technology stack and recommend the right PostHog skill
+  bundle. Run this when the user installs the PostHog plugin, asks about
+  PostHog setup, or when you detect a project that could benefit from
+  PostHog integration.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Recommend PostHog Skills
+
+You are helping the user install the right PostHog skills for their project.
+
+## Step 1: Detect the technology stack
+
+Check the project for framework indicators:
+
+\`\`\`bash
+# Check for key files
+ls package.json requirements.txt Gemfile go.mod Cargo.toml build.gradle pubspec.yaml 2>/dev/null
+
+# If package.json exists, check dependencies
+cat package.json 2>/dev/null | grep -E '"(next|react|react-native|expo|vue|nuxt|svelte|@sveltejs|astro|angular)"' | head -10
+
+# If requirements.txt or setup.py exists
+cat requirements.txt setup.py pyproject.toml 2>/dev/null | grep -iE '(django|flask|fastapi)' | head -5
+
+# If Gemfile exists
+cat Gemfile 2>/dev/null | grep -iE '(rails|sinatra)' | head -5
+\`\`\`
+
+## Step 2: Match to a bundle
+
+Based on what you find, recommend ONE bundle from this list:
+
+${bundleList}
+
+## Step 3: Recommend installation
+
+Tell the user which bundle matches their stack and give them the install command:
+
+\`\`\`
+/plugin install posthog-{bundle-name}@posthog
+\`\`\`
+
+If the project uses multiple frameworks (e.g., a Next.js frontend + Python backend), recommend multiple bundles.
+
+If no framework is detected, ask the user what they're building.
+`
+}
+
+/**
+ * Build the file tree for the core PostHog plugin.
+ * Contains MCP server config, the recommend-skills skill, and plugin metadata.
+ */
+export function buildCorePluginFiles(version: string, bundles: BundleEntry[] = []): FileTree {
     const files: FileTree = {}
 
     files['.claude-plugin/plugin.json'] = JSON.stringify(
@@ -169,6 +233,10 @@ export function buildCorePluginFiles(version: string): FileTree {
         null,
         2
     )
+
+    if (bundles.length > 0) {
+        files['skills/recommend-posthog-skills/SKILL.md'] = buildRecommendSkillContent(bundles)
+    }
 
     return files
 }

--- a/services/mcp/src/lib/plugin-content.ts
+++ b/services/mcp/src/lib/plugin-content.ts
@@ -4,6 +4,7 @@
  * Assembles FileTree maps (path → content) for:
  * - The core PostHog plugin (MCP config, hooks, auth)
  * - Individual skill plugins (each with a dependency on core)
+ * - Bundle plugins (multiple skills grouped by framework)
  *
  * Content is sourced from the context-mill archive already fetched
  * by the MCP server for resource registration.
@@ -33,6 +34,14 @@ export interface SkillEntry {
     description: string
     version: string
     files: Record<string, string>
+}
+
+export interface BundleEntry {
+    name: string
+    displayName: string
+    description: string
+    keywords: string[]
+    skills: string[]
 }
 
 /**
@@ -97,6 +106,36 @@ export function extractSkillsFromArchive(archive: Unzipped): SkillEntry[] {
 }
 
 /**
+ * Extract bundle definitions from the context-mill manifest.
+ */
+export function extractBundlesFromArchive(archive: Unzipped): BundleEntry[] {
+    const manifestData = archive['manifest.json']
+    if (!manifestData) {
+        return []
+    }
+
+    const rawManifest = JSON.parse(strFromU8(manifestData))
+    const bundles = rawManifest.bundles as Record<string, {
+        name: string
+        description: string
+        keywords?: string[]
+        skills: string[]
+    }> | undefined
+
+    if (!bundles) {
+        return []
+    }
+
+    return Object.entries(bundles).map(([id, bundle]) => ({
+        name: id,
+        displayName: bundle.name,
+        description: bundle.description,
+        keywords: bundle.keywords ?? [],
+        skills: bundle.skills,
+    }))
+}
+
+/**
  * Build the file tree for the core PostHog plugin.
  * Contains MCP server config and plugin metadata — no skills.
  */
@@ -137,7 +176,6 @@ export function buildCorePluginFiles(version: string): FileTree {
 /**
  * Build the file tree for a single skill plugin.
  * Declares a dependency on the core `posthog` plugin.
- * Includes SKILL.md and all reference files from the inner ZIP.
  */
 export function buildSkillPluginFiles(skill: SkillEntry): FileTree {
     const files: FileTree = {}
@@ -162,10 +200,46 @@ export function buildSkillPluginFiles(skill: SkillEntry): FileTree {
 }
 
 /**
- * Build the marketplace.json catalog listing all available plugins.
- * Served at /marketplace.json for Claude Code to discover.
+ * Build the file tree for a bundle plugin.
+ * Inlines all referenced skills into a single plugin.
  */
-export function buildMarketplaceJson(skills: SkillEntry[], baseUrl: string): string {
+export function buildBundlePluginFiles(bundle: BundleEntry, skills: SkillEntry[]): FileTree {
+    const files: FileTree = {}
+    const skillMap = new Map(skills.map((s) => [s.name, s]))
+
+    const resolvedSkills = bundle.skills
+        .map((id) => skillMap.get(id))
+        .filter((s): s is SkillEntry => s !== undefined)
+
+    const version = resolvedSkills[0]?.version ?? '0.0.0'
+
+    files['.claude-plugin/plugin.json'] = JSON.stringify(
+        {
+            name: `posthog-${bundle.name}`,
+            version,
+            description: bundle.description,
+            dependencies: ['posthog'],
+            author: { name: 'PostHog', email: 'hey@posthog.com' },
+            keywords: bundle.keywords,
+        },
+        null,
+        2
+    )
+
+    for (const skill of resolvedSkills) {
+        for (const [path, content] of Object.entries(skill.files)) {
+            files[`skills/${skill.name}/${path}`] = content
+        }
+    }
+
+    return files
+}
+
+/**
+ * Build the marketplace.json catalog.
+ * Lists the core plugin and bundles (not individual skills).
+ */
+export function buildMarketplaceJson(bundles: BundleEntry[], baseUrl: string): string {
     const plugins = [
         {
             name: 'posthog',
@@ -174,11 +248,12 @@ export function buildMarketplaceJson(skills: SkillEntry[], baseUrl: string): str
             policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
             category: 'Productivity',
         },
-        ...skills.map((skill) => ({
-            name: `posthog-${skill.name}`,
-            source: { source: 'url', url: `${baseUrl}/git/skills/${skill.name}` },
-            description: skill.description,
+        ...bundles.map((bundle) => ({
+            name: `posthog-${bundle.name}`,
+            source: { source: 'url', url: `${baseUrl}/git/bundles/${bundle.name}` },
+            description: bundle.description,
             dependencies: ['posthog'],
+            keywords: bundle.keywords,
             category: 'Productivity',
         })),
     ]

--- a/services/mcp/src/lib/plugin-content.ts
+++ b/services/mcp/src/lib/plugin-content.ts
@@ -105,105 +105,52 @@ export function extractSkillsFromArchive(archive: Unzipped): SkillEntry[] {
     return skills
 }
 
+export interface RecommendSkill {
+    name: string
+    content: string
+}
+
 /**
- * Extract bundle definitions from the context-mill manifest.
+ * Extract bundle definitions and recommend skill from the context-mill manifest.
  */
-export function extractBundlesFromArchive(archive: Unzipped): BundleEntry[] {
+export function extractBundlesFromArchive(archive: Unzipped): { bundles: BundleEntry[]; recommendSkill: RecommendSkill | null } {
     const manifestData = archive['manifest.json']
     if (!manifestData) {
-        return []
+        return { bundles: [], recommendSkill: null }
     }
 
     const rawManifest = JSON.parse(strFromU8(manifestData))
-    const bundles = rawManifest.bundles as Record<string, {
+
+    const bundles: BundleEntry[] = []
+    const rawBundles = rawManifest.bundles as Record<string, {
         name: string
         description: string
         keywords?: string[]
         skills: string[]
     }> | undefined
 
-    if (!bundles) {
-        return []
+    if (rawBundles) {
+        for (const [id, bundle] of Object.entries(rawBundles)) {
+            bundles.push({
+                name: id,
+                displayName: bundle.name,
+                description: bundle.description,
+                keywords: bundle.keywords ?? [],
+                skills: bundle.skills,
+            })
+        }
     }
 
-    return Object.entries(bundles).map(([id, bundle]) => ({
-        name: id,
-        displayName: bundle.name,
-        description: bundle.description,
-        keywords: bundle.keywords ?? [],
-        skills: bundle.skills,
-    }))
-}
+    const recommendSkill = rawManifest.recommendSkill as RecommendSkill | undefined
 
-/**
- * Generate the recommend-skills SKILL.md content.
- * Dynamically includes the current bundle catalog so the skill
- * always recommends from the latest available bundles.
- */
-function buildRecommendSkillContent(bundles: BundleEntry[]): string {
-    const bundleList = bundles
-        .map((b) => `- **posthog-${b.name}**: ${b.description} (keywords: ${b.keywords.join(', ')})`)
-        .join('\n')
-
-    return `---
-name: recommend-posthog-skills
-description: >
-  Detect the user's technology stack and recommend the right PostHog skill
-  bundle. Run this when the user installs the PostHog plugin, asks about
-  PostHog setup, or when you detect a project that could benefit from
-  PostHog integration.
-allowed-tools:
-  - Bash
-  - Read
----
-
-# Recommend PostHog Skills
-
-You are helping the user install the right PostHog skills for their project.
-
-## Step 1: Detect the technology stack
-
-Check the project for framework indicators:
-
-\`\`\`bash
-# Check for key files
-ls package.json requirements.txt Gemfile go.mod Cargo.toml build.gradle pubspec.yaml 2>/dev/null
-
-# If package.json exists, check dependencies
-cat package.json 2>/dev/null | grep -E '"(next|react|react-native|expo|vue|nuxt|svelte|@sveltejs|astro|angular)"' | head -10
-
-# If requirements.txt or setup.py exists
-cat requirements.txt setup.py pyproject.toml 2>/dev/null | grep -iE '(django|flask|fastapi)' | head -5
-
-# If Gemfile exists
-cat Gemfile 2>/dev/null | grep -iE '(rails|sinatra)' | head -5
-\`\`\`
-
-## Step 2: Match to a bundle
-
-Based on what you find, recommend ONE bundle from this list:
-
-${bundleList}
-
-## Step 3: Recommend installation
-
-Tell the user which bundle matches their stack and give them the install command:
-
-\`\`\`
-/plugin install posthog-{bundle-name}@posthog
-\`\`\`
-
-If the project uses multiple frameworks (e.g., a Next.js frontend + Python backend), recommend multiple bundles.
-
-If no framework is detected, ask the user what they're building.
-`
+    return { bundles, recommendSkill: recommendSkill ?? null }
 }
 
 /**
  * Build the file tree for the core PostHog plugin.
- * Contains MCP server config, the recommend-skills skill, and plugin metadata.
+ * Contains MCP server config, the recommend-skills skill (from context-mill), and plugin metadata.
  */
-export function buildCorePluginFiles(version: string, bundles: BundleEntry[] = []): FileTree {
+export function buildCorePluginFiles(version: string, recommendSkill?: RecommendSkill | null): FileTree {
     const files: FileTree = {}
 
     files['.claude-plugin/plugin.json'] = JSON.stringify(
@@ -234,8 +181,8 @@ export function buildCorePluginFiles(version: string, bundles: BundleEntry[] = [
         2
     )
 
-    if (bundles.length > 0) {
-        files['skills/recommend-posthog-skills/SKILL.md'] = buildRecommendSkillContent(bundles)
+    if (recommendSkill) {
+        files[`skills/${recommendSkill.name}/SKILL.md`] = recommendSkill.content
     }
 
     return files

--- a/services/mcp/src/lib/plugin-content.ts
+++ b/services/mcp/src/lib/plugin-content.ts
@@ -1,0 +1,186 @@
+/**
+ * Builds file trees for synthetic git plugin distribution.
+ *
+ * Assembles FileTree maps (path → content) for:
+ * - The core PostHog plugin (MCP config, hooks, auth)
+ * - Individual skill plugins (each with a dependency on core)
+ *
+ * Content is sourced from the context-mill archive already fetched
+ * by the MCP server for resource registration.
+ */
+
+import type { Unzipped } from 'fflate'
+import { strFromU8, unzipSync } from 'fflate'
+
+import type { FileTree } from '@/lib/git'
+
+import { loadContextMillManifest } from '@/resources/manifest-loader'
+import type { ContextMillManifest } from '@/resources/manifest-types'
+
+const MCP_SERVER_URL = 'https://mcp.posthog.com/mcp'
+const CORE_PLUGIN_VERSION = '2.0.0'
+const SKILL_PLUGIN_VERSION = '1.0.0'
+
+export interface SkillEntry {
+    name: string
+    description: string
+    /** All files from the inner ZIP, keyed by relative path */
+    files: Record<string, string>
+}
+
+/**
+ * Extract skill entries from the context-mill archive.
+ * Each resource references an inner ZIP containing SKILL.md + references/.
+ */
+export function extractSkillsFromArchive(archive: Unzipped): SkillEntry[] {
+    const manifestData = archive['manifest.json']
+    if (!manifestData) {
+        return []
+    }
+
+    const rawManifest = JSON.parse(strFromU8(manifestData))
+    let manifest: ContextMillManifest
+    try {
+        manifest = loadContextMillManifest(rawManifest)
+    } catch {
+        return []
+    }
+
+    const skills: SkillEntry[] = []
+
+    for (const resource of manifest.resources) {
+        if (!resource.file) {
+            continue
+        }
+
+        const zipData = archive[resource.file]
+        if (!zipData) {
+            continue
+        }
+
+        try {
+            const inner = unzipSync(zipData)
+            const files: Record<string, string> = {}
+
+            for (const [path, data] of Object.entries(inner)) {
+                // Skip directory entries (empty data, path ends with /)
+                if (data.length === 0) {
+                    continue
+                }
+                files[path] = strFromU8(data)
+            }
+
+            if (Object.keys(files).length > 0) {
+                skills.push({
+                    name: resource.id,
+                    description: resource.resource.description,
+                    files,
+                })
+            }
+        } catch {
+            // Skip malformed inner ZIPs
+            continue
+        }
+    }
+
+    return skills
+}
+
+/**
+ * Build the file tree for the core PostHog plugin.
+ * Contains MCP server config and plugin metadata — no skills.
+ */
+export function buildCorePluginFiles(): FileTree {
+    const files: FileTree = {}
+
+    files['.claude-plugin/plugin.json'] = JSON.stringify(
+        {
+            name: 'posthog',
+            version: CORE_PLUGIN_VERSION,
+            description: 'PostHog MCP tools — analytics, feature flags, experiments, error tracking, and more.',
+            author: { name: 'PostHog', email: 'hey@posthog.com', url: 'https://posthog.com' },
+            homepage: 'https://posthog.com/docs/model-context-protocol',
+            repository: 'https://github.com/PostHog/ai-plugin',
+            license: 'MIT',
+            keywords: ['analytics', 'feature-flags', 'experiments', 'error-tracking', 'a/b-testing', 'llm-analytics'],
+        },
+        null,
+        2
+    )
+
+    files['mcp.json'] = JSON.stringify(
+        {
+            mcpServers: {
+                posthog: {
+                    type: 'http',
+                    url: MCP_SERVER_URL,
+                },
+            },
+        },
+        null,
+        2
+    )
+
+    return files
+}
+
+/**
+ * Build the file tree for a single skill plugin.
+ * Declares a dependency on the core `posthog` plugin.
+ * Includes SKILL.md and all reference files from the inner ZIP.
+ */
+export function buildSkillPluginFiles(skill: SkillEntry): FileTree {
+    const files: FileTree = {}
+
+    files['.claude-plugin/plugin.json'] = JSON.stringify(
+        {
+            name: `posthog-${skill.name}`,
+            version: SKILL_PLUGIN_VERSION,
+            description: skill.description,
+            dependencies: ['posthog'],
+            author: { name: 'PostHog', email: 'hey@posthog.com' },
+        },
+        null,
+        2
+    )
+
+    for (const [path, content] of Object.entries(skill.files)) {
+        files[`skills/${skill.name}/${path}`] = content
+    }
+
+    return files
+}
+
+/**
+ * Build the marketplace.json catalog listing all available plugins.
+ * Served at /marketplace.json for Claude Code to discover.
+ */
+export function buildMarketplaceJson(skills: SkillEntry[], baseUrl: string): string {
+    const plugins = [
+        {
+            name: 'posthog',
+            source: { source: 'url', url: `${baseUrl}/git/core` },
+            description: 'PostHog MCP tools — analytics, feature flags, experiments, error tracking, and more.',
+            policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
+            category: 'Productivity',
+        },
+        ...skills.map((skill) => ({
+            name: `posthog-${skill.name}`,
+            source: { source: 'url', url: `${baseUrl}/git/skills/${skill.name}` },
+            description: skill.description,
+            dependencies: ['posthog'],
+            category: 'Productivity',
+        })),
+    ]
+
+    return JSON.stringify(
+        {
+            name: 'posthog',
+            owner: { name: 'PostHog', email: 'hey@posthog.com' },
+            interface: { displayName: 'PostHog' },
+            plugins,
+        },
+        null,
+        2
+    )
+}

--- a/services/mcp/src/routes/git.ts
+++ b/services/mcp/src/routes/git.ts
@@ -235,7 +235,8 @@ export async function handleGitRequest(
         cacheKey = 'marketplace'
     } else if (pluginType === 'core') {
         const version = skills[0]?.version ?? '0.0.0'
-        files = buildCorePluginFiles(version)
+        const bundles = getBundles(archive)
+        files = buildCorePluginFiles(version, bundles)
         cacheKey = 'core'
     } else if (pluginType === 'bundle') {
         const bundles = getBundles(archive)

--- a/services/mcp/src/routes/git.ts
+++ b/services/mcp/src/routes/git.ts
@@ -1,56 +1,63 @@
 /**
  * Git smart HTTP routes for synthetic plugin distribution.
  *
- * Serves per-skill and core plugin repos via the git smart HTTP protocol,
- * enabling per-plugin install attribution through PostHog analytics events.
+ * Serves bundles, per-skill, and core plugin repos via the git smart HTTP
+ * protocol, enabling per-plugin install attribution through PostHog events.
  *
  * Routes:
  *   GET  /marketplace.json                              → plugin catalog (plain HTTP)
- *   GET  /git/marketplace/info/refs?service=...         → marketplace repo (for `plugin marketplace add`)
- *   POST /git/marketplace/git-upload-pack               → marketplace repo packfile
- *   GET  /git/core/info/refs?service=git-upload-pack    → core plugin
- *   POST /git/core/git-upload-pack                      → core plugin packfile
- *   GET  /git/skills/:name/info/refs?service=...        → per-skill plugin
- *   POST /git/skills/:name/git-upload-pack              → per-skill packfile
+ *   GET  /git/marketplace/...                           → marketplace repo (for `plugin marketplace add`)
+ *   GET  /git/core/...                                  → core plugin
+ *   GET  /git/bundles/:name/...                         → bundle plugin (multiple skills)
+ *   GET  /git/skills/:name/...                          → individual skill plugin
  */
 
 import { createHash } from 'node:crypto'
 
+import { env } from 'cloudflare:workers'
 import type { Unzipped } from 'fflate'
 
 import { AnalyticsEvent, getPostHogClient } from '@/lib/analytics'
 import { type FileTree, GitRepoCache, handleInfoRefs, handleUploadPack } from '@/lib/git'
 import type { RequestLogger } from '@/lib/logging'
 import {
+    type BundleEntry,
+    type SkillEntry,
+    buildBundlePluginFiles,
     buildCorePluginFiles,
     buildMarketplaceJson,
     buildSkillPluginFiles,
+    extractBundlesFromArchive,
     extractSkillsFromArchive,
-    type SkillEntry,
 } from '@/lib/plugin-content'
 import { CONTEXT_MILL_URL } from '@/resources/index'
 
-import { strFromU8, unzipSync } from 'fflate'
+import { unzipSync } from 'fflate'
 
 const repoCache = new GitRepoCache()
 
-// Module-level cache for context-mill archive (shared with resources/index.ts pattern)
 let cachedArchive: Unzipped | null = null
 let cachedSkills: SkillEntry[] | null = null
+let cachedBundles: BundleEntry[] | null = null
 let cachedMarketplaceJson: string | null = null
-async function getArchive(): Promise<Unzipped> {
+
+async function getArchive(env?: Record<string, string | undefined>): Promise<Unzipped> {
     if (cachedArchive) {
         return cachedArchive
     }
 
-    const response = await fetch(CONTEXT_MILL_URL)
+    const localUrl = env?.POSTHOG_MCP_LOCAL_SKILLS_URL?.trim() || undefined
+    const url = localUrl || CONTEXT_MILL_URL
+
+    const response = await fetch(url, localUrl ? { cache: 'no-store' } : {})
     if (!response.ok) {
-        throw new Error(`Failed to fetch context-mill archive: ${response.statusText}`)
+        throw new Error(`Failed to fetch context-mill archive from ${url}: ${response.statusText}`)
     }
 
     const buffer = await response.arrayBuffer()
     cachedArchive = unzipSync(new Uint8Array(buffer))
     cachedSkills = null
+    cachedBundles = null
     cachedMarketplaceJson = null
     return cachedArchive
 }
@@ -63,16 +70,24 @@ function getSkills(archive: Unzipped): SkillEntry[] {
     return cachedSkills
 }
 
+function getBundles(archive: Unzipped): BundleEntry[] {
+    if (cachedBundles) {
+        return cachedBundles
+    }
+    cachedBundles = extractBundlesFromArchive(archive)
+    return cachedBundles
+}
+
 function deriveAnonymousId(request: Request): string {
     const ip = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown'
     const ua = request.headers.get('User-Agent') || ''
     return createHash('sha256').update(`${ip}:${ua}`).digest('hex').slice(0, 32)
 }
 
-function trackSkillFetch(
+function trackFetch(
     request: Request,
     ctx: ExecutionContext,
-    pluginType: 'marketplace' | 'core' | 'skill',
+    pluginType: 'marketplace' | 'core' | 'bundle' | 'skill',
     pluginName: string,
     requestType: 'info_refs' | 'upload_pack',
     contentHash: string
@@ -98,9 +113,35 @@ function trackSkillFetch(
 }
 
 /**
- * Handle git and marketplace requests. Returns a Response if the path matches,
- * or null to let the main router continue.
+ * Parse a git path segment: "prefix/rest" or bare "prefix".
+ * Returns [prefix, gitAction] where gitAction is "" for bare paths.
  */
+function parseSegment(gitPath: string, prefix: string): [true, string] | [false] {
+    if (gitPath === prefix) {
+        return [true, '']
+    }
+    if (gitPath.startsWith(prefix + '/')) {
+        return [true, gitPath.slice(prefix.length + 1)]
+    }
+    return [false]
+}
+
+/**
+ * Parse a named segment: "prefix/<name>/rest".
+ * Returns [name, gitAction] or null.
+ */
+function parseNamedSegment(gitPath: string, prefix: string): { name: string; gitAction: string } | null {
+    if (!gitPath.startsWith(prefix + '/')) {
+        return null
+    }
+    const rest = gitPath.slice(prefix.length + 1)
+    const slashIdx = rest.indexOf('/')
+    if (slashIdx === -1) {
+        return null
+    }
+    return { name: rest.slice(0, slashIdx), gitAction: rest.slice(slashIdx + 1) }
+}
+
 export async function handleGitRequest(
     request: Request,
     url: URL,
@@ -109,14 +150,14 @@ export async function handleGitRequest(
 ): Promise<Response | null> {
     const baseUrl = `${url.protocol}//${url.host}`
 
-    // --- Marketplace catalog ---
+    // --- Marketplace catalog (plain HTTP) ---
     if (url.pathname === '/marketplace.json' && request.method === 'GET') {
         log.extend({ route: 'marketplace.json' })
-        const archive = await getArchive()
-        const skills = getSkills(archive)
+        const archive = await getArchive(env as unknown as Record<string, string | undefined>)
+        const bundles = getBundles(archive)
 
         if (!cachedMarketplaceJson) {
-            cachedMarketplaceJson = buildMarketplaceJson(skills, baseUrl)
+            cachedMarketplaceJson = buildMarketplaceJson(bundles, baseUrl)
         }
 
         try {
@@ -125,7 +166,7 @@ export async function handleGitRequest(
                 distinctId: deriveAnonymousId(request),
                 event: AnalyticsEvent.MARKETPLACE_VIEWED,
                 properties: {
-                    skill_count: skills.length,
+                    bundle_count: bundles.length,
                     user_agent: request.headers.get('User-Agent') || undefined,
                 },
             })
@@ -135,10 +176,7 @@ export async function handleGitRequest(
         }
 
         return new Response(cachedMarketplaceJson, {
-            headers: {
-                'Content-Type': 'application/json',
-                'Cache-Control': 'public, max-age=300',
-            },
+            headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' },
         })
     }
 
@@ -149,72 +187,86 @@ export async function handleGitRequest(
 
     const gitPath = url.pathname.slice(5) // strip "/git/"
 
-    // Parse: "marketplace/info/refs", "marketplace/git-upload-pack",
-    //        "core/info/refs", "core/git-upload-pack",
-    //        "skills/<name>/info/refs", "skills/<name>/git-upload-pack"
-    let pluginType: 'marketplace' | 'core' | 'skill'
-    let skillName: string | null = null
+    let pluginType: 'marketplace' | 'core' | 'bundle' | 'skill'
+    let itemName: string | null = null
     let gitAction: string
 
-    if (gitPath === 'marketplace' || gitPath.startsWith('marketplace/')) {
+    // marketplace
+    const mp = parseSegment(gitPath, 'marketplace')
+    if (mp[0]) {
         pluginType = 'marketplace'
-        gitAction = gitPath.length > 12 ? gitPath.slice(12) : '' // strip "marketplace/" if present
+        gitAction = mp[1]
+    // core
     } else if (gitPath.startsWith('core/')) {
         pluginType = 'core'
-        gitAction = gitPath.slice(5) // strip "core/"
-    } else if (gitPath.startsWith('skills/')) {
-        pluginType = 'skill'
-        const rest = gitPath.slice(7) // strip "skills/"
-        const slashIdx = rest.indexOf('/')
-        if (slashIdx === -1) {
-            return new Response('Not found', { status: 404 })
-        }
-        skillName = rest.slice(0, slashIdx)
-        gitAction = rest.slice(slashIdx + 1)
+        gitAction = gitPath.slice(5)
+    // bundles/:name
     } else {
-        return null
+        const bundleMatch = parseNamedSegment(gitPath, 'bundles')
+        if (bundleMatch) {
+            pluginType = 'bundle'
+            itemName = bundleMatch.name
+            gitAction = bundleMatch.gitAction
+        } else {
+            // skills/:name
+            const skillMatch = parseNamedSegment(gitPath, 'skills')
+            if (skillMatch) {
+                pluginType = 'skill'
+                itemName = skillMatch.name
+                gitAction = skillMatch.gitAction
+            } else {
+                return null
+            }
+        }
     }
 
-    log.extend({ route: 'git', pluginType, skillName, gitAction })
+    log.extend({ route: 'git', pluginType, itemName, gitAction })
 
     // Build file tree
+    const archive = await getArchive(env as unknown as Record<string, string | undefined>)
+    const skills = getSkills(archive)
     let files: FileTree
     let cacheKey: string
 
     if (pluginType === 'marketplace') {
-        const archive = await getArchive()
-        const skills = getSkills(archive)
-        const marketplaceContent = buildMarketplaceJson(skills, baseUrl)
+        const bundles = getBundles(archive)
+        const marketplaceContent = buildMarketplaceJson(bundles, baseUrl)
         files = { '.claude-plugin/marketplace.json': marketplaceContent }
         cacheKey = 'marketplace'
     } else if (pluginType === 'core') {
-        const archive = await getArchive()
-        const skills = getSkills(archive)
         const version = skills[0]?.version ?? '0.0.0'
         files = buildCorePluginFiles(version)
         cacheKey = 'core'
+    } else if (pluginType === 'bundle') {
+        const bundles = getBundles(archive)
+        const bundle = bundles.find((b) => b.name === itemName)
+        if (!bundle) {
+            return new Response('Unknown bundle', { status: 404 })
+        }
+        files = buildBundlePluginFiles(bundle, skills)
+        cacheKey = `bundle:${itemName}`
     } else {
-        const archive = await getArchive()
-        const skills = getSkills(archive)
-        const skill = skills.find((s) => s.name === skillName)
+        const skill = skills.find((s) => s.name === itemName)
         if (!skill) {
             return new Response('Unknown skill', { status: 404 })
         }
         files = buildSkillPluginFiles(skill)
-        cacheKey = `skill:${skillName}`
+        cacheKey = `skill:${itemName}`
     }
 
     const { objects, headSha, contentHash } = repoCache.getOrBuild(cacheKey, files)
     const pluginName =
-        pluginType === 'marketplace' ? 'marketplace' : pluginType === 'core' ? 'posthog' : `posthog-${skillName}`
+        pluginType === 'marketplace'
+            ? 'marketplace'
+            : pluginType === 'core'
+              ? 'posthog'
+              : `posthog-${itemName}`
 
-    // Bare path (e.g. GET /git/marketplace) — Claude Code probes the URL before cloning.
-    // For the marketplace, serve the catalog JSON directly so the schema validator passes.
+    // Bare path — Claude Code probes the URL before cloning
     if (gitAction === '' && request.method === 'GET') {
         if (pluginType === 'marketplace') {
-            const archive = await getArchive()
-            const skills = getSkills(archive)
-            const content = buildMarketplaceJson(skills, baseUrl)
+            const bundles = getBundles(archive)
+            const content = buildMarketplaceJson(bundles, baseUrl)
             return new Response(content, {
                 headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' },
             })
@@ -227,13 +279,13 @@ export async function handleGitRequest(
         if (url.searchParams.get('service') !== 'git-upload-pack') {
             return new Response('Unsupported service', { status: 403 })
         }
-        trackSkillFetch(request, ctx, pluginType, pluginName, 'info_refs', contentHash)
+        trackFetch(request, ctx, pluginType, pluginName, 'info_refs', contentHash)
         return handleInfoRefs(headSha)
     }
 
     // upload-pack
     if (gitAction === 'git-upload-pack' && request.method === 'POST') {
-        trackSkillFetch(request, ctx, pluginType, pluginName, 'upload_pack', contentHash)
+        trackFetch(request, ctx, pluginType, pluginName, 'upload_pack', contentHash)
         return handleUploadPack(request, objects, headSha)
     }
 

--- a/services/mcp/src/routes/git.ts
+++ b/services/mcp/src/routes/git.ts
@@ -22,6 +22,7 @@ import { type FileTree, GitRepoCache, handleInfoRefs, handleUploadPack } from '@
 import type { RequestLogger } from '@/lib/logging'
 import {
     type BundleEntry,
+    type RecommendSkill,
     type SkillEntry,
     buildBundlePluginFiles,
     buildCorePluginFiles,
@@ -39,6 +40,7 @@ const repoCache = new GitRepoCache()
 let cachedArchive: Unzipped | null = null
 let cachedSkills: SkillEntry[] | null = null
 let cachedBundles: BundleEntry[] | null = null
+let cachedRecommendSkill: RecommendSkill | null = null
 let cachedMarketplaceJson: string | null = null
 
 async function getArchive(env?: Record<string, string | undefined>): Promise<Unzipped> {
@@ -70,12 +72,14 @@ function getSkills(archive: Unzipped): SkillEntry[] {
     return cachedSkills
 }
 
-function getBundles(archive: Unzipped): BundleEntry[] {
+function getBundlesAndRecommendSkill(archive: Unzipped): { bundles: BundleEntry[]; recommendSkill: RecommendSkill | null } {
     if (cachedBundles) {
-        return cachedBundles
+        return { bundles: cachedBundles, recommendSkill: cachedRecommendSkill }
     }
-    cachedBundles = extractBundlesFromArchive(archive)
-    return cachedBundles
+    const result = extractBundlesFromArchive(archive)
+    cachedBundles = result.bundles
+    cachedRecommendSkill = result.recommendSkill
+    return result
 }
 
 function deriveAnonymousId(request: Request): string {
@@ -154,7 +158,7 @@ export async function handleGitRequest(
     if (url.pathname === '/marketplace.json' && request.method === 'GET') {
         log.extend({ route: 'marketplace.json' })
         const archive = await getArchive(env as unknown as Record<string, string | undefined>)
-        const bundles = getBundles(archive)
+        const { bundles } = getBundlesAndRecommendSkill(archive)
 
         if (!cachedMarketplaceJson) {
             cachedMarketplaceJson = buildMarketplaceJson(bundles, baseUrl)
@@ -228,18 +232,17 @@ export async function handleGitRequest(
     let files: FileTree
     let cacheKey: string
 
+    const { bundles, recommendSkill } = getBundlesAndRecommendSkill(archive)
+
     if (pluginType === 'marketplace') {
-        const bundles = getBundles(archive)
         const marketplaceContent = buildMarketplaceJson(bundles, baseUrl)
         files = { '.claude-plugin/marketplace.json': marketplaceContent }
         cacheKey = 'marketplace'
     } else if (pluginType === 'core') {
         const version = skills[0]?.version ?? '0.0.0'
-        const bundles = getBundles(archive)
-        files = buildCorePluginFiles(version, bundles)
+        files = buildCorePluginFiles(version, recommendSkill)
         cacheKey = 'core'
     } else if (pluginType === 'bundle') {
-        const bundles = getBundles(archive)
         const bundle = bundles.find((b) => b.name === itemName)
         if (!bundle) {
             return new Response('Unknown bundle', { status: 404 })
@@ -266,7 +269,6 @@ export async function handleGitRequest(
     // Bare path — Claude Code probes the URL before cloning
     if (gitAction === '' && request.method === 'GET') {
         if (pluginType === 'marketplace') {
-            const bundles = getBundles(archive)
             const content = buildMarketplaceJson(bundles, baseUrl)
             return new Response(content, {
                 headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' },

--- a/services/mcp/src/routes/git.ts
+++ b/services/mcp/src/routes/git.ts
@@ -1,0 +1,239 @@
+/**
+ * Git smart HTTP routes for synthetic plugin distribution.
+ *
+ * Serves per-skill and core plugin repos via the git smart HTTP protocol,
+ * enabling per-plugin install attribution through PostHog analytics events.
+ *
+ * Routes:
+ *   GET  /marketplace.json                              → plugin catalog (plain HTTP)
+ *   GET  /git/marketplace/info/refs?service=...         → marketplace repo (for `plugin marketplace add`)
+ *   POST /git/marketplace/git-upload-pack               → marketplace repo packfile
+ *   GET  /git/core/info/refs?service=git-upload-pack    → core plugin
+ *   POST /git/core/git-upload-pack                      → core plugin packfile
+ *   GET  /git/skills/:name/info/refs?service=...        → per-skill plugin
+ *   POST /git/skills/:name/git-upload-pack              → per-skill packfile
+ */
+
+import { createHash } from 'node:crypto'
+
+import type { Unzipped } from 'fflate'
+
+import { AnalyticsEvent, getPostHogClient } from '@/lib/analytics'
+import { type FileTree, GitRepoCache, handleInfoRefs, handleUploadPack } from '@/lib/git'
+import type { RequestLogger } from '@/lib/logging'
+import {
+    buildCorePluginFiles,
+    buildMarketplaceJson,
+    buildSkillPluginFiles,
+    extractSkillsFromArchive,
+    type SkillEntry,
+} from '@/lib/plugin-content'
+import { CONTEXT_MILL_URL } from '@/resources/index'
+
+import { strFromU8, unzipSync } from 'fflate'
+
+const repoCache = new GitRepoCache()
+
+// Module-level cache for context-mill archive (shared with resources/index.ts pattern)
+let cachedArchive: Unzipped | null = null
+let cachedSkills: SkillEntry[] | null = null
+let cachedMarketplaceJson: string | null = null
+
+async function getArchive(): Promise<Unzipped> {
+    if (cachedArchive) {
+        return cachedArchive
+    }
+
+    const response = await fetch(CONTEXT_MILL_URL)
+    if (!response.ok) {
+        throw new Error(`Failed to fetch context-mill archive: ${response.statusText}`)
+    }
+
+    const buffer = await response.arrayBuffer()
+    cachedArchive = unzipSync(new Uint8Array(buffer))
+    cachedSkills = null
+    cachedMarketplaceJson = null
+    return cachedArchive
+}
+
+function getSkills(archive: Unzipped): SkillEntry[] {
+    if (cachedSkills) {
+        return cachedSkills
+    }
+    cachedSkills = extractSkillsFromArchive(archive)
+    return cachedSkills
+}
+
+function deriveAnonymousId(request: Request): string {
+    const ip = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown'
+    const ua = request.headers.get('User-Agent') || ''
+    return createHash('sha256').update(`${ip}:${ua}`).digest('hex').slice(0, 32)
+}
+
+function trackSkillFetch(
+    request: Request,
+    ctx: ExecutionContext,
+    pluginType: 'marketplace' | 'core' | 'skill',
+    pluginName: string,
+    requestType: 'info_refs' | 'upload_pack',
+    contentHash: string
+): void {
+    try {
+        const client = getPostHogClient()
+        client.capture({
+            distinctId: deriveAnonymousId(request),
+            event: AnalyticsEvent.SKILL_FETCHED,
+            properties: {
+                plugin_type: pluginType,
+                plugin_name: pluginName,
+                request_type: requestType,
+                content_version: contentHash,
+                user_agent: request.headers.get('User-Agent') || undefined,
+                $ip: request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || undefined,
+            },
+        })
+        ctx.waitUntil(client.flush())
+    } catch {
+        // Never let analytics break the request
+    }
+}
+
+/**
+ * Handle git and marketplace requests. Returns a Response if the path matches,
+ * or null to let the main router continue.
+ */
+export async function handleGitRequest(
+    request: Request,
+    url: URL,
+    ctx: ExecutionContext,
+    log: RequestLogger
+): Promise<Response | null> {
+    const baseUrl = `${url.protocol}//${url.host}`
+
+    // --- Marketplace catalog ---
+    if (url.pathname === '/marketplace.json' && request.method === 'GET') {
+        log.extend({ route: 'marketplace.json' })
+        const archive = await getArchive()
+        const skills = getSkills(archive)
+
+        if (!cachedMarketplaceJson) {
+            cachedMarketplaceJson = buildMarketplaceJson(skills, baseUrl)
+        }
+
+        try {
+            const client = getPostHogClient()
+            client.capture({
+                distinctId: deriveAnonymousId(request),
+                event: AnalyticsEvent.MARKETPLACE_VIEWED,
+                properties: {
+                    skill_count: skills.length,
+                    user_agent: request.headers.get('User-Agent') || undefined,
+                },
+            })
+            ctx.waitUntil(client.flush())
+        } catch {
+            // Never let analytics break the request
+        }
+
+        return new Response(cachedMarketplaceJson, {
+            headers: {
+                'Content-Type': 'application/json',
+                'Cache-Control': 'public, max-age=300',
+            },
+        })
+    }
+
+    // --- Git endpoints ---
+    if (!url.pathname.startsWith('/git/')) {
+        return null
+    }
+
+    const gitPath = url.pathname.slice(5) // strip "/git/"
+
+    // Parse: "marketplace/info/refs", "marketplace/git-upload-pack",
+    //        "core/info/refs", "core/git-upload-pack",
+    //        "skills/<name>/info/refs", "skills/<name>/git-upload-pack"
+    let pluginType: 'marketplace' | 'core' | 'skill'
+    let skillName: string | null = null
+    let gitAction: string
+
+    if (gitPath === 'marketplace' || gitPath.startsWith('marketplace/')) {
+        pluginType = 'marketplace'
+        gitAction = gitPath.length > 12 ? gitPath.slice(12) : '' // strip "marketplace/" if present
+    } else if (gitPath.startsWith('core/')) {
+        pluginType = 'core'
+        gitAction = gitPath.slice(5) // strip "core/"
+    } else if (gitPath.startsWith('skills/')) {
+        pluginType = 'skill'
+        const rest = gitPath.slice(7) // strip "skills/"
+        const slashIdx = rest.indexOf('/')
+        if (slashIdx === -1) {
+            return new Response('Not found', { status: 404 })
+        }
+        skillName = rest.slice(0, slashIdx)
+        gitAction = rest.slice(slashIdx + 1)
+    } else {
+        return null
+    }
+
+    log.extend({ route: 'git', pluginType, skillName, gitAction })
+
+    // Build file tree
+    let files: FileTree
+    let cacheKey: string
+
+    if (pluginType === 'marketplace') {
+        const archive = await getArchive()
+        const skills = getSkills(archive)
+        const marketplaceContent = buildMarketplaceJson(skills, baseUrl)
+        files = { '.claude-plugin/marketplace.json': marketplaceContent }
+        cacheKey = 'marketplace'
+    } else if (pluginType === 'core') {
+        files = buildCorePluginFiles()
+        cacheKey = 'core'
+    } else {
+        const archive = await getArchive()
+        const skills = getSkills(archive)
+        const skill = skills.find((s) => s.name === skillName)
+        if (!skill) {
+            return new Response('Unknown skill', { status: 404 })
+        }
+        files = buildSkillPluginFiles(skill)
+        cacheKey = `skill:${skillName}`
+    }
+
+    const { objects, headSha, contentHash } = repoCache.getOrBuild(cacheKey, files)
+    const pluginName =
+        pluginType === 'marketplace' ? 'marketplace' : pluginType === 'core' ? 'posthog' : `posthog-${skillName}`
+
+    // Bare path (e.g. GET /git/marketplace) — Claude Code probes the URL before cloning.
+    // For the marketplace, serve the catalog JSON directly so the schema validator passes.
+    if (gitAction === '' && request.method === 'GET') {
+        if (pluginType === 'marketplace') {
+            const archive = await getArchive()
+            const skills = getSkills(archive)
+            const content = buildMarketplaceJson(skills, baseUrl)
+            return new Response(content, {
+                headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' },
+            })
+        }
+        return new Response('', { status: 200, headers: { 'Content-Type': 'text/plain' } })
+    }
+
+    // info/refs
+    if (gitAction === 'info/refs' && request.method === 'GET') {
+        if (url.searchParams.get('service') !== 'git-upload-pack') {
+            return new Response('Unsupported service', { status: 403 })
+        }
+        trackSkillFetch(request, ctx, pluginType, pluginName, 'info_refs', contentHash)
+        return handleInfoRefs(headSha)
+    }
+
+    // upload-pack
+    if (gitAction === 'git-upload-pack' && request.method === 'POST') {
+        trackSkillFetch(request, ctx, pluginType, pluginName, 'upload_pack', contentHash)
+        return handleUploadPack(request, objects, headSha)
+    }
+
+    return new Response('Not found', { status: 404 })
+}

--- a/services/mcp/tests/unit/git.test.ts
+++ b/services/mcp/tests/unit/git.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import { type FileTree, GitRepoCache, handleInfoRefs, synthesizeRepo } from '@/lib/git'
+
+describe('synthesizeRepo', () => {
+    it('produces objects and a head SHA for a simple file tree', () => {
+        const files: FileTree = {
+            'README.md': '# Hello',
+            'src/index.ts': 'console.log("hi")',
+        }
+
+        const { objects, headSha } = synthesizeRepo(files)
+
+        expect(headSha).toMatch(/^[0-9a-f]{40}$/)
+        expect(objects.length).toBeGreaterThan(0)
+
+        // Should have: 2 blobs + 2 trees (src/ and root) + 1 commit = 5
+        expect(objects).toHaveLength(5)
+    })
+
+    it('is deterministic — same content produces same SHA', () => {
+        const files: FileTree = { 'a.txt': 'hello' }
+
+        const r1 = synthesizeRepo(files)
+        const r2 = synthesizeRepo(files)
+
+        expect(r1.headSha).toBe(r2.headSha)
+        expect(r1.objects.length).toBe(r2.objects.length)
+    })
+
+    it('produces different SHAs for different content', () => {
+        const r1 = synthesizeRepo({ 'a.txt': 'v1' })
+        const r2 = synthesizeRepo({ 'a.txt': 'v2' })
+
+        expect(r1.headSha).not.toBe(r2.headSha)
+    })
+
+    it('handles nested directories', () => {
+        const files: FileTree = {
+            'a/b/c/deep.txt': 'deep content',
+        }
+
+        const { objects, headSha } = synthesizeRepo(files)
+        expect(headSha).toMatch(/^[0-9a-f]{40}$/)
+
+        // 1 blob + 3 trees (c/, b/, a/ → root merges with a/) + root tree + commit
+        // Actually: 1 blob + tree(c) + tree(b) + tree(a) + tree(root) + commit = 6
+        // Wait: a/b/c/deep.txt → dirs: a → b → c → file: deep.txt
+        // Trees: c (has deep.txt), b (has c), a (has b), root (has a) = 4 trees
+        // Total: 1 blob + 4 trees + 1 commit = 6
+        expect(objects).toHaveLength(6)
+    })
+
+    it('handles empty file content', () => {
+        const files: FileTree = { 'empty.txt': '' }
+        const { objects, headSha } = synthesizeRepo(files)
+
+        expect(headSha).toMatch(/^[0-9a-f]{40}$/)
+        expect(objects).toHaveLength(3) // blob + tree + commit
+    })
+})
+
+describe('handleInfoRefs', () => {
+    it('returns correct content type', () => {
+        const response = handleInfoRefs('a'.repeat(40))
+
+        expect(response.headers.get('Content-Type')).toBe('application/x-git-upload-pack-advertisement')
+    })
+
+    it('includes the head SHA in the response body', async () => {
+        const sha = 'deadbeef'.repeat(5)
+        const response = handleInfoRefs(sha)
+        const body = await response.text()
+
+        expect(body).toContain(sha)
+        expect(body).toContain('refs/heads/main')
+    })
+
+    it('advertises required capabilities', async () => {
+        const response = handleInfoRefs('a'.repeat(40))
+        const body = await response.text()
+
+        expect(body).toContain('side-band-64k')
+        expect(body).toContain('symref=HEAD:refs/heads/main')
+    })
+})
+
+describe('GitRepoCache', () => {
+    it('returns cached result for identical content', () => {
+        const cache = new GitRepoCache()
+        const files: FileTree = { 'a.txt': 'hello' }
+
+        const r1 = cache.getOrBuild('test', files)
+        const r2 = cache.getOrBuild('test', files)
+
+        expect(r1.headSha).toBe(r2.headSha)
+        expect(r1.contentHash).toBe(r2.contentHash)
+    })
+
+    it('invalidates when content changes', () => {
+        const cache = new GitRepoCache()
+
+        const r1 = cache.getOrBuild('test', { 'a.txt': 'v1' })
+        const r2 = cache.getOrBuild('test', { 'a.txt': 'v2' })
+
+        expect(r1.headSha).not.toBe(r2.headSha)
+        expect(r1.contentHash).not.toBe(r2.contentHash)
+    })
+
+    it('maintains separate caches per key', () => {
+        const cache = new GitRepoCache()
+
+        const r1 = cache.getOrBuild('a', { 'a.txt': 'a' })
+        const r2 = cache.getOrBuild('b', { 'b.txt': 'b' })
+
+        expect(r1.headSha).not.toBe(r2.headSha)
+    })
+
+    it('clears all entries on invalidateAll', () => {
+        const cache = new GitRepoCache()
+        const files: FileTree = { 'a.txt': 'hello' }
+
+        const r1 = cache.getOrBuild('test', files)
+        cache.invalidateAll()
+        const r2 = cache.getOrBuild('test', files)
+
+        // Same content so same hash, but it was rebuilt (no way to test this directly,
+        // just verify it doesn't throw)
+        expect(r1.headSha).toBe(r2.headSha)
+    })
+})

--- a/services/mcp/tests/unit/plugin-content.test.ts
+++ b/services/mcp/tests/unit/plugin-content.test.ts
@@ -1,18 +1,47 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+    type BundleEntry,
+    type SkillEntry,
+    buildBundlePluginFiles,
     buildCorePluginFiles,
     buildMarketplaceJson,
     buildSkillPluginFiles,
-    type SkillEntry,
 } from '@/lib/plugin-content'
+
+const SKILLS: SkillEntry[] = [
+    {
+        name: 'feature-flags-react',
+        description: 'Feature flags for React',
+        version: '1.12.1',
+        files: { 'SKILL.md': '# Feature flags React', 'references/react.md': '# React docs' },
+    },
+    {
+        name: 'error-tracking-react',
+        description: 'Error tracking for React',
+        version: '1.12.1',
+        files: { 'SKILL.md': '# Error tracking React' },
+    },
+    {
+        name: 'error-tracking-nextjs',
+        description: 'Error tracking for Next.js',
+        version: '1.12.1',
+        files: { 'SKILL.md': '# Error tracking Next.js' },
+    },
+]
+
+const BUNDLE: BundleEntry = {
+    name: 'react',
+    displayName: 'PostHog for React',
+    description: 'Analytics, feature flags, and error tracking for React',
+    keywords: ['react', 'javascript'],
+    skills: ['feature-flags-react', 'error-tracking-react'],
+}
 
 describe('buildCorePluginFiles', () => {
     it('includes plugin.json with correct name and passed version', () => {
         const files = buildCorePluginFiles('1.12.1')
-        const raw = files['.claude-plugin/plugin.json']
-        expect(raw).toBeDefined()
-        const pluginJson = JSON.parse(raw!)
+        const pluginJson = JSON.parse(files['.claude-plugin/plugin.json']!)
 
         expect(pluginJson.name).toBe('posthog')
         expect(pluginJson.version).toBe('1.12.1')
@@ -21,9 +50,7 @@ describe('buildCorePluginFiles', () => {
 
     it('includes mcp.json pointing to MCP server', () => {
         const files = buildCorePluginFiles('1.0.0')
-        const raw = files['mcp.json']
-        expect(raw).toBeDefined()
-        const mcpJson = JSON.parse(raw!)
+        const mcpJson = JSON.parse(files['mcp.json']!)
 
         expect(mcpJson.mcpServers.posthog.type).toBe('http')
         expect(mcpJson.mcpServers.posthog.url).toContain('posthog.com')
@@ -31,98 +58,94 @@ describe('buildCorePluginFiles', () => {
 })
 
 describe('buildSkillPluginFiles', () => {
-    const skill: SkillEntry = {
-        name: 'exploring-llm-traces',
-        description: 'Debug and inspect LLM traces',
-        version: '1.12.1',
-        files: {
-            'SKILL.md': '---\nname: exploring-llm-traces\n---\n\n# Exploring LLM Traces\n\nContent here.',
-            'references/traces.md': '# Trace reference docs',
-        },
-    }
-
     it('includes plugin.json with dependency on core', () => {
-        const files = buildSkillPluginFiles(skill)
-        const raw = files['.claude-plugin/plugin.json']
-        expect(raw).toBeDefined()
-        const pluginJson = JSON.parse(raw!)
-
-        expect(pluginJson.name).toBe('posthog-exploring-llm-traces')
-        expect(pluginJson.dependencies).toEqual(['posthog'])
-    })
-
-    it('passes through skill version from frontmatter', () => {
-        const files = buildSkillPluginFiles(skill)
+        const files = buildSkillPluginFiles(SKILLS[0]!)
         const pluginJson = JSON.parse(files['.claude-plugin/plugin.json']!)
 
+        expect(pluginJson.name).toBe('posthog-feature-flags-react')
+        expect(pluginJson.dependencies).toEqual(['posthog'])
         expect(pluginJson.version).toBe('1.12.1')
     })
 
-    it('includes SKILL.md at the correct path', () => {
-        const files = buildSkillPluginFiles(skill)
+    it('includes SKILL.md and references at the correct paths', () => {
+        const files = buildSkillPluginFiles(SKILLS[0]!)
 
-        expect(files['skills/exploring-llm-traces/SKILL.md']).toBe(skill.files['SKILL.md'])
+        expect(files['skills/feature-flags-react/SKILL.md']).toBe('# Feature flags React')
+        expect(files['skills/feature-flags-react/references/react.md']).toBe('# React docs')
+    })
+})
+
+describe('buildBundlePluginFiles', () => {
+    it('includes plugin.json with bundle name and dependency on core', () => {
+        const files = buildBundlePluginFiles(BUNDLE, SKILLS)
+        const pluginJson = JSON.parse(files['.claude-plugin/plugin.json']!)
+
+        expect(pluginJson.name).toBe('posthog-react')
+        expect(pluginJson.dependencies).toEqual(['posthog'])
+        expect(pluginJson.keywords).toEqual(['react', 'javascript'])
+        expect(pluginJson.version).toBe('1.12.1')
     })
 
-    it('includes reference files at the correct path', () => {
-        const files = buildSkillPluginFiles(skill)
+    it('inlines all referenced skills', () => {
+        const files = buildBundlePluginFiles(BUNDLE, SKILLS)
 
-        expect(files['skills/exploring-llm-traces/references/traces.md']).toBe('# Trace reference docs')
+        expect(files['skills/feature-flags-react/SKILL.md']).toBe('# Feature flags React')
+        expect(files['skills/feature-flags-react/references/react.md']).toBe('# React docs')
+        expect(files['skills/error-tracking-react/SKILL.md']).toBe('# Error tracking React')
     })
 
-    it('includes description from the skill entry', () => {
-        const files = buildSkillPluginFiles(skill)
-        const raw = files['.claude-plugin/plugin.json']
-        expect(raw).toBeDefined()
-        const pluginJson = JSON.parse(raw!)
+    it('skips skills not found in the skills list', () => {
+        const bundle: BundleEntry = {
+            ...BUNDLE,
+            skills: ['feature-flags-react', 'nonexistent-skill'],
+        }
+        const files = buildBundlePluginFiles(bundle, SKILLS)
 
-        expect(pluginJson.description).toBe('Debug and inspect LLM traces')
+        expect(files['skills/feature-flags-react/SKILL.md']).toBeDefined()
+        expect(Object.keys(files).some((k) => k.includes('nonexistent'))).toBe(false)
+    })
+
+    it('does not include skills outside the bundle', () => {
+        const files = buildBundlePluginFiles(BUNDLE, SKILLS)
+
+        expect(Object.keys(files).some((k) => k.includes('error-tracking-nextjs'))).toBe(false)
     })
 })
 
 describe('buildMarketplaceJson', () => {
-    const skills: SkillEntry[] = [
-        { name: 'skill-a', description: 'Skill A', version: '1.0.0', files: { 'SKILL.md': '# A' } },
-        { name: 'skill-b', description: 'Skill B', version: '1.0.0', files: { 'SKILL.md': '# B' } },
+    const bundles: BundleEntry[] = [
+        BUNDLE,
+        {
+            name: 'nextjs',
+            displayName: 'PostHog for Next.js',
+            description: 'PostHog for Next.js',
+            keywords: ['nextjs'],
+            skills: ['error-tracking-nextjs'],
+        },
     ]
 
-    it('includes core plugin and all skills', () => {
-        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+    it('lists core plugin and bundles (not individual skills)', () => {
+        const json = JSON.parse(buildMarketplaceJson(bundles, 'https://mcp.posthog.com'))
         const plugins = json.plugins as Array<{ name: string }>
 
-        expect(plugins).toHaveLength(3)
+        expect(plugins).toHaveLength(3) // core + 2 bundles
         expect(plugins[0]!.name).toBe('posthog')
-        expect(plugins[1]!.name).toBe('posthog-skill-a')
-        expect(plugins[2]!.name).toBe('posthog-skill-b')
+        expect(plugins[1]!.name).toBe('posthog-react')
+        expect(plugins[2]!.name).toBe('posthog-nextjs')
     })
 
-    it('points core plugin at /git/core', () => {
-        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+    it('points bundles at /git/bundles/:name', () => {
+        const json = JSON.parse(buildMarketplaceJson(bundles, 'https://mcp.posthog.com'))
         const plugins = json.plugins as Array<{ source: { url: string } }>
 
-        expect(plugins[0]!.source.url).toBe('https://mcp.posthog.com/git/core')
+        expect(plugins[1]!.source.url).toBe('https://mcp.posthog.com/git/bundles/react')
+        expect(plugins[2]!.source.url).toBe('https://mcp.posthog.com/git/bundles/nextjs')
     })
 
-    it('points skill plugins at /git/skills/:name', () => {
-        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
-        const plugins = json.plugins as Array<{ source: { url: string } }>
-
-        expect(plugins[1]!.source.url).toBe('https://mcp.posthog.com/git/skills/skill-a')
-        expect(plugins[2]!.source.url).toBe('https://mcp.posthog.com/git/skills/skill-b')
-    })
-
-    it('sets marketplace owner', () => {
-        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
-
-        expect(json.owner.name).toBe('PostHog')
-        expect(json.name).toBe('posthog')
-    })
-
-    it('skill plugins declare dependency on core', () => {
-        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+    it('bundles declare dependency on core', () => {
+        const json = JSON.parse(buildMarketplaceJson(bundles, 'https://mcp.posthog.com'))
         const plugins = json.plugins as Array<{ dependencies?: string[] }>
 
         expect(plugins[1]!.dependencies).toEqual(['posthog'])
-        expect(plugins[2]!.dependencies).toEqual(['posthog'])
     })
 })

--- a/services/mcp/tests/unit/plugin-content.test.ts
+++ b/services/mcp/tests/unit/plugin-content.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    buildCorePluginFiles,
+    buildMarketplaceJson,
+    buildSkillPluginFiles,
+    type SkillEntry,
+} from '@/lib/plugin-content'
+
+describe('buildCorePluginFiles', () => {
+    it('includes plugin.json with correct name', () => {
+        const files = buildCorePluginFiles()
+        const raw = files['.claude-plugin/plugin.json']
+        expect(raw).toBeDefined()
+        const pluginJson = JSON.parse(raw!)
+
+        expect(pluginJson.name).toBe('posthog')
+        expect(pluginJson.version).toBeDefined()
+        expect(pluginJson.author.name).toBe('PostHog')
+    })
+
+    it('includes mcp.json pointing to MCP server', () => {
+        const files = buildCorePluginFiles()
+        const raw = files['mcp.json']
+        expect(raw).toBeDefined()
+        const mcpJson = JSON.parse(raw!)
+
+        expect(mcpJson.mcpServers.posthog.type).toBe('http')
+        expect(mcpJson.mcpServers.posthog.url).toContain('posthog.com')
+    })
+})
+
+describe('buildSkillPluginFiles', () => {
+    const skill: SkillEntry = {
+        name: 'exploring-llm-traces',
+        description: 'Debug and inspect LLM traces',
+        files: {
+            'SKILL.md': '---\nname: exploring-llm-traces\n---\n\n# Exploring LLM Traces\n\nContent here.',
+            'references/traces.md': '# Trace reference docs',
+        },
+    }
+
+    it('includes plugin.json with dependency on core', () => {
+        const files = buildSkillPluginFiles(skill)
+        const raw = files['.claude-plugin/plugin.json']
+        expect(raw).toBeDefined()
+        const pluginJson = JSON.parse(raw!)
+
+        expect(pluginJson.name).toBe('posthog-exploring-llm-traces')
+        expect(pluginJson.dependencies).toEqual(['posthog'])
+    })
+
+    it('includes SKILL.md at the correct path', () => {
+        const files = buildSkillPluginFiles(skill)
+
+        expect(files['skills/exploring-llm-traces/SKILL.md']).toBe(skill.files['SKILL.md'])
+    })
+
+    it('includes reference files at the correct path', () => {
+        const files = buildSkillPluginFiles(skill)
+
+        expect(files['skills/exploring-llm-traces/references/traces.md']).toBe('# Trace reference docs')
+    })
+
+    it('includes description from the skill entry', () => {
+        const files = buildSkillPluginFiles(skill)
+        const raw = files['.claude-plugin/plugin.json']
+        expect(raw).toBeDefined()
+        const pluginJson = JSON.parse(raw!)
+
+        expect(pluginJson.description).toBe('Debug and inspect LLM traces')
+    })
+})
+
+describe('buildMarketplaceJson', () => {
+    const skills: SkillEntry[] = [
+        { name: 'skill-a', description: 'Skill A', files: { 'SKILL.md': '# A' } },
+        { name: 'skill-b', description: 'Skill B', files: { 'SKILL.md': '# B' } },
+    ]
+
+    it('includes core plugin and all skills', () => {
+        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+        const plugins = json.plugins as Array<{ name: string }>
+
+        expect(plugins).toHaveLength(3)
+        expect(plugins[0]!.name).toBe('posthog')
+        expect(plugins[1]!.name).toBe('posthog-skill-a')
+        expect(plugins[2]!.name).toBe('posthog-skill-b')
+    })
+
+    it('points core plugin at /git/core', () => {
+        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+        const plugins = json.plugins as Array<{ source: { url: string } }>
+
+        expect(plugins[0]!.source.url).toBe('https://mcp.posthog.com/git/core')
+    })
+
+    it('points skill plugins at /git/skills/:name', () => {
+        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+        const plugins = json.plugins as Array<{ source: { url: string } }>
+
+        expect(plugins[1]!.source.url).toBe('https://mcp.posthog.com/git/skills/skill-a')
+        expect(plugins[2]!.source.url).toBe('https://mcp.posthog.com/git/skills/skill-b')
+    })
+
+    it('sets marketplace owner', () => {
+        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+
+        expect(json.owner.name).toBe('PostHog')
+        expect(json.name).toBe('posthog')
+    })
+
+    it('skill plugins declare dependency on core', () => {
+        const json = JSON.parse(buildMarketplaceJson(skills, 'https://mcp.posthog.com'))
+        const plugins = json.plugins as Array<{ dependencies?: string[] }>
+
+        expect(plugins[1]!.dependencies).toEqual(['posthog'])
+        expect(plugins[2]!.dependencies).toEqual(['posthog'])
+    })
+})


### PR DESCRIPTION
Adds a synthetic git smart HTTP layer to the MCP server that enables per-skill install attribution. Instead of one monolithic plugin clone from GitHub, each skill becomes an individually installable plugin served via git clone from mcp.posthog.com, with PostHog analytics events fired on every install and update fetch.

## Problem

Skill distribution is a bit of a shitshow, and worse yet, we don't know exactly what skills are most desired. This resolves the issue by putting us in direct control of the marketplace interface.

## Changes

- Git interface for MCP server
- Marketplace distribution via MCP server
- Analytics events for Skill consumption, including installs and updates
- Per-skill installation requests in the marketplace structure allow us to measure demand for skills

## How did you test this code?

MCP run locally and installed marketplace to Claude Code.

## 🤖 Agent context

Claude Code reimplemented a strategy I've used in personal projects to good success here. Supplemented with some interesting research:

> Issue #[46163](https://github.com/anthropics/claude-code/issues/46163) on anthropics/claude-code (open, no Anthropic response): plugin authors have zero visibility into installs, active users, or adoption. They're requesting exactly what the synthetic git approach provides — install counts, version distribution, usage signals. VS Code Marketplace and npm both provide this as first-party analytics. Claude Code's ecosystem has nothing.

> This means the synthetic git marketplace isn't just PostHog solving its own problem — it's a reference implementation for what every plugin author needs. That's a positioning opportunity: PostHog can dogfood its own analytics product on its own plugin distribution, and the pattern is reusable by anyone running a marketplace.
  
