### PR TITLE
feat(notebooks): sync comment selection between editor and side panel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
@@ -77,11 +77,12 @@ const DiscussionContent = ({
     children?: React.ReactNode
 }): JSX.Element => {
     const { selectedTabOptions } = useValues(sidePanelStateLogic)
-    const { setReplyingComment } = useActions(commentsLogic(logicProps))
+    const { setSelectedComment } = useActions(commentsLogic(logicProps))
     const { setCommentsListRef } = useActions(sidePanelDiscussionLogic)
 
     useEffect(() => {
-        setReplyingComment(selectedTabOptions ?? null)
+        // Use setSelectedComment without auto-focusing the composer
+        setSelectedComment(selectedTabOptions ?? null)
     }, [selectedTabOptions]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return (

--- a/frontend/src/lib/components/RichContentEditor/types.ts
+++ b/frontend/src/lib/components/RichContentEditor/types.ts
@@ -35,6 +35,7 @@ export interface RichContentEditorType {
     chain: () => EditorCommands
     destroy: () => void
     getMarks: (type: string) => { id: string; pos: number }[]
+    getAttributes: (typeOrName: string) => Record<string, any>
     setMark: (id: string) => void
     getMentions: () => number[]
     isActive: (name: string, attributes?: {}) => boolean

--- a/frontend/src/lib/components/RichContentEditor/utils.ts
+++ b/frontend/src/lib/components/RichContentEditor/utils.ts
@@ -29,6 +29,7 @@ export function createEditor(editor: TTEditor): RichContentEditorType {
         chain: () => editor.chain().focus(),
         destroy: () => editor.destroy(),
         getMarks: (type: string) => getMarks(editor, type),
+        getAttributes: (typeOrName: string) => editor.getAttributes(typeOrName),
         setMark: (id: string) => editor.commands.setMark('comment', { id }),
         isActive: (name: string, attributes?: {}) => editor.isActive(name, attributes),
         isSelectionFullyWithinSingleMark: (markName: string) => {

--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -223,12 +223,14 @@ const CommentTopRow = ({ comment }: { comment: CommentType }): JSX.Element => {
 }
 
 const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
-    const { editingComment, replyingCommentId } = useValues(commentsLogic)
+    const { editingComment, replyingCommentId, selectedCommentId } = useValues(commentsLogic)
+    const { setSelectedComment } = useActions(commentsLogic)
 
     const ref = useRef<HTMLDivElement | null>(null)
 
     const isEditing = editingComment?.id === comment.id
-    const isHighlighted = replyingCommentId === comment.id || isEditing
+    const isHighlighted = selectedCommentId === comment.id || replyingCommentId === comment.id || isEditing
+    const threadId = comment.source_comment ?? comment.id
 
     useEffect(() => {
         if (isHighlighted) {
@@ -239,8 +241,13 @@ const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
     return (
         <div
             ref={ref}
-            className={clsx('Comment border rounded-lg bg-surface-primary px-2 py-1', isHighlighted && 'border-accent')}
+            className={clsx(
+                'Comment border rounded-lg bg-surface-primary px-2 py-1',
+                isHighlighted && 'border-accent',
+                !isEditing && 'cursor-pointer'
+            )}
             data-comment-id={comment.id}
+            onClick={isEditing ? undefined : () => setSelectedComment(threadId)}
         >
             <div className="flex flex-col justify-start gap-2">
                 <div className="flex-1 flex justify-start gap-2">

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -72,6 +72,7 @@ export const commentsLogic = kea<commentsLogicType>([
         deleteComment: (comment: CommentType) => ({ comment }),
         setEditingComment: (comment: CommentType | null) => ({ comment }),
         setReplyingComment: (commentId: string | null) => ({ commentId }),
+        setSelectedComment: (commentId: string | null) => ({ commentId }),
         setItemContext: (context: Record<string, any> | null, callback?: (event: { sent: boolean }) => void) => ({
             context,
             callback,
@@ -84,6 +85,14 @@ export const commentsLogic = kea<commentsLogicType>([
             null as string | null,
             {
                 setReplyingComment: (_, { commentId }) => commentId,
+                sendComposedContentSuccess: () => null,
+            },
+        ],
+        selectedCommentId: [
+            null as string | null,
+            {
+                setSelectedComment: (_, { commentId }) => commentId,
+                setReplyingComment: (state, { commentId }) => commentId ?? state,
                 sendComposedContentSuccess: () => null,
             },
         ],

--- a/frontend/src/scenes/notebooks/Marks/NotebookMarkComment.tsx
+++ b/frontend/src/scenes/notebooks/Marks/NotebookMarkComment.tsx
@@ -1,6 +1,7 @@
 import { Mark, MarkViewProps, mergeAttributes } from '@tiptap/core'
 import { MarkViewContent, ReactMarkViewRenderer } from '@tiptap/react'
-import { useMountedLogic } from 'kea'
+import clsx from 'clsx'
+import { useMountedLogic, useValues } from 'kea'
 
 import { notebookLogic } from '../Notebook/notebookLogic'
 
@@ -44,9 +45,11 @@ export const NotebookMarkComment = Mark.create({
 
 const Component = (props: MarkViewProps): JSX.Element => {
     const mountedNotebookLogic = useMountedLogic(notebookLogic)
+    const { activeCommentMarkId } = useValues(notebookLogic)
+    const isActive = activeCommentMarkId === props.mark.attrs.id
 
     const attributes = mergeAttributes(props.HTMLAttributes, {
-        class: 'NotebookComment',
+        class: clsx('NotebookComment', isActive && 'NotebookComment--active'),
     })
 
     return (

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -591,9 +591,15 @@
         background: color-mix(in oklab, var(--color-accent) 25%, transparent);
         border-radius: 2px;
         box-decoration-break: clone;
+        transition: background 120ms ease-in-out;
 
         &:hover {
             background: color-mix(in oklab, var(--color-accent) 50%, transparent);
+        }
+
+        &--active,
+        &--active:hover {
+            background: color-mix(in oklab, var(--color-accent) 65%, transparent);
         }
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -116,7 +116,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 scope: ActivityScope.NOTEBOOK,
                 item_id: props.shortId,
             }),
-            ['comments', 'itemContext'],
+            ['comments', 'itemContext', 'selectedCommentId'],
             notebookKernelInfoLogic({ shortId: props.shortId }),
             ['kernelInfo'],
             notebookSettingsLogic,
@@ -133,7 +133,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 scope: ActivityScope.NOTEBOOK,
                 item_id: props.shortId,
             }),
-            ['setItemContext', 'maybeLoadComments'],
+            ['setItemContext', 'maybeLoadComments', 'setSelectedComment'],
             notebookCollabLogic({ shortId: props.shortId }),
             ['ackLocalSteps', 'applyRemoteSteps'],
         ],
@@ -708,6 +708,17 @@ export const notebookLogic = kea<notebookLogicType>([
                     ?.value as string
             },
         ],
+
+        activeCommentMarkId: [
+            (s) => [s.selectedCommentId, s.comments],
+            (selectedCommentId, comments): string | null => {
+                if (!selectedCommentId) {
+                    return null
+                }
+                const comment = comments?.find((c) => c.id === selectedCommentId)
+                return comment?.item_context?.type === 'mark' ? (comment.item_context.id ?? null) : null
+            },
+        ],
     }),
     listeners(({ values, actions, cache }) => ({
         insertAfterLastNode: async ({ content }) => {
@@ -892,16 +903,28 @@ export const notebookLogic = kea<notebookLogicType>([
         },
 
         onEditorSelectionUpdate: () => {
-            if (values.editor) {
-                // Throttle this too to avoid excessive calls
-                if (cache.throttledOnUpdateEditorTimeout) {
-                    clearTimeout(cache.throttledOnUpdateEditorTimeout)
-                }
-                cache.throttledOnUpdateEditorTimeout = setTimeout(() => {
-                    actions.onUpdateEditor()
-                    cache.throttledOnUpdateEditorTimeout = null
-                }, 16) // ~60fps throttling
+            if (!values.editor) {
+                return
             }
+            // Sync the active comment to the editor cursor: when the caret enters a comment mark
+            // we highlight the corresponding side-panel comment; when it leaves we clear it.
+            const markId = values.editor.getAttributes('comment').id ?? null
+            const targetSelectedId = markId
+                ? (values.comments?.find((c) => c.item_context?.type === 'mark' && c.item_context?.id === markId)?.id ??
+                  null)
+                : null
+            if (values.selectedCommentId !== targetSelectedId) {
+                actions.setSelectedComment(targetSelectedId)
+            }
+
+            // Throttle this too to avoid excessive calls
+            if (cache.throttledOnUpdateEditorTimeout) {
+                clearTimeout(cache.throttledOnUpdateEditorTimeout)
+            }
+            cache.throttledOnUpdateEditorTimeout = setTimeout(() => {
+                actions.onUpdateEditor()
+                cache.throttledOnUpdateEditorTimeout = null
+            }, 16) // ~60fps throttling
         },
         scrollToSelection: () => {
             if (values.editor) {
@@ -991,6 +1014,15 @@ export const notebookLogic = kea<notebookLogicType>([
                         editor.removeComment(mark.pos)
                     }
                 })
+            }
+        },
+        activeCommentMarkId: (markId: string | null) => {
+            if (!markId || !values.editor) {
+                return
+            }
+            const pos = values.editor.findCommentPosition(markId)
+            if (pos !== null) {
+                values.editor.scrollToPosition(pos)
             }
         },
     })),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Comments in notebooks weren't synced between the editor and the side panel:

- Clicking a comment in the side panel didn't scroll to or highlight the corresponding mark in the editor
- Moving the cursor in/out of a comment-marked area in the editor didn't reflect in the side-panel selection
- There was no visual distinction between the default highlight on every comment mark and the currently active one

## Changes

- New `selectedCommentId` state in `commentsLogic`
- Subscription scrolls the editor to the mark when a side-panel comment is selected
- `NotebookMarkComment` applies a `--active` class for a more prominent highlight
- `Comment` cards are clickable; side-panel `selectedTabOptions` effect now selects without entering reply mode

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![2026-05-01 16.58.11.gif](https://app.graphite.com/user-attachments/assets/2c951838-d6ac-4f2e-8981-ce3c1e995b95.gif)



## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->