### PR TITLE
fix(customer-analytics): include legacy tables with null deleted in dw usage metric check

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -908,7 +908,7 @@ class GroupUsageMetricSerializer(serializers.ModelSerializer, UserAccessControlS
             raise serializers.ValidationError({"math_property": "math_property must be empty when math is 'count'."})
 
         team = self.context["get_team"]()
-        if not DataWarehouseTable.objects.filter(team=team, name=filters["table_name"], deleted=False).exists():
+        if not DataWarehouseTable.objects.filter(team=team, name=filters["table_name"]).exclude(deleted=True).exists():
             raise serializers.ValidationError(
                 {"filters": f"Data warehouse table {filters['table_name']!r} does not exist."}
             )

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -2013,6 +2013,45 @@ class GroupUsageMetricViewSetTestCase(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["attr"], "filters")
 
+    def test_create_data_warehouse_metric_accepts_table_with_null_deleted(self):
+        table = self._create_dw_table()
+        table.deleted = None
+        table.save()
+
+        payload = {
+            "name": "DW signups",
+            "filters": {
+                "source": "data_warehouse",
+                "table_name": "stripe_charges",
+                "timestamp_field": "created",
+                "key_field": "customer_id",
+            },
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+
+    def test_create_data_warehouse_metric_rejects_soft_deleted_table(self):
+        table = self._create_dw_table()
+        table.deleted = True
+        table.save()
+
+        payload = {
+            "name": "DW signups",
+            "filters": {
+                "source": "data_warehouse",
+                "table_name": "stripe_charges",
+                "timestamp_field": "created",
+                "key_field": "customer_id",
+            },
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "filters")
+
     def test_create_data_warehouse_sum_requires_math_property(self):
         self._create_dw_table()
         payload = {


### PR DESCRIPTION
## Problem

The data warehouse usage metric validator rejected tables whose `deleted` column was `NULL` (legacy rows), because `filter(deleted=False)` excludes nulls.

## Changes

Switched the existence check from `filter(deleted=False)` to `.exclude(deleted=True)`, so rows with `deleted` set to `False` or `NULL` are accepted, and only soft-deleted (`True`) tables are rejected.

## How did you test this code?

I'm an agent. Added two regression tests:
- `test_create_data_warehouse_metric_accepts_table_with_null_deleted` — fails on the old code, passes on the fix.
- `test_create_data_warehouse_metric_rejects_soft_deleted_table` — confirms soft-deleted tables are still rejected.

Both run via `hogli test ee/clickhouse/views/test/test_clickhouse_groups.py::GroupUsageMetricViewSetTestCase`. The null-deleted test was watched failing against the old code before applying the fix.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7).
- Human prompt: identified the bug and supplied the exact one-line fix; asked for regression tests.
- Followed TDD: wrote tests first, watched the null-deleted case fail with the existing error message, then applied the fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*