### PR TITLE
fix: type for integration

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils import timezone
@@ -897,6 +898,18 @@ class IntegrationViewSet(
         source_team_id = request.data.get("source_team_id")
         installation_id_param = request.data.get("installation_id")
 
+        if installation_id_param and not re.fullmatch(r"\d{1,20}", str(installation_id_param)):
+            raise ValidationError("Invalid installation_id")
+
+        # installation_id is stored in JSONB and historically written as either a
+        # string or a number, so match both representations.
+        installation_id_match = (
+            Q(config__installation_id=str(installation_id_param))
+            | Q(config__installation_id=int(installation_id_param))
+            if installation_id_param
+            else None
+        )
+
         if source_team_id:
             try:
                 source_team_id_int = int(source_team_id)
@@ -906,20 +919,22 @@ class IntegrationViewSet(
             if not self.organization.teams.filter(id=source_team_id_int).exists():
                 raise ValidationError("Source team not found in your organization")
 
-            try:
-                source = Integration.objects.get(team_id=source_team_id_int, kind="github")
-            except Integration.DoesNotExist:
+            qs = Integration.objects.filter(team_id=source_team_id_int, kind="github")
+            # When the source team has multiple GitHub installations linked, the
+            # caller must pass installation_id to disambiguate.
+            if installation_id_match is not None:
+                qs = qs.filter(installation_id_match)
+
+            source = qs.order_by("id").first()
+            if source is None:
                 raise ValidationError("Source team does not have a GitHub integration")
         elif installation_id_param:
-            if not re.fullmatch(r"\d{1,20}", str(installation_id_param)):
-                raise ValidationError("Invalid installation_id")
-
             existing = (
                 Integration.objects.filter(
                     team__organization_id=self.organization_id,
                     kind="github",
-                    config__installation_id=str(installation_id_param),
                 )
+                .filter(installation_id_match)
                 .order_by("id")
                 .first()
             )

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -2314,6 +2314,82 @@ class TestGitHubLinkExisting:
         assert "Failed to verify installation access" in response.json()["detail"]
         mock_from_install.assert_not_called()
 
+    @patch("posthog.models.integration.GitHubIntegration.verify_user_installation_access", return_value=True)
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_link_existing_disambiguates_multi_install_team_via_installation_id(
+        self, mock_from_install, mock_verify, client: HttpClient
+    ):
+        # Source team has multiple GitHub installations linked. Without installation_id
+        # the request was crashing on MultipleObjectsReturned; passing installation_id
+        # should pick exactly that row.
+        Integration.objects.create(
+            team=self.source_team,
+            kind="github",
+            integration_id="22222",
+            config={"installation_id": "22222", "account": {"type": "Organization", "name": "other"}},
+            sensitive_config={"access_token": "ghs_other"},
+            created_by=self.user,
+        )
+
+        cloned = Integration.objects.create(
+            team=self.dest_team,
+            kind="github",
+            integration_id="12345",
+            config={"installation_id": "12345"},
+            sensitive_config={"access_token": "ghs_cloned"},
+            created_by=self.user,
+        )
+        mock_from_install.return_value = cloned
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.dest_team.pk}/integrations/github/link_existing/",
+            {"source_team_id": self.source_team.id, "installation_id": "12345"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_verify.assert_called_once_with("12345", "ghu_user")
+        mock_from_install.assert_called_once_with("12345", self.dest_team.pk, self.user)
+
+    @patch("posthog.models.integration.GitHubIntegration.verify_user_installation_access", return_value=True)
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_link_existing_matches_installation_id_stored_as_int(
+        self, mock_from_install, mock_verify, client: HttpClient
+    ):
+        # Some integrations have installation_id stored as a JSONB number rather than
+        # a string; the lookup must match either representation.
+        int_team = Team.objects.create(organization=self.organization, name="Int Team")
+        Integration.objects.create(
+            team=int_team,
+            kind="github",
+            integration_id="77777",
+            config={"installation_id": 77777, "account": {"type": "Organization", "name": "intacme"}},
+            sensitive_config={"access_token": "ghs_int"},
+            created_by=self.user,
+        )
+
+        cloned = Integration.objects.create(
+            team=self.dest_team,
+            kind="github",
+            integration_id="77777",
+            config={"installation_id": "77777"},
+            sensitive_config={"access_token": "ghs_cloned"},
+            created_by=self.user,
+        )
+        mock_from_install.return_value = cloned
+
+        client.force_login(self.user)
+        response = client.post(
+            f"/api/environments/{self.dest_team.pk}/integrations/github/link_existing/",
+            {"installation_id": "77777"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_verify.assert_called_once_with("77777", "ghu_user")
+        mock_from_install.assert_called_once_with("77777", self.dest_team.pk, self.user)
+
 
 class TestGitHubOAuthAuthorize:
     """Tests for POST /integrations/github/oauth_authorize/ — mints a User OAuth URL


### PR DESCRIPTION
## Problem

When a team has multiple GitHub installations linked, the `github_link_existing` endpoint was crashing with `MultipleObjectsReturned` because it used `.get()` to look up the source integration. Additionally, `installation_id` values in the JSONB `config` field were historically written as either a string or a number, meaning a strict string-only match could silently fail to find a valid integration.

## Changes

- Moved the `installation_id` format validation to the top of the handler so it applies regardless of which branch is taken.
- Replaced the `.get()` call for source team integration lookup with `.filter().order_by("id").first()`, preventing `MultipleObjectsReturned` when a team has more than one GitHub installation.
- When `installation_id` is provided alongside `source_team_id`, it is now used to filter down to the specific installation, allowing callers to disambiguate between multiple linked installations.
- Built the `installation_id` filter as a `Q` object that matches both string and integer representations in the JSONB `config` field, covering both historical storage formats.
- Added tests covering disambiguation via `installation_id` when a source team has multiple installations, and matching an `installation_id` stored as a JSONB integer rather than a string.