### PR TITLE
perf(insights): drop GROUP BY by replacing Max(insightviewed) with Subquery

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from typing import Any, Union, cast
 
 from django.db import transaction
-from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, QuerySet
+from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, QuerySet, Subquery
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
 from django.utils.text import slugify
@@ -1399,7 +1399,12 @@ class InsightViewSet(
 
         if self.action == "list":
             queryset = queryset.prefetch_related("tagged_items__tag")
-            queryset = queryset.annotate(last_viewed_at=Max("insightviewed__last_viewed_at"))
+            last_viewed_at = (
+                InsightViewed.objects.filter(insight=OuterRef("pk"))
+                .order_by("-last_viewed_at")
+                .values("last_viewed_at")[:1]
+            )
+            queryset = queryset.annotate(last_viewed_at=Subquery(last_viewed_at))
             queryset = self._filter_request(self.request, queryset)
 
         return self.order_queryset(queryset)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1604,7 +1604,7 @@ class InsightViewSet(
                     | Q(derived_name__icontains=request.GET["search"])
                     | Q(tagged_items__tag__name__icontains=request.GET["search"])
                     | Q(description__icontains=request.GET["search"])
-                )
+                ).distinct()
             elif key == "dashboards":
                 dashboards_filter = request.GET["dashboards"]
                 if dashboards_filter:

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -1952,15 +1952,11 @@
 # ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.33
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT "posthog_dashboarditem"."id" AS "col1"
-     FROM "posthog_dashboarditem"
-     INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-     LEFT OUTER JOIN "posthog_insightviewed" ON ("posthog_dashboarditem"."id" = "posthog_insightviewed"."insight_id")
-     WHERE ("posthog_team"."project_id" = 99999
-            AND NOT ("posthog_dashboarditem"."deleted"))
-     GROUP BY 1) subquery
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_team"."project_id" = 99999
+         AND NOT ("posthog_dashboarditem"."deleted"))
   '''
 # ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.34
@@ -1994,7 +1990,12 @@
          "posthog_dashboarditem"."updated_at",
          "posthog_dashboarditem"."deprecated_tags",
          "posthog_dashboarditem"."tags",
-         MAX("posthog_insightviewed"."last_viewed_at") AS "last_viewed_at",
+  
+    (SELECT U0."last_viewed_at" AS "last_viewed_at"
+     FROM "posthog_insightviewed" U0
+     WHERE U0."insight_id" = ("posthog_dashboarditem"."id")
+     ORDER BY 1 DESC
+     LIMIT 1) AS "last_viewed_at",
          "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -2125,13 +2126,9 @@
          "posthog_user"."email_opt_in"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  LEFT OUTER JOIN "posthog_insightviewed" ON ("posthog_dashboarditem"."id" = "posthog_insightviewed"."insight_id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_dashboarditem"."created_by_id" = "posthog_user"."id")
   WHERE ("posthog_team"."project_id" = 99999
          AND NOT ("posthog_dashboarditem"."deleted"))
-  GROUP BY "posthog_dashboarditem"."id",
-           "posthog_team"."id",
-           "posthog_user"."id"
   ORDER BY "posthog_dashboarditem"."order" ASC
   LIMIT 100
   '''

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -720,6 +720,25 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             f"({unsaved_no_dashboard.short_id}) must be excluded."
         )
 
+    def test_search_filter_does_not_duplicate_insights_with_multiple_matching_tags(self) -> None:
+        from posthog.models.tag import Tag
+        from posthog.models.tagged_item import TaggedItem
+
+        insight = Insight.objects.create(
+            short_id="search-tg", name="needle", team=self.team, filters={"events": [{"id": "$pageview"}]}
+        )
+        for tag_name in ("needle-tag-a", "needle-tag-b", "needle-tag-c"):
+            tag = Tag.objects.create(name=tag_name, team=self.team)
+            TaggedItem.objects.create(insight=insight, tag=tag)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?search=needle")
+        assert response.status_code == status.HTTP_200_OK
+        matching_short_ids = [r["short_id"] for r in response.json()["results"] if r["short_id"] == insight.short_id]
+        assert len(matching_short_ids) == 1, (
+            f"search=needle must return the insight once even though three tags + the name match it; "
+            f"got {len(matching_short_ids)} copies."
+        )
+
     # :KLUDGE: avoid making extra queries that are explicitly not cached in tests. Avoids false N+1-s.
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @snapshot_postgres_queries


### PR DESCRIPTION
## Summary

The basic insights list page-load on team 2 was still 1.2 seconds in the main SELECT span after #57275 landed. Pulled the trace and the SQL still has a `GROUP BY` — the EXISTS fix removed *one* aggregate (the `Count` for visible_dashboards_count) but `Max(insightviewed.last_viewed_at)` is still there forcing GROUP BY:

```sql
SELECT ..., MAX(insightviewed.last_viewed_at) AS last_viewed_at, ...
FROM dashboarditem ...
WHERE team.project_id = %s AND NOT deleted AND (saved OR EXISTS (...))
GROUP BY dashboarditem.id, team.id, user.id
ORDER BY last_modified_at DESC LIMIT 30
```

The GROUP BY blocks the `(team_id, last_modified_at DESC) WHERE NOT deleted` partial index from short-circuiting `LIMIT 30` — Postgres has to compute the aggregate for every one of the team's insights before sorting and taking 30.

## Changes

Replace the `Max + GROUP BY` with a correlated `Subquery`:

```python
last_viewed_at = (
    InsightViewed.objects.filter(insight=OuterRef("pk"))
    .order_by("-last_viewed_at")
    .values("last_viewed_at")[:1]
)
queryset = queryset.annotate(last_viewed_at=Subquery(last_viewed_at))
```

Generated SQL is now aggregation-free:

```sql
SELECT ..., (SELECT last_viewed_at FROM insightviewed WHERE insight_id = dashboarditem.id ORDER BY last_viewed_at DESC LIMIT 1) AS last_viewed_at
FROM dashboarditem ...
WHERE team.project_id = %s AND NOT deleted AND (saved OR EXISTS (...))
ORDER BY last_modified_at DESC LIMIT 30
```

Postgres can now:
1. Walk the partial index in `last_modified_at` order
2. Evaluate `saved OR EXISTS(...)` per row
3. Stop at 30 matches
4. Compute the per-row subquery only for those 30

Expect ~1.2s → <100ms on team 2's main SELECT.

## Tests

The existing parametrised n+1 tests still pass (5 cases across basic and full paths). Snapshot regenerated to reflect the new SQL shape.

## 🤖 Agent context

This is the third (and likely final) of three perf rewrites on the insights-list path:

- #57032 — trim unused joins from the `basic=true` queryset
- #57275 — replace `Count + HAVING` with `EXISTS` for the saved filter
- this PR — replace `Max + GROUP BY` with a Subquery for `last_viewed_at`

After this, the only remaining cost on the basic+saved page-load should be the 17 small queries the request fans out to (auth, RBAC, prefetches) plus pgbouncer round-trips. Server-Timing's `pg_max` should drop from ~1.2s to <100ms.

The deeper-list `recently_viewed_insights` action (line 1480) still uses `Max + GROUP BY`, but its queryset is already filtered by `view_count > 0` and sliced to `[:limit]`, so it doesn't hit the same scale problem. Left untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*