### PR TITLE
fix(insights): honor explicitDate in calendar heatmap date range

### DIFF
--- a/posthog/hogql_queries/insights/trends/calendar_heatmap_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/calendar_heatmap_query_runner.py
@@ -323,6 +323,7 @@ class CalendarHeatmapQueryRunner(AnalyticsQueryRunner[CalendarHeatmapResponse]):
             team=self.team,
             interval=interval,
             now=datetime.now(),
+            exact_timerange=bool(self.query.dateRange and self.query.dateRange.explicitDate),
         )
 
     def series_event(self, series: Union[EventsNode, ActionsNode, DataWarehouseNode]) -> str | None:

--- a/posthog/hogql_queries/insights/trends/test/test_calendar_heatmap_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_calendar_heatmap_query_runner.py
@@ -1291,3 +1291,33 @@ class TestCalendarHeatmapQueryRunner(ClickhouseTestMixin, APIBaseTest):
             f"Expected no Firefox+Windows event at 12:00, got {results_dict.get((6, 12))}"
         )
         assert response.results.allAggregations == 1, f"Expected 1 total event, got {response.results.allAggregations}"
+
+    @freeze_time("2026-05-01 14:32:11")
+    def test_explicit_date_keeps_relative_window_exact(self):
+        # Without explicitDate, "-7d" truncates the lower bound to start-of-day and rounds the
+        # upper bound to end-of-day, so the window spans 8 calendar days.
+        query_default = CalendarHeatmapQuery(
+            dateRange=DateRange(date_from="-7d"),
+            properties=[],
+            filterTestAccounts=False,
+            series=[EventsNode(kind="EventsNode", math="dau")],
+        )
+        runner_default = CalendarHeatmapQueryRunner(team=self.team, query=query_default)
+        date_from_default = runner_default.query_date_range.date_from()
+        date_to_default = runner_default.query_date_range.date_to()
+        assert (date_from_default.hour, date_from_default.minute, date_from_default.second) == (0, 0, 0)
+        assert (date_to_default.hour, date_to_default.minute, date_to_default.second) == (23, 59, 59)
+
+        # With explicitDate, both bounds are precise so the window is a true rolling 7 days.
+        query_explicit = CalendarHeatmapQuery(
+            dateRange=DateRange(date_from="-7d", explicitDate=True),
+            properties=[],
+            filterTestAccounts=False,
+            series=[EventsNode(kind="EventsNode", math="dau")],
+        )
+        runner_explicit = CalendarHeatmapQueryRunner(team=self.team, query=query_explicit)
+        date_from_explicit = runner_explicit.query_date_range.date_from()
+        date_to_explicit = runner_explicit.query_date_range.date_to()
+        assert (date_from_explicit.hour, date_from_explicit.minute, date_from_explicit.second) == (14, 32, 11)
+        assert (date_to_explicit.hour, date_to_explicit.minute, date_to_explicit.second) == (14, 32, 11)
+        assert (date_to_explicit - date_from_explicit).total_seconds() == 7 * 24 * 60 * 60

--- a/posthog/hogql_queries/insights/trends/test/test_calendar_heatmap_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_calendar_heatmap_query_runner.py
@@ -1293,31 +1293,24 @@ class TestCalendarHeatmapQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.results.allAggregations == 1, f"Expected 1 total event, got {response.results.allAggregations}"
 
     @freeze_time("2026-05-01 14:32:11")
-    def test_explicit_date_keeps_relative_window_exact(self):
-        # Without explicitDate, "-7d" truncates the lower bound to start-of-day and rounds the
-        # upper bound to end-of-day, so the window spans 8 calendar days.
-        query_default = CalendarHeatmapQuery(
-            dateRange=DateRange(date_from="-7d"),
+    @pytest.mark.parametrize(
+        "explicit_date, expected_from_hms, expected_to_hms, expected_duration_s",
+        [
+            (False, (0, 0, 0), (23, 59, 59), None),
+            (True, (14, 32, 11), (14, 32, 11), 7 * 24 * 60 * 60),
+        ],
+    )
+    def test_explicit_date_keeps_relative_window_exact(self, explicit_date, expected_from_hms, expected_to_hms, expected_duration_s):
+        query = CalendarHeatmapQuery(
+            dateRange=DateRange(date_from="-7d", explicitDate=True if explicit_date else None),
             properties=[],
             filterTestAccounts=False,
             series=[EventsNode(kind="EventsNode", math="dau")],
         )
-        runner_default = CalendarHeatmapQueryRunner(team=self.team, query=query_default)
-        date_from_default = runner_default.query_date_range.date_from()
-        date_to_default = runner_default.query_date_range.date_to()
-        assert (date_from_default.hour, date_from_default.minute, date_from_default.second) == (0, 0, 0)
-        assert (date_to_default.hour, date_to_default.minute, date_to_default.second) == (23, 59, 59)
-
-        # With explicitDate, both bounds are precise so the window is a true rolling 7 days.
-        query_explicit = CalendarHeatmapQuery(
-            dateRange=DateRange(date_from="-7d", explicitDate=True),
-            properties=[],
-            filterTestAccounts=False,
-            series=[EventsNode(kind="EventsNode", math="dau")],
-        )
-        runner_explicit = CalendarHeatmapQueryRunner(team=self.team, query=query_explicit)
-        date_from_explicit = runner_explicit.query_date_range.date_from()
-        date_to_explicit = runner_explicit.query_date_range.date_to()
-        assert (date_from_explicit.hour, date_from_explicit.minute, date_from_explicit.second) == (14, 32, 11)
-        assert (date_to_explicit.hour, date_to_explicit.minute, date_to_explicit.second) == (14, 32, 11)
-        assert (date_to_explicit - date_from_explicit).total_seconds() == 7 * 24 * 60 * 60
+        runner = CalendarHeatmapQueryRunner(team=self.team, query=query)
+        date_from = runner.query_date_range.date_from()
+        date_to = runner.query_date_range.date_to()
+        assert (date_from.hour, date_from.minute, date_from.second) == expected_from_hms
+        assert (date_to.hour, date_to.minute, date_to.second) == expected_to_hms
+        if expected_duration_s is not None:
+            assert (date_to - date_from).total_seconds() == expected_duration_s

--- a/posthog/hogql_queries/insights/trends/test/test_calendar_heatmap_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_calendar_heatmap_query_runner.py
@@ -1293,24 +1293,31 @@ class TestCalendarHeatmapQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.results.allAggregations == 1, f"Expected 1 total event, got {response.results.allAggregations}"
 
     @freeze_time("2026-05-01 14:32:11")
-    @pytest.mark.parametrize(
-        "explicit_date, expected_from_hms, expected_to_hms, expected_duration_s",
-        [
-            (False, (0, 0, 0), (23, 59, 59), None),
-            (True, (14, 32, 11), (14, 32, 11), 7 * 24 * 60 * 60),
-        ],
-    )
-    def test_explicit_date_keeps_relative_window_exact(self, explicit_date, expected_from_hms, expected_to_hms, expected_duration_s):
-        query = CalendarHeatmapQuery(
-            dateRange=DateRange(date_from="-7d", explicitDate=True if explicit_date else None),
+    def test_explicit_date_keeps_relative_window_exact(self):
+        # Without explicitDate, "-7d" truncates the lower bound to start-of-day and rounds the
+        # upper bound to end-of-day, so the window spans 8 calendar days.
+        query_default = CalendarHeatmapQuery(
+            dateRange=DateRange(date_from="-7d"),
             properties=[],
             filterTestAccounts=False,
             series=[EventsNode(kind="EventsNode", math="dau")],
         )
-        runner = CalendarHeatmapQueryRunner(team=self.team, query=query)
-        date_from = runner.query_date_range.date_from()
-        date_to = runner.query_date_range.date_to()
-        assert (date_from.hour, date_from.minute, date_from.second) == expected_from_hms
-        assert (date_to.hour, date_to.minute, date_to.second) == expected_to_hms
-        if expected_duration_s is not None:
-            assert (date_to - date_from).total_seconds() == expected_duration_s
+        runner_default = CalendarHeatmapQueryRunner(team=self.team, query=query_default)
+        date_from_default = runner_default.query_date_range.date_from()
+        date_to_default = runner_default.query_date_range.date_to()
+        assert (date_from_default.hour, date_from_default.minute, date_from_default.second) == (0, 0, 0)
+        assert (date_to_default.hour, date_to_default.minute, date_to_default.second) == (23, 59, 59)
+
+        # With explicitDate, both bounds are precise so the window is a true rolling 7 days.
+        query_explicit = CalendarHeatmapQuery(
+            dateRange=DateRange(date_from="-7d", explicitDate=True),
+            properties=[],
+            filterTestAccounts=False,
+            series=[EventsNode(kind="EventsNode", math="dau")],
+        )
+        runner_explicit = CalendarHeatmapQueryRunner(team=self.team, query=query_explicit)
+        date_from_explicit = runner_explicit.query_date_range.date_from()
+        date_to_explicit = runner_explicit.query_date_range.date_to()
+        assert (date_from_explicit.hour, date_from_explicit.minute, date_from_explicit.second) == (14, 32, 11)
+        assert (date_to_explicit.hour, date_to_explicit.minute, date_to_explicit.second) == (14, 32, 11)
+        assert (date_to_explicit - date_from_explicit).total_seconds() == 7 * 24 * 60 * 60


### PR DESCRIPTION
## Problem

Reference ticket: https://posthoghelp.zendesk.com/agent/tickets/57386 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/58693)

The calendar heatmap insight (Active hours / hours-and-days view) has two bugs that produce misleading numbers when using dau ("unique users") math, this PR fixes the first issue (second issue is here: https://github.com/PostHog/posthog/pull/57296):

Time range over-includes data. With `date_from=-7d` the query covers 8 days (2026-04-24 00:00:00 → 2026-05-01 23:59:59) instead of the last rolling 7 days. 

The "Exact time range" toggle (`explicitDate`) caps `date_to` at now() but leaves `date_from` truncated to start-of-day, so the bottom edge still leaks an extra slice of "today, last week" into the bucket for the current weekday/hour. This makes today's row visually inflated.

## Changes

Wire `dateRange.explicitDate` through to `QueryDateRange` so the calendar heatmap stops truncating `date_from` to start-of-day when "Exact time range" is enabled. Without this, a "-7d" range still leaks 8 calendar days of data, including the matching weekday/hour from a week ago, inflating today's row.

## How did you test this code?

Unit test added

## Publish to changelog?

no

## 🤖 Agent context

Generated-By: PostHog Code
Task-Id: 605a25a1-69b9-4449-bac9-4f3e0bb99328