### PR TITLE
fix(data-warehouse): scope job-status save to avoid clobbering rows_synced

### DIFF
--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -48,6 +48,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql_queries.insights.funnels.funnel import FunnelUDF
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
 from posthog.models import DataWarehouseTable
+from posthog.models.event.util import format_clickhouse_timestamp
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.team.team import Team
 from posthog.temporal.common.shutdown import ShutdownMonitor, WorkerShuttingDownError
@@ -365,7 +366,11 @@ async def _run(
 
         # Assert that app_metrics2 rows were emitted for the successful job — both
         # the success row and the rows_synced row (since a successful e2e run writes
-        # at least one row).
+        # at least one row). Pin both V3 (consumer-side) and NonDLT (workflow-side)
+        # paths so a regression in either gates here.
+        assert run.rows_synced is not None and run.rows_synced > 0, (
+            f"expected run.rows_synced to be a positive number, got {run.rows_synced}"
+        )
         produce_calls = mock_app_metrics_producer_cls.return_value.produce.call_args_list
         emitted_payloads = [call.kwargs["data"] for call in produce_calls]
         status_rows = [
@@ -378,10 +383,19 @@ async def _run(
         assert status_rows[0]["count"] == 1
         assert status_rows[0]["instance_id"] == str(schema.id)
         assert status_rows[0]["team_id"] == team.pk
+        assert status_rows[0]["timestamp"] == format_clickhouse_timestamp(run.finished_at)
         assert len(rows_rows) == 1, f"expected one rows_synced row, got {emitted_payloads}"
         assert rows_rows[0]["metric_name"] == "rows_synced"
-        assert rows_rows[0]["count"] == run.rows_synced
+        assert rows_rows[0]["count"] == run.rows_synced, (
+            f"rows_synced metric count should match run.rows_synced ({run.rows_synced}); "
+            f"got {rows_rows[0]['count']} — likely indicates rows_synced was clobbered by "
+            f"update_external_job_status's full-model save() racing with update_job_row_count"
+        )
+        assert rows_rows[0]["count"] > 0, f"rows_synced metric count should be positive, got {rows_rows[0]['count']}"
+        assert rows_rows[0]["app_source"] == "warehouse_source_sync"
+        assert rows_rows[0]["team_id"] == team.pk
         assert rows_rows[0]["instance_id"] == str(schema.id)
+        assert rows_rows[0]["timestamp"] == status_rows[0]["timestamp"]
 
         await sync_to_async(schema.refresh_from_db)()
 

--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -20,10 +20,15 @@ def update_external_job_status(
     # Kafka message can land here with the job already in a terminal state, and
     # re-emitting would inflate the counters.
     is_first_terminal_transition = status in TERMINAL_JOB_STATUSES and model.finished_at is None
+    update_fields = ["status", "latest_error", "updated_at"]
     if is_first_terminal_transition:
         model.finished_at = dt.datetime.now(dt.UTC)
+        update_fields.append("finished_at")
 
-    model.save()
+    # Scope the save to the fields we mutated so a concurrent F-update from
+    # `update_job_row_count` (V3 activity) isn't clobbered by writing back the
+    # in-memory `rows_synced` we read at the top of this function.
+    model.save(update_fields=update_fields)
 
     if status == ExternalDataJob.Status.FAILED:
         schema_status: ExternalDataSchema.Status = ExternalDataSchema.Status.FAILED

--- a/products/data_warehouse/backend/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_jobs.py
@@ -105,6 +105,41 @@ class TestUpdateExternalJobStatus:
         assert updated.finished_at is None
         mock_emit.assert_not_called()
 
+    def test_concurrent_rows_synced_update_is_not_clobbered(self):
+        """Regression: `update_external_job_status` must not overwrite `rows_synced`
+        with the in-memory value it loaded at the top of the function. In V3 the
+        consumer-side completion can race a still-pending `update_job_row_count`
+        F-update from the activity (e.g. on retry). Saving the full model would
+        rewind the count — and downstream emit `count: 0` for the rows metric."""
+        team, _source, _schema, job = _create_org_team_source_schema_job()
+        # Job loaded with rows_synced=100; simulate a concurrent F-update bumping
+        # it to 500 between objects.get() and model.save() inside the function.
+
+        original_save = ExternalDataJob.save
+
+        def save_with_concurrent_update(self, *args, **kwargs):
+            ExternalDataJob.objects.filter(id=self.id).update(rows_synced=500)
+            return original_save(self, *args, **kwargs)
+
+        with (
+            patch(
+                "products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"
+            ) as mock_emit,
+            patch.object(ExternalDataJob, "save", autospec=True, side_effect=save_with_concurrent_update),
+        ):
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.COMPLETED,
+                logger=MagicMock(),
+                latest_error=None,
+            )
+
+        # The concurrent +400 increment must survive the status save.
+        assert ExternalDataJob.objects.get(id=job.id).rows_synced == 500
+        emitted_job = mock_emit.call_args.args[0]
+        assert emitted_job.rows_synced == 500
+
     def test_failed_status_emits_and_stamps(self):
         team, _source, _schema, job = _create_org_team_source_schema_job()
 


### PR DESCRIPTION
## Problem

In the V3 pipeline, the consumer-side `_mark_job_completed` runs in a separate process from the activity that incremented `rows_synced` via `update_job_row_count` (an atomic `F('rows_synced') + count` update). When the consumer enters [`update_external_job_status`](products/data_warehouse/backend/external_data_source/jobs.py), the function:

1. Loads the job: `model = ExternalDataJob.objects.get(...)`
2. Mutates `status`, `latest_error`, `finished_at`
3. Calls `model.save()` — **writing back every column, including `rows_synced`**

If a `update_job_row_count` F-update lands between steps 1 and 3 (e.g. on a heartbeat-resumed activity, or just normal activity/consumer interleaving), the in-memory `rows_synced` from step 1 overwrites it. Downstream, `emit_data_import_app_metrics` reads `model.refresh_from_db()` and emits a stale (or zero) `rows_synced` count to `app_metrics2`. The success/failure counter (`count: 1`) is unaffected — only the rows metric is wrong.

NonDLT runs the activity and the status update in the same Temporal worker, so the race window is much narrower in practice.

## Changes

- Pin `model.save()` to `update_fields=["status", "latest_error", "updated_at"]` (plus `"finished_at"` on the first terminal transition) so concurrent F-updates on `rows_synced` survive.
- Add a regression unit test that simulates a concurrent `+400` bump landing between `objects.get()` and `model.save()` inside `update_external_job_status`, and asserts both the DB and the emitted metric see the post-bump value.
- Strengthen the existing happy-path metric assertions in `_run` (e2e harness) — `rows_synced > 0`, timestamp matches `run.finished_at`, all common fields verified — so any future regression in either pipeline mode trips the test.

## How did you test this code?

I'm an agent. Automated tests run:

- `hogli test products/data_warehouse/backend/external_data_source/test/test_jobs.py` — 5/5 passed (including the new `test_concurrent_rows_synced_update_is_not_clobbered`).
- `hogli test posthog/temporal/tests/data_imports/test_end_to_end.py::test_stripe_balance_transactions ::test_stripe_charges ::test_zendesk_brands ::test_paddle_customers` — 8/8 passed across both `non_dlt` and `v3` parametrizations.
- `ruff check && ruff format` clean on all touched files.

No manual prod verification done.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Investigation started from a comment that the V3 consumer path might be recording a 0 for the metric. Traced both paths through `update_external_job_status` and identified the unscoped `model.save()` as the only realistic clobber surface.
- Considered moving the rows_synced bump to a single atomic update inside `update_external_job_status` instead — rejected because the activity already handles the increment correctly via `update_job_row_count`, and scoping the save is the smaller surgical fix.
- Added the e2e assertions before the fix to confirm they passed in both modes against the test harness (where activity completes before the consumer marks complete, so the race window doesn't open). The unit test directly forces the race deterministically.