### PR TITLE
fix(notebooks): edit comments inline

### DIFF
--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -134,7 +134,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
     } = useActions(commentsLogic)
 
     return editingComment?.id === comment.id ? (
-        <div className="deprecated-space-y-2 border-t p-2">
+        <div className="deprecated-space-y-2">
             <LemonRichContentEditor
                 placeholder="Edit comment"
                 initialContent={comment.rich_content}
@@ -151,10 +151,10 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                 onPressCmdEnter={persistEditedComment}
                 disabled={commentsLoading}
             />
-            <div className="flex justify-between items-center gap-2">
-                <div className="flex-1" />
+            <div className="flex justify-end items-center gap-2">
                 <LemonButton
                     type="secondary"
+                    size="small"
                     onClick={() => {
                         setEditingComment(null)
                         setEditingCommentRichContentEditor(null)
@@ -165,11 +165,12 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                 </LemonButton>
                 <LemonButton
                     type="primary"
+                    size="small"
                     onClick={persistEditedComment}
                     disabledReason={isEditingCommentEmpty ? 'No message' : commentsLoading ? 'Saving...' : null}
                     sideIcon={<KeyboardShortcut command enter />}
                 >
-                    Save changes
+                    Save
                 </LemonButton>
             </div>
         </div>
@@ -226,7 +227,8 @@ const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
 
     const ref = useRef<HTMLDivElement | null>(null)
 
-    const isHighlighted = replyingCommentId === comment.id || editingComment?.id === comment.id
+    const isEditing = editingComment?.id === comment.id
+    const isHighlighted = replyingCommentId === comment.id || isEditing
 
     useEffect(() => {
         if (isHighlighted) {
@@ -244,15 +246,17 @@ const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
                 <div className="flex-1 flex justify-start gap-2">
                     <ProfilePicture size="xl" user={comment.created_by} />
 
-                    <div className="flex flex-col flex-1">
+                    <div className="flex flex-col flex-1 min-w-0">
                         <CommentTopRow comment={comment} />
-                        <LemonMarkdown lowKeyHeadings>{getText(comment)}</LemonMarkdown>
+                        {isEditing ? (
+                            <CommentEditingForm comment={comment} />
+                        ) : (
+                            <LemonMarkdown lowKeyHeadings>{getText(comment)}</LemonMarkdown>
+                        )}
                     </div>
                 </div>
-                <CommentBottomRow comment={comment} />
+                {!isEditing && <CommentBottomRow comment={comment} />}
             </div>
-
-            <CommentEditingForm comment={comment} />
         </div>
     )
 }

--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -123,7 +123,7 @@ const CommentBottomRow = ({ comment }: { comment: CommentType }): JSX.Element =>
     )
 }
 
-const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element | null => {
+const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element => {
     const { editingComment, commentsLoading, editingCommentRichContentEditor, isEditingCommentEmpty } =
         useValues(commentsLogic)
     const {
@@ -133,7 +133,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
         onEditingCommentRichContentEditorUpdate,
     } = useActions(commentsLogic)
 
-    return editingComment?.id === comment.id ? (
+    return (
         <div className="deprecated-space-y-2">
             <LemonRichContentEditor
                 placeholder="Edit comment"
@@ -174,7 +174,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                 </LemonButton>
             </div>
         </div>
-    ) : null
+    )
 }
 
 const CommentTopRow = ({ comment }: { comment: CommentType }): JSX.Element => {

--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -140,7 +140,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                 initialContent={comment.rich_content}
                 onCreate={setEditingCommentRichContentEditor}
                 onUpdate={(isEmpty) => {
-                    if (editingCommentRichContentEditor) {
+                    if (editingCommentRichContentEditor && editingComment) {
                         setEditingComment({
                             ...editingComment,
                             rich_content: editingCommentRichContentEditor.getJSON(),


### PR DESCRIPTION
## Problem

When editing a comment, the existing text was rendered twice — once as the original comment, and again in a separate composer below it with a "Save changes" button. Reported as a notebook papercut: users expected the edit to happen in place, like Slack.

## Changes

In `frontend/src/scenes/comments/Comment.tsx`:

- Replace the rendered `LemonMarkdown` with `CommentEditingForm` in the same slot when the comment is being edited, instead of appending the form below.
- Hide the bottom row (reactions / "(edited)" indicator) while editing, so the active editor isn't surrounded by noisy controls — matches the Slack reference.

<img width="2556" height="1704" alt="2026-04-30 18 59 53" src="https://github.com/user-attachments/assets/6749eae2-1783-4604-a392-74e1e7131ab6" />


## How did you test this code?
Left a few comments in a notebook, edited them, verified there's no overflow or other weird issues

## Publish to changelog?
no