### PR TITLE
fix(logs): Drop Rules blocks me from creating Rule in dev, adding more detailed error and permissions

### DIFF
--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -748,17 +748,34 @@ class PostHogFeatureFlagPermission(BasePermission):
                     return True
 
                 org_id = str(organization.id)
+                groups: dict[str, str] = {"organization": org_id}
+                group_properties: dict[str, dict[str, str]] = {"organization": {"id": org_id}}
+                # Match in-app flag evaluation: posthog-js often has project (team) context; server-only org
+                # groups miss per-environment rollouts (e.g. logs-settings-drop-rules for project 2 only).
+                try:
+                    team_for_flag = view.team
+                except (ValueError, KeyError, AttributeError):
+                    team_for_flag = None
+                if team_for_flag is not None:
+                    project_id = str(team_for_flag.id)
+                    groups["project"] = project_id
+                    group_properties["project"] = {"id": project_id}
 
                 enabled = posthoganalytics.feature_enabled(
                     required_flag,
                     str(user.distinct_id),
-                    groups={"organization": org_id},
-                    group_properties={"organization": {"id": org_id}},
+                    groups=groups,
+                    group_properties=group_properties,
                     only_evaluate_locally=False,
                     send_feature_flag_events=False,
                 )
 
-                return enabled or False
+                if enabled:
+                    return True
+                self.message = (
+                    f"This action requires feature flag {required_flag!r} to be enabled for your organization."
+                )
+                return False
 
         return True
 

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -1051,6 +1051,34 @@ class TestPostHogFeatureFlagPermission(BaseTest):
         self.assertTrue(result)
         mock_ff.assert_called_once()
         self.assertEqual(mock_ff.call_args[0][0], "my-flag")
+        kwargs = mock_ff.call_args[1]
+        self.assertEqual(
+            kwargs["groups"],
+            {"organization": str(self.organization.id), "project": str(self.team.id)},
+        )
+        self.assertEqual(
+            kwargs["group_properties"],
+            {
+                "organization": {"id": str(self.organization.id)},
+                "project": {"id": str(self.team.id)},
+            },
+        )
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_feature_flag_evaluation_passes_organization_only_when_view_has_no_team(self, mock_ff):
+        class OrgOnlyView:
+            posthog_feature_flag = "my-flag"
+            action = "list"
+            organization = self.organization
+            organization_id = str(self.organization.id)
+
+        request = self._create_mock_request()
+        view = OrgOnlyView()
+
+        self.assertTrue(self.permission.has_permission(request, view))
+        kwargs = mock_ff.call_args[1]
+        self.assertEqual(kwargs["groups"], {"organization": str(self.organization.id)})
+        self.assertEqual(kwargs["group_properties"], {"organization": {"id": str(self.organization.id)}})
 
     @patch("posthoganalytics.feature_enabled", return_value=False)
     def test_denies_when_flag_disabled(self, mock_ff):


### PR DESCRIPTION
## Problem
Need more detail around permission errors in drop rules
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
