### PR TITLE
chore(taxonomy): add missing event/person/session properties

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -597,6 +597,67 @@
             ],
             "label": "AI stream (LLM)"
         },
+        "$ai_tag_count": {
+            "description": "The number of tags assigned to the AI event.",
+            "examples": [
+                1,
+                3
+            ],
+            "label": "AI Tag Count (LLM)"
+        },
+        "$ai_tag_reasoning": {
+            "description": "The LLM's explanation for why it assigned the selected tags.",
+            "examples": [
+                "The generation discussed billing and feature flag configuration"
+            ],
+            "label": "AI Tag Reasoning (LLM)"
+        },
+        "$ai_tagger_id": {
+            "description": "The unique identifier of the tagger configuration used to classify the AI event.",
+            "examples": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
+            "label": "AI Tagger ID (LLM)"
+        },
+        "$ai_tagger_key_id": {
+            "description": "The ID of the LLM provider key used for the tagger.",
+            "examples": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
+            "label": "AI Tagger Key ID (LLM)"
+        },
+        "$ai_tagger_key_type": {
+            "description": "The type of API key used for the tagger (byok = user's own key, posthog = PostHog default).",
+            "examples": [
+                "byok",
+                "posthog"
+            ],
+            "label": "AI Tagger Key Type (LLM)"
+        },
+        "$ai_tagger_name": {
+            "description": "The name of the tagger configuration used.",
+            "examples": [
+                "Product feature tagger",
+                "Intent classifier"
+            ],
+            "label": "AI Tagger Name (LLM)"
+        },
+        "$ai_tagger_start_time": {
+            "description": "The timestamp when the tagger started executing.",
+            "examples": [
+                "2025-01-15T10:30:00Z"
+            ],
+            "label": "AI Tagger Start Time (LLM)"
+        },
+        "$ai_tags": {
+            "description": "The list of tags assigned to the AI event by the tagger.",
+            "examples": [
+                "billing",
+                "feature-flags",
+                "onboarding"
+            ],
+            "label": "AI Tags (LLM)"
+        },
         "$ai_target_event_id": {
             "description": "The unique identifier of the event being evaluated.",
             "examples": [
@@ -1061,6 +1122,16 @@
             "label": "Dead click selection changed timeout",
             "system": true
         },
+        "$dead_click_visibility_changed_delay_ms": {
+            "description": "The delay between a click and the next visibility change event",
+            "label": "Dead click visibility changed delay in milliseconds",
+            "system": true
+        },
+        "$dead_click_visibility_changed_timeout": {
+            "description": "whether the dead click autocapture passed the threshold for waiting for a visibility change event",
+            "label": "Dead click visibility changed timeout",
+            "system": true
+        },
         "$dead_clicks_enabled_server_side": {
             "description": "Whether dead clicks were enabled in remote config",
             "label": "Dead clicks enabled server side",
@@ -1136,6 +1207,18 @@
             ],
             "label": "Enabled feature flags"
         },
+        "$event_time_override_provided": {
+            "description": "Whether the SDK had to override the event timestamp because the value provided by the caller could not be used as-is.",
+            "label": "Event time override provided",
+            "system": true,
+            "used_for_debug": true
+        },
+        "$event_time_override_system_time": {
+            "description": "The system time that the SDK fell back to when overriding the event timestamp.",
+            "label": "Event time override system time",
+            "system": true,
+            "used_for_debug": true
+        },
         "$event_type": {
             "description": "When the event is an $autocapture event, this specifies what the action was against the element.",
             "examples": [
@@ -1174,6 +1257,10 @@
         "$exception_fingerprint": {
             "description": "A fingerprint used to group issues, can be set clientside.",
             "label": "Exception fingerprint"
+        },
+        "$exception_fingerprint_record": {
+            "description": "The structured fingerprint pieces used to group issues, captured per exception in a chain. Each entry records the type, id, and contributing pieces.",
+            "label": "Exception fingerprint record"
         },
         "$exception_functions": {
             "description": "A function contained in the exception.",
@@ -1248,6 +1335,13 @@
             "description": "The description of the exception.",
             "label": "Exception message"
         },
+        "$external_click_url": {
+            "description": "The URL of an external link that was clicked during autocapture. External meaning the URL points to a different host than the page the user was on.",
+            "examples": [
+                "https://example.com/some-article"
+            ],
+            "label": "External click URL"
+        },
         "$feature_flag": {
             "description": "The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag_called event. If you want to filter other events, try \"Active feature flags\".",
             "examples": [
@@ -1255,12 +1349,36 @@
             ],
             "label": "Feature flag"
         },
+        "$feature_flag_bootstrapped_payload": {
+            "description": "The payload value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",
+            "label": "Feature flag bootstrapped payload"
+        },
+        "$feature_flag_bootstrapped_response": {
+            "description": "The response value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",
+            "label": "Feature flag bootstrapped response"
+        },
+        "$feature_flag_error": {
+            "description": "The error encountered while evaluating the feature flag, if any.",
+            "label": "Feature flag error",
+            "system": true
+        },
         "$feature_flag_evaluated_at": {
             "description": "The timestamp (in milliseconds since Unix epoch) when the feature flag was evaluated.",
             "examples": [
                 "1732051200000"
             ],
             "label": "Feature flag evaluated at"
+        },
+        "$feature_flag_id": {
+            "description": "The numeric identifier of the feature flag that was called.",
+            "examples": [
+                "1234"
+            ],
+            "label": "Feature flag ID"
+        },
+        "$feature_flag_original_response": {
+            "description": "The original feature flag response from PostHog, before any local override was applied.",
+            "label": "Feature flag original response"
         },
         "$feature_flag_payload": {
             "description": "The JSON payload that the call to feature flag responded with (if any)",
@@ -1733,6 +1851,11 @@
             ],
             "label": "OS version"
         },
+        "$override_feature_flags": {
+            "description": "Locally overridden feature flag values, typically set via the toolbar or SDK override APIs.",
+            "label": "Override feature flags",
+            "system": true
+        },
         "$pageview_id": {
             "description": "PostHog's internal ID for matching events to a pageview.",
             "ignored_in_assistant": true,
@@ -2056,6 +2179,11 @@
             "type": "String",
             "used_for_debug": true
         },
+        "$sdk_debug_replay_rrweb_error": {
+            "description": "An error reported by the rrweb session recording library while capturing the replay.",
+            "label": "Replay rrweb error",
+            "used_for_debug": true
+        },
         "$sdk_debug_replay_url_trigger_status": {
             "description": "The status of the recording url trigger.",
             "examples": [
@@ -2206,6 +2334,11 @@
             ],
             "ignored_in_assistant": true,
             "label": "Session entry Path name"
+        },
+        "$session_entry_ph_keyword": {
+            "description": "PostHog keyword tracking parameter. Captured at the start of the session and remains constant for the duration of the session.",
+            "ignored_in_assistant": true,
+            "label": "Session entry ph_keyword"
         },
         "$session_entry_qclid": {
             "description": "Quora Click ID Captured at the start of the session and remains constant for the duration of the session.",
@@ -2711,6 +2844,10 @@
             "description": "Microsoft Click ID",
             "label": "msclkid"
         },
+        "ph_keyword": {
+            "description": "PostHog keyword tracking parameter.",
+            "label": "ph_keyword"
+        },
         "previous_build": {
             "description": "The previous build number for the app",
             "examples": [
@@ -2866,6 +3003,10 @@
         "$ai_span": {
             "description": "A generative AI span. Usually a span tracks a unit of work for a trace of generative AI models (LLMs).",
             "label": "AI span (LLM)"
+        },
+        "$ai_tag": {
+            "description": "A tag classification of an AI event. Contains the assigned tags, reasoning, and tagger metadata.",
+            "label": "AI tag (LLM)"
         },
         "$ai_trace": {
             "description": "A generative AI trace. Usually a trace tracks a single user interaction and contains one or more AI generation calls.",
@@ -3598,6 +3739,67 @@
             ],
             "label": "AI stream (LLM)"
         },
+        "$ai_tag_count": {
+            "description": "The number of tags assigned to the AI event.",
+            "examples": [
+                1,
+                3
+            ],
+            "label": "AI Tag Count (LLM)"
+        },
+        "$ai_tag_reasoning": {
+            "description": "The LLM's explanation for why it assigned the selected tags.",
+            "examples": [
+                "The generation discussed billing and feature flag configuration"
+            ],
+            "label": "AI Tag Reasoning (LLM)"
+        },
+        "$ai_tagger_id": {
+            "description": "The unique identifier of the tagger configuration used to classify the AI event.",
+            "examples": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
+            "label": "AI Tagger ID (LLM)"
+        },
+        "$ai_tagger_key_id": {
+            "description": "The ID of the LLM provider key used for the tagger.",
+            "examples": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
+            "label": "AI Tagger Key ID (LLM)"
+        },
+        "$ai_tagger_key_type": {
+            "description": "The type of API key used for the tagger (byok = user's own key, posthog = PostHog default).",
+            "examples": [
+                "byok",
+                "posthog"
+            ],
+            "label": "AI Tagger Key Type (LLM)"
+        },
+        "$ai_tagger_name": {
+            "description": "The name of the tagger configuration used.",
+            "examples": [
+                "Product feature tagger",
+                "Intent classifier"
+            ],
+            "label": "AI Tagger Name (LLM)"
+        },
+        "$ai_tagger_start_time": {
+            "description": "The timestamp when the tagger started executing.",
+            "examples": [
+                "2025-01-15T10:30:00Z"
+            ],
+            "label": "AI Tagger Start Time (LLM)"
+        },
+        "$ai_tags": {
+            "description": "The list of tags assigned to the AI event by the tagger.",
+            "examples": [
+                "billing",
+                "feature-flags",
+                "onboarding"
+            ],
+            "label": "AI Tags (LLM)"
+        },
         "$ai_target_event_id": {
             "description": "The unique identifier of the event being evaluated.",
             "examples": [
@@ -4062,6 +4264,16 @@
             "label": "Dead click selection changed timeout",
             "system": true
         },
+        "$dead_click_visibility_changed_delay_ms": {
+            "description": "The delay between a click and the next visibility change event",
+            "label": "Dead click visibility changed delay in milliseconds",
+            "system": true
+        },
+        "$dead_click_visibility_changed_timeout": {
+            "description": "whether the dead click autocapture passed the threshold for waiting for a visibility change event",
+            "label": "Dead click visibility changed timeout",
+            "system": true
+        },
         "$dead_clicks_enabled_server_side": {
             "description": "Whether dead clicks were enabled in remote config",
             "label": "Dead clicks enabled server side",
@@ -4137,6 +4349,18 @@
             ],
             "label": "Enabled feature flags"
         },
+        "$event_time_override_provided": {
+            "description": "Whether the SDK had to override the event timestamp because the value provided by the caller could not be used as-is.",
+            "label": "Event time override provided",
+            "system": true,
+            "used_for_debug": true
+        },
+        "$event_time_override_system_time": {
+            "description": "The system time that the SDK fell back to when overriding the event timestamp.",
+            "label": "Event time override system time",
+            "system": true,
+            "used_for_debug": true
+        },
         "$event_type": {
             "description": "When the event is an $autocapture event, this specifies what the action was against the element.",
             "examples": [
@@ -4175,6 +4399,10 @@
         "$exception_fingerprint": {
             "description": "A fingerprint used to group issues, can be set clientside.",
             "label": "Exception fingerprint"
+        },
+        "$exception_fingerprint_record": {
+            "description": "The structured fingerprint pieces used to group issues, captured per exception in a chain. Each entry records the type, id, and contributing pieces.",
+            "label": "Exception fingerprint record"
         },
         "$exception_functions": {
             "description": "A function contained in the exception.",
@@ -4249,6 +4477,13 @@
             "description": "The description of the exception.",
             "label": "Exception message"
         },
+        "$external_click_url": {
+            "description": "The URL of an external link that was clicked during autocapture. External meaning the URL points to a different host than the page the user was on.",
+            "examples": [
+                "https://example.com/some-article"
+            ],
+            "label": "External click URL"
+        },
         "$feature_flag": {
             "description": "The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag_called event. If you want to filter other events, try \"Active feature flags\".",
             "examples": [
@@ -4256,12 +4491,36 @@
             ],
             "label": "Feature flag"
         },
+        "$feature_flag_bootstrapped_payload": {
+            "description": "The payload value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",
+            "label": "Feature flag bootstrapped payload"
+        },
+        "$feature_flag_bootstrapped_response": {
+            "description": "The response value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",
+            "label": "Feature flag bootstrapped response"
+        },
+        "$feature_flag_error": {
+            "description": "The error encountered while evaluating the feature flag, if any.",
+            "label": "Feature flag error",
+            "system": true
+        },
         "$feature_flag_evaluated_at": {
             "description": "The timestamp (in milliseconds since Unix epoch) when the feature flag was evaluated.",
             "examples": [
                 "1732051200000"
             ],
             "label": "Feature flag evaluated at"
+        },
+        "$feature_flag_id": {
+            "description": "The numeric identifier of the feature flag that was called.",
+            "examples": [
+                "1234"
+            ],
+            "label": "Feature flag ID"
+        },
+        "$feature_flag_original_response": {
+            "description": "The original feature flag response from PostHog, before any local override was applied.",
+            "label": "Feature flag original response"
         },
         "$feature_flag_payload": {
             "description": "The JSON payload that the call to feature flag responded with (if any)",
@@ -4528,12 +4787,12 @@
             "used_for_debug": true
         },
         "$host": {
-            "description": "The hostname of the Current URL.",
+            "description": "The hostname of the Current URL. Data from the last time this user was seen.",
             "examples": [
                 "example.com",
                 "localhost:8000"
             ],
-            "label": "Host"
+            "label": "Latest host"
         },
         "$initial__kx": {
             "description": "Klaviyo Tracking ID Data from the first time this user was seen.",
@@ -4785,6 +5044,14 @@
             ],
             "label": "Initial timezone"
         },
+        "$initial_host": {
+            "description": "The hostname of the Current URL. Data from the first time this user was seen.",
+            "examples": [
+                "example.com",
+                "localhost:8000"
+            ],
+            "label": "Initial host"
+        },
         "$initial_igshid": {
             "description": "Instagram Share ID Data from the first time this user was seen.",
             "label": "Initial igshid"
@@ -4832,6 +5099,10 @@
             "description": "posthog-js initial person information. used in the $set_once flow",
             "label": "Initial person info",
             "system": true
+        },
+        "$initial_ph_keyword": {
+            "description": "PostHog keyword tracking parameter. Data from the first time this user was seen.",
+            "label": "Initial ph_keyword"
         },
         "$initial_qclid": {
             "description": "Quora Click ID Data from the first time this user was seen.",
@@ -4882,6 +5153,14 @@
                 "1920"
             ],
             "label": "Initial screen width"
+        },
+        "$initial_search_engine": {
+            "description": "The search engine the user came in from (if any). Data from the first time this user was seen.",
+            "examples": [
+                "Google",
+                "DuckDuckGo"
+            ],
+            "label": "Initial search engine"
         },
         "$initial_ttclid": {
             "description": "TikTok Click ID Data from the first time this user was seen.",
@@ -5137,6 +5416,11 @@
                 "15.5"
             ],
             "label": "Latest OS version"
+        },
+        "$override_feature_flags": {
+            "description": "Locally overridden feature flag values, typically set via the toolbar or SDK override APIs.",
+            "label": "Override feature flags",
+            "system": true
         },
         "$pageview_id": {
             "description": "PostHog's internal ID for matching events to a pageview.",
@@ -5461,6 +5745,11 @@
             "type": "String",
             "used_for_debug": true
         },
+        "$sdk_debug_replay_rrweb_error": {
+            "description": "An error reported by the rrweb session recording library while capturing the replay.",
+            "label": "Replay rrweb error",
+            "used_for_debug": true
+        },
         "$sdk_debug_replay_url_trigger_status": {
             "description": "The status of the recording url trigger.",
             "examples": [
@@ -5489,12 +5778,12 @@
             "used_for_debug": true
         },
         "$search_engine": {
-            "description": "The search engine the user came in from (if any).",
+            "description": "The search engine the user came in from (if any). Data from the last time this user was seen.",
             "examples": [
                 "Google",
                 "DuckDuckGo"
             ],
-            "label": "Search engine"
+            "label": "Latest search engine"
         },
         "$selected_content": {
             "description": "The content that was selected when the user copied or cut.",
@@ -6096,6 +6385,10 @@
             "description": "Microsoft Click ID Data from the last time this user was seen.",
             "label": "Latest msclkid"
         },
+        "ph_keyword": {
+            "description": "PostHog keyword tracking parameter. Data from the last time this user was seen.",
+            "label": "Latest ph_keyword"
+        },
         "previous_build": {
             "description": "The previous build number for the app",
             "examples": [
@@ -6402,6 +6695,14 @@
             "label": "End URL",
             "type": "String"
         },
+        "$end_hostname": {
+            "description": "The hostname of the last URL visited in this session.",
+            "examples": [
+                "example.com"
+            ],
+            "label": "End hostname",
+            "type": "String"
+        },
         "$end_pathname": {
             "description": "The last pathname visited in this session.",
             "examples": [
@@ -6458,6 +6759,14 @@
             "description": "Google Click Source Data from the first event in this session.",
             "label": "Entry gclsrc"
         },
+        "$entry_hostname": {
+            "description": "The hostname of the first URL visited in this session.",
+            "examples": [
+                "example.com"
+            ],
+            "label": "Entry hostname",
+            "type": "String"
+        },
         "$entry_igshid": {
             "description": "Instagram Share ID Data from the first event in this session.",
             "label": "Entry igshid"
@@ -6485,6 +6794,10 @@
             ],
             "label": "Entry pathname",
             "type": "String"
+        },
+        "$entry_ph_keyword": {
+            "description": "PostHog keyword tracking parameter. Data from the first event in this session.",
+            "label": "Entry ph_keyword"
         },
         "$entry_qclid": {
             "description": "Quora Click ID Data from the first event in this session.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1123,7 +1123,7 @@
             "system": true
         },
         "$dead_click_visibility_changed_delay_ms": {
-            "description": "The delay between a click and the next visibility change event",
+            "description": "the delay between a click and the next visibility change event",
             "label": "Dead click visibility changed delay in milliseconds",
             "system": true
         },
@@ -1209,7 +1209,7 @@
         },
         "$event_time_override_provided": {
             "description": "Whether the SDK had to override the event timestamp because the value provided by the caller could not be used as-is.",
-            "label": "Event time override provided",
+            "label": "Event time was overridden",
             "system": true,
             "used_for_debug": true
         },
@@ -4265,7 +4265,7 @@
             "system": true
         },
         "$dead_click_visibility_changed_delay_ms": {
-            "description": "The delay between a click and the next visibility change event",
+            "description": "the delay between a click and the next visibility change event",
             "label": "Dead click visibility changed delay in milliseconds",
             "system": true
         },
@@ -4351,7 +4351,7 @@
         },
         "$event_time_override_provided": {
             "description": "Whether the SDK had to override the event timestamp because the value provided by the caller could not be used as-is.",
-            "label": "Event time override provided",
+            "label": "Event time was overridden",
             "system": true,
             "used_for_debug": true
         },

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1298,7 +1298,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "examples": ["2023-05-20T15:31:00Z"],
         },
         "$event_time_override_provided": {
-            "label": "Event time override provided",
+            "label": "Event time was overridden",
             "description": "Whether the SDK had to override the event timestamp because the value provided by the caller could not be used as-is.",
             "system": True,
             "used_for_debug": True,
@@ -1942,7 +1942,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$dead_click_visibility_changed_delay_ms": {
             "label": "Dead click visibility changed delay in milliseconds",
-            "description": "The delay between a click and the next visibility change event",
+            "description": "the delay between a click and the next visibility change event",
             "system": True,
         },
         "$dead_click_visibility_changed_timeout": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -47,6 +47,7 @@ CAMPAIGN_PROPERTIES: list[str] = [
     "sccid",  # snapchat
     "irclid",  # impact
     "_kx",  # klaviyo
+    "ph_keyword",  # posthog keyword
 ]
 
 PERSON_PROPERTIES_ADAPTED_FROM_EVENT: set[str] = {
@@ -58,6 +59,7 @@ PERSON_PROPERTIES_ADAPTED_FROM_EVENT: set[str] = {
     "$browser_version",
     "$device_type",
     "$current_url",
+    "$host",
     "$pathname",
     "$os",
     "$os_version",
@@ -65,6 +67,7 @@ PERSON_PROPERTIES_ADAPTED_FROM_EVENT: set[str] = {
     "$referrer",
     "$screen_height",
     "$screen_width",
+    "$search_engine",
     "$viewport_height",
     "$viewport_width",
     "$raw_user_agent",
@@ -97,6 +100,7 @@ SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS = {
     "sccid",
     "irclid",
     "_kx",
+    "ph_keyword",
 }
 
 SESSION_PROPERTIES_ALSO_INCLUDED_IN_EVENTS = {
@@ -394,6 +398,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$sdk_debug_replay_full_snapshots": {
             "label": "Replay full snapshots debug info",
             "description": "Debug information about full snapshots in the replay session.",
+            "used_for_debug": True,
+        },
+        "$sdk_debug_replay_rrweb_error": {
+            "label": "Replay rrweb error",
+            "description": "An error reported by the rrweb session recording library while capturing the replay.",
             "used_for_debug": True,
         },
         "$sdk_debug_recording_script_not_loaded": {
@@ -786,6 +795,10 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Exception fingerprint",
             "description": "A fingerprint used to group issues, can be set clientside.",
         },
+        "$exception_fingerprint_record": {
+            "label": "Exception fingerprint record",
+            "description": "The structured fingerprint pieces used to group issues, captured per exception in a chain. Each entry records the type, id, and contributing pieces.",
+        },
         "$exception_proposed_fingerprint": {
             "label": "Exception proposed fingerprint",
             "description": "The fingerprint used to group issues. Auto generated unless provided clientside.",
@@ -857,6 +870,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Event type",
             "description": "When the event is an $autocapture event, this specifies what the action was against the element.",
             "examples": ["click", "submit", "change"],
+        },
+        "$external_click_url": {
+            "label": "External click URL",
+            "description": "The URL of an external link that was clicked during autocapture. External meaning the URL points to a different host than the page the user was on.",
+            "examples": ["https://example.com/some-article"],
         },
         "$insert_id": {
             "label": "Insert ID",
@@ -1279,6 +1297,18 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "Time the event was sent to PostHog. Used for correcting the event timestamp when the device clock is off.",
             "examples": ["2023-05-20T15:31:00Z"],
         },
+        "$event_time_override_provided": {
+            "label": "Event time override provided",
+            "description": "Whether the SDK had to override the event timestamp because the value provided by the caller could not be used as-is.",
+            "system": True,
+            "used_for_debug": True,
+        },
+        "$event_time_override_system_time": {
+            "label": "Event time override system time",
+            "description": "The system time that the SDK fell back to when overriding the event timestamp.",
+            "system": True,
+            "used_for_debug": True,
+        },
         "$browser": {
             "label": "Browser",
             "description": "Name of the browser the user has used.",
@@ -1467,6 +1497,33 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Feature flag version",
             "description": "The version of the feature flag that was called.",
             "examples": ["3"],
+        },
+        "$feature_flag_id": {
+            "label": "Feature flag ID",
+            "description": "The numeric identifier of the feature flag that was called.",
+            "examples": ["1234"],
+        },
+        "$feature_flag_bootstrapped_response": {
+            "label": "Feature flag bootstrapped response",
+            "description": "The response value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",
+        },
+        "$feature_flag_bootstrapped_payload": {
+            "label": "Feature flag bootstrapped payload",
+            "description": "The payload value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",
+        },
+        "$feature_flag_original_response": {
+            "label": "Feature flag original response",
+            "description": "The original feature flag response from PostHog, before any local override was applied.",
+        },
+        "$feature_flag_error": {
+            "label": "Feature flag error",
+            "description": "The error encountered while evaluating the feature flag, if any.",
+            "system": True,
+        },
+        "$override_feature_flags": {
+            "label": "Override feature flags",
+            "description": "Locally overridden feature flag values, typically set via the toolbar or SDK override APIs.",
+            "system": True,
         },
         "$survey_response": {
             "label": "Survey response",
@@ -1697,6 +1754,10 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "ttclid",
             "description": "TikTok Click ID",
         },
+        "ph_keyword": {
+            "label": "ph_keyword",
+            "description": "PostHog keyword tracking parameter.",
+        },
         "$is_identified": {
             "label": "Is identified",
             "description": "Client-side property set by posthog-js indicating whether the user has been previously identified on the device.",
@@ -1877,6 +1938,16 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$dead_click_selection_changed_timeout": {
             "label": "Dead click selection changed timeout",
             "description": "whether the dead click autocapture passed the threshold for waiting for a text selection change event",
+            "system": True,
+        },
+        "$dead_click_visibility_changed_delay_ms": {
+            "label": "Dead click visibility changed delay in milliseconds",
+            "description": "The delay between a click and the next visibility change event",
+            "system": True,
+        },
+        "$dead_click_visibility_changed_timeout": {
+            "label": "Dead click visibility changed timeout",
+            "description": "whether the dead click autocapture passed the threshold for waiting for a visibility change event",
             "system": True,
         },
         # AI
@@ -2530,6 +2601,18 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "End pathname",
             "description": "The last pathname visited in this session.",
             "examples": ["/interesting-article?parameter=true"],
+            "type": "String",
+        },
+        "$entry_hostname": {
+            "label": "Entry hostname",
+            "description": "The hostname of the first URL visited in this session.",
+            "examples": ["example.com"],
+            "type": "String",
+        },
+        "$end_hostname": {
+            "label": "End hostname",
+            "description": "The hostname of the last URL visited in this session.",
+            "examples": ["example.com"],
             "type": "String",
         },
         "$exit_current_url": {


### PR DESCRIPTION
## Problem

The `taxonomy entry missing` instrumentation event has been reporting a number of properties that the SDK / backend captures but that have no entry in `posthog/taxonomy/taxonomy.py`. Without taxonomy entries these properties show up un-labelled in the TaxonomicFilter and aren't included in generated frontend types.

## Changes

Adds taxonomy entries for the reported properties. For `$initial_host`, `$initial_search_engine`, and `$session_entry_ph_keyword` I extended the existing adapter sets so the auto-derivation produces the full sibling families consistently, rather than hand-defining individual entries.

**Auto-derivation hooks**
- `$host` and `$search_engine` added to `PERSON_PROPERTIES_ADAPTED_FROM_EVENT` -> auto-creates `$initial_host`, `$initial_search_engine`. ⚠️ This also renames the existing `$host` / `$search_engine` person-property labels to "Latest host" / "Latest search engine" (the underlying property keys are unchanged, so saved insights / filters keying off the property name keep working — but anything that displays the human-facing label will shift).
- `ph_keyword` added to `CAMPAIGN_PROPERTIES` and `SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS` -> auto-creates `$session_entry_ph_keyword`, `$entry_ph_keyword`, `$initial_ph_keyword`.

**New `event_properties`**
- `$sdk_debug_replay_rrweb_error`
- `$exception_fingerprint_record`
- `$external_click_url`
- `$event_time_override_provided`, `$event_time_override_system_time`
- `$feature_flag_id`, `$feature_flag_bootstrapped_response`, `$feature_flag_bootstrapped_payload`, `$feature_flag_original_response`, `$feature_flag_error`, `$override_feature_flags`
- `$dead_click_visibility_changed_delay_ms`, `$dead_click_visibility_changed_timeout`
- `ph_keyword`

**New `session_properties`**
- `$entry_hostname`, `$end_hostname`

The generated `frontend/src/taxonomy/core-filter-definitions-by-group.json` is rebuilt via `python bin/build-taxonomy-json.py` and is part of the diff.

## How did you test this code?

I'm a PostHog Code agent. Automated checks I ran:

- The four existing tests in `posthog/taxonomy/test/test_event_properties_taxonomy.py` still pass:
  - `test_event_properties_includes_campaign_properties`
  - `test_initial_person_properties_set_up_correctly`
  - `test_should_have_a_session_referring_domain_property`
  - `test_should_have_every_property_in_session_adopted_from_person`
- Spot-checked that every reported property is present in the appropriate `CORE_FILTER_DEFINITIONS_BY_GROUP` group, including the auto-derived `$initial_*`, `$entry_*`, and `$session_entry_*` siblings for `ph_keyword`, `$host`, and `$search_engine`.

No manual UI testing was performed.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code on behalf of @pauldambra.
- Prompt: a list of 18 properties flagged by the `taxonomy entry missing` event, with the instruction "we need to either fix the instrumentation or add them to the taxonomy."
- Decisions:
  - Chose to add taxonomy entries rather than "fix instrumentation" because all 18 properties are intentional captures from posthog-js / backend ingestion, not typos.
  - For `$initial_host`/`$initial_search_engine` and `$session_entry_ph_keyword`, preferred to extend the existing adapter sets so the auto-derivation produces the full sibling families consistently, rather than hand-defining individual entries.
  - Marked the genuinely debug/system properties (`$event_time_override_*`, `$override_feature_flags`, `$feature_flag_error`, `$dead_click_visibility_changed_*`, `$sdk_debug_replay_rrweb_error`) with `system: True` and/or `used_for_debug: True` to match conventions used by their neighbours.
  - Followup commit applied two qa-swarm nits: lowercase `the delay between` to match the existing description style, and renamed `$event_time_override_provided` label from a noun form to "Event time was overridden" so it reads as a boolean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
