### PR TITLE
fix(flags): make copy_flags MCP tool work end-to-end

### DIFF
--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -120,7 +120,7 @@ class OrganizationFeatureFlagView(
         request=CopyFlagsRequestSerializer,
         responses={200: CopyFlagsResponseSerializer},
     )
-    @action(detail=False, methods=["post"], url_path="copy_flags")
+    @action(detail=False, methods=["post"], url_path="copy_flags", required_scopes=["feature_flag:write"])
     def copy_flags(self, request, *args, **kwargs):
         body = request.data
         feature_flag_key = body.get("feature_flag_key")

--- a/posthog/api/test/test_organization_feature_flag.py
+++ b/posthog/api/test/test_organization_feature_flag.py
@@ -20,8 +20,11 @@ from rest_framework import status
 from posthog.models import FeatureFlag
 from posthog.models.cohort import Cohort
 from posthog.models.cohort.util import sort_cohorts_topologically
+from posthog.models.organization import Organization
+from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.scheduled_change import ScheduledChange
 from posthog.models.team.team import Team
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from products.dashboards.backend.api.dashboard import Dashboard
 from products.early_access_features.backend.models import EarlyAccessFeature
@@ -971,6 +974,104 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
             # Verify the encrypted payload can be decrypted back to the original value
             decrypted_payload = get_decrypted_flag_payload(copied_flag.filters["payloads"]["true"], should_decrypt=True)
             self.assertEqual(decrypted_payload, '{"key": "secret_value"}')
+
+
+class TestOrganizationFeatureFlagCopyPersonalAPIKey(APIBaseTest):
+    """Verify the `copy_flags` action accepts personal API keys with `feature_flag:write` scope.
+
+    The viewset declares `scope_object = "INTERNAL"`, which would normally block all personal
+    API key access. The action-level `required_scopes=["feature_flag:write"]` overrides that gate
+    for this single action while keeping the rest of the viewset INTERNAL.
+    """
+
+    CONFIG_AUTO_LOGIN = False
+
+    def setUp(self):
+        super().setUp()
+        self.team_1 = self.team
+        self.team_2 = Team.objects.create(organization=self.organization)
+
+        self.feature_flag_to_copy = FeatureFlag.objects.create(
+            team=self.team_1,
+            created_by=self.user,
+            key="key-to-copy",
+            filters={"groups": [{"rollout_percentage": 50}]},
+        )
+
+        self.url = f"/api/organizations/{self.organization.id}/feature_flags/copy_flags"
+        self.body = {
+            "feature_flag_key": self.feature_flag_to_copy.key,
+            "from_project": self.team_1.id,
+            "target_project_ids": [self.team_2.id],
+        }
+
+    def _create_key(
+        self,
+        scopes: list[str],
+        scoped_organizations: list[str] | None = None,
+        scoped_teams: list[int] | None = None,
+    ) -> str:
+        value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="test",
+            user=self.user,
+            secure_value=hash_key_value(value),
+            scopes=scopes,
+            scoped_organizations=scoped_organizations or [],
+            scoped_teams=scoped_teams or [],
+        )
+        return value
+
+    def _post_with_key(self, value: str):
+        return self.client.post(self.url, self.body, headers={"authorization": f"Bearer {value}"})
+
+    def test_allows_personal_api_key_with_feature_flag_write_scope(self):
+        value = self._create_key(scopes=["feature_flag:write"])
+
+        response = self._post_with_key(value)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["success"]) == 1
+        assert len(response.json()["failed"]) == 0
+
+    def test_rejects_personal_api_key_with_only_read_scope(self):
+        value = self._create_key(scopes=["feature_flag:read"])
+
+        response = self._post_with_key(value)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "feature_flag:write" in response.json()["detail"]
+
+    def test_rejects_personal_api_key_with_wildcard_scope_on_internal_viewset(self):
+        # `*` consent intentionally does not satisfy INTERNAL viewsets even when the
+        # action declares explicit `required_scopes`. See posthog/permissions.py:498-499.
+        value = self._create_key(scopes=["*"])
+
+        response = self._post_with_key(value)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_rejects_team_scoped_personal_api_key(self):
+        # Team-scoped keys cannot reach org-level endpoints. The user must use an
+        # org-scoped or unscoped key. Confirms `check_team_and_org_permissions` at
+        # posthog/permissions.py:541-552 still gates this behind explicit team membership.
+        value = self._create_key(scopes=["feature_flag:write"], scoped_teams=[self.team_1.id])
+
+        response = self._post_with_key(value)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_rejects_cross_organization_personal_api_key(self):
+        # A key scoped to a different org than the source flag's org should be rejected.
+        other_organization, _, _ = Organization.objects.bootstrap(self.user)
+        value = self._create_key(
+            scopes=["feature_flag:write"],
+            scoped_organizations=[str(other_organization.id)],
+        )
+
+        response = self._post_with_key(value)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 class TestOrganizationFeatureFlagCopySchedules(APIBaseTest):

--- a/posthog/api/test/test_organization_feature_flag.py
+++ b/posthog/api/test/test_organization_feature_flag.py
@@ -1034,28 +1034,22 @@ class TestOrganizationFeatureFlagCopyPersonalAPIKey(APIBaseTest):
         assert len(response.json()["success"]) == 1
         assert len(response.json()["failed"]) == 0
 
-    def test_rejects_personal_api_key_with_only_read_scope(self):
-        value = self._create_key(scopes=["feature_flag:read"])
-
-        response = self._post_with_key(value)
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "feature_flag:write" in response.json()["detail"]
-
-    def test_rejects_personal_api_key_with_wildcard_scope_on_internal_viewset(self):
-        # `*` consent intentionally does not satisfy INTERNAL viewsets even when the
-        # action declares explicit `required_scopes`. See posthog/permissions.py:498-499.
-        value = self._create_key(scopes=["*"])
-
-        response = self._post_with_key(value)
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_rejects_team_scoped_personal_api_key(self):
-        # Team-scoped keys cannot reach org-level endpoints. The user must use an
-        # org-scoped or unscoped key. Confirms `check_team_and_org_permissions` at
-        # posthog/permissions.py:541-552 still gates this behind explicit team membership.
-        value = self._create_key(scopes=["feature_flag:write"], scoped_teams=[self.team_1.id])
+    @parameterized.expand(
+        [
+            # Read scope cannot satisfy a write-scoped action.
+            ("read_scope_only", ["feature_flag:read"], False),
+            # `*` consent intentionally does not satisfy INTERNAL viewsets even when the
+            # action declares explicit `required_scopes`. See posthog/permissions.py:498-499.
+            ("wildcard_scope_on_internal_viewset", ["*"], False),
+            # Team-scoped keys cannot reach org-level endpoints. The user must use an
+            # org-scoped or unscoped key. Confirms `check_team_and_org_permissions` at
+            # posthog/permissions.py:541-552 still gates this behind explicit team membership.
+            ("team_scoped_key", ["feature_flag:write"], True),
+        ]
+    )
+    def test_rejects_insufficient_or_overly_scoped_key(self, _name, scopes, scoped_to_team):
+        scoped_teams = [self.team_1.id] if scoped_to_team else None
+        value = self._create_key(scopes=scopes, scoped_teams=scoped_teams)
 
         response = self._post_with_key(value)
 

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -1,6 +1,6 @@
 import type { ApiClient, GroupType } from '@/api/client'
 import { getPostHogClient } from '@/lib/analytics'
-import { ErrorCode, MissingProjectContextError, wrapError } from '@/lib/errors'
+import { ErrorCode, MissingOrganizationContextError, MissingProjectContextError, wrapError } from '@/lib/errors'
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
 import { sanitizeHeaderValue } from '@/lib/utils'
 import type { ApiUser } from '@/schema/api'
@@ -170,15 +170,32 @@ export class StateManager {
         return { organizationId, projectId }
     }
 
-    async getOrgID(): Promise<string | undefined> {
-        const orgId = await this._cache.get('orgId')
+    /**
+     * Resolve an organization id without throwing. Reads the cache, then falls
+     * back to the API key's default-org resolution, then derives the org from
+     * the cached project (matches the team-scoped key path in
+     * `_getDefaultOrganizationAndProject` which intentionally omits the org).
+     */
+    private async _resolveOrganizationId(): Promise<string | undefined> {
+        const cached = await this._cache.get('orgId')
+        if (cached) {
+            return cached
+        }
 
-        if (!orgId) {
-            const { organizationId } = await this.setDefaultOrganizationAndProject()
-
+        const { organizationId } = await this.setDefaultOrganizationAndProject()
+        if (organizationId) {
             return organizationId
         }
 
+        const project = await this.getCachedOrFetchProject().catch(() => undefined)
+        return project?.organization
+    }
+
+    async getOrgID(): Promise<string> {
+        const orgId = await this._resolveOrganizationId()
+        if (!orgId) {
+            throw new MissingOrganizationContextError()
+        }
         return orgId
     }
 
@@ -245,7 +262,9 @@ export class StateManager {
     }
 
     async getCachedOrFetchOrg(): Promise<CachedOrg | undefined> {
-        const orgId = await this.getOrgID()
+        // Use the non-throwing resolver: callers like `getEnvironmentPrompt` and
+        // consent checks treat "no org" as "skip", not as a hard error.
+        const orgId = await this._resolveOrganizationId()
         if (!orgId) {
             return undefined
         }

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -175,6 +175,11 @@ export class StateManager {
      * back to the API key's default-org resolution, then derives the org from
      * the cached project (matches the team-scoped key path in
      * `_getDefaultOrganizationAndProject` which intentionally omits the org).
+     *
+     * The derived org id is written back to the cache so subsequent calls
+     * short-circuit on the first read — without this, every team-scoped tool
+     * invocation would re-hit `setDefaultOrganizationAndProject` plus a project
+     * fetch.
      */
     private async _resolveOrganizationId(): Promise<string | undefined> {
         const cached = await this._cache.get('orgId')
@@ -188,7 +193,11 @@ export class StateManager {
         }
 
         const project = await this.getCachedOrFetchProject().catch(() => undefined)
-        return project?.organization
+        const derived = project?.organization
+        if (derived) {
+            await this._cache.set('orgId', derived)
+        }
+        return derived
     }
 
     async getOrgID(): Promise<string> {

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -59,6 +59,30 @@ function formatMissingProjectContextMessage(organizationId: string | undefined):
     )
 }
 
+/**
+ * Thrown by `StateManager.getOrgID()` when no organization can be resolved for
+ * the current session — neither pinned via header, cached from a prior init,
+ * nor derivable from the API key's scopes or the active project. Throwing
+ * (rather than returning `undefined`) prevents callers from interpolating
+ * literal `"undefined"` into URLs like `/api/organizations/undefined/...`.
+ */
+export class MissingOrganizationContextError extends Error {
+    constructor() {
+        super(formatMissingOrganizationContextMessage())
+        this.name = 'MissingOrganizationContextError'
+    }
+}
+
+function formatMissingOrganizationContextMessage(): string {
+    return (
+        'No PostHog organization is selected for this MCP session, and a default could not be derived from your API key.' +
+        '\n\n' +
+        'To pick one (in order of preference):\n' +
+        '1. Call `organizations-list` to list organizations you can access, then `switch-organization` with the chosen organization id.\n' +
+        '2. (For MCP client maintainers) Pin an organization at session start by sending the `x-posthog-organization-id` header on the initialize request.'
+    )
+}
+
 export interface PostHogValidationErrorOptions {
     detail: string
     attr: string | undefined
@@ -218,7 +242,7 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
     // Recoverable: agent can fix it via switch-project / projects-get. Skip
     // exception capture (this is expected user state, not a bug) and return the
     // typed error's pre-formatted multi-line message verbatim.
-    if (error instanceof MissingProjectContextError) {
+    if (error instanceof MissingProjectContextError || error instanceof MissingOrganizationContextError) {
         return {
             content: [
                 {

--- a/services/mcp/src/tools/projects/getProjects.ts
+++ b/services/mcp/src/tools/projects/getProjects.ts
@@ -9,12 +9,6 @@ export const getProjectsHandler: ToolBase<typeof schema, Schemas.ProjectBackward
 ) => {
     const orgId = await context.stateManager.getOrgID()
 
-    if (!orgId) {
-        throw new Error(
-            'API key does not have access to any organizations. This is likely because the API key is scoped to a project, and not an organization.'
-        )
-    }
-
     const projectsResult = await context.api.organizations().projects({ orgId }).list()
 
     if (!projectsResult.success) {

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -260,6 +260,55 @@ describe('StateManager', () => {
             expect(result).toBe('default-org')
             expect(spy).toHaveBeenCalledOnce()
         })
+
+        it('falls back to project.organization for team-scoped keys that omit orgId', async () => {
+            // Mirrors the team-scoped path in `_getDefaultOrganizationAndProject`
+            // which intentionally returns `{ projectId }` only — getOrgID should
+            // recover via the cached project.
+            vi.spyOn(stateManager, 'setDefaultOrganizationAndProject').mockResolvedValue({
+                organizationId: undefined,
+                projectId: 456,
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                id: 456,
+                uuid: 'uuid-456',
+                name: 'My Project',
+                organization: 'derived-org',
+            } as any)
+
+            const result = await stateManager.getOrgID()
+
+            expect(result).toBe('derived-org')
+        })
+
+        it('throws MissingOrganizationContextError when no org can be resolved', async () => {
+            vi.spyOn(stateManager, 'setDefaultOrganizationAndProject').mockResolvedValue({
+                organizationId: undefined,
+                projectId: undefined,
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue(undefined)
+
+            await expect(stateManager.getOrgID()).rejects.toMatchObject({
+                name: 'MissingOrganizationContextError',
+                message: expect.stringContaining('switch-organization'),
+            })
+        })
+    })
+
+    describe('getCachedOrFetchOrg', () => {
+        it('returns undefined when no org can be resolved (does not throw)', async () => {
+            // Preserves the best-effort contract used by getEnvironmentPrompt and
+            // consent checks: if no org is in scope, the call is a no-op.
+            vi.spyOn(stateManager, 'setDefaultOrganizationAndProject').mockResolvedValue({
+                organizationId: undefined,
+                projectId: undefined,
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue(undefined)
+
+            const result = await stateManager.getCachedOrFetchOrg()
+
+            expect(result).toBeUndefined()
+        })
     })
 
     describe('getProjectId', () => {

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -281,6 +281,32 @@ describe('StateManager', () => {
             expect(result).toBe('derived-org')
         })
 
+        it('caches the derived org id so repeat calls short-circuit', async () => {
+            // Without this caching, every tool that calls getOrgID would re-hit
+            // setDefaultOrganizationAndProject + getCachedOrFetchProject for a
+            // team-scoped key.
+            const setDefaultSpy = vi.spyOn(stateManager, 'setDefaultOrganizationAndProject').mockResolvedValue({
+                organizationId: undefined,
+                projectId: 456,
+            })
+            const getProjectSpy = vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                id: 456,
+                uuid: 'uuid-456',
+                name: 'My Project',
+                organization: 'derived-org',
+            } as any)
+
+            const first = await stateManager.getOrgID()
+            const second = await stateManager.getOrgID()
+
+            expect(first).toBe('derived-org')
+            expect(second).toBe('derived-org')
+            expect(await cache.get('orgId')).toBe('derived-org')
+            // Second call hits cache, not the resolver path.
+            expect(setDefaultSpy).toHaveBeenCalledOnce()
+            expect(getProjectSpy).toHaveBeenCalledOnce()
+        })
+
         it('throws MissingOrganizationContextError when no org can be resolved', async () => {
             vi.spyOn(stateManager, 'setDefaultOrganizationAndProject').mockResolvedValue({
                 organizationId: undefined,


### PR DESCRIPTION
## Problem

The MCP tool `feature-flags-copy-flags-create` is enabled but non-functional — it returns a 403 because of an auth-scope conflict, and the URL it builds contains a literal `undefined` in place of the org id. Users who copy feature flags between projects can't do it from an MCP client today.

Closes #57234

## Changes

Two coupled fixes that, together, make the tool work for users with a personal API key carrying `feature_flag:write` scope.

**1. Per-action scope override on `copy_flags` (`posthog/api/organization_feature_flag.py`).** `OrganizationFeatureFlagView` declares `scope_object = "INTERNAL"`, which blocks all personal API key access at the higher gate. Adding `required_scopes=["feature_flag:write"]` to the `@action` decorator overrides that gate for this single action while the rest of the viewset stays INTERNAL. The existing `UserAccessControl` editor check on the source flag and the `team_ids_visible_for_user` gate on target projects are unchanged. In-tree pattern reference: `posthog/api/exports.py:145`.

**2. Resolve the org id in `StateManager.getOrgID()` (`services/mcp/src/lib/StateManager.ts`).** For team-scoped API keys, `_getDefaultOrganizationAndProject` intentionally returns `{ projectId }` only — so the cache stayed empty and `String(undefined)` was being interpolated into URLs. `getOrgID` now extracts a `_resolveOrganizationId` helper that mirrors `getAnalyticsContext`'s cache → project fallback (look up the org via the cached project), and **throws** `MissingOrganizationContextError` when nothing resolves. Throwing prevents the bug class entirely — generated tools that interpolate `String(orgId)` into URL paths can't produce `"undefined"` anymore. `getCachedOrFetchOrg` keeps its non-throwing contract for `getEnvironmentPrompt` and consent checks.

**Constraint worth noting:** `*` consent does not satisfy INTERNAL viewsets even when `required_scopes` is set on an action (`posthog/permissions.py:498-499`). Users need explicit `feature_flag:write` or `feature_flag:*`. Team-scoped keys also can't reach this org-level endpoint — they need an org-scoped or unscoped key. Both are security-positive.

## How did you test this code?

Automated tests only:

- **Backend** — added 5 new tests in `TestOrganizationFeatureFlagCopyPersonalAPIKey` covering: allow with `feature_flag:write`, deny with `feature_flag:read`, deny with `*` on INTERNAL viewset, deny team-scoped key, deny cross-org key. All pass.
- **MCP** — added 3 tests in `tests/unit/StateManager.test.ts`: `getOrgID` falls back to `project.organization` when the default returns no org; throws `MissingOrganizationContextError` when nothing resolves; `getCachedOrFetchOrg` returns `undefined` (not throws) post-change to preserve the existing contract. All 25 StateManager tests pass.
- Typecheck (`pnpm typecheck` in `services/mcp`) clean. Ruff and oxlint clean.

A follow-up PR will add the `copying-flags-across-projects` skill once this lands.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) at the user's direction.
- Filed [#57234](https://github.com/PostHog/posthog/issues/57234) first to capture the gaps and proposed approach, then implemented PR 1 here (fixes 1 + 2). PR 2 (the skill) deliberately follows separately so it documents working behavior.
- Considered and rejected: setting `dangerously_skip_scoped_team_enforcement = True` on the viewset to let team-scoped keys reach this endpoint. Decided against because target-project access checks happen via `team_ids_visible_for_user`, not key scoping — bypassing the team-scope gate would let a team-scoped key write to teams in the same org without explicit scoping for those teams. Keeping the constraint is security-positive.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*