### PR TITLE
chore(personhog): sets up phog in hobby and by default in local

### DIFF
--- a/bin/start-backend
+++ b/bin/start-backend
@@ -14,6 +14,10 @@ export CLICKHOUSE_API_PASSWORD="apipass"
 export CLICKHOUSE_APP_USER="app"
 export CLICKHOUSE_APP_PASSWORD="apppass"
 
+export PERSONHOG_ADDR=${PERSONHOG_ADDR:-http://127.0.0.1:50052}
+export PERSONHOG_ENABLED=${PERSONHOG_ENABLED:-true}
+export PERSONHOG_ROLLOUT_PERCENTAGE=${PERSONHOG_ROLLOUT_PERCENTAGE:-100}
+
 # Suppress frozen modules warning since we only debug our code, not stdlib
 export PYDEVD_DISABLE_FILE_VALIDATION=1
 

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -350,3 +350,5 @@ always_required:
     - feature-flags
     - hypercache-server
     - property-defs-rs
+    - personhog-replica
+    - personhog-router

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -397,6 +397,33 @@ services:
             COOKIELESS_REDIS_HOST: redis7
             COOKIELESS_REDIS_PORT: 6379
 
+    personhog-replica:
+        image: ghcr.io/posthog/posthog/personhog-replica:master
+        build:
+            context: rust/
+            args:
+                BIN: personhog-replica
+        restart: on-failure
+        environment:
+            GRPC_ADDRESS: '0.0.0.0:50051'
+            PRIMARY_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog_persons'
+            RUST_LOG: 'info'
+            METRICS_PORT: '9100'
+
+    personhog-router:
+        image: ghcr.io/posthog/posthog/personhog-router:master
+        build:
+            context: rust/
+            args:
+                BIN: personhog-router
+        restart: on-failure
+        environment:
+            GRPC_ADDRESS: '0.0.0.0:50052'
+            REPLICA_URL: 'http://personhog-replica:50051'
+            BACKEND_TIMEOUT_MS: '5000'
+            RUST_LOG: 'info'
+            METRICS_PORT: '9101'
+
     hypercache-server:
         image: ghcr.io/posthog/posthog/hypercache-server:master
         build:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -97,6 +97,9 @@ services:
             RECORDING_API_URL: http://recording-api:6738
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             POSTHOG_SKIP_MIGRATION_CHECKS: '1'
+            PERSONHOG_ADDR: 'http://personhog-router:50052'
+            PERSONHOG_ENABLED: 'true'
+            PERSONHOG_ROLLOUT_PERCENTAGE: '100'
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
         depends_on:
             db:
@@ -108,6 +111,8 @@ services:
             kafka:
                 condition: service_healthy
             web:
+                condition: service_started
+            personhog-router:
                 condition: service_started
     web:
         extends:
@@ -137,6 +142,9 @@ services:
             OTEL_SDK_DISABLED: 'true'
             OPT_OUT_CAPTURE: ${OPT_OUT_CAPTURE:-false}
             DEPLOYMENT: 'hobby'
+            PERSONHOG_ADDR: 'http://personhog-router:50052'
+            PERSONHOG_ENABLED: 'true'
+            PERSONHOG_ROLLOUT_PERCENTAGE: '100'
         depends_on:
             - db
             - redis7
@@ -144,6 +152,7 @@ services:
             - kafka
             - objectstorage
             - seaweedfs
+            - personhog-router
 
     plugins:
         extends:
@@ -435,6 +444,29 @@ services:
             - LIVESTREAM_JWT_SECRET=${POSTHOG_SECRET}
         volumes:
             - ./posthog/docker/livestream/configs-hobby.yml:/configs/configs.yml
+
+    personhog-replica:
+        build:
+            context: ./posthog/rust
+        extends:
+            file: docker-compose.base.yml
+            service: personhog-replica
+        logging: *default-logging
+        environment:
+            PRIMARY_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+        depends_on:
+            db:
+                condition: service_healthy
+
+    personhog-router:
+        build:
+            context: ./posthog/rust
+        extends:
+            file: docker-compose.base.yml
+            service: personhog-router
+        logging: *default-logging
+        depends_on:
+            - personhog-replica
 
     feature-flags:
         build:


### PR DESCRIPTION
## Problem

Soon some services will rely on personhog to function so hobby needs to include personhog-router and personhog-replica. Furthermore, we should have local dev build these services by default

## Changes

- **`docker-compose.base.yml`**: Added base service definitions for `personhog-replica` and `personhog-router` (following the same pattern as `capture`, `feature-flags`, etc.). Default `PRIMARY_DATABASE_URL` points to `posthog_persons` for deployments with a separate persons database.
- **`docker-compose.hobby.yml`**: Added `personhog-replica` and `personhog-router` services, overriding `PRIMARY_DATABASE_URL` to the main `posthog` database (hobby never migrated persons tables to a separate DB). Wired `PERSONHOG_ADDR`, `PERSONHOG_ENABLED=true`, and `PERSONHOG_ROLLOUT_PERCENTAGE=100` into `web` and `worker` services, with `personhog-router` as a dependency.
- **`bin/start-backend`**: Set `PERSONHOG_ADDR`, `PERSONHOG_ENABLED`, and `PERSONHOG_ROLLOUT_PERCENTAGE` defaults so the Django backend connects to personhog out of the box in local dev. All three are overridable via env vars.
- **`devenv/intent-map.yaml`**: Added `personhog-replica` and `personhog-router` to `always_required` so they start for every local dev session regardless of intent selection.

Only the router and replica services are included — leader, writer, and etcd coordination are not needed yet.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
