### PR TITLE
chore(hog-charts): wire date x-axis through TimeSeriesLineChart config (stage 3a)

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -520,6 +520,10 @@ snapshots:
         hash: v1.k794b7964.529535e435c93c8f004cdba8f2ba29681dd679eb9bfbaff745a5f00c3b424ffd.2Kq3-2B9F2VNlkrFY-dge3vntnfrudonJ-Lle1s8m5E
     components-hogcharts-timeserieslinechart--basic--light:
         hash: v1.k794b7964.3a097fd7390b5a54fcf6e20a1769cc9058b66f4d040ed58748d0d4dc55c8788b.zqLqP936uYDq025ot6wQL3TxRVnq4UzQAtiS92DFZp8
+    components-hogcharts-timeserieslinechart--date-axis--dark:
+        hash: v1.k794b7964.5805c3a1a9848b678164dcb7f71f6e6df63feb0528585a035d46ca9494080129.e7jpy3cDRnVfLZFjsQcScQdz8mwwULxW5TsnWUE_Rq4
+    components-hogcharts-timeserieslinechart--date-axis--light:
+        hash: v1.k794b7964.7a2951f2481faf207966615e374818fb43d30ae3f16aeb2af836bc6955d80d77.WNimlXEb2nRgkA5J86byjnuJ3WUmvR_vb9glEJzoQJw
     components-hogcharts-valuelabels--cross-series-overlap-removal--dark:
         hash: v1.k794b7964.b766f038277710789aefeabc721df0c662a10aa672b24e14f7e68349f88f396a.Jef_dCFf6j8X_7hXhsuDQa6KMpkq-BS1akkcNUH46MU
     components-hogcharts-valuelabels--cross-series-overlap-removal--light:

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import { TimeSeriesLineChart } from 'lib/hog-charts'
-import type { Series } from 'lib/hog-charts'
+import type { Series, TimeInterval } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
 
@@ -33,6 +33,105 @@ export const Basic: Story = {
                     config={{ yAxis: { showGrid: true } }}
                 />
             </Stage>
+        )
+    },
+}
+
+const HOURLY_LABELS = Array.from({ length: 24 }, (_, i) => `2025-04-01 ${String(i).padStart(2, '0')}:00:00`)
+const HOURLY_SERIES: Series[] = [
+    {
+        key: 'visits',
+        label: 'Visits',
+        data: [12, 9, 7, 6, 8, 14, 22, 35, 48, 55, 60, 64, 62, 58, 54, 50, 46, 44, 40, 36, 30, 24, 18, 14],
+    },
+]
+
+const DAILY_LABELS = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date(Date.UTC(2025, 2, 15))
+    d.setUTCDate(d.getUTCDate() + i)
+    return d.toISOString().slice(0, 10)
+})
+const DAILY_SERIES: Series[] = [
+    {
+        key: 'visits',
+        label: 'Visits',
+        data: DAILY_LABELS.map((_, i) => 40 + Math.round(20 * Math.sin(i / 4))),
+    },
+]
+
+const MONTHLY_LABELS = [
+    '2024-09-01',
+    '2024-10-01',
+    '2024-11-01',
+    '2024-12-01',
+    '2025-01-01',
+    '2025-02-01',
+    '2025-03-01',
+    '2025-04-01',
+    '2025-05-01',
+    '2025-06-01',
+    '2025-07-01',
+    '2025-08-01',
+]
+const MONTHLY_SERIES: Series[] = [
+    { key: 'visits', label: 'Visits', data: [120, 135, 150, 142, 200, 220, 245, 260, 275, 290, 310, 330] },
+]
+
+interface DateAxisCellProps {
+    title: string
+    labels: string[]
+    series: Series[]
+    interval: TimeInterval
+    timezone: string
+}
+
+function DateAxisCell({ title, labels, series, interval, timezone }: DateAxisCellProps): JSX.Element {
+    const theme = useReactiveTheme()
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span className="text-xs text-muted">{title}</span>
+            <Stage width={420} height={220}>
+                <TimeSeriesLineChart
+                    series={series}
+                    labels={labels}
+                    theme={theme}
+                    config={{
+                        xAxis: { timezone, interval },
+                        yAxis: { showGrid: true },
+                    }}
+                />
+            </Stage>
+        </div>
+    )
+}
+
+export const DateAxis: Story = {
+    render: () => {
+        const cells: { interval: TimeInterval; labels: string[]; series: Series[]; title: string }[] = [
+            { interval: 'hour', labels: HOURLY_LABELS, series: HOURLY_SERIES, title: 'hour' },
+            { interval: 'day', labels: DAILY_LABELS, series: DAILY_SERIES, title: 'day' },
+            { interval: 'month', labels: MONTHLY_LABELS, series: MONTHLY_SERIES, title: 'month' },
+        ]
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, auto)', gap: 24 }}>
+                {(['UTC', 'America/New_York'] as const).map((timezone) => (
+                    // eslint-disable-next-line react/forbid-dom-props
+                    <div key={timezone} style={{ display: 'contents' }}>
+                        {cells.map(({ interval, labels, series, title }) => (
+                            <DateAxisCell
+                                key={`${timezone}-${interval}`}
+                                title={`${timezone} · ${title}`}
+                                labels={labels}
+                                series={series}
+                                interval={interval}
+                                timezone={timezone}
+                            />
+                        ))}
+                    </div>
+                ))}
+            </div>
         )
     },
 }

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -19,6 +19,10 @@ const LABELS = ['Mon', 'Tue', 'Wed']
 const SERIES: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3] }]
 
 describe('TimeSeriesLineChart', () => {
+    beforeEach(() => {
+        lineChartSpy.mockClear()
+    })
+
     it('translates config.xAxis and config.yAxis fields onto LineChartConfig', () => {
         const xTickFormatter = (v: string): string => `x:${v}`
         const yTickFormatter = (v: number): string => `y:${v}`
@@ -41,5 +45,61 @@ describe('TimeSeriesLineChart', () => {
         expect(props.config?.hideXAxis).toBe(true)
         expect(props.config?.hideYAxis).toBe(true)
         expect(props.config?.showGrid).toBe(true)
+    })
+
+    it('builds an x-axis tick formatter from xAxis.timezone + xAxis.interval', () => {
+        const allDays = ['2025-04-01 14:00:00', '2025-04-01 15:00:00', '2025-04-01 16:00:00']
+        render(
+            <TimeSeriesLineChart
+                series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                labels={['14:00', '15:00', '16:00']}
+                theme={THEME}
+                config={{
+                    xAxis: { timezone: 'UTC', interval: 'hour', allDays },
+                }}
+            />
+        )
+        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+        const formatter = props.config?.xTickFormatter
+        expect(formatter).not.toBeUndefined()
+        expect(formatter?.('ignored', 0)).toBe('14:00')
+        expect(formatter?.('ignored', 1)).toBe('15:00')
+        expect(formatter?.('ignored', 2)).toBe('16:00')
+    })
+
+    it('explicit tickFormatter wins over xAxis.timezone + xAxis.interval', () => {
+        const explicit = (_v: string, i: number): string => `tick-${i}`
+        render(
+            <TimeSeriesLineChart
+                series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                labels={['14:00', '15:00', '16:00']}
+                theme={THEME}
+                config={{
+                    xAxis: {
+                        tickFormatter: explicit,
+                        timezone: 'UTC',
+                        interval: 'hour',
+                        allDays: ['2025-04-01 14:00:00', '2025-04-01 15:00:00', '2025-04-01 16:00:00'],
+                    },
+                }}
+            />
+        )
+        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+        expect(props.config?.xTickFormatter).toBe(explicit)
+    })
+
+    it('does not auto-format when only one of timezone or interval is provided', () => {
+        render(
+            <TimeSeriesLineChart
+                series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                labels={LABELS}
+                theme={THEME}
+                config={{
+                    xAxis: { timezone: 'UTC' },
+                }}
+            />
+        )
+        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+        expect(props.config?.xTickFormatter).toBeUndefined()
     })
 })

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -2,11 +2,23 @@ import React from 'react'
 
 import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../../core/types'
 import { LineChart } from '../LineChart'
+import { createXAxisTickCallback, type TimeInterval } from './utils/dates'
 
 export interface TimeSeriesLineChartConfig {
     xAxis?: {
+        /** Custom tick label formatter. When set, it wins over the date-axis auto formatter. */
         tickFormatter?: (value: string, index: number) => string | null
         hide?: boolean
+        /** IANA timezone (e.g. `UTC`, `America/New_York`) for date-axis tick formatting.
+         * Combined with `interval`, enables auto-formatting via `createXAxisTickCallback`. */
+        timezone?: string
+        /** Bucket size of the X axis. Combined with `timezone`, enables auto-formatting. */
+        interval?: TimeInterval
+        /** Resolved date range of the chart. Reserved for future date-axis behavior. */
+        dateRange?: { start: string; end: string }
+        /** The raw date strings underlying each label, used to compute boundary-aware ticks.
+         * If omitted, falls back to `labels`. */
+        allDays?: string[]
     }
     yAxis?: {
         /** `linear` (default) or `log`. Log falls back to a linear scale when no positive values exist. */
@@ -41,9 +53,18 @@ export function TimeSeriesLineChart<Meta = unknown>({
     className,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
     const { xAxis, yAxis } = config ?? {}
+    const xTickFormatter =
+        xAxis?.tickFormatter ??
+        (xAxis?.timezone && xAxis?.interval
+            ? createXAxisTickCallback({
+                  timezone: xAxis.timezone,
+                  interval: xAxis.interval,
+                  allDays: xAxis.allDays ?? labels,
+              })
+            : undefined)
     const lineChartConfig: LineChartConfig = {
         yScaleType: yAxis?.scale,
-        xTickFormatter: xAxis?.tickFormatter,
+        xTickFormatter,
         yTickFormatter: yAxis?.tickFormatter,
         hideXAxis: xAxis?.hide,
         hideYAxis: yAxis?.hide,

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../../core/types'
 import { LineChart } from '../LineChart'
@@ -14,8 +14,6 @@ export interface TimeSeriesLineChartConfig {
         timezone?: string
         /** Bucket size of the X axis. Combined with `timezone`, enables auto-formatting. */
         interval?: TimeInterval
-        /** Resolved date range of the chart. Reserved for future date-axis behavior. */
-        dateRange?: { start: string; end: string }
         /** The raw date strings underlying each label, used to compute boundary-aware ticks.
          * If omitted, falls back to `labels`. */
         allDays?: string[]
@@ -53,15 +51,23 @@ export function TimeSeriesLineChart<Meta = unknown>({
     className,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
     const { xAxis, yAxis } = config ?? {}
-    const xTickFormatter =
-        xAxis?.tickFormatter ??
-        (xAxis?.timezone && xAxis?.interval
-            ? createXAxisTickCallback({
-                  timezone: xAxis.timezone,
-                  interval: xAxis.interval,
-                  allDays: xAxis.allDays ?? labels,
-              })
-            : undefined)
+    const xAxisTickFormatter = xAxis?.tickFormatter
+    const xAxisTimezone = xAxis?.timezone
+    const xAxisInterval = xAxis?.interval
+    const xAxisAllDays = xAxis?.allDays
+    const xTickFormatter = useMemo(() => {
+        if (xAxisTickFormatter) {
+            return xAxisTickFormatter
+        }
+        if (!xAxisTimezone || !xAxisInterval) {
+            return undefined
+        }
+        return createXAxisTickCallback({
+            timezone: xAxisTimezone,
+            interval: xAxisInterval,
+            allDays: xAxisAllDays ?? labels,
+        })
+    }, [xAxisTickFormatter, xAxisTimezone, xAxisInterval, xAxisAllDays, labels])
     const lineChartConfig: LineChartConfig = {
         yScaleType: yAxis?.scale,
         xTickFormatter,

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/dates.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/dates.ts
@@ -1,9 +1,11 @@
 import { dayjs, Dayjs } from 'lib/dayjs'
 
-import { IntervalType } from '~/types'
+/** Bucket size for a date-based X axis. Mirrors `IntervalType` from product code without
+ * coupling hog-charts to it. */
+export type TimeInterval = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month'
 
 interface CreateXAxisTickCallbackArgs {
-    interval?: IntervalType
+    interval?: TimeInterval
     allDays: (string | number)[]
     timezone: string
     numericTickPrefix?: string
@@ -71,7 +73,7 @@ export function parseDateForAxis(dateStr: string, timezone: string): Dayjs {
     }
 }
 
-function pickMode(interval: IntervalType, parsedDates: Dayjs[], first: Dayjs, last: Dayjs): TickMode {
+function pickMode(interval: TimeInterval, parsedDates: Dayjs[], first: Dayjs, last: Dayjs): TickMode {
     const spanMonths = (last.year() - first.year()) * 12 + last.month() - first.month()
     const spanDays = last.diff(first, 'day')
 
@@ -128,7 +130,7 @@ function formatMonthLabel(date: Dayjs): string {
     return date.format('MMMM')
 }
 
-function inferInterval(parsedDates: Dayjs[]): IntervalType {
+function inferInterval(parsedDates: Dayjs[]): TimeInterval {
     if (parsedDates.length < 2) {
         return 'day'
     }

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -60,3 +60,4 @@ export { computeVisibleXLabels } from './overlays/AxisLabels'
 
 // Timeseries utils
 export { createXAxisTickCallback, parseDateForAxis } from './charts/TimeSeriesLineChart/utils/dates'
+export type { TimeInterval } from './charts/TimeSeriesLineChart/utils/dates'


### PR DESCRIPTION
## Problem

Stage 3a of the [TimeSeriesLineChart migration](https://github.com/PostHog/posthog/pull/57267). Goal of this slice: wire the date X-axis surface onto `TimeSeriesLineChart.config.xAxis` and drop the last product import from the hog-charts dates helper.

The Y-axis adapter (Stage 3b) is intentionally deferred so each PR stays scoped — Stage 3a is just the X-axis surface.

## Changes

- Replace `IntervalType` from `~/types` in `dates.ts` with a local exported `TimeInterval` union (same values, including `'second'`). `frontend/src/lib/hog-charts/` now has zero imports from `~/types`.
- Add `timezone`, `interval`, `dateRange`, and `allDays` to `TimeSeriesLineChartConfig.xAxis`. When `timezone` and `interval` are both set and the consumer hasn't passed an explicit `tickFormatter`, internally call `createXAxisTickCallback` and feed the result into `LineChartConfig.xTickFormatter`. Explicit `tickFormatter` wins. `allDays` falls back to `labels` when omitted. `dateRange` is reserved for future date-axis behavior.
- Add a `DateAxis` Storybook story exercising 2 timezones (`UTC`, `America/New_York`) × 3 intervals (`hour`, `day`, `month`).
- Add unit tests covering auto-format, explicit-override-wins, and the partial-config fallback.

`TrendsLineChart` is **unchanged** — it still uses `<LineChart>` directly. The new prop surface is exercised through Storybook + unit tests only. Trends-side adoption stays deferred until the full prop surface (Stages 3–7) is in place.

The three existing consumers of `createXAxisTickCallback` (`DataVisualization/.../LineGraph.tsx`, `scenes/insights/views/LineGraph/LineGraph.tsx`, `TrendsLineChart.tsx`) needed no changes — none of them annotated the helper call with `IntervalType`, so the structurally-identical local union carried them through.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- `pnpm exec tsc --noEmit` — no errors on the changed files or the three consumers (pre-existing errors elsewhere in the repo, unrelated).
- `pnpm exec oxlint` on changed files — 0 warnings, 0 errors.
- `pnpm --filter=@posthog/frontend exec jest src/lib/hog-charts/charts/TimeSeriesLineChart` — 314/314 passing (4 in `TimeSeriesLineChart.test.tsx`, 310 in `dates.test.ts`).
- `grep '~/types' frontend/src/lib/hog-charts/` — 0 hits.

I did not manually open Storybook in a browser — the new `DateAxis` story is structured the same as `Basic` and follows the existing pattern, but a human reviewer should verify the snapshot looks right.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Code, Opus 4.7).
- Driven by a literal Stage 3a spec from the user — file list, prop shape, condition for auto-formatting, and verification steps were all specified up front.
- Decisions made along the way:
  - `dateRange` is in the prop surface but **not yet forwarded** to `createXAxisTickCallback` — the helper doesn't accept it today and adding a no-op argument would be dead code. Stage 3b can wire it through if the trends adapter needs it.
  - The three existing consumers turned out to need no changes (no `IntervalType` annotations on the helper call), so I left them untouched rather than introduce churn just to satisfy the original "update the three consumers" step.
  - Picked the name `TimeInterval` (vs `XAxisInterval`) — reads cleaner as a public hog-charts type and doesn't presume the axis orientation.
- Agent-authored PR — needs human review.