### PR TITLE
feat(taxonomic-filter): track key-only recents for column/event pickers

### DIFF
--- a/frontend/src/lib/components/FlagSelector.tsx
+++ b/frontend/src/lib/components/FlagSelector.tsx
@@ -40,6 +40,7 @@ export function FlagSelector({
         popoverEnabled: true,
         selectFirstItem: true,
         taxonomicFilterLogicKey: 'flag-selectorz',
+        selectingKeyOnly: true,
     }
 
     return (

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
@@ -338,19 +338,18 @@ describe('PropertyFilters recent selections', () => {
     it('recents from unavailable groups are hidden', async () => {
         useSetupMocks()
 
-        recentTaxonomicFiltersLogic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.PersonProperties,
-            'Person properties',
-            'location',
-            { name: 'location' },
-            undefined,
-            {
+        recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.PersonProperties,
+            groupName: 'Person properties',
+            value: 'location',
+            item: { name: 'location' },
+            propertyFilter: {
                 key: 'location',
                 type: PropertyFilterType.Person,
                 value: 'US',
                 operator: PropertyOperator.Exact,
-            }
-        )
+            },
+        })
 
         expectRecentCount(1)
 

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -130,14 +130,14 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
                 const groupType = PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE[property.type]
                 if (groupType && recentTaxonomicFiltersLogic.isMounted()) {
                     const groupName = TAXONOMIC_GROUP_TYPE_TO_DISPLAY_NAME[groupType] ?? groupType
-                    recentTaxonomicFiltersLogic.actions.recordRecentFilter(
+                    recentTaxonomicFiltersLogic.actions.recordRecentFilter({
                         groupType,
                         groupName,
-                        property.key,
-                        { name: property.key },
-                        teamLogic.values.currentTeamId ?? undefined,
-                        property
-                    )
+                        value: property.key,
+                        item: { name: property.key },
+                        teamId: teamLogic.values.currentTeamId ?? undefined,
+                        propertyFilter: property,
+                    })
                 }
             }
         },

--- a/frontend/src/lib/components/QuickFilters/QuickFilterForm.tsx
+++ b/frontend/src/lib/components/QuickFilters/QuickFilterForm.tsx
@@ -61,6 +61,7 @@ export function QuickFilterForm({ context }: QuickFilterFormProps): JSX.Element 
                                     disabled={quickFiltersLoading}
                                     type="secondary"
                                     fullWidth
+                                    selectingKeyOnly
                                 />
                             )}
                         </LemonField>

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
@@ -276,14 +276,14 @@ function SeedRecents({ count }: { count: number }): null {
     useOnMountEffect(() => {
         recentTaxonomicFiltersLogic.actions.clearRecentFilters()
         for (const recent of RECENT_ITEMS.slice(0, count)) {
-            recentTaxonomicFiltersLogic.actions.recordRecentFilter(
-                recent.groupType,
-                recent.groupName,
-                recent.value,
-                recent.item,
-                MOCK_TEAM_ID,
-                recent.propertyFilter
-            )
+            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                groupType: recent.groupType,
+                groupName: recent.groupName,
+                value: recent.value,
+                item: recent.item,
+                teamId: MOCK_TEAM_ID,
+                propertyFilter: recent.propertyFilter,
+            })
         }
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -59,6 +59,7 @@ export function TaxonomicFilter({
     hideSearchInput,
     searchQuery: controlledSearchQuery,
     enableKeywordShortcuts,
+    selectingKeyOnly,
 }: TaxonomicFilterProps): JSX.Element {
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
@@ -104,6 +105,7 @@ export function TaxonomicFilter({
         minSearchQueryLength,
         suggestedFiltersLabel: resolvedSuggestedFiltersLabel,
         enableKeywordShortcuts,
+        selectingKeyOnly,
     }
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterKeyOnly.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterKeyOnly.test.tsx
@@ -1,0 +1,226 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { initKeaTests } from '~/test/init'
+import { mockGetEventDefinitions, mockGetPropertyDefinitions } from '~/test/mocks'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { recentTaxonomicFiltersLogic } from './recentTaxonomicFiltersLogic'
+import { TaxonomicFilter } from './TaxonomicFilter'
+import { TaxonomicFilterGroupType } from './types'
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('TaxonomicFilter selectingKeyOnly mode', () => {
+    let recents: ReturnType<typeof recentTaxonomicFiltersLogic.build>
+
+    beforeEach(() => {
+        localStorage.clear()
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                '/api/projects/:team/actions': { results: [] },
+                '/api/environments/:team/persons/properties': [{ id: 1, name: 'location', count: 1 }],
+            },
+            post: {
+                '/api/environments/:team/query': { results: [] },
+            },
+        })
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+        recents = recentTaxonomicFiltersLogic.build()
+        recents.mount()
+    })
+
+    afterEach(() => {
+        recents.unmount()
+        cleanup()
+    })
+
+    function renderFilter(
+        props: Partial<React.ComponentProps<typeof TaxonomicFilter>> = {}
+    ): ReturnType<typeof render> {
+        return render(
+            <Provider>
+                <TaxonomicFilter
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                    onChange={jest.fn()}
+                    {...props}
+                />
+            </Provider>
+        )
+    }
+
+    function preloadCompleteRecent(key: string, value: string): void {
+        recents.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: key,
+            item: { name: key },
+            propertyFilter: { type: PropertyFilterType.Event, key, operator: PropertyOperator.Exact, value },
+        })
+    }
+
+    describe('recording on selection', () => {
+        it('records an EventProperty selection to recents when selectingKeyOnly is set', async () => {
+            renderFilter({ selectingKeyOnly: true })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-event_properties-0')).toBeInTheDocument()
+            })
+
+            await userEvent.click(screen.getByTestId('prop-filter-event_properties-0'))
+
+            await waitFor(() => {
+                expect(recents.values.recentFilters).toHaveLength(1)
+            })
+            const [stored] = recents.values.recentFilters
+            expect(stored.groupType).toBe(TaxonomicFilterGroupType.EventProperties)
+            expect(stored.propertyFilter).toBeUndefined()
+        })
+
+        it('does NOT record an EventProperty selection to recents in default (non-selectingKeyOnly) mode', async () => {
+            const recordSpy = jest.spyOn(recents.actions, 'recordRecentFilter')
+            renderFilter()
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-event_properties-0')).toBeInTheDocument()
+            })
+
+            await userEvent.click(screen.getByTestId('prop-filter-event_properties-0'))
+
+            // The recorder fires inside a setTimeout(0); flush macrotasks then assert.
+            // In non-selectingKeyOnly mode the listener short-circuits for property groups (propertyFilterLogic
+            // owns the recording when the filter completes), so the action must never be dispatched.
+            await new Promise((r) => setTimeout(r, 0))
+            expect(recordSpy).not.toHaveBeenCalled()
+            expect(recents.values.recentFilters).toHaveLength(0)
+        })
+
+        it('does not carry over an existing complete propertyFilter when re-selecting a recent in selectingKeyOnly mode', async () => {
+            preloadCompleteRecent('$browser', 'Chrome')
+            const onChange = jest.fn()
+
+            renderFilter({ selectingKeyOnly: true, onChange })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-tab-recent_filters')).toBeInTheDocument()
+            })
+            await userEvent.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-recent_filters-0')).toBeInTheDocument()
+            })
+            await userEvent.click(screen.getByTestId('prop-filter-recent_filters-0'))
+
+            // Consumer-facing onChange must hand back an item whose recent context has no
+            // propertyFilter, so it can't accidentally re-apply "= Chrome" downstream.
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalled()
+            })
+            const [, value, item] = onChange.mock.calls[0]
+            expect(value).toBe('$browser')
+            expect(item?._recentContext?.propertyFilter).toBeUndefined()
+
+            await waitFor(() => {
+                // The original complete record stays; a new key-only record is added on top.
+                expect(recents.values.recentFilters).toHaveLength(2)
+            })
+            expect(recents.values.recentFilters[0].propertyFilter).toBeUndefined()
+            expect(recents.values.recentFilters[1].propertyFilter).toMatchObject({
+                key: '$browser',
+                value: 'Chrome',
+            })
+        })
+    })
+
+    describe('display of recents', () => {
+        it('shows the Recent tab in selectingKeyOnly mode when key-only recents exist for the picked group', async () => {
+            recents.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.EventProperties,
+                groupName: 'Event properties',
+                value: '$os',
+                item: { name: '$os' },
+                selectingKeyOnly: true,
+            })
+
+            renderFilter({ selectingKeyOnly: true })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-tab-recent_filters')).toBeInTheDocument()
+            })
+
+            await userEvent.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-recent_filters-0')).toBeInTheDocument()
+            })
+            const row = screen.getByTestId('prop-filter-recent_filters-0')
+            expect(row.textContent).toMatch(/OS/)
+            expect(row.textContent).not.toMatch(/=|equals/i)
+        })
+
+        it('renders complete recents stripped to just the key in selectingKeyOnly mode', async () => {
+            preloadCompleteRecent('$browser', 'Chrome')
+
+            renderFilter({ selectingKeyOnly: true })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-tab-recent_filters')).toBeInTheDocument()
+            })
+            await userEvent.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-recent_filters-0')).toBeInTheDocument()
+            })
+            const row = screen.getByTestId('prop-filter-recent_filters-0')
+            expect(row.textContent).toMatch(/Browser/)
+            // The complete-filter label ("Browser equals Chrome") must NOT be rendered.
+            expect(row.textContent).not.toMatch(/Chrome/)
+        })
+
+        it('renders complete recents WITH their value label in default (non-selectingKeyOnly) mode', async () => {
+            preloadCompleteRecent('$browser', 'Chrome')
+
+            renderFilter()
+
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-tab-recent_filters')).toBeInTheDocument()
+            })
+            await userEvent.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-recent_filters-0')).toBeInTheDocument()
+            })
+            expect(screen.getByTestId('prop-filter-recent_filters-0').textContent).toMatch(/Chrome/)
+        })
+
+        it('dedups multiple complete recents for the same key into one row in selectingKeyOnly mode', async () => {
+            preloadCompleteRecent('$browser', 'Chrome')
+            preloadCompleteRecent('$browser', 'Safari')
+
+            renderFilter({ selectingKeyOnly: true })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-tab-recent_filters')).toBeInTheDocument()
+            })
+            await userEvent.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-recent_filters-0')).toBeInTheDocument()
+            })
+            expect(screen.queryByTestId('prop-filter-recent_filters-1')).not.toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -10,11 +10,12 @@ import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { mockEventDefinitions, mockEventPropertyDefinitions } from '~/test/mocks'
-import { AppContext, PropertyDefinition, PropertyType } from '~/types'
+import { AppContext, PropertyDefinition, PropertyFilterType, PropertyOperator, PropertyType } from '~/types'
 
 import { joinsLogic } from 'products/data_warehouse/frontend/shared/logics/joinsLogic'
 
 import { infiniteListLogic } from './infiniteListLogic'
+import { hasRecentContext, recentTaxonomicFiltersLogic } from './recentTaxonomicFiltersLogic'
 import { taxonomicFilterLogic } from './taxonomicFilterLogic'
 
 window.POSTHOG_APP_CONTEXT = {
@@ -870,6 +871,109 @@ describe('infiniteListLogic', () => {
             } else {
                 expect(emptyCalls).toHaveLength(0)
             }
+        })
+    })
+
+    describe('contextFilteredRecentItems with selectingKeyOnly mode', () => {
+        beforeEach(() => {
+            localStorage.clear()
+            recentTaxonomicFiltersLogic.mount()
+        })
+
+        afterEach(() => {
+            recentTaxonomicFiltersLogic.unmount()
+        })
+
+        const recordKeyOnly = (key: string, item: Record<string, any> = { name: key }): void => {
+            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.EventProperties,
+                groupName: 'Event properties',
+                value: key,
+                item: item,
+                selectingKeyOnly: true,
+            })
+        }
+
+        const recordComplete = (key: string, value: string): void => {
+            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.EventProperties,
+                groupName: 'Event properties',
+                value: key,
+                item: { name: key },
+                propertyFilter: {
+                    type: PropertyFilterType.Event,
+                    key,
+                    operator: PropertyOperator.Exact,
+                    value,
+                },
+            })
+        }
+
+        it('strips propertyFilter from recents and dedups by key when selectingKeyOnly is set', () => {
+            recordComplete('$browser', 'Chrome')
+            recordComplete('$browser', 'Safari')
+            recordKeyOnly('$os')
+
+            const listLogic = logicWith({
+                listGroupType: TaxonomicFilterGroupType.EventProperties,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties],
+                selectingKeyOnly: true,
+            })
+
+            const items = listLogic.values.contextFilteredRecentItems
+            expect(items).toHaveLength(2)
+            for (const item of items) {
+                expect(hasRecentContext(item)).toBe(true)
+                if (hasRecentContext(item)) {
+                    expect(item._recentContext.propertyFilter).toBeUndefined()
+                }
+            }
+            expect(items.map((i) => ('name' in i ? i.name : null))).toEqual(['$os', '$browser'])
+        })
+
+        it('preserves complete recents (with their propertyFilter) when selectingKeyOnly is not set', () => {
+            recordComplete('$browser', 'Chrome')
+
+            const listLogic = logicWith({
+                listGroupType: TaxonomicFilterGroupType.EventProperties,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties],
+            })
+
+            const items = listLogic.values.contextFilteredRecentItems
+            expect(items).toHaveLength(1)
+            const [item] = items
+            expect(hasRecentContext(item) && item._recentContext.propertyFilter).toBeTruthy()
+        })
+
+        it('dedups by storage value, not by display name (cohorts/actions style)', () => {
+            // Two cohorts have been recorded with the same display name ("Power users") but
+            // distinct ids — they are genuinely different recents. A name-based dedup would
+            // collapse them into one row; sourceValue-based dedup keeps them apart.
+            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Cohorts,
+                groupName: 'Cohorts',
+                value: 42,
+                item: { name: 'Power users' },
+                selectingKeyOnly: true,
+            })
+            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Cohorts,
+                groupName: 'Cohorts',
+                value: 43,
+                item: { name: 'Power users' },
+                selectingKeyOnly: true,
+            })
+
+            const listLogic = logicWith({
+                listGroupType: TaxonomicFilterGroupType.Cohorts,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Cohorts],
+                selectingKeyOnly: true,
+            })
+
+            const items = listLogic.values.contextFilteredRecentItems
+            expect(items).toHaveLength(2)
+            const sourceValues = items.map((i) => hasRecentContext(i) && i._recentContext.sourceValue)
+            expect(new Set(sourceValues)).toEqual(new Set([42, 43]))
         })
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -428,18 +428,44 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             (listGroupType, activeTab): boolean => listGroupType === activeTab,
         ],
         contextFilteredRecentItems: [
-            (s) => [s.recentFilterItems, s.taxonomicGroupTypes],
+            (s) => [
+                s.recentFilterItems,
+                s.taxonomicGroupTypes,
+                (_, props: InfiniteListLogicProps) => props.selectingKeyOnly,
+            ],
             (
                 recentFilterItems: TaxonomicDefinitionTypes[],
-                taxonomicGroupTypes: TaxonomicFilterGroupType[]
+                taxonomicGroupTypes: TaxonomicFilterGroupType[],
+                selectingKeyOnly: boolean | undefined
             ): TaxonomicDefinitionTypes[] => {
                 if (!recentFilterItems?.length) {
                     return []
                 }
                 const availableTypes = new Set(taxonomicGroupTypes)
-                return recentFilterItems.filter(
+                const inScope = recentFilterItems.filter(
                     (item) => hasRecentContext(item) && availableTypes.has(item._recentContext.sourceGroupType)
                 )
+                if (!selectingKeyOnly) {
+                    return inScope
+                }
+                const seen = new Set<string>()
+                const dedupedItems: TaxonomicDefinitionTypes[] = []
+                for (const item of inScope) {
+                    if (!hasRecentContext(item)) {
+                        continue
+                    }
+                    // Dedup by the persisted storage key (groupType + value), not by item.name —
+                    // for groups like Cohorts/Actions name is a display label that may be unstable
+                    // or duplicated across distinct ids.
+                    const dedupKey = `${item._recentContext.sourceGroupType}::${item._recentContext.sourceValue ?? ''}`
+                    if (seen.has(dedupKey)) {
+                        continue
+                    }
+                    seen.add(dedupKey)
+                    const { propertyFilter: _propertyFilter, ...restContext } = item._recentContext
+                    dedupedItems.push({ ...item, _recentContext: restContext } as unknown as TaxonomicDefinitionTypes)
+                }
+                return dedupedItems
             },
         ],
         contextFilteredPinnedItems: [

--- a/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.test.ts
@@ -28,7 +28,12 @@ describe('recentTaxonomicFiltersLogic', () => {
 
     it('records a selection with groupType, groupName, value, item, and timestamp', () => {
         const item = { name: '$pageview', id: 'uuid-1' }
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', '$pageview', item)
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: '$pageview',
+            item: item,
+        })
 
         const filters = logic.values.recentFilters
         expect(filters).toHaveLength(1)
@@ -44,21 +49,46 @@ describe('recentTaxonomicFiltersLogic', () => {
     })
 
     it('prepends new entries so most recent is first', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', 'first', { name: 'first' })
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', 'second', { name: 'second' })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: 'first',
+            item: { name: 'first' },
+        })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: 'second',
+            item: { name: 'second' },
+        })
 
         expect(logic.values.recentFilters[0].value).toBe('second')
         expect(logic.values.recentFilters[1].value).toBe('first')
     })
 
     it('deduplicates by groupType + value, keeping the most recent', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', '$pageview', {
-            name: '$pageview',
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: '$pageview',
+            item: {
+                name: '$pageview',
+            },
         })
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', '$click', { name: '$click' })
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', '$pageview', {
-            name: '$pageview',
-            updated: true,
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: '$click',
+            item: { name: '$click' },
+        })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: '$pageview',
+            item: {
+                name: '$pageview',
+                updated: true,
+            },
         })
 
         const filters = logic.values.recentFilters
@@ -69,22 +99,30 @@ describe('recentTaxonomicFiltersLogic', () => {
     })
 
     it('keeps property filters with the same key but different values as separate recents', () => {
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.EventProperties,
-            'Event properties',
-            '$browser',
-            { name: '$browser' },
-            undefined,
-            { type: PropertyFilterType.Event, key: '$browser', operator: PropertyOperator.Exact, value: 'Chrome' }
-        )
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.EventProperties,
-            'Event properties',
-            '$browser',
-            { name: '$browser' },
-            undefined,
-            { type: PropertyFilterType.Event, key: '$browser', operator: PropertyOperator.Exact, value: 'Safari' }
-        )
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: { name: '$browser' },
+            propertyFilter: {
+                type: PropertyFilterType.Event,
+                key: '$browser',
+                operator: PropertyOperator.Exact,
+                value: 'Chrome',
+            },
+        })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: { name: '$browser' },
+            propertyFilter: {
+                type: PropertyFilterType.Event,
+                key: '$browser',
+                operator: PropertyOperator.Exact,
+                value: 'Safari',
+            },
+        })
 
         const filters = logic.values.recentFilters
         expect(filters).toHaveLength(2)
@@ -93,22 +131,30 @@ describe('recentTaxonomicFiltersLogic', () => {
     })
 
     it('deduplicates property filters with the same key, operator, and value', () => {
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.EventProperties,
-            'Event properties',
-            '$browser',
-            { name: '$browser' },
-            undefined,
-            { type: PropertyFilterType.Event, key: '$browser', operator: PropertyOperator.Exact, value: 'Chrome' }
-        )
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.EventProperties,
-            'Event properties',
-            '$browser',
-            { name: '$browser' },
-            undefined,
-            { type: PropertyFilterType.Event, key: '$browser', operator: PropertyOperator.Exact, value: 'Chrome' }
-        )
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: { name: '$browser' },
+            propertyFilter: {
+                type: PropertyFilterType.Event,
+                key: '$browser',
+                operator: PropertyOperator.Exact,
+                value: 'Chrome',
+            },
+        })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: { name: '$browser' },
+            propertyFilter: {
+                type: PropertyFilterType.Event,
+                key: '$browser',
+                operator: PropertyOperator.Exact,
+                value: 'Chrome',
+            },
+        })
 
         expect(logic.values.recentFilters).toHaveLength(1)
     })
@@ -120,16 +166,20 @@ describe('recentTaxonomicFiltersLogic', () => {
             operator: PropertyOperator.Exact,
             value: 'alice@example.com',
         } satisfies PersonPropertyFilter
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.PersonProperties,
-            'Person properties',
-            'email',
-            { name: 'email' },
-            undefined,
-            complete
-        )
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.PersonProperties, 'Person properties', 'email', {
-            name: 'email',
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.PersonProperties,
+            groupName: 'Person properties',
+            value: 'email',
+            item: { name: 'email' },
+            propertyFilter: complete,
+        })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.PersonProperties,
+            groupName: 'Person properties',
+            value: 'email',
+            item: {
+                name: 'email',
+            },
         })
 
         const filters = logic.values.recentFilters
@@ -138,8 +188,13 @@ describe('recentTaxonomicFiltersLogic', () => {
     })
 
     it('replaces a key-only entry when recording a complete filter for the same key', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.PersonProperties, 'Person properties', 'email', {
-            name: 'email',
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.PersonProperties,
+            groupName: 'Person properties',
+            value: 'email',
+            item: {
+                name: 'email',
+            },
         })
         const complete = {
             type: PropertyFilterType.Person,
@@ -147,14 +202,13 @@ describe('recentTaxonomicFiltersLogic', () => {
             operator: PropertyOperator.Exact,
             value: 'bob@example.com',
         } satisfies PersonPropertyFilter
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.PersonProperties,
-            'Person properties',
-            'email',
-            { name: 'email' },
-            undefined,
-            complete
-        )
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.PersonProperties,
+            groupName: 'Person properties',
+            value: 'email',
+            item: { name: 'email' },
+            propertyFilter: complete,
+        })
 
         const filters = logic.values.recentFilters
         expect(filters).toHaveLength(1)
@@ -162,9 +216,19 @@ describe('recentTaxonomicFiltersLogic', () => {
     })
 
     it('allows the same value in different group types', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', 'name', { name: 'name' })
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.PersonProperties, 'Person properties', 'name', {
-            name: 'name',
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: 'name',
+            item: { name: 'name' },
+        })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.PersonProperties,
+            groupName: 'Person properties',
+            value: 'name',
+            item: {
+                name: 'name',
+            },
         })
 
         expect(logic.values.recentFilters).toHaveLength(2)
@@ -172,8 +236,13 @@ describe('recentTaxonomicFiltersLogic', () => {
 
     it(`caps entries at ${MAX_RECENT_FILTERS}`, () => {
         for (let i = 0; i < MAX_RECENT_FILTERS + 5; i++) {
-            logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', `event-${i}`, {
-                name: `event-${i}`,
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: `event-${i}`,
+                item: {
+                    name: `event-${i}`,
+                },
             })
         }
 
@@ -184,15 +253,25 @@ describe('recentTaxonomicFiltersLogic', () => {
     it('drops entries older than 30 days on next write', () => {
         jest.useFakeTimers()
         try {
-            logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', 'old-event', {
-                name: 'old-event',
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: 'old-event',
+                item: {
+                    name: 'old-event',
+                },
             })
             expect(logic.values.recentFilters).toHaveLength(1)
 
             jest.advanceTimersByTime(RECENT_FILTER_MAX_AGE_MS + 1000)
 
-            logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', 'new-event', {
-                name: 'new-event',
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: 'new-event',
+                item: {
+                    name: 'new-event',
+                },
             })
 
             const filters = logic.values.recentFilters
@@ -241,56 +320,215 @@ describe('recentTaxonomicFiltersLogic', () => {
             description: 'DataWarehousePersonProperties',
         },
     ])('ignores selections from excluded group type: $description', ({ groupType }) => {
-        logic.actions.recordRecentFilter(groupType, 'Ignored', 'some-value', { name: 'some-value' })
+        logic.actions.recordRecentFilter({
+            groupType: groupType,
+            groupName: 'Ignored',
+            value: 'some-value',
+            item: { name: 'some-value' },
+        })
         expect(logic.values.recentFilters).toHaveLength(0)
     })
 
     it('ignores selections with null value', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', null, { name: 'All events' })
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: null,
+            item: { name: 'All events' },
+        })
         expect(logic.values.recentFilters).toHaveLength(0)
     })
 
     it('stores a property filter when provided', () => {
         const propertyFilter = { key: '$browser', type: 'event', operator: 'exact', value: 'Chrome' }
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.EventProperties,
-            'Event properties',
-            '$browser',
-            { name: '$browser' },
-            undefined,
-            propertyFilter as any
-        )
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: { name: '$browser' },
+            propertyFilter: propertyFilter as any,
+        })
 
         expect(logic.values.recentFilters[0].propertyFilter).toEqual(propertyFilter)
     })
 
     it('stores teamId when provided', () => {
-        logic.actions.recordRecentFilter(
-            TaxonomicFilterGroupType.Events,
-            'Events',
-            '$pageview',
-            {
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: '$pageview',
+            item: {
                 name: '$pageview',
             },
-            42
-        )
+            teamId: 42,
+        })
 
         expect(logic.values.recentFilters[0].teamId).toBe(42)
     })
 
     it('stores groupName for display purposes', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.EventProperties, 'Event properties', '$browser', {
-            name: '$browser',
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: {
+                name: '$browser',
+            },
         })
 
         expect(logic.values.recentFilters[0].groupName).toBe('Event properties')
     })
 
     it('omits teamId from stored entry when not provided', () => {
-        logic.actions.recordRecentFilter(TaxonomicFilterGroupType.Events, 'Events', '$pageview', {
-            name: '$pageview',
+        logic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            groupName: 'Events',
+            value: '$pageview',
+            item: {
+                name: '$pageview',
+            },
         })
 
         expect(logic.values.recentFilters[0].teamId).toBeUndefined()
+    })
+
+    describe('selectingKeyOnly recordings', () => {
+        const complete = {
+            type: PropertyFilterType.Person,
+            key: 'email',
+            operator: PropertyOperator.Exact,
+            value: 'alice@example.com',
+        } satisfies PersonPropertyFilter
+
+        it('selectingKeyOnly write coexists with an existing complete record for the same key', () => {
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.PersonProperties,
+                groupName: 'Person properties',
+                value: 'email',
+                item: { name: 'email' },
+                propertyFilter: complete,
+            })
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.PersonProperties,
+                groupName: 'Person properties',
+                value: 'email',
+                item: { name: 'email' },
+                selectingKeyOnly: true,
+            })
+
+            const filters = logic.values.recentFilters
+            expect(filters).toHaveLength(2)
+            expect(filters[0].propertyFilter).toBeUndefined()
+            expect(filters[1].propertyFilter).toMatchObject(complete)
+        })
+
+        it('non-selectingKeyOnly partial write is still suppressed when a complete record exists', () => {
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.PersonProperties,
+                groupName: 'Person properties',
+                value: 'email',
+                item: { name: 'email' },
+                propertyFilter: complete,
+            })
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.PersonProperties,
+                groupName: 'Person properties',
+                value: 'email',
+                item: {
+                    name: 'email',
+                },
+            })
+
+            expect(logic.values.recentFilters).toHaveLength(1)
+            expect(logic.values.recentFilters[0].propertyFilter).toMatchObject(complete)
+        })
+
+        it('selectingKeyOnly writes for the same key dedup to the most recent', () => {
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.EventProperties,
+                groupName: 'Event properties',
+                value: '$browser',
+                item: { name: '$browser' },
+                selectingKeyOnly: true,
+            })
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.EventProperties,
+                groupName: 'Event properties',
+                value: '$browser',
+                item: { name: '$browser', refreshed: true },
+                selectingKeyOnly: true,
+            })
+
+            const filters = logic.values.recentFilters
+            expect(filters).toHaveLength(1)
+            expect(filters[0].item).toEqual({ name: '$browser', refreshed: true })
+        })
+
+        it('a selectingKeyOnly write replaces an existing complete record that has expired', () => {
+            jest.useFakeTimers()
+            try {
+                logic.actions.recordRecentFilter({
+                    groupType: TaxonomicFilterGroupType.PersonProperties,
+                    groupName: 'Person properties',
+                    value: 'email',
+                    item: { name: 'email' },
+                    propertyFilter: complete,
+                })
+
+                jest.advanceTimersByTime(RECENT_FILTER_MAX_AGE_MS + 1000)
+
+                logic.actions.recordRecentFilter({
+                    groupType: TaxonomicFilterGroupType.PersonProperties,
+                    groupName: 'Person properties',
+                    value: 'email',
+                    item: { name: 'email' },
+                    selectingKeyOnly: true,
+                })
+
+                const filters = logic.values.recentFilters
+                expect(filters).toHaveLength(1)
+                expect(filters[0].propertyFilter).toBeUndefined()
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('keeps both key-only and complete entries within the MAX_RECENT_FILTERS cap', () => {
+            for (let i = 0; i < MAX_RECENT_FILTERS - 1; i++) {
+                logic.actions.recordRecentFilter({
+                    groupType: TaxonomicFilterGroupType.Events,
+                    groupName: 'Events',
+                    value: `event-${i}`,
+                    item: {
+                        name: `event-${i}`,
+                    },
+                })
+            }
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.PersonProperties,
+                groupName: 'Person properties',
+                value: 'email',
+                item: { name: 'email' },
+                propertyFilter: complete,
+            })
+            logic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.PersonProperties,
+                groupName: 'Person properties',
+                value: 'email',
+                item: { name: 'email' },
+                selectingKeyOnly: true,
+            })
+
+            const filters = logic.values.recentFilters
+            expect(filters).toHaveLength(MAX_RECENT_FILTERS)
+            const emailRecords = filters.filter(
+                (f) => f.groupType === TaxonomicFilterGroupType.PersonProperties && f.value === 'email'
+            )
+            expect(emailRecords).toHaveLength(2)
+            expect(emailRecords[0].propertyFilter).toBeUndefined()
+            expect(emailRecords[1].propertyFilter).toMatchObject(complete)
+            // Oldest event was evicted to make room for the selectingKeyOnly entry that followed the complete one.
+            expect(filters.find((f) => f.value === 'event-0')).toBeUndefined()
+        })
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts
@@ -31,6 +31,7 @@ export interface RecentTaxonomicFilter {
 export interface RecentItemContext {
     sourceGroupType: TaxonomicFilterGroupType
     sourceGroupName: string
+    sourceValue: TaxonomicFilterValue
     teamId?: number
     propertyFilter?: AnyPropertyFilter
 }
@@ -86,21 +87,15 @@ const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
 export const recentTaxonomicFiltersLogic = kea<recentTaxonomicFiltersLogicType>([
     path(['lib', 'components', 'TaxonomicFilter', 'recentTaxonomicFiltersLogic']),
     actions({
-        recordRecentFilter: (
-            groupType: TaxonomicFilterGroupType,
-            groupName: string,
-            value: TaxonomicFilterValue,
-            item: any,
-            teamId?: number,
+        recordRecentFilter: (payload: {
+            groupType: TaxonomicFilterGroupType
+            groupName: string
+            value: TaxonomicFilterValue
+            item: any
+            teamId?: number
             propertyFilter?: AnyPropertyFilter
-        ) => ({
-            groupType,
-            groupName,
-            value,
-            item,
-            teamId,
-            propertyFilter,
-        }),
+            selectingKeyOnly?: boolean
+        }) => payload,
         clearRecentFilters: true,
     }),
     reducers({
@@ -109,14 +104,21 @@ export const recentTaxonomicFiltersLogic = kea<recentTaxonomicFiltersLogicType>(
             { persist: true, prefix: `${teamId}__` },
             {
                 clearRecentFilters: () => [],
-                recordRecentFilter: (state, { groupType, groupName, value, item, teamId, propertyFilter }) => {
+                recordRecentFilter: (
+                    state,
+                    { groupType, groupName, value, item, teamId, propertyFilter, selectingKeyOnly }
+                ) => {
                     if (EXCLUDED_RECENT_FILTER_GROUP_TYPES.has(groupType) || value == null) {
                         return state
                     }
 
                     const incomingComplete = isCompleteRecentPropertyFilter(propertyFilter)
+                    // A non-selectingKeyOnly partial write is treated as a stale precursor to a complete filter
+                    // and should not stomp the better record. A selectingKeyOnly write is the final value, so
+                    // it is allowed to coexist with — and bump the recency of — any complete record.
                     if (
                         !incomingComplete &&
+                        !selectingKeyOnly &&
                         state.some(
                             (f) =>
                                 f.groupType === groupType &&
@@ -168,6 +170,7 @@ export const recentTaxonomicFiltersLogic = kea<recentTaxonomicFiltersLogicType>(
                             _recentContext: {
                                 sourceGroupType: f.groupType,
                                 sourceGroupName: f.groupName,
+                                sourceValue: f.value,
                                 teamId: f.teamId,
                                 propertyFilter: f.propertyFilter,
                             } as RecentItemContext,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1772,17 +1772,19 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 })
 
                 // Record to recents (deferred to avoid render loop).
-                // Skip property groups — these are just the key-picking step;
-                // the complete filter (with operator + value) is recorded by propertyFilterLogic.
-                // Skip QuickFilterItem shortcuts — they are synthetic, not real data definitions.
+                // Record here when:
+                //   - the consumer says the selection is final (selectingKeyOnly), or
+                //   - we're re-clicking a recent that already has a complete propertyFilter, or
+                //   - this isn't a property-style group (so propertyFilterLogic isn't going to record it).
+                // QuickFilterItem shortcuts are synthetic, never recorded.
                 const hasCompletePropertyFilter = hasRecentContext(item) && item._recentContext.propertyFilter
-                const isRecordedByPropertyFilterLogic =
-                    !hasCompletePropertyFilter &&
-                    (PROPERTY_TAXONOMIC_GROUP_TYPES.has(sourceGroupType) ||
-                        SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES.has(sourceGroupType) ||
-                        sourceGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix))
+                const isPropertyFilterLogicGroup =
+                    PROPERTY_TAXONOMIC_GROUP_TYPES.has(sourceGroupType) ||
+                    SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES.has(sourceGroupType) ||
+                    sourceGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix)
+                const recordHereNow = props.selectingKeyOnly || hasCompletePropertyFilter || !isPropertyFilterLogicGroup
 
-                if (!isRecordedByPropertyFilterLogic && !isQuickFilterItem(item)) {
+                if (recordHereNow && !isQuickFilterItem(item)) {
                     setTimeout(() => {
                         if (recentTaxonomicFiltersLogic.isMounted()) {
                             const stripped = hasRecentContext(item) ? stripRecentContext(item) : item
@@ -1790,17 +1792,19 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             const sourceGroupName = hasRecentContext(item)
                                 ? item._recentContext.sourceGroupName
                                 : group.name
-                            const propertyFilterFromRecent = hasRecentContext(item)
-                                ? item._recentContext.propertyFilter
-                                : undefined
-                            recentTaxonomicFiltersLogic.actions.recordRecentFilter(
-                                sourceGroupType,
-                                sourceGroupName,
+                            const propertyFilterFromRecent =
+                                !props.selectingKeyOnly && hasRecentContext(item)
+                                    ? item._recentContext.propertyFilter
+                                    : undefined
+                            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                                groupType: sourceGroupType,
+                                groupName: sourceGroupName,
                                 value,
-                                cleanItem,
-                                teamLogic.values.currentTeamId ?? undefined,
-                                propertyFilterFromRecent
-                            )
+                                item: cleanItem,
+                                teamId: teamLogic.values.currentTeamId ?? undefined,
+                                propertyFilter: propertyFilterFromRecent,
+                                selectingKeyOnly: !!props.selectingKeyOnly,
+                            })
                         }
                     }, 0)
                 }

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -115,6 +115,11 @@ export interface TaxonomicFilterProps {
      *  query matches a known autocapture interaction keyword. Consumers must handle
      *  `isQuickFilterItem(item)` in their onChange to avoid mis-selecting as an event name. */
     enableKeywordShortcuts?: boolean
+    /** Treat every selection as final — there is no operator/value picker after the user picks a key
+     *  (e.g. picking columns to add, or picking an event name). Selections from property groups are
+     *  recorded to recents directly instead of waiting for `propertyFilterLogic` to record a complete
+     *  filter, and only key-only recents are surfaced in the recents tab. */
+    selectingKeyOnly?: boolean
 }
 
 export interface DataWarehousePopoverField {

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -51,6 +51,7 @@ export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = 
     definitionPopoverRenderer?: DefinitionPopoverRenderer
     suggestedFiltersLabel?: string
     enableKeywordShortcuts?: boolean
+    selectingKeyOnly?: boolean
 }
 
 /** Like TaxonomicPopover, but convenient when you know you will only use string values */
@@ -92,6 +93,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
         definitionPopoverRenderer,
         suggestedFiltersLabel,
         enableKeywordShortcuts,
+        selectingKeyOnly,
         width,
         placement,
         sideIcon,
@@ -150,6 +152,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     definitionPopoverRenderer={definitionPopoverRenderer}
                     suggestedFiltersLabel={suggestedFiltersLabel}
                     enableKeywordShortcuts={enableKeywordShortcuts}
+                    selectingKeyOnly={selectingKeyOnly}
                     width={width}
                 />
             }

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -57,14 +57,14 @@ function recordRecentFromPropertyFilter(propertyFilter: AnyPropertyFilter): void
     if (!groupType) {
         return
     }
-    recentTaxonomicFiltersLogic.actions.recordRecentFilter(
+    recentTaxonomicFiltersLogic.actions.recordRecentFilter({
         groupType,
-        groupType,
-        key,
-        { name: key },
-        teamLogic.values.currentTeamId ?? undefined,
-        propertyFilter
-    )
+        groupName: groupType,
+        value: key,
+        item: { name: key },
+        teamId: teamLogic.values.currentTeamId ?? undefined,
+        propertyFilter,
+    })
 }
 
 export const DEFAULT_UNIVERSAL_GROUP_FILTER: UniversalFiltersGroup = {

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -247,6 +247,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                                             }}
                                             popoverEnabled={false}
                                             selectFirstItem={false}
+                                            selectingKeyOnly
                                         />
                                     ) : null
                                 }

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -340,6 +340,7 @@ export function DataTable({
                                         renderValue={() => <>Edit column</>}
                                         type="tertiary"
                                         fullWidth
+                                        selectingKeyOnly
                                         onChange={(v, g) => {
                                             const hogQl = isActorsQuery(query.source)
                                                 ? taxonomicPersonFilterToHogQL(g, v)

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -323,6 +323,7 @@ export function DefinitionEdit(props: DefinitionLogicProps): JSX.Element {
                                                     onChange(typeof changedValue === 'string' ? changedValue : null)
                                                 }
                                                 placeholder="Select a primary property"
+                                                selectingKeyOnly
                                             />
                                         )}
                                     </LemonField>

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.tsx
@@ -177,6 +177,7 @@ export const BuilderStepNode = React.memo(function BuilderStepNode({
                         fullWidth
                         truncate
                         placeholder="Select event or action"
+                        selectingKeyOnly
                     />
                 </div>
             }

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -268,6 +268,7 @@ export function ActionFilterRow({
             filter={filter}
             suggestedFiltersLabel={suggestedFiltersLabel}
             enableKeywordShortcuts
+            selectingKeyOnly
             onChange={(changedValue, taxonomicGroupType, item) => {
                 if (isQuickFilterItem(item)) {
                     if (item.eventName) {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/BoxPlotPropertySelector.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/BoxPlotPropertySelector.tsx
@@ -37,6 +37,7 @@ export function BoxPlotPropertySelector({
                 placeholder="Select numeric property"
                 data-attr="box-plot-property-select"
                 showNumericalPropsOnly
+                selectingKeyOnly
                 renderValue={(currentValue) => (
                     <PropertyKeyInfo
                         value={currentValue}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/PropertyValueMathSelector.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/PropertyValueMathSelector.tsx
@@ -55,6 +55,7 @@ export function PropertyValueMathSelector({
                 eventNames={mathName ? [mathName] : []}
                 data-attr="math-property-select"
                 showNumericalPropsOnly={showNumericalPropsOnly}
+                selectingKeyOnly
                 renderValue={(currentValue) => (
                     <Tooltip
                         title={

--- a/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionAggregationSelector.tsx
@@ -126,6 +126,7 @@ export function RetentionAggregationSelector(): JSX.Element {
                     }}
                     placeholder="Select property"
                     data-attr="retention-aggregation-property-selector"
+                    selectingKeyOnly
                     renderValue={(currentValue) => (
                         <Tooltip
                             title={

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -235,6 +235,7 @@ function UsageMetricsForm(): JSX.Element {
                                         onChange={onChange}
                                         placeholder="Select property"
                                         data-attr="usage-metric-math-property"
+                                        selectingKeyOnly
                                     />
                                 )
                             }

--- a/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
+++ b/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
@@ -73,6 +73,7 @@ export const WebConversionGoal = ({
                 return <span className="text-overflow max-w-full">{conversionGoal?.customEventName}</span>
             }}
             groupTypes={[TaxonomicFilterGroupType.CustomEvents, TaxonomicFilterGroupType.Actions]}
+            selectingKeyOnly
             icon={<IconCursor />}
             placeholder={
                 isWindowLessThan('xl') ? 'Goal' : isWindowLessThan('2xl') ? 'Conversion goal' : 'Add conversion goal'

--- a/products/actions/frontend/components/EventName.tsx
+++ b/products/actions/frontend/components/EventName.tsx
@@ -42,6 +42,7 @@ export function EventName({
             allowClear={allEventsOption === 'clear'}
             excludedProperties={allEventsOption !== 'explicit' ? { events: [null] } : undefined}
             size="small"
+            selectingKeyOnly
             {...props}
         />
     )

--- a/products/revenue_analytics/frontend/settings/EventConfigurationModal.tsx
+++ b/products/revenue_analytics/frontend/settings/EventConfigurationModal.tsx
@@ -143,6 +143,7 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
                                 }}
                                 value={''}
                                 placeholder="Select or type an event name"
+                                selectingKeyOnly
                             />
                         )}
                     </div>
@@ -164,6 +165,7 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
                             }}
                             value={currentEvent?.revenueProperty || undefined}
                             placeholder="Select the property that contains revenue amount"
+                            selectingKeyOnly
                             disabledReason={
                                 !currentEvent?.eventName
                                     ? 'Select an event name first'


### PR DESCRIPTION
## Problem

The TaxonomicFilter tracks "Recent" picks across the app, but only stores them as recents once they have a fully-formed property filter (key + operator + value). In contexts where there is no operator/value picker — e.g. the activity page's "Add event" button and the "Configure columns" modal — picking a property goes nowhere in the recents list, so users can't recall their recent column or event picks.

here you can see it tracking recents in the configure column section which it couldn't do before

<img width="800" height="440" alt="CleanShot 2026-05-05 at 19 37 32" src="https://github.com/user-attachments/assets/3685c82a-2170-4331-9fe2-1d8291397c4b" />

## Changes

- New opt-in `keyOnly` prop on `TaxonomicFilter` and `TaxonomicPopover`. When set:
  - `selectItem` records the picked item to recents directly, even for property/groups types where it would otherwise wait for `propertyFilterLogic` to write a complete filter. The propertyFilter is dropped so the entry is stored as key-only.
  - The recents tab dedups by `(sourceGroupType, value)` and strips `propertyFilter` from the displayed `_recentContext`, so existing complete recents (`$browser = Chrome`) still surface in key-only contexts as just the key.
- `recentTaxonomicFiltersLogic.recordRecentFilter` now takes an explicit `keyOnly` flag. A keyOnly write coexists with — and bumps the recency past — any existing complete record for the same key. Default behavior unchanged.
- Wired `keyOnly` on the call sites where the picked value is the final config (no follow-up operator/value picker):
  - Activity page: `EventName` (Add event), `ColumnConfigurator` and the per-column `Edit column` picker in `DataTable`
  - Insight series and goal pickers: `ActionFilterRow`, `BuilderStepNode` (funnels), `WebConversionGoal`, `EventConfigurationModal` (revenue analytics)
  - Math/aggregation property pickers: `PropertyValueMathSelector`, `BoxPlotPropertySelector`, `RetentionAggregationSelector`, `UsageMetricsConfig`
  - Single-property selectors: `DefinitionEdit` promoted property, `QuickFilterForm` property key, `FlagSelector`

## How did you test this code?

I'm an agent (PostHog Code). I did not exercise this in a browser. I added and ran automated tests:

- Unit tests in `recentTaxonomicFiltersLogic.test.ts`: keyOnly write coexists with an existing complete record; non-keyOnly partial write is still suppressed when a complete record exists; keyOnly writes for the same key dedup to most recent.
- Unit tests in `infiniteListLogic.test.ts`: `contextFilteredRecentItems` strips `propertyFilter` and dedups by key when `keyOnly` is set; preserves complete recents when not.
- New RTL test file `TaxonomicFilterKeyOnly.test.tsx` covering the user-visible behavior:
  - Records an EventProperty selection to recents in keyOnly mode
  - Does NOT record in default mode (existing propertyFilterLogic-owned path)
  - Re-selecting an existing complete recent in keyOnly mode does not carry over its propertyFilter
  - The Recent tab appears with key-only recents in keyOnly mode
  - Complete recents render stripped to just the key in keyOnly mode (no value label)
  - Complete recents still render with their `Browser equals Chrome` label in default mode (regression guard)
  - Multiple complete recents for the same key collapse to one row in keyOnly mode

All TaxonomicFilter / TaxonomicPopover / PropertyFilters suites pass locally (372 tests). `tsc --noEmit` is clean on the changed files.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Key human prompts that shaped this work:
  - Initial framing: "the taxonomic filter writes and tracks Recents… in some contexts there is no value to select… we should be able to tell we are in a key only situation and store those recents and then offer them when we are next in a key only situation."
  - Pushed back on the first auto-detection sketch: "we can make an explicit keyOnly prop and opt in" — confirmed an explicit prop over a heuristic / propertyFilterLogic-mount probe.
  - Asked for "strong RTL tests covering this behaviour" once the logic-level tests were in place — drove the new `TaxonomicFilterKeyOnly.test.tsx` file.
  - Asked for an audit of other call sites that should opt in, and approved wiring the 12 listed above (Max `Context.tsx` left out for safety; `PathsHogQL.tsx` skipped since it's HogQLExpression-only and meta groups are excluded from recents).
- Decisions:
  - Storage rule for keyOnly writes: coexist with complete entries rather than replacing or being suppressed by them, so the most recent click always bumps recency in the right context. The display selector dedups complete recents down to their key in keyOnly mode, so users still see `$browser` from a previous full filter.
  - Display rule: in keyOnly mode, surface every recent matching the group types but strip `propertyFilter` from the displayed context — so the existing `formatPropertyLabel` codepath cleanly switches off without a render-time branch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*