### PR TITLE
fix(error-tracking): tag direct query calls

### DIFF
--- a/products/error_tracking/frontend/queries.test.ts
+++ b/products/error_tracking/frontend/queries.test.ts
@@ -1,5 +1,7 @@
+import { ProductKey } from '~/queries/schema/schema-general'
+
 import { FilterLogicalOperator } from '../../../frontend/src/types'
-import { errorTrackingQuery } from './queries'
+import { errorTrackingIssueBreakdownQuery, errorTrackingIssueEventsQuery, errorTrackingQuery } from './queries'
 
 describe('queries', () => {
     describe('errorTrackingQuery', () => {
@@ -25,6 +27,49 @@ describe('queries', () => {
                 })
                 expect(actual).toMatchSnapshot()
             })
+        })
+    })
+
+    describe('error tracking query tags', () => {
+        it('tags issue event queries as error tracking', () => {
+            const actual = errorTrackingIssueEventsQuery({
+                fingerprints: ['abc'],
+                filterTestAccounts: false,
+                filterGroup: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [],
+                        },
+                    ],
+                },
+                searchQuery: '',
+                dateRange: { date_from: '-7d', date_to: null },
+                columns: ['*'],
+            })
+
+            expect(actual.tags).toEqual({ productKey: ProductKey.ERROR_TRACKING })
+        })
+
+        it('tags issue breakdown insight queries as error tracking', () => {
+            const actual = errorTrackingIssueBreakdownQuery({
+                breakdownProperty: '$browser',
+                dateRange: { date_from: '-7d', date_to: null },
+                filterTestAccounts: false,
+                filterGroup: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [],
+                        },
+                    ],
+                },
+                issueId: 'issue-id',
+            })
+
+            expect(actual.source.tags).toEqual({ productKey: ProductKey.ERROR_TRACKING })
         })
     })
 })

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -182,6 +182,7 @@ export const errorTrackingIssueEventsQuery = ({
         filterTestAccounts: filterTestAccounts,
         after: dateRange.date_from ?? undefined,
         before: dateRange.date_to ?? undefined,
+        tags: { productKey: ProductKey.ERROR_TRACKING },
     }
 
     return eventsQuery
@@ -301,6 +302,7 @@ export const errorTrackingIssueBreakdownQuery = ({
             ],
             dateRange: dateRange,
             filterTestAccounts,
+            tags: { productKey: ProductKey.ERROR_TRACKING },
         },
     }
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.test.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.test.ts
@@ -1,0 +1,56 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { EventPropertyFilter, FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+
+import type { ErrorTrackingAssignmentRule } from '../rules/types'
+import { assignmentRuleModalLogic } from './assignmentRuleModalLogic'
+
+describe('assignmentRuleModalLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+        jest.spyOn(api, 'query').mockResolvedValue({ results: [[3, 2]] } as any)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('tags match count EventsQuery as error tracking', async () => {
+        const browserFilter: EventPropertyFilter = {
+            key: '$browser',
+            value: ['Firefox'],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        }
+        const rule: ErrorTrackingAssignmentRule = {
+            id: 'new',
+            filters: {
+                type: FilterLogicalOperator.And,
+                values: [browserFilter],
+            },
+            assignee: null,
+            disabled_data: null,
+            order_key: 0,
+        }
+        const logic = assignmentRuleModalLogic()
+        logic.mount()
+
+        await expectLogic(logic, () => {
+            logic.actions.openModal(rule)
+            logic.actions.loadMatchCount()
+        }).toFinishAllListeners()
+
+        expect(api.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tags: { productKey: ProductKey.ERROR_TRACKING },
+                fixedProperties: [{ type: FilterLogicalOperator.And, values: [browserFilter] }],
+            })
+        )
+
+        logic.unmount()
+    })
+})

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.ts
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { rulesLogic } from '../rules/rulesLogic'
@@ -73,6 +73,7 @@ export const assignmentRuleModalLogic = kea<assignmentRuleModalLogicType>([
                         event: '$exception',
                         select: ['count()', 'count(distinct properties.$exception_issue_id)'],
                         after: values.dateRange,
+                        tags: { productKey: ProductKey.ERROR_TRACKING },
                     }
 
                     if (properties.length > 0) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/groupingRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/groupingRuleModalLogic.ts
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { rulesLogic } from '../rules/rulesLogic'
@@ -73,6 +73,7 @@ export const groupingRuleModalLogic = kea<groupingRuleModalLogicType>([
                         event: '$exception',
                         select: ['count()', 'count(distinct properties.$exception_issue_id)'],
                         after: values.dateRange,
+                        tags: { productKey: ProductKey.ERROR_TRACKING },
                     }
 
                     if (properties.length > 0) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/MatchResultBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/MatchResultBanner.tsx
@@ -5,7 +5,7 @@ import { LemonButton, Link } from '@posthog/lemon-ui'
 import { urls } from 'scenes/urls'
 
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { ActivityTab, AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 
 const DATE_RANGE_LABELS: Record<string, string> = {
@@ -71,6 +71,7 @@ export function MatchResultBanner({
                     after: dateRange,
                     event: '$exception',
                     properties,
+                    tags: { productKey: ProductKey.ERROR_TRACKING },
                 },
                 propertiesViaUrl: true,
                 showPersistentColumnConfigurator: true,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/suppressionRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/suppressionRuleModalLogic.ts
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { rulesLogic } from '../rules/rulesLogic'
@@ -81,6 +81,7 @@ export const suppressionRuleModalLogic = kea<suppressionRuleModalLogicType>([
                         event: '$exception',
                         select: ['count()', 'count(distinct properties.$exception_issue_id)'],
                         after: values.dateRange,
+                        tags: { productKey: ProductKey.ERROR_TRACKING },
                     }
 
                     if (properties.length > 0) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingFingerprintsScene/ErrorTrackingIssueFingerprintsScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingFingerprintsScene/ErrorTrackingIssueFingerprintsScene.tsx
@@ -12,7 +12,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { EventsQuery, NodeKind } from '~/queries/schema/schema-general'
+import { EventsQuery, NodeKind, ProductKey } from '~/queries/schema/schema-general'
 
 import { ErrorTrackingSetupPrompt } from '../../components/SetupPrompt/SetupPrompt'
 import { errorTrackingIssueFingerprintsSceneLogic } from './errorTrackingIssueFingerprintsSceneLogic'
@@ -159,6 +159,7 @@ function FingerprintStackTrace({ fingerprint, createdAt }: { fingerprint: string
                 ],
                 orderBy: ['timestamp ASC'],
                 limit: 1,
+                tags: { productKey: ProductKey.ERROR_TRACKING },
             }
             const response = await api.query(query)
             if (response.results.length > 0) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/errorTrackingInsightsLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/errorTrackingInsightsLogic.ts
@@ -6,7 +6,7 @@ import posthog from 'posthog-js'
 import api from 'lib/api'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 
-import { HogQLQueryResponse, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { HogQLQueryResponse, InsightVizNode, NodeKind, ProductKey, TrendsQuery } from '~/queries/schema/schema-general'
 import {
     AnyPropertyFilter,
     FilterLogicalOperator,
@@ -132,6 +132,7 @@ export const errorTrackingInsightsLogic = kea<errorTrackingInsightsLogicType>([
                             properties: (values.insightsFilterGroup.values[0] as UniversalFiltersGroup)
                                 .values as AnyPropertyFilter[],
                         },
+                        tags: { productKey: ProductKey.ERROR_TRACKING },
                     })
                     const row = (response as HogQLQueryResponse)?.results?.[0]
                     if (!row) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/queries.test.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/queries.test.ts
@@ -1,0 +1,26 @@
+import { ProductKey } from '~/queries/schema/schema-general'
+import { FilterLogicalOperator } from '~/types'
+
+import { buildAffectedUsersQuery, buildCrashFreeSessionsQuery, buildExceptionVolumeQuery } from './queries'
+
+describe('error tracking insights queries', () => {
+    it('tags chart queries as error tracking', () => {
+        const filters = {
+            filterGroup: {
+                type: FilterLogicalOperator.And,
+                values: [{ type: FilterLogicalOperator.And, values: [] }],
+            },
+            filterTestAccounts: false,
+        }
+
+        expect(buildExceptionVolumeQuery('-7d', null, filters).source.tags).toEqual({
+            productKey: ProductKey.ERROR_TRACKING,
+        })
+        expect(buildAffectedUsersQuery('-7d', null, filters).source.tags).toEqual({
+            productKey: ProductKey.ERROR_TRACKING,
+        })
+        expect(buildCrashFreeSessionsQuery('-7d', null, filters).source.tags).toEqual({
+            productKey: ProductKey.ERROR_TRACKING,
+        })
+    })
+})

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/queries.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/queries.ts
@@ -2,7 +2,7 @@ import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { InsightVizNode, NodeKind, ProductKey, TrendsQuery } from '~/queries/schema/schema-general'
 import { BaseMathType, ChartDisplayType, IntervalType, PropertyGroupFilter, UniversalFiltersGroup } from '~/types'
 
 export interface InsightQueryFilters {
@@ -43,6 +43,7 @@ export function buildExceptionVolumeQuery(
             trendsFilter: { display: ChartDisplayType.ActionsBar },
             filterTestAccounts,
             properties: filterGroup as PropertyGroupFilter,
+            tags: { productKey: ProductKey.ERROR_TRACKING },
         },
         showHeader: false,
         showTable: false,
@@ -72,6 +73,7 @@ export function buildAffectedUsersQuery(
             trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
             filterTestAccounts,
             properties: filterGroup as PropertyGroupFilter,
+            tags: { productKey: ProductKey.ERROR_TRACKING },
         },
         showHeader: false,
         showTable: false,
@@ -111,6 +113,7 @@ export function buildCrashFreeSessionsQuery(
             },
             filterTestAccounts,
             properties: filterGroup as PropertyGroupFilter,
+            tags: { productKey: ProductKey.ERROR_TRACKING },
         },
         showHeader: false,
         showTable: false,


### PR DESCRIPTION
## Problem

Error tracking has several direct query calls that bypass DataNode's automatic scene tagging. Without an explicit product tag, these queries can fail query-tag validation and are harder to attribute in query logs.

## Changes

- Add `ProductKey.ERROR_TRACKING` tags to direct Error tracking query calls.
- Tag Error tracking insight chart queries and related query helpers.
- Add regression coverage for tagged query builders and rule match count queries.

## How did you test this code?

Agent-run automated tests:

- `pnpm --filter=@posthog/frontend exec jest products/error_tracking/frontend/queries.test.ts products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/queries.test.ts --runInBand`
- `pnpm --filter=@posthog/frontend exec jest products/error_tracking/frontend/queries.test.ts products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.test.ts --runInBand`
- `git diff --check`

## Publish to changelog?

No.

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by Pi coding agent. This is a stacked PR targeting `fix/error-tracking-or-filter-issues-list`; it contains only query-tagging changes on top of the Error tracking filter group fixes.
