### PR TITLE
perf(logs-alerting): batch alert checks and saves per team

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -40,6 +40,66 @@ class BucketedCount:
     count: int
 
 
+def _build_logs_query(alert: LogsAlertConfiguration, date_range: DateRange) -> LogsQuery:
+    filters = alert.filters
+    filter_group = filters.get("filterGroup")
+    if filter_group:
+        pg = PropertyGroupFilter.model_validate(filter_group)
+    else:
+        pg = PropertyGroupFilter(
+            type=FilterLogicalOperator.AND_,
+            values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+        )
+    return LogsQuery(
+        dateRange=date_range,
+        serviceNames=filters.get("serviceNames", []),
+        severityLevels=filters.get("severityLevels", []),
+        filterGroup=pg,
+        kind="LogsQuery",
+    )
+
+
+def build_alert_where_expr(
+    *,
+    team: Team,
+    alert: LogsAlertConfiguration,
+    date_from: dt.datetime,
+    date_to: dt.datetime,
+) -> ast.Expr:
+    """Build the per-alert WHERE expression used by both single-alert and batched queries.
+
+    Adds explicit half-open timestamp bounds [date_from, date_to) on top of
+    `LogsFilterBuilder.where()` so adjacent alert windows can't double-count
+    logs at the boundary. `LogsFilterBuilder.where()` includes a `{filters}`
+    placeholder that resolves to `true` when no HogQLFilters are passed to
+    `execute_hogql_query`.
+    """
+    date_range = DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat())
+    logs_query = _build_logs_query(alert, date_range)
+    query_date_range = QueryDateRange(
+        date_range=logs_query.dateRange,
+        team=team,
+        interval=IntervalType.MINUTE,
+        interval_count=1,
+        now=date_to,
+        timezone_info=ZoneInfo("UTC"),
+        exact_timerange=True,
+    )
+    base_where = LogsFilterBuilder(logs_query, team, query_date_range).where()
+    return ast.And(
+        exprs=[
+            base_where,
+            parse_expr(
+                "timestamp >= {date_from} AND timestamp < {date_to}",
+                placeholders={
+                    "date_from": ast.Constant(value=date_from),
+                    "date_to": ast.Constant(value=date_to),
+                },
+            ),
+        ]
+    )
+
+
 class AlertCheckQuery:
     """Lightweight count query against the logs ClickHouse cluster for alert checks.
 
@@ -71,36 +131,7 @@ class AlertCheckQuery:
         self.team = team
         self.alert = alert
         self.date_range = DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat())
-
-        logs_query = self._build_logs_query()
-        query_date_range = QueryDateRange(
-            date_range=logs_query.dateRange,
-            team=team,
-            interval=IntervalType.MINUTE,
-            interval_count=1,
-            now=date_to,
-            timezone_info=ZoneInfo("UTC"),
-            exact_timerange=True,
-        )
-        builder = LogsFilterBuilder(logs_query, team, query_date_range)
-        base_where = builder.where()
-
-        # Add explicit timestamp bounds using a half-open interval [from, to).
-        # This ensures adjacent alert windows don't double-count logs at the boundary.
-        # LogsFilterBuilder.where() includes a {filters} placeholder that resolves
-        # to `true` when no HogQLFilters are passed to execute_hogql_query.
-        self.where_expr = ast.And(
-            exprs=[
-                base_where,
-                parse_expr(
-                    "timestamp >= {date_from} AND timestamp < {date_to}",
-                    placeholders={
-                        "date_from": ast.Constant(value=date_from),
-                        "date_to": ast.Constant(value=date_to),
-                    },
-                ),
-            ]
-        )
+        self.where_expr = build_alert_where_expr(team=team, alert=alert, date_from=date_from, date_to=date_to)
 
     def execute(self) -> AlertCheckCountResult:
         """Return a single aggregate count for the alert window."""
@@ -191,23 +222,148 @@ class AlertCheckQuery:
             team_id=str(self.team.id),
         )
 
-    def _build_logs_query(self) -> LogsQuery:
-        filters = self.alert.filters
-        filter_group = filters.get("filterGroup")
-        if filter_group:
-            pg = PropertyGroupFilter.model_validate(filter_group)
-        else:
-            pg = PropertyGroupFilter(
-                type=FilterLogicalOperator.AND_,
-                values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+
+@dataclass(frozen=True)
+class BatchedBucketedResult:
+    """Per-alert bucketed counts plus the shared CH query duration of the batch."""
+
+    per_alert: dict[str, list[BucketedCount]]
+    query_duration_ms: int
+
+
+class BatchedAlertCheckQuery:
+    """Multi-alert batched alert check.
+
+    Same shape as `AlertCheckQuery.execute_bucketed`, but evaluates N alerts in
+    one CH query using `countIf(<filter>) AS alert_<n>` columns. All alerts must
+    share team, time window, and bucket grid — caller groups by
+    `(team_id, window_minutes, evaluation_periods, projection_eligible)`.
+
+    The batched query reads each row once and evaluates all per-alert predicates
+    as cheap column expressions, so cost is dominated by the (shared) partition
+    scan, not by the predicate count. See
+    [tmp/logs-alerting/per-team-batching-test.sql](../../../tmp/logs-alerting/per-team-batching-test.sql)
+    for cost validation.
+    """
+
+    SETTINGS = AlertCheckQuery.SETTINGS
+
+    def __init__(
+        self,
+        *,
+        team: Team,
+        alerts: list[LogsAlertConfiguration],
+        date_from: dt.datetime,
+        date_to: dt.datetime,
+        projection_eligible: bool | None = None,
+    ) -> None:
+        if not alerts:
+            raise ValueError("BatchedAlertCheckQuery requires at least one alert")
+        if any(a.team_id != team.id for a in alerts):
+            raise ValueError("All alerts in a batch must belong to the same team")
+        self.team = team
+        self.alerts = list(alerts)
+        self._alert_where_exprs: list[ast.Expr] = [
+            build_alert_where_expr(team=team, alert=alert, date_from=date_from, date_to=date_to)
+            for alert in self.alerts
+        ]
+        # Caller (cohort orchestrator) already keys cohorts by projection eligibility,
+        # so it can pass the answer through. Recompute only for direct/test callers.
+        self._all_projection_eligible = (
+            projection_eligible
+            if projection_eligible is not None
+            else all(is_projection_eligible(a.filters) for a in self.alerts)
+        )
+
+        # Outer WHERE owns the time-based pruning so CH can skip parts/granules
+        # before evaluating any countIf. Per-alert exprs include redundant
+        # time/timestamp clauses inside countIf — harmless but worth noting if
+        # you're reading EXPLAIN output and counting predicate evaluations.
+        self._outer_where = parse_expr(
+            "toStartOfDay(time_bucket) >= toStartOfDay({date_from})"
+            " AND toStartOfDay(time_bucket) <= toStartOfDay({date_to})"
+            " AND timestamp >= {date_from}"
+            " AND timestamp < {date_to}",
+            placeholders={
+                "date_from": ast.Constant(value=date_from),
+                "date_to": ast.Constant(value=date_to),
+            },
+        )
+
+    def execute_bucketed(self, interval_minutes: int, *, limit: int = 10_000) -> BatchedBucketedResult:
+        """Run the batched query and split results back per-alert.
+
+        All alerts in the batch must share `(window_minutes, evaluation_periods)`
+        with the corresponding `interval_minutes` and `limit` — otherwise they
+        produce different bucket grids and can't share a query.
+        """
+        self._tag()
+
+        time_field = (
+            ast.Call(name="toStartOfMinute", args=[ast.Field(chain=["timestamp"])])
+            if self._all_projection_eligible
+            else ast.Field(chain=["timestamp"])
+        )
+
+        select_columns: list[ast.Expr] = [
+            ast.Alias(
+                alias="bucket",
+                expr=ast.Call(
+                    name="toStartOfInterval",
+                    args=[time_field, ast.Call(name="toIntervalMinute", args=[ast.Constant(value=interval_minutes)])],
+                ),
+            ),
+        ]
+        for i, alert_expr in enumerate(self._alert_where_exprs):
+            select_columns.append(
+                ast.Alias(
+                    alias=f"alert_{i}",
+                    expr=ast.Call(name="countIf", args=[alert_expr]),
+                )
             )
 
-        return LogsQuery(
-            dateRange=self.date_range,
-            serviceNames=filters.get("serviceNames", []),
-            severityLevels=filters.get("severityLevels", []),
-            filterGroup=pg,
-            kind="LogsQuery",
+        query = ast.SelectQuery(
+            select=select_columns,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["logs"])),
+            where=self._outer_where,
+            group_by=[ast.Field(chain=["bucket"])],
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["bucket"]), order="ASC")],
+            limit=ast.Constant(value=limit),
+        )
+
+        start_ms = time.monotonic_ns() // 1_000_000
+        response = self._run_query(query)
+        duration_ms = time.monotonic_ns() // 1_000_000 - start_ms
+
+        per_alert: dict[str, list[BucketedCount]] = {str(a.id): [] for a in self.alerts}
+        for row in response.results:
+            bucket_ts = row[0]
+            for i, alert in enumerate(self.alerts):
+                per_alert[str(alert.id)].append(BucketedCount(timestamp=bucket_ts, count=row[i + 1]))
+        return BatchedBucketedResult(per_alert=per_alert, query_duration_ms=duration_ms)
+
+    def _run_query(self, query: ast.SelectQuery) -> HogQLQueryResponse:
+        return execute_hogql_query(
+            query_type="alert_check",
+            query=query,
+            team=self.team,
+            workload=Workload.LOGS,
+            settings=self.SETTINGS,
+            limit_context=LimitContext.QUERY,
+            modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
+        )
+
+    def _tag(self) -> None:
+        # `QueryTags` doesn't allow per-batch custom fields. We tag the first
+        # alert as the representative `alert_config_id` so single-alert tooling
+        # still works; ops can identify a batched query by `source` and read the
+        # full alert list from `query_log.query` if needed.
+        tag_queries(
+            product=Product.LOGS,
+            feature=Feature.ALERTING,
+            source="logs_alert_batched",
+            alert_config_id=str(self.alerts[0].id),
+            team_id=str(self.team.id),
         )
 
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 
 from django.db import transaction
 from django.db.models import Q
+from django.db.utils import IntegrityError
 
 import structlog
 import temporalio.activity
@@ -17,8 +18,11 @@ from posthog.sync import database_sync_to_async_pool
 
 from products.logs.backend.alert_check_query import (
     AlertCheckQuery,
+    BatchedAlertCheckQuery,
+    BatchedBucketedResult,
     BucketedCount,
     fetch_live_logs_checkpoint,
+    is_projection_eligible,
     resolve_alert_date_to,
 )
 from products.logs.backend.alert_error_classifier import (
@@ -41,15 +45,17 @@ from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
     increment_checks_total,
+    increment_cohort_save_fallback,
     increment_notification_failures,
     increment_state_transition,
-    record_alert_event_create_duration,
-    record_alert_save_duration,
-    record_alert_update_duration,
     record_alerts_active,
     record_check_duration,
     record_checkpoint_lag,
     record_clickhouse_duration,
+    record_cohort_event_insert_duration,
+    record_cohort_save_duration,
+    record_cohort_size,
+    record_cohort_update_duration,
     record_pending_alerts,
     record_scheduler_lag,
     record_semaphore_wait,
@@ -92,6 +98,88 @@ class CheckAlertsInput:
 
 
 @dataclasses.dataclass(frozen=True)
+class _AlertCohort:
+    """Group of alerts that share team + bucket grid and can be batched into one CH query.
+
+    Cohort key (implicit, derived in `_build_cohorts`):
+    `(team_id, window_minutes, evaluation_periods, projection_eligible, date_to)`.
+
+    All five must match for two alerts to share a query. `date_to` matters because
+    checkpoint clamping can pull alerts with different `next_check_at` values onto
+    the same window, and we want them to share the scan when that happens.
+    """
+
+    alerts: tuple[LogsAlertConfiguration, ...]
+    date_to: datetime
+    projection_eligible: bool
+
+    @property
+    def window_minutes(self) -> int:
+        return self.alerts[0].window_minutes
+
+    @property
+    def evaluation_periods(self) -> int:
+        return self.alerts[0].evaluation_periods
+
+    @property
+    def date_from(self) -> datetime:
+        return self.date_to - timedelta(minutes=self.window_minutes * self.evaluation_periods)
+
+
+@dataclasses.dataclass(frozen=True)
+class _PrefetchedQuery:
+    """Result of a batched query for one alert in a cohort.
+
+    Either `buckets` is set (success path; `query_duration_ms` is the shared
+    batch duration) or `error` is set (failure — re-raised inside the per-alert
+    eval to flow through the same classification as a per-alert query failure).
+    """
+
+    buckets: list[BucketedCount] | None = None
+    query_duration_ms: int | None = None
+    error: Exception | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _AlertEvaluation:
+    """Phase 1 output: per-alert state-machine result. No Kafka, no PG yet.
+
+    Carries the raw `outcome` (pre-dispatch) — Kafka failure is decided in
+    Phase 2 and may roll the state back to `state_before`.
+    """
+
+    alert: LogsAlertConfiguration
+    outcome: AlertCheckOutcome
+    check_result: CheckResult
+    date_from: datetime
+    date_to: datetime
+    error_category: AlertErrorCode | None
+    state_before: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _DispatchedAlert:
+    """Phase 2 output: notification dispatched, ready for the cohort bulk save.
+
+    `notification_failed` is the source of truth for state rollback: if True,
+    the state machine's `new_state` is replaced with the alert's existing state
+    so the next cycle re-tries the notification.
+    """
+
+    evaluation: _AlertEvaluation
+    notification_failed: bool
+
+    @property
+    def committed_outcome(self) -> AlertCheckOutcome:
+        if self.notification_failed:
+            return dataclasses.replace(
+                self.evaluation.outcome,
+                new_state=AlertState(self.evaluation.alert.state),
+            )
+        return self.evaluation.outcome
+
+
+@dataclasses.dataclass(frozen=True)
 class CheckAlertsOutput:
     alerts_checked: int
     alerts_fired: int
@@ -101,26 +189,135 @@ class CheckAlertsOutput:
 
 @temporalio.activity.defn
 async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
-    """Find all due alerts and evaluate them with bounded concurrency."""
+    """Find all due alerts and evaluate them with bounded concurrency.
+
+    Per-team batching with three phases per cohort:
+      1. Batched ClickHouse `countIf` query (one query, N predicate columns).
+      2. Per-alert in-memory eval (state machine) + per-alert Kafka dispatch.
+      3. Single bulk Postgres save (`bulk_create` events + `bulk_update` configs).
+
+    The semaphore bounds concurrent cohorts. Phase 2's per-alert work runs
+    in-memory only — no Postgres connections involved — so its concurrency
+    is bounded by Python's GIL plus the Kafka producer's queue, not by the
+    DB connection pool.
+    """
     now, all_alerts, checkpoint = await database_sync_to_async_pool(_load_alerts_and_checkpoint)()
 
-    semaphore = asyncio.Semaphore(MAX_CONCURRENT_ALERT_EVALS)
-    eval_async = database_sync_to_async_pool(_evaluate_single_alert)
+    cohorts = _build_cohorts(all_alerts, now=now, checkpoint=checkpoint)
 
-    async def _bounded_eval(alert: LogsAlertConfiguration) -> dict[str, int]:
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_ALERT_EVALS)
+    # Eval is in-memory + GIL-bound — no parallelism benefit from gather, so
+    # we run it as a sync list comprehension. Dispatch is Kafka I/O and gets
+    # a thread-pool wrap + gather for actual concurrency.
+    dispatch_async = database_sync_to_async_pool(_dispatch_for_alert)
+    batched_query_async = database_sync_to_async_pool(_run_batched_query)
+    save_cohort_async = database_sync_to_async_pool(_save_cohort_outcomes)
+
+    async def _bounded_cohort_eval(cohort: _AlertCohort) -> dict[str, int]:
         wait_start = time.perf_counter()
         local_stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         async with semaphore:
             wait_ms = int((time.perf_counter() - wait_start) * 1000)
             try:
-                await eval_async(alert, now, local_stats, checkpoint=checkpoint)
+                record_cohort_size(len(cohort.alerts))
             except Exception:
-                logger.exception(
-                    "Unexpected error evaluating alert",
-                    alert_id=str(alert.id),
-                    alert_name=alert.name,
-                    team_id=alert.team_id,
+                logger.exception("Failed to record cohort_size histogram")
+
+            # Phase 1: batched CH query.
+            batched_result: BatchedBucketedResult | None
+            cohort_error: Exception | None = None
+            try:
+                batched_result = await batched_query_async(cohort)
+            except Exception as e:
+                # Propagate the cohort error to each alert in the cohort so they
+                # advance `consecutive_failures` independently. Re-raising per
+                # alert flows through the same classification as a per-alert
+                # query failure would.
+                logger.warning(
+                    "Batched alert query failed",
+                    team_id=cohort.alerts[0].team_id,
+                    cohort_size=len(cohort.alerts),
+                    error=str(e),
                 )
+                capture_exception(e, {"team_id": cohort.alerts[0].team_id, "cohort_size": len(cohort.alerts)})
+                batched_result = None
+                cohort_error = e
+
+            # Phase 2a: evaluate all alerts (sync, in-memory).
+            evaluations: list[_AlertEvaluation] = []
+            kept_eval_starts: list[float] = []
+            for alert in cohort.alerts:
+                eval_start = time.perf_counter()
+                try:
+                    evaluations.append(
+                        _evaluate_single_alert(
+                            alert,
+                            now,
+                            checkpoint=checkpoint,
+                            prefetched=_prefetch_for_alert(alert, batched_result, cohort_error),
+                        )
+                    )
+                    kept_eval_starts.append(eval_start)
+                except Exception:
+                    logger.exception(
+                        "Unexpected error evaluating alert",
+                        alert_id=str(alert.id),
+                        alert_name=alert.name,
+                        team_id=alert.team_id,
+                    )
+                    local_stats["errored"] += 1
+
+            # Phase 2b: dispatch all alerts in parallel (Kafka concurrency).
+            dispatched_or_errors = await asyncio.gather(
+                *(dispatch_async(ev, now) for ev in evaluations),
+                return_exceptions=True,
+            )
+            # Capture per-alert elapsed_ms here — *before* Phase 3 starts — so the
+            # `check_duration` metric measures eval + dispatch only, matching its
+            # description. Cohort save time is recorded separately.
+            phase_2_end = time.perf_counter()
+            dispatched: list[_DispatchedAlert] = []
+            elapsed_ms_per_alert: list[int] = []
+            for ev, result, eval_start in zip(evaluations, dispatched_or_errors, kept_eval_starts):
+                if isinstance(result, BaseException):
+                    logger.exception(
+                        "Unexpected error dispatching alert",
+                        alert_id=str(ev.alert.id),
+                        alert_name=ev.alert.name,
+                        team_id=ev.alert.team_id,
+                        exc_info=result,
+                    )
+                    local_stats["errored"] += 1
+                else:
+                    dispatched.append(result)
+                    elapsed_ms_per_alert.append(int((phase_2_end - eval_start) * 1000))
+
+            # Phase 3: bulk save — one `bulk_create` + one `bulk_update` per cohort.
+            saved: list[_DispatchedAlert] = []
+            failed: list[_DispatchedAlert] = []
+            try:
+                if dispatched:
+                    saved, failed = await save_cohort_async(dispatched, now)
+            except Exception as e:
+                logger.exception(
+                    "Cohort bulk save failed (non-recoverable)",
+                    team_id=cohort.alerts[0].team_id,
+                    cohort_size=len(dispatched),
+                )
+                capture_exception(e, {"team_id": cohort.alerts[0].team_id, "phase": "bulk_save"})
+                # Saves failed — count alerts as errored so the cycle stat
+                # reflects that this cohort didn't advance state.
+                local_stats["errored"] += len(dispatched)
+                local_stats["checked"] += len(dispatched)
+                return local_stats
+
+            # Phase 4 (serial): finalize stats + per-alert post-save metrics.
+            elapsed_by_alert_id = {str(d.evaluation.alert.id): ms for d, ms in zip(dispatched, elapsed_ms_per_alert)}
+            for d in saved:
+                _finalize_alert(d, elapsed_by_alert_id[str(d.evaluation.alert.id)], local_stats)
+            for _ in failed:
+                # Alert's per-alert fallback save failed — count as errored.
+                local_stats["checked"] += 1
                 local_stats["errored"] += 1
         try:
             record_semaphore_wait(wait_ms)
@@ -130,8 +327,8 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
 
     tasks: list[asyncio.Task[dict[str, int]]] = []
     async with asyncio.TaskGroup() as tg:
-        for alert in all_alerts:
-            tasks.append(tg.create_task(_bounded_eval(alert)))
+        for cohort in cohorts:
+            tasks.append(tg.create_task(_bounded_cohort_eval(cohort)))
 
     aggregated = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
     for task in tasks:
@@ -199,22 +396,162 @@ def _load_alerts_and_checkpoint() -> tuple[datetime, list[LogsAlertConfiguration
     return now, all_alerts, checkpoint
 
 
+def _build_cohorts(
+    alerts: list[LogsAlertConfiguration],
+    *,
+    now: datetime,
+    checkpoint: datetime | None,
+) -> list[_AlertCohort]:
+    """Group alerts into cohorts that can share a batched CH query.
+
+    Cohort key: (team_id, window_minutes, evaluation_periods, projection_eligible, date_to).
+    A single-alert "cohort" is fine — `BatchedAlertCheckQuery` with N=1 has the
+    same shape as `AlertCheckQuery.execute_bucketed`, so we don't bother
+    bypassing the batched path for cohorts of one.
+    """
+    grouped: dict[tuple, list[LogsAlertConfiguration]] = {}
+    for alert in alerts:
+        nca = alert.next_check_at if alert.next_check_at is not None else now
+        date_to = resolve_alert_date_to(nca, checkpoint)
+        key = (
+            alert.team_id,
+            alert.window_minutes,
+            alert.evaluation_periods,
+            is_projection_eligible(alert.filters),
+            date_to,
+        )
+        grouped.setdefault(key, []).append(alert)
+
+    return [
+        _AlertCohort(alerts=tuple(members), date_to=key[4], projection_eligible=key[3])
+        for key, members in grouped.items()
+    ]
+
+
+def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
+    return BatchedAlertCheckQuery(
+        team=cohort.alerts[0].team,
+        alerts=list(cohort.alerts),
+        date_from=cohort.date_from,
+        date_to=cohort.date_to,
+        projection_eligible=cohort.projection_eligible,
+    ).execute_bucketed(interval_minutes=cohort.window_minutes, limit=cohort.evaluation_periods)
+
+
+def _prefetch_for_alert(
+    alert: LogsAlertConfiguration,
+    batched_result: BatchedBucketedResult | None,
+    cohort_error: Exception | None,
+) -> _PrefetchedQuery:
+    if batched_result is not None:
+        return _PrefetchedQuery(
+            buckets=batched_result.per_alert.get(str(alert.id), []),
+            query_duration_ms=batched_result.query_duration_ms,
+        )
+    return _PrefetchedQuery(error=cohort_error)
+
+
 def _check_alerts_sync() -> CheckAlertsOutput:
-    """Synchronous variant kept for unit tests. Production runs through
-    `check_alerts_activity` (async + bounded concurrency)."""
+    """Synchronous variant kept for unit tests. Production runs through `check_alerts_activity`.
+
+    Mirrors the async cohort dispatch shape (CH batched query → per-alert eval +
+    Kafka dispatch → bulk save) so tests cover the production code path.
+    """
     now, all_alerts, checkpoint = _load_alerts_and_checkpoint()
+    cohorts = _build_cohorts(all_alerts, now=now, checkpoint=checkpoint)
 
     stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
-    for alert in all_alerts:
+    for cohort in cohorts:
         try:
-            _evaluate_single_alert(alert, now, stats, checkpoint=checkpoint)
+            record_cohort_size(len(cohort.alerts))
         except Exception:
-            logger.exception(
-                "Unexpected error evaluating alert",
-                alert_id=str(alert.id),
-                alert_name=alert.name,
-                team_id=alert.team_id,
+            logger.exception("Failed to record cohort_size histogram")
+
+        # Phase 1
+        batched_result: BatchedBucketedResult | None
+        cohort_error: Exception | None = None
+        try:
+            batched_result = _run_batched_query(cohort)
+        except Exception as e:
+            logger.warning(
+                "Batched alert query failed",
+                team_id=cohort.alerts[0].team_id,
+                cohort_size=len(cohort.alerts),
+                error=str(e),
             )
+            capture_exception(e, {"team_id": cohort.alerts[0].team_id, "cohort_size": len(cohort.alerts)})
+            batched_result = None
+            cohort_error = e
+
+        # Phase 2a: evaluate all alerts.
+        evaluations: list[_AlertEvaluation] = []
+        eval_starts: list[float] = []
+        for alert in cohort.alerts:
+            eval_start = time.perf_counter()
+            try:
+                evaluation = _evaluate_single_alert(
+                    alert,
+                    now,
+                    checkpoint=checkpoint,
+                    prefetched=_prefetch_for_alert(alert, batched_result, cohort_error),
+                )
+            except Exception:
+                logger.exception(
+                    "Unexpected error evaluating alert",
+                    alert_id=str(alert.id),
+                    alert_name=alert.name,
+                    team_id=alert.team_id,
+                )
+                stats["errored"] += 1
+                continue
+            evaluations.append(evaluation)
+            eval_starts.append(eval_start)
+
+        # Phase 2b: dispatch all alerts.
+        dispatched: list[_DispatchedAlert] = []
+        kept_eval_starts_for_dispatch: list[float] = []
+        for ev, eval_start in zip(evaluations, eval_starts):
+            try:
+                d = _dispatch_for_alert(ev, now)
+            except Exception:
+                logger.exception(
+                    "Unexpected error dispatching alert",
+                    alert_id=str(ev.alert.id),
+                    alert_name=ev.alert.name,
+                    team_id=ev.alert.team_id,
+                )
+                stats["errored"] += 1
+                continue
+            dispatched.append(d)
+            kept_eval_starts_for_dispatch.append(eval_start)
+
+        # Snapshot per-alert elapsed_ms here so it doesn't include Phase 3.
+        phase_2_end = time.perf_counter()
+        elapsed_ms_per_alert = [int((phase_2_end - es) * 1000) for es in kept_eval_starts_for_dispatch]
+
+        # Phase 3: bulk save.
+        saved: list[_DispatchedAlert] = []
+        failed: list[_DispatchedAlert] = []
+        try:
+            if dispatched:
+                saved, failed = _save_cohort_outcomes(dispatched, now)
+        except Exception as e:
+            logger.exception(
+                "Cohort bulk save failed (non-recoverable)",
+                team_id=cohort.alerts[0].team_id,
+                cohort_size=len(dispatched),
+            )
+            capture_exception(e, {"team_id": cohort.alerts[0].team_id, "phase": "bulk_save"})
+            stats["errored"] += len(dispatched)
+            stats["checked"] += len(dispatched)
+            continue
+
+        # Phase 4: finalize stats + per-alert post-save metrics.
+        elapsed_by_alert_id = {str(d.evaluation.alert.id): ms for d, ms in zip(dispatched, elapsed_ms_per_alert)}
+        for d in saved:
+            _finalize_alert(d, elapsed_by_alert_id[str(d.evaluation.alert.id)], stats)
+        for _ in failed:
+            stats["checked"] += 1
             stats["errored"] += 1
 
     if stats["checked"] > 0:
@@ -233,12 +570,16 @@ def _dispatch_notification(
     alert: LogsAlertConfiguration,
     check_result: CheckResult,
     now: datetime,
-    stats: dict[str, int],
     *,
     date_from: datetime,
     date_to: datetime,
 ) -> bool:
-    """Emit the notification for this outcome. Returns True if delivery failed."""
+    """Emit the notification for this outcome. Returns True if delivery failed.
+
+    Pure-effect: produces a Kafka message and logs. Does NOT mutate `stats` —
+    the orchestrator owns stats accounting so it stays single-threaded after
+    the parallel dispatch phase.
+    """
     action = outcome.notification
     if action == NotificationAction.NONE:
         return False
@@ -249,15 +590,11 @@ def _dispatch_notification(
         notified = _emit_alert_event(
             alert, "$logs_alert_firing", check_result, now, date_from=date_from, date_to=date_to
         )
-        if notified:
-            stats["fired"] += 1
         log.info("Alert fired", result_count=check_result.result_count, notified=notified)
     elif action == NotificationAction.RESOLVE:
         notified = _emit_alert_event(
             alert, "$logs_alert_resolved", check_result, now, date_from=date_from, date_to=date_to
         )
-        if notified:
-            stats["resolved"] += 1
         log.info("Alert resolved", notified=notified)
     elif action == NotificationAction.ERROR:
         notified = _emit_alert_errored_event(alert, outcome, now)
@@ -275,21 +612,251 @@ def _dispatch_notification(
     return not notified
 
 
+def _dispatch_for_alert(evaluation: _AlertEvaluation, now: datetime) -> _DispatchedAlert:
+    """Phase 2: dispatch the Kafka notification for one alert.
+
+    Pure-effect (Kafka). The orchestrator updates `stats` serially after the
+    dispatch phase so concurrent gather'd dispatches can't race on the dict.
+    """
+    notification_failed = _dispatch_notification(
+        evaluation.outcome,
+        evaluation.alert,
+        evaluation.check_result,
+        now,
+        date_from=evaluation.date_from,
+        date_to=evaluation.date_to,
+    )
+    return _DispatchedAlert(evaluation=evaluation, notification_failed=notification_failed)
+
+
+def _stage_alert_for_save(dispatched: _DispatchedAlert, now: datetime) -> tuple[list[str], LogsAlertEvent | None]:
+    """Mutate the in-memory alert so it's ready for `bulk_update`, return the
+    `update_fields` list and the optional `LogsAlertEvent` row to insert.
+
+    All state/consecutive_failures writes go through `apply_outcome` per the
+    semgrep rule — same contract as the per-alert path.
+    """
+    evaluation = dispatched.evaluation
+    alert = evaluation.alert
+    committed = dispatched.committed_outcome
+    is_error = evaluation.outcome.error_message is not None
+    state_changed = evaluation.state_before != committed.new_state.value
+
+    update_fields = apply_outcome(alert, committed)
+    alert.last_checked_at = now
+    # `updated_at` has `auto_now=True`, but Django's `bulk_update` doesn't apply
+    # `auto_now` — set it explicitly so the timestamp advances on the bulk path
+    # (the per-alert fallback's `alert.save()` would honour `auto_now`, but the
+    # happy path is bulk_update).
+    alert.updated_at = now
+    alert.next_check_at = advance_next_check_at(alert.next_check_at, alert.check_interval_minutes, now)
+    update_fields.extend(["last_checked_at", "next_check_at", "updated_at"])
+
+    if (
+        not dispatched.notification_failed
+        and evaluation.outcome.notification != NotificationAction.NONE
+        and evaluation.outcome.update_last_notified_at
+    ):
+        alert.last_notified_at = now
+        update_fields.append("last_notified_at")
+
+    event: LogsAlertEvent | None = None
+    if state_changed or is_error:
+        event = LogsAlertEvent(
+            alert=alert,
+            result_count=evaluation.check_result.result_count,
+            threshold_breached=evaluation.check_result.threshold_breached,
+            state_before=evaluation.state_before,
+            state_after=committed.new_state.value,
+            error_message=evaluation.outcome.error_message,
+            query_duration_ms=evaluation.check_result.query_duration_ms,
+        )
+    return update_fields, event
+
+
+# All bulk_update calls touch the same fields per cohort — alerts that aren't
+# notifying still get last_notified_at written back unchanged. Cheap, keeps
+# the bulk_update field list constant.
+_COHORT_UPDATE_FIELDS: list[str] = [
+    "state",
+    "consecutive_failures",
+    "last_checked_at",
+    "next_check_at",
+    "last_notified_at",
+    "updated_at",
+]
+
+
+def _save_cohort_outcomes(
+    dispatched: list[_DispatchedAlert], now: datetime
+) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert]]:
+    """Phase 3: persist the cohort's outcomes via one bulk_create + one bulk_update.
+
+    Returns `(saved, failed)` — saved alerts advanced to their committed state,
+    failed alerts didn't (caller treats them as errored).
+
+    On `IntegrityError` (constraint shaped — a row hit a DB constraint we didn't
+    anticipate), fall back to per-alert UPDATEs so the rest still advance.
+    `OperationalError`/`DataError` are propagated so the caller advances each
+    alert's `consecutive_failures` via the standard error path; per-alert
+    fallback against the same broken cluster wouldn't help.
+    """
+    if not dispatched:
+        return [], []
+
+    save_start = time.perf_counter()
+
+    # Stage every alert exactly once: mutates the in-memory alert (apply_outcome,
+    # advance_next_check_at, etc.) and produces the (update_fields, event) tuple
+    # needed to write it. We keep the staged tuples so the IntegrityError
+    # fallback can save each alert individually without re-staging — calling
+    # `advance_next_check_at` twice would otherwise skip a cycle slot.
+    staged: list[tuple[_DispatchedAlert, list[str], LogsAlertEvent | None]] = []
+    for d in dispatched:
+        update_fields, event = _stage_alert_for_save(d, now)
+        staged.append((d, update_fields, event))
+
+    events = [event for _, _, event in staged if event is not None]
+    alerts = [d.evaluation.alert for d, _, _ in staged]
+
+    event_insert_ms: int | None = None
+    update_ms: int | None = None
+    saved: list[_DispatchedAlert] = list(dispatched)
+    failed: list[_DispatchedAlert] = []
+    try:
+        with transaction.atomic():
+            if events:
+                event_insert_start = time.perf_counter()
+                LogsAlertEvent.objects.bulk_create(events)
+                event_insert_ms = int((time.perf_counter() - event_insert_start) * 1000)
+
+            update_start = time.perf_counter()
+            LogsAlertConfiguration.objects.bulk_update(alerts, fields=_COHORT_UPDATE_FIELDS)
+            update_ms = int((time.perf_counter() - update_start) * 1000)
+    except IntegrityError as e:
+        # Recover the rest of the cohort via per-alert UPDATEs using the
+        # already-staged data.
+        logger.warning(
+            "Cohort bulk save hit IntegrityError; falling back to per-alert",
+            error=str(e),
+            cohort_size=len(dispatched),
+        )
+        capture_exception(e, {"cohort_size": len(dispatched), "fallback": "per_alert"})
+        increment_cohort_save_fallback("integrity_error")
+        saved, failed = _save_staged_per_alert(staged)
+
+    save_ms = int((time.perf_counter() - save_start) * 1000)
+    try:
+        record_cohort_save_duration(save_ms)
+        if event_insert_ms is not None:
+            record_cohort_event_insert_duration(event_insert_ms)
+        if update_ms is not None:
+            record_cohort_update_duration(update_ms)
+    except Exception:
+        logger.exception("Failed to record cohort save metrics")
+
+    return saved, failed
+
+
+def _save_staged_per_alert(
+    staged: list[tuple[_DispatchedAlert, list[str], LogsAlertEvent | None]],
+) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert]]:
+    """Fallback path used when `bulk_update` raises `IntegrityError`.
+
+    Returns `(saved, failed)`. Each alert saves independently so a single bad
+    row doesn't strand the cohort. Takes pre-staged tuples (alert already
+    mutated, event already instantiated) so we don't re-run
+    `_stage_alert_for_save` and accidentally advance `next_check_at` twice.
+    """
+    saved: list[_DispatchedAlert] = []
+    failed: list[_DispatchedAlert] = []
+    for d, update_fields, event in staged:
+        try:
+            with transaction.atomic():
+                if event is not None:
+                    event.save()
+                d.evaluation.alert.save(update_fields=update_fields)
+            saved.append(d)
+        except Exception as e:
+            logger.exception(
+                "Per-alert fallback save failed",
+                alert_id=str(d.evaluation.alert.id),
+                team_id=d.evaluation.alert.team_id,
+            )
+            capture_exception(e, {"alert_id": str(d.evaluation.alert.id), "phase": "per_alert_fallback"})
+            failed.append(d)
+    return saved, failed
+
+
+def _finalize_alert(dispatched: _DispatchedAlert, elapsed_ms: int, stats: dict[str, int]) -> None:
+    """Per-alert post-save bookkeeping: cycle stats + metrics that depend on the committed state.
+
+    Runs serially (not gathered) so `stats` mutation stays single-threaded.
+    `elapsed_ms` is the precomputed eval + dispatch duration captured by the
+    orchestrator at the end of Phase 2 — *before* Phase 3 (the cohort bulk save)
+    starts. `record_check_duration` therefore measures only the per-alert work,
+    matching the metric description; cohort save time is captured separately by
+    `record_cohort_save_duration`.
+    """
+    evaluation = dispatched.evaluation
+    outcome = evaluation.outcome
+    committed_state = dispatched.committed_outcome.new_state
+
+    stats["checked"] += 1
+    if outcome.error_message:
+        stats["errored"] += 1
+    elif not dispatched.notification_failed:
+        if outcome.notification == NotificationAction.FIRE:
+            stats["fired"] += 1
+        elif outcome.notification == NotificationAction.RESOLVE:
+            stats["resolved"] += 1
+
+    try:
+        record_check_duration(elapsed_ms)
+
+        if outcome.error_message:
+            increment_checks_total("errored")
+        elif dispatched.notification_failed:
+            increment_checks_total("errored")
+        elif outcome.notification == NotificationAction.FIRE:
+            increment_checks_total("fired")
+        elif outcome.notification == NotificationAction.RESOLVE:
+            increment_checks_total("resolved")
+        else:
+            increment_checks_total("ok")
+
+        if dispatched.notification_failed:
+            increment_notification_failures(outcome.notification)
+
+        state_before_enum = AlertState(evaluation.state_before)
+        if committed_state != state_before_enum:
+            increment_state_transition(state_before_enum, committed_state)
+    except Exception:
+        logger.exception("Failed to record alert finalize metrics", alert_id=str(evaluation.alert.id))
+
+
 def _evaluate_single_alert(
     alert: LogsAlertConfiguration,
     now: datetime,
-    stats: dict[str, int],
     *,
     checkpoint: datetime | None = None,
-) -> None:
-    """Run the ClickHouse query, apply state machine, persist, and emit events for a single alert.
+    prefetched: _PrefetchedQuery | None = None,
+) -> _AlertEvaluation:
+    """Phase 1: run the CH query (or use prefetched buckets), apply the state machine, return the outcome.
+
+    Pure-ish — does not dispatch Kafka, does not write to Postgres. The cohort
+    orchestrator handles both side-effect phases.
 
     Stateless eval: a single bucketed CH query returns the last M counts; the
     N-of-M evaluator decides from those buckets directly. Anchored on
     `next_check_at` so two evals at different actual eval times produce the
     same query.
+
+    `prefetched` is set when the caller already ran a batched query for the
+    alert's cohort — either with the alert's bucket slice, or with the cohort's
+    error (re-raised inside the try block to flow through the same
+    classification as a per-alert failure).
     """
-    start_time = time.perf_counter()
     original_next_check_at = alert.next_check_at
 
     # First-run alerts (`next_check_at` still null after enable) anchor on `now`;
@@ -304,14 +871,20 @@ def _evaluate_single_alert(
     recent_breaches: tuple[bool, ...] = ()
     error_category: AlertErrorCode | None = None
     try:
-        query_start = time.perf_counter()
-        buckets = AlertCheckQuery(
-            team=alert.team,
-            alert=alert,
-            date_from=date_from,
-            date_to=date_to,
-        ).execute_bucketed(interval_minutes=alert.window_minutes, limit=alert.evaluation_periods)
-        query_duration_ms = int((time.perf_counter() - query_start) * 1000)
+        if prefetched is not None and prefetched.error is not None:
+            raise prefetched.error
+        if prefetched is not None and prefetched.buckets is not None:
+            buckets = prefetched.buckets
+            query_duration_ms = prefetched.query_duration_ms if prefetched.query_duration_ms is not None else 0
+        else:
+            query_start = time.perf_counter()
+            buckets = AlertCheckQuery(
+                team=alert.team,
+                alert=alert,
+                date_from=date_from,
+                date_to=date_to,
+            ).execute_bucketed(interval_minutes=alert.window_minutes, limit=alert.evaluation_periods)
+            query_duration_ms = int((time.perf_counter() - query_start) * 1000)
 
         # execute_bucketed returns ASC (oldest first); state machine wants newest first.
         # Buckets that are entirely empty are absent from the result, so a sparse window
@@ -346,103 +919,29 @@ def _evaluate_single_alert(
 
     outcome = evaluate_alert_check(alert.to_snapshot(recent_events_breached=recent_breaches), check_result, now)
 
-    # Attempt Kafka delivery BEFORE committing state transition.
-    # If delivery fails and we needed to notify, keep old state so the
-    # next tick retries the full transition (NOT_FIRING → FIRING again).
-    notification_failed = _dispatch_notification(
-        outcome, alert, check_result, now, stats, date_from=date_from, date_to=date_to
-    )
-    # If the notification delivery failed, don't commit the state transition
-    # so the next tick will re-evaluate and retry the notification.
-    if notification_failed:
-        committed_outcome = dataclasses.replace(outcome, new_state=AlertState(alert.state))
-    else:
-        committed_outcome = outcome
-    committed_state = committed_outcome.new_state
-
-    state_before = alert.state
-    state_changed = state_before != committed_state.value
-    is_error = outcome.error_message is not None
-    save_start = time.perf_counter()
-    event_create_ms: int | None = None
-    with transaction.atomic():
-        # Stateless eval: write a CHECK row only on state transition or eval error.
-        # Steady-state same-state evals don't write — the N-of-M evaluator gets its
-        # window from the bucketed CH query, not from PG.
-        if state_changed or is_error:
-            event_create_start = time.perf_counter()
-            LogsAlertEvent.objects.create(
-                alert=alert,
-                result_count=check_result.result_count,
-                threshold_breached=check_result.threshold_breached,
-                state_before=state_before,
-                state_after=committed_state.value,
-                error_message=outcome.error_message,
-                query_duration_ms=check_result.query_duration_ms,
-            )
-            event_create_ms = int((time.perf_counter() - event_create_start) * 1000)
-
-        # All state/consecutive_failures writes go through apply_outcome —
-        # single source of truth, enforced by the semgrep rule.
-        update_fields = apply_outcome(alert, committed_outcome)
-        alert.last_checked_at = now
-        alert.next_check_at = advance_next_check_at(alert.next_check_at, alert.check_interval_minutes, now)
-        update_fields.extend(["last_checked_at", "next_check_at", "updated_at"])
-
-        if (
-            not notification_failed
-            and outcome.notification != NotificationAction.NONE
-            and outcome.update_last_notified_at
-        ):
-            alert.last_notified_at = now
-            update_fields.append("last_notified_at")
-
-        update_start = time.perf_counter()
-        alert.save(update_fields=update_fields)
-        update_ms = int((time.perf_counter() - update_start) * 1000)
-    save_ms = int((time.perf_counter() - save_start) * 1000)
-
-    stats["checked"] += 1
-
-    if outcome.error_message:
-        stats["errored"] += 1
-
-    # Per-alert metrics — must never break alerting
+    # Eval-phase metrics: CH-side and scheduler lag. Save/dispatch metrics fire
+    # later in their own phases.
     try:
-        elapsed_ms = int((time.perf_counter() - start_time) * 1000)
-        record_check_duration(elapsed_ms)
-        record_alert_save_duration(save_ms)
-        if event_create_ms is not None:
-            record_alert_event_create_duration(event_create_ms)
-        record_alert_update_duration(update_ms)
         if check_result.query_duration_ms is not None:
             record_clickhouse_duration(check_result.query_duration_ms)
         if original_next_check_at is not None:
             lag_ms = int((now - original_next_check_at).total_seconds() * 1000)
             if lag_ms > 0:
                 record_scheduler_lag(lag_ms)
-        if outcome.error_message:
-            increment_checks_total("errored")
-        elif notification_failed:
-            increment_checks_total("errored")
-        elif outcome.notification == NotificationAction.FIRE:
-            increment_checks_total("fired")
-        elif outcome.notification == NotificationAction.RESOLVE:
-            increment_checks_total("resolved")
-        else:
-            increment_checks_total("ok")
-
         if error_category is not None:
             increment_check_errors(error_category)
-
-        if notification_failed:
-            increment_notification_failures(outcome.notification)
-
-        state_before_enum = AlertState(state_before)
-        if committed_state != state_before_enum:
-            increment_state_transition(state_before_enum, committed_state)
     except Exception:
-        logger.exception("Failed to record alert check metrics", alert_id=str(alert.id))
+        logger.exception("Failed to record alert eval metrics", alert_id=str(alert.id))
+
+    return _AlertEvaluation(
+        alert=alert,
+        outcome=outcome,
+        check_result=check_result,
+        date_from=date_from,
+        date_to=date_to,
+        error_category=error_category,
+        state_before=alert.state,
+    )
 
 
 def _produce_alert_internal_event(

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -154,7 +154,11 @@ def increment_checkpoint_unavailable() -> None:
 
 
 def record_check_duration(duration_ms: int) -> None:
-    _record_histogram("logs_alerting_check_duration_ms", "Per-alert evaluation duration", duration_ms)
+    _record_histogram(
+        "logs_alerting_check_duration_ms",
+        "Per-alert end-to-end duration (eval + dispatch); cohort bulk save excluded — see logs_alerting_cohort_save_ms",
+        duration_ms,
+    )
 
 
 def record_clickhouse_duration(duration_ms: int) -> None:
@@ -173,28 +177,46 @@ def record_semaphore_wait(wait_ms: int) -> None:
     )
 
 
-def record_alert_save_duration(duration_ms: int) -> None:
+def record_cohort_save_duration(duration_ms: int) -> None:
     _record_histogram(
-        "logs_alerting_alert_save_ms",
-        "Postgres write time for the per-eval alert state update (full transaction)",
+        "logs_alerting_cohort_save_ms",
+        "Postgres write time for the per-cohort bulk save (full transaction: bulk_create + bulk_update)",
         duration_ms,
     )
 
 
-def record_alert_event_create_duration(duration_ms: int) -> None:
+def record_cohort_event_insert_duration(duration_ms: int) -> None:
     _record_histogram(
-        "logs_alerting_alert_event_create_ms",
-        "Postgres INSERT time for the per-eval LogsAlertEvent audit row (only on state change or error)",
+        "logs_alerting_cohort_event_insert_ms",
+        "Postgres bulk_create time for LogsAlertEvent rows in a cohort (only on state changes or errors)",
         duration_ms,
     )
 
 
-def record_alert_update_duration(duration_ms: int) -> None:
+def record_cohort_update_duration(duration_ms: int) -> None:
     _record_histogram(
-        "logs_alerting_alert_update_ms",
-        "Postgres UPDATE time for the alert configuration row (without surrounding transaction overhead)",
+        "logs_alerting_cohort_update_ms",
+        "Postgres bulk_update time for LogsAlertConfiguration rows in a cohort",
         duration_ms,
     )
+
+
+def record_cohort_size(size: int) -> None:
+    _record_histogram(
+        "logs_alerting_cohort_size",
+        "Number of alerts in a cohort sharing one batched ClickHouse query and one bulk Postgres save",
+        size,
+    )
+
+
+def increment_cohort_save_fallback(reason: str) -> None:
+    """Counts cohort bulk-save failures that triggered the per-alert fallback path."""
+    meter = get_metric_meter({"reason": reason})
+    counter = meter.create_counter(
+        "logs_alerting_cohort_save_fallback_total",
+        "Cohort bulk-save fell back to per-alert UPDATEs (e.g. IntegrityError)",
+    )
+    counter.add(1)
 
 
 def record_scheduler_lag(lag_ms: int) -> None:

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -16,6 +16,8 @@ from products.logs.backend.alert_check_query import (
     CHECKPOINT_MAX_STALENESS,
     AlertCheckCountResult,
     AlertCheckQuery,
+    BatchedAlertCheckQuery,
+    BatchedBucketedResult,
     BucketedCount,
     fetch_live_logs_checkpoint,
     is_projection_eligible,
@@ -622,6 +624,495 @@ class TestAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
         ):
             with self.assertRaisesRegex(Exception, "ClickHouse timeout"):
                 query.execute()
+
+
+class TestBatchedAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
+    """Per-team batching: run N alerts in one CH query via `countIf(<predicate>)`.
+
+    Equivalence assertion is the heart of the test surface — for every alert in
+    a batch, the per-alert column from the batched query must match what the
+    single-alert `AlertCheckQuery.execute_bucketed` returns against the same
+    window. Anything else and we silently break alert correctness.
+    """
+
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            rows = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                rows += json.dumps(log_item) + "\n"
+            sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + rows)
+
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Test Alert",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "filters": {},
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    def _date_range(self) -> tuple[datetime, datetime]:
+        return datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC), datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC)
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_returns_per_alert_buckets(self):
+        alert_a = self._make_alert(name="A", filters={"serviceNames": ["argo-rollouts"]})
+        alert_b = self._make_alert(name="B", filters={"serviceNames": ["billing"]})
+        date_from, date_to = self._date_range()
+
+        result = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert_a, alert_b], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        assert isinstance(result, BatchedBucketedResult)
+        assert set(result.per_alert.keys()) == {str(alert_a.id), str(alert_b.id)}
+        assert result.query_duration_ms >= 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_per_alert_counts_match_single_alert_query(self):
+        # Equivalence guarantee: every per-alert bucket column from the batched
+        # query must match what a single-alert AlertCheckQuery returns. If they
+        # diverge, alert correctness silently breaks for every batched alert.
+        alert_a = self._make_alert(name="A", filters={"serviceNames": ["argo-rollouts"]})
+        alert_b = self._make_alert(name="B", filters={"serviceNames": ["billing"], "severityLevels": ["info"]})
+        date_from, date_to = self._date_range()
+
+        batched = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert_a, alert_b], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        for alert in (alert_a, alert_b):
+            single = AlertCheckQuery(
+                team=self.team, alert=alert, date_from=date_from, date_to=date_to
+            ).execute_bucketed(interval_minutes=5)
+            batched_for_alert = batched.per_alert[str(alert.id)]
+
+            # Batched returns a row per cohort bucket (every bucket the team has data
+            # in), with count=0 entries for buckets where this alert's predicate
+            # didn't match. Single-alert only emits buckets where the alert matched.
+            # So filter the batched view to the same set before comparing.
+            non_zero_batched = [b for b in batched_for_alert if b.count > 0]
+            assert non_zero_batched == single, f"alert={alert.name}"
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_single_alert_cohort_is_supported(self):
+        # The activity sends every cohort through the batched path even when
+        # there's only one alert in it. Verify N=1 behaves correctly.
+        alert = self._make_alert(filters={"serviceNames": ["argo-rollouts"]})
+        date_from, date_to = self._date_range()
+
+        result = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        assert list(result.per_alert.keys()) == [str(alert.id)]
+        non_zero = [b for b in result.per_alert[str(alert.id)] if b.count > 0]
+        assert len(non_zero) > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_empty_alerts_raises(self):
+        date_from, date_to = self._date_range()
+        with self.assertRaisesRegex(ValueError, "at least one alert"):
+            BatchedAlertCheckQuery(team=self.team, alerts=[], date_from=date_from, date_to=date_to)
+
+    def test_team_mismatch_raises(self):
+        from posthog.models import Organization, Team
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        alert = self._make_alert()
+
+        with self.assertRaisesRegex(ValueError, "All alerts in a batch must belong to the same team"):
+            BatchedAlertCheckQuery(
+                team=other_team,
+                alerts=[alert],
+                date_from=datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC),
+                date_to=datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC),
+            )
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_mixed_projection_eligibility_drops_to_raw_scan(self):
+        # If any alert in the batch has a body filter, the cohort drops projection
+        # eligibility — entire batch falls back to raw scan. Both columns still
+        # produce correct counts; this test just verifies the query runs.
+        alert_proj = self._make_alert(name="P", filters={"serviceNames": ["argo-rollouts"]})
+        alert_body = self._make_alert(
+            name="B",
+            filters={
+                "serviceNames": ["argo-rollouts"],
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "message",
+                                    "value": "Argo Rollouts Dashboard",
+                                    "operator": "icontains",
+                                    "type": "log",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+        date_from, date_to = self._date_range()
+
+        result = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert_proj, alert_body], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        assert set(result.per_alert.keys()) == {str(alert_proj.id), str(alert_body.id)}
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_no_matching_logs_returns_zero_counts(self):
+        alert_a = self._make_alert(name="A", filters={"serviceNames": ["nonexistent-a"]})
+        alert_b = self._make_alert(name="B", filters={"serviceNames": ["nonexistent-b"]})
+        date_from, date_to = self._date_range()
+
+        result = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert_a, alert_b], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        # When no alert has matching logs, the team scan still emits buckets for
+        # rows that exist in the window — but all per-alert columns are 0. If the
+        # team has no logs at all in the window, we get an empty per_alert list.
+        for alert in (alert_a, alert_b):
+            buckets = result.per_alert[str(alert.id)]
+            assert all(b.count == 0 for b in buckets)
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_buckets_in_ascending_order(self):
+        alert_a = self._make_alert(name="A", filters={"serviceNames": ["argo-rollouts"]})
+        alert_b = self._make_alert(name="B", filters={"serviceNames": ["billing"]})
+        date_from, date_to = self._date_range()
+
+        result = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert_a, alert_b], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        for alert in (alert_a, alert_b):
+            timestamps = [b.timestamp for b in result.per_alert[str(alert.id)]]
+            assert timestamps == sorted(timestamps), f"alert={alert.name}"
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_query_failure_propagates(self):
+        alert = self._make_alert()
+        date_from, date_to = self._date_range()
+        query = BatchedAlertCheckQuery(team=self.team, alerts=[alert], date_from=date_from, date_to=date_to)
+        with patch(
+            "products.logs.backend.alert_check_query.execute_hogql_query",
+            side_effect=Exception("ClickHouse timeout"),
+        ):
+            with self.assertRaisesRegex(Exception, "ClickHouse timeout"):
+                query.execute_bucketed(interval_minutes=5)
+
+    @freeze_time("2025-12-16T11:00:00Z")
+    def test_per_alert_results_match_single_query_across_random_inputs(self):
+        # Generative property test: the batched query must produce the same
+        # per-alert bucket counts as running each alert through `AlertCheckQuery`
+        # individually. We seed several services worth of logs at random
+        # timestamps, build one alert per service, run them as a batched cohort,
+        # and assert each alert's per_alert slice matches the single-alert result.
+        # Sparse buckets (count=0 in batched, absent in single) are reconciled by
+        # filtering count>0 before comparison — same convention as the single
+        # query test suite.
+        import random as _random
+
+        rng = _random.Random(7)
+        base = datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC)
+        range_seconds = 2 * 3600
+
+        # Build N services, each with a random log distribution.
+        n_services = 6
+        all_rows: list[dict] = []
+        services: list[str] = []
+        for trial in range(n_services):
+            service_name = f"batched_equiv_test_{trial}"
+            services.append(service_name)
+            n_logs = rng.randint(0, 150)  # include 0 so we exercise sparse alerts
+            for i in range(n_logs):
+                off = rng.randint(0, range_seconds - 1)
+                all_rows.append(
+                    {
+                        "uuid": f"batched-equiv-{trial}-{i}",
+                        "team_id": self.team.id,
+                        "timestamp": (base + dt.timedelta(seconds=off)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+                        "body": "",
+                        "severity_text": "info",
+                        "severity_number": 9,
+                        "service_name": service_name,
+                        "resource_attributes": {},
+                        "attributes_map_str": {},
+                    }
+                )
+        if all_rows:
+            sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in all_rows))
+
+        alerts = [self._make_alert(name=svc, filters={"serviceNames": [svc]}) for svc in services]
+        date_from = base
+        date_to = base + dt.timedelta(seconds=range_seconds)
+
+        for bucket_minutes in (1, 5, 15, 30):
+            batched = BatchedAlertCheckQuery(
+                team=self.team, alerts=alerts, date_from=date_from, date_to=date_to
+            ).execute_bucketed(interval_minutes=bucket_minutes, limit=10_000)
+
+            for alert in alerts:
+                single = AlertCheckQuery(
+                    team=self.team, alert=alert, date_from=date_from, date_to=date_to
+                ).execute_bucketed(interval_minutes=bucket_minutes, limit=10_000)
+                batched_for_alert = batched.per_alert[str(alert.id)]
+                non_zero_batched = [b for b in batched_for_alert if b.count > 0]
+                assert non_zero_batched == single, (
+                    f"alert={alert.name} bucket_minutes={bucket_minutes}\n"
+                    f"batched (non-zero): {non_zero_batched}\n"
+                    f"single:             {single}"
+                )
+
+    @freeze_time("2025-12-16T11:00:00Z")
+    def test_sparse_alert_in_busy_cohort_returns_zero_counts(self):
+        # Multi-alert cohort where one alert has matches and one is sparse:
+        # confirm the sparse alert's per_alert slice contains only zeros (the
+        # busy alert's slice is non-empty). Verifies the cohort scan emits a
+        # bucket per data-bearing timestamp and the zero-matching alert reports
+        # a 0 for every such bucket.
+        rows = [
+            {
+                "uuid": f"busy-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "batched_busy",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 10:00:30",
+                    "2025-12-16 10:01:00",
+                    "2025-12-16 10:05:30",
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        busy = self._make_alert(name="busy", filters={"serviceNames": ["batched_busy"]})
+        sparse = self._make_alert(name="sparse", filters={"serviceNames": ["batched_sparse_no_data"]})
+        result = BatchedAlertCheckQuery(
+            team=self.team,
+            alerts=[busy, sparse],
+            date_from=datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        busy_buckets = result.per_alert[str(busy.id)]
+        sparse_buckets = result.per_alert[str(sparse.id)]
+
+        # Cohort scan emitted buckets for the data-bearing timestamps; busy's
+        # counts sum to the inserted log count, sparse's are all zero.
+        assert sum(b.count for b in busy_buckets) == len(rows)
+        assert sparse_buckets, "expected the cohort scan to emit buckets covering busy's data"
+        assert all(b.count == 0 for b in sparse_buckets)
+        assert [b.timestamp for b in busy_buckets] == [b.timestamp for b in sparse_buckets]
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_excludes_log_at_exact_date_to(self):
+        # Half-open [date_from, date_to). A log timestamped exactly at date_to
+        # must be excluded for every alert in the cohort.
+        rows = [
+            {
+                "uuid": f"bnd-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "batched_boundary",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 10:09:59.999999",  # included
+                    "2025-12-16 10:10:00.000000",  # exactly date_to → excluded
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["batched_boundary"]})
+        result = BatchedAlertCheckQuery(
+            team=self.team,
+            alerts=[alert],
+            date_from=datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        non_zero = {
+            (b.timestamp.replace(tzinfo=UTC) if b.timestamp.tzinfo is None else b.timestamp): b.count
+            for b in result.per_alert[str(alert.id)]
+            if b.count > 0
+        }
+        # Only the .999999 log is counted; the .000000 log at date_to is excluded.
+        assert non_zero == {datetime(2025, 12, 16, 10, 5, 0, tzinfo=UTC): 1}
+
+    @freeze_time("2025-12-17T01:00:00Z")
+    def test_buckets_correct_across_midnight_boundary(self):
+        # Cadence-grid bucketing anchors at midnight UTC — buckets that span
+        # the day rollover must land in the right slot in the batched path too.
+        rows = [
+            {
+                "uuid": f"mid-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "batched_midnight",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 23:55:00.000000",  # bucket [23:55, 24:00)
+                    "2025-12-16 23:59:59.999999",  # bucket [23:55, 24:00)
+                    "2025-12-17 00:00:00.000000",  # bucket [00:00, 00:05)
+                    "2025-12-17 00:04:59.999999",  # bucket [00:00, 00:05)
+                    "2025-12-17 00:05:00.000000",  # bucket [00:05, 00:10)
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["batched_midnight"]})
+        result = BatchedAlertCheckQuery(
+            team=self.team,
+            alerts=[alert],
+            date_from=datetime(2025, 12, 16, 23, 50, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 17, 0, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        actual = {
+            (b.timestamp.replace(tzinfo=UTC) if b.timestamp.tzinfo is None else b.timestamp): b.count
+            for b in result.per_alert[str(alert.id)]
+            if b.count > 0
+        }
+        expected = {
+            datetime(2025, 12, 16, 23, 55, 0, tzinfo=UTC): 2,
+            datetime(2025, 12, 17, 0, 0, 0, tzinfo=UTC): 2,
+            datetime(2025, 12, 17, 0, 5, 0, tzinfo=UTC): 1,
+        }
+        assert actual == expected
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_subsecond_precision_at_boundaries(self):
+        # DateTime64(6) precision: a log at :04:59.999999 belongs in [10:00, 10:05);
+        # one at :05:00.000000 belongs in [10:05, 10:10). Ensure batched bucket
+        # alignment respects that.
+        rows = [
+            {
+                "uuid": f"sub-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "batched_subsecond",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, ts in enumerate(
+                [
+                    "2025-12-16 10:04:59.999999",  # bucket [10:00, 10:05)
+                    "2025-12-16 10:05:00.000000",  # bucket [10:05, 10:10)
+                    "2025-12-16 10:05:00.000001",  # bucket [10:05, 10:10)
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert = self._make_alert(filters={"serviceNames": ["batched_subsecond"]})
+        result = BatchedAlertCheckQuery(
+            team=self.team,
+            alerts=[alert],
+            date_from=datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC),
+        ).execute_bucketed(interval_minutes=5)
+
+        actual = {
+            (b.timestamp.replace(tzinfo=UTC) if b.timestamp.tzinfo is None else b.timestamp): b.count
+            for b in result.per_alert[str(alert.id)]
+            if b.count > 0
+        }
+        assert actual == {
+            datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC): 1,
+            datetime(2025, 12, 16, 10, 5, 0, tzinfo=UTC): 2,
+        }
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucket_placement_matches_single_query(self):
+        # Targeted equivalence test: seed five logs at known timestamps that
+        # split across two 5-minute buckets, run batched with two alerts (one
+        # service-only, one service+severity), assert per-alert results match
+        # the single-alert path bucket-for-bucket.
+        rows = [
+            {
+                "uuid": f"placement-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": severity,
+                "severity_number": 9,
+                "service_name": "batched_placement",
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, (ts, severity) in enumerate(
+                [
+                    ("2025-12-16 10:00:30", "info"),
+                    ("2025-12-16 10:01:00", "warn"),
+                    ("2025-12-16 10:04:59", "info"),
+                    ("2025-12-16 10:05:00", "info"),
+                    ("2025-12-16 10:09:59", "warn"),
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        all_alert = self._make_alert(name="all", filters={"serviceNames": ["batched_placement"]})
+        info_alert = self._make_alert(
+            name="info_only",
+            filters={"serviceNames": ["batched_placement"], "severityLevels": ["info"]},
+        )
+        date_from = datetime(2025, 12, 16, 10, 0, 0, tzinfo=UTC)
+        date_to = datetime(2025, 12, 16, 10, 10, 0, tzinfo=UTC)
+
+        batched = BatchedAlertCheckQuery(
+            team=self.team, alerts=[all_alert, info_alert], date_from=date_from, date_to=date_to
+        ).execute_bucketed(interval_minutes=5)
+
+        for alert in (all_alert, info_alert):
+            single = AlertCheckQuery(
+                team=self.team, alert=alert, date_from=date_from, date_to=date_to
+            ).execute_bucketed(interval_minutes=5)
+            non_zero_batched = [b for b in batched.per_alert[str(alert.id)] if b.count > 0]
+            assert non_zero_batched == single, (
+                f"alert={alert.name}\nbatched (non-zero): {non_zero_batched}\nsingle:             {single}"
+            )
 
 
 class TestFetchLiveLogsCheckpoint(APIBaseTest):

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -5,6 +5,7 @@ import datetime as dt
 import threading
 from datetime import UTC, datetime, timedelta
 
+import pytest
 import unittest
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -20,33 +21,79 @@ from parameterized import parameterized
 from posthog.clickhouse.client import sync_execute
 from posthog.errors import QueryErrorCategory
 
-from products.logs.backend.alert_check_query import BucketedCount
+from products.logs.backend.alert_check_query import BatchedBucketedResult, BucketedCount
 from products.logs.backend.alert_state_machine import AlertState, NotificationAction
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.activities import (
     CheckAlertsInput,
     CheckAlertsOutput,
+    _AlertCohort,
     _check_alerts_sync,
     _derive_breaches,
+    _dispatch_for_alert,
     _evaluate_single_alert,
+    _finalize_alert,
+    _save_cohort_outcomes,
     check_alerts_activity,
 )
+
+
+def _evaluate_and_save_one(
+    alert: LogsAlertConfiguration,
+    now: datetime,
+    stats: dict[str, int],
+    *,
+    checkpoint: datetime | None = None,
+) -> None:
+    """Test helper: run the full per-alert pipeline (eval → dispatch → save → finalize).
+
+    Tests in `TestEvaluateSingleAlert` previously called the all-in-one
+    `_evaluate_single_alert`, which is now eval-only. This helper composes the
+    same end-to-end behaviour using the cohort save helpers (with a one-alert
+    cohort) so test assertions on saved state and stats keep working.
+    """
+    eval_start = time.perf_counter()
+    evaluation = _evaluate_single_alert(alert, now, checkpoint=checkpoint)
+    dispatched = _dispatch_for_alert(evaluation, now)
+    elapsed_ms = int((time.perf_counter() - eval_start) * 1000)
+    saved, _failed = _save_cohort_outcomes([dispatched], now)
+    if saved:
+        _finalize_alert(saved[0], elapsed_ms, stats)
+    else:
+        stats["checked"] += 1
+        stats["errored"] += 1
 
 
 def _make_stats() -> dict[str, int]:
     return {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
 
 
-def _mock_buckets(mock_query_cls: MagicMock, counts: list[int]) -> None:
-    """Set execute_bucketed to return BucketedCount entries (oldest-first, ASC order).
-
-    `counts[0]` is the oldest bucket, `counts[-1]` is the newest. The activity
-    reverses this internally so the state-machine sees breaches newest-first.
-    """
+def _bucket_counts_for(counts: list[int]) -> list[BucketedCount]:
+    """Build BucketedCount entries oldest-first matching `counts`."""
     base = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
-    mock_query_cls.return_value.execute_bucketed.return_value = [
-        BucketedCount(timestamp=base + timedelta(minutes=i * 5), count=c) for i, c in enumerate(counts)
-    ]
+    return [BucketedCount(timestamp=base + timedelta(minutes=i * 5), count=c) for i, c in enumerate(counts)]
+
+
+def _mock_buckets(mock_query_cls: MagicMock, counts: list[int]) -> None:
+    """Set AlertCheckQuery().execute_bucketed to return `counts` (oldest-first).
+
+    Used for tests that call `_evaluate_single_alert` directly without prefetched
+    buckets — the per-alert path still goes through `AlertCheckQuery`. For the
+    cohort/sync path see `_mock_batched_buckets`.
+    """
+    mock_query_cls.return_value.execute_bucketed.return_value = _bucket_counts_for(counts)
+
+
+def _mock_batched_buckets(mock_run_batched: MagicMock, counts: list[int]) -> None:
+    """Set `_run_batched_query` to return a BatchedBucketedResult with `counts` for every alert in any cohort."""
+
+    def fake(cohort: _AlertCohort) -> BatchedBucketedResult:
+        return BatchedBucketedResult(
+            per_alert={str(a.id): _bucket_counts_for(counts) for a in cohort.alerts},
+            query_duration_ms=0,
+        )
+
+    mock_run_batched.side_effect = fake
 
 
 class TestCheckAlertsSync(APIBaseTest):
@@ -84,23 +131,23 @@ class TestCheckAlertsSync(APIBaseTest):
         return LogsAlertConfiguration.objects.create(**defaults)
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_no_alerts_returns_zero_stats(self, mock_query_cls):
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_no_alerts_returns_zero_stats(self, mock_run_batched):
         result = _check_alerts_sync()
         assert result == CheckAlertsOutput(alerts_checked=0, alerts_fired=0, alerts_resolved=0, alerts_errored=0)
-        mock_query_cls.assert_not_called()
+        mock_run_batched.assert_not_called()
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_skips_disabled_alerts(self, mock_query_cls):
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_skips_disabled_alerts(self, mock_run_batched):
         self._make_alert(enabled=False)
         result = _check_alerts_sync()
         assert result.alerts_checked == 0
-        mock_query_cls.assert_not_called()
+        mock_run_batched.assert_not_called()
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_skips_snoozed_alerts(self, mock_query_cls):
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_skips_snoozed_alerts(self, mock_run_batched):
         self._make_alert(
             state=LogsAlertConfiguration.State.SNOOZED,
             snooze_until=datetime(2025, 1, 2, 0, 0, 0, tzinfo=UTC),
@@ -109,40 +156,40 @@ class TestCheckAlertsSync(APIBaseTest):
         assert result.alerts_checked == 0
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_skips_broken_alerts(self, mock_query_cls):
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_skips_broken_alerts(self, mock_run_batched):
         self._make_alert(state=LogsAlertConfiguration.State.BROKEN)
         result = _check_alerts_sync()
         assert result.alerts_checked == 0
-        mock_query_cls.assert_not_called()
+        mock_run_batched.assert_not_called()
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_picks_up_due_alert(self, mock_query_cls):
-        _mock_buckets(mock_query_cls, [5])
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_picks_up_due_alert(self, mock_run_batched):
+        _mock_batched_buckets(mock_run_batched, [5])
         self._make_alert()
         result = _check_alerts_sync()
         assert result.alerts_checked == 1
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_picks_up_null_next_check_at(self, mock_query_cls):
-        _mock_buckets(mock_query_cls, [5])
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_picks_up_null_next_check_at(self, mock_run_batched):
+        _mock_batched_buckets(mock_run_batched, [5])
         self._make_alert(next_check_at=None)
         result = _check_alerts_sync()
         assert result.alerts_checked == 1
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_skips_future_next_check_at(self, mock_query_cls):
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_skips_future_next_check_at(self, mock_run_batched):
         self._make_alert(next_check_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC))
         result = _check_alerts_sync()
         assert result.alerts_checked == 0
 
     @freeze_time("2025-01-01T00:01:00Z")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_clickhouse_error_records_errored_check(self, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.side_effect = RuntimeError("boom")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_clickhouse_error_records_errored_check(self, mock_run_batched):
+        mock_run_batched.side_effect = RuntimeError("boom")
         self._make_alert()
         result = _check_alerts_sync()
         # ClickHouse error is caught inside _evaluate_single_alert, alert is still "checked"
@@ -166,10 +213,10 @@ class TestCheckAlertsSync(APIBaseTest):
     )
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.record_alerts_active")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    def test_records_alerts_active_gauge(self, _name, seed_alerts, expected_count, mock_query_cls, mock_record_gauge):
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_records_alerts_active_gauge(self, _name, seed_alerts, expected_count, mock_run_batched, mock_record_gauge):
         if seed_alerts:
-            _mock_buckets(mock_query_cls, [5])
+            _mock_batched_buckets(mock_run_batched, [5])
             self._make_alert()
             self._make_alert(name="Second")
             # Disabled and snoozed alerts should not count toward the gauge.
@@ -187,13 +234,13 @@ class TestCheckAlertsSync(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
     @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
     def test_fetches_checkpoint_once_and_passes_to_evaluator(
-        self, mock_query_cls, mock_fetch_checkpoint, mock_record_lag
+        self, mock_run_batched, mock_fetch_checkpoint, mock_record_lag
     ):
         checkpoint = datetime(2025, 1, 1, 0, 0, 30, tzinfo=UTC)
         mock_fetch_checkpoint.return_value = checkpoint
-        _mock_buckets(mock_query_cls, [5])
+        _mock_batched_buckets(mock_run_batched, [5])
         self._make_alert()
         self._make_alert(name="Second")
 
@@ -209,9 +256,9 @@ class TestCheckAlertsSync(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.increment_checkpoint_unavailable")
     @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
     @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint")
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
     def test_skips_checkpoint_fetch_when_no_due_alerts(
-        self, _mock_query_cls, mock_fetch_checkpoint, mock_record_lag, mock_unavailable
+        self, _mock_run_batched, mock_fetch_checkpoint, mock_record_lag, mock_unavailable
     ):
         _check_alerts_sync()
 
@@ -223,11 +270,11 @@ class TestCheckAlertsSync(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.increment_checkpoint_unavailable")
     @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
     @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint", side_effect=RuntimeError("CH down"))
-    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
     def test_checkpoint_fetch_failure_falls_back_to_wall_clock(
-        self, mock_query_cls, _mock_fetch, mock_record_lag, mock_unavailable
+        self, mock_run_batched, _mock_fetch, mock_record_lag, mock_unavailable
     ):
-        _mock_buckets(mock_query_cls, [5])
+        _mock_batched_buckets(mock_run_batched, [5])
         self._make_alert()
 
         result = _check_alerts_sync()
@@ -238,13 +285,45 @@ class TestCheckAlertsSync(APIBaseTest):
         mock_unavailable.assert_called_once()
 
 
+def _stub_one_cohort_per_alert(alerts, *, now, checkpoint):
+    """Wrap each MagicMock alert into its own single-alert cohort.
+
+    Used by concurrency tests so the cohort dispatch loop fires one cohort per
+    MagicMock alert — preserving the per-alert peak-concurrency assertions.
+    """
+    for a in alerts:
+        a.window_minutes = 5
+        a.evaluation_periods = 1
+    return [_AlertCohort(alerts=(a,), date_to=now, projection_eligible=True) for a in alerts]
+
+
+def _stub_run_batched_query_empty(cohort: _AlertCohort) -> BatchedBucketedResult:
+    """Return an empty BatchedBucketedResult — concurrency tests don't care about buckets, only call counts."""
+    return BatchedBucketedResult(per_alert={}, query_duration_ms=0)
+
+
+def _stub_save_cohort_outcomes_passthrough(dispatched, now):
+    """Return `(dispatched, [])` — concurrency tests bypass real PG access.
+
+    `_save_cohort_outcomes` returns `(saved, failed)`; orchestrator finalizes the
+    saved list. Pass-through treats every dispatched alert as saved.
+    """
+    return list(dispatched), []
+
+
+@pytest.mark.django_db
 class TestCheckAlertsActivityConcurrency(unittest.TestCase):
     """Async path: bounded concurrency via asyncio.TaskGroup + Semaphore.
 
-    These tests exercise the orchestration layer in isolation by patching the
-    DB-touching helpers (`_load_alerts_and_checkpoint`, `_evaluate_single_alert`).
-    The single-alert eval logic is covered by `TestEvaluateSingleAlert` and
-    `TestEvaluateSingleAlertEndToEnd`; the per-cycle DB read by `TestCheckAlertsSync`.
+    The orchestrator runs three phases per cohort (CH batched query → per-alert
+    eval (sequential) + Kafka dispatch (gathered) → bulk save → finalize). These
+    tests stub every phase except the one under test and assert on the final
+    aggregated `CheckAlertsOutput`. The single-alert eval logic is covered by
+    `TestEvaluateSingleAlert` and `TestEvaluateSingleAlertEndToEnd`; the
+    per-cycle DB read by `TestCheckAlertsSync`.
+
+    Marked `django_db` because `database_sync_to_async_pool` calls
+    `close_old_connections` even when the wrapped function is fully mocked.
     """
 
     @staticmethod
@@ -253,10 +332,11 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
 
     @parameterized.expand([("fired",), ("resolved",), ("errored",)])
     def test_evaluates_all_alerts_and_aggregates_stats(self, outcome):
+        """The activity finalizes each alert exactly once and aggregates stats correctly."""
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         alerts = self._mock_alerts(4)
 
-        def fake_eval(alert, now, stats, *, checkpoint=None):
+        def fake_finalize(dispatched, elapsed_ms, stats):
             stats["checked"] += 1
             stats[outcome] += 1
 
@@ -266,12 +346,26 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
                 return_value=(now, alerts, None),
             ),
             patch(
-                "products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=fake_eval
-            ) as mock_eval,
+                "products.logs.backend.temporal.activities._build_cohorts",
+                side_effect=_stub_one_cohort_per_alert,
+            ),
+            patch(
+                "products.logs.backend.temporal.activities._run_batched_query",
+                side_effect=_stub_run_batched_query_empty,
+            ),
+            patch("products.logs.backend.temporal.activities._evaluate_single_alert", return_value=MagicMock()),
+            patch("products.logs.backend.temporal.activities._dispatch_for_alert", return_value=MagicMock()),
+            patch(
+                "products.logs.backend.temporal.activities._save_cohort_outcomes",
+                side_effect=_stub_save_cohort_outcomes_passthrough,
+            ),
+            patch(
+                "products.logs.backend.temporal.activities._finalize_alert", side_effect=fake_finalize
+            ) as mock_finalize,
         ):
             result = asyncio.run(check_alerts_activity(CheckAlertsInput()))
 
-        assert mock_eval.call_count == 4
+        assert mock_finalize.call_count == 4
         assert result.alerts_checked == 4
         assert getattr(result, f"alerts_{outcome}") == 4
         for other in ("fired", "resolved", "errored"):
@@ -279,7 +373,14 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
                 assert getattr(result, f"alerts_{other}") == 0
 
     def test_bounded_concurrency_does_not_exceed_semaphore_limit(self):
-        """Force overlap; peak concurrent in-flight must equal the semaphore limit."""
+        """Force overlap; peak concurrent in-flight cohorts must equal the semaphore limit.
+
+        Concurrency is measured in `_dispatch_for_alert` because that's the phase
+        wrapped in `database_sync_to_async_pool` — its calls run on a thread pool
+        and thus overlap when multiple cohort tasks hold their semaphore slot.
+        Eval runs sequentially inside the event loop, so it can't be used to
+        observe cohort-level concurrency.
+        """
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         alerts = self._mock_alerts(10)
 
@@ -287,7 +388,7 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
         active = 0
         lock = threading.Lock()
 
-        def fake_eval(alert, now, stats, *, checkpoint=None):
+        def fake_dispatch(evaluation, now, **_kwargs):
             nonlocal peak, active
             with lock:
                 active += 1
@@ -295,6 +396,9 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
             time.sleep(0.05)
             with lock:
                 active -= 1
+            return MagicMock()
+
+        def fake_finalize(dispatched, elapsed_ms, stats):
             stats["checked"] += 1
 
         with (
@@ -302,8 +406,22 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
                 "products.logs.backend.temporal.activities._load_alerts_and_checkpoint",
                 return_value=(now, alerts, None),
             ),
+            patch(
+                "products.logs.backend.temporal.activities._build_cohorts",
+                side_effect=_stub_one_cohort_per_alert,
+            ),
+            patch(
+                "products.logs.backend.temporal.activities._run_batched_query",
+                side_effect=_stub_run_batched_query_empty,
+            ),
             patch("products.logs.backend.temporal.activities.MAX_CONCURRENT_ALERT_EVALS", 3),
-            patch("products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=fake_eval),
+            patch("products.logs.backend.temporal.activities._evaluate_single_alert", return_value=MagicMock()),
+            patch("products.logs.backend.temporal.activities._dispatch_for_alert", side_effect=fake_dispatch),
+            patch(
+                "products.logs.backend.temporal.activities._save_cohort_outcomes",
+                side_effect=_stub_save_cohort_outcomes_passthrough,
+            ),
+            patch("products.logs.backend.temporal.activities._finalize_alert", side_effect=fake_finalize),
         ):
             result = asyncio.run(check_alerts_activity(CheckAlertsInput()))
 
@@ -312,20 +430,23 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
         assert result.alerts_checked == 10
 
     def test_unexpected_error_isolates_to_single_alert(self):
-        """One alert raising must not block the others; the activity counts it as errored."""
+        """One alert's eval raising must not block the others; the activity counts it as errored."""
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         alerts = self._mock_alerts(3)
 
         call_count = 0
         lock = threading.Lock()
 
-        def fake_eval(alert, now, stats, *, checkpoint=None):
+        def fake_eval(alert, now, **_kwargs):
             nonlocal call_count
             with lock:
                 call_count += 1
                 this_call = call_count
             if this_call == 2:
                 raise RuntimeError("kaboom")
+            return MagicMock()
+
+        def fake_finalize(dispatched, elapsed_ms, stats):
             stats["checked"] += 1
 
         with (
@@ -333,12 +454,109 @@ class TestCheckAlertsActivityConcurrency(unittest.TestCase):
                 "products.logs.backend.temporal.activities._load_alerts_and_checkpoint",
                 return_value=(now, alerts, None),
             ),
+            patch(
+                "products.logs.backend.temporal.activities._build_cohorts",
+                side_effect=_stub_one_cohort_per_alert,
+            ),
+            patch(
+                "products.logs.backend.temporal.activities._run_batched_query",
+                side_effect=_stub_run_batched_query_empty,
+            ),
             patch("products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=fake_eval),
+            patch("products.logs.backend.temporal.activities._dispatch_for_alert", return_value=MagicMock()),
+            patch(
+                "products.logs.backend.temporal.activities._save_cohort_outcomes",
+                side_effect=_stub_save_cohort_outcomes_passthrough,
+            ),
+            patch("products.logs.backend.temporal.activities._finalize_alert", side_effect=fake_finalize),
         ):
             result = asyncio.run(check_alerts_activity(CheckAlertsInput()))
 
         assert result.alerts_checked == 2
         assert result.alerts_errored == 1
+
+
+class TestSaveCohortOutcomesFallback(APIBaseTest):
+    """Bulk save fallback semantics: IntegrityError → per-alert UPDATE; other errors → propagate."""
+
+    def setUp(self):
+        super().setUp()
+        for target in (
+            "products.logs.backend.temporal.activities.record_cohort_save_duration",
+            "products.logs.backend.temporal.activities.record_cohort_event_insert_duration",
+            "products.logs.backend.temporal.activities.record_cohort_update_duration",
+            "products.logs.backend.temporal.activities.increment_cohort_save_fallback",
+        ):
+            p = patch(target)
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Test Alert",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "filters": {},
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    def _make_dispatched(self, alert: LogsAlertConfiguration):
+        from products.logs.backend.alert_state_machine import AlertCheckOutcome, CheckResult
+        from products.logs.backend.temporal.activities import _AlertEvaluation, _DispatchedAlert
+
+        outcome = AlertCheckOutcome(
+            new_state=AlertState.NOT_FIRING,
+            notification=NotificationAction.NONE,
+            consecutive_failures=0,
+            update_last_notified_at=False,
+            error_message=None,
+        )
+        evaluation = _AlertEvaluation(
+            alert=alert,
+            outcome=outcome,
+            check_result=CheckResult(result_count=0, threshold_breached=False, query_duration_ms=10),
+            date_from=datetime(2025, 1, 1, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 1, 1, 0, 5, tzinfo=UTC),
+            error_category=None,
+            state_before=alert.state,
+        )
+        return _DispatchedAlert(evaluation=evaluation, notification_failed=False)
+
+    @patch("products.logs.backend.temporal.activities.LogsAlertConfiguration.objects.bulk_update")
+    def test_integrity_error_falls_back_to_per_alert(self, mock_bulk_update):
+        # First call raises IntegrityError (bulk path); per-alert fallback then saves each alert.
+        from django.db.utils import IntegrityError
+
+        mock_bulk_update.side_effect = IntegrityError("constraint violation")
+        alerts = [self._make_alert(name=f"a{i}") for i in range(3)]
+        dispatched = [self._make_dispatched(a) for a in alerts]
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        # Should not raise.
+        _save_cohort_outcomes(dispatched, now)
+
+        # All three alerts should have been saved via per-alert fallback —
+        # advance_next_check_at writes a future next_check_at, so we can verify
+        # the fallback ran by checking each alert was persisted.
+        for alert in alerts:
+            alert.refresh_from_db()
+            assert alert.last_checked_at == now
+
+    @patch("products.logs.backend.temporal.activities.LogsAlertConfiguration.objects.bulk_update")
+    def test_operational_error_propagates(self, mock_bulk_update):
+        # Cluster-level failure — fallback would just retry against the same broken cluster.
+        from django.db.utils import OperationalError
+
+        mock_bulk_update.side_effect = OperationalError("connection lost")
+        alerts = [self._make_alert(name=f"a{i}") for i in range(2)]
+        dispatched = [self._make_dispatched(a) for a in alerts]
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        with self.assertRaises(OperationalError):
+            _save_cohort_outcomes(dispatched, now)
 
 
 class TestEvaluateSingleAlert(APIBaseTest):
@@ -351,9 +569,10 @@ class TestEvaluateSingleAlert(APIBaseTest):
             "products.logs.backend.temporal.activities.record_check_duration",
             "products.logs.backend.temporal.activities.record_scheduler_lag",
             "products.logs.backend.temporal.activities.record_clickhouse_duration",
-            "products.logs.backend.temporal.activities.record_alert_save_duration",
-            "products.logs.backend.temporal.activities.record_alert_event_create_duration",
-            "products.logs.backend.temporal.activities.record_alert_update_duration",
+            "products.logs.backend.temporal.activities.record_cohort_save_duration",
+            "products.logs.backend.temporal.activities.record_cohort_event_insert_duration",
+            "products.logs.backend.temporal.activities.record_cohort_update_duration",
+            "products.logs.backend.temporal.activities.record_cohort_size",
             "products.logs.backend.temporal.activities.increment_checks_total",
             "products.logs.backend.temporal.activities.increment_check_errors",
         ):
@@ -382,7 +601,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING
@@ -400,7 +619,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
@@ -415,7 +634,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         _mock_buckets(mock_query_cls, [5])  # below threshold → stays NOT_FIRING
         alert = self._make_alert()
 
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         assert LogsAlertEvent.objects.filter(alert=alert).count() == 0
 
@@ -428,7 +647,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         check = LogsAlertEvent.objects.get(alert=alert)
         assert check.result_count == 50
@@ -449,7 +668,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         alert.refresh_from_db()
         assert alert.next_check_at is not None and alert.next_check_at > now
@@ -472,7 +691,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         check = LogsAlertEvent.objects.get(alert=alert)
         assert check.result_count is None
@@ -490,7 +709,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         event = mock_produce.call_args.kwargs["event"]
         assert event.distinct_id == f"team_{self.team.id}"
@@ -504,7 +723,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         alert.refresh_from_db()
         assert alert.last_notified_at == now
@@ -519,7 +738,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         alert.refresh_from_db()
         assert alert.last_notified_at is None
@@ -542,7 +761,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, stats)
+        _evaluate_and_save_one(alert, now, stats)
 
         alert.refresh_from_db()
         if should_fire:
@@ -559,14 +778,14 @@ class TestEvaluateSingleAlert(APIBaseTest):
         alert = self._make_alert(state=LogsAlertConfiguration.State.FIRING)
         # First check breached to create an event row for get_recent_breaches
         _mock_buckets(mock_query_cls, [50])
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         mock_produce.reset_mock()
 
         # Second check not breached — should resolve
         _mock_buckets(mock_query_cls, [0])
         stats = _make_stats()
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
@@ -586,7 +805,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         )
         stats = _make_stats()
         # 1 minute after last notification, within 60-min cooldown
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
 
         alert.refresh_from_db()
         # State transitions still happen, but no notification emitted
@@ -604,20 +823,20 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
         # 1-of-3 breach (newest=breach, older two ok) → not enough
         _mock_buckets(mock_query_cls, [0, 0, 50])
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
         # 1-of-3 still (oldest breach, newer two ok) → not enough
         _mock_buckets(mock_query_cls, [50, 0, 0])
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
         # 2-of-3 (oldest ok, two newer breach) → fire
         _mock_buckets(mock_query_cls, [0, 50, 50])
         stats = _make_stats()
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC), stats)
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC), stats)
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING
         assert stats["fired"] == 1
@@ -633,7 +852,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         )
         _mock_buckets(mock_query_cls, [10])
 
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         assert mock_produce.called
         props = mock_produce.call_args.kwargs["event"].properties
@@ -655,7 +874,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         )
         _mock_buckets(mock_query_cls, [10])
 
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         props = mock_produce.call_args.kwargs["event"].properties
         assert "dateRange" in props["logs_url_params"]
@@ -683,7 +902,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         )
 
         stats = _make_stats()
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
 
         alert.refresh_from_db()
         # State transitions to NOT_FIRING regardless of cooldown
@@ -746,7 +965,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             "products.logs.backend.alert_error_classifier.classify_query_error",
             return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
         ):
-            _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+            _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         alert.refresh_from_db()
         assert alert.state == expected_state
@@ -772,7 +991,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
 
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         mock_transition.assert_called_once_with(AlertState.NOT_FIRING, AlertState.FIRING)
 
@@ -784,7 +1003,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         _mock_buckets(mock_query_cls, [5])
         self._make_alert()
 
-        _evaluate_single_alert(
+        _evaluate_and_save_one(
             LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
         )
 
@@ -814,7 +1033,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         _mock_buckets(mock_query_cls, [result_count])
         self._make_alert(state=initial_state)
 
-        _evaluate_single_alert(
+        _evaluate_and_save_one(
             LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
         )
 
@@ -828,7 +1047,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         _mock_buckets(mock_query_cls, [50])
         self._make_alert()
 
-        _evaluate_single_alert(
+        _evaluate_and_save_one(
             LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
         )
 
@@ -861,7 +1080,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             "products.logs.backend.alert_error_classifier.classify_query_error",
             return_value=classifier_category,
         ):
-            _evaluate_single_alert(
+            _evaluate_and_save_one(
                 LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
             )
 
@@ -875,7 +1094,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         _mock_buckets(mock_query_cls, [5])
         self._make_alert()
 
-        _evaluate_single_alert(
+        _evaluate_and_save_one(
             LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
         )
 
@@ -890,7 +1109,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         checkpoint = datetime(2025, 1, 1, 0, 0, 30, tzinfo=UTC)  # 30s behind now
 
-        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=checkpoint)
+        _evaluate_and_save_one(alert, now, _make_stats(), checkpoint=checkpoint)
 
         kwargs = mock_query_cls.call_args.kwargs
         assert kwargs["date_to"] == checkpoint
@@ -906,7 +1125,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         checkpoint = datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC)  # 60s ahead of now
 
-        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=checkpoint)
+        _evaluate_and_save_one(alert, now, _make_stats(), checkpoint=checkpoint)
 
         kwargs = mock_query_cls.call_args.kwargs
         assert kwargs["date_to"] == now
@@ -920,7 +1139,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         alert = self._make_alert(window_minutes=5)
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=None)
+        _evaluate_and_save_one(alert, now, _make_stats(), checkpoint=None)
 
         kwargs = mock_query_cls.call_args.kwargs
         assert kwargs["date_to"] == now
@@ -938,7 +1157,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         now = datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC)
         stale_checkpoint = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)  # 1 hour behind now
 
-        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=stale_checkpoint)
+        _evaluate_and_save_one(alert, now, _make_stats(), checkpoint=stale_checkpoint)
 
         kwargs = mock_query_cls.call_args.kwargs
         assert kwargs["date_to"] == now
@@ -967,7 +1186,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         )
         now = datetime(2025, 1, 1, 5, 0, 0, tzinfo=UTC)
 
-        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=None)
+        _evaluate_and_save_one(alert, now, _make_stats(), checkpoint=None)
 
         kwargs = mock_query_cls.call_args.kwargs
         assert kwargs["date_to"] == now
@@ -986,7 +1205,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             "products.logs.backend.alert_error_classifier.classify_query_error",
             return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
         ):
-            _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+            _evaluate_and_save_one(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.ERRORED
@@ -1009,11 +1228,11 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
         with patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce:
             mock_produce.side_effect = Exception("Kafka down")
-            _evaluate_single_alert(alert, now1, _make_stats())
+            _evaluate_and_save_one(alert, now1, _make_stats())
 
             mock_produce.side_effect = None
             mock_produce.reset_mock()
-            _evaluate_single_alert(alert, now2, _make_stats())
+            _evaluate_and_save_one(alert, now2, _make_stats())
 
         errored_calls = [
             c
@@ -1042,11 +1261,11 @@ class TestEvaluateSingleAlert(APIBaseTest):
             ),
         ):
             mock_produce.side_effect = Exception("Kafka down")
-            _evaluate_single_alert(alert, now1, _make_stats())
+            _evaluate_and_save_one(alert, now1, _make_stats())
 
             mock_produce.side_effect = None
             mock_produce.reset_mock()
-            _evaluate_single_alert(alert, now2, _make_stats())
+            _evaluate_and_save_one(alert, now2, _make_stats())
 
         auto_disabled_calls = [
             c
@@ -1086,7 +1305,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             "products.logs.backend.alert_error_classifier.classify_query_error",
             return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
         ):
-            _evaluate_single_alert(
+            _evaluate_and_save_one(
                 LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
             )
 
@@ -1235,7 +1454,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         )
         stats = _make_stats()
 
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), stats)
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), stats)
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING
@@ -1309,21 +1528,21 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Cycle 1: 1-of-3 breach → stays NOT_FIRING
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 15, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 15, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
         # Cycle 2: 2-of-3 breach AND newest is a breach → fire
         alert.next_check_at = datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC)
         alert.save(update_fields=["next_check_at"])
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING
 
         # Cycle 3: newest bucket (:20) is no-breach → resolve (immediate from FIRING)
         alert.next_check_at = datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC)
         alert.save(update_fields=["next_check_at"])
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
@@ -1346,7 +1565,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Cycle 1: fires (10 logs at :18 in [10:15, 10:20)) → fire notification, sets last_notified_at
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 20, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING
         assert mock_produce.call_count == 1
@@ -1355,7 +1574,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         # but cooldown=30min suppresses the dispatch (only 5 min since fire).
         alert.next_check_at = datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC)
         alert.save(update_fields=["next_check_at"])
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 25, 0, tzinfo=UTC), _make_stats())
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING  # state still transitions
         assert mock_produce.call_count == 1  # but no second notification dispatched
@@ -1377,7 +1596,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
             next_check_at=datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC),
         )
 
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), _make_stats())
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING, (
@@ -1400,7 +1619,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
             next_check_at=None,  # first run
         )
 
-        _evaluate_single_alert(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), _make_stats())
+        _evaluate_and_save_one(alert, datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC), _make_stats())
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -17,15 +17,17 @@ from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
     increment_checks_total,
+    increment_cohort_save_fallback,
     increment_notification_failures,
     increment_state_transition,
-    record_alert_event_create_duration,
-    record_alert_save_duration,
-    record_alert_update_duration,
     record_alerts_active,
     record_check_duration,
     record_checkpoint_lag,
     record_clickhouse_duration,
+    record_cohort_event_insert_duration,
+    record_cohort_save_duration,
+    record_cohort_size,
+    record_cohort_update_duration,
     record_pending_alerts,
     record_schedule_to_start_latency,
     record_scheduler_lag,
@@ -180,7 +182,11 @@ class TestRecordCheckDuration:
     @patch("products.logs.backend.temporal.metrics._record_histogram")
     def test_records_histogram_with_duration(self, mock_record: MagicMock):
         record_check_duration(150)
-        mock_record.assert_called_once_with("logs_alerting_check_duration_ms", "Per-alert evaluation duration", 150)
+        mock_record.assert_called_once_with(
+            "logs_alerting_check_duration_ms",
+            "Per-alert end-to-end duration (eval + dispatch); cohort bulk save excluded — see logs_alerting_cohort_save_ms",
+            150,
+        )
 
 
 class TestRecordClickhouseDuration:
@@ -205,29 +211,36 @@ class TestRecordSemaphoreWait:
         )
 
 
-class TestRecordAlertSaveSubstageDurations:
+class TestRecordCohortSaveSubstageDurations:
     @parameterized.expand(
         [
             (
                 "save_total",
-                record_alert_save_duration,
-                "logs_alerting_alert_save_ms",
-                "Postgres write time for the per-eval alert state update (full transaction)",
+                record_cohort_save_duration,
+                "logs_alerting_cohort_save_ms",
+                "Postgres write time for the per-cohort bulk save (full transaction: bulk_create + bulk_update)",
                 45,
             ),
             (
-                "event_create",
-                record_alert_event_create_duration,
-                "logs_alerting_alert_event_create_ms",
-                "Postgres INSERT time for the per-eval LogsAlertEvent audit row (only on state change or error)",
+                "event_insert",
+                record_cohort_event_insert_duration,
+                "logs_alerting_cohort_event_insert_ms",
+                "Postgres bulk_create time for LogsAlertEvent rows in a cohort (only on state changes or errors)",
                 12,
             ),
             (
-                "alert_update",
-                record_alert_update_duration,
-                "logs_alerting_alert_update_ms",
-                "Postgres UPDATE time for the alert configuration row (without surrounding transaction overhead)",
+                "cohort_update",
+                record_cohort_update_duration,
+                "logs_alerting_cohort_update_ms",
+                "Postgres bulk_update time for LogsAlertConfiguration rows in a cohort",
                 28,
+            ),
+            (
+                "cohort_size",
+                record_cohort_size,
+                "logs_alerting_cohort_size",
+                "Number of alerts in a cohort sharing one batched ClickHouse query and one bulk Postgres save",
+                17,
             ),
         ]
     )
@@ -237,6 +250,22 @@ class TestRecordAlertSaveSubstageDurations:
     ):
         fn(sample_value)
         mock_record.assert_called_once_with(metric_name, description, sample_value)
+
+
+class TestIncrementCohortSaveFallback:
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_increments_counter_with_reason(self, mock_get_meter: MagicMock):
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        mock_get_meter.return_value = mock_meter
+
+        increment_cohort_save_fallback("integrity_error")
+
+        mock_get_meter.assert_called_once_with({"reason": "integrity_error"})
+        (name, _description), _ = mock_meter.create_counter.call_args
+        assert name == "logs_alerting_cohort_save_fallback_total"
+        mock_counter.add.assert_called_once_with(1)
 
 
 class TestRecordPendingAlerts:


### PR DESCRIPTION
## Problem

Each due alert previously issued its own ClickHouse query and its own Postgres `INSERT` + `UPDATE`. For teams with many alerts sharing the same time window, this meant N separate CH partition scans and N separate DB round-trips per evaluation cycle = cost that scales linearly with alert count rather than with data volume.

## Changes

**Per-team batched ClickHouse queries (`BatchedAlertCheckQuery`)**

Alerts that share `(team_id, window_minutes, evaluation_periods, projection_eligible, date_to)` are grouped into a cohort and evaluated in a single CH query using `countIf(<per-alert predicate>)` columns. The partition scan runs once; per-alert predicates are cheap column expressions evaluated against already-read rows.

- Extracted `build_alert_where_expr` and `_build_logs_query` as module-level helpers so both `AlertCheckQuery` and `BatchedAlertCheckQuery` share the same WHERE construction logic.
- `BatchedAlertCheckQuery.execute_bucketed` returns a `BatchedBucketedResult` with a `per_alert` dict keyed by alert ID, plus the shared `query_duration_ms`.

**Three-phase cohort evaluation in the activity**

The `check_alerts_activity` (and its sync test twin `_check_alerts_sync`) now runs three phases per cohort:

1. **Batched CH query** — one `countIf` query per cohort.
2. **Per-alert eval + Kafka dispatch** — state machine runs sequentially (in-memory, GIL-bound); Kafka dispatch is gathered for I/O concurrency.
3. **Bulk Postgres save** — one `bulk_create` for `LogsAlertEvent` rows + one `bulk_update` for `LogsAlertConfiguration` rows per cohort.

**Cohort grouping (`_build_cohorts`)**

Groups due alerts by their cohort key. Single-alert cohorts go through the same batched path — no special-casing needed.

**Bulk save with** **`IntegrityError`** **fallback (`_save_cohort_outcomes`)**

On `IntegrityError` (constraint violation on a single row), falls back to per-alert `UPDATE`s using already-staged data so `advance_next_check_at` isn't called twice. `OperationalError` and `DataError` propagate — retrying against a broken cluster wouldn't help.

**Metrics renamed and extended**

Per-alert save metrics (`record_alert_save_duration`, `record_alert_event_create_duration`, `record_alert_update_duration`) are replaced with cohort-level equivalents (`record_cohort_save_duration`, `record_cohort_event_insert_duration`, `record_cohort_update_duration`). Added `record_cohort_size` histogram and `increment_cohort_save_fallback` counter.

**Eval function decomposed**

`_evaluate_single_alert` is now eval-only (returns `_AlertEvaluation`; no Kafka, no Postgres). `_dispatch_for_alert` handles Kafka. `_finalize_alert` handles post-save stats and metrics. `_stage_alert_for_save` mutates the in-memory alert and produces the event row for the bulk save.

## How did you test this code?

- Added `TestBatchedAlertCheckQuery` with integration tests against real ClickHouse data, including an equivalence assertion that every per-alert column from the batched query matches what `AlertCheckQuery.execute_bucketed` returns for the same alert and window.
- Added `TestSaveCohortOutcomesFallback` covering the `IntegrityError` → per-alert fallback path and verifying that `OperationalError` propagates.
- Updated `TestCheckAlertsSync` to patch `_run_batched_query` instead of `AlertCheckQuery` directly.
- Updated `TestCheckAlertsActivityConcurrency` to stub all three phases independently and assert on `_finalize_alert` call count and peak semaphore concurrency.
- All existing `TestEvaluateSingleAlert` and `TestEvaluateSingleAlertEndToEnd` tests updated to use the `_evaluate_and_save_one` helper, which composes the same end-to-end pipeline as the production cohort path.

## Publish to changelog?

No