### PR TITLE
chore(mcp): downgrade 403 permission_denied log to warn

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -231,7 +231,9 @@ export class ApiClient {
                     if (response.status === 403 && errorData?.code === 'permission_denied') {
                         const scopeMatch = /required scope ['"]([^'"]+)['"]/.exec(errorData.detail || '')
                         const missingScope = scopeMatch?.[1]
-                        console.error(
+                        // Warn, not error: PostHogPermissionError is thrown and handled by callers,
+                        // and a missing scope is a user-config issue rather than a service bug.
+                        console.warn(
                             `[API] Permission denied on ${method} ${url}: ${errorData.detail || 'unknown'}${missingScope ? ` (missing scope: ${missingScope})` : ''}`
                         )
                         throw new PostHogPermissionError({


### PR DESCRIPTION
## Problem

The MCP API client (`services/mcp/src/api/client.ts:234`) logs every upstream `403 permission_denied` at `console.error` before re-throwing `PostHogPermissionError`. The error is already handled by callers — `formatPermissionErrorMessage` in `services/mcp/src/lib/errors.ts` surfaces a clear remediation message to the user (add the missing scope, or use the "MCP Server" preset).

The result is that ordinary user-config issues — for example a personal API key that doesn't include `project:read` — flood error tracking for the production Cloudflare MCP worker. Every tool call goes through `StateManager.getCachedOrFetchProject()` → `GET /api/projects/{id}/`, which requires `project:read`, so a single misconfigured key produces one error-tracking event per tool call.

## Changes

Downgrade the log statement from `console.error` to `console.warn`. The structured `PostHogPermissionError` throw is unchanged — clients still get the same actionable error.

## How did you test this code?

I'm an agent. Ran:

- `pnpm typecheck` in `services/mcp` — passes
- `pnpm test tests/unit/permission-errors.test.ts` — 18 tests pass

No tests assert on the log level, so behavior is preserved end-to-end.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- User prompt: investigate the recurring `[API] Permission denied on GET .../api/projects/.../` error in the Cloudflare MCP worker
- Decision: don't suppress the log entirely (still useful for local debugging) but lower the severity since the throw + remediation message already cover the user-facing path.