### PR TITLE
test(phrocs): de-flake HasPrompt tests via fake reader

### DIFF
--- a/tools/phrocs/internal/process/proc_test.go
+++ b/tools/phrocs/internal/process/proc_test.go
@@ -337,31 +337,32 @@ func TestReadLoop_batchesOutput(t *testing.T) {
 	}
 }
 
+// runReadLoop drives readLoop against an in-memory reader and waits for it to
+// return. Bypassing the PTY avoids a known Linux kernel race (commit
+// 1a48632ffed6) where data written and immediately followed by close() on the
+// child's PTY end can be dropped before the parent's read is scheduled.
+func runReadLoop(t *testing.T, p *Process, input string) {
+	t.Helper()
+	outChannel := make(chan tea.Msg, 64)
+	done := make(chan struct{})
+	go func() {
+		p.readLoop(strings.NewReader(input), outChannel)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not return")
+	}
+}
+
 func TestHasPrompt_partialLine(t *testing.T) {
-	// printf writes a partial line (no trailing \n), which readLoop should
-	// detect and set HasPrompt = true.
-	p := NewProcess("prompt-test", config.ProcConfig{
-		Shell: `printf "Enter name: "`,
-	}, 100, "")
+	p := NewProcess("prompt-test", config.ProcConfig{}, 100, "")
+	runReadLoop(t, p, "Enter name: ")
 
-	send, _, _ := collectMsgs()
-	if err := p.Start(send); err != nil {
-		t.Skipf("skipping: cannot spawn subprocess: %v", err)
+	if !p.HasPrompt() {
+		t.Error("HasPrompt should be true for a partial line")
 	}
-
-	deadline := time.After(5 * time.Second)
-	for {
-		select {
-		case <-deadline:
-			t.Fatal("timed out waiting for HasPrompt")
-		default:
-		}
-		if p.HasPrompt() {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-
 	lines := p.Lines()
 	if len(lines) == 0 {
 		t.Fatal("expected at least one buffered line")
@@ -372,30 +373,8 @@ func TestHasPrompt_partialLine(t *testing.T) {
 }
 
 func TestHasPrompt_completeLine(t *testing.T) {
-	// echo writes a complete line (with trailing \n), so HasPrompt should
-	// be false once the process finishes.
-	p := NewProcess("no-prompt", config.ProcConfig{
-		Shell: `echo "hello"`,
-	}, 100, "")
-
-	send, _, _ := collectMsgs()
-	if err := p.Start(send); err != nil {
-		t.Skipf("skipping: cannot spawn subprocess: %v", err)
-	}
-
-	deadline := time.After(5 * time.Second)
-	for {
-		select {
-		case <-deadline:
-			t.Fatal("timed out waiting for process to finish")
-		default:
-		}
-		st := p.Status()
-		if st == StatusDone || st == StatusCrashed {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	p := NewProcess("no-prompt", config.ProcConfig{}, 100, "")
+	runReadLoop(t, p, "hello\n")
 
 	if p.HasPrompt() {
 		t.Error("HasPrompt should be false after a complete line")


### PR DESCRIPTION
## Problem

`TestHasPrompt_partialLine` was flaky on Linux CI — it spawned a real subprocess that wrote a partial line and exited immediately, racing against a known Linux kernel bug ([commit 1a48632ffed6](https://lists.archive.carbon60.com/linux/kernel/1790583)) where data written and immediately followed by close() on the child's PTY end can be dropped before the parent's read is scheduled. The master `read()` returns EIO with no chunk delivered, `HasPrompt` never flips true, the test hits its 5s deadline and fails.

`TestHasPrompt_completeLine` had the same race window — it would have passed for the wrong reason if data were lost, since lost data also produces `HasPrompt=false`.

## Changes

Both tests now drive `readLoop` directly against `strings.NewReader(...)` via a `runReadLoop` helper. No subprocess, no PTY, no kernel race window. Each test runs in ~0ms, deterministic.

PTY plumbing remains covered end-to-end by `TestWriteInput`, `TestBackpressure_concurrentFloodDoesNotStall`, and `TestReadLoop_batchesOutput`.

## How did you test this code?

I'm an agent. Automated checks only:

- `go test -count=50 -run TestHasPrompt ./internal/process/` — 250 runs across 5 batches in `golang:1.25` Docker, 0 failures.
- `go test -race ./...` — clean across the full `tools/phrocs` tree on Linux Docker.
- Reproduced the original flake on Linux Docker before the fix (~3% failure rate at `-count=20`); 0 failures after.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with Claude Code (Opus 4.7).
- Initial fix attempt was `printf "..."; sleep 0.5` to keep the child's PTY end open. Rejected on review as a band-aid: arbitrary timing, slows the suite, not future-proof on contended CI runners.
- Considered just deleting the test. Rejected because the `HasPrompt = true` codepath would lose its only regression guard, and the feature drives interactive stdin in the TUI (#52595) — silent breakage would mean the TUI stops entering input mode for prompts.
- Final approach: unit-test `readLoop` directly with a fake `io.Reader`. Same public-behavior assertions, deterministic, ~5000× faster than the original integration test.