### PR TITLE
chore(hog-charts): clean up BarChart follow-ups

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -424,6 +424,10 @@ snapshots:
         hash: v1.k794b7964.2590c767710f5896460119705f0703bc9cd21a20c8c126f4db366b61a5bcba28.u1i4S-zmIzVZld-cgvuMd17GRZxPmS3ViBkJIPAdeDg
     components-hedgehogmode--static-hedgehog--light:
         hash: v1.k794b7964.43d71f5c3ad02bd9e1fa87433d34df79e0de653c4b55004188bed5de78a2c3f5.i2ATBYyqY7uq7UxwlL2Rdte6AuMyySa8Jnbeb1VouoQ
+    components-hogcharts-barchart--stacked-mixed-sign--dark:
+        hash: v1.k794b7964.7b2c423832b7905806ed16876aacdd7ea4ec19d15c0f73b72059b1f310e0bac3.F7Y16r39vAX_WB-IAajDmLutSQNdMY-90TusfLyGNO4
+    components-hogcharts-barchart--stacked-mixed-sign--light:
+        hash: v1.k794b7964.520cec44a9bdf1647114354349bb796712202aa45e2c4f81994f334bce5bb685.ZQznGFg-M_qzXFfcfIabLDmIfGYMYYIp1fLKKMDzcnc
     components-hogcharts-linechart--combined-overlays--dark:
         hash: v1.k794b7964.7a5d75d739b30755468fe69e4b938e16d93630e7d2f444d2a76563563879a8f5.-qZogPFTjOPrh2r16ccI1VbZlTPiwhGHuF4WbzwpHT4
     components-hogcharts-linechart--combined-overlays--light:

--- a/frontend/src/lib/hog-charts/charts/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { BarChart } from 'lib/hog-charts'
+import type { BarChartConfig, Series } from 'lib/hog-charts'
+
+import { Stage, useReactiveTheme } from '../story-helpers'
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const meta: Meta = { title: 'Components/HogCharts/BarChart', parameters: { layout: 'centered' } }
+export default meta
+
+type Story = StoryObj<{}>
+
+/** Stacked bars with a mix of positive and negative values per index. The d3 stack splits
+ *  positive and negative contributions either side of the baseline, so the topmost positive
+ *  series and bottommost negative series both round their cap. */
+export const StackedMixedSign: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const series: Series[] = [
+            { key: 'inflow', label: 'Inflow', color: '', data: [12, 18, 9, 22, 14, 20, 16] },
+            { key: 'refunds', label: 'Refunds', color: '', data: [-4, -7, -3, -10, -6, -8, -5] },
+            { key: 'chargebacks', label: 'Chargebacks', color: '', data: [-1, -2, -1, -3, 0, -1, -2] },
+        ]
+        const config: BarChartConfig = { showGrid: true, barLayout: 'stacked' }
+        return (
+            <Stage>
+                <BarChart series={series} labels={DAYS} config={config} theme={theme} />
+            </Stage>
+        )
+    },
+}

--- a/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
@@ -1,8 +1,17 @@
 import { cleanup, render } from '@testing-library/react'
 
-import type { ChartTheme, Series } from '../core/types'
+import { drawBars } from '../core/canvas-renderer'
+import type { BarRect } from '../core/canvas-renderer'
+import type { ChartTheme, ResolvedSeries, Series } from '../core/types'
 import { setupJsdom } from '../test-helpers'
 import { BarChart } from './BarChart'
+
+jest.mock('../core/canvas-renderer', () => {
+    const actual = jest.requireActual('../core/canvas-renderer')
+    return { __esModule: true, ...actual, drawBars: jest.fn() }
+})
+
+const mockedDrawBars = drawBars as jest.MockedFunction<typeof drawBars>
 
 const THEME: ChartTheme = {
     colors: ['#1f77b4', '#ff7f0e', '#2ca02c'],
@@ -24,13 +33,24 @@ type Orientation = 'vertical' | 'horizontal'
 describe('BarChart', () => {
     let teardown: () => void
 
+    let originalRaf: typeof global.requestAnimationFrame | undefined
     beforeEach(() => {
         teardown = setupJsdom()
+        mockedDrawBars.mockClear()
+        originalRaf = global.requestAnimationFrame
+        // Run draw effects synchronously so the static-layer RAF fires before the test reads the spy.
+        global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+            cb(0)
+            return 0
+        }) as typeof global.requestAnimationFrame
     })
 
     afterEach(() => {
         teardown()
         cleanup()
+        if (originalRaf) {
+            global.requestAnimationFrame = originalRaf
+        }
     })
 
     describe.each<[Layout, Orientation]>([
@@ -101,5 +121,34 @@ describe('BarChart', () => {
         const broken: Series[] = [{ key: 'a', label: 'A', data: [Number.NaN, Number.NaN, Number.NaN] }]
         const { container } = render(<BarChart series={broken} labels={LABELS} theme={THEME} />)
         expect(container.querySelector('canvas')).not.toBeNull()
+    })
+
+    // Pins today's behaviour for multi-axis stacked bars: cap rounding picks the last visible
+    // series in array order, regardless of yAxisId. The topmost rendered layer per axis isn't
+    // necessarily that key — see the multi-axis follow-up in PROGRESS.md.
+    it('rounds the cap of only the last visible series across axes (multi-axis stacked)', () => {
+        const series: Series[] = [
+            { key: 'left-1', label: 'L1', data: [10, 20, 30], yAxisId: 'left' },
+            { key: 'left-2', label: 'L2', data: [5, 15, 25], yAxisId: 'left' },
+            { key: 'right-1', label: 'R1', data: [1, 2, 3], yAxisId: 'right' },
+        ]
+        render(<BarChart series={series} labels={LABELS} theme={THEME} config={{ barLayout: 'stacked' }} />)
+
+        const callsByKey = new Map<string, BarRect[]>()
+        for (const call of mockedDrawBars.mock.calls) {
+            const drawnSeries = call[1] as ResolvedSeries
+            const bars = call[2] as BarRect[]
+            callsByKey.set(drawnSeries.key, bars)
+        }
+
+        const hasRoundedCap = (bars: BarRect[] | undefined): boolean =>
+            !!bars && bars.some((b) => b.corners.topLeft || b.corners.topRight)
+
+        expect(hasRoundedCap(callsByKey.get('right-1'))).toBe(true)
+        // Today's behaviour: the topmost layer of the left axis (left-2) does not get the
+        // rounded cap, because the selection only considers array order. Pinning so the fix
+        // flips this assertion intentionally when it lands.
+        expect(hasRoundedCap(callsByKey.get('left-2'))).toBe(false)
+        expect(hasRoundedCap(callsByKey.get('left-1'))).toBe(false)
     })
 })

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useRef } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
-import { computeSeriesBars } from '../core/bar-layout'
+import { computeBarAtIndex, computeSeriesBars } from '../core/bar-layout'
 import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../core/canvas-renderer'
 import { Chart } from '../core/Chart'
 import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
@@ -24,6 +24,13 @@ import type {
     Series,
     TooltipContext,
 } from '../core/types'
+
+// Brand for the private ChartScales._private slot used by BarChart. The base Chart
+// and other chart types treat this as opaque; BarChart's draw callbacks narrow back to it.
+// Mirrors the LineChart pattern — see ARCHITECTURE.md "Passing chart-type-private state to drawStatic".
+interface BarChartPrivate {
+    __barChart: BarScaleSet
+}
 
 function bandCenter(scales: BarScaleSet, label: string): number | undefined {
     const start = scales.band(label)
@@ -107,8 +114,6 @@ function BarChartInner<Meta = unknown>({
         }
     }, [config, barLayout])
 
-    const d3ScalesRef = useRef<BarScaleSet | null>(null)
-
     const createScales: CreateScalesFn = useCallback(
         (coloredSeries: ResolvedSeries[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
             // For stacked/percent, the value-axis domain must reflect cumulative sums, not
@@ -129,10 +134,15 @@ function BarChartInner<Meta = unknown>({
                 groupPadding,
                 stackedSeries,
             })
-            d3ScalesRef.current = d3Scales
 
             const tickAxisLength = isHorizontal ? dimensions.plotWidth : dimensions.plotHeight
             const yTickCount = yTickCountForHeight(tickAxisLength)
+
+            // Stash the raw d3 scales in the private slot so drawStatic/drawHover can read them
+            // without a side-channel ref — every render gets a self-contained ChartScales object,
+            // which avoids strict-mode / concurrent-rendering races between createScales and the
+            // static-draw effect. See LineChart.tsx and ARCHITECTURE.md for the canonical pattern.
+            const barChartPrivate: BarChartPrivate = { __barChart: d3Scales }
 
             // For horizontal, expose the value scale as `y` (since AxisLabels horizontal mode
             // calls `scales.y(tick)` for x-pixel positioning of value ticks).
@@ -141,14 +151,15 @@ function BarChartInner<Meta = unknown>({
                 x: (label: string) => bandCenter(d3Scales, label),
                 y: (value: number) => d3Scales.value(value),
                 yTicks: () => d3Scales.value.ticks?.(yTickCount) ?? [],
+                _private: barChartPrivate,
             }
         },
         [yScaleType, barLayout, axisOrientation, bandPadding, groupPadding, stackedData, isHorizontal]
     )
 
     const drawStatic = useCallback(
-        ({ ctx, dimensions, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
-            const d3Scales = d3ScalesRef.current
+        ({ ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
+            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
             if (!d3Scales) {
                 return
             }
@@ -195,28 +206,29 @@ function BarChartInner<Meta = unknown>({
     )
 
     const drawHover = useCallback(
-        ({ ctx, series: coloredSeries, labels: drawLabels, hoverIndex, theme }: ChartDrawArgs) => {
-            const d3Scales = d3ScalesRef.current
+        ({ ctx, scales, series: coloredSeries, labels: drawLabels, hoverIndex, theme }: ChartDrawArgs) => {
+            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
             if (!d3Scales || hoverIndex < 0) {
                 return
             }
             const highlightColor = theme.crosshairColor ?? 'rgba(0, 0, 0, 0.4)'
+            const hoveredLabel = drawLabels[hoverIndex]
             for (const s of coloredSeries) {
                 if (s.visibility?.excluded) {
                     continue
                 }
                 const stackedBand = stackedData?.get(s.key)
                 const isTop = topStackedKey !== null && s.key === topStackedKey
-                const bars = computeSeriesBars({
+                const bar = computeBarAtIndex({
                     series: s,
-                    labels: drawLabels,
+                    label: hoveredLabel,
+                    dataIndex: hoverIndex,
                     scales: d3Scales,
                     layout: barLayout,
                     isHorizontal,
                     stackedBand,
                     isTopOfStack: isTop,
                 })
-                const bar = bars[hoverIndex]
                 if (bar) {
                     drawBarHighlight(ctx, bar, highlightColor, barCornerRadius)
                 }
@@ -240,11 +252,6 @@ function BarChartInner<Meta = unknown>({
         }
     }, [stackedData])
 
-    const labelToCoord = useCallback((label: string): number | undefined => {
-        const d3Scales = d3ScalesRef.current
-        return d3Scales ? bandCenter(d3Scales, label) : undefined
-    }, [])
-
     return (
         <Chart
             series={series}
@@ -259,7 +266,6 @@ function BarChartInner<Meta = unknown>({
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}
-            labelToCoord={isHorizontal ? labelToCoord : undefined}
         >
             {children}
         </Chart>

--- a/frontend/src/lib/hog-charts/core/bar-layout.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.test.ts
@@ -1,6 +1,18 @@
 import { dimensions, makeSeries } from '../test-helpers'
 import { type ComputeSeriesBarsOptions, computeSeriesBars, cornersFor } from './bar-layout'
+import type { BarRect } from './canvas-renderer'
 import { computeStackData, createBarScales } from './scales'
+import type { ChartDimensions } from './types'
+
+// Compact plot area chosen so band/value scales produce round pixel values for snapshots.
+const PIXEL_TEST_DIMENSIONS: ChartDimensions = {
+    width: 200,
+    height: 100,
+    plotLeft: 0,
+    plotTop: 0,
+    plotWidth: 200,
+    plotHeight: 100,
+}
 
 function layoutOf(
     args: Partial<ComputeSeriesBarsOptions> & Pick<ComputeSeriesBarsOptions, 'series' | 'scales'>
@@ -125,5 +137,204 @@ describe('hog-charts bar-layout', () => {
         expect(bars[0]?.dataIndex).toBe(0)
         expect(bars[1]).toBeNull()
         expect(bars[2]?.dataIndex).toBe(2)
+    })
+
+    describe('computeSeriesBars — exact pixel positions', () => {
+        interface PixelCase {
+            name: string
+            labels: string[]
+            seriesData: { key: string; data: number[] }[]
+            layout: 'stacked' | 'grouped'
+            isHorizontal: boolean
+            expected: { key: string; isTopOfStack: boolean; bars: BarRect[] }[]
+        }
+
+        it.each<PixelCase>([
+            {
+                name: 'vertical stacked',
+                labels: ['L1', 'L2'],
+                seriesData: [
+                    { key: 'a', data: [25, 50] },
+                    { key: 'b', data: [25, 50] },
+                ],
+                layout: 'stacked',
+                isHorizontal: false,
+                expected: [
+                    {
+                        key: 'a',
+                        isTopOfStack: false,
+                        bars: [
+                            { x: 0, y: 75, width: 100, height: 25, corners: {}, dataIndex: 0 },
+                            { x: 100, y: 50, width: 100, height: 50, corners: {}, dataIndex: 1 },
+                        ],
+                    },
+                    {
+                        key: 'b',
+                        isTopOfStack: true,
+                        bars: [
+                            {
+                                x: 0,
+                                y: 50,
+                                width: 100,
+                                height: 25,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 0,
+                            },
+                            {
+                                x: 100,
+                                y: 0,
+                                width: 100,
+                                height: 50,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                name: 'vertical grouped',
+                labels: ['L1', 'L2'],
+                seriesData: [
+                    { key: 'a', data: [10, 20] },
+                    { key: 'b', data: [20, 10] },
+                ],
+                layout: 'grouped',
+                isHorizontal: false,
+                expected: [
+                    {
+                        key: 'a',
+                        isTopOfStack: false,
+                        bars: [
+                            {
+                                x: 0,
+                                y: 50,
+                                width: 50,
+                                height: 50,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 0,
+                            },
+                            {
+                                x: 100,
+                                y: 0,
+                                width: 50,
+                                height: 100,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 1,
+                            },
+                        ],
+                    },
+                    {
+                        key: 'b',
+                        isTopOfStack: false,
+                        bars: [
+                            {
+                                x: 50,
+                                y: 0,
+                                width: 50,
+                                height: 100,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 0,
+                            },
+                            {
+                                x: 150,
+                                y: 50,
+                                width: 50,
+                                height: 50,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                name: 'horizontal stacked',
+                labels: ['L1'],
+                seriesData: [
+                    { key: 'a', data: [50] },
+                    { key: 'b', data: [50] },
+                ],
+                layout: 'stacked',
+                isHorizontal: true,
+                expected: [
+                    {
+                        key: 'a',
+                        isTopOfStack: false,
+                        bars: [{ x: 0, y: 0, width: 100, height: 100, corners: {}, dataIndex: 0 }],
+                    },
+                    {
+                        key: 'b',
+                        isTopOfStack: true,
+                        bars: [
+                            {
+                                x: 100,
+                                y: 0,
+                                width: 100,
+                                height: 100,
+                                corners: { topRight: true, bottomRight: true },
+                                dataIndex: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                name: 'vertical grouped with positive and negative values',
+                labels: ['L1', 'L2'],
+                seriesData: [{ key: 'a', data: [50, -50] }],
+                layout: 'grouped',
+                isHorizontal: false,
+                expected: [
+                    {
+                        key: 'a',
+                        isTopOfStack: false,
+                        bars: [
+                            {
+                                x: 0,
+                                y: 0,
+                                width: 100,
+                                height: 50,
+                                corners: { topLeft: true, topRight: true },
+                                dataIndex: 0,
+                            },
+                            {
+                                x: 100,
+                                y: 50,
+                                width: 100,
+                                height: 50,
+                                corners: { bottomLeft: true, bottomRight: true },
+                                dataIndex: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ])('$name', ({ labels, seriesData, layout, isHorizontal, expected }) => {
+            const series = seriesData.map((s) => makeSeries(s))
+            const stacks = layout === 'stacked' ? computeStackData(series, labels) : undefined
+            const stackedSeries = stacks ? series.map((s) => ({ ...s, data: stacks.get(s.key)!.top })) : undefined
+            const scales = createBarScales(series, labels, PIXEL_TEST_DIMENSIONS, {
+                barLayout: layout,
+                axisOrientation: isHorizontal ? 'horizontal' : 'vertical',
+                bandPadding: 0,
+                groupPadding: 0,
+                stackedSeries,
+            })
+
+            for (const { key, isTopOfStack, bars: expectedBars } of expected) {
+                const seriesForKey = series.find((s) => s.key === key)!
+                const bars = computeSeriesBars({
+                    series: seriesForKey,
+                    labels,
+                    scales,
+                    layout,
+                    isHorizontal,
+                    stackedBand: stacks?.get(key),
+                    isTopOfStack,
+                })
+                expect(bars).toEqual(expectedBars)
+            }
+        })
     })
 })

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -52,50 +52,80 @@ export function computeSeriesBars({
     stackedBand,
     isTopOfStack,
 }: ComputeSeriesBarsOptions): SeriesBarLayout {
-    const isGrouped = layout === 'grouped'
-    if (!isGrouped && !stackedBand) {
-        throw new Error(`computeSeriesBars: stackedBand is required for layout '${layout}'`)
-    }
-
-    const result: SeriesBarLayout = []
-    const bandWidth = scales.band.bandwidth()
-    const valueAtZero = scales.value(0)
-    const shouldRoundCap = isGrouped || isTopOfStack
-    const groupOffsetForKey = isGrouped ? scales.group?.(series.key) : undefined
-    const groupBandWidth = isGrouped ? (scales.group?.bandwidth() ?? bandWidth) : bandWidth
-    // For stacked/percent the bar's "positive direction" depends on which pixel is further from baseline,
-    // which differs by orientation: horizontal = larger x-pixel, vertical = smaller y-pixel (axis is inverted).
-    const isPositiveByPixels = (topPx: number, bottomPx: number): boolean =>
-        isHorizontal ? topPx >= bottomPx : topPx <= bottomPx
-
+    const result: SeriesBarLayout = new Array(labels.length)
     for (let i = 0; i < labels.length; i++) {
-        const bandStart = scales.band(labels[i])
-        const raw = series.data[i]
-        if (bandStart == null || raw == null || !isFinite(raw)) {
-            result.push(null)
-            continue
-        }
-
-        if (isGrouped) {
-            const valuePixel = scales.value(raw)
-            if (groupOffsetForKey == null || !isFinite(valuePixel)) {
-                result.push(null)
-                continue
-            }
-            const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
-            const start = bandStart + groupOffsetForKey
-            result.push(makeBarRect(isHorizontal, start, groupBandWidth, valueAtZero, valuePixel, corners, i))
-            continue
-        }
-
-        const topPixel = scales.value(stackedBand!.top[i])
-        const bottomPixel = scales.value(stackedBand!.bottom[i])
-        if (!isFinite(topPixel) || !isFinite(bottomPixel)) {
-            result.push(null)
-            continue
-        }
-        const corners = cornersFor(isHorizontal, isPositiveByPixels(topPixel, bottomPixel), shouldRoundCap)
-        result.push(makeBarRect(isHorizontal, bandStart, bandWidth, topPixel, bottomPixel, corners, i))
+        result[i] = computeBarAtIndex({
+            series,
+            label: labels[i],
+            dataIndex: i,
+            scales,
+            layout,
+            isHorizontal,
+            stackedBand,
+            isTopOfStack,
+        })
     }
     return result
+}
+
+export interface ComputeBarAtIndexOptions {
+    series: Series
+    label: string
+    dataIndex: number
+    scales: BarScaleSet
+    layout: 'stacked' | 'grouped' | 'percent'
+    isHorizontal: boolean
+    /** Required for `stacked` and `percent` layouts. Must be omitted for `grouped`. */
+    stackedBand?: StackedBand
+    isTopOfStack: boolean
+}
+
+/** Single-bar fast path for `drawHover` so the overlay redraw doesn't recompute every bar
+ *  on every mousemove. Returns `null` for indices with no renderable bar. */
+export function computeBarAtIndex({
+    series,
+    label,
+    dataIndex,
+    scales,
+    layout,
+    isHorizontal,
+    stackedBand,
+    isTopOfStack,
+}: ComputeBarAtIndexOptions): BarRect | null {
+    const isGrouped = layout === 'grouped'
+    if (!isGrouped && !stackedBand) {
+        throw new Error(`computeBarAtIndex: stackedBand is required for layout '${layout}'`)
+    }
+
+    const bandStart = scales.band(label)
+    const raw = series.data[dataIndex]
+    if (bandStart == null || raw == null || !isFinite(raw)) {
+        return null
+    }
+
+    const shouldRoundCap = isGrouped || isTopOfStack
+    const bandWidth = scales.band.bandwidth()
+
+    if (isGrouped) {
+        const groupOffsetForKey = scales.group?.(series.key)
+        const valuePixel = scales.value(raw)
+        if (groupOffsetForKey == null || !isFinite(valuePixel)) {
+            return null
+        }
+        const groupBandWidth = scales.group?.bandwidth() ?? bandWidth
+        const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
+        const start = bandStart + groupOffsetForKey
+        return makeBarRect(isHorizontal, start, groupBandWidth, scales.value(0), valuePixel, corners, dataIndex)
+    }
+
+    const topPixel = scales.value(stackedBand!.top[dataIndex])
+    const bottomPixel = scales.value(stackedBand!.bottom[dataIndex])
+    if (!isFinite(topPixel) || !isFinite(bottomPixel)) {
+        return null
+    }
+    // For stacked/percent the bar's "positive direction" depends on which pixel is further from baseline,
+    // which differs by orientation: horizontal = larger x-pixel, vertical = smaller y-pixel (axis is inverted).
+    const isPositive = isHorizontal ? topPixel >= bottomPixel : topPixel <= bottomPixel
+    const corners = cornersFor(isHorizontal, isPositive, shouldRoundCap)
+    return makeBarRect(isHorizontal, bandStart, bandWidth, topPixel, bottomPixel, corners, dataIndex)
 }

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -11,8 +11,8 @@ interface AxisLabelsProps {
     hideYAxis?: boolean
     axisColor?: string
     orientation?: 'vertical' | 'horizontal'
-    /** Required when orientation is horizontal — maps labels to y-pixel coordinates (band centers).
-     *  Omitting it in horizontal mode hides all category labels. */
+    /** Optional override for label → coord mapping. Falls back to `scales.x`, which chart types
+     *  serving horizontal orientation are expected to set to a label→band-center function. */
     labelToCoord?: (label: string) => number | undefined
 }
 
@@ -120,7 +120,9 @@ export function AxisLabels({
     const rightFormatter = yRightTickFormatter ?? yTickFormatter
 
     if (orientation === 'horizontal') {
-        // In horizontal mode `scales.y` holds value→x-pixel; `labelToCoord` holds label→y-pixel.
+        // In horizontal mode `scales.y` holds value→x-pixel and the label→y-pixel function lives
+        // on `scales.x` (or `labelToCoord` if explicitly overridden).
+        const labelToY = labelToCoord ?? scales.x
         return (
             <>
                 {!hideYAxis &&
@@ -129,7 +131,7 @@ export function AxisLabels({
                         if (text === null) {
                             return null
                         }
-                        const y = labelToCoord ? labelToCoord(labelText) : undefined
+                        const y = labelToY(labelText)
                         if (y == null || !isFinite(y)) {
                             return null
                         }


### PR DESCRIPTION
## Problem

Cleaning up the post-merge follow-ups left behind by the BarChart PR (#57212): a side-channel `useRef` that disagrees with LineChart's `_private`-slot convention, redundant per-mousemove work in the hover path, missing tests for known-fragile behaviour, and a missing story.

## Changes

- Switch `BarChart` from `d3ScalesRef` to the `ChartScales._private` slot so its draw callbacks read scales from the same render-scoped object, matching `LineChart`. Drops the redundant `labelToCoord` prop wiring; `AxisLabels` falls back to `scales.x` in horizontal mode.
- Add `computeBarAtIndex` to `core/bar-layout.ts` and call it from `drawHover` so the overlay redraw doesn't recompute every bar on each mousemove. `computeSeriesBars` delegates to it so the two paths can't drift.
- Pin today's multi-axis stacked cap-rounding behaviour with a new test in `BarChart.test.tsx` (last visible series in array order gets the cap, regardless of `yAxisId`). The fix should flip the assertion intentionally.
- Add a `StackedMixedSign` Storybook story for mixed positive/negative stacked bars.
- Add exact pixel-position tests for `computeSeriesBars` in `bar-layout.test.ts` covering vertical stacked, vertical grouped, horizontal stacked, and vertical grouped with negatives.

## How did you test this code?

I'm an agent — only ran automated tests:

- `jest --testPathPattern='hog-charts'` — all suites pass.
- No manual UI verification of the new story.

## Publish to changelog?