### PR TITLE
fix(perf): cancel running animations on unmount to release detached scene trees

### DIFF
--- a/frontend/src/lib/hooks/useCancelAnimationsOnUnmount.ts
+++ b/frontend/src/lib/hooks/useCancelAnimationsOnUnmount.ts
@@ -1,0 +1,29 @@
+import { RefObject, useEffect, useRef } from 'react'
+
+/**
+ * Returns a ref that, when attached to a DOM element with running CSS or
+ * Web Animations, cancels every animation on the element and its subtree
+ * during React's unmount cleanup.
+ *
+ * Why this exists: Chromium's `DocumentTimeline` keeps a strong reference
+ * to every running animation. A running animation keeps a strong reference
+ * to its target element via `KeyframeEffect`. If a component unmounts
+ * while an `animation: ... infinite` declaration is still running, the
+ * detached subtree becomes pinned: timeline -> animation -> element ->
+ * parent React tree. Across many SPA navigations this accumulates into
+ * multi-GB tab memory.
+ *
+ * Cancelling animations on unmount severs the timeline back-reference so
+ * the detached element (and its parent tree) can be garbage-collected
+ * normally.
+ */
+export function useCancelAnimationsOnUnmount<T extends Element>(): RefObject<T | null> {
+    const ref = useRef<T>(null)
+    useEffect(
+        () => () => {
+            ref.current?.getAnimations({ subtree: true }).forEach((a) => a.cancel())
+        },
+        []
+    )
+    return ref
+}

--- a/frontend/src/lib/hooks/useCancelAnimationsOnUnmount.ts
+++ b/frontend/src/lib/hooks/useCancelAnimationsOnUnmount.ts
@@ -17,7 +17,7 @@ import { RefObject, useEffect, useRef } from 'react'
  * the detached element (and its parent tree) can be garbage-collected
  * normally.
  */
-export function useCancelAnimationsOnUnmount<T extends Element>(): RefObject<T | null> {
+export function useCancelAnimationsOnUnmount<T extends Element>(): RefObject<T> {
     const ref = useRef<T>(null)
     useEffect(() => {
         // Capture the element when the effect runs (ref is populated). If we

--- a/frontend/src/lib/hooks/useCancelAnimationsOnUnmount.ts
+++ b/frontend/src/lib/hooks/useCancelAnimationsOnUnmount.ts
@@ -19,11 +19,15 @@ import { RefObject, useEffect, useRef } from 'react'
  */
 export function useCancelAnimationsOnUnmount<T extends Element>(): RefObject<T | null> {
     const ref = useRef<T>(null)
-    useEffect(
-        () => () => {
-            ref.current?.getAnimations({ subtree: true }).forEach((a) => a.cancel())
-        },
-        []
-    )
+    useEffect(() => {
+        // Capture the element when the effect runs (ref is populated). If we
+        // read ref.current inside the cleanup instead, React may have already
+        // nulled the ref by then in some commit orderings, leaving the cancel
+        // a no-op.
+        const element = ref.current
+        return () => {
+            element?.getAnimations({ subtree: true }).forEach((a) => a.cancel())
+        }
+    }, [])
     return ref
 }

--- a/frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.tsx
@@ -19,7 +19,10 @@ export interface LemonSkeletonProps {
 // `LemonSkeleton` would mean the same JSX is reused across N repeats, all
 // sharing one ref — only the last-mounted skeleton would have its animations
 // cancelled, silently disabling the leak fix for the repeat case.
-function LemonSkeletonItem({ className, active = true }: Pick<LemonSkeletonProps, 'className' | 'active'>): JSX.Element {
+function LemonSkeletonItem({
+    className,
+    active = true,
+}: Pick<LemonSkeletonProps, 'className' | 'active'>): JSX.Element {
     const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
     return (
         <div

--- a/frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.tsx
@@ -14,6 +14,11 @@ export interface LemonSkeletonProps {
     active?: boolean
 }
 
+// Extracted as its own component so each `repeat={N}` instance gets its own
+// ref + `useCancelAnimationsOnUnmount` hook. Inlining this back into
+// `LemonSkeleton` would mean the same JSX is reused across N repeats, all
+// sharing one ref — only the last-mounted skeleton would have its animations
+// cancelled, silently disabling the leak fix for the repeat case.
 function LemonSkeletonItem({ className, active = true }: Pick<LemonSkeletonProps, 'className' | 'active'>): JSX.Element {
     const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
     return (

--- a/frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.tsx
@@ -1,5 +1,6 @@
 import './LemonSkeleton.scss'
 
+import { useCancelAnimationsOnUnmount } from 'lib/hooks/useCancelAnimationsOnUnmount'
 import { LemonButtonProps } from 'lib/lemon-ui/LemonButton'
 import { range } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
@@ -12,27 +13,34 @@ export interface LemonSkeletonProps {
     fade?: boolean
     active?: boolean
 }
-export function LemonSkeleton({ className, repeat, active = true, fade = false }: LemonSkeletonProps): JSX.Element {
-    const content = (
-        <div className={cn('LemonSkeleton rounded', !active && 'LemonSkeleton--static', className || 'h-4 w-full')}>
+
+function LemonSkeletonItem({ className, active = true }: Pick<LemonSkeletonProps, 'className' | 'active'>): JSX.Element {
+    const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
+    return (
+        <div
+            ref={ref}
+            className={cn('LemonSkeleton rounded', !active && 'LemonSkeleton--static', className || 'h-4 w-full')}
+        >
             {/* The span is for accessibility, but also because @storybook/test-runner smoke tests require content */}
             <span>Loading…</span>
         </div>
     )
+}
 
+export function LemonSkeleton({ className, repeat, active = true, fade = false }: LemonSkeletonProps): JSX.Element {
     if (repeat) {
         return (
             <>
                 {range(repeat).map((i) => (
                     // eslint-disable-next-line react/forbid-dom-props
                     <div key={i} style={fade ? { opacity: 1 - i / repeat } : undefined}>
-                        {content}
+                        <LemonSkeletonItem className={className} active={active} />
                     </div>
                 ))}
             </>
         )
     }
-    return content
+    return <LemonSkeletonItem className={className} active={active} />
 }
 
 LemonSkeleton.Text = function LemonSkeletonText({ className, ...props }: LemonSkeletonProps) {

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTableLoader.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTableLoader.tsx
@@ -2,6 +2,8 @@ import './LemonTableLoader.scss'
 
 import React from 'react'
 
+import { useCancelAnimationsOnUnmount } from 'lib/hooks/useCancelAnimationsOnUnmount'
+
 export function LemonTableLoader({
     loading = false,
     tag = 'div',
@@ -13,10 +15,12 @@ export function LemonTableLoader({
     /** @default 'bottom' */
     placement?: 'bottom' | 'top'
 }): JSX.Element | null {
+    const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
     if (!loading) {
         return null
     }
     return React.createElement(tag, {
+        ref,
         className: `LemonTableLoader LemonTableLoader--active ${placement === 'top' ? 'top-0' : '-bottom-px'}`,
     })
 }

--- a/frontend/src/lib/lemon-ui/Spinner/Spinner.tsx
+++ b/frontend/src/lib/lemon-ui/Spinner/Spinner.tsx
@@ -6,6 +6,8 @@ import { twJoin, twMerge } from 'tailwind-merge'
 
 import { IconPencil } from '@posthog/icons'
 
+import { useCancelAnimationsOnUnmount } from 'lib/hooks/useCancelAnimationsOnUnmount'
+
 function useTimingCapture(captureTime: boolean): void {
     const mountTimeRef = useRef<number>(performance.now())
 
@@ -44,9 +46,11 @@ export function Spinner({
     size = 'small',
 }: SpinnerProps): JSX.Element {
     useTimingCapture(captureTime)
+    const ref = useCancelAnimationsOnUnmount<SVGSVGElement>()
 
     return (
         <svg
+            ref={ref}
             // eslint-disable-next-line react/forbid-dom-props
             style={{ '--spinner-speed': speed } as React.CSSProperties}
             className={twMerge(

--- a/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.tsx
+++ b/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.tsx
@@ -1,5 +1,6 @@
 import './WrappingLoadingSkeleton.scss'
 
+import { useCancelAnimationsOnUnmount } from 'lib/hooks/useCancelAnimationsOnUnmount'
 import { cn } from 'lib/utils/css-classes'
 
 export interface WrappingLoadingSkeletonProps {
@@ -12,8 +13,10 @@ export function WrappingLoadingSkeleton({
     fullWidth = false,
     className,
 }: WrappingLoadingSkeletonProps): JSX.Element {
+    const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
     return (
         <div
+            ref={ref}
             className={cn(
                 'wrapping-loading-skeleton [&>*]:opacity-0 rounded flex flex-col gap-px w-fit overflow-hidden',
                 fullWidth && 'w-full',

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -126,9 +126,7 @@ function AppScene(): JSX.Element | null {
     if (activeExportedScene?.component) {
         const { component: SceneComponent } = activeExportedScene
         sceneElement = (
-            <SceneAnimationRoot
-                key={`scene-${activeSceneId}-${activeSceneLogicPropsWithTabId.tabId}`}
-            >
+            <SceneAnimationRoot key={`scene-${activeSceneId}-${activeSceneLogicPropsWithTabId.tabId}`}>
                 <SceneComponent user={user} {...activeSceneComponentParamsWithTabId} />
             </SceneAnimationRoot>
         )

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -43,6 +43,11 @@ window.process = MOCK_NODE_PROCESS
 function SceneAnimationRoot({ children }: { children: React.ReactNode }): JSX.Element {
     const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
     return (
+        // `className="contents"` is load-bearing: the wrapper must take a DOM
+        // node so the ref has something to attach to (we need an element to
+        // call `getAnimations({ subtree: true })` on), but it must also be
+        // transparent to layout. `display: contents` removes it from the box
+        // tree so children render as if there's no wrapper.
         <div ref={ref} className="contents">
             {children}
         </div>

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -4,6 +4,7 @@ import { Slide, ToastContainer } from 'react-toastify'
 import { Command } from 'lib/components/Command/Command'
 import { globalSetupLogic, useSetupHighlight } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS, MOCK_NODE_PROCESS } from 'lib/constants'
+import { useCancelAnimationsOnUnmount } from 'lib/hooks/useCancelAnimationsOnUnmount'
 import { useThemedHtml } from 'lib/hooks/useThemedHtml'
 import { KeaDevtools } from 'lib/KeaDevTools'
 import { ToastCloseButton } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -29,6 +30,24 @@ import { ImpersonationNotice } from '~/layout/navigation/ImpersonationNotice'
 import { MaxInstance } from './max/Max'
 
 window.process = MOCK_NODE_PROCESS
+
+/**
+ * Wraps each rendered scene so that when the scene unmounts (on tab change
+ * or scene swap), every running CSS / Web Animation under it is cancelled
+ * before the DOM detaches. This severs the `DocumentTimeline -> animation
+ * -> element` chain that otherwise pins detached scene trees in memory
+ * across SPA navigation, and lets the browser GC the trees normally.
+ *
+ * `display: contents` keeps the wrapper transparent to layout.
+ */
+function SceneAnimationRoot({ children }: { children: React.ReactNode }): JSX.Element {
+    const ref = useCancelAnimationsOnUnmount<HTMLDivElement>()
+    return (
+        <div ref={ref} className="contents">
+            {children}
+        </div>
+    )
+}
 
 export function App(): JSX.Element | null {
     const { showApp, showingDelayedSpinner, showingDevTools } = useValues(appLogic)
@@ -102,11 +121,11 @@ function AppScene(): JSX.Element | null {
     if (activeExportedScene?.component) {
         const { component: SceneComponent } = activeExportedScene
         sceneElement = (
-            <SceneComponent
-                key={`tab-${activeSceneLogicPropsWithTabId.tabId}`}
-                user={user}
-                {...activeSceneComponentParamsWithTabId}
-            />
+            <SceneAnimationRoot
+                key={`scene-${activeSceneId}-${activeSceneLogicPropsWithTabId.tabId}`}
+            >
+                <SceneComponent user={user} {...activeSceneComponentParamsWithTabId} />
+            </SceneAnimationRoot>
         )
     } else {
         sceneElement = <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />


### PR DESCRIPTION
## Problem

Real users hit multi-GB tab memory and browser OOM crashes after extended
PostHog use — heap snapshots and Chrome's task manager have shown 11 GB on a
single tab. The leak is in the renderer process: detached React trees pile up
across SPA navigations and never get released.

Root cause is Chromium's `DocumentTimeline`. It holds a strong reference to
every running animation, and each animation holds its target element via
`KeyframeEffect`. When a component with an `animation: ... infinite`
declaration unmounts, the detached subtree stays pinned by the chain
`DocumentTimeline -> animation -> element`. Spinners, table loaders, skeleton
shimmers — every loading indicator on the page is an infinite animation, and
each scene render mounts and unmounts dozens of them.

Verified empirically against a 30-minute SPA-usage simulation (250 navigations
across 10 scenes, forced GC each measurement):

- replacing `Spinner` with a `null` render dropped the leak by 70–90% — proved
  the timeline-pinning mechanism was the keystone
- a heap retainer walk on the post-sim snapshot showed every leaked
  `CSSAnimation` chained back to a single shared `DocumentTimeline`

## Changes

Small shared hook `useCancelAnimationsOnUnmount` calls
`element.getAnimations({ subtree: true }).forEach(a => a.cancel())` from a
`useEffect` cleanup. Cancelling a running animation removes it from the
timeline, severing the back-reference so the browser GCs the element normally.

Applied at two layers:

- **Leaf**: `Spinner`, `LemonTableLoader`, `LemonSkeleton` (with inner div
  extracted to `LemonSkeletonItem` so each repeated instance gets its own
  ref), `WrappingLoadingSkeleton`. Catches loading indicators that appear and
  disappear inside a single scene's lifetime.
- **Scene root**: a `SceneAnimationRoot` wrapper added in `App.tsx` around
  the rendered scene, keyed on scene id + tab id so it actually unmounts on
  each scene swap. Catches anything else animated under the scene tree we
  haven't hooked individually. `display: contents` keeps it transparent to
  layout.

## How did you test this code?

I'm an agent; tested via a 30-minute scripted SPA-navigation simulation
through 10 scenes (~250 navigations), with PRE/POST V8 heap snapshots and
periodic `Memory.getDOMCounters` + `Performance.getMetrics` samples taken via
CDP after forced GC. The measurement methodology was contaminated in earlier
runs by repeated `__leakHunter.scan()` calls — the trustworthy signal is
DOM-node and listener counts after `HeapProfiler.collectGarbage` is called
twice.

| metric | before fix Δ | after fix Δ |
| --- | ---: | ---: |
| heap | +231 MB | +43 MB |
| DOM nodes | +1,078,286 | +13,642 |
| JS event listeners | +62,947 | +14,937 |

The remaining +43 MB / +13,642 nodes / +14,937 listeners is essentially the
currently-rendered scene's own state — the POST snapshot was on
`/feature_flags` (which has ~17k natural nodes / 17k listeners). On
apples-to-apples same-scene comparison mid-run (`/home` at t=20min, after 17
nav cycles) the fix shows +83 nodes / +146 listeners vs the unfixed run's
+732k / +43k.

Manually verified the seekbar / spinner / skeleton / loader UI still works
visually after the change — `cancel()` only fires on unmount, so animations
play normally during the element's lifetime.

No automated tests added; this is a leak-scope fix that's hard to assert in a
unit test. The metric trajectory across the 30-min sim is the regression
guard, captured in [`tools/leak-hunter/long-simulation.mjs`](dev-only).

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) during a memory-leak investigation session
with Paul. Reviewed by Paul before opening — the convergent analysis (heap
retainer walk + Spinner-null A/B test + combined-fix measurement) was driven
end-to-end by him.

Tools used:
- CDP `HeapProfiler.takeHeapSnapshot` / `collectGarbage` /
  `Memory.getDOMCounters` / `Performance.getMetrics` for stable measurements
- Custom heap-snapshot streaming parser to handle 800MB+ snapshots that
  exceed Node's max string length
- `Element.getAnimations({ subtree: true })` is the standard Web Animations
  API method available in all modern browsers — no library, no shim