### PR TITLE
chore(demo_data): rm creation of persons db demo data w/ orm

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -32,6 +32,7 @@ env:
     REDIS_URL: redis://localhost
     DATABASE_URL: postgres://posthog:posthog@localhost:5432/posthog_e2e_test
     PERSONS_DB_WRITER_URL: postgres://posthog:posthog@localhost:5432/posthog_persons_e2e_test
+    PERSONS_DATABASE_URL: postgres://posthog:posthog@localhost:5432/posthog_persons_e2e_test
     KAFKA_HOSTS: kafka:9092
     DISABLE_SECURE_SSL_REDIRECT: 1
     SECURE_COOKIES: 0
@@ -454,7 +455,6 @@ jobs:
                   python manage.py migrate --noinput
 
                   # Run Rust migrations for persons e2e test database
-                  PERSONS_DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons_e2e_test"
                   sqlx database create -D "$PERSONS_DATABASE_URL"
                   sqlx migrate run -D "$PERSONS_DATABASE_URL" --source rust/persons_migrations/
 

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -240,7 +240,7 @@ def _django_db_setup(django_db_keepdb, django_db_blocker):
     settings.DATABASES["persons_db_reader"]["NAME"] = test_persons_db_name
 
     db_cfg = settings.DATABASES["persons_db_writer"]
-    password_part = f":{db_cfg['PASSWORD']}" if db_cfg.get("PASSWORD") else ""
+    password_part = f":{quote_plus(db_cfg['PASSWORD'])}" if db_cfg.get("PASSWORD") else ""
     os.environ["PERSONS_DATABASE_URL"] = (
         f"postgres://{db_cfg['USER']}{password_part}@{db_cfg['HOST']}:{db_cfg['PORT']}/{test_persons_db_name}"
     )

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -239,6 +239,12 @@ def _django_db_setup(django_db_keepdb, django_db_blocker):
     settings.DATABASES["persons_db_writer"]["NAME"] = test_persons_db_name
     settings.DATABASES["persons_db_reader"]["NAME"] = test_persons_db_name
 
+    db_cfg = settings.DATABASES["persons_db_writer"]
+    password_part = f":{db_cfg['PASSWORD']}" if db_cfg.get("PASSWORD") else ""
+    os.environ["PERSONS_DATABASE_URL"] = (
+        f"postgres://{db_cfg['USER']}{password_part}@{db_cfg['HOST']}:{db_cfg['PORT']}/{test_persons_db_name}"
+    )
+
     # Update product database NAMEs to use test-prefixed names
     from posthog.product_db_config import load_product_db_routes
 

--- a/posthog/demo/legacy/data_generator.py
+++ b/posthog/demo/legacy/data_generator.py
@@ -79,7 +79,6 @@ class DataGenerator:
                     """,
                     distinct_id_rows,
                 )
-            conn.commit()
 
         from posthog.models.person.util import create_person, create_person_distinct_id
 

--- a/posthog/demo/legacy/data_generator.py
+++ b/posthog/demo/legacy/data_generator.py
@@ -1,4 +1,5 @@
 import json
+import datetime as dt
 from uuid import uuid4
 
 from django.conf import settings
@@ -41,12 +42,14 @@ class DataGenerator:
         person_table_name = settings.PERSON_TABLE_NAME
         persons_db_url = _get_persons_db_url()
 
+        now = dt.datetime.now(dt.UTC)
         person_rows = [
             (
                 self.team.pk,
                 str(person.uuid),
                 json.dumps(person.properties),
                 person.is_identified,
+                now,
             )
             for person in self.people
         ]
@@ -56,7 +59,7 @@ class DataGenerator:
                 results = execute_values(
                     cur,
                     f"""
-                    INSERT INTO {person_table_name} (team_id, uuid, properties, is_identified)
+                    INSERT INTO {person_table_name} (team_id, uuid, properties, is_identified, created_at)
                     VALUES %s
                     RETURNING id, uuid
                     """,

--- a/posthog/demo/legacy/data_generator.py
+++ b/posthog/demo/legacy/data_generator.py
@@ -1,6 +1,13 @@
+import json
 from uuid import uuid4
 
-from posthog.models import Person, PersonDistinctId, Team
+from django.conf import settings
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+from posthog.demo.matrix.persons_db_sync import _get_persons_db_url
+from posthog.models import Person, Team
 from posthog.models.utils import UUIDT
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 
@@ -30,13 +37,50 @@ class DataGenerator:
     def create_people(self):
         self.people = [self.make_person(i) for i in range(self.n_people)]
         self.distinct_ids = [str(UUIDT()) for _ in self.people]
-        self.people = Person.objects.bulk_create(self.people)  # nosemgrep: no-direct-persons-db-orm
 
-        pids = [
-            PersonDistinctId(team=self.team, person=person, distinct_id=distinct_id)
-            for person, distinct_id in zip(self.people, self.distinct_ids)
+        person_table_name = settings.PERSON_TABLE_NAME
+        persons_db_url = _get_persons_db_url()
+
+        person_rows = [
+            (
+                self.team.pk,
+                str(person.uuid),
+                json.dumps(person.properties),
+                person.is_identified,
+            )
+            for person in self.people
         ]
-        PersonDistinctId.objects.bulk_create(pids)  # nosemgrep: no-direct-persons-db-orm
+
+        with psycopg2.connect(persons_db_url) as conn:
+            with conn.cursor() as cur:
+                results = execute_values(
+                    cur,
+                    f"""
+                    INSERT INTO {person_table_name} (team_id, uuid, properties, is_identified)
+                    VALUES %s
+                    RETURNING id, uuid
+                    """,
+                    person_rows,
+                    fetch=True,
+                )
+                uuid_to_pk = {str(uuid): pk for pk, uuid in results}
+                for person in self.people:
+                    person.pk = uuid_to_pk[str(person.uuid)]
+
+                distinct_id_rows = [
+                    (self.team.pk, distinct_id, person.pk, 0)
+                    for person, distinct_id in zip(self.people, self.distinct_ids)
+                ]
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO posthog_persondistinctid (team_id, distinct_id, person_id, version)
+                    VALUES %s
+                    """,
+                    distinct_id_rows,
+                )
+            conn.commit()
+
         from posthog.models.person.util import create_person, create_person_distinct_id
 
         for person in self.people:
@@ -47,8 +91,8 @@ class DataGenerator:
                 is_identified=person.is_identified,
                 version=0,
             )
-        for pid in pids:
-            create_person_distinct_id(pid.team.pk, pid.distinct_id, str(pid.person.uuid))  # use dummy number for id
+        for person, distinct_id in zip(self.people, self.distinct_ids):
+            create_person_distinct_id(person.team.pk, distinct_id, str(person.uuid))
 
     def make_person(self, index):
         return Person(team=self.team, properties={"is_demo": True})

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -1,26 +1,22 @@
 # ruff: noqa: T201 allow print statements
 
-import json
 import datetime as dt
 from time import sleep
 from typing import Any, Literal, cast
 
 from django.conf import settings
 from django.core import exceptions
-from django.db import IntegrityError, transaction
+from django.db import transaction
 
-from posthog.clickhouse.client import query_with_columns, sync_execute
-from posthog.demo.matrix.taxonomy_inference import infer_taxonomy_for_team
-from posthog.models import (
-    Group,
-    GroupTypeMapping,
-    Organization,
-    OrganizationMembership,
-    Person,
-    PersonDistinctId,
-    Team,
-    User,
+from posthog.clickhouse.client import sync_execute
+from posthog.demo.matrix.persons_db_sync import (
+    bulk_create_group_type_mappings,
+    copy_group_type_mappings,
+    delete_group_type_mappings,
+    sync_persons_to_postgres,
 )
+from posthog.demo.matrix.taxonomy_inference import infer_taxonomy_for_team
+from posthog.models import Organization, OrganizationMembership, Team, User
 from posthog.models.utils import UUIDT, generate_random_token_project
 
 from products.cohorts.backend.models.cohort import Cohort
@@ -166,18 +162,16 @@ class MatrixManager:
         if self.print_steps:
             print(f"Saving simulated data...")
         sim_persons = self.matrix.people
-        bulk_group_type_mappings = []
+        group_type_mapping_dicts = []
         if len(self.matrix.groups.keys()) + self.matrix.group_type_index_offset > 5:
             raise ValueError("Too many group types! The maximum for a project is 5.")
         for group_type_index, (group_type, groups) in enumerate(self.matrix.groups.items()):
             group_type_index += self.matrix.group_type_index_offset  # Adjust
-            bulk_group_type_mappings.append(
-                GroupTypeMapping(
-                    team_id=data_team.id,
-                    project_id=data_team.project_id,
-                    group_type_index=group_type_index,
-                    group_type=group_type,
-                )
+            group_type_mapping_dicts.append(
+                {
+                    "group_type_index": group_type_index,
+                    "group_type": group_type,
+                }
             )
             for group_key, group in groups.items():
                 self._save_sim_group(
@@ -187,10 +181,7 @@ class MatrixManager:
                     group,
                     self.matrix.now,
                 )
-        try:
-            GroupTypeMapping.objects.bulk_create(bulk_group_type_mappings)  # nosemgrep: no-direct-persons-db-orm
-        except IntegrityError as e:
-            print(f"SKIPPING GROUP TYPE MAPPING CREATION: {e}")
+        bulk_create_group_type_mappings(data_team.id, data_team.project_id, group_type_mapping_dicts)
         for sim_person in sim_persons:
             self._save_sim_person(data_team, sim_person)
         # We need to wait a bit for data just queued into Kafka to show up in CH
@@ -224,7 +215,7 @@ class MatrixManager:
         #         )
         #     ]
         # )
-        GroupTypeMapping.objects.filter(project_id=cls.MASTER_TEAM_ID).delete()  # nosemgrep: no-direct-persons-db-orm
+        delete_group_type_mappings(cls.MASTER_TEAM_ID)
 
     def _copy_analytics_data_from_master_team(self, target_team: Team):
         from posthog.models.event.sql import COPY_EVENTS_BETWEEN_TEAMS
@@ -242,93 +233,11 @@ class MatrixManager:
         sync_execute(COPY_PERSON_DISTINCT_ID2S_BETWEEN_TEAMS, copy_params)
         sync_execute(COPY_EVENTS_BETWEEN_TEAMS, copy_params)
         sync_execute(COPY_GROUPS_BETWEEN_TEAMS, copy_params)
-        GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-            project_id=target_team.project_id
-        ).delete()  # nosemgrep: no-direct-persons-db-orm
-        GroupTypeMapping.objects.bulk_create(  # nosemgrep: no-direct-persons-db-orm
-            (
-                GroupTypeMapping(team_id=target_team.id, project_id=target_team.project_id, **record)
-                for record in GroupTypeMapping.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-                    project_id=self.MASTER_TEAM_ID
-                ).values(  # nosemgrep: no-direct-persons-db-orm
-                    "group_type", "group_type_index", "name_singular", "name_plural"
-                )
-            ),
-        )
+        copy_group_type_mappings(self.MASTER_TEAM_ID, target_team.id, target_team.project_id)
 
     @classmethod
     def _sync_postgres_with_clickhouse_data(cls, source_team_id: int, target_team_id: int):
-        from posthog.models.group.sql import SELECT_GROUPS_OF_TEAM
-        from posthog.models.person.sql import SELECT_PERSON_DISTINCT_ID2S_OF_TEAM, SELECT_PERSONS_OF_TEAM
-
-        list_params = {"source_team_id": source_team_id}
-        # Persons
-        clickhouse_persons = query_with_columns(
-            SELECT_PERSONS_OF_TEAM,
-            list_params,
-            columns_to_rename={"id": "uuid"},
-        )
-        bulk_persons: dict[str, Person] = {}
-        person_fields = {f.name for f in Person._meta.get_fields()}
-        for row in clickhouse_persons:
-            filtered_row = {k: v for k, v in row.items() if k in person_fields}
-            properties = json.loads(filtered_row.pop("properties", "{}"))
-            bulk_persons[row["uuid"]] = Person(team_id=target_team_id, properties=properties, **filtered_row)
-        # This sets the pk in the bulk_persons dict so we can use them later
-        Person.objects.bulk_create(bulk_persons.values())  # nosemgrep: no-direct-persons-db-orm
-        # Person distinct IDs
-        pre_existing_id_count = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-            team_id=target_team_id
-        ).count()  # nosemgrep: no-direct-persons-db-orm
-        clickhouse_distinct_ids = query_with_columns(
-            SELECT_PERSON_DISTINCT_ID2S_OF_TEAM,
-            list_params,
-            ["team_id", "is_deleted", "_timestamp", "_offset", "_partition"],
-            {"person_id": "person_uuid"},
-        )
-        bulk_person_distinct_ids = []
-        person_distinct_id_fields = {f.name for f in PersonDistinctId._meta.get_fields()}
-        for row in clickhouse_distinct_ids:
-            person_uuid = row.pop("person_uuid")
-            try:
-                filtered_row = {k: v for k, v in row.items() if k in person_distinct_id_fields}
-                bulk_person_distinct_ids.append(
-                    PersonDistinctId(
-                        team_id=target_team_id,
-                        person_id=bulk_persons[person_uuid].pk,
-                        **filtered_row,
-                    )
-                )
-            except KeyError:
-                pre_existing_id_count -= 1
-        if pre_existing_id_count > 0:
-            print(f"{pre_existing_id_count} IDS UNACCOUNTED FOR")
-        PersonDistinctId.objects.bulk_create(  # nosemgrep: no-direct-persons-db-orm
-            bulk_person_distinct_ids, ignore_conflicts=True
-        )  # nosemgrep: no-direct-persons-db-orm
-        # Groups
-        clickhouse_groups = query_with_columns(
-            SELECT_GROUPS_OF_TEAM,
-            list_params,
-            ["team_id", "_timestamp", "_offset", "is_deleted"],
-        )
-        bulk_groups = []
-        group_fields = {f.name for f in Group._meta.get_fields()}
-        for row in clickhouse_groups:
-            filtered_row = {k: v for k, v in row.items() if k in group_fields}
-            group_properties = json.loads(filtered_row.pop("group_properties", "{}"))
-            bulk_groups.append(
-                Group(
-                    team_id=target_team_id,
-                    version=0,
-                    group_properties=group_properties,
-                    **filtered_row,
-                )
-            )
-        try:
-            Group.objects.bulk_create(bulk_groups)  # nosemgrep: no-direct-persons-db-orm
-        except IntegrityError as e:
-            print(f"SKIPPING GROUP CREATION: {e}")
+        sync_persons_to_postgres(source_team_id, target_team_id, person_table_name=settings.PERSON_TABLE_NAME)
 
     def _save_sim_person(self, team: Team, subject: SimPerson):
         # We only want to save directly if there are past events

--- a/posthog/demo/matrix/persons_db_sync.py
+++ b/posthog/demo/matrix/persons_db_sync.py
@@ -88,7 +88,7 @@ def _insert_persons(
                 target_team_id,
                 uuid,
                 properties_json,
-                row.get("is_identified", False),
+                bool(row.get("is_identified", False)),
                 row.get("created_at"),
                 row.get("version"),
                 row.get("last_seen_at"),

--- a/posthog/demo/matrix/persons_db_sync.py
+++ b/posthog/demo/matrix/persons_db_sync.py
@@ -11,6 +11,7 @@ persons database.
 import os
 import json
 from typing import Any
+from urllib.parse import quote_plus
 
 import psycopg2
 from psycopg2.extras import execute_values
@@ -25,7 +26,8 @@ def _get_persons_db_url() -> str:
         pg_password = os.getenv("PGPASSWORD", "posthog")
         pg_host = os.getenv("PGHOST", "localhost")
         pg_port = os.getenv("PGPORT", "5432")
-        url = f"postgres://{pg_user}:{pg_password}@{pg_host}:{pg_port}/posthog_persons"
+        password_part = f":{quote_plus(pg_password)}" if pg_password else ""
+        url = f"postgres://{pg_user}{password_part}@{pg_host}:{pg_port}/posthog_persons"
     return url
 
 

--- a/posthog/demo/matrix/persons_db_sync.py
+++ b/posthog/demo/matrix/persons_db_sync.py
@@ -1,0 +1,276 @@
+# ruff: noqa: T201 allow print statements
+"""
+Syncs person/group data from ClickHouse into the persons Postgres database
+using raw psycopg2, bypassing Django ORM and Django's database configuration.
+
+The persons DB URL is read directly from PERSONS_DATABASE_URL (the same env var
+used by Rust/Node services), keeping Django completely decoupled from the
+persons database.
+"""
+
+import os
+import json
+from typing import Any
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+from posthog.clickhouse.client import query_with_columns
+
+
+def _get_persons_db_url() -> str:
+    url = os.getenv("PERSONS_DATABASE_URL")
+    if not url:
+        pg_user = os.getenv("PGUSER", "posthog")
+        pg_password = os.getenv("PGPASSWORD", "posthog")
+        pg_host = os.getenv("PGHOST", "localhost")
+        pg_port = os.getenv("PGPORT", "5432")
+        url = f"postgres://{pg_user}:{pg_password}@{pg_host}:{pg_port}/posthog_persons"
+    return url
+
+
+def sync_persons_to_postgres(
+    source_team_id: int, target_team_id: int, person_table_name: str = "posthog_person"
+) -> None:
+    from posthog.models.group.sql import SELECT_GROUPS_OF_TEAM
+    from posthog.models.person.sql import SELECT_PERSON_DISTINCT_ID2S_OF_TEAM, SELECT_PERSONS_OF_TEAM
+
+    persons_db_url = _get_persons_db_url()
+    list_params = {"source_team_id": source_team_id}
+
+    clickhouse_persons = query_with_columns(
+        SELECT_PERSONS_OF_TEAM,
+        list_params,
+        columns_to_rename={"id": "uuid"},
+    )
+
+    clickhouse_distinct_ids = query_with_columns(
+        SELECT_PERSON_DISTINCT_ID2S_OF_TEAM,
+        list_params,
+        ["team_id", "is_deleted", "_timestamp", "_offset", "_partition"],
+        {"person_id": "person_uuid"},
+    )
+
+    clickhouse_groups = query_with_columns(
+        SELECT_GROUPS_OF_TEAM,
+        list_params,
+        ["team_id", "_timestamp", "_offset", "is_deleted"],
+    )
+
+    with psycopg2.connect(persons_db_url) as conn:
+        with conn.cursor() as cur:
+            uuid_to_pk = _insert_persons(cur, clickhouse_persons, target_team_id, person_table_name)
+            _insert_person_distinct_ids(cur, clickhouse_distinct_ids, target_team_id, uuid_to_pk)
+            _insert_groups(cur, clickhouse_groups, target_team_id)
+        conn.commit()
+
+
+def _insert_persons(
+    cur: Any,
+    clickhouse_persons: list[dict],
+    target_team_id: int,
+    person_table_name: str,
+) -> dict[str, int]:
+    if not clickhouse_persons:
+        return {}
+
+    rows = []
+    uuids_in_order: list[str] = []
+    for row in clickhouse_persons:
+        uuid = str(row["uuid"])
+        properties = row.get("properties", "{}")
+        if isinstance(properties, str):
+            properties = json.loads(properties)
+        properties_json = json.dumps(properties)
+
+        rows.append(
+            (
+                target_team_id,
+                uuid,
+                properties_json,
+                row.get("is_identified", False),
+                row.get("created_at"),
+                row.get("version"),
+                row.get("last_seen_at"),
+            )
+        )
+        uuids_in_order.append(uuid)
+
+    result = execute_values(
+        cur,
+        f"""
+        INSERT INTO {person_table_name} (team_id, uuid, properties, is_identified, created_at, version, last_seen_at)
+        VALUES %s
+        RETURNING id, uuid
+        """,
+        rows,
+        fetch=True,
+    )
+
+    uuid_to_pk: dict[str, int] = {}
+    for pk, uuid in result:
+        uuid_to_pk[str(uuid)] = pk
+
+    return uuid_to_pk
+
+
+def _insert_person_distinct_ids(
+    cur: Any,
+    clickhouse_distinct_ids: list[dict],
+    target_team_id: int,
+    uuid_to_pk: dict[str, int],
+) -> None:
+    if not clickhouse_distinct_ids:
+        return
+
+    rows = []
+    for row in clickhouse_distinct_ids:
+        person_uuid = str(row.get("person_uuid", ""))
+        person_pk = uuid_to_pk.get(person_uuid)
+        if person_pk is None:
+            continue
+
+        rows.append(
+            (
+                target_team_id,
+                row.get("distinct_id"),
+                person_pk,
+                row.get("version", 0),
+            )
+        )
+
+    if rows:
+        execute_values(
+            cur,
+            """
+            INSERT INTO posthog_persondistinctid (team_id, distinct_id, person_id, version)
+            VALUES %s
+            ON CONFLICT DO NOTHING
+            """,
+            rows,
+        )
+
+
+def _insert_groups(
+    cur: Any,
+    clickhouse_groups: list[dict],
+    target_team_id: int,
+) -> None:
+    if not clickhouse_groups:
+        return
+
+    rows = []
+    for row in clickhouse_groups:
+        group_properties = row.get("group_properties", "{}")
+        if isinstance(group_properties, str):
+            group_properties = json.loads(group_properties)
+
+        rows.append(
+            (
+                target_team_id,
+                row.get("group_type_index"),
+                row.get("group_key"),
+                json.dumps(group_properties),
+                row.get("created_at"),
+                0,  # version
+                json.dumps({}),  # properties_last_updated_at
+                json.dumps({}),  # properties_last_operation
+            )
+        )
+
+    execute_values(
+        cur,
+        """
+        INSERT INTO posthog_group
+            (team_id, group_type_index, group_key, group_properties, created_at, version,
+             properties_last_updated_at, properties_last_operation)
+        VALUES %s
+        ON CONFLICT DO NOTHING
+        """,
+        rows,
+    )
+
+
+def bulk_create_group_type_mappings(
+    team_id: int,
+    project_id: int,
+    mappings: list[dict[str, Any]],
+) -> None:
+    if not mappings:
+        return
+
+    persons_db_url = _get_persons_db_url()
+    rows = []
+    for m in mappings:
+        rows.append(
+            (
+                team_id,
+                project_id,
+                m["group_type_index"],
+                m["group_type"],
+                m.get("name_singular"),
+                m.get("name_plural"),
+            )
+        )
+
+    with psycopg2.connect(persons_db_url) as conn:
+        with conn.cursor() as cur:
+            try:
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO posthog_grouptypemapping
+                        (team_id, project_id, group_type_index, group_type, name_singular, name_plural)
+                    VALUES %s
+                    """,
+                    rows,
+                )
+            except psycopg2.IntegrityError as e:
+                print(f"SKIPPING GROUP TYPE MAPPING CREATION: {e}")
+                conn.rollback()
+                return
+        conn.commit()
+
+
+def delete_group_type_mappings(project_id: int) -> None:
+    persons_db_url = _get_persons_db_url()
+    with psycopg2.connect(persons_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM posthog_grouptypemapping WHERE project_id = %s",
+                (project_id,),
+            )
+        conn.commit()
+
+
+def copy_group_type_mappings(source_project_id: int, target_team_id: int, target_project_id: int) -> None:
+    persons_db_url = _get_persons_db_url()
+    with psycopg2.connect(persons_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM posthog_grouptypemapping WHERE project_id = %s",
+                (target_project_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO posthog_grouptypemapping
+                    (team_id, project_id, group_type, group_type_index, name_singular, name_plural)
+                SELECT %s, %s, group_type, group_type_index, name_singular, name_plural
+                FROM posthog_grouptypemapping
+                WHERE project_id = %s
+                """,
+                (target_team_id, target_project_id, source_project_id),
+            )
+        conn.commit()
+
+
+def get_group_type_mapping_count(project_id: int) -> int:
+    persons_db_url = _get_persons_db_url()
+    with psycopg2.connect(persons_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM posthog_grouptypemapping WHERE project_id = %s",
+                (project_id,),
+            )
+            result = cur.fetchone()
+            return result[0] if result else 0

--- a/posthog/demo/matrix/persons_db_sync.py
+++ b/posthog/demo/matrix/persons_db_sync.py
@@ -62,7 +62,6 @@ def sync_persons_to_postgres(
             uuid_to_pk = _insert_persons(cur, clickhouse_persons, target_team_id, person_table_name)
             _insert_person_distinct_ids(cur, clickhouse_distinct_ids, target_team_id, uuid_to_pk)
             _insert_groups(cur, clickhouse_groups, target_team_id)
-        conn.commit()
 
 
 def _insert_persons(
@@ -75,7 +74,6 @@ def _insert_persons(
         return {}
 
     rows = []
-    uuids_in_order: list[str] = []
     for row in clickhouse_persons:
         uuid = str(row["uuid"])
         properties = row.get("properties", "{}")
@@ -94,7 +92,6 @@ def _insert_persons(
                 row.get("last_seen_at"),
             )
         )
-        uuids_in_order.append(uuid)
 
     result = execute_values(
         cur,
@@ -125,7 +122,7 @@ def _insert_person_distinct_ids(
 
     rows = []
     for row in clickhouse_distinct_ids:
-        person_uuid = str(row.get("person_uuid", ""))
+        person_uuid = str(row["person_uuid"])
         person_pk = uuid_to_pk.get(person_uuid)
         if person_pk is None:
             continue
@@ -133,9 +130,9 @@ def _insert_person_distinct_ids(
         rows.append(
             (
                 target_team_id,
-                row.get("distinct_id"),
+                row["distinct_id"],
                 person_pk,
-                row.get("version", 0),
+                row["version"],
             )
         )
 
@@ -168,10 +165,10 @@ def _insert_groups(
         rows.append(
             (
                 target_team_id,
-                row.get("group_type_index"),
-                row.get("group_key"),
+                row["group_type_index"],
+                row["group_key"],
                 json.dumps(group_properties),
-                row.get("created_at"),
+                row["created_at"],
                 0,  # version
                 json.dumps({}),  # properties_last_updated_at
                 json.dumps({}),  # properties_last_operation
@@ -228,8 +225,6 @@ def bulk_create_group_type_mappings(
             except psycopg2.IntegrityError as e:
                 print(f"SKIPPING GROUP TYPE MAPPING CREATION: {e}")
                 conn.rollback()
-                return
-        conn.commit()
 
 
 def delete_group_type_mappings(project_id: int) -> None:
@@ -240,7 +235,6 @@ def delete_group_type_mappings(project_id: int) -> None:
                 "DELETE FROM posthog_grouptypemapping WHERE project_id = %s",
                 (project_id,),
             )
-        conn.commit()
 
 
 def copy_group_type_mappings(source_project_id: int, target_team_id: int, target_project_id: int) -> None:
@@ -261,7 +255,6 @@ def copy_group_type_mappings(source_project_id: int, target_team_id: int, target
                 """,
                 (target_team_id, target_project_id, source_project_id),
             )
-        conn.commit()
 
 
 def get_group_type_mapping_count(project_id: int) -> int:

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -16,13 +16,13 @@ from django.db.utils import OperationalError
 from posthog.api.person import PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
 from posthog.demo.dashboard_template_seeds import seed_dev_dashboard_templates
 from posthog.demo.matrix import Matrix, MatrixManager
+from posthog.demo.matrix.persons_db_sync import get_group_type_mapping_count
 from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.demo.products.spikegpt import SpikeGPTMatrix
 from posthog.health import get_pending_postgres_migrations
 from posthog.management.commands.sync_feature_flags_from_api import sync_feature_flags_from_api
 from posthog.models import User
 from posthog.models.file_system.user_product_list import UserProductList
-from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.team.setup_tasks import SetupTaskId
 from posthog.models.team.team import Team
 from posthog.products import Products
@@ -166,9 +166,7 @@ class Command(BaseCommand):
             days_past=options["days_past"],
             days_future=options["days_future"],
             n_clusters=options["n_clusters"],
-            group_type_index_offset=(
-                len(get_group_types_for_project(existing_team.project_id)) if existing_team else 0
-            ),
+            group_type_index_offset=(get_group_type_mapping_count(existing_team.project_id) if existing_team else 0),
         )
         print("Running simulation...")
         matrix.simulate()


### PR DESCRIPTION
## Problem

Working toward removing the persons database connection from Django services entirely. The demo data generation code (`MatrixManager`, legacy `DataGenerator`, and `generate_demo_data` management command) currently uses Django ORM to write directly to persons DB tables (`posthog_person`, `posthog_persondistinctid`, `posthog_group`, `posthog_grouptypemapping`), which requires Django to have a `persons_db_writer` database configured.

This blocks removing that database connection from Django's `DATABASES` config.

## Changes

Introduced `posthog/demo/matrix/persons_db_sync.py` — a module that uses raw `psycopg2` to write to the persons Postgres database, bypassing Django ORM and Django's database configuration entirely. The persons DB URL is read from `PERSONS_DATABASE_URL` (the same env var used by Rust/Node services) or constructed from `PG*` env vars, keeping Django completely decoupled.

**`posthog/demo/matrix/persons_db_sync.py`** (new):
- `sync_persons_to_postgres()` — reads persons, distinct IDs, and groups from ClickHouse, bulk inserts into Postgres via raw SQL
- `bulk_create_group_type_mappings()` — inserts group type mappings via raw SQL
- `delete_group_type_mappings()` / `copy_group_type_mappings()` — group type mapping CRUD via raw SQL
- `get_group_type_mapping_count()` — replaces `GroupTypeMapping.objects.filter().count()`

**`posthog/demo/matrix/manager.py`**:
- `_sync_postgres_with_clickhouse_data()` — replaced full ORM implementation with single call to `sync_persons_to_postgres()`
- `_save_analytics_data()` — replaced `GroupTypeMapping.objects.bulk_create()` with `bulk_create_group_type_mappings()`
- `_erase_master_team_data()` — replaced `GroupTypeMapping.objects.filter().delete()` with `delete_group_type_mappings()`
- `_copy_analytics_data_from_master_team()` — replaced GroupTypeMapping ORM CRUD with `copy_group_type_mappings()`
- Removed imports: `Group`, `GroupTypeMapping`, `Person`, `PersonDistinctId`, `IntegrityError`, `json`

**`posthog/demo/legacy/data_generator.py`**:
- `create_people()` — replaced `Person.objects.bulk_create()` and `PersonDistinctId.objects.bulk_create()` with raw psycopg2 inserts using `RETURNING id, uuid` to build the uuid-to-pk mapping
- Removed import: `PersonDistinctId`

**`posthog/management/commands/generate_demo_data.py`**:
- Replaced `GroupTypeMapping.objects.filter().count()` with `get_group_type_mapping_count()` from the new module
- Removed import: `GroupTypeMapping`


## How did you test this code?

- Ran `generate_demo_data --n-clusters 3` against a local dev environment with Docker services running
- Verified persons DB was populated: 11 persons, 11 distinct IDs, 1 group type mapping in `posthog_persons` Postgres database
- Confirmed ClickHouse counts match (12 persons/distinct IDs — the extra 1 is from a different team_id)
- Verified raw psycopg2 connection works independently of Django's `DATABASES` config
- Fixed `is_identified` type mismatch (ClickHouse returns int, Postgres column is boolean) discovered during testing
