### PR TITLE
fix(flags): surface full error chain from AWS SDK errors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
 name = "common-s3"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/rust/common/s3/Cargo.toml
+++ b/rust/common/s3/Cargo.toml
@@ -16,5 +16,6 @@ tokio = { workspace = true }
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 aws-config = { workspace = true }
 common-s3 = { path = ".", features = ["mock-client"] }

--- a/rust/common/s3/src/lib.rs
+++ b/rust/common/s3/src/lib.rs
@@ -23,8 +23,29 @@ pub enum S3Error {
 
 impl From<aws_sdk_s3::Error> for S3Error {
     fn from(err: aws_sdk_s3::Error) -> Self {
-        S3Error::OperationFailed(err.to_string())
+        S3Error::OperationFailed(format_with_source_chain(&err))
     }
+}
+
+/// Walk an error's source chain and join each layer with ": ".
+///
+/// AWS SDK errors implement `Display` tersely (e.g. `SdkError`'s top-level message is
+/// "service error" / "dispatch failure"). The actionable detail — HTTP status, error code,
+/// signature/permission failure — only lives in the `source()` chain. Without walking
+/// it, every `OperationFailed` collapses to the same uninformative string.
+fn format_with_source_chain(err: &dyn std::error::Error) -> String {
+    let mut msg = err.to_string();
+    let mut src = err.source();
+    while let Some(e) = src {
+        msg.push_str(": ");
+        msg.push_str(&e.to_string());
+        src = e.source();
+    }
+    msg
+}
+
+fn op_failed(prefix: &str, err: &dyn std::error::Error) -> S3Error {
+    S3Error::OperationFailed(format!("{prefix}: {}", format_with_source_chain(err)))
 }
 
 impl From<std::string::FromUtf8Error> for S3Error {
@@ -70,20 +91,22 @@ impl S3Client for S3Impl {
             .send()
             .await
             .map_err(|e| {
-                let error_message = format!("Failed to get object from S3: {e}");
-                if let aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_) =
-                    e.into_service_error()
-                {
+                let svc_err = e.into_service_error();
+                if matches!(
+                    svc_err,
+                    aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_)
+                ) {
                     S3Error::NotFound(key.to_string())
                 } else {
-                    S3Error::OperationFailed(error_message)
+                    op_failed("Failed to get object from S3", &svc_err)
                 }
             })?;
 
-        let body_bytes =
-            get_object_output.body.collect().await.map_err(|e| {
-                S3Error::OperationFailed(format!("Failed to read S3 object body: {e}"))
-            })?;
+        let body_bytes = get_object_output
+            .body
+            .collect()
+            .await
+            .map_err(|e| op_failed("Failed to read S3 object body", &e))?;
 
         let body_str = String::from_utf8(body_bytes.to_vec())
             .map_err(|e| S3Error::ParseError(format!("S3 object body is not valid UTF-8: {e}")))?;
@@ -98,7 +121,7 @@ impl S3Client for S3Impl {
             .body(ByteStream::from(value.to_owned().into_bytes()))
             .send()
             .await
-            .map_err(|e| S3Error::OperationFailed(format!("Failed to put object to S3: {e}")))?;
+            .map_err(|e| op_failed("Failed to put object to S3", &e))?;
         Ok(())
     }
 
@@ -109,9 +132,7 @@ impl S3Client for S3Impl {
             .key(key)
             .send()
             .await
-            .map_err(|e| {
-                S3Error::OperationFailed(format!("Failed to delete object from S3: {e}"))
-            })?;
+            .map_err(|e| op_failed("Failed to delete object from S3", &e))?;
         Ok(())
     }
 }
@@ -128,5 +149,24 @@ mod tests {
         let utf8_error = String::from_utf8(vec![0, 159, 146, 150]).unwrap_err();
         let s3_error = S3Error::from(utf8_error);
         assert!(matches!(s3_error, S3Error::ParseError(_)));
+    }
+
+    #[test]
+    fn test_format_with_source_chain_single_layer() {
+        let err = anyhow::anyhow!("top");
+        assert_eq!(format_with_source_chain(err.as_ref()), "top");
+    }
+
+    #[test]
+    fn test_format_with_source_chain_walks_full_chain() {
+        // anyhow's `.context()` wraps the previous error as `source`, so the outermost
+        // context becomes the head of the chain — the same shape AWS SDK errors produce.
+        let err = anyhow::anyhow!("AccessDenied: User is not authorized")
+            .context("PutObjectError")
+            .context("service error");
+        assert_eq!(
+            format_with_source_chain(err.as_ref()),
+            "service error: PutObjectError: AccessDenied: User is not authorized"
+        );
     }
 }

--- a/rust/feature-flags/src/bin/warm-flags-cache.rs
+++ b/rust/feature-flags/src/bin/warm-flags-cache.rs
@@ -277,10 +277,7 @@ async fn run_warm(
         join_set.spawn(async move {
             warm_team(pg, &writer, team_id, ttl_seconds)
                 .await
-                // Debug format walks Box<dyn Error>'s nested chain so SDK errors
-                // (e.g. an S3 PutObject 403) surface their code + message instead
-                // of being collapsed to a top-level "service error" string.
-                .map_err(|e| (team_id, format!("{e:?}")))
+                .map_err(|e| (team_id, e.to_string()))
         });
     }
 


### PR DESCRIPTION
## Problem

When `warm-flags-cache` failed to write to S3, the only thing it logged was `"S3 operation failed: service error"`. The actionable details (HTTP status, error code, auth message) live inside the AWS SDK error's `source()` chain, and the SDK's `Display` impl never walks them. Every operational failure collapsed to the same uninformative string, so logs offered no clue what actually went wrong.

## Changes

Walk the error source chain at the boundary where AWS SDK errors become `S3Error`. The flattened string is stored in `S3Error::OperationFailed(String)`, so every consumer of `common-s3` gets the full context for free.

Two helpers added to `common-s3`:

- `format_with_source_chain(err)` walks `err.source()` and joins each layer with `": "`.
- `op_failed(prefix, err)` wraps the result in `S3Error::OperationFailed` with a leading prefix.

The four `map_err` sites in `S3Impl` now use `op_failed`. The `From<aws_sdk_s3::Error>` impl uses `format_with_source_chain`. In `get_string`, formatting is deferred into the `else` branch so the `NotFound` hot path does not allocate.

In `warm-flags-cache`, `format!("{e:?}")` is replaced with `e.to_string()`. The previous Debug-format trick relied on a misleading comment claiming Debug walks the chain; it does not, since `S3Error::OperationFailed` wraps a `String` and not a nested error. With the chain pre-baked at the boundary, the plain `Display` impl now produces the full message.

## How did you test this code?

Unit tests for `format_with_source_chain`:

- Single-layer error returns the message verbatim.
- Multi-layer error built with `anyhow!(...).context(...).context(...)` returns layers joined with `": "`.

`cargo test -p common-s3` passes. `cargo clippy --all-targets --all-features -- -D warnings` is clean.

## Publish to changelog?

no