### PR TITLE
feat(hog-charts): add bar scales and bar-layout module

### DIFF
--- a/frontend/src/lib/hog-charts/core/bar-layout.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.test.ts
@@ -1,0 +1,106 @@
+import { dimensions, makeSeries } from '../test-helpers'
+import { computeSeriesBars, cornersFor } from './bar-layout'
+import { computeStackData, createBarScales } from './scales'
+
+describe('hog-charts bar-layout', () => {
+    describe('cornersFor', () => {
+        it.each([
+            { isHorizontal: false, isPositive: true, expected: { topLeft: true, topRight: true } },
+            { isHorizontal: false, isPositive: false, expected: { bottomLeft: true, bottomRight: true } },
+            { isHorizontal: true, isPositive: true, expected: { topRight: true, bottomRight: true } },
+            { isHorizontal: true, isPositive: false, expected: { topLeft: true, bottomLeft: true } },
+        ])('rounds the cap end (h=$isHorizontal, +=$isPositive)', ({ isHorizontal, isPositive, expected }) => {
+            expect(cornersFor(isHorizontal, isPositive, true)).toEqual(expected)
+        })
+
+        it('returns no rounding when shouldRoundCap is false', () => {
+            expect(cornersFor(false, true, false)).toEqual({})
+            expect(cornersFor(true, false, false)).toEqual({})
+        })
+    })
+
+    describe('computeSeriesBars — grouped', () => {
+        it('lays out positive grouped bars from baseline upward', () => {
+            const labels = ['a', 'b']
+            const a = makeSeries({ key: 'a', data: [10, 20] })
+            const b = makeSeries({ key: 'b', data: [5, 15] })
+            const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'grouped' })
+            const bars = computeSeriesBars(a, labels, scales, 'grouped', false, undefined, false)
+            expect(bars).toHaveLength(2)
+            expect(bars[0]?.dataIndex).toBe(0)
+            expect(bars[0]?.height).toBeGreaterThan(0)
+            // Vertical: bar.y should be smaller than baseline pixel since positive values map up.
+            const baselinePixel = scales.value(0)
+            expect(bars[0]!.y).toBeLessThan(baselinePixel)
+            expect(bars[0]!.y + bars[0]!.height).toBeCloseTo(baselinePixel, 5)
+        })
+
+        it('flips corners and origin for negative grouped bars', () => {
+            const labels = ['a']
+            const s = makeSeries({ key: 's', data: [-10] })
+            const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
+            const bars = computeSeriesBars(s, labels, scales, 'grouped', false, undefined, false)
+            expect(bars[0]?.corners).toEqual({ bottomLeft: true, bottomRight: true })
+            const baselinePixel = scales.value(0)
+            // Negative values draw below the baseline; bar.y is at the baseline.
+            expect(bars[0]!.y).toBeCloseTo(baselinePixel, 5)
+        })
+
+        it('produces band-axis-y / value-axis-x rects in horizontal grouped mode', () => {
+            const labels = ['a']
+            const s = makeSeries({ key: 's', data: [10] })
+            const scales = createBarScales([s], labels, dimensions, {
+                barLayout: 'grouped',
+                axisOrientation: 'horizontal',
+            })
+            const bars = computeSeriesBars(s, labels, scales, 'grouped', true, undefined, false)
+            expect(bars[0]?.corners).toEqual({ topRight: true, bottomRight: true })
+            const baselinePixel = scales.value(0)
+            expect(bars[0]!.x).toBeCloseTo(baselinePixel, 5)
+            expect(bars[0]!.width).toBeGreaterThan(0)
+        })
+    })
+
+    describe('computeSeriesBars — stacked', () => {
+        it('uses the band top/bottom values for stack height', () => {
+            const labels = ['a', 'b']
+            const a = makeSeries({ key: 'a', data: [10, 20] })
+            const b = makeSeries({ key: 'b', data: [5, 15] })
+            const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'stacked' })
+            const stacks = computeStackData([a, b], labels)
+            const stackB = stacks.get('b')!
+
+            const bars = computeSeriesBars(b, labels, scales, 'stacked', false, stackB, true)
+            expect(bars).toHaveLength(2)
+            // Stacked bar height must equal pixel distance between band top and bottom.
+            const expectedHeight0 = Math.abs(scales.value(stackB.top[0]) - scales.value(stackB.bottom[0]))
+            expect(bars[0]!.height).toBeCloseTo(expectedHeight0, 5)
+        })
+
+        it('only rounds the top stack layer', () => {
+            const labels = ['a']
+            const a = makeSeries({ key: 'a', data: [10] })
+            const b = makeSeries({ key: 'b', data: [5] })
+            const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'stacked' })
+            const stacks = computeStackData([a, b], labels)
+
+            const bottomBars = computeSeriesBars(a, labels, scales, 'stacked', false, stacks.get('a'), false)
+            const topBars = computeSeriesBars(b, labels, scales, 'stacked', false, stacks.get('b'), true)
+            expect(bottomBars[0]?.corners).toEqual({})
+            expect(topBars[0]?.corners).toEqual({ topLeft: true, topRight: true })
+        })
+    })
+
+    describe('computeSeriesBars — null handling', () => {
+        it('returns null for null/NaN data points but preserves dataIndex order', () => {
+            const labels = ['a', 'b', 'c']
+            const s = makeSeries({ key: 's', data: [10, NaN, 20] })
+            const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
+            const bars = computeSeriesBars(s, labels, scales, 'grouped', false, undefined, false)
+            expect(bars).toHaveLength(3)
+            expect(bars[0]?.dataIndex).toBe(0)
+            expect(bars[1]).toBeNull()
+            expect(bars[2]?.dataIndex).toBe(2)
+        })
+    })
+})

--- a/frontend/src/lib/hog-charts/core/bar-layout.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.test.ts
@@ -13,109 +13,69 @@ describe('hog-charts bar-layout', () => {
             expect(cornersFor(isHorizontal, isPositive, true)).toEqual(expected)
         })
 
-        it('returns no rounding when shouldRoundCap is false', () => {
-            expect(cornersFor(false, true, false)).toEqual({})
-            expect(cornersFor(true, false, false)).toEqual({})
+        it.each([
+            { isHorizontal: false, isPositive: true },
+            { isHorizontal: true, isPositive: false },
+        ])('returns no rounding when shouldRoundCap is false', ({ isHorizontal, isPositive }) => {
+            expect(cornersFor(isHorizontal, isPositive, false)).toEqual({})
         })
     })
 
     describe('computeSeriesBars — grouped', () => {
-        it('lays out positive grouped bars from baseline upward', () => {
-            const labels = ['a', 'b']
-            const a = makeSeries({ key: 'a', data: [10, 20] })
-            const b = makeSeries({ key: 'b', data: [5, 15] })
-            const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'grouped' })
+        it.each([
+            {
+                desc: 'vertical positive',
+                data: [10],
+                isHorizontal: false,
+                expectedCorners: { topLeft: true, topRight: true },
+            },
+            {
+                desc: 'vertical negative',
+                data: [-10],
+                isHorizontal: false,
+                expectedCorners: { bottomLeft: true, bottomRight: true },
+            },
+            {
+                desc: 'horizontal positive',
+                data: [10],
+                isHorizontal: true,
+                expectedCorners: { topRight: true, bottomRight: true },
+            },
+            {
+                desc: 'horizontal negative',
+                data: [-10],
+                isHorizontal: true,
+                expectedCorners: { topLeft: true, bottomLeft: true },
+            },
+        ])('rounds caps for $desc bars', ({ data, isHorizontal, expectedCorners }) => {
+            const s = makeSeries({ key: 's', data })
+            const scales = createBarScales([s], ['a'], dimensions, {
+                barLayout: 'grouped',
+                axisOrientation: isHorizontal ? 'horizontal' : 'vertical',
+            })
             const bars = computeSeriesBars({
-                series: a,
-                labels,
+                series: s,
+                labels: ['a'],
                 scales,
                 layout: 'grouped',
-                isHorizontal: false,
-                stackedBand: undefined,
+                isHorizontal,
                 isTopOfStack: false,
             })
-            expect(bars).toHaveLength(2)
-            expect(bars[0]?.dataIndex).toBe(0)
+            expect(bars[0]?.corners).toEqual(expectedCorners)
+            expect(bars[0]?.width).toBeGreaterThan(0)
             expect(bars[0]?.height).toBeGreaterThan(0)
-            const baselinePixel = scales.value(0)
-            expect(bars[0]!.y).toBeLessThan(baselinePixel)
-            expect(bars[0]!.y + bars[0]!.height).toBeCloseTo(baselinePixel, 5)
-        })
-
-        it('flips corners and origin for negative grouped bars', () => {
-            const labels = ['a']
-            const s = makeSeries({ key: 's', data: [-10] })
-            const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
-            const bars = computeSeriesBars({
-                series: s,
-                labels,
-                scales,
-                layout: 'grouped',
-                isHorizontal: false,
-                stackedBand: undefined,
-                isTopOfStack: false,
-            })
-            expect(bars[0]?.corners).toEqual({ bottomLeft: true, bottomRight: true })
-            const baselinePixel = scales.value(0)
-            expect(bars[0]!.y).toBeCloseTo(baselinePixel, 5)
-        })
-
-        it('produces band-axis-y / value-axis-x rects in horizontal grouped mode', () => {
-            const labels = ['a']
-            const s = makeSeries({ key: 's', data: [10] })
-            const scales = createBarScales([s], labels, dimensions, {
-                barLayout: 'grouped',
-                axisOrientation: 'horizontal',
-            })
-            const bars = computeSeriesBars({
-                series: s,
-                labels,
-                scales,
-                layout: 'grouped',
-                isHorizontal: true,
-                stackedBand: undefined,
-                isTopOfStack: false,
-            })
-            expect(bars[0]?.corners).toEqual({ topRight: true, bottomRight: true })
-            const baselinePixel = scales.value(0)
-            expect(bars[0]!.x).toBeCloseTo(baselinePixel, 5)
-            expect(bars[0]!.width).toBeGreaterThan(0)
-        })
-
-        it('flips corners for horizontal + negative grouped bars', () => {
-            const labels = ['a']
-            const s = makeSeries({ key: 's', data: [-10] })
-            const scales = createBarScales([s], labels, dimensions, {
-                barLayout: 'grouped',
-                axisOrientation: 'horizontal',
-            })
-            const bars = computeSeriesBars({
-                series: s,
-                labels,
-                scales,
-                layout: 'grouped',
-                isHorizontal: true,
-                stackedBand: undefined,
-                isTopOfStack: false,
-            })
-            expect(bars[0]?.corners).toEqual({ topLeft: true, bottomLeft: true })
-            const baselinePixel = scales.value(0)
-            // Negative horizontal bar extends left of baseline; bar.x + width sits at the baseline.
-            expect(bars[0]!.x + bars[0]!.width).toBeCloseTo(baselinePixel, 5)
         })
 
         it('skips bars for excluded series in the grouped sub-band', () => {
-            const labels = ['a']
             const visible = makeSeries({ key: 'visible', data: [10] })
             const excluded = makeSeries({ key: 'excluded', data: [10], visibility: { excluded: true } })
-            const scales = createBarScales([visible, excluded], labels, dimensions, { barLayout: 'grouped' })
+            const scales = createBarScales([visible, excluded], ['a'], dimensions, { barLayout: 'grouped' })
             const bars = computeSeriesBars({
                 series: excluded,
-                labels,
+                labels: ['a'],
                 scales,
                 layout: 'grouped',
                 isHorizontal: false,
-                stackedBand: undefined,
                 isTopOfStack: false,
             })
             expect(bars[0]).toBeNull()
@@ -141,20 +101,19 @@ describe('hog-charts bar-layout', () => {
                 isTopOfStack: true,
             })
             expect(bars).toHaveLength(2)
-            const expectedHeight0 = Math.abs(scales.value(stackB.top[0]) - scales.value(stackB.bottom[0]))
-            expect(bars[0]!.height).toBeCloseTo(expectedHeight0, 5)
+            const expectedHeight = Math.abs(scales.value(stackB.top[0]) - scales.value(stackB.bottom[0]))
+            expect(bars[0]!.height).toBeCloseTo(expectedHeight, 5)
         })
 
         it('only rounds the top stack layer', () => {
-            const labels = ['a']
             const a = makeSeries({ key: 'a', data: [10] })
             const b = makeSeries({ key: 'b', data: [5] })
-            const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'stacked' })
-            const stacks = computeStackData([a, b], labels)
+            const scales = createBarScales([a, b], ['a'], dimensions, { barLayout: 'stacked' })
+            const stacks = computeStackData([a, b], ['a'])
 
             const bottomBars = computeSeriesBars({
                 series: a,
-                labels,
+                labels: ['a'],
                 scales,
                 layout: 'stacked',
                 isHorizontal: false,
@@ -163,7 +122,7 @@ describe('hog-charts bar-layout', () => {
             })
             const topBars = computeSeriesBars({
                 series: b,
-                labels,
+                labels: ['a'],
                 scales,
                 layout: 'stacked',
                 isHorizontal: false,
@@ -172,6 +131,21 @@ describe('hog-charts bar-layout', () => {
             })
             expect(bottomBars[0]?.corners).toEqual({})
             expect(topBars[0]?.corners).toEqual({ topLeft: true, topRight: true })
+        })
+
+        it('throws when stackedBand is omitted for non-grouped layouts', () => {
+            const s = makeSeries({ key: 's', data: [10] })
+            const scales = createBarScales([s], ['a'], dimensions, { barLayout: 'stacked' })
+            expect(() =>
+                computeSeriesBars({
+                    series: s,
+                    labels: ['a'],
+                    scales,
+                    layout: 'stacked',
+                    isHorizontal: false,
+                    isTopOfStack: true,
+                })
+            ).toThrow(/stackedBand is required/)
         })
     })
 
@@ -186,7 +160,6 @@ describe('hog-charts bar-layout', () => {
                 scales,
                 layout: 'grouped',
                 isHorizontal: false,
-                stackedBand: undefined,
                 isTopOfStack: false,
             })
             expect(bars).toHaveLength(3)

--- a/frontend/src/lib/hog-charts/core/bar-layout.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.test.ts
@@ -1,6 +1,12 @@
 import { dimensions, makeSeries } from '../test-helpers'
-import { computeSeriesBars, cornersFor } from './bar-layout'
+import { type ComputeSeriesBarsOptions, computeSeriesBars, cornersFor } from './bar-layout'
 import { computeStackData, createBarScales } from './scales'
+
+function layoutOf(
+    args: Partial<ComputeSeriesBarsOptions> & Pick<ComputeSeriesBarsOptions, 'series' | 'scales'>
+): ReturnType<typeof computeSeriesBars> {
+    return computeSeriesBars({ labels: ['a'], layout: 'grouped', isHorizontal: false, isTopOfStack: false, ...args })
+}
 
 describe('hog-charts bar-layout', () => {
     describe('cornersFor', () => {
@@ -23,45 +29,33 @@ describe('hog-charts bar-layout', () => {
 
     describe('computeSeriesBars — grouped', () => {
         it.each([
-            {
-                desc: 'vertical positive',
-                data: [10],
-                isHorizontal: false,
-                expectedCorners: { topLeft: true, topRight: true },
-            },
+            { desc: 'vertical positive', data: [10], isHorizontal: false, corners: { topLeft: true, topRight: true } },
             {
                 desc: 'vertical negative',
                 data: [-10],
                 isHorizontal: false,
-                expectedCorners: { bottomLeft: true, bottomRight: true },
+                corners: { bottomLeft: true, bottomRight: true },
             },
             {
                 desc: 'horizontal positive',
                 data: [10],
                 isHorizontal: true,
-                expectedCorners: { topRight: true, bottomRight: true },
+                corners: { topRight: true, bottomRight: true },
             },
             {
                 desc: 'horizontal negative',
                 data: [-10],
                 isHorizontal: true,
-                expectedCorners: { topLeft: true, bottomLeft: true },
+                corners: { topLeft: true, bottomLeft: true },
             },
-        ])('rounds caps for $desc bars', ({ data, isHorizontal, expectedCorners }) => {
+        ])('rounds caps for $desc bars', ({ data, isHorizontal, corners }) => {
             const s = makeSeries({ key: 's', data })
             const scales = createBarScales([s], ['a'], dimensions, {
                 barLayout: 'grouped',
                 axisOrientation: isHorizontal ? 'horizontal' : 'vertical',
             })
-            const bars = computeSeriesBars({
-                series: s,
-                labels: ['a'],
-                scales,
-                layout: 'grouped',
-                isHorizontal,
-                isTopOfStack: false,
-            })
-            expect(bars[0]?.corners).toEqual(expectedCorners)
+            const bars = layoutOf({ series: s, scales, isHorizontal })
+            expect(bars[0]?.corners).toEqual(corners)
             expect(bars[0]?.width).toBeGreaterThan(0)
             expect(bars[0]?.height).toBeGreaterThan(0)
         })
@@ -70,15 +64,7 @@ describe('hog-charts bar-layout', () => {
             const visible = makeSeries({ key: 'visible', data: [10] })
             const excluded = makeSeries({ key: 'excluded', data: [10], visibility: { excluded: true } })
             const scales = createBarScales([visible, excluded], ['a'], dimensions, { barLayout: 'grouped' })
-            const bars = computeSeriesBars({
-                series: excluded,
-                labels: ['a'],
-                scales,
-                layout: 'grouped',
-                isHorizontal: false,
-                isTopOfStack: false,
-            })
-            expect(bars[0]).toBeNull()
+            expect(layoutOf({ series: excluded, scales })[0]).toBeNull()
         })
     })
 
@@ -88,15 +74,12 @@ describe('hog-charts bar-layout', () => {
             const a = makeSeries({ key: 'a', data: [10, 20] })
             const b = makeSeries({ key: 'b', data: [5, 15] })
             const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'stacked' })
-            const stacks = computeStackData([a, b], labels)
-            const stackB = stacks.get('b')!
-
-            const bars = computeSeriesBars({
+            const stackB = computeStackData([a, b], labels).get('b')!
+            const bars = layoutOf({
                 series: b,
                 labels,
                 scales,
                 layout: 'stacked',
-                isHorizontal: false,
                 stackedBand: stackB,
                 isTopOfStack: true,
             })
@@ -105,67 +88,42 @@ describe('hog-charts bar-layout', () => {
             expect(bars[0]!.height).toBeCloseTo(expectedHeight, 5)
         })
 
-        it('only rounds the top stack layer', () => {
+        it.each([
+            { layer: 'bottom', isTopOfStack: false, expectedCorners: {} },
+            { layer: 'top', isTopOfStack: true, expectedCorners: { topLeft: true, topRight: true } },
+        ])('rounds only the top stack layer ($layer)', ({ isTopOfStack, expectedCorners }) => {
             const a = makeSeries({ key: 'a', data: [10] })
             const b = makeSeries({ key: 'b', data: [5] })
             const scales = createBarScales([a, b], ['a'], dimensions, { barLayout: 'stacked' })
             const stacks = computeStackData([a, b], ['a'])
-
-            const bottomBars = computeSeriesBars({
-                series: a,
-                labels: ['a'],
+            const series = isTopOfStack ? b : a
+            const bars = layoutOf({
+                series,
                 scales,
                 layout: 'stacked',
-                isHorizontal: false,
-                stackedBand: stacks.get('a'),
-                isTopOfStack: false,
+                stackedBand: stacks.get(series.key),
+                isTopOfStack,
             })
-            const topBars = computeSeriesBars({
-                series: b,
-                labels: ['a'],
-                scales,
-                layout: 'stacked',
-                isHorizontal: false,
-                stackedBand: stacks.get('b'),
-                isTopOfStack: true,
-            })
-            expect(bottomBars[0]?.corners).toEqual({})
-            expect(topBars[0]?.corners).toEqual({ topLeft: true, topRight: true })
+            expect(bars[0]?.corners).toEqual(expectedCorners)
         })
 
         it('throws when stackedBand is omitted for non-grouped layouts', () => {
             const s = makeSeries({ key: 's', data: [10] })
             const scales = createBarScales([s], ['a'], dimensions, { barLayout: 'stacked' })
-            expect(() =>
-                computeSeriesBars({
-                    series: s,
-                    labels: ['a'],
-                    scales,
-                    layout: 'stacked',
-                    isHorizontal: false,
-                    isTopOfStack: true,
-                })
-            ).toThrow(/stackedBand is required/)
+            expect(() => layoutOf({ series: s, scales, layout: 'stacked', isTopOfStack: true })).toThrow(
+                /stackedBand is required/
+            )
         })
     })
 
-    describe('computeSeriesBars — null handling', () => {
-        it('returns null for null/NaN data points but preserves dataIndex order', () => {
-            const labels = ['a', 'b', 'c']
-            const s = makeSeries({ key: 's', data: [10, NaN, 20] })
-            const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
-            const bars = computeSeriesBars({
-                series: s,
-                labels,
-                scales,
-                layout: 'grouped',
-                isHorizontal: false,
-                isTopOfStack: false,
-            })
-            expect(bars).toHaveLength(3)
-            expect(bars[0]?.dataIndex).toBe(0)
-            expect(bars[1]).toBeNull()
-            expect(bars[2]?.dataIndex).toBe(2)
-        })
+    it('returns null for null/NaN data points but preserves dataIndex order', () => {
+        const labels = ['a', 'b', 'c']
+        const s = makeSeries({ key: 's', data: [10, NaN, 20] })
+        const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
+        const bars = layoutOf({ series: s, labels, scales })
+        expect(bars).toHaveLength(3)
+        expect(bars[0]?.dataIndex).toBe(0)
+        expect(bars[1]).toBeNull()
+        expect(bars[2]?.dataIndex).toBe(2)
     })
 })

--- a/frontend/src/lib/hog-charts/core/bar-layout.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.test.ts
@@ -25,11 +25,18 @@ describe('hog-charts bar-layout', () => {
             const a = makeSeries({ key: 'a', data: [10, 20] })
             const b = makeSeries({ key: 'b', data: [5, 15] })
             const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'grouped' })
-            const bars = computeSeriesBars(a, labels, scales, 'grouped', false, undefined, false)
+            const bars = computeSeriesBars({
+                series: a,
+                labels,
+                scales,
+                layout: 'grouped',
+                isHorizontal: false,
+                stackedBand: undefined,
+                isTopOfStack: false,
+            })
             expect(bars).toHaveLength(2)
             expect(bars[0]?.dataIndex).toBe(0)
             expect(bars[0]?.height).toBeGreaterThan(0)
-            // Vertical: bar.y should be smaller than baseline pixel since positive values map up.
             const baselinePixel = scales.value(0)
             expect(bars[0]!.y).toBeLessThan(baselinePixel)
             expect(bars[0]!.y + bars[0]!.height).toBeCloseTo(baselinePixel, 5)
@@ -39,10 +46,17 @@ describe('hog-charts bar-layout', () => {
             const labels = ['a']
             const s = makeSeries({ key: 's', data: [-10] })
             const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
-            const bars = computeSeriesBars(s, labels, scales, 'grouped', false, undefined, false)
+            const bars = computeSeriesBars({
+                series: s,
+                labels,
+                scales,
+                layout: 'grouped',
+                isHorizontal: false,
+                stackedBand: undefined,
+                isTopOfStack: false,
+            })
             expect(bars[0]?.corners).toEqual({ bottomLeft: true, bottomRight: true })
             const baselinePixel = scales.value(0)
-            // Negative values draw below the baseline; bar.y is at the baseline.
             expect(bars[0]!.y).toBeCloseTo(baselinePixel, 5)
         })
 
@@ -53,11 +67,58 @@ describe('hog-charts bar-layout', () => {
                 barLayout: 'grouped',
                 axisOrientation: 'horizontal',
             })
-            const bars = computeSeriesBars(s, labels, scales, 'grouped', true, undefined, false)
+            const bars = computeSeriesBars({
+                series: s,
+                labels,
+                scales,
+                layout: 'grouped',
+                isHorizontal: true,
+                stackedBand: undefined,
+                isTopOfStack: false,
+            })
             expect(bars[0]?.corners).toEqual({ topRight: true, bottomRight: true })
             const baselinePixel = scales.value(0)
             expect(bars[0]!.x).toBeCloseTo(baselinePixel, 5)
             expect(bars[0]!.width).toBeGreaterThan(0)
+        })
+
+        it('flips corners for horizontal + negative grouped bars', () => {
+            const labels = ['a']
+            const s = makeSeries({ key: 's', data: [-10] })
+            const scales = createBarScales([s], labels, dimensions, {
+                barLayout: 'grouped',
+                axisOrientation: 'horizontal',
+            })
+            const bars = computeSeriesBars({
+                series: s,
+                labels,
+                scales,
+                layout: 'grouped',
+                isHorizontal: true,
+                stackedBand: undefined,
+                isTopOfStack: false,
+            })
+            expect(bars[0]?.corners).toEqual({ topLeft: true, bottomLeft: true })
+            const baselinePixel = scales.value(0)
+            // Negative horizontal bar extends left of baseline; bar.x + width sits at the baseline.
+            expect(bars[0]!.x + bars[0]!.width).toBeCloseTo(baselinePixel, 5)
+        })
+
+        it('skips bars for excluded series in the grouped sub-band', () => {
+            const labels = ['a']
+            const visible = makeSeries({ key: 'visible', data: [10] })
+            const excluded = makeSeries({ key: 'excluded', data: [10], visibility: { excluded: true } })
+            const scales = createBarScales([visible, excluded], labels, dimensions, { barLayout: 'grouped' })
+            const bars = computeSeriesBars({
+                series: excluded,
+                labels,
+                scales,
+                layout: 'grouped',
+                isHorizontal: false,
+                stackedBand: undefined,
+                isTopOfStack: false,
+            })
+            expect(bars[0]).toBeNull()
         })
     })
 
@@ -70,9 +131,16 @@ describe('hog-charts bar-layout', () => {
             const stacks = computeStackData([a, b], labels)
             const stackB = stacks.get('b')!
 
-            const bars = computeSeriesBars(b, labels, scales, 'stacked', false, stackB, true)
+            const bars = computeSeriesBars({
+                series: b,
+                labels,
+                scales,
+                layout: 'stacked',
+                isHorizontal: false,
+                stackedBand: stackB,
+                isTopOfStack: true,
+            })
             expect(bars).toHaveLength(2)
-            // Stacked bar height must equal pixel distance between band top and bottom.
             const expectedHeight0 = Math.abs(scales.value(stackB.top[0]) - scales.value(stackB.bottom[0]))
             expect(bars[0]!.height).toBeCloseTo(expectedHeight0, 5)
         })
@@ -84,8 +152,24 @@ describe('hog-charts bar-layout', () => {
             const scales = createBarScales([a, b], labels, dimensions, { barLayout: 'stacked' })
             const stacks = computeStackData([a, b], labels)
 
-            const bottomBars = computeSeriesBars(a, labels, scales, 'stacked', false, stacks.get('a'), false)
-            const topBars = computeSeriesBars(b, labels, scales, 'stacked', false, stacks.get('b'), true)
+            const bottomBars = computeSeriesBars({
+                series: a,
+                labels,
+                scales,
+                layout: 'stacked',
+                isHorizontal: false,
+                stackedBand: stacks.get('a'),
+                isTopOfStack: false,
+            })
+            const topBars = computeSeriesBars({
+                series: b,
+                labels,
+                scales,
+                layout: 'stacked',
+                isHorizontal: false,
+                stackedBand: stacks.get('b'),
+                isTopOfStack: true,
+            })
             expect(bottomBars[0]?.corners).toEqual({})
             expect(topBars[0]?.corners).toEqual({ topLeft: true, topRight: true })
         })
@@ -96,7 +180,15 @@ describe('hog-charts bar-layout', () => {
             const labels = ['a', 'b', 'c']
             const s = makeSeries({ key: 's', data: [10, NaN, 20] })
             const scales = createBarScales([s], labels, dimensions, { barLayout: 'grouped' })
-            const bars = computeSeriesBars(s, labels, scales, 'grouped', false, undefined, false)
+            const bars = computeSeriesBars({
+                series: s,
+                labels,
+                scales,
+                layout: 'grouped',
+                isHorizontal: false,
+                stackedBand: undefined,
+                isTopOfStack: false,
+            })
             expect(bars).toHaveLength(3)
             expect(bars[0]?.dataIndex).toBe(0)
             expect(bars[1]).toBeNull()

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -4,8 +4,8 @@ import type { Series } from './types'
 
 export type SeriesBarLayout = (BarRect | null)[]
 
-/** Cap is the side away from the value-axis baseline; for stacked layers below the topmost
- *  the caller should pass `shouldRoundCap: false`. */
+/** Cap is the side away from the value-axis baseline; pass `shouldRoundCap: false` for stacked
+ *  layers below the topmost. */
 export function cornersFor(isHorizontal: boolean, isPositive: boolean, shouldRoundCap: boolean): BarRoundedCorners {
     if (!shouldRoundCap) {
         return {}
@@ -16,13 +16,30 @@ export function cornersFor(isHorizontal: boolean, isPositive: boolean, shouldRou
     return isPositive ? { topLeft: true, topRight: true } : { bottomLeft: true, bottomRight: true }
 }
 
+function makeBarRect(
+    isHorizontal: boolean,
+    bandStart: number,
+    bandSize: number,
+    valueA: number,
+    valueB: number,
+    corners: BarRoundedCorners,
+    dataIndex: number
+): BarRect {
+    const valueMin = Math.min(valueA, valueB)
+    const valueSize = Math.abs(valueA - valueB)
+    return isHorizontal
+        ? { x: valueMin, y: bandStart, width: valueSize, height: bandSize, corners, dataIndex }
+        : { x: bandStart, y: valueMin, width: bandSize, height: valueSize, corners, dataIndex }
+}
+
 export interface ComputeSeriesBarsOptions {
     series: Series
     labels: string[]
     scales: BarScaleSet
     layout: 'stacked' | 'grouped' | 'percent'
     isHorizontal: boolean
-    stackedBand: StackedBand | undefined
+    /** Required for `stacked` and `percent` layouts. Must be omitted for `grouped`. */
+    stackedBand?: StackedBand
     isTopOfStack: boolean
 }
 
@@ -35,92 +52,59 @@ export function computeSeriesBars({
     stackedBand,
     isTopOfStack,
 }: ComputeSeriesBarsOptions): SeriesBarLayout {
+    const isGrouped = layout === 'grouped'
+    if (!isGrouped && !stackedBand) {
+        throw new Error(`computeSeriesBars: stackedBand is required for layout '${layout}'`)
+    }
+
     const result: SeriesBarLayout = []
     const bandWidth = scales.band.bandwidth()
     const valueAtZero = scales.value(0)
-    const isGrouped = layout === 'grouped'
     const shouldRoundCap = isGrouped || isTopOfStack
     const groupOffsetForKey = isGrouped ? scales.group?.(series.key) : undefined
     const groupBandWidth = isGrouped ? (scales.group?.bandwidth() ?? bandWidth) : bandWidth
+    // For stacked/percent the bar's "positive direction" depends on which pixel is further from baseline,
+    // which differs by orientation: horizontal = larger x-pixel, vertical = smaller y-pixel (axis is inverted).
+    const isPositiveByPixels = (topPx: number, bottomPx: number): boolean =>
+        isHorizontal ? topPx >= bottomPx : topPx <= bottomPx
 
     for (let i = 0; i < labels.length; i++) {
         const bandStart = scales.band(labels[i])
-        if (bandStart == null) {
-            result.push(null)
-            continue
-        }
-
         const raw = series.data[i]
-        if (raw == null || !isFinite(raw)) {
+        if (bandStart == null || raw == null || !isFinite(raw)) {
             result.push(null)
             continue
         }
 
         if (isGrouped) {
-            if (groupOffsetForKey == null) {
-                result.push(null)
-                continue
-            }
             const valuePixel = scales.value(raw)
-            if (!isFinite(valuePixel)) {
+            if (groupOffsetForKey == null || !isFinite(valuePixel)) {
                 result.push(null)
                 continue
             }
-
             const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
-            if (isHorizontal) {
-                result.push({
-                    x: Math.min(valueAtZero, valuePixel),
-                    y: bandStart + groupOffsetForKey,
-                    width: Math.abs(valuePixel - valueAtZero),
-                    height: groupBandWidth,
+            result.push(
+                makeBarRect(
+                    isHorizontal,
+                    bandStart + groupOffsetForKey,
+                    groupBandWidth,
+                    valueAtZero,
+                    valuePixel,
                     corners,
-                    dataIndex: i,
-                })
-            } else {
-                result.push({
-                    x: bandStart + groupOffsetForKey,
-                    y: Math.min(valueAtZero, valuePixel),
-                    width: groupBandWidth,
-                    height: Math.abs(valuePixel - valueAtZero),
-                    corners,
-                    dataIndex: i,
-                })
-            }
+                    i
+                )
+            )
             continue
         }
 
-        // Stacked / percent: stack data is non-negative (computeStackData clamps via Math.max(0, …)),
-        // so cornersFor's `isPositive=true` is correct here.
-        const top = stackedBand?.top[i] ?? raw
-        const bottom = stackedBand?.bottom[i] ?? 0
-        const topPixel = scales.value(top)
-        const bottomPixel = scales.value(bottom)
+        const topPixel = scales.value(stackedBand!.top[i])
+        const bottomPixel = scales.value(stackedBand!.bottom[i])
         if (!isFinite(topPixel) || !isFinite(bottomPixel)) {
             result.push(null)
             continue
         }
-
-        const corners = cornersFor(isHorizontal, true, shouldRoundCap)
-        if (isHorizontal) {
-            result.push({
-                x: Math.min(topPixel, bottomPixel),
-                y: bandStart,
-                width: Math.abs(topPixel - bottomPixel),
-                height: bandWidth,
-                corners,
-                dataIndex: i,
-            })
-        } else {
-            result.push({
-                x: bandStart,
-                y: Math.min(topPixel, bottomPixel),
-                width: bandWidth,
-                height: Math.abs(topPixel - bottomPixel),
-                corners,
-                dataIndex: i,
-            })
-        }
+        const corners = cornersFor(isHorizontal, isPositiveByPixels(topPixel, bottomPixel), shouldRoundCap)
+        result.push(makeBarRect(isHorizontal, bandStart, bandWidth, topPixel, bottomPixel, corners, i))
     }
     return result
 }

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -83,17 +83,8 @@ export function computeSeriesBars({
                 continue
             }
             const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
-            result.push(
-                makeBarRect(
-                    isHorizontal,
-                    bandStart + groupOffsetForKey,
-                    groupBandWidth,
-                    valueAtZero,
-                    valuePixel,
-                    corners,
-                    i
-                )
-            )
+            const start = bandStart + groupOffsetForKey
+            result.push(makeBarRect(isHorizontal, start, groupBandWidth, valueAtZero, valuePixel, corners, i))
             continue
         }
 

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -1,0 +1,126 @@
+import type { BarRect, BarRoundedCorners } from './canvas-renderer'
+import type { BarScaleSet, StackedBand } from './scales'
+import type { Series } from './types'
+
+/** Bars laid out for a single series across all labels, indexed by data index. */
+export type SeriesBarLayout = (BarRect | null)[]
+
+/** Pick which corners to round for a bar's cap. The cap is the side away from the
+ *  value-axis baseline; for stacked layers below the topmost we don't round at all. */
+export function cornersFor(isHorizontal: boolean, isPositive: boolean, shouldRoundCap: boolean): BarRoundedCorners {
+    if (!shouldRoundCap) {
+        return {}
+    }
+    if (isHorizontal) {
+        return isPositive ? { topRight: true, bottomRight: true } : { topLeft: true, bottomLeft: true }
+    }
+    return isPositive ? { topLeft: true, topRight: true } : { bottomLeft: true, bottomRight: true }
+}
+
+/** Computes bar geometry for one series given the layout mode and band scales.
+ *  Returns one entry per data index (or null when the bar is not drawable). */
+export function computeSeriesBars(
+    series: Series,
+    labels: string[],
+    scales: BarScaleSet,
+    layout: 'stacked' | 'grouped' | 'percent',
+    isHorizontal: boolean,
+    stackedBand: StackedBand | undefined,
+    isTopOfStack: boolean
+): SeriesBarLayout {
+    const result: SeriesBarLayout = []
+    const bandWidth = scales.band.bandwidth()
+    const valueAtZero = scales.value(0)
+
+    for (let i = 0; i < labels.length; i++) {
+        const bandStart = scales.band(labels[i])
+        if (bandStart == null) {
+            result.push(null)
+            continue
+        }
+
+        const raw = series.data[i]
+        if (raw == null || !isFinite(raw)) {
+            result.push(null)
+            continue
+        }
+
+        // Cap is the side away from the value-axis baseline; stacked layers below the topmost don't round.
+        const shouldRoundCap = layout === 'grouped' || isTopOfStack
+
+        if (layout === 'grouped') {
+            const groupOffset = scales.group?.(series.key)
+            if (groupOffset == null) {
+                result.push(null)
+                continue
+            }
+            const groupBandWidth = scales.group?.bandwidth() ?? bandWidth
+            const valuePixel = scales.value(raw)
+            if (!isFinite(valuePixel)) {
+                result.push(null)
+                continue
+            }
+
+            const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
+            if (isHorizontal) {
+                const x = Math.min(valueAtZero, valuePixel)
+                const width = Math.abs(valuePixel - valueAtZero)
+                result.push({
+                    x,
+                    y: bandStart + groupOffset,
+                    width,
+                    height: groupBandWidth,
+                    corners,
+                    dataIndex: i,
+                })
+            } else {
+                const y = Math.min(valueAtZero, valuePixel)
+                const height = Math.abs(valuePixel - valueAtZero)
+                result.push({
+                    x: bandStart + groupOffset,
+                    y,
+                    width: groupBandWidth,
+                    height,
+                    corners,
+                    dataIndex: i,
+                })
+            }
+            continue
+        }
+
+        // Stacked / percent: use the band's stacked top/bottom values.
+        const top = stackedBand?.top[i] ?? raw
+        const bottom = stackedBand?.bottom[i] ?? 0
+        const topPixel = scales.value(top)
+        const bottomPixel = scales.value(bottom)
+        if (!isFinite(topPixel) || !isFinite(bottomPixel)) {
+            result.push(null)
+            continue
+        }
+
+        if (isHorizontal) {
+            const x = Math.min(topPixel, bottomPixel)
+            const width = Math.abs(topPixel - bottomPixel)
+            result.push({
+                x,
+                y: bandStart,
+                width,
+                height: bandWidth,
+                corners: shouldRoundCap ? { topRight: true, bottomRight: true } : {},
+                dataIndex: i,
+            })
+        } else {
+            const y = Math.min(topPixel, bottomPixel)
+            const height = Math.abs(topPixel - bottomPixel)
+            result.push({
+                x: bandStart,
+                y,
+                width: bandWidth,
+                height,
+                corners: shouldRoundCap ? { topLeft: true, topRight: true } : {},
+                dataIndex: i,
+            })
+        }
+    }
+    return result
+}

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -2,11 +2,10 @@ import type { BarRect, BarRoundedCorners } from './canvas-renderer'
 import type { BarScaleSet, StackedBand } from './scales'
 import type { Series } from './types'
 
-/** Bars laid out for a single series across all labels, indexed by data index. */
 export type SeriesBarLayout = (BarRect | null)[]
 
-/** Pick which corners to round for a bar's cap. The cap is the side away from the
- *  value-axis baseline; for stacked layers below the topmost we don't round at all. */
+/** Cap is the side away from the value-axis baseline; for stacked layers below the topmost
+ *  the caller should pass `shouldRoundCap: false`. */
 export function cornersFor(isHorizontal: boolean, isPositive: boolean, shouldRoundCap: boolean): BarRoundedCorners {
     if (!shouldRoundCap) {
         return {}
@@ -17,20 +16,32 @@ export function cornersFor(isHorizontal: boolean, isPositive: boolean, shouldRou
     return isPositive ? { topLeft: true, topRight: true } : { bottomLeft: true, bottomRight: true }
 }
 
-/** Computes bar geometry for one series given the layout mode and band scales.
- *  Returns one entry per data index (or null when the bar is not drawable). */
-export function computeSeriesBars(
-    series: Series,
-    labels: string[],
-    scales: BarScaleSet,
-    layout: 'stacked' | 'grouped' | 'percent',
-    isHorizontal: boolean,
-    stackedBand: StackedBand | undefined,
+export interface ComputeSeriesBarsOptions {
+    series: Series
+    labels: string[]
+    scales: BarScaleSet
+    layout: 'stacked' | 'grouped' | 'percent'
+    isHorizontal: boolean
+    stackedBand: StackedBand | undefined
     isTopOfStack: boolean
-): SeriesBarLayout {
+}
+
+export function computeSeriesBars({
+    series,
+    labels,
+    scales,
+    layout,
+    isHorizontal,
+    stackedBand,
+    isTopOfStack,
+}: ComputeSeriesBarsOptions): SeriesBarLayout {
     const result: SeriesBarLayout = []
     const bandWidth = scales.band.bandwidth()
     const valueAtZero = scales.value(0)
+    const isGrouped = layout === 'grouped'
+    const shouldRoundCap = isGrouped || isTopOfStack
+    const groupOffsetForKey = isGrouped ? scales.group?.(series.key) : undefined
+    const groupBandWidth = isGrouped ? (scales.group?.bandwidth() ?? bandWidth) : bandWidth
 
     for (let i = 0; i < labels.length; i++) {
         const bandStart = scales.band(labels[i])
@@ -45,16 +56,11 @@ export function computeSeriesBars(
             continue
         }
 
-        // Cap is the side away from the value-axis baseline; stacked layers below the topmost don't round.
-        const shouldRoundCap = layout === 'grouped' || isTopOfStack
-
-        if (layout === 'grouped') {
-            const groupOffset = scales.group?.(series.key)
-            if (groupOffset == null) {
+        if (isGrouped) {
+            if (groupOffsetForKey == null) {
                 result.push(null)
                 continue
             }
-            const groupBandWidth = scales.group?.bandwidth() ?? bandWidth
             const valuePixel = scales.value(raw)
             if (!isFinite(valuePixel)) {
                 result.push(null)
@@ -63,24 +69,20 @@ export function computeSeriesBars(
 
             const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
             if (isHorizontal) {
-                const x = Math.min(valueAtZero, valuePixel)
-                const width = Math.abs(valuePixel - valueAtZero)
                 result.push({
-                    x,
-                    y: bandStart + groupOffset,
-                    width,
+                    x: Math.min(valueAtZero, valuePixel),
+                    y: bandStart + groupOffsetForKey,
+                    width: Math.abs(valuePixel - valueAtZero),
                     height: groupBandWidth,
                     corners,
                     dataIndex: i,
                 })
             } else {
-                const y = Math.min(valueAtZero, valuePixel)
-                const height = Math.abs(valuePixel - valueAtZero)
                 result.push({
-                    x: bandStart + groupOffset,
-                    y,
+                    x: bandStart + groupOffsetForKey,
+                    y: Math.min(valueAtZero, valuePixel),
                     width: groupBandWidth,
-                    height,
+                    height: Math.abs(valuePixel - valueAtZero),
                     corners,
                     dataIndex: i,
                 })
@@ -88,7 +90,8 @@ export function computeSeriesBars(
             continue
         }
 
-        // Stacked / percent: use the band's stacked top/bottom values.
+        // Stacked / percent: stack data is non-negative (computeStackData clamps via Math.max(0, …)),
+        // so cornersFor's `isPositive=true` is correct here.
         const top = stackedBand?.top[i] ?? raw
         const bottom = stackedBand?.bottom[i] ?? 0
         const topPixel = scales.value(top)
@@ -98,26 +101,23 @@ export function computeSeriesBars(
             continue
         }
 
+        const corners = cornersFor(isHorizontal, true, shouldRoundCap)
         if (isHorizontal) {
-            const x = Math.min(topPixel, bottomPixel)
-            const width = Math.abs(topPixel - bottomPixel)
             result.push({
-                x,
+                x: Math.min(topPixel, bottomPixel),
                 y: bandStart,
-                width,
+                width: Math.abs(topPixel - bottomPixel),
                 height: bandWidth,
-                corners: shouldRoundCap ? { topRight: true, bottomRight: true } : {},
+                corners,
                 dataIndex: i,
             })
         } else {
-            const y = Math.min(topPixel, bottomPixel)
-            const height = Math.abs(topPixel - bottomPixel)
             result.push({
                 x: bandStart,
-                y,
+                y: Math.min(topPixel, bottomPixel),
                 width: bandWidth,
-                height,
-                corners: shouldRoundCap ? { topLeft: true, topRight: true } : {},
+                height: Math.abs(topPixel - bottomPixel),
+                corners,
                 dataIndex: i,
             })
         }

--- a/frontend/src/lib/hog-charts/core/bar-scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-scales.test.ts
@@ -53,14 +53,12 @@ describe('hog-charts bar scales', () => {
             const grouped = createBarScales(series, ['a', 'b'], dimensions, { barLayout: 'grouped' })
             expect(stacked.group).toBeUndefined()
             expect(grouped.group).not.toBeUndefined()
-            // Two series so each gets ~half the band, minus padding
             expect(grouped.group!.bandwidth()).toBeLessThan(grouped.band.bandwidth())
         })
 
         it('uses [0, 1] for the value domain in percent layout', () => {
             const series = [makeSeries({ key: 's1', data: [50, 100, 150] })]
             const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { barLayout: 'percent' })
-            // Linear nice() over [0,1] keeps the domain at [0, 1]
             const yAt1 = value(1)
             const yAt0 = value(0)
             expect(yAt1).toBeLessThan(yAt0)
@@ -86,8 +84,6 @@ describe('hog-charts bar scales', () => {
     })
 
     describe('createBarScales — pixel positioning', () => {
-        // Vertical: y-axis inverts, so larger value → smaller pixel.
-        // Horizontal: x-axis runs left→right, so larger value → larger pixel.
         it.each([
             { orientation: 'vertical' as const, expected: 'less' as const },
             { orientation: 'horizontal' as const, expected: 'greater' as const },

--- a/frontend/src/lib/hog-charts/core/bar-scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-scales.test.ts
@@ -135,10 +135,36 @@ describe('hog-charts bar scales', () => {
                 barLayout: 'stacked',
                 stackedSeries,
             })
-            // The "30" stack top should map within the plot area
             const yAtStackTop = value(30)
             expect(yAtStackTop).toBeGreaterThanOrEqual(dimensions.plotTop - 1)
             expect(yAtStackTop).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
+        })
+
+        it('skips excluded series when building the grouped sub-band', () => {
+            const visible = makeSeries({ key: 'visible', data: [10] })
+            const excluded = makeSeries({ key: 'excluded', data: [10], visibility: { excluded: true } })
+            const { group } = createBarScales([visible, excluded], ['a'], dimensions, { barLayout: 'grouped' })
+            expect(group?.('visible')).not.toBeUndefined()
+            expect(group?.('excluded')).toBeUndefined()
+        })
+    })
+
+    describe('createBarScales — log scale', () => {
+        it('snaps the domain to enclosing decade boundaries with positive data', () => {
+            const series = [makeSeries({ key: 's1', data: [3, 50, 700] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { scaleType: 'log' })
+            const [lo, hi] = value.domain()
+            expect(lo).toBeLessThanOrEqual(3)
+            expect(hi).toBeGreaterThanOrEqual(700)
+            expect(value(700)).toBeLessThan(value(3))
+        })
+
+        it('falls back to linear when the data has no positive values', () => {
+            const series = [makeSeries({ key: 's1', data: [-10, -5, 0] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { scaleType: 'log' })
+            const domain = value.domain()
+            expect(domain[0]).toBeLessThanOrEqual(-10)
+            expect(domain[1]).toBeGreaterThanOrEqual(0)
         })
     })
 })

--- a/frontend/src/lib/hog-charts/core/bar-scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-scales.test.ts
@@ -1,0 +1,144 @@
+import { dimensions, makeSeries } from '../test-helpers'
+import { createBarScales } from './scales'
+
+describe('hog-charts bar scales', () => {
+    describe('createBarScales — vertical orientation (default)', () => {
+        it('builds a band scale across the plot width', () => {
+            const series = [makeSeries({ key: 's1', data: [10, 20, 30] })]
+            const { band } = createBarScales(series, ['a', 'b', 'c'], dimensions)
+            const bandStart = band('a')!
+            expect(bandStart).toBeGreaterThanOrEqual(dimensions.plotLeft)
+            expect(bandStart + band.bandwidth()).toBeLessThanOrEqual(dimensions.plotLeft + dimensions.plotWidth + 1)
+        })
+
+        it('produces a bandwidth proportional to the number of labels', () => {
+            const series = [makeSeries({ key: 's1', data: [1, 2, 3, 4] })]
+            const four = createBarScales(series, ['a', 'b', 'c', 'd'], dimensions)
+            const two = createBarScales(series, ['a', 'b'], dimensions)
+            expect(four.band.bandwidth()).toBeLessThan(two.band.bandwidth())
+        })
+
+        it('inverts the value scale so larger values map to smaller y pixels', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 50, 100] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions)
+            expect(value(100)).toBeLessThan(value(0))
+        })
+
+        // Both signs must extend the value domain to include zero so the bar baselines align
+        // with the plot edge rather than floating mid-plot.
+        it.each([
+            { sign: 'positive', data: [40, 60, 80], extreme: 80 },
+            { sign: 'negative', data: [-40, -60, -80], extreme: -80 },
+        ])(
+            'extends the value domain to include zero when all data is $sign (zero at the baseline)',
+            ({ data, extreme }) => {
+                const series = [makeSeries({ key: 's1', data })]
+                const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions)
+                const yAtZero = value(0)
+                const yAtExtreme = value(extreme)
+                // zero must sit within the plot area, with the extreme value on the far side
+                expect(yAtZero).toBeGreaterThanOrEqual(dimensions.plotTop - 1)
+                expect(yAtZero).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
+                if (extreme > 0) {
+                    expect(yAtExtreme).toBeLessThan(yAtZero)
+                } else {
+                    expect(yAtExtreme).toBeGreaterThan(yAtZero)
+                }
+            }
+        )
+
+        it('returns a group scale only for grouped layout', () => {
+            const series = [makeSeries({ key: 's1', data: [1, 2] }), makeSeries({ key: 's2', data: [3, 4] })]
+            const stacked = createBarScales(series, ['a', 'b'], dimensions, { barLayout: 'stacked' })
+            const grouped = createBarScales(series, ['a', 'b'], dimensions, { barLayout: 'grouped' })
+            expect(stacked.group).toBeUndefined()
+            expect(grouped.group).not.toBeUndefined()
+            // Two series so each gets ~half the band, minus padding
+            expect(grouped.group!.bandwidth()).toBeLessThan(grouped.band.bandwidth())
+        })
+
+        it('uses [0, 1] for the value domain in percent layout', () => {
+            const series = [makeSeries({ key: 's1', data: [50, 100, 150] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { barLayout: 'percent' })
+            // Linear nice() over [0,1] keeps the domain at [0, 1]
+            const yAt1 = value(1)
+            const yAt0 = value(0)
+            expect(yAt1).toBeLessThan(yAt0)
+            expect(value.domain()[0]).toBeCloseTo(0)
+            expect(value.domain()[1]).toBeCloseTo(1)
+        })
+    })
+
+    describe('createBarScales — horizontal orientation', () => {
+        it('places bands across the plot height', () => {
+            const series = [makeSeries({ key: 's1', data: [10, 20, 30] })]
+            const { band } = createBarScales(series, ['a', 'b', 'c'], dimensions, { axisOrientation: 'horizontal' })
+            const bandStart = band('a')!
+            expect(bandStart).toBeGreaterThanOrEqual(dimensions.plotTop)
+            expect(bandStart + band.bandwidth()).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
+        })
+
+        it('produces a value scale that increases left-to-right', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 50, 100] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { axisOrientation: 'horizontal' })
+            expect(value(100)).toBeGreaterThan(value(0))
+        })
+    })
+
+    describe('createBarScales — pixel positioning', () => {
+        // Vertical: y-axis inverts, so larger value → smaller pixel.
+        // Horizontal: x-axis runs left→right, so larger value → larger pixel.
+        it.each([
+            { orientation: 'vertical' as const, expected: 'less' as const },
+            { orientation: 'horizontal' as const, expected: 'greater' as const },
+        ])('places a positive value $expected than value(0) in $orientation mode', ({ orientation, expected }) => {
+            const series = [makeSeries({ key: 's1', data: [0, 50] })]
+            const { value } = createBarScales(series, ['a', 'b'], dimensions, { axisOrientation: orientation })
+            if (expected === 'less') {
+                expect(value(50)).toBeLessThan(value(0))
+            } else {
+                expect(value(50)).toBeGreaterThan(value(0))
+            }
+        })
+
+        it('makes consecutive band starts equally spaced', () => {
+            const series = [makeSeries({ key: 's1', data: [1, 2, 3, 4] })]
+            const { band } = createBarScales(series, ['a', 'b', 'c', 'd'], dimensions)
+            const a = band('a')!
+            const b = band('b')!
+            const c = band('c')!
+            expect(b - a).toBeCloseTo(c - b, 5)
+        })
+
+        it('group bandwidth times series count plus padding does not exceed band bandwidth', () => {
+            const seriesArr = [
+                makeSeries({ key: 's1', data: [1] }),
+                makeSeries({ key: 's2', data: [2] }),
+                makeSeries({ key: 's3', data: [3] }),
+            ]
+            const grouped = createBarScales(seriesArr, ['a'], dimensions, { barLayout: 'grouped' })
+            const totalGroupSpan = grouped.group!.bandwidth() * 3
+            expect(totalGroupSpan).toBeLessThanOrEqual(grouped.band.bandwidth())
+        })
+    })
+
+    describe('createBarScales — empty / edge inputs', () => {
+        it('returns a [0, 1] value domain when no series are provided', () => {
+            const { value } = createBarScales([], ['a', 'b'], dimensions)
+            expect(value.domain()).toEqual([0, 1])
+        })
+
+        it('uses stackedSeries values for the value domain when provided', () => {
+            const rawSeries = [makeSeries({ key: 's1', data: [10] }), makeSeries({ key: 's2', data: [20] })]
+            const stackedSeries = [makeSeries({ key: 's1', data: [10] }), makeSeries({ key: 's2', data: [30] })]
+            const { value } = createBarScales(rawSeries, ['a'], dimensions, {
+                barLayout: 'stacked',
+                stackedSeries,
+            })
+            // The "30" stack top should map within the plot area
+            const yAtStackTop = value(30)
+            expect(yAtStackTop).toBeGreaterThanOrEqual(dimensions.plotTop - 1)
+            expect(yAtStackTop).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
+        })
+    })
+})

--- a/frontend/src/lib/hog-charts/core/bar-scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-scales.test.ts
@@ -3,12 +3,23 @@ import { createBarScales } from './scales'
 
 describe('hog-charts bar scales', () => {
     describe('createBarScales — vertical orientation (default)', () => {
-        it('builds a band scale across the plot width', () => {
+        it.each([
+            {
+                orientation: 'vertical' as const,
+                rangeStart: dimensions.plotLeft,
+                rangeEnd: dimensions.plotLeft + dimensions.plotWidth,
+            },
+            {
+                orientation: 'horizontal' as const,
+                rangeStart: dimensions.plotTop,
+                rangeEnd: dimensions.plotTop + dimensions.plotHeight,
+            },
+        ])('places bands across the categorical axis ($orientation)', ({ orientation, rangeStart, rangeEnd }) => {
             const series = [makeSeries({ key: 's1', data: [10, 20, 30] })]
-            const { band } = createBarScales(series, ['a', 'b', 'c'], dimensions)
+            const { band } = createBarScales(series, ['a', 'b', 'c'], dimensions, { axisOrientation: orientation })
             const bandStart = band('a')!
-            expect(bandStart).toBeGreaterThanOrEqual(dimensions.plotLeft)
-            expect(bandStart + band.bandwidth()).toBeLessThanOrEqual(dimensions.plotLeft + dimensions.plotWidth + 1)
+            expect(bandStart).toBeGreaterThanOrEqual(rangeStart)
+            expect(bandStart + band.bandwidth()).toBeLessThanOrEqual(rangeEnd + 1)
         })
 
         it('produces a bandwidth proportional to the number of labels', () => {
@@ -64,22 +75,6 @@ describe('hog-charts bar scales', () => {
             expect(yAt1).toBeLessThan(yAt0)
             expect(value.domain()[0]).toBeCloseTo(0)
             expect(value.domain()[1]).toBeCloseTo(1)
-        })
-    })
-
-    describe('createBarScales — horizontal orientation', () => {
-        it('places bands across the plot height', () => {
-            const series = [makeSeries({ key: 's1', data: [10, 20, 30] })]
-            const { band } = createBarScales(series, ['a', 'b', 'c'], dimensions, { axisOrientation: 'horizontal' })
-            const bandStart = band('a')!
-            expect(bandStart).toBeGreaterThanOrEqual(dimensions.plotTop)
-            expect(bandStart + band.bandwidth()).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
-        })
-
-        it('produces a value scale that increases left-to-right', () => {
-            const series = [makeSeries({ key: 's1', data: [0, 50, 100] })]
-            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { axisOrientation: 'horizontal' })
-            expect(value(100)).toBeGreaterThan(value(0))
         })
     })
 

--- a/frontend/src/lib/hog-charts/core/bar-scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-scales.test.ts
@@ -35,28 +35,20 @@ describe('hog-charts bar scales', () => {
             expect(value(100)).toBeLessThan(value(0))
         })
 
-        // Both signs must extend the value domain to include zero so the bar baselines align
-        // with the plot edge rather than floating mid-plot.
+        // Both signs must extend the value domain to include zero so bar baselines align with
+        // the plot edge. expectedSign tracks whether the extreme pixel sits above (-1) or below
+        // (+1) the zero pixel.
         it.each([
-            { sign: 'positive', data: [40, 60, 80], extreme: 80 },
-            { sign: 'negative', data: [-40, -60, -80], extreme: -80 },
-        ])(
-            'extends the value domain to include zero when all data is $sign (zero at the baseline)',
-            ({ data, extreme }) => {
-                const series = [makeSeries({ key: 's1', data })]
-                const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions)
-                const yAtZero = value(0)
-                const yAtExtreme = value(extreme)
-                // zero must sit within the plot area, with the extreme value on the far side
-                expect(yAtZero).toBeGreaterThanOrEqual(dimensions.plotTop - 1)
-                expect(yAtZero).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
-                if (extreme > 0) {
-                    expect(yAtExtreme).toBeLessThan(yAtZero)
-                } else {
-                    expect(yAtExtreme).toBeGreaterThan(yAtZero)
-                }
-            }
-        )
+            { sign: 'positive', data: [40, 60, 80], extreme: 80, expectedSign: -1 },
+            { sign: 'negative', data: [-40, -60, -80], extreme: -80, expectedSign: 1 },
+        ])('extends the value domain to include zero ($sign data)', ({ data, extreme, expectedSign }) => {
+            const series = [makeSeries({ key: 's1', data })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions)
+            const yAtZero = value(0)
+            expect(yAtZero).toBeGreaterThanOrEqual(dimensions.plotTop - 1)
+            expect(yAtZero).toBeLessThanOrEqual(dimensions.plotTop + dimensions.plotHeight + 1)
+            expect(Math.sign(value(extreme) - yAtZero)).toBe(expectedSign)
+        })
 
         it('returns a group scale only for grouped layout', () => {
             const series = [makeSeries({ key: 's1', data: [1, 2] }), makeSeries({ key: 's2', data: [3, 4] })]
@@ -80,16 +72,12 @@ describe('hog-charts bar scales', () => {
 
     describe('createBarScales — pixel positioning', () => {
         it.each([
-            { orientation: 'vertical' as const, expected: 'less' as const },
-            { orientation: 'horizontal' as const, expected: 'greater' as const },
-        ])('places a positive value $expected than value(0) in $orientation mode', ({ orientation, expected }) => {
+            { orientation: 'vertical' as const, expectedSign: -1 },
+            { orientation: 'horizontal' as const, expectedSign: 1 },
+        ])('places value(50) on the right side of value(0) for $orientation', ({ orientation, expectedSign }) => {
             const series = [makeSeries({ key: 's1', data: [0, 50] })]
             const { value } = createBarScales(series, ['a', 'b'], dimensions, { axisOrientation: orientation })
-            if (expected === 'less') {
-                expect(value(50)).toBeLessThan(value(0))
-            } else {
-                expect(value(50)).toBeGreaterThan(value(0))
-            }
+            expect(Math.sign(value(50) - value(0))).toBe(expectedSign)
         })
 
         it('makes consecutive band starts equally spaced', () => {

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -291,40 +291,37 @@ export function createBarScales(
         ? [dimensions.plotLeft, dimensions.plotLeft + dimensions.plotWidth]
         : [dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop]
 
+    return {
+        band,
+        value: buildBarValueScale(series, valueRange, tickCount, barLayout, scaleType, stackedSeries),
+        group,
+    }
+}
+
+function buildBarValueScale(
+    series: Series[],
+    valueRange: [number, number],
+    tickCount: number,
+    barLayout: 'stacked' | 'grouped' | 'percent',
+    scaleType: 'linear' | 'log',
+    stackedSeries: Series[] | undefined
+): D3YScale {
     if (barLayout === 'percent') {
-        const value = d3.scaleLinear().domain([0, 1]).nice(tickCount).range(valueRange)
-        return { band, value, group }
+        return d3.scaleLinear().domain([0, 1]).nice(tickCount).range(valueRange)
     }
-
-    const seriesForRange = stackedSeries ?? series
-    const range = seriesValueRange(seriesForRange)
-
+    const range = seriesValueRange(stackedSeries ?? series)
     if (range.count === 0) {
-        const value = d3.scaleLinear().domain([0, 1]).range(valueRange)
-        return { band, value, group }
+        return d3.scaleLinear().domain([0, 1]).range(valueRange)
     }
-
-    let { min, max } = range
-    if (min > 0) {
-        min = 0
-    } else if (max < 0) {
-        max = 0
-    }
-
-    if (scaleType === 'log') {
-        if (!isFinite(range.minPositive)) {
-            const value = d3.scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
-            return { band, value, group }
-        }
+    const min = range.min > 0 ? 0 : range.min
+    const max = range.max < 0 ? 0 : range.max
+    if (scaleType === 'log' && isFinite(range.minPositive)) {
         const niceMin = Math.pow(10, Math.ceil(Math.log10(range.minPositive)) - 1)
         const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
         const niceMax = Math.ceil(max / maxDecade) * maxDecade
-        const value = d3.scaleLog().domain([niceMin, niceMax]).range(valueRange).clamp(true)
-        return { band, value, group }
+        return d3.scaleLog().domain([niceMin, niceMax]).range(valueRange).clamp(true)
     }
-
-    const value = d3.scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
-    return { band, value, group }
+    return d3.scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
 }
 
 export function autoFormatYTick(value: number, domainMax: number): string {

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -239,26 +239,12 @@ export function computePercentStackData(series: Series[], labels: string[]): Map
 }
 
 export interface BarScaleSet {
-    /** Categorical band scale — maps a label to the leading edge of its band. */
     band: d3.ScaleBand<string>
-    /** Value scale — maps a numeric data value to a pixel coordinate along the value axis. */
     value: D3YScale
-    /** Per-axis value scales when multiple value axes are in use. */
-    valueAxes?: Record<string, { scale: D3YScale; position: 'left' | 'right' }>
-    /** Within-band sub-scale for grouped layout — maps a series key to its offset inside a band. */
+    /** Sub-band for grouped layout — maps a series key to its offset inside a band. */
     group?: d3.ScaleBand<string>
 }
 
-/** Builds bar-chart scales: a band scale on the categorical axis and a value scale on the value axis.
- *
- * `axisOrientation`:
- *  - `'vertical'` (default): categories on x, values on y. The value scale's range is inverted (top = max).
- *  - `'horizontal'`: categories on y, values on x. The value scale's range increases left-to-right.
- *
- * `barLayout`:
- *  - `'stacked'` / `'percent'`: value-axis domain spans cumulative totals (or [0, 1]).
- *  - `'grouped'`: value-axis domain spans individual series ranges; a sub-band scale is returned in `group`.
- */
 export function createBarScales(
     series: Series[],
     labels: string[],

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -238,6 +238,109 @@ export function computePercentStackData(series: Series[], labels: string[]): Map
     return buildStackData(series, labels, d3.stackOffsetExpand)
 }
 
+export interface BarScaleSet {
+    /** Categorical band scale — maps a label to the leading edge of its band. */
+    band: d3.ScaleBand<string>
+    /** Value scale — maps a numeric data value to a pixel coordinate along the value axis. */
+    value: D3YScale
+    /** Per-axis value scales when multiple value axes are in use. */
+    valueAxes?: Record<string, { scale: D3YScale; position: 'left' | 'right' }>
+    /** Within-band sub-scale for grouped layout — maps a series key to its offset inside a band. */
+    group?: d3.ScaleBand<string>
+}
+
+/** Builds bar-chart scales: a band scale on the categorical axis and a value scale on the value axis.
+ *
+ * `axisOrientation`:
+ *  - `'vertical'` (default): categories on x, values on y. The value scale's range is inverted (top = max).
+ *  - `'horizontal'`: categories on y, values on x. The value scale's range increases left-to-right.
+ *
+ * `barLayout`:
+ *  - `'stacked'` / `'percent'`: value-axis domain spans cumulative totals (or [0, 1]).
+ *  - `'grouped'`: value-axis domain spans individual series ranges; a sub-band scale is returned in `group`.
+ */
+export function createBarScales(
+    series: Series[],
+    labels: string[],
+    dimensions: ChartDimensions,
+    options: {
+        scaleType?: 'linear' | 'log'
+        barLayout?: 'stacked' | 'grouped' | 'percent'
+        axisOrientation?: 'vertical' | 'horizontal'
+        bandPadding?: number
+        groupPadding?: number
+        stackedSeries?: Series[]
+    } = {}
+): BarScaleSet {
+    const {
+        scaleType = 'linear',
+        barLayout = 'stacked',
+        axisOrientation = 'vertical',
+        bandPadding = 0.2,
+        groupPadding = 0.1,
+        stackedSeries,
+    } = options
+
+    const isHorizontal = axisOrientation === 'horizontal'
+    const tickCount = yTickCountForHeight(isHorizontal ? dimensions.plotWidth : dimensions.plotHeight)
+
+    const band = d3
+        .scaleBand<string>()
+        .domain(labels)
+        .range(
+            isHorizontal
+                ? [dimensions.plotTop, dimensions.plotTop + dimensions.plotHeight]
+                : [dimensions.plotLeft, dimensions.plotLeft + dimensions.plotWidth]
+        )
+        .paddingInner(bandPadding)
+        .paddingOuter(bandPadding / 2)
+
+    let group: d3.ScaleBand<string> | undefined
+    if (barLayout === 'grouped') {
+        const visibleKeys = series.filter((s) => !s.visibility?.excluded).map((s) => s.key)
+        group = d3.scaleBand<string>().domain(visibleKeys).range([0, band.bandwidth()]).padding(groupPadding)
+    }
+
+    const valueRange: [number, number] = isHorizontal
+        ? [dimensions.plotLeft, dimensions.plotLeft + dimensions.plotWidth]
+        : [dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop]
+
+    if (barLayout === 'percent') {
+        const value = d3.scaleLinear().domain([0, 1]).nice(tickCount).range(valueRange)
+        return { band, value, group }
+    }
+
+    const seriesForRange = stackedSeries ?? series
+    const range = seriesValueRange(seriesForRange)
+
+    if (range.count === 0) {
+        const value = d3.scaleLinear().domain([0, 1]).range(valueRange)
+        return { band, value, group }
+    }
+
+    let { min, max } = range
+    if (min > 0) {
+        min = 0
+    } else if (max < 0) {
+        max = 0
+    }
+
+    if (scaleType === 'log') {
+        if (!isFinite(range.minPositive)) {
+            const value = d3.scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
+            return { band, value, group }
+        }
+        const niceMin = Math.pow(10, Math.ceil(Math.log10(range.minPositive)) - 1)
+        const maxDecade = Math.pow(10, Math.floor(Math.log10(max)))
+        const niceMax = Math.ceil(max / maxDecade) * maxDecade
+        const value = d3.scaleLog().domain([niceMin, niceMax]).range(valueRange).clamp(true)
+        return { band, value, group }
+    }
+
+    const value = d3.scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
+    return { band, value, group }
+}
+
 export function autoFormatYTick(value: number, domainMax: number): string {
     if (domainMax < 2) {
         return value.toFixed(2)

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -169,17 +169,11 @@ export interface TooltipConfig {
 }
 
 export interface BarChartConfig extends ChartConfig {
-    /** How bars from different series are arranged at each x-axis position.
-     *  `stacked` (default): bars are stacked on top of each other, summed values determine y-extent.
-     *  `grouped`: bars are placed side-by-side at each x.
-     *  `percent`: stacked bars normalized to 100%. */
+    /** Defaults to `stacked`. */
     barLayout?: 'stacked' | 'grouped' | 'percent'
-    /** Inner padding between adjacent bands (categorical groups) as a fraction of the band width. 0–1. Defaults to 0.2. */
     bandPadding?: number
-    /** Inner padding between bars within a `grouped` band. 0–1. Defaults to 0.1. */
     groupPadding?: number
-    /** Corner radius for the outer (cap) end of each bar in CSS pixels. Defaults to 4.
-     *  Stacked bars only round the top of the topmost segment. */
+    /** Stacked bars only round the topmost segment. */
     barCornerRadius?: number
 }
 

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -168,6 +168,21 @@ export interface TooltipConfig {
     placement?: 'follow-data' | 'top'
 }
 
+export interface BarChartConfig extends ChartConfig {
+    /** How bars from different series are arranged at each x-axis position.
+     *  `stacked` (default): bars are stacked on top of each other, summed values determine y-extent.
+     *  `grouped`: bars are placed side-by-side at each x.
+     *  `percent`: stacked bars normalized to 100%. */
+    barLayout?: 'stacked' | 'grouped' | 'percent'
+    /** Inner padding between adjacent bands (categorical groups) as a fraction of the band width. 0–1. Defaults to 0.2. */
+    bandPadding?: number
+    /** Inner padding between bars within a `grouped` band. 0–1. Defaults to 0.1. */
+    groupPadding?: number
+    /** Corner radius for the outer (cap) end of each bar in CSS pixels. Defaults to 4.
+     *  Stacked bars only round the top of the topmost segment. */
+    barCornerRadius?: number
+}
+
 export interface LineChartConfig extends ChartConfig {
     percentStackView?: boolean
 }


### PR DESCRIPTION
## Problem

Stacked on #57210 (bar canvas primitives). Adds the scale construction and per-series bar geometry as pure modules — still no chart type, still no consumer of any of this in production code paths.

## Changes

\`scales.ts\`:
- \`BarScaleSet\` — \`{ band, value, valueAxes, group }\`.
- \`createBarScales\` — builds the scale set for a given orientation (\`vertical\`/\`horizontal\`) and layout (\`stacked\`/\`grouped\`/\`percent\`). Percent domain pins to \`[0,1].nice()\`; mixed-sign data extends the value domain through zero so bar baselines align with the plot edge.

\`bar-layout.ts\` (new module, sibling to \`scales.ts\`):
- \`cornersFor(isHorizontal, isPositive, shouldRoundCap)\` — picks the corner mask for a bar's cap end.
- \`computeSeriesBars(series, labels, scales, layout, isHorizontal, stackedBand, isTopOfStack)\` — produces one \`BarRect | null\` per data index (null when the bar isn't drawable). Lives next to scales rather than in \`charts/BarChart.tsx\` so the geometry can be unit-tested independent of React.

\`types.ts\`:
- \`BarChartConfig extends ChartConfig\` — \`barLayout\`, \`bandPadding\`, \`groupPadding\`, \`barCornerRadius\`.

Tests:
- \`bar-scales.test.ts\` covers band layout, value-domain construction, group-only sub-band, percent domain, horizontal orientation, the stacked-series override.
- \`bar-layout.test.ts\` covers grouped + stacked positioning in both orientations, corner-mask rules, null/NaN passthrough preserving \`dataIndex\`.

## How did you test this code?

I'm an agent. \`pnpm jest --testPathPattern='hog-charts'\` — all 270 tests pass (11 suites). The new helpers have no consumer yet.

## Publish to changelog?

no

## 🤖 Agent context

Authored end-to-end by PostHog Code (Claude Opus 4.7). PR 3 of 5 in the BarChart stack — depends on #57210. Follows: PR 4 (BarChart component, thin once geometry lives here), PR 5 (stories).