### PR TITLE
chore(taxonomic-filter): remove icon variant from category dropdown

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
@@ -449,56 +449,50 @@ describe('PropertyFilters recent selections', () => {
             unmountFeatureFlagLogic = null
         })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant: clicking the inline category trigger does not close the property modal',
-            async (variant) => {
-                useSetupMocks()
-                featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN], {
-                    [FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]: variant,
-                })
+        it('pill variant: clicking the inline category trigger does not close the property modal', async () => {
+            useSetupMocks()
+            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN], {
+                [FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]: 'pill',
+            })
 
-                renderFilters({
-                    taxonomicGroupTypes: [
-                        TaxonomicFilterGroupType.EventProperties,
-                        TaxonomicFilterGroupType.PersonProperties,
-                    ],
-                })
+            renderFilters({
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                ],
+            })
 
-                await openNewFilter()
+            await openNewFilter()
 
-                const trigger = await screen.findByTestId(`taxonomic-category-dropdown-trigger-${variant}`)
-                await userEvent.click(trigger)
+            const trigger = await screen.findByTestId('taxonomic-category-dropdown-trigger-pill')
+            await userEvent.click(trigger)
 
-                expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
-            }
-        )
+            expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
+        })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant: picking a category in the inline dropdown does not close the property modal',
-            async (variant) => {
-                useSetupMocks()
-                featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN], {
-                    [FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]: variant,
-                })
+        it('pill variant: picking a category in the inline dropdown does not close the property modal', async () => {
+            useSetupMocks()
+            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN], {
+                [FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]: 'pill',
+            })
 
-                renderFilters({
-                    taxonomicGroupTypes: [
-                        TaxonomicFilterGroupType.EventProperties,
-                        TaxonomicFilterGroupType.PersonProperties,
-                    ],
-                })
+            renderFilters({
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                ],
+            })
 
-                await openNewFilter()
+            await openNewFilter()
 
-                const trigger = await screen.findByTestId(`taxonomic-category-dropdown-trigger-${variant}`)
-                await userEvent.click(trigger)
+            const trigger = await screen.findByTestId('taxonomic-category-dropdown-trigger-pill')
+            await userEvent.click(trigger)
 
-                const item = await screen.findByTestId('taxonomic-category-dropdown-item-person_properties')
-                await userEvent.click(item)
+            const item = await screen.findByTestId('taxonomic-category-dropdown-item-person_properties')
+            await userEvent.click(item)
 
-                expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
-            }
-        )
+            expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
+        })
 
         it('control: clicking outside the property modal closes it', async () => {
             useSetupMocks()

--- a/frontend/src/lib/components/TaxonomicFilter/CategoryDropdown.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/CategoryDropdown.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useCallback } from 'react'
 
-import { IconChevronDown, IconFilter } from '@posthog/icons'
+import { IconChevronDown } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -76,30 +76,15 @@ export function CategoryDropdown({
 }
 
 function renderTrigger(variant: Exclude<CategoryDropdownVariant, 'control'>, activeLabel: string): JSX.Element {
-    const dataAttr = `taxonomic-category-dropdown-trigger-${variant}`
-
-    if (variant === 'pill') {
-        return (
-            <LemonButton
-                type="secondary"
-                size="xsmall"
-                sideIcon={<IconChevronDown />}
-                data-attr={dataAttr}
-                aria-label={`Current category: ${activeLabel}. Click to change.`}
-            >
-                {activeLabel}
-            </LemonButton>
-        )
-    }
-
     return (
         <LemonButton
             type="secondary"
             size="xsmall"
-            icon={<IconFilter />}
             sideIcon={<IconChevronDown />}
-            data-attr={dataAttr}
+            data-attr={`taxonomic-category-dropdown-trigger-${variant}`}
             aria-label={`Current category: ${activeLabel}. Click to change.`}
-        />
+        >
+            {activeLabel}
+        </LemonButton>
     )
 }

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
@@ -501,17 +501,3 @@ export const CategoryDropdownPill: Story = {
         },
     },
 }
-
-export const CategoryDropdownIcon: Story = {
-    render: (args) => <CategoryDropdownStoryRender {...args} variant="icon" />,
-    args: CATEGORY_DROPDOWN_ARGS,
-    tags: ['test-skip'], // featureFlagLogic setup via useEffect races with the visual-regression runner — verified manually in storybook
-    parameters: {
-        ...CATEGORY_DROPDOWN_PARAMETERS,
-        docs: {
-            description: {
-                story: 'Test variant "icon": left-hand Categories column is hidden; a generic filter icon in the right-hand suffix opens the category dropdown.',
-            },
-        },
-    },
-}

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -959,23 +959,20 @@ describe('TaxonomicFilter', () => {
             expect(screen.queryByTestId(/taxonomic-category-dropdown-trigger-/)).not.toBeInTheDocument()
         })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant with hideSearchInput: does not render the categories column or an in-filter dropdown; the host is expected to render CategoryDropdown inside its own input',
-            async (variant) => {
-                setVariant(variant)
-                renderFilter({
-                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
-                    hideSearchInput: true,
-                })
+        it('pill variant with hideSearchInput: does not render the categories column or an in-filter dropdown; the host is expected to render CategoryDropdown inside its own input', async () => {
+            setVariant('pill')
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+                hideSearchInput: true,
+            })
 
-                await waitFor(() => {
-                    expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
-                })
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+            })
 
-                expect(screen.queryByText('Categories')).not.toBeInTheDocument()
-                expect(screen.queryByTestId(/taxonomic-category-dropdown-trigger-/)).not.toBeInTheDocument()
-            }
-        )
+            expect(screen.queryByText('Categories')).not.toBeInTheDocument()
+            expect(screen.queryByTestId(/taxonomic-category-dropdown-trigger-/)).not.toBeInTheDocument()
+        })
 
         it('control variant: default suggested-filters label is "Suggestions"', async () => {
             setVariant('control')
@@ -988,88 +985,76 @@ describe('TaxonomicFilter', () => {
             })
         })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant: default suggested-filters label is "All" (seen in the dropdown items)',
-            async (variant) => {
-                setVariant(variant)
-                renderFilter({
-                    taxonomicGroupTypes: [TaxonomicFilterGroupType.SuggestedFilters, TaxonomicFilterGroupType.Events],
-                })
+        it('pill variant: default suggested-filters label is "All" (seen in the dropdown items)', async () => {
+            setVariant('pill')
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.SuggestedFilters, TaxonomicFilterGroupType.Events],
+            })
 
-                await waitFor(() => {
-                    expect(screen.getByTestId(`taxonomic-category-dropdown-trigger-${variant}`)).toBeInTheDocument()
-                })
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-category-dropdown-trigger-pill')).toBeInTheDocument()
+            })
 
-                await userEvent.click(screen.getByTestId(`taxonomic-category-dropdown-trigger-${variant}`))
+            await userEvent.click(screen.getByTestId('taxonomic-category-dropdown-trigger-pill'))
 
-                const item = await screen.findByTestId('taxonomic-category-dropdown-item-suggested_filters')
-                expect(item).toHaveTextContent('All')
-            }
-        )
+            const item = await screen.findByTestId('taxonomic-category-dropdown-item-suggested_filters')
+            expect(item).toHaveTextContent('All')
+        })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant: hides the categories column and renders the in-input affordance',
-            async (variant) => {
-                setVariant(variant)
-                renderFilter({
-                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
-                })
+        it('pill variant: hides the categories column and renders the in-input affordance', async () => {
+            setVariant('pill')
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+            })
 
-                await waitFor(() => {
-                    expect(screen.getByTestId(`taxonomic-category-dropdown-trigger-${variant}`)).toBeInTheDocument()
-                })
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-category-dropdown-trigger-pill')).toBeInTheDocument()
+            })
 
-                expect(screen.queryByText('Categories')).not.toBeInTheDocument()
-            }
-        )
+            expect(screen.queryByText('Categories')).not.toBeInTheDocument()
+        })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant: opening the dropdown and picking a category switches the visible results',
-            async (variant) => {
-                setVariant(variant)
-                renderFilter({
-                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
-                })
+        it('pill variant: opening the dropdown and picking a category switches the visible results', async () => {
+            setVariant('pill')
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+            })
 
-                await waitFor(() => {
-                    expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
-                })
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+            })
 
-                await userEvent.click(screen.getByTestId(`taxonomic-category-dropdown-trigger-${variant}`))
+            await userEvent.click(screen.getByTestId('taxonomic-category-dropdown-trigger-pill'))
 
-                await userEvent.click(await screen.findByTestId('taxonomic-category-dropdown-item-actions'))
+            await userEvent.click(await screen.findByTestId('taxonomic-category-dropdown-item-actions'))
 
-                await waitFor(() => {
-                    expect(screen.getByTestId('prop-filter-actions-0')).toBeInTheDocument()
-                })
-            }
-        )
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-actions-0')).toBeInTheDocument()
+            })
+        })
 
-        it.each(['pill', 'icon'] as const)(
-            '%s variant: pressing Tab in the search input does not switch category',
-            async (variant) => {
-                setVariant(variant)
-                renderFilter({
-                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
-                })
+        it('pill variant: pressing Tab in the search input does not switch category', async () => {
+            setVariant('pill')
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+            })
 
-                await waitFor(() => {
-                    expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
-                })
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+            })
 
-                const trigger = screen.getByTestId(`taxonomic-category-dropdown-trigger-${variant}`)
-                expect(trigger).toHaveAttribute('aria-label', expect.stringContaining('Events'))
+            const trigger = screen.getByTestId('taxonomic-category-dropdown-trigger-pill')
+            expect(trigger).toHaveAttribute('aria-label', expect.stringContaining('Events'))
 
-                const input = screen.getByTestId('taxonomic-filter-searchfield') as HTMLInputElement
-                input.focus()
-                await userEvent.keyboard('{Tab}')
+            const input = screen.getByTestId('taxonomic-filter-searchfield') as HTMLInputElement
+            input.focus()
+            await userEvent.keyboard('{Tab}')
 
-                expect(screen.getByTestId(`taxonomic-category-dropdown-trigger-${variant}`)).toHaveAttribute(
-                    'aria-label',
-                    expect.stringContaining('Events')
-                )
-            }
-        )
+            expect(screen.getByTestId('taxonomic-category-dropdown-trigger-pill')).toHaveAttribute(
+                'aria-label',
+                expect.stringContaining('Events')
+            )
+        })
     })
 
     describe('log attribute value-match indicator', () => {

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -111,7 +111,7 @@ export interface TaxonomicFilterProps {
     /** Override the "Suggested filters" tab label for specific contexts. */
     suggestedFiltersLabel?: string
     /** Hide the built-in search input when an external input drives the search query.
-     *  Note: the pill/icon category-dropdown affordance lives inside the built-in input,
+     *  Note: the pill category-dropdown affordance lives inside the built-in input,
      *  so when you hide it the host is responsible for rendering `CategoryDropdown` itself
      *  (e.g. as the suffix of its external input, under a shared `taxonomicFilterLogicKey`). */
     hideSearchInput?: boolean
@@ -324,7 +324,7 @@ export type TaxonomicDefinitionTypes =
     | MaxContextTaxonomicFilterOption
     | QuickFilterItem
 
-export const CATEGORY_DROPDOWN_VARIANTS = ['control', 'pill', 'icon'] as const
+export const CATEGORY_DROPDOWN_VARIANTS = ['control', 'pill'] as const
 
 export type CategoryDropdownVariant = (typeof CATEGORY_DROPDOWN_VARIANTS)[number]
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -472,7 +472,7 @@ export const FEATURE_FLAGS = {
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASK_TOOL: 'phai-task-tool', // owner: @kappa90 #team-posthog-ai
     TASKS: 'tasks', // owner: #team-llm-analytics
-    TAXONOMIC_FILTER_CATEGORY_DROPDOWN: 'taxonomic-filter-category-dropdown', // owner: @pauldambra #team-product-analytics multivariate=control,pill,icon
+    TAXONOMIC_FILTER_CATEGORY_DROPDOWN: 'taxonomic-filter-category-dropdown', // owner: @pauldambra #team-product-analytics multivariate=control,pill
     TOGGLE_PROPERTY_ARRAYS: 'toggle-property-arrays', // owner: @arthurdedeus #team-customer-analytics
     TRACING: 'tracing', // owner: #team-apm (@jonmcwest, @frankh)
     TRAFFIC_TYPE_VIRTUAL_PROPERTIES: 'traffic-type-virtual-properties', // owner: #team-web-analytics


### PR DESCRIPTION
## Problem

The `taxonomic-filter-category-dropdown` experiment is keeping `control` and `pill` only — the `icon` variant has been removed from the experiment configuration.

## Changes

- `frontend/src/lib/constants.tsx` — flag comment now reads `multivariate=control,pill`
- `frontend/src/lib/components/TaxonomicFilter/types.ts` — `CATEGORY_DROPDOWN_VARIANTS` reduced to `['control', 'pill']`
- `frontend/src/lib/components/TaxonomicFilter/CategoryDropdown.tsx` — drop the dead icon-only branch and the `IconFilter` import
- `frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx` — remove the `CategoryDropdownIcon` story
- `*.test.tsx` — de-parameterize the `it.each(['pill', 'icon'])` blocks down to single `it('pill ...')` cases

No behavior change for users on `control` or `pill` — only dead-code/test removal.

## How did you test this code?

I'm an agent. I did not run the affected jest test files end-to-end (the local jest run failed with a pre-existing `@posthog/hogvm` resolution issue unrelated to this change). I relied on type narrowing plus a focused grep across the codebase to confirm there are no remaining references to an `'icon'` variant for this flag. CI will run the jest suites.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) on the user's local machine.
- Human prompt: \"remove the icon variant from the taxonomic-filter-category-dropdown feature flag. we just want to keep control and pill — i've already updated the experiment, we can just clean up the code\".
- Decisions:
  - Kept the `CategoryDropdown` `variant` prop and the `posthog.capture('taxonomic filter category dropdown opened', { variant })` call rather than hardcoding `'pill'`. The variant is still meaningful as an exposure-tagged event property, and keeping the prop avoids churn if a third variant is reintroduced.
  - Collapsed `it.each(['pill', 'icon'])` blocks into single `it('pill ...')` tests rather than keeping a 1-element parameterization.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*