### PR TITLE
fix(test): bound k8s-awareness kube calls with per-call timeout

### DIFF
--- a/rust/common/k8s-awareness/src/discovery.rs
+++ b/rust/common/k8s-awareness/src/discovery.rs
@@ -1,9 +1,21 @@
+use std::time::Duration;
+
 use k8s_openapi::api::apps::v1::ReplicaSet;
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::Api;
 use kube::Client;
+use tracing::warn;
 
 use crate::types::{ControllerKind, ControllerRef, PodInfo};
+
+/// Per-call timeout for synchronous kube `get` / `list` requests issued by
+/// k8s-awareness. kube-rs / reqwest's default request timeout is ~290s, longer
+/// than most callers' overall budget, so a single hung call against a zombie
+/// API server (TCP alive, no response) can blow past those budgets. Bounding
+/// each call here turns a zombie into a quick error the caller can surface or
+/// retry. Does not apply to long-poll watch streams, which manage their own
+/// timeouts via `WatcherConfig::timeout`.
+pub(crate) const KUBE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {
@@ -17,6 +29,8 @@ pub enum DiscoveryError {
     ReplicaSetNoDeploymentOwner(String),
     #[error("pod {0} missing generation label")]
     MissingGenerationLabel(String),
+    #[error("kubernetes API call timed out after {0:?}: {1}")]
+    Timeout(Duration, String),
     #[error("kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
 }
@@ -33,13 +47,23 @@ pub async fn discover_controller(
     pod_name: &str,
 ) -> Result<PodInfo, DiscoveryError> {
     let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
-    let pod = pods.get(pod_name).await.map_err(|e| {
-        if is_not_found(&e) {
-            DiscoveryError::PodNotFound(pod_name.to_string())
-        } else {
-            DiscoveryError::Kube(e)
-        }
-    })?;
+    let pod = tokio::time::timeout(KUBE_CALL_TIMEOUT, pods.get(pod_name))
+        .await
+        .map_err(|_| {
+            warn!(
+                pod = pod_name,
+                timeout = ?KUBE_CALL_TIMEOUT,
+                "kube pod.get timed out"
+            );
+            DiscoveryError::Timeout(KUBE_CALL_TIMEOUT, format!("pod.get({pod_name})"))
+        })?
+        .map_err(|e| {
+            if is_not_found(&e) {
+                DiscoveryError::PodNotFound(pod_name.to_string())
+            } else {
+                DiscoveryError::Kube(e)
+            }
+        })?;
 
     let owner_refs = pod.metadata.owner_references.as_deref().unwrap_or_default();
 
@@ -68,7 +92,19 @@ pub async fn discover_controller(
     // ReplicaSet → Deployment
     if let Some(rs_owner) = owner_refs.iter().find(|r| r.kind == "ReplicaSet") {
         let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
-        let rs = rs_api.get(&rs_owner.name).await?;
+        let rs = tokio::time::timeout(KUBE_CALL_TIMEOUT, rs_api.get(&rs_owner.name))
+            .await
+            .map_err(|_| {
+                warn!(
+                    replicaset = %rs_owner.name,
+                    timeout = ?KUBE_CALL_TIMEOUT,
+                    "kube replicaset.get timed out"
+                );
+                DiscoveryError::Timeout(
+                    KUBE_CALL_TIMEOUT,
+                    format!("replicaset.get({})", rs_owner.name),
+                )
+            })??;
 
         let rs_owners = rs.metadata.owner_references.as_deref().unwrap_or_default();
 

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::detection;
-use crate::discovery::{self, DiscoveryError};
+use crate::discovery::{self, DiscoveryError, KUBE_CALL_TIMEOUT};
 use crate::types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
 
 #[derive(Debug, thiserror::Error)]
@@ -238,8 +238,22 @@ async fn handle_deployment_event(
     // If this fails, skip the entire intent update to avoid mixing fresh
     // deployment fields (like rollout_in_progress) with stale generation data,
     // which would create an inconsistent ClusterIntent.
-    let owned_rses =
-        list_owned_replicasets(client, namespace, &controller.name, &label_selector).await;
+    let owned_rses = match tokio::time::timeout(
+        KUBE_CALL_TIMEOUT,
+        list_owned_replicasets(client, namespace, &controller.name, &label_selector),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            warn!(
+                controller = %controller,
+                timeout = ?KUBE_CALL_TIMEOUT,
+                "kube replicaset.list timed out, skipping intent update"
+            );
+            return;
+        }
+    };
     let rses = match owned_rses {
         Ok(rses) => rses,
         Err(e) => {


### PR DESCRIPTION
## Problem

Master CI flake on 2026-05-01 (run [25218170298](https://github.com/PostHog/posthog/actions/runs/25218170298/job/73943503545)): `deployment_rollout_reassigns_partitions` panics at the **first** `wait_for_condition` (initial assignment, line 554) — upstream of the `wait_for_k3s_api_ready` protection from #55688 / #55696. Tight burst of ~200 `kube_client ... Connect` errors clustered into ~50 ms at panic time, consistent with watchers tearing down on panic.

## Root cause

The single-node k3s testcontainer can enter a zombie state (TCP alive, no response). Synchronous kube calls in `k8s-awareness` then hit reqwest's ~290 s default — past the 180 s test budget. Affected: `pods.get`, `rs_api.get` (in `discover_controller`), and `list_owned_replicasets` (in the deployment watcher).

## Changes

Wraps each call with `tokio::time::timeout(30 s)`, surfaces a typed `DiscoveryError::Timeout`, and logs a `warn!` on every fire. 30 s is generous for a healthy API (real calls return in ms) and well inside the 180 s test budget, so a zombie now degrades to a quick error the next attempt can recover from. **Watch streams are deliberately untouched** — kube-rs's ~290 s long-poll is intentional.

## Relationship to prior work

Re-applies the diagnosis of [#56549](https://github.com/PostHog/posthog/pull/56549) (closed unmerged on 2026-04-30 after the `infra_cicd` deny-list gate, not on technical grounds), narrower in scope: drops the `WatcherConfig::timeout(30)` change (conflated request and watch timeouts), shares one constant, and adds tracing on every timeout fire.

## How did you test this code?

I'm an agent. Automated only:

- `cargo build -p k8s-awareness -p kafka-assigner` — clean.
- `cargo test -p k8s-awareness` — 18/18 pass (lib + mock_discovery).
- `cargo test -p kafka-assigner --lib` — 42/42 pass.
- `cargo clippy -p k8s-awareness --all-targets` and `cargo fmt --check` — clean.

Flake requires the k3s zombie state and won't reproduce on demand — CI on master is the signal.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code.