### PR TITLE
feat(hog-charts): add axis-orientation hooks to Chart base

### DIFF
--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -78,11 +78,9 @@ export interface ChartProps<Meta = unknown> {
      *  should ensure that toggle also updates `series` or the chart's scales — otherwise
      *  a held pin will keep showing values from the previous resolver. */
     resolveValue?: ResolveValueFn
-    /** Which axis the categorical-label hit detection runs on. Defaults to 'x'.
-     *  `'y'` is used for horizontal bar charts. */
-    interactionAxis?: 'x' | 'y'
-    /** Used instead of `scales.x` to map labels to a coordinate on `interactionAxis`.
-     *  Useful for bar charts that map labels to band centers, not point positions. */
+    /** Required for horizontal orientation — maps labels to the coordinate on the categorical
+     *  axis (y in horizontal mode). Should be referentially stable; non-stable identities
+     *  invalidate the interaction memo on every render. */
     labelToCoord?: (label: string) => number | undefined
 }
 
@@ -99,7 +97,6 @@ export function Chart<Meta = unknown>({
     className,
     children,
     resolveValue,
-    interactionAxis = 'x',
     labelToCoord,
 }: ChartProps<Meta>): React.ReactElement {
     const {
@@ -111,6 +108,7 @@ export function Chart<Meta = unknown>({
         showCrosshair = false,
         axisOrientation = 'vertical',
     } = config ?? {}
+    const interactionAxis: 'x' | 'y' = axisOrientation === 'horizontal' ? 'y' : 'x'
     const {
         enabled: showTooltip = true,
         pinnable: pinnableTooltip = false,

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -78,6 +78,12 @@ export interface ChartProps<Meta = unknown> {
      *  should ensure that toggle also updates `series` or the chart's scales — otherwise
      *  a held pin will keep showing values from the previous resolver. */
     resolveValue?: ResolveValueFn
+    /** Which axis the categorical-label hit detection runs on. Defaults to 'x'.
+     *  `'y'` is used for horizontal bar charts. */
+    interactionAxis?: 'x' | 'y'
+    /** Used instead of `scales.x` to map labels to a coordinate on `interactionAxis`.
+     *  Useful for bar charts that map labels to band centers, not point positions. */
+    labelToCoord?: (label: string) => number | undefined
 }
 
 export function Chart<Meta = unknown>({
@@ -93,6 +99,8 @@ export function Chart<Meta = unknown>({
     className,
     children,
     resolveValue,
+    interactionAxis = 'x',
+    labelToCoord,
 }: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
@@ -101,6 +109,7 @@ export function Chart<Meta = unknown>({
         hideYAxis = false,
         tooltip: tooltipConfig,
         showCrosshair = false,
+        axisOrientation = 'vertical',
     } = config ?? {}
     const {
         enabled: showTooltip = true,
@@ -108,7 +117,15 @@ export function Chart<Meta = unknown>({
         placement: tooltipPlacement = 'follow-data',
     } = tooltipConfig ?? {}
 
-    const margins = useChartMargins({ series, labels, hideXAxis, hideYAxis, xTickFormatter, yTickFormatter })
+    const margins = useChartMargins({
+        series,
+        labels,
+        hideXAxis,
+        hideYAxis,
+        xTickFormatter,
+        yTickFormatter,
+        axisOrientation,
+    })
 
     const { canvasRef, overlayCanvasRef, wrapperRef, dimensions, ctx, overlayCtx } = useChartCanvas({ margins })
 
@@ -141,13 +158,21 @@ export function Chart<Meta = unknown>({
         pinnable: pinnableTooltip,
         onPointClick,
         resolveValue,
+        interactionAxis,
+        labelToCoord,
     })
 
     // ref keeps composedDrawHover stable across drawHover identity changes
     const drawHoverRef = useLatest(drawHover)
     const composedDrawHover = useMemo(
-        () => composeDrawHoverWithCrosshair(() => drawHoverRef.current, theme.crosshairColor, showCrosshair),
-        [showCrosshair, theme.crosshairColor]
+        () =>
+            composeDrawHoverWithCrosshair(() => drawHoverRef.current, {
+                crosshairColor: theme.crosshairColor,
+                showCrosshair,
+                axisOrientation,
+                labelToCoord,
+            }),
+        [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord]
     )
 
     useChartDraw({
@@ -217,6 +242,8 @@ export function Chart<Meta = unknown>({
                                 hideXAxis={hideXAxis}
                                 hideYAxis={hideYAxis}
                                 axisColor={theme.axisColor}
+                                orientation={axisOrientation}
+                                labelToCoord={labelToCoord}
                             />
 
                             {children}

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -494,7 +494,6 @@ describe('hog-charts canvas-renderer', () => {
             drawGrid(drawCtx, { orientation: 'horizontal' })
             const tickCount = ctx.moveTo.mock.calls.length - 1
             expect(tickCount).toBeGreaterThan(0)
-            // All tick lines run vertically — moveX === lineX, with moveY/lineY spanning the plot height.
             for (let i = 0; i < tickCount; i++) {
                 const [moveX, moveY] = ctx.moveTo.mock.calls[i] as [number, number]
                 const [lineX, lineY] = ctx.lineTo.mock.calls[i] as [number, number]
@@ -502,7 +501,6 @@ describe('hog-charts canvas-renderer', () => {
                 expect(moveY).toBe(dimensions.plotTop)
                 expect(lineY).toBe(dimensions.plotTop + dimensions.plotHeight)
             }
-            // The final stroke is the horizontal categorical-axis baseline at the top of the plot.
             const lastMoveTo = ctx.moveTo.mock.calls[ctx.moveTo.mock.calls.length - 1] as [number, number]
             const lastLineTo = ctx.lineTo.mock.calls[ctx.lineTo.mock.calls.length - 1] as [number, number]
             expect(lastMoveTo[1]).toBe(dimensions.plotTop + 0.5)

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -487,6 +487,29 @@ describe('hog-charts canvas-renderer', () => {
             drawGrid(drawCtx, { gridColor: 'rgb(1, 2, 3)' })
             expect(ctx.strokeStyle).toBe('rgb(1, 2, 3)')
         })
+
+        it('draws vertical grid lines and a top baseline in horizontal orientation', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+            drawGrid(drawCtx, { orientation: 'horizontal' })
+            const tickCount = ctx.moveTo.mock.calls.length - 1
+            expect(tickCount).toBeGreaterThan(0)
+            // All tick lines run vertically — moveX === lineX, with moveY/lineY spanning the plot height.
+            for (let i = 0; i < tickCount; i++) {
+                const [moveX, moveY] = ctx.moveTo.mock.calls[i] as [number, number]
+                const [lineX, lineY] = ctx.lineTo.mock.calls[i] as [number, number]
+                expect(moveX).toBe(lineX)
+                expect(moveY).toBe(dimensions.plotTop)
+                expect(lineY).toBe(dimensions.plotTop + dimensions.plotHeight)
+            }
+            // The final stroke is the horizontal categorical-axis baseline at the top of the plot.
+            const lastMoveTo = ctx.moveTo.mock.calls[ctx.moveTo.mock.calls.length - 1] as [number, number]
+            const lastLineTo = ctx.lineTo.mock.calls[ctx.lineTo.mock.calls.length - 1] as [number, number]
+            expect(lastMoveTo[1]).toBe(dimensions.plotTop + 0.5)
+            expect(lastLineTo[1]).toBe(dimensions.plotTop + 0.5)
+            expect(lastMoveTo[0]).toBe(dimensions.plotLeft)
+            expect(lastLineTo[0]).toBe(dimensions.plotLeft + dimensions.plotWidth)
+        })
     })
 
     describe('composeDrawHoverWithCrosshair', () => {
@@ -514,35 +537,50 @@ describe('hog-charts canvas-renderer', () => {
         it('always invokes the underlying drawHover', () => {
             const ctx = mockCanvasContext()
             const drawHover = jest.fn()
-            const composed = composeDrawHoverWithCrosshair(() => drawHover, '#f00', true)
+            const composed = composeDrawHoverWithCrosshair(() => drawHover, {
+                crosshairColor: '#f00',
+                showCrosshair: true,
+            })
             composed(makeArgs(ctx, 1, 200))
             expect(drawHover).toHaveBeenCalledTimes(1)
         })
 
         it('skips crosshair when showCrosshair is false', () => {
             const ctx = mockCanvasContext()
-            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), '#f00', false)
+            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), {
+                crosshairColor: '#f00',
+                showCrosshair: false,
+            })
             composed(makeArgs(ctx, 1, 200))
             expect(ctx.stroke).not.toHaveBeenCalled()
         })
 
         it('skips crosshair when crosshairColor is undefined', () => {
             const ctx = mockCanvasContext()
-            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), undefined, true)
+            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), {
+                crosshairColor: undefined,
+                showCrosshair: true,
+            })
             composed(makeArgs(ctx, 1, 200))
             expect(ctx.stroke).not.toHaveBeenCalled()
         })
 
         it('skips crosshair when hoverIndex is negative', () => {
             const ctx = mockCanvasContext()
-            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), '#f00', true)
+            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), {
+                crosshairColor: '#f00',
+                showCrosshair: true,
+            })
             composed(makeArgs(ctx, -1, 200))
             expect(ctx.stroke).not.toHaveBeenCalled()
         })
 
         it('skips crosshair when scales.x returns a non-finite value', () => {
             const ctx = mockCanvasContext()
-            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), '#f00', true)
+            const composed = composeDrawHoverWithCrosshair(() => jest.fn(), {
+                crosshairColor: '#f00',
+                showCrosshair: true,
+            })
             composed(makeArgs(ctx, 1, undefined))
             expect(ctx.stroke).not.toHaveBeenCalled()
         })
@@ -550,11 +588,34 @@ describe('hog-charts canvas-renderer', () => {
         it('draws the crosshair on the happy path', () => {
             const ctx = mockCanvasContext()
             const drawHover = jest.fn()
-            const composed = composeDrawHoverWithCrosshair(() => drawHover, '#abc', true)
+            const composed = composeDrawHoverWithCrosshair(() => drawHover, {
+                crosshairColor: '#abc',
+                showCrosshair: true,
+            })
             composed(makeArgs(ctx, 1, 200))
             expect(ctx.stroke).toHaveBeenCalled()
             expect(ctx.strokeStyle).toBe('#abc')
             expect(drawHover).toHaveBeenCalledTimes(1)
+        })
+
+        it('uses labelToCoord when provided in horizontal orientation', () => {
+            const ctx = mockCanvasContext()
+            const drawHover = jest.fn()
+            const labelToCoord = jest.fn((label: string) => (label === 'Tue' ? 150 : undefined))
+            const composed = composeDrawHoverWithCrosshair(() => drawHover, {
+                crosshairColor: '#0f0',
+                showCrosshair: true,
+                axisOrientation: 'horizontal',
+                labelToCoord,
+            })
+            composed(makeArgs(ctx, 1, 200))
+            expect(labelToCoord).toHaveBeenCalledWith('Tue')
+            const moves = (ctx.moveTo as jest.Mock).mock.calls
+            const lines = (ctx.lineTo as jest.Mock).mock.calls
+            const lastMove = moves[moves.length - 1]
+            const lastLine = lines[lines.length - 1]
+            expect(lastMove[1]).toBeCloseTo(lastLine[1])
+            expect(lastMove[0]).not.toBeCloseTo(lastLine[0])
         })
 
         it('reads the latest drawHover via the getter on each call', () => {
@@ -562,7 +623,10 @@ describe('hog-charts canvas-renderer', () => {
             const first = jest.fn()
             const second = jest.fn()
             let current = first
-            const composed = composeDrawHoverWithCrosshair(() => current, '#f00', false)
+            const composed = composeDrawHoverWithCrosshair(() => current, {
+                crosshairColor: '#f00',
+                showCrosshair: false,
+            })
             composed(makeArgs(ctx, 0, 100))
             current = second
             composed(makeArgs(ctx, 0, 100))

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -6,8 +6,6 @@ import type { ChartDimensions, ChartDrawArgs, ResolvedSeries } from './types'
 export interface DrawContext {
     ctx: CanvasRenderingContext2D
     dimensions: ChartDimensions
-    /** Maps a categorical label to a pixel coordinate on the categorical axis.
-     *  For point/line charts this is `d3.ScalePoint<string>`; bar charts pass a band-derived center function. */
     xScale: (label: string) => number | undefined
     yScale: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
     labels: string[]
@@ -317,7 +315,6 @@ export function drawGrid(
     ctx.setLineDash([])
 
     if (orientation === 'horizontal') {
-        // Value axis runs horizontally — grid lines are vertical at each value tick.
         for (const tick of valueTicks) {
             const x = Math.round(yScale(tick)) + 0.5
             ctx.beginPath()
@@ -325,7 +322,6 @@ export function drawGrid(
             ctx.lineTo(x, dimensions.plotTop + dimensions.plotHeight)
             ctx.stroke()
         }
-        // Categorical-axis baseline runs along the top of the plot area.
         const axisY = Math.round(dimensions.plotTop) + 0.5
         ctx.beginPath()
         ctx.moveTo(dimensions.plotLeft, axisY)

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -6,7 +6,9 @@ import type { ChartDimensions, ChartDrawArgs, ResolvedSeries } from './types'
 export interface DrawContext {
     ctx: CanvasRenderingContext2D
     dimensions: ChartDimensions
-    xScale: d3.ScalePoint<string>
+    /** Maps a categorical label to a pixel coordinate on the categorical axis.
+     *  For point/line charts this is `d3.ScalePoint<string>`; bar charts pass a band-derived center function. */
+    xScale: (label: string) => number | undefined
     yScale: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
     labels: string[]
 }
@@ -290,17 +292,49 @@ export function drawPoints(drawCtx: DrawContext, series: ResolvedSeries, yValues
     }
 }
 
-export function drawGrid(drawCtx: DrawContext, options: { gridColor?: string } = {}): void {
+/** Draws the grid lines and the categorical-axis baseline.
+ *
+ * `orientation`:
+ *  - `'vertical'` (default): horizontal grid lines at value-axis (y) tick positions, vertical baseline on the left.
+ *  - `'horizontal'`: vertical grid lines at value-axis (x) tick positions, horizontal baseline on the top.
+ *
+ * In both modes, `yScale` maps a value to a pixel on the value axis — for vertical that's a y-pixel,
+ * for horizontal that's an x-pixel. The function uses `dimensions` to size the perpendicular axis.
+ */
+export function drawGrid(
+    drawCtx: DrawContext,
+    options: { gridColor?: string; orientation?: 'vertical' | 'horizontal' } = {}
+): void {
     const { ctx, yScale, dimensions } = drawCtx
     const gridColor = options.gridColor ?? 'rgba(0, 0, 0, 0.1)'
+    const orientation = options.orientation ?? 'vertical'
+    const tickAxisLength = orientation === 'horizontal' ? dimensions.plotWidth : dimensions.plotHeight
 
-    const yTicks = (yScale as d3.ScaleLinear<number, number>).ticks?.(yTickCountForHeight(dimensions.plotHeight)) ?? []
+    const valueTicks = (yScale as d3.ScaleLinear<number, number>).ticks?.(yTickCountForHeight(tickAxisLength)) ?? []
 
     ctx.strokeStyle = gridColor
     ctx.lineWidth = 1
     ctx.setLineDash([])
 
-    for (const tick of yTicks) {
+    if (orientation === 'horizontal') {
+        // Value axis runs horizontally — grid lines are vertical at each value tick.
+        for (const tick of valueTicks) {
+            const x = Math.round(yScale(tick)) + 0.5
+            ctx.beginPath()
+            ctx.moveTo(x, dimensions.plotTop)
+            ctx.lineTo(x, dimensions.plotTop + dimensions.plotHeight)
+            ctx.stroke()
+        }
+        // Categorical-axis baseline runs along the top of the plot area.
+        const axisY = Math.round(dimensions.plotTop) + 0.5
+        ctx.beginPath()
+        ctx.moveTo(dimensions.plotLeft, axisY)
+        ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, axisY)
+        ctx.stroke()
+        return
+    }
+
+    for (const tick of valueTicks) {
         const y = Math.round(yScale(tick)) + 0.5
         ctx.beginPath()
         ctx.moveTo(dimensions.plotLeft, y)
@@ -318,17 +352,23 @@ export function drawGrid(drawCtx: DrawContext, options: { gridColor?: string } =
 export function drawCrosshair(
     ctx: CanvasRenderingContext2D,
     dimensions: ChartDimensions,
-    x: number,
-    color: string
+    coord: number,
+    color: string,
+    orientation: 'vertical' | 'horizontal' = 'vertical'
 ): void {
     // 0.5 offset keeps the 1px line crisp on integer pixel boundaries.
-    const lineX = Math.round(x) + 0.5
+    const line = Math.round(coord) + 0.5
     ctx.strokeStyle = color
     ctx.lineWidth = 1
     ctx.setLineDash([])
     ctx.beginPath()
-    ctx.moveTo(lineX, dimensions.plotTop)
-    ctx.lineTo(lineX, dimensions.plotTop + dimensions.plotHeight)
+    if (orientation === 'vertical') {
+        ctx.moveTo(line, dimensions.plotTop)
+        ctx.lineTo(line, dimensions.plotTop + dimensions.plotHeight)
+    } else {
+        ctx.moveTo(dimensions.plotLeft, line)
+        ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, line)
+    }
     ctx.stroke()
 }
 
@@ -353,17 +393,25 @@ export function drawHighlightPoint(
 
 type DrawHoverFn = (args: ChartDrawArgs) => void
 
+interface ComposeDrawHoverOptions {
+    crosshairColor: string | undefined
+    showCrosshair: boolean
+    axisOrientation?: 'vertical' | 'horizontal'
+    labelToCoord?: (label: string) => number | undefined
+}
+
 // Crosshair drawn first so the chart-type's highlight rings render on top.
 export function composeDrawHoverWithCrosshair(
     getDrawHover: () => DrawHoverFn,
-    crosshairColor: string | undefined,
-    showCrosshair: boolean
+    options: ComposeDrawHoverOptions
 ): DrawHoverFn {
+    const { crosshairColor, showCrosshair, axisOrientation = 'vertical', labelToCoord } = options
     return (args) => {
         if (showCrosshair && crosshairColor && args.hoverIndex >= 0) {
-            const x = args.scales.x(args.labels[args.hoverIndex])
-            if (x != null && isFinite(x)) {
-                drawCrosshair(args.ctx, args.dimensions, x, crosshairColor)
+            const label = args.labels[args.hoverIndex]
+            const coord = labelToCoord ? labelToCoord(label) : args.scales.x(label)
+            if (coord != null && isFinite(coord)) {
+                drawCrosshair(args.ctx, args.dimensions, coord, crosshairColor, axisOrientation)
             }
         }
         getDrawHover()(args)

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -58,10 +58,7 @@ interface UseChartInteractionOptions<Meta> {
     pinnable: boolean
     onPointClick?: (data: PointClickData<Meta>) => void
     resolveValue?: ResolveValueFn
-    /** Which axis the categorical-label hit detection runs on. Defaults to 'x'.
-     *  `'y'` is used for horizontal bar charts where labels are mapped to y pixels. */
     interactionAxis?: 'x' | 'y'
-    /** When set, used instead of `scales.x` to map labels to coordinates on `interactionAxis`. */
     labelToCoord?: (label: string) => number | undefined
 }
 
@@ -107,7 +104,6 @@ export function useChartInteraction<Meta = unknown>({
     const isPinned = tooltipCtx?.isPinned ?? false
 
     // Precompute the (coord, index) lookup table once per (labels, scale) change.
-    // For vertical orientation this is x positions; for horizontal it's y positions.
     const labelPositions = useMemo(
         () => (scales ? buildLabelPositions(labels, labelToCoord ?? scales.x) : []),
         [labels, scales, labelToCoord]

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -58,6 +58,11 @@ interface UseChartInteractionOptions<Meta> {
     pinnable: boolean
     onPointClick?: (data: PointClickData<Meta>) => void
     resolveValue?: ResolveValueFn
+    /** Which axis the categorical-label hit detection runs on. Defaults to 'x'.
+     *  `'y'` is used for horizontal bar charts where labels are mapped to y pixels. */
+    interactionAxis?: 'x' | 'y'
+    /** When set, used instead of `scales.x` to map labels to coordinates on `interactionAxis`. */
+    labelToCoord?: (label: string) => number | undefined
 }
 
 interface UseChartInteractionResult<Meta> {
@@ -81,6 +86,8 @@ export function useChartInteraction<Meta = unknown>({
     pinnable,
     onPointClick,
     resolveValue = defaultResolveValue,
+    interactionAxis = 'x',
+    labelToCoord,
 }: UseChartInteractionOptions<Meta>): UseChartInteractionResult<Meta> {
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
     const [tooltipCtx, setTooltipCtx] = useState<TooltipContext<Meta> | null>(null)
@@ -99,8 +106,12 @@ export function useChartInteraction<Meta = unknown>({
 
     const isPinned = tooltipCtx?.isPinned ?? false
 
-    // Precompute the (x, index) lookup table once per (labels, scales.x) change.
-    const labelPositions = useMemo(() => (scales ? buildLabelPositions(labels, scales.x) : []), [labels, scales])
+    // Precompute the (coord, index) lookup table once per (labels, scale) change.
+    // For vertical orientation this is x positions; for horizontal it's y positions.
+    const labelPositions = useMemo(
+        () => (scales ? buildLabelPositions(labels, labelToCoord ?? scales.x) : []),
+        [labels, scales, labelToCoord]
+    )
 
     // Rebuild or clear the pinned tooltip when its underlying inputs change.
     // Without this, the pin keeps stale values at stale pixel positions after the
@@ -125,11 +136,12 @@ export function useChartInteraction<Meta = unknown>({
                 prev.dataIndex,
                 series,
                 labels,
-                scales.x,
+                labelToCoord ?? scales.x,
                 scales.y,
                 canvasBounds,
                 resolveValueRef.current,
-                scales.yAxes
+                scales.yAxes,
+                interactionAxis
             )
             if (!fresh) {
                 return null
@@ -226,7 +238,8 @@ export function useChartInteraction<Meta = unknown>({
                 return
             }
 
-            const index = findNearestIndexFromPositions(mouseX, labelPositions)
+            const probe = interactionAxis === 'y' ? mouseY : mouseX
+            const index = findNearestIndexFromPositions(probe, labelPositions)
             setHoverIndex(index)
 
             if (index >= 0 && showTooltip) {
@@ -237,11 +250,12 @@ export function useChartInteraction<Meta = unknown>({
                         index,
                         series,
                         labels,
-                        scales.x,
+                        labelToCoord ?? scales.x,
                         scales.y,
                         canvasBounds,
                         resolveValue,
-                        scales.yAxes
+                        scales.yAxes,
+                        interactionAxis
                     )
                 )
             }
@@ -257,6 +271,8 @@ export function useChartInteraction<Meta = unknown>({
             isPinned,
             clearTooltip,
             labelPositions,
+            labelToCoord,
+            interactionAxis,
         ]
     )
 

--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.test.ts
@@ -63,4 +63,37 @@ describe('useChartMargins', () => {
         const small: Series[] = [{ key: 'a', label: 'A', data: [1, 2] }]
         expect(render({ series: big }).left).toBeGreaterThan(render({ series: small }).left)
     })
+
+    describe('horizontal orientation', () => {
+        it('sizes the left margin from the widest category label, not value-tick width', () => {
+            const longCategoryLabels = ['shortest', 'a-considerably-longer-label']
+            const shortValueData: Series[] = [{ key: 'a', label: 'A', data: [1, 2] }]
+            const horizontal = render({
+                series: shortValueData,
+                labels: longCategoryLabels,
+                axisOrientation: 'horizontal',
+            })
+            const vertical = render({ series: shortValueData, labels: longCategoryLabels })
+            // Horizontal: left margin reflects category-label width (25 chars × 10 = 250 + padding).
+            // Vertical: left margin reflects value-tick width (single-digit ticks → small).
+            expect(horizontal.left).toBeGreaterThan(vertical.left)
+        })
+
+        it('sizes the right margin from the widest value tick, not category-label width', () => {
+            const shortLabels = ['a', 'b']
+            const bigValueData: Series[] = [{ key: 'a', label: 'A', data: [1_000_000_000, 2_000_000_000] }]
+            const horizontal = render({
+                series: bigValueData,
+                labels: shortLabels,
+                axisOrientation: 'horizontal',
+            })
+            const vertical = render({
+                series: bigValueData,
+                labels: shortLabels,
+            })
+            // Horizontal: bottom-axis value ticks force the right margin wider to accommodate the
+            // rightmost tick's half-width. Vertical's right margin only sees the (tiny) category label.
+            expect(horizontal.right).toBeGreaterThan(vertical.right)
+        })
+    })
 })

--- a/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartMargins.ts
@@ -21,6 +21,41 @@ interface UseChartMarginsOptions {
     hideYAxis: boolean
     xTickFormatter?: (value: string, index: number) => string | null
     yTickFormatter?: (value: number) => string
+    axisOrientation?: 'vertical' | 'horizontal'
+}
+
+function widestCategoryLabelWidth(
+    labels: string[],
+    xTickFormatter: ((value: string, index: number) => string | null) | undefined
+): number {
+    let widest = 0
+    for (let i = 0; i < labels.length; i++) {
+        const text = xTickFormatter ? xTickFormatter(labels[i], i) : labels[i]
+        if (text === null) {
+            continue
+        }
+        widest = Math.max(widest, measureLabelWidth(text))
+    }
+    return widest
+}
+
+function widestValueLabelWidth(series: Series[], yTickFormatter: ((value: number) => string) | undefined): number {
+    const range = seriesValueRange(series)
+    if (range.count === 0) {
+        return 0
+    }
+    const min = range.min > 0 ? 0 : range.min
+    const max = range.max < 0 ? 0 : range.max
+    const ticks = d3.scaleLinear().domain([min, max]).nice(6).ticks(6)
+    if (ticks.length === 0) {
+        return 0
+    }
+    const formatter = yTickFormatter ?? autoFormatterFor(ticks)
+    let widest = 0
+    for (const t of ticks) {
+        widest = Math.max(widest, measureLabelWidth(formatter(t)))
+    }
+    return widest
 }
 
 export function useChartMargins({
@@ -30,7 +65,10 @@ export function useChartMargins({
     hideYAxis,
     xTickFormatter,
     yTickFormatter,
+    axisOrientation = 'vertical',
 }: UseChartMarginsOptions): ChartMargins {
+    const isHorizontal = axisOrientation === 'horizontal'
+
     const hasMultipleAxes = useMemo(() => {
         const axisIds = new Set(
             series.filter((s) => !s.visibility?.excluded).map((s) => s.yAxisId ?? DEFAULT_Y_AXIS_ID)
@@ -42,38 +80,25 @@ export function useChartMargins({
         if (hideYAxis) {
             return 0
         }
-        const range = seriesValueRange(series)
-        if (range.count === 0) {
-            return 0
+        if (isHorizontal) {
+            return widestCategoryLabelWidth(labels, xTickFormatter)
         }
-        const min = range.min > 0 ? 0 : range.min
-        const max = range.max < 0 ? 0 : range.max
-        const ticks = d3.scaleLinear().domain([min, max]).nice(6).ticks(6)
-        if (ticks.length === 0) {
-            return 0
-        }
-        const formatter = yTickFormatter ?? autoFormatterFor(ticks)
-        let widest = 0
-        for (const t of ticks) {
-            widest = Math.max(widest, measureLabelWidth(formatter(t)))
-        }
-        return widest
-    }, [series, yTickFormatter, hideYAxis])
+        return widestValueLabelWidth(series, yTickFormatter)
+    }, [series, yTickFormatter, hideYAxis, isHorizontal, labels, xTickFormatter])
 
     const xLabelHalfWidth = useMemo<number>(() => {
-        if (hideXAxis || labels.length === 0) {
+        if (hideXAxis) {
             return 0
         }
-        let widest = 0
-        for (let i = 0; i < labels.length; i++) {
-            const text = xTickFormatter ? xTickFormatter(labels[i], i) : labels[i]
-            if (text === null) {
-                continue
-            }
-            widest = Math.max(widest, measureLabelWidth(text))
+        if (isHorizontal) {
+            const widest = widestValueLabelWidth(series, yTickFormatter)
+            return Math.ceil(widest / 2)
         }
-        return Math.ceil(widest / 2)
-    }, [labels, xTickFormatter, hideXAxis])
+        if (labels.length === 0) {
+            return 0
+        }
+        return Math.ceil(widestCategoryLabelWidth(labels, xTickFormatter) / 2)
+    }, [labels, xTickFormatter, hideXAxis, isHorizontal, series, yTickFormatter])
 
     return useMemo<ChartMargins>(() => {
         const bottom = hideXAxis ? COLLAPSED_AXIS_MARGIN : DEFAULT_MARGINS.bottom

--- a/frontend/src/lib/hog-charts/core/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.test.ts
@@ -251,13 +251,10 @@ describe('hog-charts interaction', () => {
         })
 
         it('swaps and picks the rightmost (max) value pixel when interactionAxis is "y"', () => {
-            // Horizontal-bar mode: the categorical axis is y, the value axis is x.
-            // - position.x should be max(valuePixels) — the rightmost (visually furthest) value
-            // - position.y should be the band pixel returned by xScale
             const s1 = makeSeries({ key: 's1', data: [10] })
             const s2 = makeSeries({ key: 's2', data: [50] })
-            const xFixed = (): number => 150 // band y-pixel
-            const xPxScale = (v: number): number => (v === 10 ? 200 : 400) // value x-pixels
+            const xFixed = (): number => 150
+            const xPxScale = (v: number): number => (v === 10 ? 200 : 400)
             const result = buildTooltipContext(
                 0,
                 [s1, s2],

--- a/frontend/src/lib/hog-charts/core/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.test.ts
@@ -249,6 +249,29 @@ describe('hog-charts interaction', () => {
             )
             expect(result?.position.y).toBe(42)
         })
+
+        it('swaps and picks the rightmost (max) value pixel when interactionAxis is "y"', () => {
+            // Horizontal-bar mode: the categorical axis is y, the value axis is x.
+            // - position.x should be max(valuePixels) — the rightmost (visually furthest) value
+            // - position.y should be the band pixel returned by xScale
+            const s1 = makeSeries({ key: 's1', data: [10] })
+            const s2 = makeSeries({ key: 's2', data: [50] })
+            const xFixed = (): number => 150 // band y-pixel
+            const xPxScale = (v: number): number => (v === 10 ? 200 : 400) // value x-pixels
+            const result = buildTooltipContext(
+                0,
+                [s1, s2],
+                ['a'],
+                xFixed,
+                xPxScale,
+                fakeCanvasBounds,
+                defaultResolveValue,
+                undefined,
+                'y'
+            )
+            expect(result?.position.x).toBe(400)
+            expect(result?.position.y).toBe(150)
+        })
     })
 
     describe('buildPointClickData', () => {

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -68,9 +68,7 @@ export function buildTooltipContext<Meta = unknown>(
     canvasBounds: DOMRect,
     resolveValue: ResolveValueFn,
     yAxes?: Record<string, YAxisScale>,
-    /** Which axis the categorical labels live on. `'x'` (default) = labels on x, values on y (vertical chart).
-     *  `'y'` = labels on y, values on x (horizontal chart). The returned `position.{x,y}` are always
-     *  canvas-pixel coordinates regardless of orientation. */
+    /** Returned `position.{x,y}` are canvas-pixel coordinates regardless of orientation. */
     interactionAxis: 'x' | 'y' = 'x'
 ): TooltipContext<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -67,20 +67,24 @@ export function buildTooltipContext<Meta = unknown>(
     yScale: (value: number) => number,
     canvasBounds: DOMRect,
     resolveValue: ResolveValueFn,
-    yAxes?: Record<string, YAxisScale>
+    yAxes?: Record<string, YAxisScale>,
+    /** Which axis the categorical labels live on. `'x'` (default) = labels on x, values on y (vertical chart).
+     *  `'y'` = labels on y, values on x (horizontal chart). The returned `position.{x,y}` are always
+     *  canvas-pixel coordinates regardless of orientation. */
+    interactionAxis: 'x' | 'y' = 'x'
 ): TooltipContext<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {
         return null
     }
 
     const label = labels[dataIndex]
-    const x = xScale(label)
-    if (x == null) {
+    const bandPixel = xScale(label)
+    if (bandPixel == null) {
         return null
     }
 
     const seriesData: TooltipContext<Meta>['seriesData'] = []
-    const yPixels: number[] = []
+    const valuePixels: number[] = []
     for (const s of series) {
         if (s.visibility?.excluded) {
             continue
@@ -89,20 +93,27 @@ export function buildTooltipContext<Meta = unknown>(
         if (!s.visibility?.fromTooltip) {
             seriesData.push({ series: s, value, color: s.color })
         }
-        const seriesYScale = yAxes?.[s.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? yScale
-        const yVal = seriesYScale(value)
-        if (isFinite(yVal)) {
-            yPixels.push(yVal)
+        const seriesValueScale = yAxes?.[s.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? yScale
+        const px = seriesValueScale(value)
+        if (isFinite(px)) {
+            valuePixels.push(px)
         }
     }
 
-    const y = yPixels.length > 0 ? Math.min(...yPixels) : 0
+    // Anchor at the visual "tip" of the data column at this hover index — topmost in vertical
+    // mode, rightmost in horizontal mode.
+    let valueAnchor = 0
+    if (valuePixels.length > 0) {
+        valueAnchor = interactionAxis === 'y' ? Math.max(...valuePixels) : Math.min(...valuePixels)
+    }
+
+    const position = interactionAxis === 'y' ? { x: valueAnchor, y: bandPixel } : { x: bandPixel, y: valueAnchor }
 
     return {
         dataIndex,
         label,
         seriesData,
-        position: { x, y },
+        position,
         canvasBounds,
         isPinned: false,
     }

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -153,8 +153,7 @@ export interface ChartConfig {
     tooltip?: TooltipConfig
     /** Show a vertical crosshair line that follows the cursor. */
     showCrosshair?: boolean
-    /** Orientation of the categorical axis. `vertical` (default) puts categories on x and values on y;
-     *  `horizontal` swaps them. Affects margin computation and axis-label layout. */
+    /** `vertical` (default): categories on x, values on y. `horizontal`: swapped. */
     axisOrientation?: 'vertical' | 'horizontal'
 }
 

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -153,6 +153,9 @@ export interface ChartConfig {
     tooltip?: TooltipConfig
     /** Show a vertical crosshair line that follows the cursor. */
     showCrosshair?: boolean
+    /** Orientation of the categorical axis. `vertical` (default) puts categories on x and values on y;
+     *  `horizontal` swaps them. Affects margin computation and axis-label layout. */
+    axisOrientation?: 'vertical' | 'horizontal'
 }
 
 export interface TooltipConfig {

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -139,6 +139,7 @@ export function AxisLabels({
                         return (
                             <div
                                 key={`y-cat-${i}`}
+                                data-attr="hog-chart-axis-tick-y"
                                 style={{
                                     ...TICK_STYLE_BASE,
                                     right: dimensions.width - dimensions.plotLeft + 8,
@@ -161,6 +162,7 @@ export function AxisLabels({
                         return (
                             <div
                                 key={`x-val-${tick}`}
+                                data-attr="hog-chart-axis-tick-x"
                                 style={{
                                     ...TICK_STYLE_BASE,
                                     left: x,

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -10,11 +10,9 @@ interface AxisLabelsProps {
     hideXAxis?: boolean
     hideYAxis?: boolean
     axisColor?: string
-    /** Axis orientation: `vertical` (default) puts categories on the x-axis bottom and value ticks on the y-axis left.
-     *  `horizontal` swaps them — categories on the y-axis left, value ticks on the x-axis bottom. */
     orientation?: 'vertical' | 'horizontal'
-    /** Required for horizontal orientation — maps labels to y pixel coordinates (band centers).
-     *  When omitted in horizontal mode, every category label is hidden. Ignored in vertical mode. */
+    /** Required when orientation is horizontal — maps labels to y-pixel coordinates (band centers).
+     *  Omitting it in horizontal mode hides all category labels. */
     labelToCoord?: (label: string) => number | undefined
 }
 
@@ -122,8 +120,7 @@ export function AxisLabels({
     const rightFormatter = yRightTickFormatter ?? yTickFormatter
 
     if (orientation === 'horizontal') {
-        // Categories on the left, numeric ticks on the bottom.
-        // `scales.y` is the value scale (x pixel coords for horizontal); `labelToCoord` maps to y.
+        // In horizontal mode `scales.y` holds value→x-pixel; `labelToCoord` holds label→y-pixel.
         return (
             <>
                 {!hideYAxis &&

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -13,8 +13,8 @@ interface AxisLabelsProps {
     /** Axis orientation: `vertical` (default) puts categories on the x-axis bottom and value ticks on the y-axis left.
      *  `horizontal` swaps them — categories on the y-axis left, value ticks on the x-axis bottom. */
     orientation?: 'vertical' | 'horizontal'
-    /** Used for horizontal orientation — maps labels to y pixel coordinates (band centers).
-     *  When omitted, falls back to `scales.x` which only makes sense for vertical orientation. */
+    /** Required for horizontal orientation — maps labels to y pixel coordinates (band centers).
+     *  When omitted in horizontal mode, every category label is hidden. Ignored in vertical mode. */
     labelToCoord?: (label: string) => number | undefined
 }
 

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -10,6 +10,12 @@ interface AxisLabelsProps {
     hideXAxis?: boolean
     hideYAxis?: boolean
     axisColor?: string
+    /** Axis orientation: `vertical` (default) puts categories on the x-axis bottom and value ticks on the y-axis left.
+     *  `horizontal` swaps them — categories on the y-axis left, value ticks on the x-axis bottom. */
+    orientation?: 'vertical' | 'horizontal'
+    /** Used for horizontal orientation — maps labels to y pixel coordinates (band centers).
+     *  When omitted, falls back to `scales.x` which only makes sense for vertical orientation. */
+    labelToCoord?: (label: string) => number | undefined
 }
 
 export const LABEL_FONT =
@@ -93,6 +99,8 @@ export function AxisLabels({
     hideXAxis,
     hideYAxis,
     axisColor = 'rgba(0, 0, 0, 0.5)',
+    orientation = 'vertical',
+    labelToCoord,
 }: AxisLabelsProps): React.ReactElement | null {
     const { scales, dimensions, labels } = useChartLayout()
     const yTicks = scales.yTicks()
@@ -106,11 +114,68 @@ export function AxisLabels({
     const rightTicks = useMemo(() => rightAxis?.ticks() ?? [], [rightAxis])
 
     const visibleXLabels = useMemo(
-        () => (hideXAxis ? [] : computeVisibleXLabels(labels, scales.x, xTickFormatter)),
-        [hideXAxis, labels, scales.x, xTickFormatter]
+        () =>
+            hideXAxis || orientation === 'horizontal' ? [] : computeVisibleXLabels(labels, scales.x, xTickFormatter),
+        [hideXAxis, labels, scales.x, xTickFormatter, orientation]
     )
 
     const rightFormatter = yRightTickFormatter ?? yTickFormatter
+
+    if (orientation === 'horizontal') {
+        // Categories on the left, numeric ticks on the bottom.
+        // `scales.y` is the value scale (x pixel coords for horizontal); `labelToCoord` maps to y.
+        return (
+            <>
+                {!hideYAxis &&
+                    labels.map((labelText, i) => {
+                        const text = xTickFormatter ? xTickFormatter(labelText, i) : labelText
+                        if (text === null) {
+                            return null
+                        }
+                        const y = labelToCoord ? labelToCoord(labelText) : undefined
+                        if (y == null || !isFinite(y)) {
+                            return null
+                        }
+                        return (
+                            <div
+                                key={`y-cat-${i}`}
+                                style={{
+                                    ...TICK_STYLE_BASE,
+                                    right: dimensions.width - dimensions.plotLeft + 8,
+                                    top: y,
+                                    transform: 'translateY(-50%)',
+                                    color: axisColor,
+                                }}
+                            >
+                                {text}
+                            </div>
+                        )
+                    })}
+                {!hideXAxis &&
+                    yTicks.map((tick: number) => {
+                        const x = scales.y(tick)
+                        if (!isFinite(x)) {
+                            return null
+                        }
+                        const label = yTickFormatter ? yTickFormatter(tick) : String(tick)
+                        return (
+                            <div
+                                key={`x-val-${tick}`}
+                                style={{
+                                    ...TICK_STYLE_BASE,
+                                    left: x,
+                                    top: dimensions.plotTop + dimensions.plotHeight + 8,
+                                    transform: 'translateX(-50%)',
+                                    color: axisColor,
+                                }}
+                            >
+                                {label}
+                            </div>
+                        )
+                    })}
+            </>
+        )
+    }
 
     return (
         <>


### PR DESCRIPTION
## Problem

The Chart base only supports vertical orientation (categorical-on-x, value-on-y). To add a BarChart that supports horizontal layout — and any future categorical-on-y chart type — the base needs to grow a few extension points.

## Changes

- \`axisOrientation: 'vertical' | 'horizontal'\` field on \`ChartConfig\`. Vertical is the default; line/area charts ignore it.
- \`useChartMargins\` accepts \`axisOrientation\` and swaps which axis sources from category labels vs. value-tick formatter when horizontal — so the right margin is sized for value ticks instead of category labels.
- \`Chart\` accepts two new optional props: \`interactionAxis: 'x' | 'y'\` (defaults to \`'x'\`) and \`labelToCoord: (label) => number | undefined\`. \`useChartInteraction\` binary-searches against either axis using these.
- \`composeDrawHoverWithCrosshair\` now takes an options bag with \`axisOrientation\` and \`labelToCoord\`. \`drawCrosshair\` renders a horizontal or vertical line accordingly.
- \`DrawContext.xScale\` widened from \`d3.ScalePoint<string>\` to \`(label) => number | undefined\` so chart types can pass band-center functions without an awkward cast. Existing line/area paths still pass d3 scales — the wider type is a strict superset.
- \`AxisLabels\` renders categories on the left + value ticks on the bottom in horizontal mode.

Tests cover the horizontal-orientation paths in \`useChartMargins\`, \`useChartInteraction\`, \`interaction\`, and \`canvas-renderer\`.

## How did you test this code?

There's no changes to test, yey. This is just some initial work needed before we add bar charts.  
Though tests added and pass. 

## Publish to changelog?

no

## 🤖 Agent context

Authored end-to-end by PostHog Code (Claude Opus 4.7). This is PR 1 of 5 in a stack that lands BarChart (PR 2: bar canvas primitives, PR 3: bar scales + layout, PR 4: BarChart component, PR 5: stories). Originally bundled in #57033 — split for reviewability.