### PR TITLE
fix(endpoints): clear stale versions when switching endpoints

### DIFF
--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -123,6 +123,12 @@ export const endpointLogic = kea<endpointLogicType>([
                 loadEndpoint: () => null,
             },
         ],
+        versions: [
+            [] as EndpointVersionType[],
+            {
+                loadEndpoint: () => [],
+            },
+        ],
         // Extend the loader reducer to clear on action
         materializationStatus: [
             null as EndpointType['materialization'] | null,


### PR DESCRIPTION
## Problem

On `/endpoints/<name>?tab=versions`, navigating from one endpoint to another leaves the previous endpoint's versions stacked above the new endpoint's versions in the list — duplicate version numbers and two `Latest` badges show up. A hard refresh clears it.

## Changes

`endpointLogic` is `permanentlyMount()`-ed and keyed by `tabId`, so the same instance is reused across endpoint navigations in the same scene tab. Almost every piece of endpoint-scoped state in this logic resets on `loadEndpoint` — `endpoint`, `materializationStatus`, plus the analogous resets in `endpointSceneLogic` (`localQuery`, `payloadJson`, `viewingVersion`, `endpointResult`, `materializationPreview`, …). The `versions` loader was the only piece without a reset, so the previous endpoint's array stayed in store memory between `loadEndpoint(B)` and the time `loadVersions(B)` resolved.

The fix mirrors the existing pattern: a `loadEndpoint: () => []` handler in the `versions` reducer entry. `kea-loaders` merges its auto-generated `loadVersionsSuccess` handler in, so the loader's success/loading behavior is preserved.

## How did you test this code?

I'm an agent — I have not run this in a browser. I verified:

- The change does not introduce any new TypeScript errors (`pnpm --filter=@posthog/frontend typescript:check` shows the same pre-existing error count before and after).
- Formatting passes `pnpm exec oxfmt --check`.

The bug is a runtime navigation behavior, so manual verification by a reviewer is needed:

1. Open endpoint A, click the **Versions** tab — only A's versions, one `Latest` badge.
2. Navigate to endpoint B (sidebar or URL).
3. Click the **Versions** tab on B — expected only B's versions, one `Latest` badge. Before this PR, A's versions appeared above B's with two `Latest` badges.
4. Repeat A → B → A to confirm both directions work.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) via the local PostHog Code harness.
- Initial human prompt: a bug report with a screenshot of the duplicated Versions list and the URL `https://eu.posthog.com/project/{projectid}/endpoints/location_campaign_ctr?tab=versions`.
- Approach considered and rejected:
  - clearing in a listener (extra action + handler — more code than the reducer entry),
  - hiding the table while loading (masks the symptom, doesn't fix the underlying state, causes a flicker),
  - filtering versions by endpoint name in the component (`EndpointVersionType` doesn't carry the parent name),
  - dropping `permanentlyMount()` (broad blast radius for unrelated state).
- Chosen approach matches the pattern already used for `endpoint` and `materializationStatus` in the same `reducers({...})` block, two entries above.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*