### PR TITLE
fix(data-warehouse): include Invoice items in Stripe restricted-key prefill

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -70,6 +70,7 @@ PERMISSIONS = [
     "rak_product_read",
     "rak_credit_note_read",
     "rak_invoice_read",
+    "rak_invoice_item_read",  # Separate scope from invoice — /v1/invoiceitems requires this even if invoice_read is set
     "rak_plan_read",  # This is `price` in the UI, but `plan` in their API
     "rak_subscription_read",
     "rak_application_fee_read",
@@ -108,7 +109,7 @@ class StripeSource(
             caption=f"Connect your Stripe account to automatically sync your Stripe data into PostHog. You can choose between OAuth (recommended) or legacy RAK Stripe keys. If you choose the latter, you will need your [Stripe account ID]({STRIPE_ACCOUNT_URL}), and create a [restricted API key]({STRIPE_API_KEYS_URL})",
             permissionsCaption="""Currently, **read permissions are required** for the following resources:
             - Under the **Core** resource type, select *read* for **Balance transaction sources**, **Charges**, **Customers**, **Disputes**, **Payouts**, and **Products**
-            - Under the **Billing** resource type, select *read* for **Credit notes**, **Invoices**, **Prices**, and **Subscriptions**
+            - Under the **Billing** resource type, select *read* for **Credit notes**, **Invoices**, **Invoice items**, **Prices**, and **Subscriptions**
             - Under the **Connect** resource type, select *read* for the **entire resource**
             - Under the **Webhooks** resource type, select *write* for **Webhook endpoints** (required for automatic webhook creation)
             These permissions are automatically pre-filled in the API key creation form if you use the link above, so all you need to do is scroll down and click "Create Key".


### PR DESCRIPTION
## Problem

Stripe treats `rak_invoice_item_read` as a distinct scope from `rak_invoice_read`. Our pre-filled restricted-key creation link and in-app help caption only request the latter, so a customer who follows our docs verbatim still hits a 403 on `/v1/invoiceitems` once PostHog tries to sync the InvoiceItem table — and reports a missing permission they had no obvious reason to enable.

Split out from #56795 because the broader credential-error surfacing work in that PR is unrelated.

## Changes

`posthog/temporal/data_imports/sources/stripe/source.py`
- Add `rak_invoice_item_read` to the `PERMISSIONS` list (it gets serialized into the prefill query string, so customers see the box pre-ticked when they click through to Stripe).
- Mention "Invoice items" in the `permissionsCaption` so the manual instructions match the prefill.

## How did you test this code?

I'm an agent; no manual UI testing was performed. The PERMISSIONS list and caption are pure data, no test coverage existed previously and none is added here.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) via Claude Code. Surfaced from a customer report whose final blocker on /v1/invoiceitems persisted after following the in-app docs end to end, indicating the prefill itself was incomplete. Human review required before merge.