### PR TITLE
fix(data-warehouse): Fix webhook being skipped

### DIFF
--- a/posthog/temporal/data_imports/sources/common/webhook_s3.py
+++ b/posthog/temporal/data_imports/sources/common/webhook_s3.py
@@ -66,7 +66,7 @@ class WebhookSourceManager:
     def _strip_s3_protocol(self, s3_path: str) -> str:
         return s3_path.replace("s3://", "")
 
-    async def webhook_enabled(self, skip_initial_sync_complete_check: bool | None = None) -> bool:
+    async def webhook_enabled(self, skip_initial_sync_complete_check: bool = False) -> bool:
         from posthog.models.hog_functions.hog_function import HogFunction
 
         from products.data_warehouse.backend.models import ExternalDataSchema

--- a/posthog/temporal/data_imports/sources/common/webhook_s3.py
+++ b/posthog/temporal/data_imports/sources/common/webhook_s3.py
@@ -85,7 +85,7 @@ class WebhookSourceManager:
             or (skip_initial_sync_complete_check is not True and not schema.initial_sync_complete)
             or self._inputs.reset_pipeline
         ):
-            self._logger.debug(
+            await self._logger.adebug(
                 f"webhook_enabled=False. schema.is_webhook={schema.is_webhook}. schema.initial_sync_complete={schema.initial_sync_complete}. self._inputs.reset_pipeline={self._inputs.reset_pipeline}"
             )
             return False

--- a/posthog/temporal/data_imports/sources/common/webhook_s3.py
+++ b/posthog/temporal/data_imports/sources/common/webhook_s3.py
@@ -66,7 +66,7 @@ class WebhookSourceManager:
     def _strip_s3_protocol(self, s3_path: str) -> str:
         return s3_path.replace("s3://", "")
 
-    async def webhook_enabled(self) -> bool:
+    async def webhook_enabled(self, skip_initial_sync_complete_check: bool | None = None) -> bool:
         from posthog.models.hog_functions.hog_function import HogFunction
 
         from products.data_warehouse.backend.models import ExternalDataSchema
@@ -80,7 +80,14 @@ class WebhookSourceManager:
             id=self._inputs.schema_id, team_id=self._inputs.team_id
         )
 
-        if not schema.is_webhook or not schema.initial_sync_complete or self._inputs.reset_pipeline:
+        if (
+            not schema.is_webhook
+            or (skip_initial_sync_complete_check is not True and not schema.initial_sync_complete)
+            or self._inputs.reset_pipeline
+        ):
+            self._logger.debug(
+                f"webhook_enabled=False. schema.is_webhook={schema.is_webhook}. schema.initial_sync_complete={schema.initial_sync_complete}. self._inputs.reset_pipeline={self._inputs.reset_pipeline}"
+            )
             return False
 
         has_webhook_function = await database_sync_to_async_pool(

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -217,7 +217,7 @@ class CustomerIOSource(
 
     def _webhook_source_response(self, inputs: SourceInputs) -> SourceResponse:
         webhook_source_manager = self.get_webhook_source_manager(inputs)
-        webhook_enabled = async_to_sync(webhook_source_manager.webhook_enabled)()
+        webhook_enabled = async_to_sync(webhook_source_manager.webhook_enabled)(True)
 
         def items() -> Iterable[Any] | AsyncIterable[Any]:
             if webhook_enabled:


### PR DESCRIPTION
## Problem
customer io source wasn't reading from S3 cos there's no API endpoint for the schema to initially complete with to switch the schema flag `initial_sync_complete` over to `True`

## Changes
Override this logic
