### PR TITLE
fix(storybook): use domcontentloaded for initial iframe goto

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -1,6 +1,6 @@
 import type { Locator, LocatorScreenshotOptions, Page } from '@playwright/test'
 import { StoryContext } from '@storybook/csf'
-import { TestContext, TestRunnerConfig, getStoryContext } from '@storybook/test-runner'
+import { PrepareContext, TestContext, TestRunnerConfig, getStoryContext } from '@storybook/test-runner'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
 import path from 'path'
 
@@ -107,6 +107,28 @@ module.exports = {
         expect.extend({ toMatchImageSnapshot })
         jest.retryTimes(RETRY_TIMES, { logErrorsBeforeRetry: true })
         jest.setTimeout(JEST_TIMEOUT_MS)
+    },
+
+    // Replaces test-runner's defaultPrepare. The default uses `waitUntil: 'load'`, which on webkit
+    // under CI contention regularly exceeds the 30s page.goto budget while the bundle loads — failing
+    // the entire file before any test runs. We don't read anything from the bare iframe.html; the
+    // per-story `waitForPageReady` below already enforces full readiness before each snapshot, so
+    // shifting this initial navigation to `domcontentloaded` is safe.
+    async prepare({ page, browserContext, testRunnerConfig }: PrepareContext): Promise<void> {
+        const targetURL = process.env.TARGET_URL
+        const iframeURL = new URL('iframe.html', targetURL).toString()
+        if (testRunnerConfig?.getHttpHeaders) {
+            const headers = await testRunnerConfig.getHttpHeaders(iframeURL)
+            await browserContext.setExtraHTTPHeaders(headers)
+        }
+        await page.goto(iframeURL, { waitUntil: 'domcontentloaded' }).catch((err) => {
+            if (err.message?.includes('ERR_CONNECTION_REFUSED')) {
+                throw new Error(
+                    `Could not access the Storybook instance at ${targetURL}. Are you sure it's running?\n\n${err.message}`
+                )
+            }
+            throw err
+        })
     },
 
     async preVisit(page, context) {


### PR DESCRIPTION
## Problem

Webkit visual regression tests intermittently fail with `page.goto: Timeout 30000ms exceeded` while navigating to the bare `iframe.html` in `@storybook/test-runner`'s `defaultPrepare`. Different stories fail each run — recent master examples include AutocapturePreviewImage, LemonRadio, LemonColorButton. Bumping the timeout was previously rejected as not addressing root cause.


## Fix

Override the test-runner's `prepare` hook (the documented extension point) to use `waitUntil: 'domcontentloaded'` instead of `'load'` for the initial bare-iframe navigation. The per-story `waitForPageReady` already enforces `load` + `networkidle` + `document.fonts.ready` + image-natural-width before each snapshot, so this defers the bundle-load wait from the 30s `page.goto` budget to the 60s jest test budget without weakening any visual check.