### PR TITLE
perf(insights): use EXISTS instead of Count+HAVING for saved=true

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from typing import Any, Union, cast
 
 from django.db import transaction
-from django.db.models import Count, F, Max, Prefetch, QuerySet
+from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, QuerySet
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
 from django.utils.text import slugify
@@ -1517,12 +1517,10 @@ class InsightViewSet(
         for key in filters:
             if key == "saved":
                 if str_to_bool(request.GET["saved"]):
-                    queryset = queryset.annotate(
-                        visible_dashboards_count=Count(
-                            "dashboards", filter=~Q(dashboard_tiles__dashboard__creation_mode="unlisted")
-                        )
+                    visible_tile_for_insight = DashboardTile.objects.filter(insight=OuterRef("pk")).exclude(
+                        dashboard__creation_mode="unlisted"
                     )
-                    queryset = queryset.filter(Q(saved=True) | Q(visible_dashboards_count__gte=1))
+                    queryset = queryset.filter(Q(saved=True) | Exists(visible_tile_for_insight))
                 else:
                     queryset = queryset.filter(Q(saved=False))
             elif key == "feature_flag":

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -692,6 +692,34 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             },
         )
 
+    def test_saved_filter_returns_saved_or_on_visible_dashboard(self) -> None:
+        default_dashboard = Dashboard.objects.create(name="d-default", team=self.team, creation_mode="default")
+        template_dashboard = Dashboard.objects.create(name="d-template", team=self.team, creation_mode="template")
+        unlisted_dashboard = Dashboard.objects.create(name="d-unlisted", team=self.team, creation_mode="unlisted")
+
+        filters = {"events": [{"id": "$pageview"}]}
+        saved_no_dashboard = Insight.objects.create(short_id="ins-sn", saved=True, team=self.team, filters=filters)
+        unsaved_on_default = Insight.objects.create(short_id="ins-ud", saved=False, team=self.team, filters=filters)
+        unsaved_on_template = Insight.objects.create(short_id="ins-ut", saved=False, team=self.team, filters=filters)
+        unsaved_on_unlisted = Insight.objects.create(short_id="ins-uu", saved=False, team=self.team, filters=filters)
+        unsaved_no_dashboard = Insight.objects.create(short_id="ins-un", saved=False, team=self.team, filters=filters)
+
+        DashboardTile.objects.create(insight=unsaved_on_default, dashboard=default_dashboard)
+        DashboardTile.objects.create(insight=unsaved_on_template, dashboard=template_dashboard)
+        DashboardTile.objects.create(insight=unsaved_on_unlisted, dashboard=unlisted_dashboard)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true")
+        assert response.status_code == status.HTTP_200_OK
+        returned = sorted(r["short_id"] for r in response.json()["results"])
+
+        assert returned == sorted(
+            [saved_no_dashboard.short_id, unsaved_on_default.short_id, unsaved_on_template.short_id]
+        ), (
+            f"`saved=true` must return saved insights and unsaved-on-non-unlisted-dashboard insights. "
+            f"unsaved-on-unlisted-dashboard ({unsaved_on_unlisted.short_id}) and unsaved-no-dashboard "
+            f"({unsaved_no_dashboard.short_id}) must be excluded."
+        )
+
     # :KLUDGE: avoid making extra queries that are explicitly not cached in tests. Avoids false N+1-s.
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @snapshot_postgres_queries


### PR DESCRIPTION
## Summary

The insights list endpoint with `?saved=true` was the slow part of the page load — 3+ seconds on team 2. A Jaeger trace pinpointed the main `posthog_dashboarditem` SELECT as the 3.1s span:

```sql
SELECT ...
FROM posthog_dashboarditem ...
WHERE team.project_id = %s AND NOT deleted
GROUP BY dashboarditem.id, dashboarditem.saved, team.id, user.id
HAVING (dashboarditem.saved OR COUNT(...) >= %s)
ORDER BY last_modified_at DESC LIMIT 30
```

The `Count("dashboards", filter=...)` annotation forced the predicate into `HAVING`, which means Postgres has to compute `visible_dashboards_count` for every one of the team's insights before `LIMIT` can short-circuit. The partial index on `(team_id, last_modified_at DESC) WHERE NOT deleted` is unusable because GROUP BY + HAVING blocks ordered-scan-with-early-exit.

## Changes

Replace the `Count + HAVING` pair with `EXISTS`:

```python
visible_tile_exists = DashboardTile.objects.filter(insight=OuterRef("pk")).exclude(dashboard__creation_mode="unlisted")
queryset = queryset.filter(Q(saved=True) | Exists(visible_tile_exists))
```

Same product semantics: `saved=true` returns saved insights *plus* unsaved-but-on-a-visible-dashboard ones. New SQL:

```sql
WHERE team.project_id = %s AND NOT deleted
  AND (saved OR EXISTS (SELECT 1 FROM posthog_dashboardtile JOIN posthog_dashboard ...
                        WHERE insight_id = dashboarditem.id AND creation_mode != 'unlisted'))
ORDER BY last_modified_at DESC LIMIT 30
```

Now the planner can walk the partial index in `last_modified_at` order, evaluate `saved OR EXISTS(...)` per row, and stop at 30 matches. Expect this to drop from ~3s to <100ms on team 2.

## Tests

New parameterised test `test_saved_filter_returns_saved_or_on_visible_dashboard` locks in the OR semantic across:
- saved + no dashboard → appears
- unsaved + default-mode dashboard → appears
- unsaved + template-mode dashboard → appears
- unsaved + unlisted-mode dashboard → does NOT appear (the legacy exclusion)
- unsaved + no dashboard → does NOT appear

## 🤖 Agent context

Found by reading the trace JSON for a 4.1-second `?basic=true&saved=true` page-load on team 2. The N+1 fix in #57121 trimmed prefetch overhead but didn't touch this filter shape; this PR is the actual win for team 2 specifically.

Plan-friendly: the change is semantically equivalent (verified by parametrised test), purely a query-shape rewrite, no migration.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*