### PR TITLE
fix(visual-review): anchor universe on completed runs and key history on baseline_artifact

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1817,8 +1817,8 @@ _DEFAULT_BRANCHES = ("master", "main")
 _SNAPSHOT_HISTORY_DEDUP_SQL = """
 WITH ordered AS (
     SELECT rs.id,
-           rs.current_artifact_id,
-           LAG(rs.current_artifact_id) OVER (ORDER BY r.created_at DESC) AS prev_artifact_id,
+           rs.baseline_artifact_id,
+           LAG(rs.baseline_artifact_id) OVER (ORDER BY r.created_at) AS prev_baseline_id,
            r.created_at
     FROM visual_review_runsnapshot rs
     JOIN visual_review_run r ON r.id = rs.run_id
@@ -1827,11 +1827,10 @@ WITH ordered AS (
       AND r.branch = ANY(%s)
       AND r.status = 'completed'
       AND rs.identifier = %s
-      AND rs.result IN ('changed', 'removed', 'new')
 )
 SELECT id
 FROM ordered
-WHERE prev_artifact_id IS DISTINCT FROM current_artifact_id
+WHERE prev_baseline_id IS DISTINCT FROM baseline_artifact_id
 ORDER BY created_at DESC
 """
 
@@ -1839,29 +1838,30 @@ ORDER BY created_at DESC
 def get_snapshot_history(repo_id: UUID, identifier: str, run_type: str) -> list[RunSnapshot]:
     """Baseline timeline for a snapshot identifier on the default branch.
 
-    Returns one entry per *baseline event* — i.e. each time the committed content
-    actually changed. Dedup happens server-side via a `LAG` window function over
-    runs ordered by `created_at DESC`: a row is kept only when its
-    `current_artifact_id` differs from its predecessor's. Plan stays the same as
-    the un-deduped query (verified on prod) — the WindowAgg piggybacks on the
-    sort already needed for ORDER BY, so the dedup is essentially free and we
-    avoid shipping the full raw history (often 100×–1000× larger) to Python.
+    Returns one entry per *baseline transition* — every time the committed
+    `.snapshots.yml` baseline actually moved. LAG-on-`baseline_artifact_id`
+    (over ASC ordering) keeps the FIRST run of each baseline period, so the
+    user sees the inception event plus every change since.
 
-    Filters applied at the DB level:
-      - branch ∈ master/main, run_type, repo: scope to default-branch runs of this kind
-      - status=completed: drop pre-classification rows. `result` defaults to NEW
-        on upload and is only finalised when the run completes; runs stuck in
-        pending/processing leave noise behind that isn't a real history event.
-      - result IN (changed, removed, new): only rows that move the baseline.
-        `unchanged` rows must be excluded *before* the LAG window — each capture
-        gets its own Artifact row even when the diff says the content matches
-        baseline (pixel jitter → different bytes → different content_hash), so
-        consecutive `unchanged` rows have differing `current_artifact_id`s and
-        would all slip past the dedup as fake "baseline events". For one prod
-        identifier we observed 99 fake events behind 2 real baselines.
-        Including `new` so first captures (the initial baseline event) appear
-        in history; `status=completed` already keeps pre-classification NEW
-        out.
+    Why LAG on `baseline_artifact_id` and not `current_artifact_id`:
+      - `current_artifact_id` is the bytes captured by THIS run. Pixel jitter
+        and tolerated drift produce different content_hash → different Artifact
+        rows even though the *baseline* didn't move. Keying on current_ caused
+        a prod regression (252 fake history events on a single tolerated-drift
+        story) because the artifact alternated between near-identical hashes
+        the matcher kept absorbing. LAG-on-current-with-result-filter (the
+        prior fix) hid those false events but also hid genuine first-appearance
+        rows whose `result=unchanged` against an existing YAML baseline.
+      - `baseline_artifact_id` reflects the YAML state at run time. It only
+        changes when a baseline-update PR merges. Pixel jitter and tolerated
+        drift leave it untouched, so LAG dedup naturally collapses noise while
+        catching every real baseline flip — without needing a `result` filter.
+
+    DB-level filters:
+      - branch ∈ master/main, run_type, repo: scope to default-branch runs of
+        this kind
+      - status=completed: drop pre-classification rows where the baseline FK
+        hasn't been hydrated yet (pending/processing leave NULL baseline_artifact)
     """
     with connections[READER_DB].cursor() as cursor:
         cursor.execute(
@@ -1909,15 +1909,21 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     # `recent_diff_avg`. `DAYS - 1` aligns with the day-key window.
     sparkline_cutoff = now - timedelta(days=BASELINE_SPARKLINE_DAYS - 1)
 
-    # 1. Find the latest non-superseded run on the default branch for every
-    # (repo, run_type). The partial unique index `unique_latest_run_per_group`
-    # ensures at most one row per group.
+    # 1. Find the latest *completed* run on the default branch per (repo,
+    # branch, run_type). Filtering on `superseded_by IS NULL` looks tempting
+    # but is wrong here: a freshly started PENDING/PROCESSING master run is
+    # un-superseded yet has zero (or sparse) RunSnapshots ingested, and would
+    # collapse the universe to whatever it has loaded so far. `status=completed`
+    # makes the universe fall through to the most recent fully-ingested run.
     universe_runs = list(
         Run.objects.filter(
             repo_id=repo_id,
             branch__in=_DEFAULT_BRANCHES,
-            superseded_by__isnull=True,
-        ).only("id", "run_type", "completed_at", "created_at")
+            status=RunStatus.COMPLETED,
+        )
+        .order_by("repo_id", "branch", "run_type", "-created_at")
+        .distinct("repo_id", "branch", "run_type")
+        .only("id", "run_type", "completed_at", "created_at")
     )
     universe_run_ids = [r.id for r in universe_runs]
     if not universe_run_ids:

--- a/products/visual_review/backend/tests/test_baselines.py
+++ b/products/visual_review/backend/tests/test_baselines.py
@@ -163,8 +163,14 @@ class TestBaselinesOverview(APIBaseTest):
         _mk_snapshot(completed, identifier="canon-b")
 
         # Real flow: PENDING run starts and supersedes the completed one
-        # before any RunSnapshots have been written for it.
-        pending = Run.objects.create(
+        # before any RunSnapshots have been written for it. The partial
+        # unique index `unique_latest_run_per_group` forbids two un-superseded
+        # rows per (repo, branch, run_type), so supersede the prior latest
+        # with the new id BEFORE inserting it.
+        pending_id = uuid4()
+        Run.objects.filter(id=completed.id).update(superseded_by_id=pending_id)
+        Run.objects.create(
+            id=pending_id,
             team_id=self.repo.team_id,
             repo=self.repo,
             run_type=RunType.STORYBOOK,
@@ -172,7 +178,6 @@ class TestBaselinesOverview(APIBaseTest):
             commit_sha=uuid4().hex[:12],
             status=RunStatus.PENDING,
         )
-        Run.objects.filter(id=completed.id).update(superseded_by=pending)
 
         result = vr_api.get_baselines_overview(self.repo.id)
 

--- a/products/visual_review/backend/tests/test_baselines.py
+++ b/products/visual_review/backend/tests/test_baselines.py
@@ -151,6 +151,35 @@ class TestBaselinesOverview(APIBaseTest):
         assert result.totals.all_snapshots == 2
         assert result.totals.by_run_type == {RunType.STORYBOOK: 2}
 
+    def test_in_flight_pending_master_run_does_not_replace_universe(self):
+        """A freshly started PENDING master run sets `superseded_by` on the
+        prior completed run while still having 0 RunSnapshots ingested.
+        Anchoring on `superseded_by IS NULL` would collapse the universe to
+        whatever sparse rows the in-flight run has loaded so far. Anchor on
+        `status=COMPLETED` instead so the previous fully-ingested run wins.
+        """
+        completed = _mk_run(self.repo, branch="master", completed_offset=timedelta(hours=1))
+        _mk_snapshot(completed, identifier="canon-a")
+        _mk_snapshot(completed, identifier="canon-b")
+
+        # Real flow: PENDING run starts and supersedes the completed one
+        # before any RunSnapshots have been written for it.
+        pending = Run.objects.create(
+            team_id=self.repo.team_id,
+            repo=self.repo,
+            run_type=RunType.STORYBOOK,
+            branch="master",
+            commit_sha=uuid4().hex[:12],
+            status=RunStatus.PENDING,
+        )
+        Run.objects.filter(id=completed.id).update(superseded_by=pending)
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+
+        identifiers = sorted(e.identifier for e in result.entries)
+        assert identifiers == ["canon-a", "canon-b"]
+        assert result.totals.all_snapshots == 2
+
     def test_main_branch_treated_same_as_master(self):
         # Some repos use `main`, some use `master`. Both anchor the universe.
         run = _mk_run(self.repo, branch="main")

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -200,6 +200,7 @@ class TestRunViewSet(APIBaseTest):
         branch: str,
         content_hash: str,
         *,
+        baseline_content_hash: str | None = None,
         run_type: str = RunType.STORYBOOK,
         run_status: str = RunStatus.COMPLETED,
         result: str = SnapshotResult.UNCHANGED,
@@ -210,6 +211,15 @@ class TestRunViewSet(APIBaseTest):
             content_hash=content_hash,
             storage_path=f"visual_review/{content_hash}",
         )
+        # History dedup keys on `baseline_artifact_id`, so tests must seed it.
+        # Default to the same artifact as `current_` for trivial cases.
+        baseline_artifact = artifact
+        if baseline_content_hash is not None and baseline_content_hash != content_hash:
+            baseline_artifact, _ = logic.get_or_create_artifact(
+                repo_id=self.vr_project.id,
+                content_hash=baseline_content_hash,
+                storage_path=f"visual_review/{baseline_content_hash}",
+            )
         # Only one un-superseded run per (repo, branch, run_type) is allowed (partial unique
         # index). Supersede the prior latest with the new run's id before insert.
         new_id = uuid4()
@@ -231,6 +241,7 @@ class TestRunViewSet(APIBaseTest):
             identifier="Button",
             current_hash=content_hash,
             current_artifact=artifact,
+            baseline_artifact=baseline_artifact,
             result=result,
         )
 
@@ -241,42 +252,51 @@ class TestRunViewSet(APIBaseTest):
         )
 
     def test_snapshot_history(self):
-        """History returns one entry per distinct baseline (`current_artifact_id`),
-        scoped to default-branch + completed runs.
+        """History returns one entry per *baseline transition* — every time
+        the committed `.snapshots.yml` baseline actually moved.
 
-        Only rows that move the baseline (`result` ∈ changed/removed/new)
-        appear; `unchanged` rows are excluded outright. The LAG dedup then
-        collapses consecutive rows that share an artifact_id.
+        LAG-on-`baseline_artifact_id` (ASC) keeps the FIRST run of each
+        baseline period, so the user sees the inception event plus every
+        change since. Tolerated drift / pixel jitter (current_ flickers but
+        baseline_ stays put) collapse naturally — no `result` filter needed.
         """
-        # Two completed master runs share `hash-A` → same artifact → must collapse to one entry.
-        # Use CHANGED so they survive the filter; the dedup-on-artifact still has to fire.
-        self._seed_history_row(sha="aaa1111", branch="master", content_hash="hash-A", result=SnapshotResult.CHANGED)
-        self._seed_history_row(sha="aaa2222", branch="master", content_hash="hash-A", result=SnapshotResult.CHANGED)
-        # Then a more recent main run with a different content → distinct entry.
-        self._seed_history_row(sha="bbb1111", branch="main", content_hash="hash-B", result=SnapshotResult.CHANGED)
-
-        # Steady-state master run with `result=UNCHANGED` — must be filtered out outright,
-        # otherwise pixel-jitter on the captured artifact lets these slip past LAG dedup
-        # and pollutes the timeline (the prod bug this filter was added for).
-        self._seed_history_row(sha="ddd0000", branch="master", content_hash="hash-jitter")
-
-        # PR-branch run — must be filtered out by branch.
+        # Two master runs sharing baseline `base-1` — collapse; the older
+        # one is the inception event for that baseline period.
+        self._seed_history_row(sha="aaa1111", branch="master", content_hash="hash-A", baseline_content_hash="base-1")
+        self._seed_history_row(sha="aaa2222", branch="master", content_hash="hash-A", baseline_content_hash="base-1")
+        # New baseline on main — distinct entry (transition to base-2).
         self._seed_history_row(
-            sha="ddd1111", branch="feat/something", content_hash="hash-feat", result=SnapshotResult.CHANGED
+            sha="bbb1111",
+            branch="main",
+            content_hash="hash-B",
+            baseline_content_hash="base-2",
+            result=SnapshotResult.CHANGED,
         )
-        # Playwright run on master — must be filtered out by run_type.
+        # Tolerated drift on master: current_ flickers, baseline stays at
+        # base-2 — must NOT create a new entry (the prod bug behind 252
+        # fake events on a single tolerated-drift story).
+        self._seed_history_row(
+            sha="ddd0000", branch="master", content_hash="hash-jitter", baseline_content_hash="base-2"
+        )
+
+        # PR-branch run — filtered out by branch.
+        self._seed_history_row(
+            sha="ddd1111", branch="feat/something", content_hash="hash-feat", baseline_content_hash="base-3"
+        )
+        # Playwright run on master — filtered out by run_type.
         self._seed_history_row(
             sha="ccc1111",
             branch="master",
             content_hash="hash-pw",
+            baseline_content_hash="base-pw",
             run_type=RunType.PLAYWRIGHT,
-            result=SnapshotResult.CHANGED,
         )
-        # Pending master run — must be filtered out by status (result=NEW alone wouldn't filter it now).
+        # Pending master run — filtered out by status (no baseline_artifact yet).
         self._seed_history_row(
             sha="eee1111",
             branch="master",
             content_hash="hash-pending",
+            baseline_content_hash="base-pending",
             run_status=RunStatus.PENDING,
             result=SnapshotResult.NEW,
         )
@@ -286,11 +306,13 @@ class TestRunViewSet(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         results = body["results"]
-        # Two distinct baselines: hash-B (newest) and hash-A (collapsed from two master runs).
+        # Two baseline transitions: aaa1111 (inception, base-1) and bbb1111
+        # (transition to base-2). aaa2222 collapses into aaa1111's period;
+        # ddd0000 collapses into bbb1111's.
         self.assertEqual(body["count"], 2)
-        # Newest first; the dedup keeps the most recent run for each artifact.
+        # Output is newest-first.
         self.assertEqual(results[0]["commit_sha"], "bbb1111")
-        self.assertEqual(results[1]["commit_sha"], "aaa2222")
+        self.assertEqual(results[1]["commit_sha"], "aaa1111")
         for entry in results:
             self.assertIn("snapshot_id", entry)
             self.assertIn("review_state", entry)


### PR DESCRIPTION
## Problem

Two prod bugs in the visual review backend, both surfaced after #56963 merged:

**Baselines overview universe** anchors on \`superseded_by IS NULL\`, which collapses to whatever the latest run holds — including a freshly started PENDING/PROCESSING master run that has 0 RunSnapshots ingested yet. On prod this is exactly what happened: a single in-flight storybook run on master with no snapshots dragged the visible universe from ~2976 identifiers down to 3.

**Snapshot history** uses LAG on \`current_artifact_id\` plus a \`result IN (changed, new, removed)\` filter to suppress pixel-jitter noise. That hides genuine first-appearance rows whose result classifies as \`unchanged\` against an existing YAML baseline, and on tolerated-drift stories the \`current_artifact_id\` alternates between near-identical hashes the matcher keeps absorbing — producing hundreds of fake events on one path or a single visible row on another.

## Changes

**Universe** — anchor on \`status=COMPLETED\` with \`DISTINCT ON (repo_id, branch, run_type)\` ordered by \`-created_at\`. Falls through to the most recent fully-ingested run, ignoring any in-flight pending run that hasn't finished its uploads.

**History** — LAG on \`baseline_artifact_id\` (ASC) with no result filter. Pixel jitter and tolerated drift leave the YAML baseline untouched so they collapse naturally; baseline-update PRs move it so transitions surface; the oldest row's LAG returns NULL so the inception event is always kept.

Tests: rewrote the history seed helper to take \`baseline_content_hash\`, rewrote the test in terms of baseline transitions, added a test for the in-flight pending universe regression.

## How did you test this code?

I'm an agent. Counts verified across two problem identifiers — a tolerated-drift story and a recently-changed story.

## Publish to changelog?

no

## 🤖 Agent context

- Investigation traced two bugs back to filter choices in \`logic.get_baselines_overview\` and \`logic.get_snapshot_history\`
- Decisions made along the way:
  - Considered re-adding \`status=completed\` to the existing \`superseded_by IS NULL\` filter — rejected because pending runs supersede their predecessors before completing, so the previous completed run already has \`superseded_by\` set and would also be excluded. \`DISTINCT ON\` over completed runs is the right shape.
  - Considered keying history LAG on \`current_artifact_id\` with a tolerated-drift carve-out — rejected; \`baseline_artifact_id\` is the canonical "what does the YAML say" column and naturally collapses both pixel jitter and tolerated drift while catching every real baseline flip.
  - Considered a churn badge ("touched N× since inception") on the overview grid — deferred. \`COUNT(DISTINCT baseline_artifact_id)\` runs ~4.6s on a 2.7M-row scan; would need a covering index, time window, or materialized counter to be acceptable.