### PR TITLE
fix(phai): demote durable object teardown errors to warn

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -9,11 +9,17 @@ import {
 import { RequestLogger, withLogging } from '@/lib/logging'
 import { extractClientInfoFromBody } from '@/lib/mcp-client-info'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
+import { installTransientConsoleFilter, isTransientShutdownError } from '@/lib/transient-errors'
 import { hash, parseMcpMode, sanitizeHeaderValue } from '@/lib/utils'
 import type { CloudRegion } from '@/tools/types'
 
 import { MCP, RequestProperties } from './mcp'
 import RAW_LANDING_HTML from './static/landing.html'
+
+// Demote partyserver/agents framework console.error calls that fire on normal
+// Durable Object teardown (webSocketClose, "destroyed") to warn — they are
+// lifecycle noise, not real failures.
+installTransientConsoleFilter()
 
 const PARSED_LANDING_HTML = RAW_LANDING_HTML.replace('{{DOCS_URL}}', MCP_DOCS_URL)
 
@@ -103,6 +109,19 @@ const onCatchErrorHandler = async (
     const knownErrorResponse = generateErrorResponseFromMessage(error.message)
     if (knownErrorResponse) {
         return knownErrorResponse
+    }
+
+    // Durable Object teardown / websocket close races bubble up here as
+    // `Error: destroyed`. They are normal lifecycle events — skip exception
+    // capture and emit the wide log at warn level instead of cluttering error
+    // tracking.
+    if (isTransientShutdownError(error)) {
+        log.setSeverity('warn')
+        log.extend({
+            transientError: error?.name,
+            transientMessage: error?.message,
+        })
+        return new Response('Internal server error', { status: 500 })
     }
 
     // Unrecognized error → opaque 500 to the client. Surface the underlying

--- a/services/mcp/src/lib/logging.ts
+++ b/services/mcp/src/lib/logging.ts
@@ -1,9 +1,12 @@
 const SENSITIVE_HEADERS = ['authorization', 'cookie', 'x-api-key']
 
+type LogSeverity = 'info' | 'warn'
+
 // Wide log class for accumulating request data and emitting a single log at the end
 export class RequestLogger {
     private data: Record<string, unknown> = {}
     private startTime = Date.now()
+    private severity: LogSeverity = 'info'
 
     constructor(requestId?: string) {
         this.data.requestId = requestId ?? crypto.randomUUID().slice(0, 8)
@@ -13,10 +16,19 @@ export class RequestLogger {
         Object.assign(this.data, data)
     }
 
+    setSeverity(severity: LogSeverity): void {
+        this.severity = severity
+    }
+
     emit(status: number): void {
         this.data.status = status
         this.data.durationMs = Date.now() - this.startTime
-        console.info('[MCP]', JSON.stringify(this.data))
+        const line = JSON.stringify(this.data)
+        if (this.severity === 'warn') {
+            console.warn('[MCP]', line)
+        } else {
+            console.info('[MCP]', line)
+        }
     }
 }
 

--- a/services/mcp/src/lib/transient-errors.ts
+++ b/services/mcp/src/lib/transient-errors.ts
@@ -1,0 +1,58 @@
+// Transient errors that signal a normal Cloudflare runtime lifecycle event
+// (durable object reset, websocket teardown) rather than a real bug. They
+// fire when the DO is replaced after a deploy or hibernation cycle, so they
+// produce a lot of error-level log noise that we want demoted to warn.
+const TRANSIENT_PATTERNS: readonly RegExp[] = [
+    /webSocketClose:/i,
+    /webSocketError:/i,
+    /\bdestroyed\b/i,
+    /Durable Object reset/i,
+]
+
+function matches(value: string): boolean {
+    return TRANSIENT_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+export function isTransientShutdownError(error: unknown): boolean {
+    if (!error) {
+        return false
+    }
+    if (error instanceof Error) {
+        return matches(error.message) || (typeof error.stack === 'string' && matches(error.stack))
+    }
+    return matches(String(error))
+}
+
+// Demote console.error calls whose serialized arguments match a transient
+// pattern to console.warn. Keeps unrelated error logs intact. Idempotent.
+let consoleFilterInstalled = false
+
+export function installTransientConsoleFilter(): void {
+    if (consoleFilterInstalled) {
+        return
+    }
+    consoleFilterInstalled = true
+
+    const originalError = console.error.bind(console)
+    const originalWarn = console.warn.bind(console)
+
+    console.error = (...args: unknown[]): void => {
+        const serialized = args
+            .map((arg) => {
+                if (typeof arg === 'string') {
+                    return arg
+                }
+                if (arg instanceof Error) {
+                    return `${arg.name}: ${arg.message}`
+                }
+                return ''
+            })
+            .join(' ')
+
+        if (matches(serialized)) {
+            originalWarn('[MCP transient]', ...args)
+            return
+        }
+        originalError(...args)
+    }
+}

--- a/services/mcp/tests/unit/transient-errors.test.ts
+++ b/services/mcp/tests/unit/transient-errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+
+import { isTransientShutdownError } from '@/lib/transient-errors'
+
+describe('isTransientShutdownError', () => {
+    test.each([
+        ['Error: destroyed', true],
+        ['destroyed', true],
+        ['DESTROYED', true],
+        [
+            'Error in MCP:streamable-http:abc123 webSocketClose: Error: Durable Object reset because its code was updated.',
+            true,
+        ],
+        ['Error in MCP:streamable-http:abc webSocketError: connection closed', true],
+        ['Durable Object reset because its code was updated.', true],
+        ['INVALID_API_KEY', false],
+        ['Cannot read properties of null', false],
+        ['', false],
+        ['Failed to get user', false],
+    ])('%s -> %s', (message, expected) => {
+        expect(isTransientShutdownError(new Error(message))).toBe(expected)
+    })
+
+    test('returns false for null/undefined', () => {
+        expect(isTransientShutdownError(null)).toBe(false)
+        expect(isTransientShutdownError(undefined)).toBe(false)
+    })
+
+    test('matches plain string errors', () => {
+        expect(isTransientShutdownError('destroyed')).toBe(true)
+        expect(isTransientShutdownError('something else')).toBe(false)
+    })
+})


### PR DESCRIPTION
## Problem

The Cloudflare MCP worker (`mcp1`) logs error-level noise every time a durable object restarts mid-session. Two sources:

1. **partyserver** `console.error`s `Error in MCP:streamable-http:<id> webSocketClose: Error: Durable Object reset because its code was updated.` whenever a hibernated WebSocket reconnects after a deploy or DO reset (`node_modules/.pnpm/partyserver*/dist/index.js:471`).
2. **`onCatchErrorHandler`** in `services/mcp/src/index.ts` catches `Error: destroyed` (thrown from the agents framework's `ctx.abort("destroyed")` call when the DO tears down) and forwards it to PostHog Error Tracking via `captureException`, plus logs it as a 500 with full `errorName/errorMessage/errorStack`.

These are normal lifecycle events — connections close, durable objects restart and respawn — not real failures. They drown out actual errors in error tracking and the Cloudflare log feed.

## Changes

- New `services/mcp/src/lib/transient-errors.ts` — single source of truth for transient lifecycle patterns (`webSocketClose:`, `webSocketError:`, `\bdestroyed\b`, `Durable Object reset`). Exposes `isTransientShutdownError(error)` plus an idempotent `installTransientConsoleFilter()` that wraps `console.error` to redirect matches to `console.warn` (prefixed `[MCP transient]`).
- `services/mcp/src/index.ts` — calls `installTransientConsoleFilter()` once at module init so partyserver/agents framework `console.error`s are demoted. Adds a transient short-circuit in `onCatchErrorHandler` that skips `captureException`, drops the loud `errorName/errorMessage/errorStack` fields, and emits the wide log at warn level instead.
- `services/mcp/src/lib/logging.ts` — `RequestLogger` gains a `setSeverity('info' | 'warn')` knob so `emit()` can route through `console.warn` for transient-tagged requests.

Untouched paths (real errors with permission or known token issues) still capture exceptions and log at error level.

## How did you test this code?

I'm an agent. Automated tests I ran:

- New `services/mcp/tests/unit/transient-errors.test.ts` — 12 parameterized cases covering each transient pattern plus negatives (`INVALID_API_KEY`, `Cannot read properties of null`, empty/null/undefined). All pass.
- `npx tsc --noEmit -p tsconfig.json` against `services/mcp` — clean.

Not yet tested in production / against a live worker.

## Publish to changelog?

no

## 🤖 Agent context

Authored with Claude Code. Investigation used the PostHog `query-logs` tool to confirm the two log patterns in production (`mcp1` service), then read partyserver and the agents framework to locate the `console.error` call sites. Key decision: rather than fork partyserver or override the private `webSocketClose` reimplementation, monkey-patch `console.error` at module init since partyserver's `try/catch` already swallows the error before any caller can intercept it.