### PR TITLE
refactor(scim): extract member-id parsing and role assignment helpers

### DIFF
--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -111,47 +111,59 @@ class PostHogSCIMGroup(SCIMGroup):
         return cls(role, organization_domain)
 
     @classmethod
+    def _parse_member_id(cls, raw_member_id) -> str | None:
+        """
+        Normalize a SCIM `members[].value` to the string form of an integer ID,
+        matching the always-string `current_user_ids` set in `_update_members`.
+
+        Some IdPs send `value` as a JSON number; without this, the set diff
+        would be type-asymmetric and silently delete the membership the IdP
+        asked to keep. Non-coercible values (e.g. nested-group UUIDs from
+        Entra ID) return None and are logged once.
+        """
+        if raw_member_id is None:
+            return None
+        try:
+            return str(int(raw_member_id))
+        except (TypeError, ValueError):
+            logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": raw_member_id})
+            return None
+
+    @classmethod
+    def _assign_role_member(cls, role: Role, user_pk: int, organization_domain: OrganizationDomain) -> None:
+        try:
+            user = User.objects.get(id=user_pk)
+        except User.DoesNotExist:
+            return
+
+        org_membership = OrganizationMembership.objects.filter(
+            user=user, organization=organization_domain.organization
+        ).first()
+        if not org_membership:
+            return
+
+        # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, org gated by middleware)
+        RoleMembership.objects.get_or_create(role=role, user=user, defaults={"organization_member": org_membership})
+
+    @classmethod
     def _update_members(cls, role: Role, members_data: list[dict], organization_domain: OrganizationDomain) -> None:
         """
         Update role membership based on SCIM members list.
         """
-        # Normalize SCIM `members[].value` to string form of integer IDs to match the always-string
-        # `current_user_ids` set below. Some IdPs send `value` as a JSON number; without this, the
-        # set diff would be type-asymmetric and silently delete the membership the IdP asked to keep.
         member_user_ids: set[str] = set()
         for member in members_data:
-            raw_member_id = member.get("value")
-            if raw_member_id is None:
-                continue
-            try:
-                member_user_ids.add(str(int(raw_member_id)))
-            except (TypeError, ValueError):
-                logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": raw_member_id})
+            parsed = cls._parse_member_id(member.get("value"))
+            if parsed is not None:
+                member_user_ids.add(parsed)
 
-        # Get current role members
         current_memberships = RoleMembership.objects.filter(role=role).select_related("user", "organization_member")
-
         current_user_ids = {str(rm.user.id) for rm in current_memberships}
         to_add = member_user_ids - current_user_ids
         to_remove = current_user_ids - member_user_ids
 
         for raw_member_id in to_add:
-            user_pk = int(raw_member_id)
-            try:
-                user = User.objects.get(id=user_pk)
-                org_membership = OrganizationMembership.objects.filter(
-                    user=user, organization=organization_domain.organization
-                ).first()
+            cls._assign_role_member(role, int(raw_member_id), organization_domain)
 
-                if org_membership:
-                    # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, org gated by middleware)
-                    RoleMembership.objects.get_or_create(
-                        role=role, user=user, defaults={"organization_member": org_membership}
-                    )
-            except User.DoesNotExist:
-                continue
-
-        # Remove members no longer in the group
         RoleMembership.objects.filter(role=role, user__id__in=to_remove).delete()
 
     def put(self, data: dict) -> None:

--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -110,8 +110,8 @@ class PostHogSCIMGroup(SCIMGroup):
 
         return cls(role, organization_domain)
 
-    @classmethod
-    def _parse_member_id(cls, raw_member_id) -> str | None:
+    @staticmethod
+    def _parse_member_id(raw_member_id) -> str | None:
         """
         Normalize a SCIM `members[].value` to the string form of an integer ID,
         matching the always-string `current_user_ids` set in `_update_members`.
@@ -129,8 +129,8 @@ class PostHogSCIMGroup(SCIMGroup):
             logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": raw_member_id})
             return None
 
-    @classmethod
-    def _assign_role_member(cls, role: Role, user_pk: int, organization_domain: OrganizationDomain) -> None:
+    @staticmethod
+    def _assign_role_member(role: Role, user_pk: int, organization_domain: OrganizationDomain) -> None:
         try:
             user = User.objects.get(id=user_pk)
         except User.DoesNotExist:
@@ -239,27 +239,10 @@ class PostHogSCIMGroup(SCIMGroup):
                     members_to_add = [{"value": value}]
 
                 for member_data in members_to_add:
-                    user_id = member_data.get("value")
-
-                    try:
-                        user = User.objects.get(id=user_id)
-                        org_membership = OrganizationMembership.objects.filter(
-                            user=user, organization=self._organization_domain.organization
-                        ).first()
-
-                        if not org_membership:
-                            continue  # cannot assign a role to a non-member
-
-                        # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, org gated by middleware)
-                        RoleMembership.objects.get_or_create(
-                            role=self.obj, user=user, defaults={"organization_member": org_membership}
-                        )
-                    except User.DoesNotExist:
+                    parsed = self._parse_member_id(member_data.get("value"))
+                    if parsed is None:
                         continue
-                    except ValueError:
-                        # Skip non-user members (e.g., nested group references from IdPs)
-                        logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": user_id})
-                        continue
+                    self._assign_role_member(self.obj, int(parsed), self._organization_domain)
 
     def handle_remove(self, path: AttrPath, value: Union[str, list, dict], operation: dict) -> None:
         """

--- a/ee/api/scim/test/test_groups_api.py
+++ b/ee/api/scim/test/test_groups_api.py
@@ -8,6 +8,7 @@ from posthog.models import Organization, OrganizationMembership, User
 from posthog.models.organization_domain import OrganizationDomain
 
 from ee.api.scim.auth import generate_scim_token
+from ee.api.scim.group import PostHogSCIMGroup
 from ee.api.scim.views import MAX_ITEMS_PER_PAGE
 from ee.api.test.base import APILicensedTest
 from ee.models.rbac.role import Role, RoleMembership
@@ -724,6 +725,64 @@ class TestSCIMGroupsAPI(APILicensedTest):
         assert RoleMembership.objects.filter(role=role, user=user_str).exists()
         assert not RoleMembership.objects.filter(role=role, user=user_removed).exists()
         assert RoleMembership.objects.filter(role=role).count() == 2
+
+    # ── Helper contract tests ──
+
+    @parameterized.expand(
+        [
+            ("none_returns_none", None, None),
+            ("string_int_passes_through", "123", "123"),
+            ("raw_int_normalized_to_str", 123, "123"),
+            ("non_numeric_string_returns_none", "abc", None),
+            ("uuid_string_returns_none", "550e8400-e29b-41d4-a716-446655440000", None),
+        ]
+    )
+    def test_parse_member_id(self, _name: str, raw, expected: str | None):
+        assert PostHogSCIMGroup._parse_member_id(raw) == expected
+
+    def test_put_silently_skips_member_not_in_org(self):
+        # User exists but belongs to a different org — _assign_role_member should
+        # return early on the missing org_membership, leaving the role empty.
+        other_org = Organization.objects.create(name="Other Org")
+        external_user = User.objects.create_user(
+            email="external_put@other.com", password=None, first_name="External", is_email_verified=True
+        )
+        OrganizationMembership.objects.create(
+            user=external_user, organization=other_org, level=OrganizationMembership.Level.MEMBER
+        )
+        role = Role.objects.create(name="ExternalPutRole", organization=self.organization)
+
+        put_data = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "displayName": "ExternalPutRole",
+            "members": [{"value": str(external_user.id)}],
+        }
+
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Groups/{role.id}", data=put_data, content_type="application/scim+json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert not RoleMembership.objects.filter(role=role, user=external_user).exists()
+        assert RoleMembership.objects.filter(role=role).count() == 0
+
+    def test_put_silently_skips_nonexistent_member(self):
+        # Stale user id from the IdP — _assign_role_member should swallow
+        # User.DoesNotExist and continue.
+        role = Role.objects.create(name="GhostRole", organization=self.organization)
+
+        put_data = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "displayName": "GhostRole",
+            "members": [{"value": "999999999"}],
+        }
+
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Groups/{role.id}", data=put_data, content_type="application/scim+json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert RoleMembership.objects.filter(role=role).count() == 0
 
     # ── Pagination tests ──
 


### PR DESCRIPTION
Address review feedback on PR #55852: flatten the multi-level nesting in `_update_members` by extracting `_parse_member_id` and `_assign_role_member` helpers and using early returns. No behavior change.
