### PR TITLE
docs: update Python feature flag onboarding

### DIFF
--- a/docs/onboarding/feature-flags/_snippets/boolean-flag.tsx
+++ b/docs/onboarding/feature-flags/_snippets/boolean-flag.tsx
@@ -45,11 +45,11 @@ export const BooleanFlagSnippet = memo(({ language = 'javascript' }: { language?
             }
         `,
         python: dedent`
-            is_my_flag_enabled = posthog.feature_enabled('flag-key', 'distinct_id_of_your_user')
-            if is_my_flag_enabled:
+            flags = posthog.evaluate_flags('distinct_id_of_your_user')
+            if flags.is_enabled('flag-key'):
                 # Do something differently for this user
                 # Optional: fetch the payload
-                matched_flag_payload = posthog.get_feature_flag_payload('flag-key', 'distinct_id_of_your_user')
+                matched_flag_payload = flags.get_flag_payload('flag-key')
         `,
         php: dedent`
             $isMyFlagEnabledForUser = PostHog::isFeatureEnabled('flag-key', 'distinct_id_of_your_user')

--- a/docs/onboarding/feature-flags/_snippets/multivariate-flag.tsx
+++ b/docs/onboarding/feature-flags/_snippets/multivariate-flag.tsx
@@ -50,11 +50,12 @@ export const MultivariateFlagSnippet = memo(({ language = 'javascript' }: { lang
             }
         `,
         python: dedent`
-            enabled_variant = posthog.get_feature_flag('flag-key', 'distinct_id_of_your_user')
+            flags = posthog.evaluate_flags('distinct_id_of_your_user')
+            enabled_variant = flags.get_flag('flag-key')
             if enabled_variant == 'variant-key': # replace 'variant-key' with the key of your variant
                 # Do something differently for this user
                 # Optional: fetch the payload
-                matched_flag_payload = posthog.get_feature_flag_payload('flag-key', 'distinct_id_of_your_user')
+                matched_flag_payload = flags.get_flag_payload('flag-key')
         `,
         php: dedent`
             $enabledVariant = PostHog::getFeatureFlag('flag-key', 'distinct_id_of_your_user')

--- a/docs/onboarding/feature-flags/_snippets/override-properties.tsx
+++ b/docs/onboarding/feature-flags/_snippets/override-properties.tsx
@@ -33,18 +33,22 @@ export const OverridePropertiesSnippet = memo(({ language = 'javascript' }: { la
             )
         `,
         python: dedent`
-            posthog.get_feature_flag(
-                'flag-key',
+            flags = posthog.evaluate_flags(
                 'distinct_id_of_the_user',
                 person_properties={'property_name': 'value'},
                 groups={
                     'your_group_type': 'your_group_id',
-                    'another_group_type': 'your_group_id'},
+                    'another_group_type': 'your_group_id',
+                },
                 group_properties={
                     'your_group_type': {'group_property_name': 'value'},
-                    'another_group_type': {'group_property_name': 'value'}
+                    'another_group_type': {'group_property_name': 'value'},
                 },
             )
+
+            if flags.is_enabled('flag-key'):
+                # Do something differently for this user
+                pass
         `,
         php: dedent`
             PostHog::getFeatureFlag(

--- a/docs/onboarding/feature-flags/python.tsx
+++ b/docs/onboarding/feature-flags/python.tsx
@@ -54,16 +54,16 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                             **Note:** This step is only required for events captured using our server-side SDKs or API.
                         `}
                     </Markdown>
-                    <Tab.Group tabs={['Set send_feature_flags (recommended)', 'Include $feature property']}>
+                    <Tab.Group tabs={['Pass evaluated flags (recommended)', 'Include $feature property']}>
                         <Tab.List>
-                            <Tab>Set send_feature_flags (recommended)</Tab>
+                            <Tab>Pass evaluated flags (recommended)</Tab>
                             <Tab>Include $feature property</Tab>
                         </Tab.List>
                         <Tab.Panels>
                             <Tab.Panel>
                                 <Markdown>
                                     {dedent`
-                                        Set \`send_feature_flags\` to \`True\` in your capture call:
+                                        Pass the same \`flags\` snapshot that you used for branching. This attaches the exact flag values from that evaluation and doesn't make another \`/flags\` request:
                                     `}
                                 </Markdown>
                                 <CodeBlock
@@ -72,10 +72,12 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                             language: 'python',
                                             file: 'Python',
                                             code: dedent`
+                                                flags = posthog.evaluate_flags("distinct_id_of_the_user")
+
                                                 posthog.capture(
+                                                    "event_name",
                                                     distinct_id="distinct_id_of_the_user",
-                                                    event='event_name',
-                                                    send_feature_flags=True
+                                                    flags=flags,
                                                 )
                                             `,
                                         },


### PR DESCRIPTION
## Problem

The Python Feature Flags installation docs on posthog.com import shared onboarding content from this repo. Those snippets still recommended standalone flag calls and `send_feature_flags`, but the Python SDK now exposes `evaluate_flags()` as the canonical feature flag evaluation API.

## Changes

- Update Python boolean and multivariate feature flag onboarding snippets to use `posthog.evaluate_flags()`.
- Update the event enrichment step to pass the evaluated `flags` snapshot to `capture()` instead of recommending `send_feature_flags=True`.
- Update the Python property override snippet to pass overrides through `evaluate_flags()`.

## How did you test this code?

Agent-authored docs-only change. Ran `git diff --check`; the commit hook also ran `bin/hogli format:js` on the staged files.

## Publish to changelog?

Do not publish to changelog.

## Docs update

This is a docs update.

## 🤖 Agent context

Authored by pi coding agent. The implementation was fact-checked against the local `~/dev/posthog/posthog-python` branch that implements `evaluate_flags()`. Key decision: keep the installation/onboarding page accurate by updating the shared onboarding source that posthog.com imports.
