### PR TITLE
feat(hog-charts): add bar canvas primitives

### DIFF
--- a/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
@@ -192,8 +192,7 @@ describe('hog-charts canvas-renderer (bars)', () => {
             const ctx = mockCanvasContext()
             const drawCtx = makeDrawContext(ctx, ['a'])
             const series = makeSeries({ key: 's', data: [1] })
-            drawBars(drawCtx, series, [{ ...SQUARE, corners: { topLeft: true, topRight: true } }], { cornerRadius: 12 })
-            // 2 rounded corners → 2 quadraticCurveTo calls
+            drawBars(drawCtx, series, [{ ...SQUARE, corners: { topLeft: true, topRight: true } }], 12)
             expect(ctx.quadraticCurveTo).toHaveBeenCalledTimes(2)
         })
 

--- a/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
@@ -59,8 +59,6 @@ describe('hog-charts canvas-renderer (bars)', () => {
         })
 
         it('clamps the radius to half the smaller dimension without throwing', () => {
-            // With width 4 and a requested radius of 20, each rounded corner consumes radius 2
-            // — we just verify it doesn't throw and still emits the curves.
             const ctx = mockCanvasContext()
             traceRoundedBarPath(ctx, 0, 0, 4, 50, 20, {
                 topLeft: true,
@@ -69,6 +67,25 @@ describe('hog-charts canvas-renderer (bars)', () => {
                 bottomRight: true,
             })
             expect(ctx.quadraticCurveTo).toHaveBeenCalledTimes(4)
+        })
+
+        it('walks corners clockwise from top-left, with each curve anchored at the right corner', () => {
+            const ctx = mockCanvasContext()
+            traceRoundedBarPath(ctx, 0, 0, 100, 100, 10, {
+                topLeft: true,
+                topRight: true,
+                bottomLeft: true,
+                bottomRight: true,
+            })
+            expect(ctx.moveTo).toHaveBeenCalledWith(10, 0)
+            expect(ctx.lineTo).toHaveBeenNthCalledWith(1, 90, 0)
+            expect(ctx.quadraticCurveTo).toHaveBeenNthCalledWith(1, 100, 0, 100, 10)
+            expect(ctx.lineTo).toHaveBeenNthCalledWith(2, 100, 90)
+            expect(ctx.quadraticCurveTo).toHaveBeenNthCalledWith(2, 100, 100, 90, 100)
+            expect(ctx.lineTo).toHaveBeenNthCalledWith(3, 10, 100)
+            expect(ctx.quadraticCurveTo).toHaveBeenNthCalledWith(3, 0, 100, 0, 90)
+            expect(ctx.lineTo).toHaveBeenNthCalledWith(4, 0, 10)
+            expect(ctx.quadraticCurveTo).toHaveBeenNthCalledWith(4, 0, 0, 10, 0)
         })
     })
 

--- a/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
@@ -29,10 +29,10 @@ function makeDrawContext(ctx: CanvasRenderingContext2D, labels: string[]): DrawC
     return { ctx, dimensions, xScale, yScale, labels }
 }
 
-const SQUARE: BarRect = { x: 100, y: 100, width: 50, height: 80, corners: {}, dataIndex: 0 }
+const BASE_BAR: BarRect = { x: 100, y: 100, width: 50, height: 80, corners: {}, dataIndex: 0 }
 
 function bar(overrides: Partial<BarRect> & { dataIndex: number }): BarRect {
-    return { ...SQUARE, ...overrides }
+    return { ...BASE_BAR, ...overrides }
 }
 
 describe('hog-charts canvas-renderer (bars)', () => {
@@ -128,7 +128,7 @@ describe('hog-charts canvas-renderer (bars)', () => {
             const ctx = mockCanvasContext()
             const drawCtx = makeDrawContext(ctx, ['a'])
             const series = makeSeries({ key: 's', data: [1], color: '#abcdef' })
-            drawBars(drawCtx, series, [SQUARE])
+            drawBars(drawCtx, series, [BASE_BAR])
             expect(ctx.fillStyle).toBe('#abcdef')
         })
 
@@ -179,11 +179,7 @@ describe('hog-charts canvas-renderer (bars)', () => {
                 color: '#11223344',
                 stroke: { partial: { fromIndex: 3 } },
             })
-            const bars = [
-                bar({ x: 0, dataIndex: 1 }), // solid
-                bar({ x: 60, dataIndex: 3 }), // hatched (>= fromIndex)
-                bar({ x: 120, dataIndex: 4 }), // hatched
-            ]
+            const bars = [bar({ x: 0, dataIndex: 1 }), bar({ x: 60, dataIndex: 3 }), bar({ x: 120, dataIndex: 4 })]
             const fillStyleSeen: (string | CanvasPattern)[] = []
             const original = Object.getOwnPropertyDescriptor(ctx, 'fillStyle')
             Object.defineProperty(ctx, 'fillStyle', {
@@ -198,8 +194,6 @@ describe('hog-charts canvas-renderer (bars)', () => {
             if (original) {
                 Object.defineProperty(ctx, 'fillStyle', original)
             }
-            // Bar 0 (dataIndex=1) → solid color string
-            // Bars 1,2 (dataIndex=3,4) → hatch pattern (object, not the color string)
             expect(fillStyleSeen[0]).toBe('#11223344')
             expect(typeof fillStyleSeen[1]).not.toBe('string')
             expect(typeof fillStyleSeen[2]).not.toBe('string')
@@ -209,14 +203,14 @@ describe('hog-charts canvas-renderer (bars)', () => {
             const ctx = mockCanvasContext()
             const drawCtx = makeDrawContext(ctx, ['a'])
             const series = makeSeries({ key: 's', data: [1] })
-            drawBars(drawCtx, series, [{ ...SQUARE, corners: { topLeft: true, topRight: true } }], 12)
+            drawBars(drawCtx, series, [{ ...BASE_BAR, corners: { topLeft: true, topRight: true } }], 12)
             expect(ctx.quadraticCurveTo).toHaveBeenCalledTimes(2)
         })
 
         it('does not invoke createPattern when no partial dashing is set', () => {
             const ctx = mockCanvasContext()
             const drawCtx = makeDrawContext(ctx, ['a'])
-            drawBars(drawCtx, makeSeries({ key: 's', data: [1] }), [SQUARE])
+            drawBars(drawCtx, makeSeries({ key: 's', data: [1] }), [BASE_BAR])
             expect(ctx.createPattern).not.toHaveBeenCalled()
         })
     })
@@ -224,7 +218,7 @@ describe('hog-charts canvas-renderer (bars)', () => {
     describe('drawBarHighlight', () => {
         it('strokes a single rectangle', () => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, SQUARE, '#000')
+            drawBarHighlight(ctx, BASE_BAR, '#000')
             expect(ctx.stroke).toHaveBeenCalledTimes(1)
         })
 
@@ -235,19 +229,19 @@ describe('hog-charts canvas-renderer (bars)', () => {
             { desc: 'negative height', width: 50, height: -5 },
         ])('does nothing on a bar with $desc', ({ width, height }) => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, { ...SQUARE, width, height }, '#000')
+            drawBarHighlight(ctx, { ...BASE_BAR, width, height }, '#000')
             expect(ctx.stroke).not.toHaveBeenCalled()
         })
 
         it('uses the provided color as strokeStyle', () => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, SQUARE, '#abcabc')
+            drawBarHighlight(ctx, BASE_BAR, '#abcabc')
             expect(ctx.strokeStyle).toBe('#abcabc')
         })
 
         it('clears the dash pattern before stroking', () => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, SQUARE, '#000')
+            drawBarHighlight(ctx, BASE_BAR, '#000')
             expect(ctx.setLineDash).toHaveBeenCalledWith([])
         })
     })

--- a/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
@@ -1,0 +1,238 @@
+import * as d3 from 'd3'
+
+import { dimensions, makeSeries } from '../test-helpers'
+import { type BarRect, drawBarHighlight, drawBars, type DrawContext, traceRoundedBarPath } from './canvas-renderer'
+
+function mockCanvasContext(): jest.Mocked<CanvasRenderingContext2D> {
+    return {
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        quadraticCurveTo: jest.fn(),
+        stroke: jest.fn(),
+        fill: jest.fn(),
+        closePath: jest.fn(),
+        setLineDash: jest.fn(),
+        createPattern: jest.fn(() => ({}) as CanvasPattern),
+        strokeStyle: '',
+        fillStyle: '',
+        lineWidth: 0,
+    } as unknown as jest.Mocked<CanvasRenderingContext2D>
+}
+
+function makeDrawContext(ctx: CanvasRenderingContext2D, labels: string[]): DrawContext {
+    const xScale = (label: string): number | undefined => {
+        const idx = labels.indexOf(label)
+        return idx < 0 ? undefined : 100 + idx * 60
+    }
+    const yScale = d3.scaleLinear().domain([0, 100]).range([368, 16])
+    return { ctx, dimensions, xScale, yScale, labels }
+}
+
+const SQUARE: BarRect = { x: 100, y: 100, width: 50, height: 80, corners: {}, dataIndex: 0 }
+
+function bar(overrides: Partial<BarRect> & { dataIndex: number }): BarRect {
+    return { ...SQUARE, ...overrides }
+}
+
+describe('hog-charts canvas-renderer (bars)', () => {
+    describe('traceRoundedBarPath', () => {
+        it.each([
+            { desc: 'no corners', corners: {}, expectedCurves: 0 },
+            { desc: 'two top corners', corners: { topLeft: true, topRight: true }, expectedCurves: 2 },
+            {
+                desc: 'all four corners',
+                corners: { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true },
+                expectedCurves: 4,
+            },
+            { desc: 'only one corner', corners: { topRight: true }, expectedCurves: 1 },
+        ])('emits one quadraticCurveTo per rounded corner ($desc)', ({ corners, expectedCurves }) => {
+            const ctx = mockCanvasContext()
+            traceRoundedBarPath(ctx, 0, 0, 100, 50, 8, corners)
+            expect(ctx.quadraticCurveTo).toHaveBeenCalledTimes(expectedCurves)
+        })
+
+        it('always closes the path, even when no corners are rounded or the rectangle is degenerate', () => {
+            const ctx = mockCanvasContext()
+            traceRoundedBarPath(ctx, 0, 0, 100, 0, 8, { topLeft: true })
+            expect(ctx.closePath).toHaveBeenCalledTimes(1)
+        })
+
+        it('clamps the radius to half the smaller dimension without throwing', () => {
+            // With width 4 and a requested radius of 20, each rounded corner consumes radius 2
+            // — we just verify it doesn't throw and still emits the curves.
+            const ctx = mockCanvasContext()
+            traceRoundedBarPath(ctx, 0, 0, 4, 50, 20, {
+                topLeft: true,
+                topRight: true,
+                bottomLeft: true,
+                bottomRight: true,
+            })
+            expect(ctx.quadraticCurveTo).toHaveBeenCalledTimes(4)
+        })
+    })
+
+    describe('drawBars', () => {
+        it('does nothing when given no bars', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+            drawBars(drawCtx, makeSeries({ key: 's', data: [1, 2] }), [])
+            expect(ctx.fill).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            { desc: 'zero width', width: 0, height: 50 },
+            { desc: 'negative width', width: -5, height: 50 },
+            { desc: 'zero height', width: 50, height: 0 },
+            { desc: 'negative height', width: 50, height: -5 },
+        ])('skips a bar with $desc', ({ width, height }) => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a'])
+            drawBars(drawCtx, makeSeries({ key: 's', data: [1] }), [
+                { x: 0, y: 0, width, height, corners: {}, dataIndex: 0 },
+            ])
+            expect(ctx.fill).not.toHaveBeenCalled()
+        })
+
+        it('fills each non-empty bar exactly once', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b', 'c'])
+            const series = makeSeries({ key: 's', data: [1, 2, 3] })
+            const bars: BarRect[] = [
+                bar({ x: 0, dataIndex: 0 }),
+                bar({ x: 60, dataIndex: 1 }),
+                bar({ x: 120, dataIndex: 2 }),
+            ]
+            drawBars(drawCtx, series, bars)
+            expect(ctx.fill).toHaveBeenCalledTimes(3)
+        })
+
+        it('sets the series color as fillStyle for non-dashed bars', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a'])
+            const series = makeSeries({ key: 's', data: [1], color: '#abcdef' })
+            drawBars(drawCtx, series, [SQUARE])
+            expect(ctx.fillStyle).toBe('#abcdef')
+        })
+
+        it('fills all bars when partial fromIndex is set (some hatched, some solid)', () => {
+            // The hatch pattern cache is module-level keyed by color; we verify the bar count
+            // rather than whether createPattern was invoked, since prior tests may have warmed the cache.
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b', 'c'])
+            const series = makeSeries({
+                key: 's',
+                data: [1, 2, 3],
+                color: '#aabbcc',
+                stroke: { partial: { fromIndex: 1 } },
+            })
+            drawBars(drawCtx, series, [
+                bar({ x: 0, dataIndex: 0 }),
+                bar({ x: 60, dataIndex: 1 }),
+                bar({ x: 120, dataIndex: 2 }),
+            ])
+            expect(ctx.fill).toHaveBeenCalledTimes(3)
+        })
+
+        it('fills all bars when partial toIndex is set', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b', 'c'])
+            const series = makeSeries({
+                key: 's',
+                data: [1, 2, 3],
+                color: '#ccbbaa',
+                stroke: { partial: { toIndex: 0 } },
+            })
+            drawBars(drawCtx, series, [
+                bar({ x: 0, dataIndex: 0 }),
+                bar({ x: 60, dataIndex: 1 }),
+                bar({ x: 120, dataIndex: 2 }),
+            ])
+            expect(ctx.fill).toHaveBeenCalledTimes(3)
+        })
+
+        it('hatches bars by their dataIndex, not their array position (filtered bars stay correct)', () => {
+            // Series has 5 data points; bars 0 and 2 are absent (filtered out).
+            // partial.fromIndex=3 should hatch bars with dataIndex >= 3, regardless of where they sit in the array.
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a', 'b', 'c', 'd', 'e'])
+            const series = makeSeries({
+                key: 's',
+                data: [1, 2, 3, 4, 5],
+                color: '#11223344',
+                stroke: { partial: { fromIndex: 3 } },
+            })
+            const bars = [
+                bar({ x: 0, dataIndex: 1 }), // solid
+                bar({ x: 60, dataIndex: 3 }), // hatched (>= fromIndex)
+                bar({ x: 120, dataIndex: 4 }), // hatched
+            ]
+            const fillStyleSeen: (string | CanvasPattern)[] = []
+            const original = Object.getOwnPropertyDescriptor(ctx, 'fillStyle')
+            Object.defineProperty(ctx, 'fillStyle', {
+                set(v) {
+                    fillStyleSeen.push(v)
+                },
+                get() {
+                    return ''
+                },
+            })
+            drawBars(drawCtx, series, bars)
+            if (original) {
+                Object.defineProperty(ctx, 'fillStyle', original)
+            }
+            // Bar 0 (dataIndex=1) → solid color string
+            // Bars 1,2 (dataIndex=3,4) → hatch pattern (object, not the color string)
+            expect(fillStyleSeen[0]).toBe('#11223344')
+            expect(typeof fillStyleSeen[1]).not.toBe('string')
+            expect(typeof fillStyleSeen[2]).not.toBe('string')
+        })
+
+        it('respects the cornerRadius option', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a'])
+            const series = makeSeries({ key: 's', data: [1] })
+            drawBars(drawCtx, series, [{ ...SQUARE, corners: { topLeft: true, topRight: true } }], { cornerRadius: 12 })
+            // 2 rounded corners → 2 quadraticCurveTo calls
+            expect(ctx.quadraticCurveTo).toHaveBeenCalledTimes(2)
+        })
+
+        it('does not invoke createPattern when no partial dashing is set', () => {
+            const ctx = mockCanvasContext()
+            const drawCtx = makeDrawContext(ctx, ['a'])
+            drawBars(drawCtx, makeSeries({ key: 's', data: [1] }), [SQUARE])
+            expect(ctx.createPattern).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('drawBarHighlight', () => {
+        it('strokes a single rectangle', () => {
+            const ctx = mockCanvasContext()
+            drawBarHighlight(ctx, SQUARE, '#000')
+            expect(ctx.stroke).toHaveBeenCalledTimes(1)
+        })
+
+        it.each([
+            { desc: 'zero width', width: 0, height: 80 },
+            { desc: 'negative width', width: -5, height: 80 },
+            { desc: 'zero height', width: 50, height: 0 },
+            { desc: 'negative height', width: 50, height: -5 },
+        ])('does nothing on a bar with $desc', ({ width, height }) => {
+            const ctx = mockCanvasContext()
+            drawBarHighlight(ctx, { ...SQUARE, width, height }, '#000')
+            expect(ctx.stroke).not.toHaveBeenCalled()
+        })
+
+        it('uses the provided color as strokeStyle', () => {
+            const ctx = mockCanvasContext()
+            drawBarHighlight(ctx, SQUARE, '#abcabc')
+            expect(ctx.strokeStyle).toBe('#abcabc')
+        })
+
+        it('clears the dash pattern before stroking', () => {
+            const ctx = mockCanvasContext()
+            drawBarHighlight(ctx, SQUARE, '#000')
+            expect(ctx.setLineDash).toHaveBeenCalledWith([])
+        })
+    })
+})

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -368,7 +368,6 @@ export function drawCrosshair(
     ctx.stroke()
 }
 
-/** Which corners of a bar rectangle to round. */
 export interface BarRoundedCorners {
     topLeft?: boolean
     topRight?: boolean
@@ -376,9 +375,7 @@ export interface BarRoundedCorners {
     bottomRight?: boolean
 }
 
-/** Traces a rectangle path with optional per-corner rounding. The radius is clamped
- *  to half the smaller dimension so very thin/short bars degrade gracefully. Caller
- *  owns beginPath/fill/stroke. */
+/** Caller owns beginPath / fill / stroke; this only emits the path. */
 export function traceRoundedBarPath(
     ctx: CanvasRenderingContext2D,
     x: number,
@@ -414,25 +411,20 @@ export function traceRoundedBarPath(
 }
 
 export interface BarRect {
-    /** Pixel coordinates of the rectangle. */
     x: number
     y: number
     width: number
     height: number
-    /** Which corners should be rounded (e.g. only the cap end). */
     corners: BarRoundedCorners
-    /** Index into the original `series.data` array. Used to resolve partial-dash hatch ranges
-     *  against the source data, not the (possibly filtered) bars array. */
+    /** Index into the original `series.data` — partial-dash hatch ranges resolve against the
+     *  source array, not against this bars[] which the caller may have pre-filtered. */
     dataIndex: number
 }
 
-/** Draws a list of bars for a series with corner rounding and hatched dashed-pattern support.
- *  When `series.stroke?.partial` is set, bars whose `dataIndex` falls inside the partial range
- *  are filled with a diagonal hatch pattern (mirrors the line/area dashed-region convention).
- *  The partial-range indices are clamped against `series.data.length`, so callers may pre-filter
- *  out non-drawable bars without distorting the hatch boundary. */
 export const DEFAULT_BAR_CORNER_RADIUS = 4
 
+/** Hatch ranges (`series.stroke?.partial`) clamp against `series.data.length`; callers may
+ *  pre-filter `bars` without shifting the hatch boundary. */
 export function drawBars(
     drawCtx: DrawContext,
     series: ResolvedSeries,

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -368,6 +368,118 @@ export function drawCrosshair(
     ctx.stroke()
 }
 
+/** Which corners of a bar rectangle to round. */
+export interface BarRoundedCorners {
+    topLeft?: boolean
+    topRight?: boolean
+    bottomLeft?: boolean
+    bottomRight?: boolean
+}
+
+/** Traces a rectangle path with optional per-corner rounding. The radius is clamped
+ *  to half the smaller dimension so very thin/short bars degrade gracefully. Caller
+ *  owns beginPath/fill/stroke. */
+export function traceRoundedBarPath(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    radius: number,
+    corners: BarRoundedCorners
+): void {
+    const r = Math.max(0, Math.min(radius, Math.abs(width) / 2, Math.abs(height) / 2))
+    const tl = corners.topLeft ? r : 0
+    const tr = corners.topRight ? r : 0
+    const br = corners.bottomRight ? r : 0
+    const bl = corners.bottomLeft ? r : 0
+    ctx.moveTo(x + tl, y)
+    ctx.lineTo(x + width - tr, y)
+    if (tr > 0) {
+        ctx.quadraticCurveTo(x + width, y, x + width, y + tr)
+    }
+    ctx.lineTo(x + width, y + height - br)
+    if (br > 0) {
+        ctx.quadraticCurveTo(x + width, y + height, x + width - br, y + height)
+    }
+    ctx.lineTo(x + bl, y + height)
+    if (bl > 0) {
+        ctx.quadraticCurveTo(x, y + height, x, y + height - bl)
+    }
+    ctx.lineTo(x, y + tl)
+    if (tl > 0) {
+        ctx.quadraticCurveTo(x, y, x + tl, y)
+    }
+    ctx.closePath()
+}
+
+export interface BarRect {
+    /** Pixel coordinates of the rectangle. */
+    x: number
+    y: number
+    width: number
+    height: number
+    /** Which corners should be rounded (e.g. only the cap end). */
+    corners: BarRoundedCorners
+    /** Index into the original `series.data` array. Used to resolve partial-dash hatch ranges
+     *  against the source data, not the (possibly filtered) bars array. */
+    dataIndex: number
+}
+
+/** Draws a list of bars for a series with corner rounding and hatched dashed-pattern support.
+ *  When `series.stroke?.partial` is set, bars whose `dataIndex` falls inside the partial range
+ *  are filled with a diagonal hatch pattern (mirrors the line/area dashed-region convention).
+ *  The partial-range indices are clamped against `series.data.length`, so callers may pre-filter
+ *  out non-drawable bars without distorting the hatch boundary. */
+export function drawBars(
+    drawCtx: DrawContext,
+    series: ResolvedSeries,
+    bars: BarRect[],
+    options: { cornerRadius?: number } = {}
+): void {
+    const { ctx } = drawCtx
+    if (bars.length === 0) {
+        return
+    }
+
+    const cornerRadius = options.cornerRadius ?? 4
+    const dataLength = series.data.length
+    const dashedFrom = resolvePartialIndex(series.stroke?.partial?.fromIndex, dataLength)
+    const dashedTo = resolvePartialIndex(series.stroke?.partial?.toIndex, dataLength)
+    const hatch = dashedFrom !== null || dashedTo !== null ? getHatchPattern(ctx, series.color) : null
+
+    for (const bar of bars) {
+        if (bar.width <= 0 || bar.height <= 0) {
+            continue
+        }
+        const useHatch =
+            hatch !== null &&
+            ((dashedFrom !== null && bar.dataIndex >= dashedFrom) || (dashedTo !== null && bar.dataIndex <= dashedTo))
+        ctx.fillStyle = useHatch && hatch ? hatch : series.color
+        ctx.beginPath()
+        traceRoundedBarPath(ctx, bar.x, bar.y, bar.width, bar.height, cornerRadius, bar.corners)
+        ctx.fill()
+    }
+}
+
+/** Draws a thin highlight ring around a bar rectangle. */
+export function drawBarHighlight(
+    ctx: CanvasRenderingContext2D,
+    bar: BarRect,
+    color: string,
+    cornerRadius: number = 4
+): void {
+    if (bar.width <= 0 || bar.height <= 0) {
+        return
+    }
+    ctx.strokeStyle = color
+    ctx.lineWidth = 2
+    ctx.setLineDash([])
+    ctx.beginPath()
+    traceRoundedBarPath(ctx, bar.x, bar.y, bar.width, bar.height, cornerRadius, bar.corners)
+    ctx.stroke()
+}
+
 export function drawHighlightPoint(
     ctx: CanvasRenderingContext2D,
     x: number,

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -431,18 +431,19 @@ export interface BarRect {
  *  are filled with a diagonal hatch pattern (mirrors the line/area dashed-region convention).
  *  The partial-range indices are clamped against `series.data.length`, so callers may pre-filter
  *  out non-drawable bars without distorting the hatch boundary. */
+export const DEFAULT_BAR_CORNER_RADIUS = 4
+
 export function drawBars(
     drawCtx: DrawContext,
     series: ResolvedSeries,
     bars: BarRect[],
-    options: { cornerRadius?: number } = {}
+    cornerRadius: number = DEFAULT_BAR_CORNER_RADIUS
 ): void {
     const { ctx } = drawCtx
     if (bars.length === 0) {
         return
     }
 
-    const cornerRadius = options.cornerRadius ?? 4
     const dataLength = series.data.length
     const dashedFrom = resolvePartialIndex(series.stroke?.partial?.fromIndex, dataLength)
     const dashedTo = resolvePartialIndex(series.stroke?.partial?.toIndex, dataLength)
@@ -455,19 +456,18 @@ export function drawBars(
         const useHatch =
             hatch !== null &&
             ((dashedFrom !== null && bar.dataIndex >= dashedFrom) || (dashedTo !== null && bar.dataIndex <= dashedTo))
-        ctx.fillStyle = useHatch && hatch ? hatch : series.color
+        ctx.fillStyle = useHatch ? hatch : series.color
         ctx.beginPath()
         traceRoundedBarPath(ctx, bar.x, bar.y, bar.width, bar.height, cornerRadius, bar.corners)
         ctx.fill()
     }
 }
 
-/** Draws a thin highlight ring around a bar rectangle. */
 export function drawBarHighlight(
     ctx: CanvasRenderingContext2D,
     bar: BarRect,
     color: string,
-    cornerRadius: number = 4
+    cornerRadius: number = DEFAULT_BAR_CORNER_RADIUS
 ): void {
     if (bar.width <= 0 || bar.height <= 0) {
         return


### PR DESCRIPTION
## Problem

Stacked on #57209 (axis-orientation hooks). Adds the canvas primitives a BarChart needs without introducing the chart type itself — pure helpers, fully tested in isolation.

## Changes

Added to \`core/canvas-renderer.ts\`:

- \`BarRoundedCorners\` — which corners of a bar to round.
- \`traceRoundedBarPath\` — emits a rectangle path with optional per-corner rounding; clamps the radius to half the smaller dimension so degenerate bars degrade gracefully.
- \`BarRect\` — pixel rectangle + corner mask + \`dataIndex\` (the original \`series.data\` position; resolves partial-dash hatch ranges against source data, not the possibly-filtered bars array).
- \`drawBars\` — fills bars with corner rounding plus diagonal-hatch fills for partial-dash ranges (mirrors the line/area dashed-region treatment).
- \`drawBarHighlight\` — strokes a thin highlight ring around a bar with the same corner mask as the underlying fill.

\`bar-canvas-renderer.test.ts\` (~250 LOC) covers rounded-rect tracing edge cases, hatch-pattern usage, zero-dimension skipping, and \`dataIndex\`-based hatching under filtering.

## How did you test this code?

I'm an agent. \`pnpm jest --testPathPattern='hog-charts'\` — all 244 tests pass (9 suites). The new primitives have no consumer yet, so existing chart behavior is unaffected.

## Publish to changelog?

no

## 🤖 Agent context

Authored end-to-end by PostHog Code (Claude Opus 4.7). PR 2 of 5 in the BarChart stack — depends on #57209. Follows: PR 3 (bar scales + layout), PR 4 (BarChart component), PR 5 (stories).