### PR TITLE
perf(insights): index InsightViewed on (insight_id, last_viewed_at DESC)

### DIFF
--- a/posthog/migrations/1134_insightviewed_insight_lva_idx.py
+++ b/posthog/migrations/1134_insightviewed_insight_lva_idx.py
@@ -1,0 +1,20 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1133_alter_integration_kind"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="insightviewed",
+            index=models.Index(
+                fields=["insight_id", "-last_viewed_at"],
+                name="insightviewed_insight_lva_idx",
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1133_alter_integration_kind
+1134_insightviewed_insight_lva_idx

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -350,7 +350,10 @@ class InsightViewed(models.Model):
 
     class Meta:
         constraints = [models.UniqueConstraint(fields=["team", "user", "insight"], name="posthog_unique_insightviewed")]
-        indexes = [models.Index(fields=["team_id", "user_id", "-last_viewed_at"])]
+        indexes = [
+            models.Index(fields=["team_id", "user_id", "-last_viewed_at"]),
+            models.Index(fields=["insight_id", "-last_viewed_at"], name="insightviewed_insight_lva_idx"),
+        ]
 
 
 @timed("generate_insight_cache_key")


### PR DESCRIPTION
## Problem

The insights list endpoint was reported as 800 ms in prod with a 389 ms max single Postgres query. After dropping the `GROUP BY` in #57262 (replacing `Max(insightviewed)` with a correlated `Subquery`), the per-row subquery now runs on every insight in the page.

`InsightViewed` only has indexes on `(team_id, user_id, -last_viewed_at)` and the implicit FK index on `insight_id`. The subquery filters by `insight_id` and orders by `last_viewed_at DESC`, so Postgres scans the FK index for the matching rows and then sorts. For insights with many `InsightViewed` rows (popular shared dashboards), the sort hurts.

## Changes

Add a composite index on `(insight_id, -last_viewed_at)` so the subquery resolves to a single-row index lookup with no sort.

- `posthog/models/insight.py` — add the index to `InsightViewed.Meta.indexes` so model state and migrations stay in sync.
- `posthog/migrations/1134_insightviewed_insight_lva_idx.py` — `AddIndexConcurrently` with `atomic = False`. Generated SQL: `CREATE INDEX CONCURRENTLY "insightviewed_insight_lva_idx" ON "posthog_insightviewed" ("insight_id", "last_viewed_at" DESC);`

## How did you test this code?

I'm an agent. Verified:

- `./manage.py makemigrations --check --dry-run` reports "No changes detected" — model `Meta.indexes` matches the migration.
- `./manage.py sqlmigrate posthog 1134` produces the expected `CREATE INDEX CONCURRENTLY` statement.

No prod / staging verification.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

PostHog Code session investigating insights list endpoint perf. The 389 ms max query observed in Server-Timing prompted this — the previous PR (#57262) optimized the query plan but the data shape (popular insights with many view rows) still drives a sort per insight. Used `AddIndexConcurrently` per the safe-django-migrations guide. Sibling PR #57326 adds Server-Timing instrumentation to the home view so we can investigate the separately-observed slow root HTML.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*