### PR TITLE
chore(workflows): drop hogflowbatchjob.scheduled_at column

### DIFF
--- a/products/workflows/backend/migrations/0006_drop_hogflowbatchjob_scheduled_at_column.py
+++ b/products/workflows/backend/migrations/0006_drop_hogflowbatchjob_scheduled_at_column.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflows", "0005_remove_hogflowbatchjob_scheduled_at"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[],
+            database_operations=[
+                migrations.RunSQL(
+                    sql='ALTER TABLE "workflows_hogflowbatchjob" DROP COLUMN IF EXISTS "scheduled_at"',
+                    reverse_sql='ALTER TABLE "workflows_hogflowbatchjob" ADD COLUMN "scheduled_at" timestamptz NULL',
+                ),
+            ],
+        ),
+    ]

--- a/products/workflows/backend/migrations/max_migration.txt
+++ b/products/workflows/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0005_remove_hogflowbatchjob_scheduled_at
+0006_drop_hogflowbatchjob_scheduled_at_column


### PR DESCRIPTION
## Problem

Phase 2 of the multi-phase column drop for `HogFlowBatchJob.scheduled_at`. Phase 1 (#54926) removed the field from Django's model state in PR via `SeparateDatabaseAndState`. The column is now unused but still exists in PostgreSQL.

## Changes

Drops the `scheduled_at` column from `workflows_hogflowbatchjob` via `RunSQL` (with reverse SQL for rollback).

## How did you test this code?

Verified locally that migration applies cleanly

## Publish to changelog?

No