### PR TITLE
chore(flags): remove beta tag from evaluation contexts

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagEvaluationContexts.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagEvaluationContexts.tsx
@@ -174,9 +174,6 @@ export function FeatureFlagEvaluationContexts({
             <div className="flex flex-col gap-1">
                 <span className="text-sm font-medium inline-flex items-center gap-1">
                     Evaluation contexts
-                    <LemonTag type="warning" size="small">
-                        BETA
-                    </LemonTag>
                     {(context === 'form' || isEditingContexts) && (
                         <Tooltip
                             interactive


### PR DESCRIPTION
## Problem

Evaluation contexts for feature flags have been rolled out everywhere, so the BETA tag next to the section heading is no longer accurate.

## Changes

Remove the `BETA` `LemonTag` from the "Evaluation contexts" heading in `FeatureFlagEvaluationContexts.tsx`.

## How did you test this code?

I'm an agent — no manual testing performed. Change is a pure UI tag removal with no logic impact.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: pi (Claude)
- Prompts: "can you remove the beta tag from evaluation contexts in feature flags? I just rolled that out everywhere" → "make a PR on a new branch pls"
- Verified the only relevant BETA tag was on the Evaluation contexts section heading; other "Beta" mentions in nearby files (CSP reporting, chart color themes, `betaFeature` placeholder text) were unrelated and left intact.
