### PR TITLE
feat(logs-alerting): split alert_save_ms into postgres sub-stage metrics

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -43,7 +43,9 @@ from products.logs.backend.temporal.metrics import (
     increment_checks_total,
     increment_notification_failures,
     increment_state_transition,
+    record_alert_event_create_duration,
     record_alert_save_duration,
+    record_alert_update_duration,
     record_alerts_active,
     record_check_duration,
     record_checkpoint_lag,
@@ -362,11 +364,13 @@ def _evaluate_single_alert(
     state_changed = state_before != committed_state.value
     is_error = outcome.error_message is not None
     save_start = time.perf_counter()
+    event_create_ms: int | None = None
     with transaction.atomic():
         # Stateless eval: write a CHECK row only on state transition or eval error.
         # Steady-state same-state evals don't write — the N-of-M evaluator gets its
         # window from the bucketed CH query, not from PG.
         if state_changed or is_error:
+            event_create_start = time.perf_counter()
             LogsAlertEvent.objects.create(
                 alert=alert,
                 result_count=check_result.result_count,
@@ -376,6 +380,7 @@ def _evaluate_single_alert(
                 error_message=outcome.error_message,
                 query_duration_ms=check_result.query_duration_ms,
             )
+            event_create_ms = int((time.perf_counter() - event_create_start) * 1000)
 
         # All state/consecutive_failures writes go through apply_outcome —
         # single source of truth, enforced by the semgrep rule.
@@ -392,7 +397,9 @@ def _evaluate_single_alert(
             alert.last_notified_at = now
             update_fields.append("last_notified_at")
 
+        update_start = time.perf_counter()
         alert.save(update_fields=update_fields)
+        update_ms = int((time.perf_counter() - update_start) * 1000)
     save_ms = int((time.perf_counter() - save_start) * 1000)
 
     stats["checked"] += 1
@@ -405,6 +412,9 @@ def _evaluate_single_alert(
         elapsed_ms = int((time.perf_counter() - start_time) * 1000)
         record_check_duration(elapsed_ms)
         record_alert_save_duration(save_ms)
+        if event_create_ms is not None:
+            record_alert_event_create_duration(event_create_ms)
+        record_alert_update_duration(update_ms)
         if check_result.query_duration_ms is not None:
             record_clickhouse_duration(check_result.query_duration_ms)
         if original_next_check_at is not None:

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -38,6 +38,8 @@ LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS = (
     "logs_alerting_clickhouse_duration_ms",
     "logs_alerting_semaphore_wait_ms",
     "logs_alerting_alert_save_ms",
+    "logs_alerting_alert_event_create_ms",
+    "logs_alerting_alert_update_ms",
 )
 
 LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS = [
@@ -174,7 +176,23 @@ def record_semaphore_wait(wait_ms: int) -> None:
 def record_alert_save_duration(duration_ms: int) -> None:
     _record_histogram(
         "logs_alerting_alert_save_ms",
-        "Postgres write time for the per-eval alert state update",
+        "Postgres write time for the per-eval alert state update (full transaction)",
+        duration_ms,
+    )
+
+
+def record_alert_event_create_duration(duration_ms: int) -> None:
+    _record_histogram(
+        "logs_alerting_alert_event_create_ms",
+        "Postgres INSERT time for the per-eval LogsAlertEvent audit row (only on state change or error)",
+        duration_ms,
+    )
+
+
+def record_alert_update_duration(duration_ms: int) -> None:
+    _record_histogram(
+        "logs_alerting_alert_update_ms",
+        "Postgres UPDATE time for the alert configuration row (without surrounding transaction overhead)",
         duration_ms,
     )
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -352,6 +352,8 @@ class TestEvaluateSingleAlert(APIBaseTest):
             "products.logs.backend.temporal.activities.record_scheduler_lag",
             "products.logs.backend.temporal.activities.record_clickhouse_duration",
             "products.logs.backend.temporal.activities.record_alert_save_duration",
+            "products.logs.backend.temporal.activities.record_alert_event_create_duration",
+            "products.logs.backend.temporal.activities.record_alert_update_duration",
             "products.logs.backend.temporal.activities.increment_checks_total",
             "products.logs.backend.temporal.activities.increment_check_errors",
         ):

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -1,9 +1,12 @@
 import datetime as dt
+from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
+
+from parameterized import parameterized
 
 from products.logs.backend.alert_state_machine import AlertState, NotificationAction
 from products.logs.backend.temporal.metrics import (
@@ -16,7 +19,9 @@ from products.logs.backend.temporal.metrics import (
     increment_checks_total,
     increment_notification_failures,
     increment_state_transition,
+    record_alert_event_create_duration,
     record_alert_save_duration,
+    record_alert_update_duration,
     record_alerts_active,
     record_check_duration,
     record_checkpoint_lag,
@@ -200,15 +205,38 @@ class TestRecordSemaphoreWait:
         )
 
 
-class TestRecordAlertSaveDuration:
+class TestRecordAlertSaveSubstageDurations:
+    @parameterized.expand(
+        [
+            (
+                "save_total",
+                record_alert_save_duration,
+                "logs_alerting_alert_save_ms",
+                "Postgres write time for the per-eval alert state update (full transaction)",
+                45,
+            ),
+            (
+                "event_create",
+                record_alert_event_create_duration,
+                "logs_alerting_alert_event_create_ms",
+                "Postgres INSERT time for the per-eval LogsAlertEvent audit row (only on state change or error)",
+                12,
+            ),
+            (
+                "alert_update",
+                record_alert_update_duration,
+                "logs_alerting_alert_update_ms",
+                "Postgres UPDATE time for the alert configuration row (without surrounding transaction overhead)",
+                28,
+            ),
+        ]
+    )
     @patch("products.logs.backend.temporal.metrics._record_histogram")
-    def test_records_histogram_with_duration(self, mock_record: MagicMock):
-        record_alert_save_duration(45)
-        mock_record.assert_called_once_with(
-            "logs_alerting_alert_save_ms",
-            "Postgres write time for the per-eval alert state update",
-            45,
-        )
+    def test_records_histogram_with_duration(
+        self, _name: str, fn: Any, metric_name: str, description: str, sample_value: int, mock_record: MagicMock
+    ):
+        fn(sample_value)
+        mock_record.assert_called_once_with(metric_name, description, sample_value)
 
 
 class TestRecordPendingAlerts:


### PR DESCRIPTION
## Problem

The existing `logs_alerting_alert_save_ms` metric captures the total Postgres transaction time for each alert evaluation, but doesn't break down where time is being spent within that transaction. This makes it difficult to distinguish between time spent on the `LogsAlertEvent` INSERT (which only happens on state change or error) versus the alert configuration row UPDATE.

## Changes

Two new fine-grained histogram metrics have been added to complement the existing total transaction metric:

- `logs_alerting_alert_event_create_ms` — measures the Postgres INSERT time for the `LogsAlertEvent` audit row, recorded only when a state change or error occurs
- `logs_alerting_alert_update_ms` — measures the Postgres UPDATE time for the alert configuration row, excluding surrounding transaction overhead

The description of `logs_alerting_alert_save_ms` has been updated to clarify it represents the full transaction duration.

## How did you test this code?

The existing `TestRecordAlertSaveDuration` test class has been refactored into `TestRecordAlertSaveSubstageDurations` using `@parameterized.expand` to cover all three metrics (`save_total`, `event_create`, `alert_update`) with a single parameterized test. The new metric recording functions are also patched in the activity-level tests to prevent unintended side effects.

## Publish to changelog?

No