### PR TITLE
fix(experiments): use previous month for ARR billing lookup

### DIFF
--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -328,7 +328,7 @@ class DebugCHQueries(viewsets.ViewSet):
                     cus.organization_id IN ({org_id_list})
                     AND iwa.type NOT LIKE '%upcoming%'
                     AND iwa.mrr > 0
-                    AND toStartOfMonth(toTimeZone(iwa.period_end, 'UTC')) = toStartOfMonth(now())
+                    AND toStartOfMonth(toTimeZone(iwa.period_end, 'UTC')) = toStartOfMonth(now() - INTERVAL 1 MONTH)
                 GROUP BY cus.organization_id
                 """,
                 team=team,


### PR DESCRIPTION
## Problem

ARR values in the **internal staff-only query performance debugging scene** (`/instance/query_performance`) are wrong/missing at the start of a new month. The scene reads from billing data warehouse tables (read-only) to display revenue context next to slow queries — no billing logic is modified.

## Changes

One-line SQL filter change in the read-only HogQL query inside `debug_ch_queries.py`: use previous month instead of current month for the billing period lookup. Previous month always has complete data.

No billing code, billing models, or billing endpoints are touched.

## How did you test this code?

Code review — single SQL filter change in internal debugging tooling.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code assisted with implementation.