### PR TITLE
fix(web-analytics): Prevent SCRIPT_PLACEHOLDER from showing on heatmaps

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -22,7 +22,7 @@ import {
     recordingMetaJson,
     setupSessionRecordingTest,
 } from './__mocks__/test-setup'
-import { findNewEvents, findSegmentForTimestamp } from './sessionRecordingPlayerLogic'
+import { findNewEvents, findSegmentForTimestamp, stripRrwebScriptShims } from './sessionRecordingPlayerLogic'
 import { snapshotDataLogic } from './snapshotDataLogic'
 import { deleteRecording as deleteRecordingMock } from './utils/playerUtils'
 
@@ -84,6 +84,56 @@ describe('findNewEvents', () => {
         const currentEvents = current.map((ts) => makeEvent(ts))
         const result = findNewEvents(allSnapshots, currentEvents)
         expect(result.map((e) => e.timestamp)).toEqual(expected)
+    })
+})
+
+describe('stripRrwebScriptShims', () => {
+    const countTag = (html: string, tag: string): number => (html.match(new RegExp(`<${tag}\\b`, 'gi')) || []).length
+
+    it.each([
+        { description: 'empty string', input: '' },
+        { description: 'no noscript tags', input: '<head></head><body><div>hello</div></body>' },
+    ])('passes through unchanged when there is nothing to strip ($description)', ({ input }) => {
+        expect(stripRrwebScriptShims(input)).toBe(input)
+    })
+
+    it('removes inline-script shims (noscript with SCRIPT_PLACEHOLDER body)', () => {
+        const input = '<head></head><body><p>real</p><noscript>SCRIPT_PLACEHOLDER</noscript></body>'
+        const output = stripRrwebScriptShims(input)
+        expect(output).not.toContain('SCRIPT_PLACEHOLDER')
+        expect(output).not.toContain('<noscript')
+        expect(output).toContain('<p>real</p>')
+    })
+
+    it('removes external-script shims (noscript with src/type/async attrs)', () => {
+        const input =
+            '<head><noscript type="text/javascript" async="" src="https://cdn.example.com/array.js"></noscript></head><body></body>'
+        const output = stripRrwebScriptShims(input)
+        expect(output).not.toContain('<noscript')
+        expect(output).not.toContain('cdn.example.com/array.js')
+    })
+
+    it('removes every noscript when many appear in a row (the reported repro)', () => {
+        const input =
+            '<head>' +
+            '<noscript type="text/javascript" async="" src="https://pcdn.example.com/array.js"></noscript>' +
+            '<noscript>SCRIPT_PLACEHOLDER</noscript>' +
+            '<noscript>SCRIPT_PLACEHOLDER</noscript>' +
+            '</head><body><h1>page</h1></body>'
+        const output = stripRrwebScriptShims(input)
+        expect(countTag(output, 'noscript')).toBe(0)
+        expect(output).not.toContain('SCRIPT_PLACEHOLDER')
+        expect(output).toContain('<h1>page</h1>')
+    })
+
+    it('preserves surrounding DOM structure (head + body content)', () => {
+        const input =
+            '<head><title>t</title><noscript>SCRIPT_PLACEHOLDER</noscript></head>' +
+            '<body><main><p>kept</p></main></body>'
+        const output = stripRrwebScriptShims(input)
+        expect(output).toContain('<title>t</title>')
+        expect(output).toContain('<main><p>kept</p></main>')
+        expect(countTag(output, 'noscript')).toBe(0)
     })
 })
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -191,7 +191,7 @@ const NOSCRIPT_BLOCK_RE = /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi
  * the heatmap iframe.
  */
 export function stripRrwebScriptShims(html: string): string {
-    if (!html || !html.includes('<noscript')) {
+    if (!html || !/<noscript\b/i.test(html)) {
         return html
     }
     return html.replace(NOSCRIPT_BLOCK_RE, '')

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -184,6 +184,19 @@ export function removeReplayIframeDataFromLocalStorage(): void {
     removeFromLocalStorageWithPrefix(ReplayIframeDatakeyPrefix)
 }
 
+const NOSCRIPT_BLOCK_RE = /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi
+
+/**
+ * Strip <noscript> elements from rrweb replay iframe HTML before handing it to
+ * the heatmap iframe.
+ */
+export function stripRrwebScriptShims(html: string): string {
+    if (!html || !html.includes('<noscript')) {
+        return html
+    }
+    return html.replace(NOSCRIPT_BLOCK_RE, '')
+}
+
 /**
  * returns the relative second in the recording
  * e.g. if the player starts at 1000ms and the snapshot is at 2000ms or 1500ms, the relative second is 1
@@ -2143,16 +2156,16 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         openHeatmap: () => {
             actions.setPause()
             const iframe = values.rootFrame?.querySelector('iframe')
-            const iframeHtml = iframe?.contentWindow?.document?.documentElement?.innerHTML
+            const rawIframeHtml = iframe?.contentWindow?.document?.documentElement?.innerHTML
             const resolution = values.resolution
-            if (!iframeHtml || !resolution) {
+            if (!rawIframeHtml || !resolution) {
                 return
             }
 
             removeFromLocalStorageWithPrefix(ReplayIframeDatakeyPrefix)
             const key = ReplayIframeDatakeyPrefix + uuid()
             const data: ReplayIframeData = {
-                html: iframeHtml,
+                html: stripRrwebScriptShims(rawIframeHtml),
                 width: resolution.width,
                 height: resolution.height,
                 startDateTime: values.sessionPlayerMetaData?.start_time,


### PR DESCRIPTION
## Problem
When navigating to a heatmap from a session replay, "SCRIPT_PLACEHOLDER" is displayed across the screen.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Strip `<noscript>` tags from the iframe before passing it to the heatmap.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Added tests
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
