### PR TITLE
fix(data-warehouse): exclude disabled schemas from negative source status

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -486,12 +486,15 @@ class ExternalDataSourceSerializers(UserAccessControlSerializerMixin, serializer
 
     def get_status(self, instance: ExternalDataSource) -> str:
         active_schemas: list[ExternalDataSchema] = list(instance.active_schemas)  # type: ignore
-        any_failures = any(schema.status == ExternalDataSchema.Status.FAILED for schema in active_schemas)
+        # Negative statuses should ignore schemas the user has disabled — those can linger in
+        # active_schemas via the latest_error prefetch but shouldn't drag the source into a failed state.
+        syncing_schemas = [schema for schema in active_schemas if schema.should_sync]
+        any_failures = any(schema.status == ExternalDataSchema.Status.FAILED for schema in syncing_schemas)
         any_billing_limits_reached = any(
-            schema.status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED for schema in active_schemas
+            schema.status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED for schema in syncing_schemas
         )
         any_billing_limits_too_low = any(
-            schema.status == ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW for schema in active_schemas
+            schema.status == ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW for schema in syncing_schemas
         )
         any_paused = any(schema.status == ExternalDataSchema.Status.PAUSED for schema in active_schemas)
         any_running = any(schema.status == ExternalDataSchema.Status.RUNNING for schema in active_schemas)

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -949,6 +949,65 @@ class TestExternalDataSource(APIBaseTest):
             ],
         )
 
+    @parameterized.expand(
+        [
+            (
+                "failed_disabled_schema_ignored",
+                ExternalDataSchema.Status.FAILED,
+                ExternalDataSchema.Status.COMPLETED,
+                ExternalDataSchema.Status.COMPLETED,
+            ),
+            (
+                "billing_limit_reached_disabled_schema_ignored",
+                ExternalDataSchema.Status.BILLING_LIMIT_REACHED,
+                ExternalDataSchema.Status.COMPLETED,
+                ExternalDataSchema.Status.COMPLETED,
+            ),
+            (
+                "billing_limit_too_low_disabled_schema_ignored",
+                ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,
+                ExternalDataSchema.Status.RUNNING,
+                ExternalDataSchema.Status.RUNNING,
+            ),
+            (
+                "failed_enabled_schema_still_propagates",
+                ExternalDataSchema.Status.COMPLETED,
+                ExternalDataSchema.Status.FAILED,
+                ExternalDataSchema.Status.FAILED,
+            ),
+        ]
+    )
+    def test_status_excludes_disabled_schemas_from_negative_statuses(
+        self,
+        _name: str,
+        disabled_schema_status: str,
+        enabled_schema_status: str,
+        expected_source_status: str,
+    ):
+        source = self._create_external_data_source()
+        ExternalDataSchema.objects.create(
+            name="DisabledWithError",
+            team_id=self.team.pk,
+            source_id=source.pk,
+            table=None,
+            should_sync=False,
+            status=disabled_schema_status,
+            latest_error="boom",
+        )
+        ExternalDataSchema.objects.create(
+            name="EnabledHealthy",
+            team_id=self.team.pk,
+            source_id=source.pk,
+            table=None,
+            should_sync=True,
+            status=enabled_schema_status,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == expected_source_status
+
     def test_delete_external_data_source(self):
         source = self._create_external_data_source()
         schema = self._create_external_data_schema(source.pk)


### PR DESCRIPTION
## Problem

A data warehouse source was surfacing as `Failed` (or `Billing limits` / `Billing limits too low`) when the only schema in that state was one the user had disabled (`should_sync=False`). The disabled schema leaks into the source's `active_schemas` because the prefetch intentionally includes any schema that has a `latest_error` — that's needed so we can still surface the error on the schema itself, but it shouldn't drag the source-level status into a failed state.

## Changes

- `ExternalDataSourceSerializer.get_status` now derives a `syncing_schemas` subset (filtered on `should_sync=True`) and uses it for the three negative status checks: `FAILED`, `BILLING_LIMIT_REACHED`, `BILLING_LIMIT_TOO_LOW`.
- `PAUSED` / `RUNNING` / `COMPLETED` continue to use the full `active_schemas` set since those reflect actual current activity rather than user-actionable problems.
- The `schemas` prefetch is unchanged so `get_latest_error` still surfaces errors on disabled schemas.

## How did you test this code?

I'm an agent. I added a parameterized test (`test_status_excludes_disabled_schemas_from_negative_statuses`) covering four cases:

- A disabled `FAILED` schema alongside an enabled `COMPLETED` schema → source reports `Completed`
- A disabled `BILLING_LIMIT_REACHED` schema alongside an enabled `COMPLETED` schema → source reports `Completed`
- A disabled `BILLING_LIMIT_TOO_LOW` schema alongside an enabled `RUNNING` schema → source reports `Running`
- An enabled `FAILED` schema alongside a disabled `COMPLETED` schema → source still reports `Failed` (regression guard so the filter doesn't suppress real failures)

Each disabled schema in the test has `latest_error` set so it actually appears in the prefetched `active_schemas` list — without that, the test wouldn't exercise the bug.

Ran `hogli test` for the new test plus the adjacent `test_get_external_data_source_with_schema` — all 5 cases pass. Ran `ruff check` on both touched files — clean. No manual UI testing performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code on behalf of @tomowers. Human prompt: a source was being marked failed even when the failing schema was disabled, and the negative statuses (failed, billing limits) should ignore `should_sync=False` schemas. The fix was scoped to the status decision rather than the prefetch, since the prefetch's inclusion of errored disabled schemas is load-bearing for `get_latest_error`.