### PR TITLE
fix(observability): emit django Server-Timing in milliseconds

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -453,8 +453,8 @@ class QueryTimeCountingMiddleware:
             response: HttpResponse = self.get_response(request)
 
         response.headers["Server-Timing"] = self._construct_header(
-            durations={
-                "django": time.perf_counter() - start_time,
+            durations_ms={
+                "django": (time.perf_counter() - start_time) * 1000,
                 "pg": pg_query_counter.query_time_ms,
                 "pg_max": pg_query_counter.max_query_time_ms,
                 "ch": ch_query_counter.query_time_ms,
@@ -469,8 +469,8 @@ class QueryTimeCountingMiddleware:
         )
         return response
 
-    def _construct_header(self, durations: dict[str, float], counts: dict[str, int]) -> str:
-        parts = [f"{key};dur={round(value)}" for key, value in durations.items()]
+    def _construct_header(self, durations_ms: dict[str, float], counts: dict[str, int]) -> str:
+        parts = [f"{key};dur={round(value)}" for key, value in durations_ms.items()]
         parts += [f'{key};desc="{value}"' for key, value in counts.items()]
         return ", ".join(parts)
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1774,3 +1774,19 @@ def test_chqueries_middleware_mcp_defaults(user_agent, expected_source, expected
     assert captured["source"] == expected_source
     assert captured["product"] == expected_product
     assert captured["feature"] == expected_feature
+
+
+def test_query_time_counting_middleware_emits_durations_in_milliseconds() -> None:
+    from posthog.middleware import QueryTimeCountingMiddleware
+
+    middleware = QueryTimeCountingMiddleware(get_response=lambda r: None)
+    header = middleware._construct_header(
+        durations_ms={"django": 2050.4, "pg": 1490.6, "pg_max": 1200.0, "ch": 0.0, "ch_max": 0.0},
+        counts={"pg_count": 17, "pg_slow": 2, "ch_count": 0, "ch_slow": 0},
+    )
+
+    assert "django;dur=2050" in header
+    assert "pg;dur=1491" in header
+    assert "pg_max;dur=1200" in header
+    assert 'pg_count;desc="17"' in header
+    assert 'pg_slow;desc="2"' in header


### PR DESCRIPTION
## Summary

`time.perf_counter()` returns seconds, but the Server-Timing `dur` field is defined in milliseconds. The `django` value in our `QueryTimeCountingMiddleware` was being emitted as `dur=2` for a 2-second request, which browsers render as "2 ms" — making the django timing look 1000x faster than reality. Spotted while diagnosing a slow insights list page-load: `django: 2.00ms` next to `pg: 1.49s` was clearly inconsistent.

## Changes

```python
durations_ms={
    "django": (time.perf_counter() - start_time) * 1000,  # was missing × 1000
    "pg": pg_query_counter.query_time_ms,                  # already in ms
    ...
}
```

Renamed the kwarg `durations` → `durations_ms` so future callers can't trip over the same unit confusion.

Added a unit test (`test_query_time_counting_middleware_emits_durations_in_milliseconds`) that locks in the formatting — both that durations come out as `dur=<rounded_ms>` and that counts come out as `desc="<n>"`.

## 🤖 Agent context

The pg/ch fields were already correct because `QueryCounter.query_time_ms` is `total_query_time * 1000`. Only `django` was paying the unit penalty.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*