### PR TITLE
fix(perf): dispatch initial visibility on usePageVisibilityCb mount

### DIFF
--- a/frontend/src/lib/hooks/usePageVisibility.test.ts
+++ b/frontend/src/lib/hooks/usePageVisibility.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { usePageVisibility, usePageVisibilityCb } from './usePageVisibility'
+
+function setHidden(hidden: boolean): void {
+    Object.defineProperty(document, 'hidden', { configurable: true, value: hidden })
+    Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: hidden ? 'hidden' : 'visible',
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('usePageVisibility hooks', () => {
+    afterEach(() => {
+        Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    })
+
+    describe.each([
+        { name: 'mounted while visible, becomes hidden, becomes visible', initialHidden: false },
+        { name: 'mounted while hidden, becomes visible, becomes hidden', initialHidden: true },
+    ])('usePageVisibilityCb — $name', ({ initialHidden }) => {
+        it('fires the callback with the initial state on mount and on every change', () => {
+            Object.defineProperty(document, 'hidden', { configurable: true, value: initialHidden })
+            Object.defineProperty(document, 'visibilityState', {
+                configurable: true,
+                value: initialHidden ? 'hidden' : 'visible',
+            })
+
+            const calls: boolean[] = []
+            const callback = (visible: boolean): void => {
+                calls.push(visible)
+            }
+
+            renderHook(() => usePageVisibilityCb(callback))
+
+            expect(calls).toEqual([!initialHidden])
+
+            act(() => setHidden(!initialHidden))
+            act(() => setHidden(initialHidden))
+
+            expect(calls).toEqual([!initialHidden, initialHidden, !initialHidden])
+        })
+    })
+
+    it('usePageVisibilityCb removes the listener on unmount', () => {
+        const calls: boolean[] = []
+        const { unmount } = renderHook(() => usePageVisibilityCb((v) => calls.push(v)))
+
+        const callsAfterMount = calls.length
+        unmount()
+
+        act(() => setHidden(true))
+        expect(calls).toHaveLength(callsAfterMount)
+    })
+
+    it('usePageVisibility reflects the current visibility', () => {
+        const { result } = renderHook(() => usePageVisibility())
+        expect(result.current.isVisible).toBe(true)
+
+        act(() => setHidden(true))
+        expect(result.current.isVisible).toBe(false)
+
+        act(() => setHidden(false))
+        expect(result.current.isVisible).toBe(true)
+    })
+})

--- a/frontend/src/lib/hooks/usePageVisibility.ts
+++ b/frontend/src/lib/hooks/usePageVisibility.ts
@@ -17,7 +17,13 @@ function isPageVisible(): boolean {
  *
  * see https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
  *
- * @param callback when page visibility changes this is called with true if the page is visible and false otherwise
+ * The callback is invoked once on mount with the current visibility, and again on every
+ * visibilitychange. Without the mount-time invocation, tabs loaded while hidden (e.g. via
+ * "Open in background tab" or after a multi-tab refresh while focus stays on one tab) never
+ * receive a "hidden" signal — consumers like the experiment / dashboard auto-refresh
+ * intervals would then run on a tab the user can't see.
+ *
+ * @param callback called with true if the page is visible, false if hidden
  */
 export function usePageVisibilityCb(callback: (pageIsVisible: boolean) => void): void {
     useEffect(() => {
@@ -25,6 +31,7 @@ export function usePageVisibilityCb(callback: (pageIsVisible: boolean) => void):
             callback(isPageVisible())
         }
 
+        callback(isPageVisible())
         document.addEventListener(VISIBILITY_CHANGE_EVENT, onVisibilityChange)
 
         return function cleanUp() {


### PR DESCRIPTION
## Problem

\`usePageVisibilityCb\` only fires its callback on subsequent \`visibilitychange\` events, not on mount. Tabs loaded while hidden — multi-tab refresh while focus stays on one tab, "Open in background tab", session-restore, etc. — never receive an initial "hidden" signal.

That means consumers like the experiment + dashboard auto-refresh intervals (\`scenes/experiments/experimentLogic.tsx\`, \`scenes/dashboard/...\`) sit ticking on a tab the user can't see, repeatedly re-rendering charts and accumulating listener / off-heap state.

This was uncovered while hunting the residual idle-tab memory growth that remained after the animation-cancel fix in #57179. Multi-GB tabs in the background turn out to be ~95% off-heap; listener / closure accumulation is the contributing pattern, and silently-running auto-refresh intervals are the cleanest reproducer.

## Changes

- \`usePageVisibilityCb\` now invokes the callback once on mount with the current visibility, then registers the \`visibilitychange\` listener as before.
- Added unit tests covering: visible-on-mount, hidden-on-mount, listener removal on unmount, and a smoke test for the sibling \`usePageVisibility\` hook.

## How did you test this code?

I'm a Claude Code agent. I added the unit tests in \`usePageVisibility.test.ts\` covering both initial-state cases and the unmount path. The local jest harness has a pre-existing \`side-channel\` module-resolution issue that prevents in-place verification (also breaks \`usePeriodicRerender.test.ts\` on master), so CI will validate.

Manual reasoning: \`usePageVisibility\` (the value-returning sibling) already uses \`useSyncExternalStore\` with a getter, so it was always returning current state correctly — only the callback variant had the bug.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Co-authored by Claude Opus 4.7. Investigated as part of an off-heap idle-tab memory growth hunt following PR #57179. The session involved instrumenting MemLens with a dev-only \`__leakHunter\` helper, multi-tab interaction harnesses, heap-snapshot retainer walks, and Performance-trace observation of C++ GC reclaiming ~300 listeners on a single sweep.

Key decision: shipped narrowly — just the visibility-callback bug + test. Did not bundle the broader diagnostic infra (those changes stay in the local leak-hunter skill).