### PR TITLE
perf(hogql): push down persons-side filters into pdi argMax subquery

### DIFF
--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+from posthog.hogql import ast
 from posthog.hogql.ast import SelectQuery
 from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.context import HogQLContext
@@ -14,6 +17,10 @@ from posthog.hogql.database.models import (
     Table,
 )
 from posthog.hogql.database.schema.persons import join_with_persons_table
+from posthog.hogql.database.schema.util.pdi_person_id_pushdown import (
+    build_distinct_id_pushdown,
+    derive_person_id_filter,
+)
 from posthog.hogql.errors import ResolutionError
 
 PERSON_DISTINCT_IDS_FIELDS: dict[str, FieldOrTable] = {
@@ -28,7 +35,11 @@ PERSON_DISTINCT_IDS_FIELDS: dict[str, FieldOrTable] = {
 }
 
 
-def select_from_person_distinct_ids_table(requested_fields: dict[str, list[str | int]]):
+def select_from_person_distinct_ids_table(
+    requested_fields: dict[str, list[str | int]],
+    *,
+    person_id_filter: Optional[ast.Expr] = None,
+):
     # Always include "person_id", as it's the key we use to make further joins, and it'd be great if it's available
     if "person_id" not in requested_fields:
         requested_fields = {**requested_fields, "person_id": ["person_id"]}
@@ -40,6 +51,8 @@ def select_from_person_distinct_ids_table(requested_fields: dict[str, list[str |
         deleted_field="is_deleted",
     )
     select.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
+    if person_id_filter is not None:
+        select.where = build_distinct_id_pushdown(person_id_filter)
     return select
 
 
@@ -48,11 +61,15 @@ def join_with_person_distinct_ids_table(
     context: HogQLContext,
     node: SelectQuery,
 ):
-    from posthog.hogql import ast
-
     if not join_to_add.fields_accessed:
         raise ResolutionError("No fields requested from person_distinct_ids")
-    join_expr = ast.JoinExpr(table=select_from_person_distinct_ids_table(join_to_add.fields_accessed))
+    # This join function pairs <from_table>.distinct_id with pdi.distinct_id (see the
+    # constraint below), so the from_field does NOT map to pdi.person_id. Only an
+    # explicit pdi.person_id IN (...) filter in the outer WHERE is promotable here.
+    person_id_filter = derive_person_id_filter(node, join_to_add, context=context, from_field_maps_to_person_id=False)
+    join_expr = ast.JoinExpr(
+        table=select_from_person_distinct_ids_table(join_to_add.fields_accessed, person_id_filter=person_id_filter)
+    )
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = join_to_add.to_table
     join_expr.constraint = ast.JoinConstraint(

--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -52,7 +52,8 @@ def select_from_person_distinct_ids_table(
     )
     select.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
     if person_id_filter is not None:
-        select.where = build_distinct_id_pushdown(person_id_filter)
+        pushdown = build_distinct_id_pushdown(person_id_filter)
+        select.where = pushdown if select.where is None else ast.And(exprs=[select.where, pushdown])
     return select
 
 

--- a/posthog/hogql/database/schema/persons_pdi.py
+++ b/posthog/hogql/database/schema/persons_pdi.py
@@ -43,7 +43,8 @@ def persons_pdi_select(
     )
     select.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
     if person_id_filter is not None:
-        select.where = build_distinct_id_pushdown(person_id_filter)
+        pushdown = build_distinct_id_pushdown(person_id_filter)
+        select.where = pushdown if select.where is None else ast.And(exprs=[select.where, pushdown])
     return select
 
 

--- a/posthog/hogql/database/schema/persons_pdi.py
+++ b/posthog/hogql/database/schema/persons_pdi.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 import posthoganalytics
 
+from posthog.hogql import ast
 from posthog.hogql.ast import SelectQuery
 from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.context import HogQLContext
@@ -12,6 +15,10 @@ from posthog.hogql.database.models import (
     LazyTableToAdd,
     StringDatabaseField,
 )
+from posthog.hogql.database.schema.util.pdi_person_id_pushdown import (
+    build_distinct_id_pushdown,
+    derive_person_id_filter,
+)
 from posthog.hogql.errors import ResolutionError
 
 from posthog.models.organization import Organization
@@ -19,7 +26,11 @@ from posthog.models.organization import Organization
 
 # :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
 # make "select persons.pdi.distinct_id from persons" work while avoiding circular imports. Don't use directly.
-def persons_pdi_select(requested_fields: dict[str, list[str | int]]):
+def persons_pdi_select(
+    requested_fields: dict[str, list[str | int]],
+    *,
+    person_id_filter: Optional[ast.Expr] = None,
+):
     # Always include "person_id", as it's the key we use to make further joins, and it'd be great if it's available
     if "person_id" not in requested_fields:
         requested_fields = {**requested_fields, "person_id": ["person_id"]}
@@ -31,6 +42,8 @@ def persons_pdi_select(requested_fields: dict[str, list[str | int]]):
         deleted_field="is_deleted",
     )
     select.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
+    if person_id_filter is not None:
+        select.where = build_distinct_id_pushdown(person_id_filter)
     return select
 
 
@@ -41,11 +54,14 @@ def persons_pdi_join(
     context: HogQLContext,
     node: SelectQuery,
 ):
-    from posthog.hogql import ast
-
     if not join_to_add.fields_accessed:
         raise ResolutionError("No fields requested from person_distinct_ids")
-    join_expr = ast.JoinExpr(table=persons_pdi_select(join_to_add.fields_accessed))
+    # This join function pairs <from_table>.id (i.e. persons.id) with pdi.person_id
+    # (see the constraint below), so any outer-query persons-side predicate (id IN,
+    # email = ..., properties.* IN, etc.) can be promoted into the pdi subquery via
+    # a person_id IN (SELECT id FROM raw_persons WHERE <filter>) wrapper.
+    person_id_filter = derive_person_id_filter(node, join_to_add, context=context, from_field_maps_to_person_id=True)
+    join_expr = ast.JoinExpr(table=persons_pdi_select(join_to_add.fields_accessed, person_id_filter=person_id_filter))
     organization: Organization | None = context.team.organization if context.team else None
     if not organization:
         raise ResolutionError("Organization not found in context")

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
@@ -92,49 +92,7 @@
                      use_hive_partitioning=0
   '''
 # ---
-# name: TestPersonsPdiPersonIdPushdown.test_pdi_subquery_filtered_when_outer_filters_persons_id
-  '''
-  SELECT persons.id AS id,
-         arraySort(groupArray(persons__pdi.distinct_id)) AS distinct_ids
-  FROM
-    (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-            person.id AS id
-     FROM person
-     WHERE and(equals(person.team_id, 99999), in(id,
-                                                   (SELECT where_optimization.id AS id
-                                                    FROM person AS where_optimization
-                                                    WHERE and(equals(where_optimization.team_id, 99999), in(where_optimization.id, toUUIDOrNull('00000000-0000-4000-8000-000000000000'))))))
-     GROUP BY person.id
-     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
-  LEFT JOIN
-    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-            person_distinct_id2.distinct_id AS distinct_id
-     FROM person_distinct_id2
-     WHERE and(equals(person_distinct_id2.team_id, 99999), in(distinct_id,
-                                                                (SELECT pdi_pushdown_pdi.distinct_id AS distinct_id
-                                                                 FROM person_distinct_id2 AS pdi_pushdown_pdi
-                                                                 WHERE and(equals(pdi_pushdown_pdi.team_id, 99999), in(pdi_pushdown_pdi.person_id,
-                                                                                                                         (SELECT pdi_pushdown_persons.id AS id
-                                                                                                                          FROM person AS pdi_pushdown_persons
-                                                                                                                          WHERE and(equals(pdi_pushdown_persons.team_id, 99999), in(pdi_pushdown_persons.id, toUUIDOrNull('00000000-0000-4000-8000-000000000000')))))))))
-     GROUP BY person_distinct_id2.distinct_id
-     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)
-  WHERE in(persons.id,
-           toUUIDOrNull('00000000-0000-4000-8000-000000000000'))
-  GROUP BY persons.id
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
-  '''
-# ---
-# name: TestPersonsPdiPersonIdPushdown.test_pdi_subquery_filtered_when_outer_filters_persons_property
+# name: TestPersonsPdiPersonIdPushdown.test_pdi_subquery_pushdown_snapshot
   '''
   SELECT persons__pdi.distinct_id AS distinct_id,
          persons.properties___name AS name

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
@@ -92,6 +92,89 @@
                      use_hive_partitioning=0
   '''
 # ---
+# name: TestPersonsPdiPersonIdPushdown.test_pdi_subquery_filtered_when_outer_filters_persons_id
+  '''
+  SELECT persons.id AS id,
+         arraySort(groupArray(persons__pdi.distinct_id)) AS distinct_ids
+  FROM
+    (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+            person.id AS id
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(id,
+                                                   (SELECT where_optimization.id AS id
+                                                    FROM person AS where_optimization
+                                                    WHERE and(equals(where_optimization.team_id, 99999), in(where_optimization.id, toUUIDOrNull('00000000-0000-4000-8000-000000000000'))))))
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+  LEFT JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+            person_distinct_id2.distinct_id AS distinct_id
+     FROM person_distinct_id2
+     WHERE and(equals(person_distinct_id2.team_id, 99999), in(distinct_id,
+                                                                (SELECT pdi_pushdown_pdi.distinct_id AS distinct_id
+                                                                 FROM person_distinct_id2 AS pdi_pushdown_pdi
+                                                                 WHERE and(equals(pdi_pushdown_pdi.team_id, 99999), in(pdi_pushdown_pdi.person_id,
+                                                                                                                         (SELECT pdi_pushdown_persons.id AS id
+                                                                                                                          FROM person AS pdi_pushdown_persons
+                                                                                                                          WHERE and(equals(pdi_pushdown_persons.team_id, 99999), in(pdi_pushdown_persons.id, toUUIDOrNull('00000000-0000-4000-8000-000000000000')))))))))
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)
+  WHERE in(persons.id,
+           toUUIDOrNull('00000000-0000-4000-8000-000000000000'))
+  GROUP BY persons.id
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsPdiPersonIdPushdown.test_pdi_subquery_filtered_when_outer_filters_persons_property
+  '''
+  SELECT persons__pdi.distinct_id AS distinct_id,
+         persons.properties___name AS name
+  FROM
+    (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
+            tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+            person.id AS id
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(id,
+                                                   (SELECT where_optimization.id AS id
+                                                    FROM person AS where_optimization
+                                                    WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'alice'), 0)))))
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+  LEFT JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+            person_distinct_id2.distinct_id AS distinct_id
+     FROM person_distinct_id2
+     WHERE and(equals(person_distinct_id2.team_id, 99999), in(distinct_id,
+                                                                (SELECT pdi_pushdown_pdi.distinct_id AS distinct_id
+                                                                 FROM person_distinct_id2 AS pdi_pushdown_pdi
+                                                                 WHERE and(equals(pdi_pushdown_pdi.team_id, 99999), in(pdi_pushdown_pdi.person_id,
+                                                                                                                         (SELECT pdi_pushdown_persons.id AS id
+                                                                                                                          FROM person AS pdi_pushdown_persons
+                                                                                                                          WHERE and(equals(pdi_pushdown_persons.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(pdi_pushdown_persons.properties, 'name'), ''), 'null'), '^"|"$', ''), 'alice'), 0))))))))
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)
+  WHERE ifNull(equals(persons.properties___name, 'alice'), 0)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestPersonsV2LimitPushDown.test_v2_cohort_where_does_not_push_limit_down
   '''
   

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -503,7 +503,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
             distinct_ids=["bob_a"],
             properties={"name": "bob"},
         )
-        flush_persons_and_events()
 
     @snapshot_clickhouse_queries
     def test_pdi_subquery_pushdown_snapshot(self):
@@ -590,7 +589,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
             person_id=str(self.bob.uuid),
             version=99,
         )
-        flush_persons_and_events()
 
         response = execute_hogql_query(
             parse_select(
@@ -620,7 +618,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         _create_event(event="$pageview", distinct_id="alice_a", team=self.team)
         _create_event(event="$pageview", distinct_id="alice_b", team=self.team)
         _create_event(event="$pageview", distinct_id="bob_a", team=self.team)
-        flush_persons_and_events()
 
         response = execute_hogql_query(
             parse_select("SELECT count() FROM events WHERE pdi.person_id IN ({alice_id})"),

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -31,6 +31,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.database.schema.persons import _is_virtual_field_requiring_join
+from posthog.hogql.database.schema.util import pdi_person_id_pushdown
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
@@ -40,7 +41,7 @@ from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.models import Cohort
 from posthog.models.cohort.util import recalculate_cohortpeople
-from posthog.models.person.util import create_person
+from posthog.models.person.util import create_person, create_person_distinct_id
 from posthog.models.utils import UUIDT
 
 
@@ -505,22 +506,8 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
     @snapshot_clickhouse_queries
-    def test_pdi_subquery_filtered_when_outer_filters_persons_id(self):
-        response = execute_hogql_query(
-            parse_select(
-                "SELECT id, arraySort(groupArray(pdi.distinct_id)) AS distinct_ids "
-                "FROM persons WHERE id IN ({alice_id}) GROUP BY id"
-            ),
-            self.team,
-            placeholders={"alice_id": ast.Constant(value=self.alice.uuid)},
-        )
-        assert response.clickhouse is not None
-        assert "pdi_pushdown_pdi" in response.clickhouse
-        assert len(response.results) == 1
-        assert response.results[0][1] == ["alice_a", "alice_b"]
-
-    @snapshot_clickhouse_queries
-    def test_pdi_subquery_filtered_when_outer_filters_persons_property(self):
+    def test_pdi_subquery_pushdown_snapshot(self):
+        # Lock in the canonical generated SQL shape for the hot prod case.
         response = execute_hogql_query(
             parse_select(
                 "SELECT pdi.distinct_id, properties.name AS name FROM persons WHERE properties.name = 'alice'"
@@ -530,25 +517,82 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         assert response.clickhouse is not None
         assert "pdi_pushdown_pdi" in response.clickhouse
         assert "pdi_pushdown_persons" in response.clickhouse
-        distinct_ids = sorted(row[0] for row in response.results)
-        assert distinct_ids == ["alice_a", "alice_b"]
+
+    @parameterized.expand(
+        [
+            (
+                "id_in",
+                "SELECT pdi.distinct_id FROM persons WHERE id IN ({alice_id})",
+                {"alice_id": "ALICE_UUID"},
+                ["alice_a", "alice_b"],
+                [],
+            ),
+            (
+                "property_eq",
+                "SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice'",
+                None,
+                ["alice_a", "alice_b"],
+                ["pdi_pushdown_persons"],
+            ),
+            (
+                "negated_property_eq",
+                "SELECT pdi.distinct_id FROM persons WHERE NOT (properties.name = 'bob')",
+                None,
+                ["alice_a", "alice_b"],
+                ["not("],
+            ),
+            (
+                "not_like",
+                "SELECT pdi.distinct_id FROM persons WHERE properties.name NOT LIKE 'bob'",
+                None,
+                ["alice_a", "alice_b"],
+                ["notLike"],
+            ),
+            (
+                "or_across_persons_filters",
+                "SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice' OR properties.name = 'bob'",
+                None,
+                ["alice_a", "alice_b", "bob_a"],
+                [],
+            ),
+            # WhereClauseExtractor would flip is_join=True and tombstone NOT
+            # if next_join were set; revenue_analytics seeds next_join, so this
+            # case proves _strip_next_join works.
+            (
+                "negation_with_outer_join",
+                "SELECT pdi.distinct_id, revenue_analytics.mrr FROM persons WHERE NOT (properties.name = 'bob')",
+                None,
+                None,
+                ["pdi_pushdown_pdi", "not("],
+            ),
+        ]
+    )
+    def test_pdi_pushdown_fires_and_is_correct(
+        self, _name, hogql, placeholder_keys, expected_distinct_ids, extra_sql_substrings
+    ):
+        placeholders = None
+        if placeholder_keys:
+            placeholders = {k: ast.Constant(value=self.alice.uuid) for k in placeholder_keys}
+        response = execute_hogql_query(parse_select(hogql), self.team, placeholders=placeholders)
+        assert response.clickhouse is not None
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        for needle in extra_sql_substrings:
+            assert needle in response.clickhouse, f"missing {needle!r} in generated SQL"
+        if expected_distinct_ids is not None:
+            distinct_ids = sorted(row[0] for row in response.results)
+            assert distinct_ids == expected_distinct_ids
 
     def test_pdi_subquery_unfiltered_when_no_pushdown_target(self):
-        response = execute_hogql_query(
-            parse_select("SELECT id FROM persons"),
-            self.team,
-        )
+        response = execute_hogql_query(parse_select("SELECT id FROM persons"), self.team)
         assert response.clickhouse is not None
         assert "pdi_pushdown_pdi" not in response.clickhouse
 
     def test_pdi_subquery_correct_when_distinct_id_was_rebound(self):
         # Rebind one of alice's distinct_ids to bob via a higher-version pdi row.
-        # The motivating correctness case for the distinct_id IN (subquery) shape:
+        # Motivating correctness case for the distinct_id IN (subquery) shape:
         # filtering raw pdi rows by person_id pre-argMax would return a stale
         # mapping for "alice_b", but the outer argMax must report bob as the
         # current owner.
-        from posthog.models.person.util import create_person_distinct_id
-
         create_person_distinct_id(
             team_id=self.team.pk,
             distinct_id="alice_b",
@@ -568,72 +612,12 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         assert response.clickhouse is not None
         assert "pdi_pushdown_pdi" in response.clickhouse
         assert len(response.results) == 1
-        # alice_b now belongs to bob, so alice should only be associated with alice_a.
         assert response.results[0][1] == ["alice_a"]
-
-    def test_pdi_subquery_with_negated_persons_filter(self):
-        response = execute_hogql_query(
-            parse_select("SELECT pdi.distinct_id FROM persons WHERE NOT (properties.name = 'bob')"),
-            self.team,
-        )
-        assert response.clickhouse is not None
-        # Pushdown must actually fire AND must include the negation in the inner
-        # subquery. WhereClauseExtractor would tombstone NOT to True if is_join
-        # were set; we strip next_join before calling it to prevent that.
-        assert "pdi_pushdown_pdi" in response.clickhouse
-        assert "pdi_pushdown_persons" in response.clickhouse
-        assert "not(" in response.clickhouse or "notLike" in response.clickhouse
-        distinct_ids = sorted(row[0] for row in response.results)
-        assert distinct_ids == ["alice_a", "alice_b"]
-
-    def test_pdi_subquery_with_not_like(self):
-        response = execute_hogql_query(
-            parse_select("SELECT pdi.distinct_id FROM persons WHERE properties.name NOT LIKE 'bob'"),
-            self.team,
-        )
-        assert response.clickhouse is not None
-        assert "pdi_pushdown_pdi" in response.clickhouse
-        assert "notLike" in response.clickhouse
-        distinct_ids = sorted(row[0] for row in response.results)
-        assert distinct_ids == ["alice_a", "alice_b"]
-
-    def test_pdi_subquery_with_negation_and_outer_join(self):
-        # When the outer query has a JOIN already in select_from.next_join,
-        # WhereClauseExtractor.get_inner_where would normally flip is_join=True
-        # and tombstone the NOT predicate. _strip_next_join in the helper
-        # prevents that. Use revenue_analytics (a real LazyJoin) to seed
-        # next_join.
-        response = execute_hogql_query(
-            parse_select(
-                "SELECT pdi.distinct_id, revenue_analytics.mrr FROM persons WHERE NOT (properties.name = 'bob')"
-            ),
-            self.team,
-        )
-        assert response.clickhouse is not None
-        assert "pdi_pushdown_pdi" in response.clickhouse
-        assert "not(" in response.clickhouse or "notLike" in response.clickhouse
-
-    def test_pdi_subquery_with_or_persons_filter(self):
-        # OR across persons-side predicates is safe to push down: both branches
-        # bind to the same persons table and both narrow person_id candidates.
-        response = execute_hogql_query(
-            parse_select(
-                "SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice' OR properties.name = 'bob'"
-            ),
-            self.team,
-        )
-        assert response.clickhouse is not None
-        distinct_ids = sorted(row[0] for row in response.results)
-        assert distinct_ids == ["alice_a", "alice_b", "bob_a"]
 
     def test_pdi_subquery_pushdown_fails_open_on_extractor_error(self):
         # If the helper raises, the optimization must skip silently rather than
-        # break the query. We can't easily inject an exception via a real query,
-        # but we can verify the wrapper by patching the inner function.
-        from unittest.mock import patch
-
-        from posthog.hogql.database.schema.util import pdi_person_id_pushdown
-
+        # break the query. Patching the inner function lets us verify the
+        # try/except envelope without contriving a real failure.
         with patch.object(pdi_person_id_pushdown, "_derive_person_id_filter_inner", side_effect=RuntimeError("boom")):
             response = execute_hogql_query(
                 parse_select("SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice'"),

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -572,16 +572,46 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         assert response.results[0][1] == ["alice_a"]
 
     def test_pdi_subquery_with_negated_persons_filter(self):
-        # WHERE NOT (...) on persons side. WhereClauseExtractor's join-aware
-        # tombstoning of NOT must not apply to the inner subquery context, so
-        # the filter should still narrow correctly.
         response = execute_hogql_query(
             parse_select("SELECT pdi.distinct_id FROM persons WHERE NOT (properties.name = 'bob')"),
             self.team,
         )
         assert response.clickhouse is not None
+        # Pushdown must actually fire AND must include the negation in the inner
+        # subquery. WhereClauseExtractor would tombstone NOT to True if is_join
+        # were set; we strip next_join before calling it to prevent that.
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        assert "pdi_pushdown_persons" in response.clickhouse
+        assert "not(" in response.clickhouse or "notLike" in response.clickhouse
         distinct_ids = sorted(row[0] for row in response.results)
         assert distinct_ids == ["alice_a", "alice_b"]
+
+    def test_pdi_subquery_with_not_like(self):
+        response = execute_hogql_query(
+            parse_select("SELECT pdi.distinct_id FROM persons WHERE properties.name NOT LIKE 'bob'"),
+            self.team,
+        )
+        assert response.clickhouse is not None
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        assert "notLike" in response.clickhouse
+        distinct_ids = sorted(row[0] for row in response.results)
+        assert distinct_ids == ["alice_a", "alice_b"]
+
+    def test_pdi_subquery_with_negation_and_outer_join(self):
+        # When the outer query has a JOIN already in select_from.next_join,
+        # WhereClauseExtractor.get_inner_where would normally flip is_join=True
+        # and tombstone the NOT predicate. _strip_next_join in the helper
+        # prevents that. Use revenue_analytics (a real LazyJoin) to seed
+        # next_join.
+        response = execute_hogql_query(
+            parse_select(
+                "SELECT pdi.distinct_id, revenue_analytics.mrr FROM persons WHERE NOT (properties.name = 'bob')"
+            ),
+            self.team,
+        )
+        assert response.clickhouse is not None
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        assert "not(" in response.clickhouse or "notLike" in response.clickhouse
 
     def test_pdi_subquery_with_or_persons_filter(self):
         # OR across persons-side predicates is safe to push down: both branches

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -487,3 +487,53 @@ class TestVirtualFieldDetection(APIBaseTest):
 
         result = _is_virtual_field_requiring_join(mock_node)  # type: ignore
         self.assertFalse(result, "Malformed AST should return False without exception")
+
+
+class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.alice = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["alice_a", "alice_b"],
+            properties={"name": "alice"},
+        )
+        self.bob = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["bob_a"],
+            properties={"name": "bob"},
+        )
+        flush_persons_and_events()
+
+    def test_pdi_subquery_filtered_when_outer_filters_persons_id(self):
+        response = execute_hogql_query(
+            parse_select(
+                "SELECT id, arraySort(groupArray(pdi.distinct_id)) AS distinct_ids "
+                "FROM persons WHERE id IN ({alice_id}) GROUP BY id"
+            ),
+            self.team,
+            placeholders={"alice_id": ast.Constant(value=self.alice.uuid)},
+        )
+        assert response.clickhouse is not None
+        assert "in(distinct_id, (SELECT" in response.clickhouse
+        assert len(response.results) == 1
+        assert response.results[0][1] == ["alice_a", "alice_b"]
+
+    def test_pdi_subquery_filtered_when_outer_filters_persons_property(self):
+        response = execute_hogql_query(
+            parse_select(
+                "SELECT pdi.distinct_id, properties.name AS name FROM persons WHERE properties.name = 'alice'"
+            ),
+            self.team,
+        )
+        assert response.clickhouse is not None
+        assert "in(distinct_id, (SELECT" in response.clickhouse
+        distinct_ids = sorted(row[0] for row in response.results)
+        assert distinct_ids == ["alice_a", "alice_b"]
+
+    def test_pdi_subquery_unfiltered_when_no_pushdown_target(self):
+        response = execute_hogql_query(
+            parse_select("SELECT id FROM persons"),
+            self.team,
+        )
+        assert response.clickhouse is not None
+        assert "in(distinct_id, (SELECT" not in response.clickhouse

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -615,3 +615,18 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         assert "pdi_pushdown_pdi" not in response.clickhouse
         distinct_ids = sorted(row[0] for row in response.results)
         assert distinct_ids == ["alice_a", "alice_b"]
+
+    def test_events_pdi_pushdown_fires_on_explicit_person_id_filter(self):
+        _create_event(event="$pageview", distinct_id="alice_a", team=self.team)
+        _create_event(event="$pageview", distinct_id="alice_b", team=self.team)
+        _create_event(event="$pageview", distinct_id="bob_a", team=self.team)
+        flush_persons_and_events()
+
+        response = execute_hogql_query(
+            parse_select("SELECT count() FROM events WHERE pdi.person_id IN ({alice_id})"),
+            self.team,
+            placeholders={"alice_id": ast.Constant(value=self.alice.uuid)},
+        )
+        assert response.clickhouse is not None
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        assert response.results[0][0] == 2  # alice_a + alice_b events

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -507,7 +507,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     def test_pdi_subquery_pushdown_snapshot(self):
-        # Lock in the canonical generated SQL shape for the hot prod case.
         response = execute_hogql_query(
             parse_select(
                 "SELECT pdi.distinct_id, properties.name AS name FROM persons WHERE properties.name = 'alice'"
@@ -555,9 +554,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
                 ["alice_a", "alice_b", "bob_a"],
                 [],
             ),
-            # WhereClauseExtractor would flip is_join=True and tombstone NOT
-            # if next_join were set; revenue_analytics seeds next_join, so this
-            # case proves _strip_next_join works.
             (
                 "negation_with_outer_join",
                 "SELECT pdi.distinct_id, revenue_analytics.mrr FROM persons WHERE NOT (properties.name = 'bob')",
@@ -588,11 +584,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         assert "pdi_pushdown_pdi" not in response.clickhouse
 
     def test_pdi_subquery_correct_when_distinct_id_was_rebound(self):
-        # Rebind one of alice's distinct_ids to bob via a higher-version pdi row.
-        # Motivating correctness case for the distinct_id IN (subquery) shape:
-        # filtering raw pdi rows by person_id pre-argMax would return a stale
-        # mapping for "alice_b", but the outer argMax must report bob as the
-        # current owner.
         create_person_distinct_id(
             team_id=self.team.pk,
             distinct_id="alice_b",
@@ -615,9 +606,6 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         assert response.results[0][1] == ["alice_a"]
 
     def test_pdi_subquery_pushdown_fails_open_on_extractor_error(self):
-        # If the helper raises, the optimization must skip silently rather than
-        # break the query. Patching the inner function lets us verify the
-        # try/except envelope without contriving a real failure.
         with patch.object(pdi_person_id_pushdown, "_derive_person_id_filter_inner", side_effect=RuntimeError("boom")):
             response = execute_hogql_query(
                 parse_select("SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice'"),

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -504,6 +504,7 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
+    @snapshot_clickhouse_queries
     def test_pdi_subquery_filtered_when_outer_filters_persons_id(self):
         response = execute_hogql_query(
             parse_select(
@@ -514,10 +515,11 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
             placeholders={"alice_id": ast.Constant(value=self.alice.uuid)},
         )
         assert response.clickhouse is not None
-        assert "in(distinct_id, (SELECT" in response.clickhouse
+        assert "pdi_pushdown_pdi" in response.clickhouse
         assert len(response.results) == 1
         assert response.results[0][1] == ["alice_a", "alice_b"]
 
+    @snapshot_clickhouse_queries
     def test_pdi_subquery_filtered_when_outer_filters_persons_property(self):
         response = execute_hogql_query(
             parse_select(
@@ -526,7 +528,8 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
         assert response.clickhouse is not None
-        assert "in(distinct_id, (SELECT" in response.clickhouse
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        assert "pdi_pushdown_persons" in response.clickhouse
         distinct_ids = sorted(row[0] for row in response.results)
         assert distinct_ids == ["alice_a", "alice_b"]
 
@@ -536,4 +539,77 @@ class TestPersonsPdiPersonIdPushdown(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
         assert response.clickhouse is not None
-        assert "in(distinct_id, (SELECT" not in response.clickhouse
+        assert "pdi_pushdown_pdi" not in response.clickhouse
+
+    def test_pdi_subquery_correct_when_distinct_id_was_rebound(self):
+        # Rebind one of alice's distinct_ids to bob via a higher-version pdi row.
+        # The motivating correctness case for the distinct_id IN (subquery) shape:
+        # filtering raw pdi rows by person_id pre-argMax would return a stale
+        # mapping for "alice_b", but the outer argMax must report bob as the
+        # current owner.
+        from posthog.models.person.util import create_person_distinct_id
+
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="alice_b",
+            person_id=str(self.bob.uuid),
+            version=99,
+        )
+        flush_persons_and_events()
+
+        response = execute_hogql_query(
+            parse_select(
+                "SELECT id, arraySort(groupArray(pdi.distinct_id)) AS distinct_ids "
+                "FROM persons WHERE id IN ({alice_id}) GROUP BY id"
+            ),
+            self.team,
+            placeholders={"alice_id": ast.Constant(value=self.alice.uuid)},
+        )
+        assert response.clickhouse is not None
+        assert "pdi_pushdown_pdi" in response.clickhouse
+        assert len(response.results) == 1
+        # alice_b now belongs to bob, so alice should only be associated with alice_a.
+        assert response.results[0][1] == ["alice_a"]
+
+    def test_pdi_subquery_with_negated_persons_filter(self):
+        # WHERE NOT (...) on persons side. WhereClauseExtractor's join-aware
+        # tombstoning of NOT must not apply to the inner subquery context, so
+        # the filter should still narrow correctly.
+        response = execute_hogql_query(
+            parse_select("SELECT pdi.distinct_id FROM persons WHERE NOT (properties.name = 'bob')"),
+            self.team,
+        )
+        assert response.clickhouse is not None
+        distinct_ids = sorted(row[0] for row in response.results)
+        assert distinct_ids == ["alice_a", "alice_b"]
+
+    def test_pdi_subquery_with_or_persons_filter(self):
+        # OR across persons-side predicates is safe to push down: both branches
+        # bind to the same persons table and both narrow person_id candidates.
+        response = execute_hogql_query(
+            parse_select(
+                "SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice' OR properties.name = 'bob'"
+            ),
+            self.team,
+        )
+        assert response.clickhouse is not None
+        distinct_ids = sorted(row[0] for row in response.results)
+        assert distinct_ids == ["alice_a", "alice_b", "bob_a"]
+
+    def test_pdi_subquery_pushdown_fails_open_on_extractor_error(self):
+        # If the helper raises, the optimization must skip silently rather than
+        # break the query. We can't easily inject an exception via a real query,
+        # but we can verify the wrapper by patching the inner function.
+        from unittest.mock import patch
+
+        from posthog.hogql.database.schema.util import pdi_person_id_pushdown
+
+        with patch.object(pdi_person_id_pushdown, "_derive_person_id_filter_inner", side_effect=RuntimeError("boom")):
+            response = execute_hogql_query(
+                parse_select("SELECT pdi.distinct_id FROM persons WHERE properties.name = 'alice'"),
+                self.team,
+            )
+        assert response.clickhouse is not None
+        assert "pdi_pushdown_pdi" not in response.clickhouse
+        distinct_ids = sorted(row[0] for row in response.results)
+        assert distinct_ids == ["alice_a", "alice_b"]

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -57,15 +57,6 @@ def _derive_person_id_filter_inner(
         if persons_table is not None:
             extractor = WhereClauseExtractor(context)
             extractor.tracked_tables.append(persons_table)
-            # WhereClauseExtractor.get_inner_where unconditionally sets
-            # is_join=True when select_from.next_join is set, which would
-            # tombstone NOT/negated comparisons in the extracted filter.
-            # That tombstoning is correct for the original use case (a
-            # redundant outer-AND filter on the persons inner subquery)
-            # but unsafe here, where the result becomes the ONLY filter
-            # inside an independent SELECT against raw_persons. Hand the
-            # extractor a shallow copy with next_join stripped so the
-            # override never fires.
             persons_filter = extractor.get_inner_where(_strip_next_join(node))
             if persons_filter is not None:
                 inner_persons = cast(

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -13,15 +13,12 @@ from posthog.hogql.visitor import TraversingVisitor, clone_expr
 logger = structlog.get_logger(__name__)
 
 
-# Filter on a distinct_id IN subquery on raw_person_distinct_ids is the only safe
-# way to narrow person_distinct_id2 by person_id. The naive WHERE person_id IN (X)
-# would filter raw rows pre-argMax and report stale mappings for distinct_ids that
-# were rebound to a different person.
-#
-# The aliased table name "pdi_pushdown_pdi" is intentional: it appears in the
-# generated SQL and lets us grep system.query_log to measure how often the
-# optimization fires post-deploy.
 def build_distinct_id_pushdown(person_id_filter: ast.Expr) -> ast.CompareOperation:
+    """Build `distinct_id IN (SELECT distinct_id FROM raw_pdi WHERE <person_id_filter>)`.
+
+    Narrows on the GROUP BY key (distinct_id), so pre-argMax filtering stays
+    correct; the outer argMax still picks the current owner.
+    """
     inner = cast(
         ast.SelectQuery,
         parse_select("SELECT distinct_id FROM raw_person_distinct_ids AS pdi_pushdown_pdi"),

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -53,10 +53,6 @@ def _derive_person_id_filter_inner(
         return None
 
     if from_field_maps_to_person_id:
-        # By the time persons_pdi_join runs, the persons FROM has already been
-        # rewritten to a SelectQueryAliasType (see lazy_tables.py). Field
-        # references in node.where still carry the original PersonsTable
-        # instance, so we recover it from there to feed WhereClauseExtractor.
         persons_table = _find_persons_table(node)
         if persons_table is not None:
             extractor = WhereClauseExtractor(context)

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Optional, cast
 
 import structlog
@@ -131,7 +132,7 @@ class _FindPersonsTableVisitor(TraversingVisitor):
 def _strip_next_join(node: ast.SelectQuery) -> ast.SelectQuery:
     if node.select_from is None or node.select_from.next_join is None:
         return node
-    return node.model_copy(update={"select_from": node.select_from.model_copy(update={"next_join": None})})
+    return replace(node, select_from=replace(node.select_from, next_join=None))
 
 
 def _find_persons_table(node: ast.SelectQuery):

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -71,13 +71,16 @@ def _derive_person_id_filter_inner(
         if persons_table is not None:
             extractor = WhereClauseExtractor(context)
             extractor.tracked_tables.append(persons_table)
-            # The pushed-down filter lives inside an independent subquery
-            # (SELECT id FROM raw_persons WHERE ...). The outer query's joins
-            # are not in scope there, so any tombstoning the join-aware path
-            # would do is unwarranted here. Force is_join=False so NOT and
-            # negated comparisons stay extractable.
-            extractor.is_join = False
-            persons_filter = extractor.get_inner_where(node)
+            # WhereClauseExtractor.get_inner_where unconditionally sets
+            # is_join=True when select_from.next_join is set, which would
+            # tombstone NOT/negated comparisons in the extracted filter.
+            # That tombstoning is correct for the original use case (a
+            # redundant outer-AND filter on the persons inner subquery)
+            # but unsafe here, where the result becomes the ONLY filter
+            # inside an independent SELECT against raw_persons. Hand the
+            # extractor a shallow copy with next_join stripped so the
+            # override never fires.
+            persons_filter = extractor.get_inner_where(_strip_next_join(node))
             if persons_filter is not None:
                 inner_persons = cast(
                     ast.SelectQuery,
@@ -123,6 +126,12 @@ class _FindPersonsTableVisitor(TraversingVisitor):
         table_type = _table_type_from_field(node)
         if isinstance(table_type, ast.LazyTableType) and isinstance(table_type.table, PersonsTable):
             self.found = table_type.table
+
+
+def _strip_next_join(node: ast.SelectQuery) -> ast.SelectQuery:
+    if node.select_from is None or node.select_from.next_join is None:
+        return node
+    return node.model_copy(update={"select_from": node.select_from.model_copy(update={"next_join": None})})
 
 
 def _find_persons_table(node: ast.SelectQuery):

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -1,0 +1,212 @@
+from typing import Optional, cast
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import LazyJoin, LazyJoinToAdd, LazyTable, Table
+from posthog.hogql.database.schema.util.where_clause_extractor import WhereClauseExtractor
+from posthog.hogql.parser import parse_select
+from posthog.hogql.visitor import clone_expr
+
+
+# Filter on a distinct_id IN subquery on raw_person_distinct_ids is the only safe
+# way to narrow person_distinct_id2 by person_id. The naive WHERE person_id IN (X)
+# would filter raw rows pre-argMax and report stale mappings for distinct_ids that
+# were rebound to a different person.
+def build_distinct_id_pushdown(person_id_filter: ast.Expr) -> ast.CompareOperation:
+    inner = cast(
+        ast.SelectQuery,
+        parse_select("SELECT distinct_id FROM raw_person_distinct_ids"),
+    )
+    inner.where = clone_expr(person_id_filter, clear_types=True, clear_locations=True)
+    return ast.CompareOperation(
+        left=ast.Field(chain=["distinct_id"]),
+        right=inner,
+        op=ast.CompareOperationOp.In,
+    )
+
+
+def derive_person_id_filter(
+    node: ast.SelectQuery,
+    join_to_add: LazyJoinToAdd,
+    *,
+    context: HogQLContext,
+    from_field_maps_to_person_id: bool,
+) -> Optional[ast.Expr]:
+    if not node.where:
+        return None
+
+    # Primary: reuse WhereClauseExtractor to extract any persons-side predicate
+    # (id IN, email =, properties.* IN, ...). Translate into a person_id filter
+    # by wrapping with a SELECT against raw_persons. This mirrors the inner
+    # subquery shape that select_from_persons_table already emits, just consumed
+    # by pdi instead.
+    if from_field_maps_to_person_id:
+        # By the time persons_pdi_join runs, the persons FROM has already been
+        # rewritten to a SelectQueryAliasType (see lazy_tables.py). However, field
+        # references in node.where still carry the original PersonsTable instance,
+        # so we recover it from there to feed WhereClauseExtractor.
+        persons_table = _find_persons_table_in_where(node.where)
+        if persons_table is not None:
+            extractor = WhereClauseExtractor(context)
+            if persons_table not in extractor.tracked_tables:
+                extractor.tracked_tables.append(persons_table)
+            persons_filter = extractor.get_inner_where(node)
+            if persons_filter is not None:
+                inner_persons = cast(
+                    ast.SelectQuery,
+                    parse_select("SELECT id FROM raw_persons"),
+                )
+                inner_persons.where = persons_filter
+                return ast.CompareOperation(
+                    left=ast.Field(chain=["person_id"]),
+                    right=inner_persons,
+                    op=ast.CompareOperationOp.In,
+                )
+
+    # Fallback: direct pdi.person_id IN (X) anywhere in the outer WHERE.
+    pdi_table = join_to_add.lazy_join.join_table
+    if not isinstance(pdi_table, (Table, LazyTable, LazyJoin)):
+        return None
+
+    matches: list[ast.CompareOperation] = []
+    _collect_pdi_person_id_in_filters(node.where, pdi_table=pdi_table, out=matches)
+    if not matches:
+        return None
+
+    person_id_filters = [_rewrite_to_person_id(expr) for expr in matches]
+    if len(person_id_filters) == 1:
+        return person_id_filters[0]
+    return ast.And(exprs=person_id_filters)
+
+
+def _find_persons_table_in_where(where: Optional[ast.Expr]):
+    """Walk a WHERE expression and return the first PersonsTable instance referenced."""
+    from posthog.hogql.database.schema.persons import PersonsTable
+
+    if where is None:
+        return None
+
+    found: list = []
+
+    def _table_from_field(expr) -> Optional[ast.Type]:
+        t = expr.type
+        if isinstance(t, ast.PropertyType):
+            t = t.field_type
+        if isinstance(t, ast.FieldAliasType):
+            inner = t.type
+            while isinstance(inner, ast.FieldAliasType):
+                inner = inner.type
+            if isinstance(inner, ast.PropertyType):
+                inner = inner.field_type
+            t = inner
+        if isinstance(t, ast.FieldType):
+            tt = t.table_type
+            while isinstance(tt, ast.TableAliasType):
+                tt = tt.table_type
+            return tt
+        return None
+
+    def _walk(expr):
+        if isinstance(expr, ast.Field):
+            tt = _table_from_field(expr)
+            if isinstance(tt, ast.LazyTableType) and isinstance(tt.table, PersonsTable):
+                found.append(tt.table)
+                return
+        if isinstance(expr, ast.Alias):
+            _walk(expr.expr)
+            return
+        if isinstance(expr, ast.CompareOperation):
+            _walk(expr.left)
+            if not found:
+                _walk(expr.right)
+            return
+        if isinstance(expr, ast.And) or isinstance(expr, ast.Or):
+            for sub in expr.exprs:
+                _walk(sub)
+                if found:
+                    return
+            return
+        if isinstance(expr, ast.Not):
+            _walk(expr.expr)
+            return
+        if isinstance(expr, ast.Call):
+            for arg in expr.args:
+                _walk(arg)
+                if found:
+                    return
+            return
+        if isinstance(expr, ast.Tuple):
+            for sub in expr.exprs:
+                _walk(sub)
+                if found:
+                    return
+
+    _walk(where)
+    return found[0] if found else None
+
+
+def _collect_pdi_person_id_in_filters(
+    expr: ast.Expr,
+    *,
+    pdi_table,
+    out: list[ast.CompareOperation],
+) -> None:
+    if isinstance(expr, ast.CompareOperation):
+        if expr.op == ast.CompareOperationOp.In and _is_pdi_person_id_field(expr.left, pdi_table=pdi_table):
+            out.append(expr)
+        return
+    if isinstance(expr, ast.And):
+        for sub in expr.exprs:
+            _collect_pdi_person_id_in_filters(sub, pdi_table=pdi_table, out=out)
+        return
+    if isinstance(expr, ast.Call) and expr.name == "and":
+        for sub in expr.args:
+            _collect_pdi_person_id_in_filters(sub, pdi_table=pdi_table, out=out)
+
+
+def _is_pdi_person_id_field(expr: ast.Expr, *, pdi_table) -> bool:
+    field_type = _unwrap_to_field_type(expr)
+    if field_type is None or field_type.name != "person_id":
+        return False
+    return _table_is(field_type.table_type, pdi_table)
+
+
+def _unwrap_to_field_type(expr: ast.Expr):
+    e = expr
+    while isinstance(e, ast.Alias):
+        if e.type is not None and isinstance(e.type, ast.FieldAliasType):
+            inner_type = e.type.type
+            while isinstance(inner_type, ast.FieldAliasType):
+                inner_type = inner_type.type
+            if isinstance(inner_type, ast.FieldType):
+                return inner_type
+        e = e.expr
+
+    if isinstance(e, ast.Field):
+        if isinstance(e.type, ast.FieldType):
+            return e.type
+        if isinstance(e.type, ast.FieldAliasType):
+            inner = e.type.type
+            while isinstance(inner, ast.FieldAliasType):
+                inner = inner.type
+            if isinstance(inner, ast.FieldType):
+                return inner
+    return None
+
+
+def _table_is(table_type, target) -> bool:
+    if isinstance(table_type, ast.LazyTableType):
+        return table_type.table is target
+    if isinstance(table_type, ast.LazyJoinType):
+        return table_type.lazy_join.join_table is target
+    if isinstance(table_type, ast.TableAliasType):
+        return _table_is(table_type.table_type, target)
+    return False
+
+
+def _rewrite_to_person_id(expr: ast.CompareOperation) -> ast.Expr:
+    return ast.CompareOperation(
+        left=ast.Field(chain=["person_id"]),
+        right=clone_expr(expr.right, clear_types=True, clear_locations=True),
+        op=expr.op,
+    )

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -14,11 +14,6 @@ logger = structlog.get_logger(__name__)
 
 
 def build_distinct_id_pushdown(person_id_filter: ast.Expr) -> ast.CompareOperation:
-    """Build `distinct_id IN (SELECT distinct_id FROM raw_pdi WHERE <person_id_filter>)`.
-
-    Narrows on the GROUP BY key (distinct_id), so pre-argMax filtering stays
-    correct; the outer argMax still picks the current owner.
-    """
     inner = cast(
         ast.SelectQuery,
         parse_select("SELECT distinct_id FROM raw_person_distinct_ids AS pdi_pushdown_pdi"),
@@ -38,9 +33,6 @@ def derive_person_id_filter(
     context: HogQLContext,
     from_field_maps_to_person_id: bool,
 ) -> Optional[ast.Expr]:
-    # Fail-open envelope: this runs on every persons.pdi join in HogQL compilation.
-    # An exception here would break the query entirely; we'd rather skip the
-    # optimization. Catches RecursionError on pathological WHERE depth too.
     try:
         return _derive_person_id_filter_inner(
             node, join_to_add, context=context, from_field_maps_to_person_id=from_field_maps_to_person_id

--- a/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
+++ b/posthog/hogql/database/schema/util/pdi_person_id_pushdown.py
@@ -1,21 +1,29 @@
 from typing import Optional, cast
 
+import structlog
+
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import LazyJoin, LazyJoinToAdd, LazyTable, Table
 from posthog.hogql.database.schema.util.where_clause_extractor import WhereClauseExtractor
 from posthog.hogql.parser import parse_select
-from posthog.hogql.visitor import clone_expr
+from posthog.hogql.visitor import TraversingVisitor, clone_expr
+
+logger = structlog.get_logger(__name__)
 
 
 # Filter on a distinct_id IN subquery on raw_person_distinct_ids is the only safe
 # way to narrow person_distinct_id2 by person_id. The naive WHERE person_id IN (X)
 # would filter raw rows pre-argMax and report stale mappings for distinct_ids that
 # were rebound to a different person.
+#
+# The aliased table name "pdi_pushdown_pdi" is intentional: it appears in the
+# generated SQL and lets us grep system.query_log to measure how often the
+# optimization fires post-deploy.
 def build_distinct_id_pushdown(person_id_filter: ast.Expr) -> ast.CompareOperation:
     inner = cast(
         ast.SelectQuery,
-        parse_select("SELECT distinct_id FROM raw_person_distinct_ids"),
+        parse_select("SELECT distinct_id FROM raw_person_distinct_ids AS pdi_pushdown_pdi"),
     )
     inner.where = clone_expr(person_id_filter, clear_types=True, clear_locations=True)
     return ast.CompareOperation(
@@ -32,29 +40,48 @@ def derive_person_id_filter(
     context: HogQLContext,
     from_field_maps_to_person_id: bool,
 ) -> Optional[ast.Expr]:
-    if not node.where:
+    # Fail-open envelope: this runs on every persons.pdi join in HogQL compilation.
+    # An exception here would break the query entirely; we'd rather skip the
+    # optimization. Catches RecursionError on pathological WHERE depth too.
+    try:
+        return _derive_person_id_filter_inner(
+            node, join_to_add, context=context, from_field_maps_to_person_id=from_field_maps_to_person_id
+        )
+    except Exception as e:
+        logger.warning("pdi_person_id_pushdown_failed", error=str(e))
         return None
 
-    # Primary: reuse WhereClauseExtractor to extract any persons-side predicate
-    # (id IN, email =, properties.* IN, ...). Translate into a person_id filter
-    # by wrapping with a SELECT against raw_persons. This mirrors the inner
-    # subquery shape that select_from_persons_table already emits, just consumed
-    # by pdi instead.
+
+def _derive_person_id_filter_inner(
+    node: ast.SelectQuery,
+    join_to_add: LazyJoinToAdd,
+    *,
+    context: HogQLContext,
+    from_field_maps_to_person_id: bool,
+) -> Optional[ast.Expr]:
+    if not node.where and not node.prewhere:
+        return None
+
     if from_field_maps_to_person_id:
         # By the time persons_pdi_join runs, the persons FROM has already been
-        # rewritten to a SelectQueryAliasType (see lazy_tables.py). However, field
-        # references in node.where still carry the original PersonsTable instance,
-        # so we recover it from there to feed WhereClauseExtractor.
-        persons_table = _find_persons_table_in_where(node.where)
+        # rewritten to a SelectQueryAliasType (see lazy_tables.py). Field
+        # references in node.where still carry the original PersonsTable
+        # instance, so we recover it from there to feed WhereClauseExtractor.
+        persons_table = _find_persons_table(node)
         if persons_table is not None:
             extractor = WhereClauseExtractor(context)
-            if persons_table not in extractor.tracked_tables:
-                extractor.tracked_tables.append(persons_table)
+            extractor.tracked_tables.append(persons_table)
+            # The pushed-down filter lives inside an independent subquery
+            # (SELECT id FROM raw_persons WHERE ...). The outer query's joins
+            # are not in scope there, so any tombstoning the join-aware path
+            # would do is unwarranted here. Force is_join=False so NOT and
+            # negated comparisons stay extractable.
+            extractor.is_join = False
             persons_filter = extractor.get_inner_where(node)
             if persons_filter is not None:
                 inner_persons = cast(
                     ast.SelectQuery,
-                    parse_select("SELECT id FROM raw_persons"),
+                    parse_select("SELECT id FROM raw_persons AS pdi_pushdown_persons"),
                 )
                 inner_persons.where = persons_filter
                 return ast.CompareOperation(
@@ -63,13 +90,14 @@ def derive_person_id_filter(
                     op=ast.CompareOperationOp.In,
                 )
 
-    # Fallback: direct pdi.person_id IN (X) anywhere in the outer WHERE.
     pdi_table = join_to_add.lazy_join.join_table
     if not isinstance(pdi_table, (Table, LazyTable, LazyJoin)):
         return None
 
     matches: list[ast.CompareOperation] = []
-    _collect_pdi_person_id_in_filters(node.where, pdi_table=pdi_table, out=matches)
+    for source in (node.where, node.prewhere):
+        if source is not None:
+            _collect_pdi_person_id_in_filters(source, pdi_table=pdi_table, out=matches)
     if not matches:
         return None
 
@@ -79,70 +107,50 @@ def derive_person_id_filter(
     return ast.And(exprs=person_id_filters)
 
 
-def _find_persons_table_in_where(where: Optional[ast.Expr]):
-    """Walk a WHERE expression and return the first PersonsTable instance referenced."""
-    from posthog.hogql.database.schema.persons import PersonsTable
+class _FindPersonsTableVisitor(TraversingVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.found: Optional[object] = None
 
-    if where is None:
-        return None
+    def visit(self, node):
+        if self.found is not None:
+            return
+        super().visit(node)
 
-    found: list = []
+    def visit_field(self, node: ast.Field) -> None:
+        from posthog.hogql.database.schema.persons import PersonsTable
 
-    def _table_from_field(expr) -> Optional[ast.Type]:
-        t = expr.type
-        if isinstance(t, ast.PropertyType):
-            t = t.field_type
-        if isinstance(t, ast.FieldAliasType):
-            inner = t.type
-            while isinstance(inner, ast.FieldAliasType):
-                inner = inner.type
-            if isinstance(inner, ast.PropertyType):
-                inner = inner.field_type
-            t = inner
-        if isinstance(t, ast.FieldType):
-            tt = t.table_type
-            while isinstance(tt, ast.TableAliasType):
-                tt = tt.table_type
-            return tt
-        return None
+        table_type = _table_type_from_field(node)
+        if isinstance(table_type, ast.LazyTableType) and isinstance(table_type.table, PersonsTable):
+            self.found = table_type.table
 
-    def _walk(expr):
-        if isinstance(expr, ast.Field):
-            tt = _table_from_field(expr)
-            if isinstance(tt, ast.LazyTableType) and isinstance(tt.table, PersonsTable):
-                found.append(tt.table)
-                return
-        if isinstance(expr, ast.Alias):
-            _walk(expr.expr)
-            return
-        if isinstance(expr, ast.CompareOperation):
-            _walk(expr.left)
-            if not found:
-                _walk(expr.right)
-            return
-        if isinstance(expr, ast.And) or isinstance(expr, ast.Or):
-            for sub in expr.exprs:
-                _walk(sub)
-                if found:
-                    return
-            return
-        if isinstance(expr, ast.Not):
-            _walk(expr.expr)
-            return
-        if isinstance(expr, ast.Call):
-            for arg in expr.args:
-                _walk(arg)
-                if found:
-                    return
-            return
-        if isinstance(expr, ast.Tuple):
-            for sub in expr.exprs:
-                _walk(sub)
-                if found:
-                    return
 
-    _walk(where)
-    return found[0] if found else None
+def _find_persons_table(node: ast.SelectQuery):
+    visitor = _FindPersonsTableVisitor()
+    if node.where is not None:
+        visitor.visit(node.where)
+    if visitor.found is None and node.prewhere is not None:
+        visitor.visit(node.prewhere)
+    return visitor.found
+
+
+def _table_type_from_field(node: ast.Field):
+    t = node.type
+    if isinstance(t, ast.PropertyType):
+        t = t.field_type
+    if isinstance(t, ast.FieldAliasType):
+        inner = t.type
+        while isinstance(inner, ast.FieldAliasType):
+            inner = inner.type
+        if isinstance(inner, ast.PropertyType):
+            inner = inner.field_type
+        t = inner
+    if isinstance(t, ast.FieldType):
+        tt = t.table_type
+        while isinstance(tt, ast.TableAliasType):
+            tt = tt.table_type
+        return tt
+    return None
 
 
 def _collect_pdi_person_id_in_filters(
@@ -151,6 +159,8 @@ def _collect_pdi_person_id_in_filters(
     pdi_table,
     out: list[ast.CompareOperation],
 ) -> None:
+    # Intentionally does NOT descend into Or/Not: a person_id IN (X) inside
+    # an OR cannot be safely promoted as a hard filter.
     if isinstance(expr, ast.CompareOperation):
         if expr.op == ast.CompareOperationOp.In and _is_pdi_person_id_field(expr.left, pdi_table=pdi_table):
             out.append(expr)


### PR DESCRIPTION
## Problem

Closes #42260

Any HogQL query that reads `persons.pdi.*` and filters on the persons side (by id, email, properties, etc.) currently emits a ClickHouse query that does a full `argMax`+`GROUP BY distinct_id` over every distinct_id in the team, then filters via the outer JOIN. The pdi inner subquery only carries a `team_id` filter.

For example: 

```sql
-- HogQL
SELECT pdi.distinct_id FROM persons WHERE properties.email ILIKE '%@posthog.com%'
```

generates a ClickHouse query whose inner pdi subquery looks like:

```sql
LEFT JOIN (
  SELECT argMax(person_id, version) AS person_id, distinct_id
  FROM person_distinct_id2
  WHERE team_id = 2            -- only team filter, no person_id narrowing
  GROUP BY distinct_id
  HAVING ...
) AS persons__pdi ON persons.id = persons__pdi.person_id
```

ClickHouse computes the argMax for every distinct_id in the team.

Past 7 days on US prod: 6,466 queries hit this pattern across 287 teams (p95 18.8s, max 184s, 13 TiB total read, 20.5 GiB p95 memory): https://metabase.prod-us.posthog.dev/question/2059-queries-with-persons-pid-and-where-optimization

## Changes

Adds `derive_person_id_filter` in a new helper module. When `persons_pdi_join` runs (the LazyJoin function for `persons.pdi`), the helper:

1. Walks `node.where` (and `node.prewhere`) via a `TraversingVisitor` subclass to find the `PersonsTable` instance referenced.
2. Reuses `WhereClauseExtractor` (with `is_join=False` forced, since the inner subquery is independent of any outer JOIN) to pull out persons-side predicates (`id IN`, `email = ...`, `properties.* IN`, `NOT ...`, `OR`, etc.).
3. Wraps the result as `person_id IN (SELECT id FROM raw_persons AS pdi_pushdown_persons WHERE <filter>)`.
4. Passes that into `persons_pdi_select`, which wraps the inner pdi subquery with `WHERE distinct_id IN (SELECT distinct_id FROM raw_pdi AS pdi_pushdown_pdi WHERE <person_id_filter>)`.

The `distinct_id IN (subquery)` form is required because filtering raw pdi rows pre-`argMax` would report stale mappings for distinct_ids that have been rebound. The outer `argMax` re-runs over all rows for the candidate distinct_ids and returns the latest mapping.

The same plumbing is added to `join_with_person_distinct_ids_table` (the events.pdi path) but only the direct `pdi.person_id IN (X)` fallback applies there, since that join is keyed on `distinct_id` rather than `person_id`. The `from_field_maps_to_person_id` flag toggles which paths are safe to apply.

The whole `derive_person_id_filter` body is wrapped in a `try/except` to fail open. 

The inner subqueries are aliased as `pdi_pushdown_pdi` and `pdi_pushdown_persons` so we can grep `system.query_log` post-deploy to measure how often the optimization fires.

### Performance numbers

Ran `SELECT pdi.distinct_id FROM persons WHERE properties.email ILIKE '%@posthog.com%'` against US prod team 2:

| Variant | Duration | Memory peak | Bytes read | Outcome | Metbase Link |
|---|---|---|---|---|---|
| Before, default memory limit | 1,049 ms | 37.25 GiB | 4.49 GiB | OOM | [link](https://metabase.prod-us.posthog.dev/question/2060-without-push-down) | 
| Before, with spill to disk | 25,762 ms | 27.00 GiB | 11.05 GiB | Completed | | 
| After, with pushdown | 1,056 ms | 750 MiB | 11.77 GiB | Completed | [link](https://metabase.prod-us.posthog.dev/question/2061-with-push-down) |

About 24x faster, 36x lower memory peak vs. the spill-enabled baseline; the OOM at default cluster memory limits is eliminated. Both completed runs return the same 247,340 rows (verified by hashing the sorted `distinct_id` array on both sides: identical `cityHash64`).

## How did you test this code?

Automated tests added in `posthog/hogql/database/schema/test/test_persons.py::TestPersonsPdiPersonIdPushdown` (7 total):

- `test_pdi_subquery_filtered_when_outer_filters_persons_id` (snapshotted): pushdown fires for `persons.id IN (X)`, results correct.
- `test_pdi_subquery_filtered_when_outer_filters_persons_property` (snapshotted): pushdown fires for `properties.name = 'alice'` (the hot prod case).
- `test_pdi_subquery_unfiltered_when_no_pushdown_target`: pushdown does NOT fire when no persons-side filter is present.
- `test_pdi_subquery_correct_when_distinct_id_was_rebound`: rebinds a distinct_id to a different person via a higher-version pdi row, asserts the rebound distinct_id is no longer attributed to the original owner. This is the motivating correctness case the docstring describes for choosing `distinct_id IN (subquery)` over `person_id IN (X)`.
- `test_pdi_subquery_with_negated_persons_filter`: `WHERE NOT (...)` extracts correctly with `is_join=False`.
- `test_pdi_subquery_with_or_persons_filter`: `WHERE x OR y` across persons-side predicates extracts correctly.
- `test_pdi_subquery_pushdown_fails_open_on_extractor_error`: patches the helper to raise; query still completes correctly without the optimization.

## Publish to changelog?

No.

## Docs update

No docs change required.