### PR TITLE
fix(web-analytics): routing to page-reports works

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2567,7 +2567,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
         return {
             '/web': toAction,
-            '/web/page-reports': toAction,
             '/web/bots': (_, searchParams) => {
                 toAction({ productTab: ProductTab.BOT_ANALYTICS }, searchParams)
             },


### PR DESCRIPTION
## Problem

Navigating directly to `/web/page-reports` (e.g. via the URL bar, a deep link, or the browser back button) immediately redirected to `/web`, making the Page reports tab unreachable by URL. The tab could only be opened by clicking it in the web analytics nav.

## Changes

Removed the redundant `'/web/page-reports': toAction` entry in `webAnalyticsLogic.tsx`'s `urlToAction` map. That literal route called `toAction` without passing a `productTab`, which defaulted to `ProductTab.ANALYTICS` — the subsequent `setProductTab(ANALYTICS)` then triggered `actionToUrl` to rewrite the URL back to `/web`.

The catch-all `'/web/:productTab': toAction` already handles `/web/page-reports` correctly by populating `productTab` from the path param (`ProductTab.PAGE_REPORTS = 'page-reports'`), the same way `/web/web-vitals` works today.

## How did you test this code?

Manually reviewed in local dev.

<img width="844" height="486" alt="image" src="https://github.com/user-attachments/assets/ac91301f-8a92-4dc3-b7b0-d4de48ebdc86" />


## Publish to changelog?

no

## Docs update

No docs changes required.

## 🤖 Agent context

- Agent: PostHog Code (Claude Opus 4.7)
- Human prompt: "In the web vitals dashboard, if I navigate to Page reports `/web/page-reports` it immediately re-directs to `/web`"
- Investigation: Traced the redirect to `urlToAction` in `frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx`. The literal `/web/page-reports` route handler was calling `toAction` with no arguments, causing the `productTab` parameter to fall through to its `ProductTab.ANALYTICS` default. The resulting state change re-triggered `actionToUrl`, which produced `basePath = '/web'` and replaced the URL.
- Decision: Two viable fixes — (a) delete the redundant entry and let the catch-all `/web/:productTab` handle it, or (b) add an explicit handler that passes `{ productTab: ProductTab.PAGE_REPORTS }` (mirroring the `/web/bots` pattern). Chose (a) because the catch-all already handles `/web/web-vitals` the same way — no reason to special-case page reports.