### PR TITLE
chore(mcp): sample 10% of worker logs

### DIFF
--- a/services/mcp/wrangler.jsonc
+++ b/services/mcp/wrangler.jsonc
@@ -40,7 +40,7 @@
         "logs": {
             "enabled": true,
             "destinations": ["posthog"],
-            "head_sampling_rate": 1.0, // Collect all logs for now
+            "head_sampling_rate": 0.1,
             "persist": true, // Keep showing logs in Cloudflare dashboard
         },
     },


### PR DESCRIPTION
## Problem

The MCP Cloudflare worker was configured with `head_sampling_rate: 1.0`, forwarding every invocation's logs to PostHog. The original comment (`// Collect all logs for now`) flagged it as temporary. At current volume (~150M success + ~1M error invocations/day) that's billions of log events per month — more than we need for debugging.

## Changes

Drop `head_sampling_rate` from `1.0` to `0.1` in `services/mcp/wrangler.jsonc`. Cloudflare's head sampling is per-invocation and all-or-nothing, so 10% of invocations have their full log stream forwarded; the rest are dropped at the observability layer. `console.*` calls are unchanged.

## How did you test this code?

I'm an agent. No automated tests run — this is a config-only change to a Cloudflare Workers Observability setting. Verification will happen post-deploy by checking the log volume drop in PostHog and that errors are still surfacing.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code at the user's request after a discussion of MCP worker log volume.
- Considered the alternative of keeping `1.0` and trimming chatty `console.log` calls on the success path; rejected for now in favor of the simpler config-only knob. Note that head sampling drops errors proportionally — if error capture becomes the priority, app-level gating is the next step.