### PR TITLE
chore(hog-charts): add TimeSeriesLineChart wrapper (stage 1)

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -512,6 +512,10 @@ snapshots:
         hash: v1.k794b7964.8f27aa8ee4161d4041693a5549046f0e348aab5fdccc466ea461d6a0f5cf97e2.KEpUtlvBURMPzv1Vyq9Pvf8i_sDKoF3t7fZO8Ed1yPs
     components-hogcharts-referenceline--vertical-reference-lines--light:
         hash: v1.k794b7964.c5c09ab055b1b0fde7a5d73279e6a1adba9cc4165d0883ea8c641d4cd68ebf2b.hb7hZ9GBhWL6oRE5jtOZuUEer6xZ5dTyjpH0qB4Dfpk
+    components-hogcharts-timeserieslinechart--basic--dark:
+        hash: v1.k794b7964.529535e435c93c8f004cdba8f2ba29681dd679eb9bfbaff745a5f00c3b424ffd.2Kq3-2B9F2VNlkrFY-dge3vntnfrudonJ-Lle1s8m5E
+    components-hogcharts-timeserieslinechart--basic--light:
+        hash: v1.k794b7964.3a097fd7390b5a54fcf6e20a1769cc9058b66f4d040ed58748d0d4dc55c8788b.zqLqP936uYDq025ot6wQL3TxRVnq4UzQAtiS92DFZp8
     components-hogcharts-valuelabels--cross-series-overlap-removal--dark:
         hash: v1.k794b7964.b766f038277710789aefeabc721df0c662a10aa672b24e14f7e68349f88f396a.Jef_dCFf6j8X_7hXhsuDQa6KMpkq-BS1akkcNUH46MU
     components-hogcharts-valuelabels--cross-series-overlap-removal--light:

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -2,20 +2,7 @@
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { TimeSeriesLineChart } from './timeseries/TimeSeriesLineChart'
-export type {
-    TimeSeriesAnnotation,
-    TimeSeriesAnomalies,
-    TimeSeriesConfidenceInterval,
-    TimeSeriesGoalLine,
-    TimeSeriesInProgress,
-    TimeSeriesLineChartProps,
-    TimeSeriesMovingAverage,
-    TimeSeriesThresholds,
-    TimeSeriesTrendLines,
-    TimeSeriesValueLabels,
-    TimeSeriesXAxis,
-    TimeSeriesYAxis,
-} from './timeseries/TimeSeriesLineChart'
+export type { TimeSeriesLineChartProps, TimeSeriesXAxis, TimeSeriesYAxis } from './timeseries/TimeSeriesLineChart'
 
 // Base chart (for building new chart types)
 export { Chart } from './core/Chart'

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -2,7 +2,7 @@
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { TimeSeriesLineChart } from './timeseries/TimeSeriesLineChart'
-export type { TimeSeriesLineChartProps, TimeSeriesXAxis, TimeSeriesYAxis } from './timeseries/TimeSeriesLineChart'
+export type { TimeSeriesLineChartConfig, TimeSeriesLineChartProps } from './timeseries/TimeSeriesLineChart'
 
 // Base chart (for building new chart types)
 export { Chart } from './core/Chart'

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -1,6 +1,21 @@
 // Components
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
+export { TimeSeriesLineChart } from './timeseries/TimeSeriesLineChart'
+export type {
+    TimeSeriesAnnotation,
+    TimeSeriesAnomalies,
+    TimeSeriesConfidenceInterval,
+    TimeSeriesGoalLine,
+    TimeSeriesInProgress,
+    TimeSeriesLineChartProps,
+    TimeSeriesMovingAverage,
+    TimeSeriesThresholds,
+    TimeSeriesTrendLines,
+    TimeSeriesValueLabels,
+    TimeSeriesXAxis,
+    TimeSeriesYAxis,
+} from './timeseries/TimeSeriesLineChart'
 
 // Base chart (for building new chart types)
 export { Chart } from './core/Chart'

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.stories.tsx
@@ -3,14 +3,14 @@ import { Meta, StoryObj } from '@storybook/react'
 import { TimeSeriesLineChart } from 'lib/hog-charts'
 import type { Series } from 'lib/hog-charts'
 
-import { useReactiveTheme } from '../story-helpers'
+import { Stage, useReactiveTheme } from '../story-helpers'
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const SERIES: Series[] = [
-    { key: 'visits', label: 'Visits', color: '', data: [20, 35, 28, 60, 45, 70, 52] },
-    { key: 'signups', label: 'Sign-ups', color: '', data: [4, 8, 6, 14, 11, 19, 13] },
-    { key: 'activations', label: 'Activations', color: '', data: [2, 5, 4, 9, 7, 12, 8] },
+    { key: 'visits', label: 'Visits', data: [20, 35, 28, 60, 45, 70, 52] },
+    { key: 'signups', label: 'Sign-ups', data: [4, 8, 6, 14, 11, 19, 13] },
+    { key: 'activations', label: 'Activations', data: [2, 5, 4, 9, 7, 12, 8] },
 ]
 
 const meta: Meta = {
@@ -25,14 +25,14 @@ export const Basic: Story = {
     render: () => {
         const theme = useReactiveTheme()
         return (
-            <TimeSeriesLineChart
-                series={SERIES}
-                xAxis={{ labels: DAYS }}
-                yAxis={{ showGrid: true }}
-                theme={theme}
-                width={480}
-                height={280}
-            />
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    xAxis={{ labels: DAYS }}
+                    yAxis={{ showGrid: true }}
+                    theme={theme}
+                />
+            </Stage>
         )
     },
 }

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { TimeSeriesLineChart } from 'lib/hog-charts'
+import type { Series } from 'lib/hog-charts'
+
+import { useReactiveTheme } from '../story-helpers'
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', color: '', data: [20, 35, 28, 60, 45, 70, 52] },
+    { key: 'signups', label: 'Sign-ups', color: '', data: [4, 8, 6, 14, 11, 19, 13] },
+    { key: 'activations', label: 'Activations', color: '', data: [2, 5, 4, 9, 7, 12, 8] },
+]
+
+const meta: Meta = {
+    title: 'Components/HogCharts/TimeSeriesLineChart',
+    parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const Basic: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <TimeSeriesLineChart
+                series={SERIES}
+                xAxis={{ labels: DAYS }}
+                yAxis={{ showGrid: true }}
+                theme={theme}
+                width={480}
+                height={280}
+            />
+        )
+    },
+}

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.stories.tsx
@@ -28,9 +28,9 @@ export const Basic: Story = {
             <Stage>
                 <TimeSeriesLineChart
                     series={SERIES}
-                    xAxis={{ labels: DAYS }}
-                    yAxis={{ showGrid: true }}
+                    labels={DAYS}
                     theme={theme}
+                    config={{ yAxis: { showGrid: true } }}
                 />
             </Stage>
         )

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import type { LineChartProps } from '../charts/LineChart'
 import type { ChartTheme, Series } from '../core/types'
@@ -19,52 +19,24 @@ const LABELS = ['Mon', 'Tue', 'Wed']
 const SERIES: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3] }]
 
 describe('TimeSeriesLineChart', () => {
-    afterEach(() => cleanup())
-
-    it('renders without crashing', () => {
-        const { getByTestId } = render(<TimeSeriesLineChart series={SERIES} xAxis={{ labels: LABELS }} theme={THEME} />)
-        expect(getByTestId('line-chart-mock')).toBeTruthy()
-    })
-
-    it('passes series and labels through to the underlying LineChart', () => {
-        const series: Series[] = [
-            { key: 'a', label: 'A', data: [1, 2, 3] },
-            { key: 'b', label: 'B', data: [4, 5, 6] },
-        ]
+    it('translates xAxis and yAxis fields onto LineChartConfig', () => {
+        const xTickFormatter = (v: string): string => `x:${v}`
+        const yTickFormatter = (v: number): string => `y:${v}`
         render(
             <TimeSeriesLineChart
-                series={series}
-                xAxis={{ labels: LABELS }}
-                yAxis={{ scale: 'log', showGrid: true }}
-                theme={THEME}
-            />
-        )
-        expect(lineChartSpy).toHaveBeenCalledTimes(1)
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.series).toBe(series)
-        expect(props.labels).toBe(LABELS)
-        expect(props.theme).toBe(THEME)
-        expect(props.config?.yScaleType).toBe('log')
-        expect(props.config?.showGrid).toBe(true)
-    })
-
-    it.each<[string, number | string, number | string]>([
-        ['numeric pixels', 640, 320],
-        ['percentage / px mix', '75%', 200],
-    ])('respects width/height (%s)', (_name, width, height) => {
-        const { container } = render(
-            <TimeSeriesLineChart
                 series={SERIES}
-                xAxis={{ labels: LABELS }}
+                xAxis={{ labels: LABELS, tickFormatter: xTickFormatter, hide: true }}
+                yAxis={{ scale: 'log', tickFormatter: yTickFormatter, hide: true, showGrid: true }}
                 theme={THEME}
-                width={width}
-                height={height}
             />
         )
-        const wrapper = container.firstElementChild as HTMLDivElement
-        const expectedWidth = typeof width === 'number' ? `${width}px` : width
-        const expectedHeight = typeof height === 'number' ? `${height}px` : height
-        expect(wrapper.style.width).toBe(expectedWidth)
-        expect(wrapper.style.height).toBe(expectedHeight)
+        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+        expect(props.labels).toBe(LABELS)
+        expect(props.config?.yScaleType).toBe('log')
+        expect(props.config?.xTickFormatter).toBe(xTickFormatter)
+        expect(props.config?.yTickFormatter).toBe(yTickFormatter)
+        expect(props.config?.hideXAxis).toBe(true)
+        expect(props.config?.hideYAxis).toBe(true)
+        expect(props.config?.showGrid).toBe(true)
     })
 })

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx
@@ -19,15 +19,18 @@ const LABELS = ['Mon', 'Tue', 'Wed']
 const SERIES: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3] }]
 
 describe('TimeSeriesLineChart', () => {
-    it('translates xAxis and yAxis fields onto LineChartConfig', () => {
+    it('translates config.xAxis and config.yAxis fields onto LineChartConfig', () => {
         const xTickFormatter = (v: string): string => `x:${v}`
         const yTickFormatter = (v: number): string => `y:${v}`
         render(
             <TimeSeriesLineChart
                 series={SERIES}
-                xAxis={{ labels: LABELS, tickFormatter: xTickFormatter, hide: true }}
-                yAxis={{ scale: 'log', tickFormatter: yTickFormatter, hide: true, showGrid: true }}
+                labels={LABELS}
                 theme={THEME}
+                config={{
+                    xAxis: { tickFormatter: xTickFormatter, hide: true },
+                    yAxis: { scale: 'log', tickFormatter: yTickFormatter, hide: true, showGrid: true },
+                }}
             />
         )
         const props = lineChartSpy.mock.calls[0][0] as LineChartProps

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render } from '@testing-library/react'
+
+import type { LineChartProps } from '../charts/LineChart'
+import type { ChartTheme, Series } from '../core/types'
+
+const lineChartSpy = jest.fn()
+
+jest.mock('../charts/LineChart', () => ({
+    LineChart: (props: LineChartProps) => {
+        lineChartSpy(props)
+        return <div data-attr="line-chart-mock" />
+    },
+}))
+
+import { TimeSeriesLineChart } from './TimeSeriesLineChart'
+
+const THEME: ChartTheme = { colors: ['#111', '#222', '#333'], backgroundColor: '#ffffff' }
+const LABELS = ['Mon', 'Tue', 'Wed']
+const SERIES: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3] }]
+
+describe('TimeSeriesLineChart', () => {
+    afterEach(() => cleanup())
+
+    it('renders without crashing', () => {
+        const { getByTestId } = render(<TimeSeriesLineChart series={SERIES} xAxis={{ labels: LABELS }} theme={THEME} />)
+        expect(getByTestId('line-chart-mock')).toBeTruthy()
+    })
+
+    it('passes series and labels through to the underlying LineChart', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [1, 2, 3] },
+            { key: 'b', label: 'B', data: [4, 5, 6] },
+        ]
+        render(
+            <TimeSeriesLineChart
+                series={series}
+                xAxis={{ labels: LABELS }}
+                yAxis={{ scale: 'log', showGrid: true }}
+                theme={THEME}
+            />
+        )
+        expect(lineChartSpy).toHaveBeenCalledTimes(1)
+        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+        expect(props.series).toBe(series)
+        expect(props.labels).toBe(LABELS)
+        expect(props.theme).toBe(THEME)
+        expect(props.config?.yScaleType).toBe('log')
+        expect(props.config?.showGrid).toBe(true)
+    })
+
+    it.each<[string, number | string, number | string]>([
+        ['numeric pixels', 640, 320],
+        ['percentage / px mix', '75%', 200],
+    ])('respects width/height (%s)', (_name, width, height) => {
+        const { container } = render(
+            <TimeSeriesLineChart
+                series={SERIES}
+                xAxis={{ labels: LABELS }}
+                theme={THEME}
+                width={width}
+                height={height}
+            />
+        )
+        const wrapper = container.firstElementChild as HTMLDivElement
+        const expectedWidth = typeof width === 'number' ? `${width}px` : width
+        const expectedHeight = typeof height === 'number' ? `${height}px` : height
+        expect(wrapper.style.width).toBe(expectedWidth)
+        expect(wrapper.style.height).toBe(expectedHeight)
+    })
+})

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.tsx
@@ -1,124 +1,33 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { LineChart } from '../charts/LineChart'
 import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../core/types'
 
-/** X-axis configuration. The labels array is the only stage-1 input the chart actually
- *  consumes — the rest is reserved for later stages so the public shape locks early. */
 export interface TimeSeriesXAxis {
     /** Categorical labels — typically pre-formatted timestamps. Length must match each series.data. */
     labels: string[]
-    /** Optional render-time formatter for each tick. Return null to skip a tick. */
     tickFormatter?: (value: string, index: number) => string | null
-    /** Hide x-axis labels and reduce bottom margin. */
     hide?: boolean
 }
 
-/** Y-axis configuration. */
 export interface TimeSeriesYAxis {
-    /** `linear` (default) or `log`. Log clamps to a small positive epsilon to avoid log(0). */
+    /** `linear` (default) or `log`. Log falls back to a linear scale when no positive values exist. */
     scale?: 'linear' | 'log'
-    /** Optional formatter for y-axis tick labels. */
     tickFormatter?: (value: number) => string
-    /** Hide y-axis labels and reduce left margin. */
     hide?: boolean
-    /** Render horizontal grid lines at y-tick positions. */
     showGrid?: boolean
 }
 
-// TODO: stage 2 — render in-progress trailing segments (dashed tail, projected bucket).
-export interface TimeSeriesInProgress {
-    fromIndex?: number
-}
-// TODO: stage 3 — confidence-interval bands attached to a series by key.
-export interface TimeSeriesConfidenceInterval {
-    seriesKey: string
-    upper: number[]
-    lower: number[]
-}
-// TODO: stage 4 — moving-average overlay computed from the underlying series.
-export interface TimeSeriesMovingAverage {
-    seriesKey: string
-    window: number
-}
-// TODO: stage 5 — least-squares trend lines for the listed series.
-export interface TimeSeriesTrendLines {
-    seriesKeys: string[]
-}
-// TODO: stage 6 — horizontal goal lines.
-export interface TimeSeriesGoalLine {
-    value: number
-    label?: string
-}
-// TODO: stage 7 — colored threshold bands for upper/lower bounds.
-export interface TimeSeriesThresholds {
-    upper?: number
-    lower?: number
-}
-// TODO: stage 8 — anomaly markers attached to specific (seriesKey, dataIndex) points.
-export interface TimeSeriesAnomalies {
-    points: { seriesKey: string; dataIndex: number; severity?: 'low' | 'medium' | 'high' }[]
-}
-// TODO: stage 9 — vertical annotations at specific x-axis labels.
-export interface TimeSeriesAnnotation {
-    label: string
-    at: string
-    color?: string
-}
-// TODO: stage 10 — value labels above each data point.
-export interface TimeSeriesValueLabels {
-    enabled?: boolean
-    formatter?: (value: number) => string
-}
-
 export interface TimeSeriesLineChartProps<Meta = unknown> {
-    /** Time-ordered series. Each `data` entry must align with `xAxis.labels` by index. */
     series: Series<Meta>[]
-    /** X-axis configuration. */
     xAxis: TimeSeriesXAxis
-    /** Y-axis configuration. Defaults to a linear primary axis. */
     yAxis?: TimeSeriesYAxis
-    /** Theme colors. Build with `buildTheme()` so the wrapper itself stays PostHog-free. */
     theme: ChartTheme
-    /** Wrapper width applied to the host container. */
-    width?: number | string
-    /** Wrapper height applied to the host container. */
-    height?: number | string
-    /** `data-attr` applied to the wrapper for product-level test selectors. */
+    /** `data-attr` applied to the chart wrapper for product-level test selectors. */
     dataAttr?: string
-    /** Class applied to the wrapper. */
     className?: string
-
-    // The fields below intentionally lock the public shape early so future stages are
-    // strictly additive. They are not consumed in stage 1 — passing them is a no-op.
-
-    // TODO: stage 2
-    inProgress?: TimeSeriesInProgress
-    // TODO: stage 3
-    confidenceIntervals?: TimeSeriesConfidenceInterval[]
-    // TODO: stage 4
-    movingAverage?: TimeSeriesMovingAverage
-    // TODO: stage 5
-    trendLines?: TimeSeriesTrendLines
-    // TODO: stage 6
-    goalLines?: TimeSeriesGoalLine[]
-    // TODO: stage 7
-    thresholds?: TimeSeriesThresholds
-    // TODO: stage 8
-    anomalies?: TimeSeriesAnomalies
-    // TODO: stage 9
-    annotations?: TimeSeriesAnnotation[]
-    // TODO: stage 10
-    valueLabels?: TimeSeriesValueLabels
-    // TODO: stage 11
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
-    // TODO: stage 11
     onPointClick?: (data: PointClickData<Meta>) => void
-}
-
-const WRAPPER_BASE_STYLE: React.CSSProperties = {
-    display: 'flex',
-    flexDirection: 'column',
 }
 
 export function TimeSeriesLineChart<Meta = unknown>({
@@ -126,33 +35,30 @@ export function TimeSeriesLineChart<Meta = unknown>({
     xAxis,
     yAxis,
     theme,
-    width = '100%',
-    height = 280,
     dataAttr,
     className,
+    tooltip,
+    onPointClick,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
-    const config = useMemo<LineChartConfig>(
-        () => ({
-            yScaleType: yAxis?.scale,
-            xTickFormatter: xAxis.tickFormatter,
-            yTickFormatter: yAxis?.tickFormatter,
-            hideXAxis: xAxis.hide,
-            hideYAxis: yAxis?.hide,
-            showGrid: yAxis?.showGrid,
-        }),
-        [xAxis.tickFormatter, xAxis.hide, yAxis?.scale, yAxis?.tickFormatter, yAxis?.hide, yAxis?.showGrid]
-    )
-
-    const wrapperStyle = useMemo<React.CSSProperties>(() => ({ ...WRAPPER_BASE_STYLE, width, height }), [width, height])
+    const config: LineChartConfig = {
+        yScaleType: yAxis?.scale,
+        xTickFormatter: xAxis.tickFormatter,
+        yTickFormatter: yAxis?.tickFormatter,
+        hideXAxis: xAxis.hide,
+        hideYAxis: yAxis?.hide,
+        showGrid: yAxis?.showGrid,
+    }
 
     return (
-        <div
-            data-attr={dataAttr}
+        <LineChart
+            series={series}
+            labels={xAxis.labels}
+            config={config}
+            theme={theme}
+            tooltip={tooltip}
+            onPointClick={onPointClick}
             className={className}
-            // eslint-disable-next-line react/forbid-dom-props
-            style={wrapperStyle}
-        >
-            <LineChart series={series} labels={xAxis.labels} config={config} theme={theme} />
-        </div>
+            dataAttr={dataAttr}
+        />
     )
 }

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo } from 'react'
+
+import { LineChart } from '../charts/LineChart'
+import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../core/types'
+
+/** X-axis configuration. The labels array is the only stage-1 input the chart actually
+ *  consumes — the rest is reserved for later stages so the public shape locks early. */
+export interface TimeSeriesXAxis {
+    /** Categorical labels — typically pre-formatted timestamps. Length must match each series.data. */
+    labels: string[]
+    /** Optional render-time formatter for each tick. Return null to skip a tick. */
+    tickFormatter?: (value: string, index: number) => string | null
+    /** Hide x-axis labels and reduce bottom margin. */
+    hide?: boolean
+}
+
+/** Y-axis configuration. */
+export interface TimeSeriesYAxis {
+    /** `linear` (default) or `log`. Log clamps to a small positive epsilon to avoid log(0). */
+    scale?: 'linear' | 'log'
+    /** Optional formatter for y-axis tick labels. */
+    tickFormatter?: (value: number) => string
+    /** Hide y-axis labels and reduce left margin. */
+    hide?: boolean
+    /** Render horizontal grid lines at y-tick positions. */
+    showGrid?: boolean
+}
+
+// TODO: stage 2 — render in-progress trailing segments (dashed tail, projected bucket).
+export interface TimeSeriesInProgress {
+    fromIndex?: number
+}
+// TODO: stage 3 — confidence-interval bands attached to a series by key.
+export interface TimeSeriesConfidenceInterval {
+    seriesKey: string
+    upper: number[]
+    lower: number[]
+}
+// TODO: stage 4 — moving-average overlay computed from the underlying series.
+export interface TimeSeriesMovingAverage {
+    seriesKey: string
+    window: number
+}
+// TODO: stage 5 — least-squares trend lines for the listed series.
+export interface TimeSeriesTrendLines {
+    seriesKeys: string[]
+}
+// TODO: stage 6 — horizontal goal lines.
+export interface TimeSeriesGoalLine {
+    value: number
+    label?: string
+}
+// TODO: stage 7 — colored threshold bands for upper/lower bounds.
+export interface TimeSeriesThresholds {
+    upper?: number
+    lower?: number
+}
+// TODO: stage 8 — anomaly markers attached to specific (seriesKey, dataIndex) points.
+export interface TimeSeriesAnomalies {
+    points: { seriesKey: string; dataIndex: number; severity?: 'low' | 'medium' | 'high' }[]
+}
+// TODO: stage 9 — vertical annotations at specific x-axis labels.
+export interface TimeSeriesAnnotation {
+    label: string
+    at: string
+    color?: string
+}
+// TODO: stage 10 — value labels above each data point.
+export interface TimeSeriesValueLabels {
+    enabled?: boolean
+    formatter?: (value: number) => string
+}
+
+export interface TimeSeriesLineChartProps<Meta = unknown> {
+    /** Time-ordered series. Each `data` entry must align with `xAxis.labels` by index. */
+    series: Series<Meta>[]
+    /** X-axis configuration. */
+    xAxis: TimeSeriesXAxis
+    /** Y-axis configuration. Defaults to a linear primary axis. */
+    yAxis?: TimeSeriesYAxis
+    /** Theme colors. Build with `buildTheme()` so the wrapper itself stays PostHog-free. */
+    theme: ChartTheme
+    /** Wrapper width applied to the host container. */
+    width?: number | string
+    /** Wrapper height applied to the host container. */
+    height?: number | string
+    /** `data-attr` applied to the wrapper for product-level test selectors. */
+    dataAttr?: string
+    /** Class applied to the wrapper. */
+    className?: string
+
+    // The fields below intentionally lock the public shape early so future stages are
+    // strictly additive. They are not consumed in stage 1 — passing them is a no-op.
+
+    // TODO: stage 2
+    inProgress?: TimeSeriesInProgress
+    // TODO: stage 3
+    confidenceIntervals?: TimeSeriesConfidenceInterval[]
+    // TODO: stage 4
+    movingAverage?: TimeSeriesMovingAverage
+    // TODO: stage 5
+    trendLines?: TimeSeriesTrendLines
+    // TODO: stage 6
+    goalLines?: TimeSeriesGoalLine[]
+    // TODO: stage 7
+    thresholds?: TimeSeriesThresholds
+    // TODO: stage 8
+    anomalies?: TimeSeriesAnomalies
+    // TODO: stage 9
+    annotations?: TimeSeriesAnnotation[]
+    // TODO: stage 10
+    valueLabels?: TimeSeriesValueLabels
+    // TODO: stage 11
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    // TODO: stage 11
+    onPointClick?: (data: PointClickData<Meta>) => void
+}
+
+const WRAPPER_BASE_STYLE: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+}
+
+export function TimeSeriesLineChart<Meta = unknown>({
+    series,
+    xAxis,
+    yAxis,
+    theme,
+    width = '100%',
+    height = 280,
+    dataAttr,
+    className,
+}: TimeSeriesLineChartProps<Meta>): React.ReactElement {
+    const config = useMemo<LineChartConfig>(
+        () => ({
+            yScaleType: yAxis?.scale,
+            xTickFormatter: xAxis.tickFormatter,
+            yTickFormatter: yAxis?.tickFormatter,
+            hideXAxis: xAxis.hide,
+            hideYAxis: yAxis?.hide,
+            showGrid: yAxis?.showGrid,
+        }),
+        [xAxis.tickFormatter, xAxis.hide, yAxis?.scale, yAxis?.tickFormatter, yAxis?.hide, yAxis?.showGrid]
+    )
+
+    const wrapperStyle = useMemo<React.CSSProperties>(() => ({ ...WRAPPER_BASE_STYLE, width, height }), [width, height])
+
+    return (
+        <div
+            data-attr={dataAttr}
+            className={className}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={wrapperStyle}
+        >
+            <LineChart series={series} labels={xAxis.labels} config={config} theme={theme} />
+        </div>
+    )
+}

--- a/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/timeseries/TimeSeriesLineChart.tsx
@@ -3,48 +3,49 @@ import React from 'react'
 import { LineChart } from '../charts/LineChart'
 import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../core/types'
 
-export interface TimeSeriesXAxis {
-    /** Categorical labels — typically pre-formatted timestamps. Length must match each series.data. */
-    labels: string[]
-    tickFormatter?: (value: string, index: number) => string | null
-    hide?: boolean
-}
-
-export interface TimeSeriesYAxis {
-    /** `linear` (default) or `log`. Log falls back to a linear scale when no positive values exist. */
-    scale?: 'linear' | 'log'
-    tickFormatter?: (value: number) => string
-    hide?: boolean
-    showGrid?: boolean
+export interface TimeSeriesLineChartConfig {
+    xAxis?: {
+        tickFormatter?: (value: string, index: number) => string | null
+        hide?: boolean
+    }
+    yAxis?: {
+        /** `linear` (default) or `log`. Log falls back to a linear scale when no positive values exist. */
+        scale?: 'linear' | 'log'
+        tickFormatter?: (value: number) => string
+        hide?: boolean
+        showGrid?: boolean
+    }
 }
 
 export interface TimeSeriesLineChartProps<Meta = unknown> {
     series: Series<Meta>[]
-    xAxis: TimeSeriesXAxis
-    yAxis?: TimeSeriesYAxis
+    /** Pre-formatted time labels. Length must match each series.data. */
+    labels: string[]
     theme: ChartTheme
+    config?: TimeSeriesLineChartConfig
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    onPointClick?: (data: PointClickData<Meta>) => void
     /** `data-attr` applied to the chart wrapper for product-level test selectors. */
     dataAttr?: string
     className?: string
-    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
-    onPointClick?: (data: PointClickData<Meta>) => void
 }
 
 export function TimeSeriesLineChart<Meta = unknown>({
     series,
-    xAxis,
-    yAxis,
+    labels,
     theme,
-    dataAttr,
-    className,
+    config,
     tooltip,
     onPointClick,
+    dataAttr,
+    className,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
-    const config: LineChartConfig = {
+    const { xAxis, yAxis } = config ?? {}
+    const lineChartConfig: LineChartConfig = {
         yScaleType: yAxis?.scale,
-        xTickFormatter: xAxis.tickFormatter,
+        xTickFormatter: xAxis?.tickFormatter,
         yTickFormatter: yAxis?.tickFormatter,
-        hideXAxis: xAxis.hide,
+        hideXAxis: xAxis?.hide,
         hideYAxis: yAxis?.hide,
         showGrid: yAxis?.showGrid,
     }
@@ -52,8 +53,8 @@ export function TimeSeriesLineChart<Meta = unknown>({
     return (
         <LineChart
             series={series}
-            labels={xAxis.labels}
-            config={config}
+            labels={labels}
+            config={lineChartConfig}
             theme={theme}
             tooltip={tooltip}
             onPointClick={onPointClick}


### PR DESCRIPTION
## Problem

The new layered timeseries architecture wants a single chart entry point whose public prop shape is locked up front, so each subsequent stage (in-progress tail, CI bands, moving average, trend lines, goal lines, thresholds, anomalies, annotations, value labels, tooltip, click) is strictly additive rather than reshaping the API.

## Changes

Adds a thin `TimeSeriesLineChart` wrapper around the existing `LineChart` in `frontend/src/lib/hog-charts/timeseries/`.

- Defines the full prop interface — `series`, `xAxis`, `yAxis`, `inProgress`, `confidenceIntervals`, `movingAverage`, `trendLines`, `goalLines`, `thresholds`, `anomalies`, `annotations`, `valueLabels`, `tooltip`, `onPointClick`. Only `series`/`xAxis`/`yAxis` are wired in this revision; everything else is typed and marked `// TODO: stage N` so future stages just fill them in.
- Forwards `width`/`height` to a flex-column wrapper so the underlying canvas chart sizes itself correctly when used standalone.
- Exports the component and prop types from `lib/hog-charts`.
- Adds one Storybook story (`Components/HogCharts/TimeSeriesLineChart › Basic`) rendering 3 series.
- Adds unit tests covering renders-without-crashing, series/labels/theme/config pass-through, and width/height application.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- `pnpm exec jest src/lib/hog-charts/timeseries/TimeSeriesLineChart.test.tsx` — 4/4 passing
- `pnpm exec tsc --noEmit -p tsconfig.json` — clean for the changed files (pre-existing errors elsewhere in the tree are unrelated)
- `oxlint --quiet` on the 4 changed files — 0 warnings, 0 errors
- Pre-commit `hogli format:js` ran cleanly over the staged files

I have not run the Storybook story in a browser.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: PostHog Code (Claude Code, Opus 4.7), Task ID `78ba0479-5e1a-48ec-9826-e7430b66717f`
- Key prompts that shaped the work:
  - "Create hog-charts/timeseries/TimeSeriesLineChart.tsx as a minimal component that wraps LineChart. Just enough surface to render a single line series with a labels array."
  - "Define the full prop type interface even though most fields are unused — … Mark all but series/xAxis/yAxis as // TODO: stage N and don't implement them. This locks the API shape early and makes future stages obviously additive."
- Decisions:
  - Modeled `xAxis`/`yAxis` as objects (`{ labels, tickFormatter, hide }`, `{ scale, tickFormatter, hide, showGrid }`) rather than flat props, so future per-axis options have a natural home without widening the top level. The wrapper translates these into the existing `LineChartConfig`.
  - Defaulted `width` to `'100%'` and `height` to `280px` so the wrapper is usable standalone — `LineChart` itself relies on its parent for sizing.
  - Did not pass `tooltip`/`onPointClick` through to `LineChart` even though it accepts them, since the task explicitly required everything outside `series`/`xAxis`/`yAxis` to be a TODO no-op in stage 1.
  - In tests, mocked `LineChart` so we can assert on the props passed to it without spinning up the canvas/d3 stack.