### PR TITLE
fix(traces): when fetches spans for a trace check if they match filters

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2792,13 +2792,21 @@ const api = {
         },
         async getTrace(
             traceId: string,
-            dateRange?: { date_from?: string | null; date_to?: string | null }
+            query?: {
+                dateRange?: { date_from?: string | null; date_to?: string | null }
+                serviceNames?: string[]
+                statusCodes?: number[]
+                filterGroup?: PropertyGroupFilter
+            }
         ): Promise<{ results: Record<string, any>[] }> {
             return new ApiRequest()
                 .tracingSpans()
                 .withAction(`trace/${traceId}`)
                 .create({
-                    data: { dateRange: dateRange ?? { date_from: '-24h' } },
+                    data: {
+                        ...query,
+                        dateRange: query?.dateRange ?? { date_from: '-24h' },
+                    },
                 })
         },
         async sparkline(query: {

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -155,9 +155,21 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         except ValueError:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
+        try:
+            filter_group = (
+                self.get_model(query_data["filterGroup"], PropertyGroupFilter)
+                if query_data.get("filterGroup")
+                else None
+            )
+        except (ValidationError, ValueError, ParseError):
+            filter_group = None
+
         spans_query = TraceSpansQuery(
             dateRange=date_range,
             traceId=trace_id,
+            serviceNames=query_data.get("serviceNames", None),
+            statusCodes=query_data.get("statusCodes", None),
+            filterGroup=filter_group,
             limit=1000,
             prefetchSpans=2000,
             rootSpans=False,

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -156,8 +156,12 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
             {
                 loadTraceSpans: async (traceId: string): Promise<Span[]> => {
                     const response = await api.tracing.getTrace(traceId, {
-                        date_from: values.utcDateRange.date_from ?? '-24h',
-                        date_to: values.utcDateRange.date_to ?? undefined,
+                        dateRange: {
+                            date_from: values.utcDateRange.date_from ?? '-24h',
+                            date_to: values.utcDateRange.date_to ?? undefined,
+                        },
+                        serviceNames: values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
+                        filterGroup: values.filters.filterGroup as PropertyGroupFilter,
                     })
                     return response.results as Span[]
                 },


### PR DESCRIPTION

## Problem
currently if you open a trace with more than 20 spans it requests all spans for the trace but doesn't record if they match the filter or not

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
pass in filters to the get_trace call and mark spans on if they're filtered or not (the same behaviour as when we've prefetched the trace)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
