### PR TITLE
feat(hog-charts): add BarChart component

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render } from '@testing-library/react'
+import React from 'react'
+
+import type { ChartTheme, Series } from '../core/types'
+import { setupJsdom } from '../test-helpers'
+import { BarChart } from './BarChart'
+
+const THEME: ChartTheme = {
+    colors: ['#1f77b4', '#ff7f0e', '#2ca02c'],
+    backgroundColor: '#ffffff',
+    gridColor: '#eeeeee',
+    crosshairColor: '#888888',
+}
+
+const SERIES: Series[] = [
+    { key: 'a', label: 'A', data: [10, 20, 30] },
+    { key: 'b', label: 'B', data: [5, 15, 25] },
+]
+
+const LABELS = ['Mon', 'Tue', 'Wed']
+
+type Layout = 'stacked' | 'grouped' | 'percent'
+type Orientation = 'vertical' | 'horizontal'
+
+describe('BarChart', () => {
+    let teardown: () => void
+
+    beforeEach(() => {
+        teardown = setupJsdom()
+    })
+
+    afterEach(() => {
+        teardown()
+        cleanup()
+    })
+
+    describe.each<[Layout, Orientation]>([
+        ['stacked', 'vertical'],
+        ['grouped', 'vertical'],
+        ['percent', 'vertical'],
+        ['stacked', 'horizontal'],
+        ['grouped', 'horizontal'],
+        ['percent', 'horizontal'],
+    ])('%s / %s', (barLayout, axisOrientation) => {
+        it('renders a canvas without throwing', () => {
+            const { container } = render(
+                <BarChart series={SERIES} labels={LABELS} theme={THEME} config={{ barLayout, axisOrientation }} />
+            )
+            expect(container.querySelector('canvas')).not.toBeNull()
+        })
+    })
+
+    it('forwards `dataAttr` to the chart wrapper for product-test selection', () => {
+        const { container } = render(
+            <BarChart series={SERIES} labels={LABELS} theme={THEME} dataAttr="bar-chart-instance" />
+        )
+        expect(container.querySelector('[data-attr="bar-chart-instance"]')).not.toBeNull()
+    })
+
+    it('renders empty state without crashing', () => {
+        const { container } = render(<BarChart series={[]} labels={[]} theme={THEME} />)
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+
+    it('skips excluded series in stacked layout', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [10, 20, 30] },
+            { key: 'b', label: 'B', data: [5, 15, 25], visibility: { excluded: true } },
+            { key: 'c', label: 'C', data: [3, 6, 9] },
+        ]
+        const { container } = render(
+            <BarChart series={series} labels={LABELS} theme={THEME} config={{ barLayout: 'stacked' }} />
+        )
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+
+    it('renders custom percent formatter when consumer supplies one', () => {
+        const formatter = jest.fn((v: number) => `${Math.round(v * 1000) / 10}‰`)
+        render(
+            <BarChart
+                series={SERIES}
+                labels={LABELS}
+                theme={THEME}
+                config={{ barLayout: 'percent', yTickFormatter: formatter }}
+            />
+        )
+        expect(formatter).toHaveBeenCalled()
+        // Built-in default would have produced '%' suffix; consumer's '‰' wins.
+        expect(formatter.mock.results.some((r) => typeof r.value === 'string' && r.value.endsWith('‰'))).toBe(true)
+    })
+
+    it('applies a default percent formatter when consumer omits one', () => {
+        const { container } = render(
+            <BarChart series={SERIES} labels={LABELS} theme={THEME} config={{ barLayout: 'percent' }} />
+        )
+        // AxisLabels renders tick text into divs; default percent formatter emits values like "50%".
+        const text = container.textContent ?? ''
+        expect(text).toMatch(/\d+%/)
+    })
+
+    it('tolerates NaN data values without throwing', () => {
+        const broken: Series[] = [{ key: 'a', label: 'A', data: [Number.NaN, Number.NaN, Number.NaN] }]
+        const { container } = render(<BarChart series={broken} labels={LABELS} theme={THEME} />)
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render } from '@testing-library/react'
-import React from 'react'
 
 import type { ChartTheme, Series } from '../core/types'
 import { setupJsdom } from '../test-helpers'

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -269,7 +269,6 @@ function BarChartInner<Meta = unknown>({
             onPointClick={onPointClick}
             className={className}
             resolveValue={resolveValue}
-            interactionAxis={isHorizontal ? 'y' : 'x'}
             labelToCoord={isHorizontal ? labelToCoord : undefined}
         >
             {children}

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -102,8 +102,6 @@ function BarChartInner<Meta = unknown>({
         }
     }, [config, barLayout])
 
-    // Keep a ref to the raw d3 scales so the draw callback can use them
-    // without exposing d3 types through the ChartScales abstraction
     const d3ScalesRef = useRef<BarScaleSet | null>(null)
 
     const createScales: CreateScalesFn = useCallback(
@@ -235,10 +233,7 @@ function BarChartInner<Meta = unknown>({
         if (!stackedData) {
             return undefined
         }
-        // Return the stacked top so the tooltip anchor lands at the visual top of each bar segment,
-        // not at the raw series value. This matches LineChart's behavior for stacked area charts —
-        // consumers wanting raw per-series values in the tooltip should override the tooltip render
-        // and look up `series.data[dataIndex]` themselves.
+        // Return the stacked top so the tooltip anchor lands at the visual top of each segment, not the raw series value.
         return (s: Series, dataIndex: number): number => {
             const stacked = stackedData.get(s.key)?.top[dataIndex]
             if (stacked != null && Number.isFinite(stacked)) {
@@ -249,8 +244,6 @@ function BarChartInner<Meta = unknown>({
         }
     }, [stackedData])
 
-    // Pass band-center coordinates through to the interaction layer.
-    // For horizontal layout, the interaction axis is y; otherwise x.
     const labelToCoord = useCallback((label: string): number | undefined => {
         const d3Scales = d3ScalesRef.current
         if (!d3Scales) {

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -25,6 +25,11 @@ import type {
     TooltipContext,
 } from '../core/types'
 
+function bandCenter(scales: BarScaleSet, label: string): number | undefined {
+    const start = scales.band(label)
+    return start == null ? undefined : start + scales.band.bandwidth() / 2
+}
+
 export interface BarChartProps<Meta = unknown> {
     series: Series<Meta>[]
     labels: string[]
@@ -133,13 +138,7 @@ function BarChartInner<Meta = unknown>({
             // calls `scales.y(tick)` for x-pixel positioning of value ticks).
             // For vertical, `y` is the value scale on the y-axis.
             return {
-                x: (label: string) => {
-                    const start = d3Scales.band(label)
-                    if (start == null) {
-                        return undefined
-                    }
-                    return start + d3Scales.band.bandwidth() / 2
-                },
+                x: (label: string) => bandCenter(d3Scales, label),
                 y: (value: number) => d3Scales.value(value),
                 yTicks: () => d3Scales.value.ticks?.(yTickCount) ?? [],
             }
@@ -157,10 +156,7 @@ function BarChartInner<Meta = unknown>({
             const baseDrawCtx: DrawContext = {
                 ctx,
                 dimensions,
-                xScale: (label: string) => {
-                    const start = d3Scales.band(label)
-                    return start == null ? undefined : start + d3Scales.band.bandwidth() / 2
-                },
+                xScale: (label: string) => bandCenter(d3Scales, label),
                 yScale: d3Scales.value,
                 labels: drawLabels,
             }
@@ -246,11 +242,7 @@ function BarChartInner<Meta = unknown>({
 
     const labelToCoord = useCallback((label: string): number | undefined => {
         const d3Scales = d3ScalesRef.current
-        if (!d3Scales) {
-            return undefined
-        }
-        const start = d3Scales.band(label)
-        return start == null ? undefined : start + d3Scales.band.bandwidth() / 2
+        return d3Scales ? bandCenter(d3Scales, label) : undefined
     }, [])
 
     return (

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -5,6 +5,7 @@ import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } 
 import { Chart } from '../core/Chart'
 import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
 import {
+    type BarScaleSet,
     computePercentStackData,
     computeStackData,
     createBarScales,

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -20,6 +20,7 @@ import type {
     ChartTheme,
     CreateScalesFn,
     PointClickData,
+    ResolvedSeries,
     Series,
     TooltipContext,
 } from '../core/types'
@@ -32,6 +33,8 @@ export interface BarChartProps<Meta = unknown> {
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
     className?: string
+    /** `data-attr` applied to the chart wrapper. See `ChartProps.dataAttr`. */
+    dataAttr?: string
     children?: React.ReactNode
     onError?: (error: Error, info: React.ErrorInfo) => void
 }
@@ -52,6 +55,7 @@ function BarChartInner<Meta = unknown>({
     tooltip,
     onPointClick,
     className,
+    dataAttr,
     children,
 }: Omit<BarChartProps<Meta>, 'onError'>): React.ReactElement {
     const {
@@ -103,7 +107,7 @@ function BarChartInner<Meta = unknown>({
     const d3ScalesRef = useRef<BarScaleSet | null>(null)
 
     const createScales: CreateScalesFn = useCallback(
-        (coloredSeries: Series[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
+        (coloredSeries: ResolvedSeries[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
             // For stacked/percent, the value-axis domain must reflect cumulative sums, not
             // individual series ranges — pass a synthetic series whose data is each layer's top.
             let stackedSeries: Series[] | undefined
@@ -268,6 +272,7 @@ function BarChartInner<Meta = unknown>({
             tooltip={tooltip}
             onPointClick={onPointClick}
             className={className}
+            dataAttr={dataAttr}
             resolveValue={resolveValue}
             labelToCoord={isHorizontal ? labelToCoord : undefined}
         >

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -1,0 +1,261 @@
+import React, { useCallback, useMemo, useRef } from 'react'
+
+import { computeSeriesBars } from '../core/bar-layout'
+import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../core/canvas-renderer'
+import { Chart } from '../core/Chart'
+import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
+import {
+    computePercentStackData,
+    computeStackData,
+    createBarScales,
+    type StackedBand,
+    yTickCountForHeight,
+} from '../core/scales'
+import type {
+    BarChartConfig,
+    ChartDimensions,
+    ChartDrawArgs,
+    ChartScales,
+    ChartTheme,
+    CreateScalesFn,
+    PointClickData,
+    Series,
+    TooltipContext,
+} from '../core/types'
+
+export interface BarChartProps<Meta = unknown> {
+    series: Series<Meta>[]
+    labels: string[]
+    config?: BarChartConfig
+    theme: ChartTheme
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    onPointClick?: (data: PointClickData<Meta>) => void
+    className?: string
+    children?: React.ReactNode
+    onError?: (error: Error, info: React.ErrorInfo) => void
+}
+
+export function BarChart<Meta = unknown>({ onError, ...rest }: BarChartProps<Meta>): React.ReactElement {
+    return (
+        <ChartErrorBoundary onError={onError}>
+            <BarChartInner {...rest} />
+        </ChartErrorBoundary>
+    )
+}
+
+function BarChartInner<Meta = unknown>({
+    series,
+    labels,
+    config,
+    theme,
+    tooltip,
+    onPointClick,
+    className,
+    children,
+}: Omit<BarChartProps<Meta>, 'onError'>): React.ReactElement {
+    const {
+        yScaleType = 'linear',
+        showGrid = false,
+        barLayout = 'stacked',
+        bandPadding = 0.2,
+        groupPadding = 0.1,
+        barCornerRadius = 4,
+        axisOrientation = 'vertical',
+    } = config ?? {}
+    const isHorizontal = axisOrientation === 'horizontal'
+
+    const stackedData = useMemo((): Map<string, StackedBand> | undefined => {
+        if (barLayout === 'percent') {
+            return computePercentStackData(series, labels)
+        }
+        if (barLayout === 'stacked') {
+            return computeStackData(series, labels)
+        }
+        return undefined
+    }, [barLayout, series, labels])
+
+    // Pick which series should round its cap in stacked/percent layouts.
+    // d3.stack uses the order passed to `stack.keys()` (here: visible series in their array order),
+    // so the topmost visual layer at every x is the last visible series. That key gets cap rounding.
+    // If the consumer reorders or hides series, this recomputes — `series` and `excluded` flags
+    // are both in the dep array.
+    const topStackedKey = useMemo<string | null>(() => {
+        if (barLayout === 'grouped') {
+            return null
+        }
+        const visible = series.filter((s) => !s.visibility?.excluded)
+        return visible.length > 0 ? visible[visible.length - 1].key : null
+    }, [barLayout, series])
+
+    const chartConfig = useMemo<BarChartConfig | undefined>(() => {
+        if (barLayout !== 'percent' || config?.yTickFormatter) {
+            return config
+        }
+        return {
+            ...config,
+            yTickFormatter: (v: number) => `${Math.round(v * 100)}%`,
+        }
+    }, [config, barLayout])
+
+    // Keep a ref to the raw d3 scales so the draw callback can use them
+    // without exposing d3 types through the ChartScales abstraction
+    const d3ScalesRef = useRef<BarScaleSet | null>(null)
+
+    const createScales: CreateScalesFn = useCallback(
+        (coloredSeries: Series[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
+            // For stacked/percent, the value-axis domain must reflect cumulative sums, not
+            // individual series ranges — pass a synthetic series whose data is each layer's top.
+            let stackedSeries: Series[] | undefined
+            if (stackedData && barLayout === 'stacked') {
+                stackedSeries = coloredSeries.map((s) => {
+                    const band = stackedData.get(s.key)
+                    return band ? { ...s, data: band.top } : s
+                })
+            }
+
+            const d3Scales = createBarScales(coloredSeries, scaleLabels, dimensions, {
+                scaleType: yScaleType,
+                barLayout,
+                axisOrientation,
+                bandPadding,
+                groupPadding,
+                stackedSeries,
+            })
+            d3ScalesRef.current = d3Scales
+
+            const tickAxisLength = isHorizontal ? dimensions.plotWidth : dimensions.plotHeight
+            const yTickCount = yTickCountForHeight(tickAxisLength)
+
+            // For horizontal, expose the value scale as `y` (since AxisLabels horizontal mode
+            // calls `scales.y(tick)` for x-pixel positioning of value ticks).
+            // For vertical, `y` is the value scale on the y-axis.
+            return {
+                x: (label: string) => {
+                    const start = d3Scales.band(label)
+                    if (start == null) {
+                        return undefined
+                    }
+                    return start + d3Scales.band.bandwidth() / 2
+                },
+                y: (value: number) => d3Scales.value(value),
+                yTicks: () => d3Scales.value.ticks?.(yTickCount) ?? [],
+            }
+        },
+        [yScaleType, barLayout, axisOrientation, bandPadding, groupPadding, stackedData, isHorizontal]
+    )
+
+    const drawStatic = useCallback(
+        ({ ctx, dimensions, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
+            const d3Scales = d3ScalesRef.current
+            if (!d3Scales) {
+                return
+            }
+
+            const baseDrawCtx: DrawContext = {
+                ctx,
+                dimensions,
+                xScale: (label: string) => {
+                    const start = d3Scales.band(label)
+                    return start == null ? undefined : start + d3Scales.band.bandwidth() / 2
+                },
+                yScale: d3Scales.value,
+                labels: drawLabels,
+            }
+
+            if (showGrid) {
+                drawGrid(baseDrawCtx, {
+                    gridColor: theme.gridColor,
+                    orientation: isHorizontal ? 'horizontal' : 'vertical',
+                })
+            }
+
+            for (const s of coloredSeries) {
+                if (s.visibility?.excluded) {
+                    continue
+                }
+                const stackedBand = stackedData?.get(s.key)
+                const isTop = topStackedKey !== null && s.key === topStackedKey
+                const bars = computeSeriesBars(s, drawLabels, d3Scales, barLayout, isHorizontal, stackedBand, isTop)
+                drawBars(
+                    baseDrawCtx,
+                    s,
+                    bars.filter((b): b is BarRect => b !== null),
+                    { cornerRadius: barCornerRadius }
+                )
+            }
+        },
+        [showGrid, stackedData, barLayout, isHorizontal, topStackedKey, barCornerRadius]
+    )
+
+    const drawHover = useCallback(
+        ({ ctx, series: coloredSeries, labels: drawLabels, hoverIndex, theme }: ChartDrawArgs) => {
+            const d3Scales = d3ScalesRef.current
+            if (!d3Scales || hoverIndex < 0) {
+                return
+            }
+            const highlightColor = theme.crosshairColor ?? 'rgba(0, 0, 0, 0.4)'
+            for (const s of coloredSeries) {
+                if (s.visibility?.excluded) {
+                    continue
+                }
+                const stackedBand = stackedData?.get(s.key)
+                const isTop = topStackedKey !== null && s.key === topStackedKey
+                const bars = computeSeriesBars(s, drawLabels, d3Scales, barLayout, isHorizontal, stackedBand, isTop)
+                const bar = bars[hoverIndex]
+                if (bar) {
+                    drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)
+                }
+            }
+        },
+        [stackedData, barLayout, isHorizontal, topStackedKey, barCornerRadius]
+    )
+
+    const resolveValue = useMemo(() => {
+        if (!stackedData) {
+            return undefined
+        }
+        // Return the stacked top so the tooltip anchor lands at the visual top of each bar segment,
+        // not at the raw series value. This matches LineChart's behavior for stacked area charts —
+        // consumers wanting raw per-series values in the tooltip should override the tooltip render
+        // and look up `series.data[dataIndex]` themselves.
+        return (s: Series, dataIndex: number): number => {
+            const stacked = stackedData.get(s.key)?.top[dataIndex]
+            if (stacked != null && Number.isFinite(stacked)) {
+                return stacked
+            }
+            const raw = s.data[dataIndex]
+            return typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
+        }
+    }, [stackedData])
+
+    // Pass band-center coordinates through to the interaction layer.
+    // For horizontal layout, the interaction axis is y; otherwise x.
+    const labelToCoord = useCallback((label: string): number | undefined => {
+        const d3Scales = d3ScalesRef.current
+        if (!d3Scales) {
+            return undefined
+        }
+        const start = d3Scales.band(label)
+        return start == null ? undefined : start + d3Scales.band.bandwidth() / 2
+    }, [])
+
+    return (
+        <Chart
+            series={series}
+            labels={labels}
+            config={chartConfig}
+            theme={theme}
+            createScales={createScales}
+            drawStatic={drawStatic}
+            drawHover={drawHover}
+            tooltip={tooltip}
+            onPointClick={onPointClick}
+            className={className}
+            resolveValue={resolveValue}
+            interactionAxis={isHorizontal ? 'y' : 'x'}
+            labelToCoord={isHorizontal ? labelToCoord : undefined}
+        >
+            {children}
+        </Chart>
+    )
+}

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -176,7 +176,15 @@ function BarChartInner<Meta = unknown>({
                 }
                 const stackedBand = stackedData?.get(s.key)
                 const isTop = topStackedKey !== null && s.key === topStackedKey
-                const bars = computeSeriesBars(s, drawLabels, d3Scales, barLayout, isHorizontal, stackedBand, isTop)
+                const bars = computeSeriesBars({
+                    series: s,
+                    labels: drawLabels,
+                    scales: d3Scales,
+                    layout: barLayout,
+                    isHorizontal,
+                    stackedBand,
+                    isTopOfStack: isTop,
+                })
                 drawBars(
                     baseDrawCtx,
                     s,
@@ -201,7 +209,15 @@ function BarChartInner<Meta = unknown>({
                 }
                 const stackedBand = stackedData?.get(s.key)
                 const isTop = topStackedKey !== null && s.key === topStackedKey
-                const bars = computeSeriesBars(s, drawLabels, d3Scales, barLayout, isHorizontal, stackedBand, isTop)
+                const bars = computeSeriesBars({
+                    series: s,
+                    labels: drawLabels,
+                    scales: d3Scales,
+                    layout: barLayout,
+                    isHorizontal,
+                    stackedBand,
+                    isTopOfStack: isTop,
+                })
                 const bar = bars[hoverIndex]
                 if (bar) {
                     drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -191,7 +191,7 @@ function BarChartInner<Meta = unknown>({
                     baseDrawCtx,
                     s,
                     bars.filter((b): b is BarRect => b !== null),
-                    { cornerRadius: barCornerRadius }
+                    barCornerRadius
                 )
             }
         },

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -1,4 +1,6 @@
 // Components
+export { BarChart } from './charts/BarChart'
+export type { BarChartProps } from './charts/BarChart'
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 
@@ -13,6 +15,7 @@ export type { BaseChartContext, ChartHoverContextValue, ChartLayoutContextValue 
 
 // Core types
 export type {
+    BarChartConfig,
     ChartConfig,
     ChartDimensions,
     ChartDrawArgs,


### PR DESCRIPTION
## Problem

Stacked on #57211 (bar scales + layout). Composes the orientation hooks (#57209), the canvas primitives (#57210), and the scales + bar-layout module (#57211) into the public BarChart component.

## Changes

- Three layouts via \`config.barLayout\`: \`stacked\` (default), \`grouped\`, \`percent\` (auto-formats the value axis as %).
- Vertical or horizontal orientation via \`config.axisOrientation\` — drives margin computation, axis labels, interaction axis, and crosshair direction (all wired up in PR 1).
- Hatched fills for bars within \`stroke.partial.fromIndex\` / \`toIndex\` ranges, matching the existing line/area incomplete-period treatment.
- \`visibility.excluded\` skips a layer cleanly without leaving gaps in stacked or percent layouts.
- Wrapped in \`ChartErrorBoundary\` matching \`LineChart\`'s pattern; forwards \`onError\`.

The component is now thin wiring (~260 LOC) — geometry lives in \`core/bar-layout\` and \`core/scales\`, drawing primitives in \`core/canvas-renderer\`. No inline math.

## How did you test this code?

I'm an agent. \`pnpm jest --testPathPattern='hog-charts'\` — all 270 tests pass (11 suites). The component itself doesn't have a dedicated test file; geometry is covered by \`bar-layout.test.ts\` (PR 3) and the canvas primitives by \`bar-canvas-renderer.test.ts\` (PR 2). Visual verification follows in PR 5 with the Storybook stories.

## Publish to changelog?

no

## 🤖 Agent context

Authored end-to-end by PostHog Code (Claude Opus 4.7). PR 4 of 5 in the BarChart stack — depends on #57211. Follows: PR 5 (stories) which will trigger Visual Review baseline approval for the new chart type.