### PR TITLE
fix(replay): show cancel button while summary is loading

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -78,7 +78,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
         >
             {isOpen && <Resizer {...resizerProps} />}
             <div className="flex items-center justify-between h-11 px-3 shrink-0">
-                {hasSummary || sessionSummaryLoading ? (
+                {hasSummary ? (
                     <div className="flex items-center gap-2 font-semibold">
                         <IconMagicWand className="text-primary" />
                         AI summary


### PR DESCRIPTION
## Problem

PRs #56934 and #56960 introduced an unreachable branch in `PlayerSummaryDock`. After both merged, the cancel button added in #56960 never renders because the outer ternary's "show AI summary header" branch fires whenever `sessionSummaryLoading` is true, swallowing the case the cancel branch was meant to handle:

```ts
{hasSummary || sessionSummaryLoading ? (
    <div>AI summary header</div>
) : sessionSummaryLoading ? (              // unreachable: outer ternary already caught this
    <LemonButton ... data-attr="cancel-session-summary">
        Cancel summarization
    </LemonButton>
) : (
    <LemonButton ... data-attr="load-session-summary">
        Use AI to summarize this session
    </LemonButton>
)}
```

`#56934` widened the outer condition from `hasSummary` to `hasSummary || sessionSummaryLoading` (so loading would show the header instead of a spinning button). `#56960` later inserted a new branch positioned for the loading state but didn't update the outer condition. The branches end up logically overlapping and the cancel button is dead.

## Changes

Drop `|| sessionSummaryLoading` from the outer ternary in `frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx`. The three branches are now genuinely exclusive:

- `hasSummary` → "AI summary" header
- `sessionSummaryLoading` → "Cancel summarization" button (now actually reachable)
- otherwise → "Use AI to summarize this session" button

## How did you test this code?

I'm an agent; I have not manually tested this in a browser. The change is a one-character logical fix verified by reading the post-merge file from `master` and tracing the ternary against the three reachable states. No automated tests exist for this component yet, and none were added in this PR.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7) at the user's direction after they reported the cancel button was missing from production despite #56960 having merged.
- Investigation: read the merged file from `master`, traced the ternary, and identified the unreachable branch as a merge-resolution artifact between #56934 and #56960.
- Decision: minimal one-line fix, restoring exclusive branches, rather than restructuring the ternary into separate `if` blocks.
- No manual browser testing performed. Reviewer should verify in dev that the cancel button appears while a summary is generating and that the existing "loading does not show the spinning button" behavior from #56934 is preserved.
