### PR TITLE
fix(replay): make the replay summary text selectable for c+v

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryViews.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryViews.tsx
@@ -478,7 +478,7 @@ function SessionSegmentView({
                 header={
                     <div className="py-2">
                         <div className="flex flex-row gap-2">
-                            <h3 className="mb-1">{segment.name}</h3>
+                            <h3 className="mb-1 select-text">{segment.name}</h3>
                             {segmentOutcome && Object.keys(segmentOutcome).length > 0 ? (
                                 <div>
                                     {segmentOutcome.success ? null : (
@@ -493,7 +493,7 @@ function SessionSegmentView({
                         </div>
                         {segmentOutcome && (
                             <>
-                                <p className="text-sm font-normal mb-0">{segmentOutcome.summary}</p>
+                                <p className="text-sm font-normal mb-0 select-text">{segmentOutcome.summary}</p>
                             </>
                         )}
                         <SegmentMetaTable


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
current implementation of `LemonCollapse` component uses `LemonButton` for the header clickable section, `LemonButton` disables user selecting over the text etc (which makes sense) but for summary text it makes sense to enable users to select over the text to let them copy + paste etc.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- make the text within summaries selectable.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
