### PR TITLE
feat(notebooks): show insights as selected

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -106,6 +106,13 @@
     }
 }
 
+.NotebookNode--in-selection {
+    .NotebookNode__box {
+        border-color: Highlight;
+        box-shadow: 0 0 0 1px Highlight;
+    }
+}
+
 .NotebookNodeTitle {
     padding: 0.25rem;
     overflow: hidden;

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -61,10 +61,6 @@
         }
     }
 
-    &--selected {
-        --border-color: var(--border-bold);
-    }
-
     &--auto-hide-metadata {
         --border-color: transparent;
 
@@ -106,8 +102,12 @@
     }
 }
 
-.NotebookNode--in-selection {
-    .NotebookNode__box {
+.ProseMirror.ProseMirror-focused {
+    .NotebookNode--selected {
+        --border-color: var(--border-bold);
+    }
+
+    .NotebookNode--in-selection .NotebookNode__box {
         border-color: Highlight;
         box-shadow: 0 0 0 1px Highlight;
     }

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -529,7 +529,7 @@ export function createPostHogWidgetNode<T extends CustomNotebookNodeAttributes>(
             const jsonAttr = (name: string): Record<string, any> => ({
                 parseHTML: (element: HTMLElement) => {
                     const raw = element.getAttribute(name)
-                    return raw === null ? null : JSON.parse(raw)
+                    return raw ? JSON.parse(raw) : null
                 },
                 renderHTML: (attrs: Record<string, any>) => {
                     const value = attrs[name]

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -65,6 +65,7 @@ import { notebookCollabLogic } from './notebookCollabLogic'
 import { NotebookDefaultBlockOnEnter } from './NotebookDefaultBlockOnEnter'
 import { notebookLogic } from './notebookLogic'
 import { NotebookTrailingParagraph } from './NotebookTrailingParagraph'
+import { RangeSelectedNodes } from './RangeSelectedNodes'
 import { RemotePresenceExtension } from './RemotePresenceExtension'
 import { SlashCommandsExtension } from './SlashCommands'
 import { TableMenu } from './TableMenu'
@@ -173,6 +174,7 @@ export function Editor(): JSX.Element {
         NotebookNodeCustomerJourney,
         NotebookTrailingParagraph,
         NotebookDefaultBlockOnEnter,
+        RangeSelectedNodes,
     ]
 
     if (useCollab) {

--- a/frontend/src/scenes/notebooks/Notebook/RangeSelectedNodes.ts
+++ b/frontend/src/scenes/notebooks/Notebook/RangeSelectedNodes.ts
@@ -33,7 +33,7 @@ export const RangeSelectedNodes = Extension.create({
                                     })
                                 )
                             }
-                            return true
+                            return false
                         })
                         return DecorationSet.create(state.doc, decorations)
                     },

--- a/frontend/src/scenes/notebooks/Notebook/RangeSelectedNodes.ts
+++ b/frontend/src/scenes/notebooks/Notebook/RangeSelectedNodes.ts
@@ -1,0 +1,44 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+// This plugin decorates atom blocks (insights, sql, python, etc.)
+// so they can pick up the same highlight as a directly-selected node.
+const pluginKey = new PluginKey('rangeSelectedNodes')
+
+export const RangeSelectedNodes = Extension.create({
+    name: 'rangeSelectedNodes',
+
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: pluginKey,
+                props: {
+                    decorations(state) {
+                        const { from, to, empty } = state.selection
+                        if (empty) {
+                            return DecorationSet.empty
+                        }
+                        const decorations: Decoration[] = []
+                        state.doc.nodesBetween(from, to, (node, pos) => {
+                            if (!node.isAtom || !node.isBlock) {
+                                return true
+                            }
+                            const nodeFrom = pos
+                            const nodeTo = pos + node.nodeSize
+                            if (from <= nodeFrom && nodeTo <= to) {
+                                decorations.push(
+                                    Decoration.node(nodeFrom, nodeTo, {
+                                        class: 'NotebookNode--in-selection',
+                                    })
+                                )
+                            }
+                            return true
+                        })
+                        return DecorationSet.create(state.doc, decorations)
+                    },
+                },
+            }),
+        ]
+    },
+})


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

When you select text spanning across an embedded notebook node (insight, recording, SQL, Python, etc.), the surrounding text shows the standard selection highlight but the node itself has no visual feedback. The node is part of the selection — Cmd+C, Backspace and friends all act on it, but visually it looks excluded.

## Changes

Added a small TipTap extension (RangeSelectedNodes) that scans the active selection on every change, finds atom block nodes fully covered by it, and emits a `Decoration.node` with class `NotebookNode--in-selection`. SCSS rule on that class draws a 1px Highlight-color border.

Covers all `createPostHogWidgetNode` widgets (insights, recordings, queries, Python, SQL, …). Inline atoms like backlinks aren't touched — the browser's native text-selection paint already handles those.

This is the canonical pattern for the gap ProseMirror's built-ins don't cover: selected only fires for NodeSelection, selectedOnTextSelection fires for cursor-inside-content (inapplicable to atoms).

## How did you test this code?

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## ![2026-05-01 00.07.21.gif](https://app.graphite.com/user-attachments/assets/604b2b50-edb3-481a-9891-e337924f1fec.gif)

## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include: tools/agent used, link to session, key decisions made, and anything that helps reviewers. -->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->