### PR TITLE
feat(data-warehouse): auto-enable Customer.io webhook on signing secret

### DIFF
--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -177,9 +177,15 @@ class WebhookSource(_BaseSource[ConfigType], Generic[ConfigType]):
 
     def webhook_inputs_updated(
         self, config: ConfigType, webhook_url: str, team_id: int, inputs: dict[str, Any]
-    ) -> None:
-        """Called when webhook inputs have been set on the underlying hog function"""
-        pass
+    ) -> tuple[bool, str | None]:
+        """Called when webhook inputs have been set on the underlying hog function.
+
+        Returns ``(success, error)``. Implementations that need to call out to the
+        external service (e.g. enabling a previously-disabled webhook) should return
+        ``(False, message)`` on failure so the API view can surface the error to the
+        user instead of silently dropping it.
+        """
+        return True, None
 
     @property
     @abstractmethod

--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -175,6 +175,12 @@ class WebhookSource(_BaseSource[ConfigType], Generic[ConfigType]):
         """
         raise NotImplementedError()
 
+    def webhook_inputs_updated(
+        self, config: ConfigType, webhook_url: str, team_id: int, inputs: dict[str, Any]
+    ) -> None:
+        """Called when webhook inputs have been set on the underlying hog function"""
+        pass
+
     @property
     @abstractmethod
     def webhook_resource_map(self) -> dict[str, str]:

--- a/posthog/temporal/data_imports/sources/customer_io/api_client.py
+++ b/posthog/temporal/data_imports/sources/customer_io/api_client.py
@@ -185,6 +185,7 @@ def create_webhook(
         "name": CIO_AUTO_WEBHOOK_NAME,
         "endpoint": webhook_url,
         "events": events,
+        "disabled": True,
     }
 
     url = f"{_base_url(region)}{REPORTING_WEBHOOKS_PATH}"
@@ -192,18 +193,9 @@ def create_webhook(
     try:
         existing = _find_webhook_by_url(_list_webhooks(api_key, region), webhook_url)
         if existing is not None:
-            if existing.get("disabled"):
-                # A disabled webhook on the same URL would silently drop events; bail
-                # out and ask the user to re-enable or remove it in Customer.io.
-                return WebhookCreationResult(
-                    success=False,
-                    error=(
-                        "A disabled reporting webhook already exists for this URL in Customer.io. "
-                        "Re-enable it (or delete it) from the Reporting Webhooks page and try again."
-                    ),
-                )
             # Webhook already exists for this URL — treat as success so the user can
-            # finish setup by entering the signing key.
+            # finish setup by entering the signing key. The webhook will be enabled
+            # once the signing key is provided.
             return WebhookCreationResult(success=True, pending_inputs=["signing_secret"])
 
         response = _session(api_key).post(
@@ -222,6 +214,41 @@ def create_webhook(
     # Customer.io does NOT return the signing key in the create response — the user
     # has to copy it from the Reporting Webhooks page in the Customer.io UI.
     return WebhookCreationResult(success=True, pending_inputs=["signing_secret"])
+
+
+def enable_webhook(api_key: str, region: str | None, webhook_url: str) -> tuple[bool, str | None]:
+    """Flip the matching reporting webhook to ``disabled: false`` on Customer.io.
+
+    Webhooks are created in a disabled state so Customer.io doesn't start firing
+    against the endpoint before PostHog has the signing secret to verify
+    deliveries. This is called from ``webhook_inputs_updated`` once the user
+    provides that secret.
+    """
+    logger = LOGGER.bind(region=region or "us")
+
+    try:
+        existing = _find_webhook_by_url(_list_webhooks(api_key, region), webhook_url)
+        if existing is None:
+            return False, "No reporting webhook found for this URL in Customer.io."
+
+        webhook_id = existing.get("id")
+        if webhook_id is None:
+            return False, "Customer.io returned a webhook without an id; please enable it manually."
+
+        if not existing.get("disabled"):
+            return True, None
+
+        url = f"{_base_url(region)}{REPORTING_WEBHOOKS_PATH}/{webhook_id}"
+        response = _session(api_key).put(url, json={"disabled": False}, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        logger.warning("Failed to enable Customer.io reporting webhook", error=str(e))
+        return False, _format_http_error(e)
+    except requests.RequestException as e:
+        logger.warning("Could not reach Customer.io to enable webhook", error=str(e))
+        return False, f"Could not reach Customer.io: {e}"
+
+    return True, None
 
 
 def delete_webhook(api_key: str, region: str | None, webhook_url: str) -> WebhookDeletionResult:

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -204,13 +204,13 @@ class CustomerIOSource(
 
     def webhook_inputs_updated(
         self, config: CustomerIOSourceConfig, webhook_url: str, team_id: int, inputs: dict[str, Any]
-    ) -> None:
+    ) -> tuple[bool, str | None]:
         # The webhook is created in a disabled state so Customer.io doesn't fire
         # events at PostHog before we can verify them with the signing secret.
         # Now that the user has provided the secret, enable the webhook.
         if not inputs.get("signing_secret"):
-            return
-        api_client.enable_webhook(config.app_api_key, config.region, webhook_url)
+            return True, None
+        return api_client.enable_webhook(config.app_api_key, config.region, webhook_url)
 
     def get_external_webhook_info(
         self, config: CustomerIOSourceConfig, webhook_url: str, team_id: int

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -202,6 +202,16 @@ class CustomerIOSource(
             resource_names=list(RESOURCE_TO_CIO_OBJECT_TYPE.keys()),
         )
 
+    def webhook_inputs_updated(
+        self, config: CustomerIOSourceConfig, webhook_url: str, team_id: int, inputs: dict[str, Any]
+    ) -> None:
+        # The webhook is created in a disabled state so Customer.io doesn't fire
+        # events at PostHog before we can verify them with the signing secret.
+        # Now that the user has provided the secret, enable the webhook.
+        if not inputs.get("signing_secret"):
+            return
+        api_client.enable_webhook(config.app_api_key, config.region, webhook_url)
+
     def get_external_webhook_info(
         self, config: CustomerIOSourceConfig, webhook_url: str, team_id: int
     ) -> ExternalWebhookInfo | None:

--- a/posthog/temporal/data_imports/sources/customer_io/tests/test_api_client.py
+++ b/posthog/temporal/data_imports/sources/customer_io/tests/test_api_client.py
@@ -131,8 +131,9 @@ class TestCreateWebhook:
         assert body["endpoint"] == "https://example.com/hook"
         assert "email_sent" in body["events"]
         assert "customer_subscribed" in body["events"]
-        # No `disabled` flag should be sent so the webhook is enabled by default.
-        assert "disabled" not in body
+        # Created disabled — Customer.io would 404 on webhook deliveries until the
+        # signing secret is in place, so we wait until the user provides it.
+        assert body["disabled"] is True
 
     @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
     def test_subscribes_to_in_app_events(self, mock_session):
@@ -150,8 +151,14 @@ class TestCreateWebhook:
         assert "in_app_sent" in body["events"]
         assert "in_app_clicked" in body["events"]
 
+    @parameterized.expand(
+        [
+            ("disabled_existing_webhook", True),
+            ("enabled_existing_webhook", False),
+        ]
+    )
     @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
-    def test_returns_failure_when_existing_webhook_is_disabled(self, mock_session):
+    def test_skips_create_when_webhook_already_exists_for_url(self, _name, disabled, mock_session):
         mock_session.return_value.get.return_value = _ok_json_response(
             {
                 "reporting_webhooks": [
@@ -159,28 +166,10 @@ class TestCreateWebhook:
                         "id": 7,
                         "endpoint": "https://example.com/hook",
                         "events": ["email_sent"],
-                        "disabled": True,
+                        "disabled": disabled,
                     }
                 ]
             }
-        )
-
-        result = api_client.create_webhook(
-            api_key="key",
-            region="us",
-            webhook_url="https://example.com/hook",
-            resource_names=["email_events"],
-        )
-
-        assert result.success is False
-        assert result.error is not None
-        assert "disabled" in result.error.lower()
-        mock_session.return_value.post.assert_not_called()
-
-    @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
-    def test_skips_create_when_webhook_already_exists_for_url(self, mock_session):
-        mock_session.return_value.get.return_value = _ok_json_response(
-            {"reporting_webhooks": [{"id": 7, "endpoint": "https://example.com/hook", "events": ["email_sent"]}]}
         )
 
         result = api_client.create_webhook(
@@ -226,6 +215,78 @@ class TestCreateWebhook:
         assert result.success is False
         assert result.error is not None
         assert "App API Key" in result.error
+
+
+class TestEnableWebhook:
+    @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
+    def test_enables_disabled_webhook(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_json_response(
+            {
+                "reporting_webhooks": [
+                    {"id": 7, "endpoint": "https://example.com/hook", "disabled": True},
+                ]
+            }
+        )
+        mock_session.return_value.put.return_value = _ok_json_response()
+
+        success, error = api_client.enable_webhook("key", "us", "https://example.com/hook")
+
+        assert success is True
+        assert error is None
+        mock_session.return_value.put.assert_called_once()
+        called_url = mock_session.return_value.put.call_args.args[0]
+        assert called_url == f"{CIO_US_BASE_URL}/v1/reporting_webhooks/7"
+        body = mock_session.return_value.put.call_args.kwargs["json"]
+        assert body == {"disabled": False}
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
+    def test_noop_when_already_enabled(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_json_response(
+            {"reporting_webhooks": [{"id": 7, "endpoint": "https://example.com/hook", "disabled": False}]}
+        )
+
+        success, error = api_client.enable_webhook("key", "us", "https://example.com/hook")
+
+        assert success is True
+        assert error is None
+        mock_session.return_value.put.assert_not_called()
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
+    def test_returns_failure_when_webhook_not_found(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_json_response({"reporting_webhooks": []})
+
+        success, error = api_client.enable_webhook("key", "us", "https://example.com/hook")
+
+        assert success is False
+        assert error is not None
+        assert "No reporting webhook" in error
+        mock_session.return_value.put.assert_not_called()
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
+    def test_returns_failure_on_put_http_error(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_json_response(
+            {"reporting_webhooks": [{"id": 7, "endpoint": "https://example.com/hook", "disabled": True}]}
+        )
+        response = MagicMock()
+        response.status_code = 401
+        response.raise_for_status.side_effect = requests.HTTPError(response=response)
+        mock_session.return_value.put.return_value = response
+
+        success, error = api_client.enable_webhook("key", "us", "https://example.com/hook")
+
+        assert success is False
+        assert error is not None
+        assert "App API Key" in error
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.api_client._session")
+    def test_returns_failure_on_network_error(self, mock_session):
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+
+        success, error = api_client.enable_webhook("key", "us", "https://example.com/hook")
+
+        assert success is False
+        assert error is not None
+        assert "Could not reach Customer.io" in error
 
 
 class TestDeleteWebhook:

--- a/posthog/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py
@@ -104,6 +104,48 @@ class TestCustomerIOSourceCreateWebhook:
         assert set(kwargs["resource_names"]) == set(RESOURCE_TO_CIO_OBJECT_TYPE.keys())
 
 
+class TestCustomerIOSourceWebhookInputsUpdated:
+    @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.enable_webhook")
+    def test_enables_webhook_when_signing_secret_is_provided(self, mock_enable):
+        mock_enable.return_value = (True, None)
+        source = CustomerIOSource()
+
+        source.webhook_inputs_updated(
+            _config(app_api_key="key", region="eu"),
+            "https://example.com/h",
+            team_id=1,
+            inputs={"signing_secret": "shh"},
+        )
+
+        mock_enable.assert_called_once_with("key", "eu", "https://example.com/h")
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.enable_webhook")
+    def test_skips_enable_when_signing_secret_is_missing(self, mock_enable):
+        source = CustomerIOSource()
+
+        source.webhook_inputs_updated(
+            _config(app_api_key="key", region="us"),
+            "https://example.com/h",
+            team_id=1,
+            inputs={},
+        )
+
+        mock_enable.assert_not_called()
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.enable_webhook")
+    def test_skips_enable_when_signing_secret_is_empty(self, mock_enable):
+        source = CustomerIOSource()
+
+        source.webhook_inputs_updated(
+            _config(app_api_key="key", region="us"),
+            "https://example.com/h",
+            team_id=1,
+            inputs={"signing_secret": ""},
+        )
+
+        mock_enable.assert_not_called()
+
+
 class TestCustomerIOSourceDeleteWebhook:
     @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.delete_webhook")
     def test_delegates_to_api_client(self, mock_delete):

--- a/posthog/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py
@@ -110,40 +110,66 @@ class TestCustomerIOSourceWebhookInputsUpdated:
         mock_enable.return_value = (True, None)
         source = CustomerIOSource()
 
-        source.webhook_inputs_updated(
+        success, error = source.webhook_inputs_updated(
             _config(app_api_key="key", region="eu"),
             "https://example.com/h",
             team_id=1,
             inputs={"signing_secret": "shh"},
         )
 
+        assert success is True
+        assert error is None
         mock_enable.assert_called_once_with("key", "eu", "https://example.com/h")
 
     @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.enable_webhook")
     def test_skips_enable_when_signing_secret_is_missing(self, mock_enable):
         source = CustomerIOSource()
 
-        source.webhook_inputs_updated(
+        success, error = source.webhook_inputs_updated(
             _config(app_api_key="key", region="us"),
             "https://example.com/h",
             team_id=1,
             inputs={},
         )
 
+        assert success is True
+        assert error is None
         mock_enable.assert_not_called()
 
     @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.enable_webhook")
     def test_skips_enable_when_signing_secret_is_empty(self, mock_enable):
         source = CustomerIOSource()
 
-        source.webhook_inputs_updated(
+        success, error = source.webhook_inputs_updated(
             _config(app_api_key="key", region="us"),
             "https://example.com/h",
             team_id=1,
             inputs={"signing_secret": ""},
         )
 
+        assert success is True
+        assert error is None
         mock_enable.assert_not_called()
+
+    @patch("posthog.temporal.data_imports.sources.customer_io.source.api_client.enable_webhook")
+    def test_propagates_failure_from_enable_webhook(self, mock_enable):
+        # If the upstream call fails (e.g. Customer.io returns a 401, or the
+        # webhook record is missing), the failure must surface to the caller so
+        # the API view can return a non-200 response — silently dropping the
+        # error would leave the webhook disabled with no user-visible signal.
+        mock_enable.return_value = (False, "Customer.io rejected the App API Key (401).")
+        source = CustomerIOSource()
+
+        success, error = source.webhook_inputs_updated(
+            _config(app_api_key="key", region="us"),
+            "https://example.com/h",
+            team_id=1,
+            inputs={"signing_secret": "shh"},
+        )
+
+        assert success is False
+        assert error == "Customer.io rejected the App API Key (401)."
+        mock_enable.assert_called_once_with("key", "us", "https://example.com/h")
 
 
 class TestCustomerIOSourceDeleteWebhook:

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1892,6 +1892,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
     def update_webhook_inputs(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         instance: ExternalDataSource = self.get_object()
 
+        if not instance.job_inputs:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "Source has no configuration"},
+            )
+
         source_type = ExternalDataSourceType(instance.source_type)
         source = SourceRegistry.get_source(source_type)
 
@@ -1957,6 +1963,20 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 data={"message": "No webhook function found for this source. Create a webhook first."},
             )
 
+        try:
+            config = source.parse_config(instance.job_inputs)
+        except ValidationError as e:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "Invalid source configuration", "details": getattr(e, "detail", str(e))},
+            )
+        except Exception as e:
+            capture_exception(e)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "Failed to load source configuration"},
+            )
+
         assert hog_function.inputs is not None
         hog_function.inputs = {
             **hog_function.inputs,
@@ -1964,9 +1984,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         }
         hog_function.save(update_fields=["inputs", "encrypted_inputs"])
 
-        source.webhook_inputs_updated(
-            source.parse_config(instance.job_inputs), get_webhook_url(hog_function.id), self.team.pk, inputs
-        )
+        success, error = source.webhook_inputs_updated(config, get_webhook_url(hog_function.id), self.team.pk, inputs)
+        if not success:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"success": False, "error": error or "Failed to update webhook on the external source."},
+            )
 
         return Response(status=status.HTTP_200_OK, data={"success": True})
 

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1964,6 +1964,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         }
         hog_function.save(update_fields=["inputs", "encrypted_inputs"])
 
+        source.webhook_inputs_updated(
+            source.parse_config(instance.job_inputs), get_webhook_url(hog_function.id), self.team.pk, inputs
+        )
+
         return Response(status=status.HTTP_200_OK, data={"success": True})
 
     @extend_schema(

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -4486,6 +4486,7 @@ class TestCreateWebhook(APIBaseTest):
         from posthog.models.hog_functions.hog_function import HogFunction
 
         mock_create_webhook.return_value = self._webhook_result()
+        mock_inputs_updated.return_value = (True, None)
 
         self._create_hog_function_template()
         source = self._create_stripe_source()
@@ -4515,6 +4516,53 @@ class TestCreateWebhook(APIBaseTest):
         assert call_args.args[1].endswith(f"/public/webhooks/dwh/{hog_function.id}")
         assert call_args.args[2] == self.team.pk
         assert call_args.args[3] == {"signing_secret": "whsec_manual123"}
+
+    @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
+    @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.webhook_inputs_updated")
+    @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.create_webhook")
+    def test_update_webhook_inputs_propagates_failure_from_source(
+        self, mock_create_webhook, mock_inputs_updated, _mock_flag
+    ):
+        # If the source's webhook_inputs_updated reports failure (e.g. Customer.io
+        # rejects the request to enable the webhook), surface that to the caller as
+        # a 400 instead of returning 200 + success=true while the webhook stays
+        # disabled on the external service.
+        mock_create_webhook.return_value = self._webhook_result()
+        mock_inputs_updated.return_value = (False, "Customer.io rejected the App API Key (401).")
+
+        self._create_hog_function_template()
+        source = self._create_stripe_source()
+        self._create_webhook_schema(source, STRIPE_CUSTOMER_RESOURCE_NAME)
+        self.client.post(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/create_webhook/")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/update_webhook_inputs/",
+            data={"inputs": {"signing_secret": "whsec_bad"}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["success"] is False
+        assert "Customer.io rejected" in body["error"]
+
+    @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
+    @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.webhook_inputs_updated")
+    def test_update_webhook_inputs_requires_job_inputs(self, mock_inputs_updated, _mock_flag):
+        # Sources persisted without job_inputs can't be parsed into a config, so
+        # we should bail out with a 400 before saving anything to the HogFunction.
+        source = self._create_stripe_source(job_inputs={})
+        self._create_webhook_schema(source, STRIPE_CUSTOMER_RESOURCE_NAME)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/update_webhook_inputs/",
+            data={"inputs": {"signing_secret": "whsec_test"}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["message"] == "Source has no configuration"
+        mock_inputs_updated.assert_not_called()
 
     @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
     @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.webhook_inputs_updated")

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -4480,8 +4480,9 @@ class TestCreateWebhook(APIBaseTest):
         assert hog_function.encrypted_inputs["signing_secret"]["value"] == "whsec_test123"
 
     @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
+    @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.webhook_inputs_updated")
     @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.create_webhook")
-    def test_update_webhook_inputs(self, mock_create_webhook, _mock_flag):
+    def test_update_webhook_inputs(self, mock_create_webhook, mock_inputs_updated, _mock_flag):
         from posthog.models.hog_functions.hog_function import HogFunction
 
         mock_create_webhook.return_value = self._webhook_result()
@@ -4507,8 +4508,17 @@ class TestCreateWebhook(APIBaseTest):
         assert hog_function.encrypted_inputs is not None
         assert hog_function.encrypted_inputs["signing_secret"]["value"] == "whsec_manual123"
 
+        # The source should be notified so it can apply the new inputs (e.g.
+        # Customer.io enables the reporting webhook once the signing secret arrives).
+        mock_inputs_updated.assert_called_once()
+        call_args = mock_inputs_updated.call_args
+        assert call_args.args[1].endswith(f"/public/webhooks/dwh/{hog_function.id}")
+        assert call_args.args[2] == self.team.pk
+        assert call_args.args[3] == {"signing_secret": "whsec_manual123"}
+
     @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
-    def test_update_webhook_inputs_rejects_invalid_keys(self, _mock_flag):
+    @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.webhook_inputs_updated")
+    def test_update_webhook_inputs_rejects_invalid_keys(self, mock_inputs_updated, _mock_flag):
         source = self._create_stripe_source()
         self._create_webhook_schema(source, STRIPE_CUSTOMER_RESOURCE_NAME)
 
@@ -4520,9 +4530,11 @@ class TestCreateWebhook(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Invalid input keys" in response.json()["message"]
+        mock_inputs_updated.assert_not_called()
 
     @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
-    def test_update_webhook_inputs_no_hog_function(self, _mock_flag):
+    @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.webhook_inputs_updated")
+    def test_update_webhook_inputs_no_hog_function(self, mock_inputs_updated, _mock_flag):
         source = self._create_stripe_source()
         self._create_webhook_schema(source, STRIPE_CUSTOMER_RESOURCE_NAME)
 
@@ -4534,6 +4546,7 @@ class TestCreateWebhook(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "No webhook function found" in response.json()["message"]
+        mock_inputs_updated.assert_not_called()
 
     @patch("posthog.temporal.data_imports.sources.stripe.source.is_webhook_feature_flag_enabled", return_value=True)
     @patch("posthog.temporal.data_imports.sources.stripe.source.StripeSource.create_webhook")


### PR DESCRIPTION
## Problem

When PostHog auto-registers a Customer.io reporting webhook for a new data warehouse source, the webhook endpoint on our side rejects deliveries until the user provides the signing secret (Customer.io doesn't return it on create — it has to be copied from the Reporting Webhooks page in their UI). With the webhook enabled from the moment of creation, Customer.io starts firing immediately and every delivery 404s during the window between create and the user pasting the secret.

## Changes

- Customer.io reporting webhooks are now created with `disabled: true` so Customer.io doesn't start firing before we can verify deliveries.
- New `WebhookSource.webhook_inputs_updated` hook on the source base class — sources can opt in to react when the user submits webhook inputs (e.g. signing secret) via `update_webhook_inputs`.
- The Customer.io source implements that hook to PUT `disabled: false` on the matching webhook once `signing_secret` is provided.
- The `update_webhook_inputs` viewset action now invokes the hook after the HogFunction is updated.
- Removed the prior \"existing disabled webhook\" failure branch in `create_webhook` — that's now the expected intermediate state on a retry/reconnect; we treat any matching webhook as success and re-prompt for the signing secret.

## How did you test this code?

I'm an agent — only ran automated tests, no manual verification.

- `posthog/temporal/data_imports/sources/customer_io/tests/test_api_client.py` — added 5 tests for `enable_webhook` (PUTs the right URL/body, no-ops if already enabled, errors when not found / on HTTP / on network failure) and parameterized the existing \"webhook already exists for URL\" test to cover both enabled and disabled.
- `posthog/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py` — added 3 tests for `webhook_inputs_updated` (delegates to `enable_webhook` with signing secret, no-ops when missing or empty).
- `products/data_warehouse/backend/api/test/test_external_data_source.py::TestCreateWebhook` — `test_update_webhook_inputs` now asserts the source hook is called with the webhook URL, team ID, and inputs; the validation-failure tests assert the hook is NOT called.

All 59 tests pass locally.

## Publish to changelog?

no