### PR TITLE
fix(llma): fall back to events when ai_events lacks the requested trace

### DIFF
--- a/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
@@ -5,6 +5,7 @@
          max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  HAVING ifNull(greater(count(), 0), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -56,6 +57,7 @@
          max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  HAVING ifNull(greater(count(), 0), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -107,6 +109,7 @@
          max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  HAVING ifNull(greater(count(), 0), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -158,6 +161,7 @@
          max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  HAVING ifNull(greater(count(), 0), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -226,6 +230,7 @@
          max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  HAVING ifNull(greater(count(), 0), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/ai/test/test_trace_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_trace_query_runner.py
@@ -1548,3 +1548,80 @@ class TestTraceQueryRunner(ClickhouseTestMixin, BaseTest):
         gen_event = next(e for e in trace.events if e.event == "$ai_generation")
         assert "$ai_input" in gen_event.properties
         assert "$ai_output_choices" in gen_event.properties
+
+    @freeze_time("2025-01-15T12:00:00Z")
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.is_ai_events_enabled", return_value=True)
+    @patch("posthog.test.base._flush_ai_events", return_value=None)
+    def test_fallback_when_ai_events_has_other_traces_but_not_this_one(self, _mock_flush, _mock_flag):
+        # Regression for INC-828. Production scenario: ai_events has plenty of recent
+        # rows, just not for the requested trace_id. The bounds query's min/max over
+        # the filtered (empty) subset returns one row of (epoch_0, epoch_0) instead of
+        # zero rows, defeating the resolver's empty-check and skipping the fallback.
+        # Without the HAVING count() > 0 guard on the bounds query, the bounds resolve
+        # to epoch and the main trace query then finds nothing.
+        #
+        # Patches `_flush_ai_events` so the events created via _create_event land in
+        # the events table only, mimicking 'older than the ai_events dual-write start'.
+        # Then seeds ai_events directly with an unrelated trace so the table is
+        # non-empty, matching the production shape that exposes the aggregation bug.
+        from posthog.models.ai_events.test_util import bulk_create_ai_events
+
+        target_trace_id = "target-trace-only-in-events"
+        unrelated_trace_id = "unrelated-trace-in-ai-events"
+        _create_person(distinct_ids=["person1"], team=self.team)
+
+        # Target trace: events table only (auto-mirror to ai_events suppressed via patch)
+        _create_ai_trace_event(
+            trace_id=target_trace_id,
+            trace_name="target-trace",
+            input_state=None,
+            output_state=None,
+            distinct_id="person1",
+            team=self.team,
+            timestamp=datetime(2025, 1, 15, 0, 0),
+        )
+        _create_ai_generation_event(
+            distinct_id="person1",
+            trace_id=target_trace_id,
+            input=[{"role": "user", "content": "Hello"}],
+            output=[{"role": "assistant", "content": "Hi there"}],
+            team=self.team,
+            timestamp=datetime(2025, 1, 15, 0, 1),
+            properties={"$ai_parent_id": target_trace_id},
+        )
+
+        # Unrelated trace: ai_events only. Makes the table non-empty so min/max over
+        # a WHERE-filtered-empty subset returns (epoch_0, epoch_0) — the production
+        # behavior we need to reproduce.
+        bulk_create_ai_events(
+            [
+                {
+                    "event": "$ai_generation",
+                    "distinct_id": "person1",
+                    "team": self.team,
+                    "timestamp": datetime(2025, 1, 15, 0, 30),
+                    "properties": {
+                        "$ai_trace_id": unrelated_trace_id,
+                        "$ai_input": [{"role": "user", "content": "noise"}],
+                        "$ai_output_choices": [{"role": "assistant", "content": "noise"}],
+                    },
+                }
+            ]
+        )
+
+        response = TraceQueryRunner(
+            team=self.team,
+            query=TraceQuery(
+                traceId=target_trace_id,
+                dateRange=DateRange(date_from="2025-01-15T00:00:00Z", date_to="2025-01-15T01:00:00Z"),
+            ),
+        ).calculate()
+
+        assert len(response.results) == 1, (
+            "Trace should be returned via the events fallback. "
+            "If this asserts 0, the bounds query is satisfying the empty-check with an "
+            "(epoch_0, epoch_0) row and skipping the fallback — see INC-828."
+        )
+        trace = response.results[0]
+        assert trace.id == target_trace_id
+        assert trace.traceName == "target-trace"

--- a/posthog/hogql_queries/ai/trace_query_runner.py
+++ b/posthog/hogql_queries/ai/trace_query_runner.py
@@ -99,6 +99,12 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
         )
 
     def _discover_trace_bounds(self) -> tuple[datetime, datetime] | None:
+        # HAVING count() > 0 makes the aggregate return zero rows when the WHERE clause
+        # matches nothing. Without it, min/max over an empty subset still returns one row
+        # of (epoch_0, epoch_0), defeating execute_with_ai_events_fallback's empty-check
+        # and skipping the events-table fallback. That breaks trace lookups for traces
+        # older than the team's ai_events dual-write start while ai_events itself has
+        # plenty of recent rows for OTHER traces. INC-828.
         bounds_query = parse_select(
             """
             SELECT
@@ -109,6 +115,7 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
                 '$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace'
             )
               AND {filter_conditions}
+            HAVING count() > 0
             """,
         )
 


### PR DESCRIPTION
## Problem

The trace detail page renders `<NotFound object="trace" />` for any trace older than the team's ai_events dual-write start, even though the list view (which reads `events` directly) still shows the trace. Reproducible by filtering the LLM analytics traces list to a date range outside the dedicated table's data window and clicking through.

`TraceQueryRunner._discover_trace_bounds` (introduced in #57093) runs an aggregation pre-query against `posthog.ai_events` to narrow the timestamp window before the main trace query. When ai_events has plenty of rows for *other* traces but none for the requested `trace_id`, `min(timestamp)/max(timestamp)` over the filtered (empty) subset returns one row of `(epoch_0, epoch_0)` — non-empty, non-NULL. `execute_with_ai_events_fallback`'s `if result.results:` empty-check reads that as 'ai_events has data' and skips the events-table fallback. Bounds resolve to epoch, the main query runs against `1969-12-31 23:59 ↔ 1970-01-01 00:01`, returns nothing, and the page renders not-found.

This composes with the `ai-events-table-rollout` flag being on for teams whose ai_events backfill hasn't completed: any trace older than the per-team dual-write cutoff hits this path.

The flag has been rolled back to 0% as a mitigation; this PR is the structural fix so the read flag can ramp back up safely.

## Changes

Add `HAVING count() > 0` to the bounds discovery query so the aggregate returns zero rows when nothing matches. The resolver's existing empty-check then triggers the events-table fallback as designed, bounds resolve from `events`, and the main trace query runs against the right window.

```sql
SELECT min(timestamp), max(timestamp)
FROM posthog.ai_events
WHERE event IN (...) AND {filter_conditions}
HAVING count() > 0   -- this PR
```

No frontend or contract changes. The `events` fallback also picks up the new `HAVING` clause when the rewriter swaps `ai_events` → `events`, which is harmless: the same semantic applies (return zero rows when nothing matches, instead of one row of epoch).

## How did you test this code?

I'm an agent (Claude Code, Opus 4.7). All testing below is automated.

- New regression test `test_fallback_when_ai_events_has_other_traces_but_not_this_one` in `posthog/hogql_queries/ai/test/test_trace_query_runner.py`. Reproduces the production scenario: ai_events seeded with an unrelated trace (so `min/max` over the WHERE-filtered-empty subset returns `(epoch_0, epoch_0)` rather than 0 rows), target trace's events written only to `events`, flag mocked on. Verified the test FAILS on master (bounds resolve to epoch, response is empty), and PASSES with this fix.
- Full `posthog/hogql_queries/ai/test/` suite: 192 passed, 2 skipped.
- Snapshot updates for `test_event_property_filters` and `test_person_property_filters` pick up the new `HAVING ifNull(greater(count(), 0), 0)` line on the bounds query — see snapshot diff in this PR.

## Publish to changelog?

no — internal migration fix, no user-facing surface change.

## Docs update

`skip-inkeep-docs`

## 🤖 Agent context

Authored end-to-end by Claude Code (Opus 4.7) during incident response.

Investigation flow:
1. Confirmed via the LLMA list-vs-detail repro that the list view still shows traces (events table) but the detail page renders NotFound.
2. Verified data state on project 2 via execute-sql: ai_events covers ~3 days back; events covers ~14 days. A representative stuck trace had 13 rows in events, 0 in ai_events.
3. Traced through the resolver's empty-check semantics. Initial hypothesis was that `min/max` over zero rows returned `(NULL, NULL)`. Direct query against project 2 showed it returns `(epoch_0, epoch_0)` instead — non-NULL DateTime default — which is the actual mechanism that defeats the empty-check.
4. Identified PR #57093 as the change that introduced the aggregation pre-query, and the timing alignment with the flag ramp on the same day.
5. Reproduced the bug in a test by patching `_flush_ai_events` (the test-base auto-mirror that normally writes AI events to both `events` and `ai_events`) so events land in `events` only, and seeding `ai_events` with an unrelated trace so the table is non-empty.
6. Picked `HAVING count() > 0` over alternatives (caller-side null check, query-shape-aware predicate in the resolver, separate non-aggregation bounds query) for being the smallest viable patch with no contract change.

Decisions rejected:
- **Resolver-level fix detecting all-NULL aggregate rows.** Cleaner long-term but harder to scope correctly across all callers; deferred to a separate hardening PR.
- **Bypassing the resolver in `_discover_trace_bounds`.** Would duplicate fallback logic and make the routing semantics inconsistent.
- **`GROUP BY trace_id`.** Works mechanically but changes the result shape (multiple rows instead of one) and would force a downstream change.