### PR TITLE
feat(notebooks): show comment previews in side-panel

### DIFF
--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -134,7 +134,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
     } = useActions(commentsLogic)
 
     return (
-        <div className="deprecated-space-y-2">
+        <div className="deprecated-space-y-2 border-t p-2">
             <LemonRichContentEditor
                 placeholder="Edit comment"
                 initialContent={comment.rich_content}
@@ -223,8 +223,10 @@ const CommentTopRow = ({ comment }: { comment: CommentType }): JSX.Element => {
 }
 
 const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
-    const { editingComment, replyingCommentId, selectedCommentId } = useValues(commentsLogic)
+    const { editingComment, replyingCommentId, selectedCommentId, commentContexts } = useValues(commentsLogic)
     const { setSelectedComment } = useActions(commentsLogic)
+    const contextText = commentContexts[comment.id]
+    const isInlineComment = comment.item_context?.type === 'mark'
 
     const ref = useRef<HTMLDivElement | null>(null)
 
@@ -255,6 +257,11 @@ const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
 
                     <div className="flex flex-col flex-1 min-w-0">
                         <CommentTopRow comment={comment} />
+                        {contextText && !isEditing && isInlineComment && (
+                            <div className="border-l-2 border-border pl-2 my-2">
+                                <span className="block text-muted truncate text-sm">{contextText}</span>
+                            </div>
+                        )}
                         {isEditing ? (
                             <CommentEditingForm comment={comment} />
                         ) : (

--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -134,7 +134,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
     } = useActions(commentsLogic)
 
     return (
-        <div className="deprecated-space-y-2 border-t p-2">
+        <div className="deprecated-space-y-2">
             <LemonRichContentEditor
                 placeholder="Edit comment"
                 initialContent={comment.rich_content}

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -73,6 +73,7 @@ export const commentsLogic = kea<commentsLogicType>([
         setEditingComment: (comment: CommentType | null) => ({ comment }),
         setReplyingComment: (commentId: string | null) => ({ commentId }),
         setSelectedComment: (commentId: string | null) => ({ commentId }),
+        setCommentContexts: (contexts: Record<string, string>) => ({ contexts }),
         setItemContext: (context: Record<string, any> | null, callback?: (event: { sent: boolean }) => void) => ({
             context,
             callback,
@@ -94,6 +95,12 @@ export const commentsLogic = kea<commentsLogicType>([
                 setSelectedComment: (_, { commentId }) => commentId,
                 setReplyingComment: (state, { commentId }) => commentId ?? state,
                 sendComposedContentSuccess: () => null,
+            },
+        ],
+        commentContexts: [
+            {} as Record<string, string>,
+            {
+                setCommentContexts: (_, { contexts }) => contexts,
             },
         ],
         itemContext: [

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -205,6 +205,7 @@ export function Editor(): JSX.Element {
                 const notebookEditor: NotebookEditor = {
                     ...createEditor(editor),
                     findCommentPosition: (markId: string) => findCommentPosition(editor, markId),
+                    getMarkText: (markId: string) => getMarkText(editor, markId),
                     removeComment: (pos: number) => removeCommentMark(editor, pos),
                     getText: () => textContent(editor.state.doc),
                 }
@@ -259,6 +260,16 @@ function findCommentPosition(editor: TTEditor, markId: string): number | null {
         }
     })
     return result
+}
+
+function getMarkText(editor: TTEditor, markId: string): string {
+    const parts: string[] = []
+    editor.state.doc.descendants((node) => {
+        if (node.isText && node.marks.some((m) => m.type.name === 'comment' && m.attrs.id === markId)) {
+            parts.push(node.text ?? '')
+        }
+    })
+    return parts.join('')
 }
 
 function removeCommentMark(editor: TTEditor, pos: number): void {

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -205,7 +205,7 @@ export function Editor(): JSX.Element {
                 const notebookEditor: NotebookEditor = {
                     ...createEditor(editor),
                     findCommentPosition: (markId: string) => findCommentPosition(editor, markId),
-                    getMarkText: (markId: string) => getMarkText(editor, markId),
+                    getAllCommentTexts: () => getAllCommentTexts(editor),
                     removeComment: (pos: number) => removeCommentMark(editor, pos),
                     getText: () => textContent(editor.state.doc),
                 }
@@ -262,14 +262,19 @@ function findCommentPosition(editor: TTEditor, markId: string): number | null {
     return result
 }
 
-function getMarkText(editor: TTEditor, markId: string): string {
-    const parts: string[] = []
+function getAllCommentTexts(editor: TTEditor): Record<string, string> {
+    const result: Record<string, string> = {}
     editor.state.doc.descendants((node) => {
-        if (node.isText && node.marks.some((m) => m.type.name === 'comment' && m.attrs.id === markId)) {
-            parts.push(node.text ?? '')
+        if (!node.isText) {
+            return
+        }
+        for (const m of node.marks) {
+            if (m.type.name === 'comment' && m.attrs.id) {
+                result[m.attrs.id] = (result[m.attrs.id] ?? '') + (node.text ?? '')
+            }
         }
     })
-    return parts.join('')
+    return result
 }
 
 function removeCommentMark(editor: TTEditor, pos: number): void {

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -101,6 +101,24 @@ async function runWhenEditorIsReady(waitForEditor: () => boolean, fn: () => any)
     return fn()
 }
 
+function buildCommentContexts(editor: NotebookEditor, comments: CommentType[], title: string): Record<string, string> {
+    const contexts: Record<string, string> = {}
+    for (const comment of comments) {
+        if (comment.source_comment) {
+            continue
+        }
+        if (comment.item_context?.type === 'mark') {
+            const text = editor.getMarkText(comment.item_context.id)
+            if (text) {
+                contexts[comment.id] = text
+            }
+        } else {
+            contexts[comment.id] = title
+        }
+    }
+    return contexts
+}
+
 export const notebookLogic = kea<notebookLogicType>([
     props({} as NotebookLogicProps),
     path((key) => ['scenes', 'notebooks', 'Notebook', 'notebookLogic', key]),
@@ -133,7 +151,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 scope: ActivityScope.NOTEBOOK,
                 item_id: props.shortId,
             }),
-            ['setItemContext', 'maybeLoadComments', 'setSelectedComment'],
+            ['setItemContext', 'maybeLoadComments', 'setSelectedComment', 'setCommentContexts'],
             notebookCollabLogic({ shortId: props.shortId }),
             ['ackLocalSteps', 'applyRemoteSteps'],
         ],
@@ -884,7 +902,12 @@ export const notebookLogic = kea<notebookLogicType>([
                 cache.throttledOnUpdateEditorTimeout = null
             }, 16) // ~60fps throttling
         },
-        setEditor: () => {},
+        setEditor: () => {
+            // Compute contexts immediately if comments are already loaded when the editor mounts
+            if (values.editor && values.comments) {
+                actions.setCommentContexts(buildCommentContexts(values.editor, values.comments, values.title))
+            }
+        },
 
         saveNotebookSuccess: actions.scheduleNotebookRefresh,
         loadNotebookSuccess: () => {
@@ -1014,6 +1037,8 @@ export const notebookLogic = kea<notebookLogicType>([
                         editor.removeComment(mark.pos)
                     }
                 })
+
+                actions.setCommentContexts(buildCommentContexts(editor, comments, values.title))
             }
         },
         activeCommentMarkId: (markId: string | null) => {

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -101,19 +101,15 @@ async function runWhenEditorIsReady(waitForEditor: () => boolean, fn: () => any)
     return fn()
 }
 
-function buildCommentContexts(editor: NotebookEditor, comments: CommentType[], title: string): Record<string, string> {
+function buildCommentContexts(editor: NotebookEditor, comments: CommentType[]): Record<string, string> {
     const contexts: Record<string, string> = {}
     for (const comment of comments) {
-        if (comment.source_comment) {
+        if (comment.source_comment || comment.item_context?.type !== 'mark') {
             continue
         }
-        if (comment.item_context?.type === 'mark') {
-            const text = editor.getMarkText(comment.item_context.id)
-            if (text) {
-                contexts[comment.id] = text
-            }
-        } else {
-            contexts[comment.id] = title
+        const text = editor.getMarkText(comment.item_context.id)
+        if (text) {
+            contexts[comment.id] = text
         }
     }
     return contexts
@@ -905,7 +901,7 @@ export const notebookLogic = kea<notebookLogicType>([
         setEditor: () => {
             // Compute contexts immediately if comments are already loaded when the editor mounts
             if (values.editor && values.comments) {
-                actions.setCommentContexts(buildCommentContexts(values.editor, values.comments, values.title))
+                actions.setCommentContexts(buildCommentContexts(values.editor, values.comments))
             }
         },
 
@@ -1038,7 +1034,7 @@ export const notebookLogic = kea<notebookLogicType>([
                     }
                 })
 
-                actions.setCommentContexts(buildCommentContexts(editor, comments, values.title))
+                actions.setCommentContexts(buildCommentContexts(editor, comments))
             }
         },
         activeCommentMarkId: (markId: string | null) => {

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -131,7 +131,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 scope: ActivityScope.NOTEBOOK,
                 item_id: props.shortId,
             }),
-            ['comments', 'itemContext', 'selectedCommentId'],
+            ['comments', 'itemContext', 'selectedCommentId', 'commentContexts'],
             notebookKernelInfoLogic({ shortId: props.shortId }),
             ['kernelInfo'],
             notebookSettingsLogic,
@@ -904,6 +904,20 @@ export const notebookLogic = kea<notebookLogicType>([
             if (values.editor && values.comments) {
                 actions.setCommentContexts(buildCommentContexts(values.editor, values.comments))
             }
+        },
+        onUpdateEditor: () => {
+            // Re-sync previews so they track edits to text under comment marks.
+            // Skip the dispatch when nothing changed to avoid re-rendering every Comment per keystroke.
+            if (!values.editor || !values.comments) {
+                return
+            }
+            const next = buildCommentContexts(values.editor, values.comments)
+            const prev = values.commentContexts
+            const nextKeys = Object.keys(next)
+            if (nextKeys.length === Object.keys(prev).length && nextKeys.every((k) => prev[k] === next[k])) {
+                return
+            }
+            actions.setCommentContexts(next)
         },
 
         saveNotebookSuccess: actions.scheduleNotebookRefresh,

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -102,12 +102,13 @@ async function runWhenEditorIsReady(waitForEditor: () => boolean, fn: () => any)
 }
 
 function buildCommentContexts(editor: NotebookEditor, comments: CommentType[]): Record<string, string> {
+    const markTexts = editor.getAllCommentTexts()
     const contexts: Record<string, string> = {}
     for (const comment of comments) {
         if (comment.source_comment || comment.item_context?.type !== 'mark') {
             continue
         }
-        const text = editor.getMarkText(comment.item_context.id)
+        const text = markTexts[comment.item_context.id]
         if (text) {
             contexts[comment.id] = text
         }

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -155,7 +155,7 @@ export type NotebookNodeAction = Pick<LemonButtonProps, 'icon'> & {
 
 export interface NotebookEditor extends RichContentEditorType {
     findCommentPosition: (markId: string) => number | null
-    getMarkText: (markId: string) => string
+    getAllCommentTexts: () => Record<string, string>
     removeComment: (pos: number) => void
     getText: () => string
 }

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -155,6 +155,7 @@ export type NotebookNodeAction = Pick<LemonButtonProps, 'icon'> & {
 
 export interface NotebookEditor extends RichContentEditorType {
     findCommentPosition: (markId: string) => number | null
+    getMarkText: (markId: string) => string
     removeComment: (pos: number) => void
     getText: () => string
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Looking at comments in the side panel, it's hard to tell a notebook-wide comment apart from an inline one. In the first PR in the stack, clicking an inline comment in the side panel selects and highlights it, but clicking a notebook-level comment did nothing visible.

After experimenting with a few versions, I landed on a muted blockquote-style preview inside the card that shows the anchored text, truncated to a single line.

## Changes

- Comment.tsx renders a preview between the author row and the body, only for inline comments.
- New commentContexts map in commentsLogic — generic per-comment text label, populated by callers.
- getMarkText(markId) primitive on NotebookEditor — returns the document text under a comment mark.
- notebookLogic builds the map from comments + editor; runs in both the comments subscription and the setEditor listener so the data is ready whichever arrives first.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![Screenshot 2026-05-02 at 00.35.37.png](https://app.graphite.com/user-attachments/assets/77365be0-8d5f-49d7-a3db-4d23b4bbb52e.png)

## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->