### PR TITLE
feat(visual-review): add triaging-visual-review-runs skill

### DIFF
--- a/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
+++ b/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
@@ -76,20 +76,39 @@ user can click straight to the diff viewer.
 
 ### "Is the diff real or unrelated?"
 
-The most useful judgment a code-aware agent can add. Compare the **scope** of the visual diff against the
-**scope** of the code change. When a PR that touches `posthog/session_recordings/...` produces a diff on
-`scenes-app-settings-user--settings-user-profile`, that's a strong signal of flake / shared-component bleed
-/ stale baseline rather than a real regression.
+The most useful judgment a code-aware agent can add. Combine three signals: **scope match**, **flake history**,
+and **the actual rendered images**. The agent should look at the screenshots — not just describe metadata.
 
-1. `git diff master...HEAD --stat` (or against the PR's base branch) → list of touched paths.
-2. `visual-review-runs-snapshots-list { id }` filtered to `result: changed` → list of story identifiers.
-3. Cross-reference: does the file scope plausibly explain the story scope?
-4. If yes — recommend approving in the UI.
-   If no — escalate: "this diff is unrelated to the code, likely flake or shared-component change", and run
-   the flake check below before approving anything.
+1. **Scope check** — `git diff master...HEAD --stat` (or against the PR's base branch) → list of touched paths.
+   Cross-reference with `visual-review-runs-snapshots-list { id }` filtered to `result: changed` → story identifiers.
+   Stories are namespaced like `<area>-<scene>--<story>--<theme>`; e.g. `scenes-app-settings-user--settings-user-profile--dark`
+   maps to `frontend/src/scenes/settings/user/...`. Use this to translate story id → likely source path.
 
-Stories are namespaced like `<area>-<scene>--<story>--<theme>`. Example: `scenes-app-settings-user--settings-user-profile--dark`
-maps to `frontend/src/scenes/settings/user/...`. Use this to translate from story id → likely source path.
+2. **Visual inspection** — for each `changed` snapshot, the tool result contains `current_artifact.download_url`
+   and `baseline_artifact.download_url`. These are pre-signed S3 URLs to PNG files; pull them and look:
+
+   ```bash
+   curl -s -o /tmp/vr-baseline.png "<baseline_artifact.download_url>"
+   curl -s -o /tmp/vr-current.png "<current_artifact.download_url>"
+   ```
+
+   Then `Read` both files (the Read tool renders images visually) and compare. Things to call out:
+   - The actual visible delta (text changed, button moved, layout shift, color drift, missing element).
+   - Whether the change is consistent with the diff_pixel_count and diff_percentage in the metadata
+     (e.g. 54% diff but the images look near-identical → screenshot framing changed, not the UI).
+   - Whether the baseline and current have different dimensions (`width` / `height` fields). Mismatched
+     dimensions usually mean the story rendered to a different viewport or didn't fully render before
+     screenshot — a flake signal, not a regression.
+
+3. **Flake history** — run the flake check below for any story that looks suspect.
+
+4. **Verdict** — combine all three:
+   - Scope plausible + visible regression matches the code change → real diff, recommend approval.
+   - Scope mismatch + dimensions mismatch + frequent prior changes → flake, recommend tolerating the hash.
+   - Scope plausible + visible regression looks unintended → push a fix; do not approve.
+
+Always include a one-line description of what you saw in the images — the user uses this to decide whether to
+trust your verdict without opening the VR UI themselves.
 
 ### Flake check: "Has this story been changing?"
 
@@ -126,7 +145,7 @@ For triage / aggregate questions, a short table beats prose. Group by what the u
 
 - Do not approve or tolerate snapshots from this skill — those endpoints are intentionally not exposed as
   MCP tools yet. Direct the user to the run's `_posthogUrl`.
-- Do not download or describe the screenshot images themselves; the artifact URLs in tool output are
-  pre-signed S3 links for the UI, not for agent inspection.
 - Do not assume the failing GitHub check on a PR is unrelated to VR — if a `visual-review` check is red on
   a PR you're working on, that's the trigger to run this skill.
+- Do not declare a verdict from metadata alone when `result: changed`. Pull the baseline and current PNGs
+  and look at them; metadata can only say "something changed", not whether the change is intended.

--- a/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
+++ b/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
@@ -67,9 +67,9 @@ These appear in tool output and matter for interpretation:
 
 The single most common job. Map a PR number to its run state in two calls.
 
-1. `visual-review-runs-list { pr_number: <n>, limit: 5 }` — sort by `created_at` desc, take the latest non-stale one.
+1. `posthog:visual-review-runs-list { pr_number: <n>, limit: 5 }` — sort by `created_at` desc, take the latest non-stale one.
 2. If the run has `summary.changed > 0` or `summary.unresolved > 0`, drill in:
-   `visual-review-runs-snapshots-list { id: <run_id> }` and report the `changed` snapshots.
+   `posthog:visual-review-runs-snapshots-list { id: <run_id> }` and report the `changed` snapshots.
 
 Report back: PR number, run UUID, `review_state`, summary counts, and the `_posthogUrl` deep link so the
 user can click straight to the diff viewer.
@@ -80,7 +80,7 @@ The most useful judgment a code-aware agent can add. Combine three signals: **sc
 and **the actual rendered images**. The agent should look at the screenshots — not just describe metadata.
 
 1. **Scope check** — `git diff master...HEAD --stat` (or against the PR's base branch) → list of touched paths.
-   Cross-reference with `visual-review-runs-snapshots-list { id }` filtered to `result: changed` → story identifiers.
+   Cross-reference with `posthog:visual-review-runs-snapshots-list { id }` filtered to `result: changed` → story identifiers.
    Stories are namespaced like `<area>-<scene>--<story>--<theme>`; e.g. `scenes-app-settings-user--settings-user-profile--dark`
    maps to `frontend/src/scenes/settings/user/...`. Use this to translate story id → likely source path.
 
@@ -114,7 +114,7 @@ trust your verdict without opening the VR UI themselves.
 
 Once you have a suspect snapshot identifier:
 
-`visual-review-runs-snapshot-history-list { id: <snapshot_id> }` → returns prior outcomes for the same story.
+`posthog:visual-review-runs-snapshot-history-list { id: <snapshot_id> }` → returns prior outcomes for the same story.
 
 Verdicts:
 
@@ -126,8 +126,8 @@ Verdicts:
 
 When the user is doing housekeeping rather than asking about a specific PR:
 
-1. `visual-review-runs-counts-retrieve` → total queue size.
-2. `visual-review-runs-list { review_state: needs_review, limit: 50 }` (paginate if needed).
+1. `posthog:visual-review-runs-counts-retrieve` → total queue size.
+2. `posthog:visual-review-runs-list { review_state: needs_review, limit: 50 }` (paginate if needed).
 3. Group by `branch` author or `run_type` to surface clusters (e.g., "12 PRs blocked on the same shared
    component change" usually means a single underlying root cause to address).
 4. Prefer surfacing runs whose `summary.changed > 0` over runs that are only `new` — `new` means no baseline

--- a/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
+++ b/products/visual_review/skills/triaging-visual-review-runs/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: triaging-visual-review-runs
+description: >
+  Inspects PostHog Visual Review (VR) runs that gate PR merges with screenshot regression checks.
+  Use when the user mentions "visual review", "VR", "snapshot diff", "screenshot test", "storybook regression",
+  "playwright snapshot", asks why a PR is blocked or what changed visually, wants to triage the VR backlog,
+  decide whether a snapshot diff is real vs flaky, or check whether a story has been changing across runs.
+  Also invoke when a PR has a failing `visual-review` status check, when a PR comment mentions "Visual review",
+  or when the user is on a branch with an open VR run.
+---
+
+# Triaging visual review runs
+
+Visual Review is PostHog's screenshot-regression product: CI captures storybook + playwright screenshots,
+diffs them against committed baseline hashes, and gates the PR until a human approves the visible changes.
+A PR with visual changes carries a `visual-review` GitHub status check that stays red until each diffed
+snapshot is approved or tolerated in the [VR UI](https://us.posthog.com/project/2/visual_review).
+
+This skill teaches an agent how to answer the questions a human reviewer would actually ask, by chaining
+the read-only VR MCP tools — instead of reaching for `gh pr view` and tab-hopping to the VR web UI.
+
+## When this skill applies
+
+Trigger this skill on any of:
+
+- A PR number, branch name, or commit SHA paired with words like _visual review_, _VR_, _snapshot_, _screenshot_,
+  _storybook diff_, _playwright snapshot_, _baseline_, _approve_, _tolerated_, _quarantine_.
+- Questions about why a PR is blocked, what visually changed, or whether a diff is real.
+- "Is my run done?" / "What's left to review?" / "Has this story flaked recently?"
+- A failing `visual-review` GitHub check or a PR comment from the `posthog-bot` mentioning visual review.
+
+When the user asks for the rendered diff image itself, the [VR web UI](https://us.posthog.com/project/2/visual_review)
+is faster — direct them there. This skill is for everything around the diff: status, scope, history, triage.
+
+## Tools
+
+All read-only. None of these require write scopes; approval/toleration still happens in the web UI.
+
+| Tool                                               | Purpose                                                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `posthog:visual-review-runs-list`                  | List runs, filter by `pr_number` / `commit_sha` / `branch` / `review_state`. Start here.                           |
+| `posthog:visual-review-runs-retrieve`              | Full detail for a single run (status, summary counts, supersession).                                               |
+| `posthog:visual-review-runs-snapshots-list`        | Per-snapshot results inside a run: identifier, `result`, diff %, classification, baseline + current artifact URLs. |
+| `posthog:visual-review-runs-snapshot-history-list` | A single story's last N runs across master/PRs — the flake check.                                                  |
+| `posthog:visual-review-runs-counts-retrieve`       | Aggregate counts for queue triage (how many runs in `needs_review`, etc.).                                         |
+| `posthog:visual-review-runs-tolerated-hashes-list` | Hashes the team has explicitly accepted as "known flake / acceptable variation".                                   |
+| `posthog:visual-review-repos-list`                 | Repos (one per GitHub repo) — usually only one matters; useful for filtering.                                      |
+| `posthog:visual-review-repos-retrieve`             | Repo metadata: baseline file paths, PR-comment configuration.                                                      |
+
+## Vocabulary cheat sheet
+
+These appear in tool output and matter for interpretation:
+
+- **Run `review_state`**: `needs_review` (open, awaiting human), `clean` (zero diffs), `processing` (CI still uploading),
+  `stale` (a newer run on the same PR has superseded this one — check `superseded_by_id`).
+- **Run `run_type`**: `storybook` (component snapshots) or `playwright` (full-page e2e snapshots).
+- **Snapshot `result`**: `unchanged`, `changed` (real diff), `new` (no baseline yet), `removed`.
+- **Snapshot `classification_reason`**: `tolerated_hash` (matches a known-tolerated hash, no action needed),
+  `below_threshold` (under the noise floor), `exact` (byte-identical), `""` (real diff requiring review).
+- **Snapshot `review_state`**: `pending` or `approved`.
+- **Run `summary`**: `total / changed / new / removed / unchanged / unresolved / tolerated_matched` —
+  `unresolved` is what's actually blocking review.
+
+## Workflows
+
+### "What's the VR status of this PR?"
+
+The single most common job. Map a PR number to its run state in two calls.
+
+1. `visual-review-runs-list { pr_number: <n>, limit: 5 }` — sort by `created_at` desc, take the latest non-stale one.
+2. If the run has `summary.changed > 0` or `summary.unresolved > 0`, drill in:
+   `visual-review-runs-snapshots-list { id: <run_id> }` and report the `changed` snapshots.
+
+Report back: PR number, run UUID, `review_state`, summary counts, and the `_posthogUrl` deep link so the
+user can click straight to the diff viewer.
+
+### "Is the diff real or unrelated?"
+
+The most useful judgment a code-aware agent can add. Compare the **scope** of the visual diff against the
+**scope** of the code change. When a PR that touches `posthog/session_recordings/...` produces a diff on
+`scenes-app-settings-user--settings-user-profile`, that's a strong signal of flake / shared-component bleed
+/ stale baseline rather than a real regression.
+
+1. `git diff master...HEAD --stat` (or against the PR's base branch) → list of touched paths.
+2. `visual-review-runs-snapshots-list { id }` filtered to `result: changed` → list of story identifiers.
+3. Cross-reference: does the file scope plausibly explain the story scope?
+4. If yes — recommend approving in the UI.
+   If no — escalate: "this diff is unrelated to the code, likely flake or shared-component change", and run
+   the flake check below before approving anything.
+
+Stories are namespaced like `<area>-<scene>--<story>--<theme>`. Example: `scenes-app-settings-user--settings-user-profile--dark`
+maps to `frontend/src/scenes/settings/user/...`. Use this to translate from story id → likely source path.
+
+### Flake check: "Has this story been changing?"
+
+Once you have a suspect snapshot identifier:
+
+`visual-review-runs-snapshot-history-list { id: <snapshot_id> }` → returns prior outcomes for the same story.
+
+Verdicts:
+
+- Mostly `unchanged` and this run's diff is the outlier → likely a real regression caused by this PR.
+- Frequent `changed` across unrelated branches/master → flaky story; recommend tolerating the hash via the UI.
+- Recent `removed` or large-jump dimension change → baseline likely stale; recommend re-baselining on master.
+
+### Triaging the queue
+
+When the user is doing housekeeping rather than asking about a specific PR:
+
+1. `visual-review-runs-counts-retrieve` → total queue size.
+2. `visual-review-runs-list { review_state: needs_review, limit: 50 }` (paginate if needed).
+3. Group by `branch` author or `run_type` to surface clusters (e.g., "12 PRs blocked on the same shared
+   component change" usually means a single underlying root cause to address).
+4. Prefer surfacing runs whose `summary.changed > 0` over runs that are only `new` — `new` means no baseline
+   yet, which is usually trivial to approve; `changed` is the real review work.
+
+## Output expectations
+
+For PR-status questions, lead with the verdict in one line, then 2-4 bullets of supporting context. Always
+include the `_posthogUrl` deep link to the run — humans need to see the rendered images to make the call,
+the agent can only describe the metadata.
+
+For triage / aggregate questions, a short table beats prose. Group by what the user is going to act on.
+
+## What NOT to do
+
+- Do not approve or tolerate snapshots from this skill — those endpoints are intentionally not exposed as
+  MCP tools yet. Direct the user to the run's `_posthogUrl`.
+- Do not download or describe the screenshot images themselves; the artifact URLs in tool output are
+  pre-signed S3 links for the UI, not for agent inspection.
+- Do not assume the failing GitHub check on a PR is unrelated to VR — if a `visual-review` check is red on
+  a PR you're working on, that's the trigger to run this skill.


### PR DESCRIPTION
## Problem

The visual-review MCP tools (8 read-only endpoints) shipped with the read-only MCP tools + pr/commit/branch filters PR (#55574) but agents don't reliably reach for them. Without a skill, an agent asked "is my PR blocked on visual review?" defaults to \`gh pr view\` and tab-hopping to the VR web UI instead of chaining \`visual-review-runs-list\` → \`visual-review-runs-snapshots-list\`. This is a discoverability problem the MCP tool descriptions alone don't solve.

## Changes

Adds \`products/visual_review/skills/triaging-visual-review-runs/SKILL.md\`. Single-file skill — no references needed for an 8-tool surface. Contents:

- Description loaded with trigger phrases (visual review, VR, snapshot diff, screenshot test, storybook regression, playwright snapshot, failing \`visual-review\` GitHub check) so the agent self-activates on the right prompts.
- Tool reference table covering all 8 read-only tools.
- Vocabulary cheat sheet for \`review_state\`, \`result\`, \`classification_reason\`, summary fields — interpretation context the tool descriptions don't carry.
- Four workflows: PR-status check, code-vs-visual scope mismatch (the heuristic for distinguishing real regressions from flakes), flake history check, queue triage.
- Output expectations and explicit "what NOT to do" (no approve/tolerate from MCP, don't try to inspect screenshot artifacts).

## How did you test this code?

Agent-authored. Verified locally:

- \`hogli lint:skills\` → 28 skills pass (mine included)
- \`hogli build:skills\` → bundle includes \`triaging-visual-review-runs\`

No runtime testing — skills are static markdown distributed via the build pipeline.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code session, Opus 4.7
- Triggered by: noticing the visual-review MCP tools don't surface unless you name them. We worked through the discoverability gap end-to-end (deploy verification, OAuth scope mismatch on existing tokens, then the skill).
- Followed the \`writing-skills\` skill template; scaffolded with \`hogli init:skill\`.
- Single-file SKILL.md was a deliberate choice — the surface is small enough that progressive disclosure via \`references/\` would be overkill.