### PR TITLE
fix(flags): move duplicate/remove into kebab on collapsed condition row

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -19,6 +19,7 @@ import {
     IconBalance,
     IconCollapse,
     IconCopy,
+    IconEllipsis,
     IconExpand,
     IconInfo,
     IconLaptop,
@@ -28,7 +29,16 @@ import {
     IconTrash,
     IconCheckCircle,
 } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonInput,
+    LemonLabel,
+    LemonMenu,
+    LemonSelect,
+    Spinner,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -171,28 +181,33 @@ function ConditionHeader({
                     ({rollout}%{group.variant && ` · ${group.variant}`}
                     {countSummary !== null && ` · ${countSummary}`})
                 </span>
-                <LemonButton
-                    icon={<IconCopy />}
-                    size="xsmall"
-                    noPadding
-                    tooltip="Duplicate condition set"
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        onDuplicate()
-                    }}
-                />
-                {totalGroups > 1 && (
+                <LemonMenu
+                    items={[
+                        {
+                            label: 'Duplicate condition set',
+                            icon: <IconCopy />,
+                            onClick: onDuplicate,
+                        },
+                        ...(totalGroups > 1
+                            ? [
+                                  {
+                                      label: 'Remove condition set',
+                                      icon: <IconTrash />,
+                                      onClick: onRemove,
+                                      status: 'danger' as const,
+                                  },
+                              ]
+                            : []),
+                    ]}
+                >
                     <LemonButton
-                        icon={<IconTrash />}
+                        icon={<IconEllipsis />}
                         size="xsmall"
                         noPadding
-                        tooltip="Remove condition set"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onRemove()
-                        }}
+                        aria-label="Condition set actions"
+                        onClick={(e) => e.stopPropagation()}
                     />
-                )}
+                </LemonMenu>
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem

On the collapsed feature flag condition row, the copy (duplicate) and trash icons sit right next to the expand chevron. Users mousing toward the chevron to expand a row often hit the copy icon by mistake — duplicating the condition set instead of opening it for editing. Editing is far more common than duplicating, so duplicate should be a secondary action.

Related ticket: https://posthoghelp.zendesk.com/agent/tickets/57329 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/58688)

## Demo

https://screen.studio/share/FLhKDz07

## Changes

Replaced the inline copy + trash icon buttons in the collapsed `ConditionHeader` with a single `IconEllipsis` kebab opening a `LemonMenu` with text-labelled entries:

- "Duplicate condition set" (copy icon)
- "Remove condition set" (trash icon, `status: 'danger'`) — only shown when `totalGroups > 1`, matching prior behaviour

The expand chevron is now the only visible affordance on the right of the row, so the whole-row click-to-expand isn't crowded by mistakeable icons. Kebab `onClick` calls `stopPropagation` so opening the menu doesn't toggle the row.

File: `frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx`

## How did you test this code?

I'm an agent. Automated checks I ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in feature-flags scope (pre-existing failures in `products/workflows/` are unrelated)
- lint-staged ran on commit (oxfmt format pass)

I did **not** manually test in a browser. Worth a manual eyeball on: kebab hit area at `xsmall` size, dropdown placement near the row's right edge, and that the row-level click handler doesn't swallow kebab clicks via keyboard/touch.

## Publish to changelog?

no

## 🤖 Agent context

Authored by PostHog Code agent on behalf of @dmarticus. Decisions:

- Picked overflow kebab over hover-reveal or visible text labels — least visual noise, hardest to mis-click. User confirmed this direction before implementation.
- Moved trash into the menu too (rather than leaving it visible) for consistency, per user request to "try moving both to a kebab".
- Did not touch the non-collapsible legacy `FeatureFlagReleaseConditions.tsx` — out of scope for the reported issue.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*