### PR TITLE
fix(ci): agent skills render query

### DIFF
--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -79,7 +79,7 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
             hogql_filters = HogQLFilters(dateRange=runner.query.dateRange)
 
         if isinstance(runner, TraceQueryRunner):
-            ast_query = replace_placeholders(ast_query, {"filter_conditions": runner._get_where_clause()})
+            ast_query = replace_placeholders(ast_query, {"filter_conditions": runner._get_bounds_where_clause()})
 
         ast_query = replace_filters(ast_query, hogql_filters, _cached_team)
 


### PR DESCRIPTION
## Problem

The `check agent skills` CI step fails on master after #57093 refactored `TraceQueryRunner` into a two-stage pattern. Stage one discovers trace timestamp bounds, stage two uses those bounds to fetch events. The `render_hogql_example` helper in `build_skills.py` calls `runner._get_where_clause()` directly — but that method now asserts that stage one has already run, which it hasn't in the skill-building context. This causes an `AssertionError` on every CI run.

## Changes

- Switched `hogql_example/__init__.py` to call `_get_bounds_where_clause()` instead of `_get_where_clause()`. The bounds clause is self-contained (uses the query's date range directly) and doesn't require stage one to have run. The rendered SQL is only used as an example in AI agent skill prompts, so the slight difference in buffer width (10min vs 1min) is cosmetic.

## How did you test this code?

- Verified `_get_bounds_where_clause` is self-contained (no assertions on internal state) by reading the source
- Confirmed the rendered output is only used for agent skill documentation, not production queries
- Confirmed no other callers of `_get_where_clause` exist outside the runner itself

