### PR TITLE
fix(k8s-awareness): fix k8s awareness test

### DIFF
--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet, StatefulSet};
@@ -14,12 +15,16 @@ use crate::detection;
 use crate::discovery::{self, DiscoveryError};
 use crate::types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
 
+const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(10);
+
 #[derive(Debug, thiserror::Error)]
 pub enum K8sAwarenessError {
     #[error("discovery failed: {0}")]
     Discovery(#[from] DiscoveryError),
     #[error("kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
+    #[error("discovery timed out after {0:?}")]
+    Timeout(Duration),
 }
 
 /// Manages K8s watchers for multiple controllers.
@@ -50,9 +55,15 @@ impl K8sAwareness {
     ///
     /// Walks ownerReferences: pod → ReplicaSet → Deployment, or pod → StatefulSet.
     /// Starts a watcher for the controller if not already watching.
+    /// Times out after [`DISCOVERY_TIMEOUT`] to avoid blocking callers when
+    /// the K8s API server is slow or unavailable.
     pub async fn discover_controller(&self, pod_name: &str) -> Result<PodInfo, K8sAwarenessError> {
-        let pod_info =
-            discovery::discover_controller(&self.client, &self.namespace, pod_name).await?;
+        let pod_info = tokio::time::timeout(
+            DISCOVERY_TIMEOUT,
+            discovery::discover_controller(&self.client, &self.namespace, pod_name),
+        )
+        .await
+        .map_err(|_| K8sAwarenessError::Timeout(DISCOVERY_TIMEOUT))??;
 
         self.ensure_watching(&pod_info.controller).await?;
 
@@ -140,6 +151,8 @@ async fn unregister_watcher(
     info!(controller = %controller, "unregistered watcher");
 }
 
+const WATCHER_ERROR_BACKOFF: Duration = Duration::from_secs(2);
+
 /// Watch a Deployment and update its ClusterIntent on changes.
 async fn run_deployment_watcher(
     client: &Client,
@@ -174,8 +187,9 @@ async fn run_deployment_watcher(
                         warn!(
                             controller = %controller,
                             error = %e,
-                            "deployment watcher error, stream will retry"
+                            "deployment watcher error, backing off before retry"
                         );
+                        tokio::time::sleep(WATCHER_ERROR_BACKOFF).await;
                     }
                     None => {
                         info!(controller = %controller, "deployment watcher stream ended");
@@ -396,8 +410,9 @@ async fn run_statefulset_watcher(
                         warn!(
                             controller = %controller,
                             error = %e,
-                            "statefulset watcher error, stream will retry"
+                            "statefulset watcher error, backing off before retry"
                         );
+                        tokio::time::sleep(WATCHER_ERROR_BACKOFF).await;
                     }
                     None => {
                         info!(controller = %controller, "statefulset watcher stream ended");

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet, StatefulSet};
@@ -15,16 +14,12 @@ use crate::detection;
 use crate::discovery::{self, DiscoveryError};
 use crate::types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
 
-const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(10);
-
 #[derive(Debug, thiserror::Error)]
 pub enum K8sAwarenessError {
     #[error("discovery failed: {0}")]
     Discovery(#[from] DiscoveryError),
     #[error("kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
-    #[error("discovery timed out after {0:?}")]
-    Timeout(Duration),
 }
 
 /// Manages K8s watchers for multiple controllers.
@@ -55,15 +50,9 @@ impl K8sAwareness {
     ///
     /// Walks ownerReferences: pod → ReplicaSet → Deployment, or pod → StatefulSet.
     /// Starts a watcher for the controller if not already watching.
-    /// Times out after [`DISCOVERY_TIMEOUT`] to avoid blocking callers when
-    /// the K8s API server is slow or unavailable.
     pub async fn discover_controller(&self, pod_name: &str) -> Result<PodInfo, K8sAwarenessError> {
-        let pod_info = tokio::time::timeout(
-            DISCOVERY_TIMEOUT,
-            discovery::discover_controller(&self.client, &self.namespace, pod_name),
-        )
-        .await
-        .map_err(|_| K8sAwarenessError::Timeout(DISCOVERY_TIMEOUT))??;
+        let pod_info =
+            discovery::discover_controller(&self.client, &self.namespace, pod_name).await?;
 
         self.ensure_watching(&pod_info.controller).await?;
 
@@ -151,8 +140,6 @@ async fn unregister_watcher(
     info!(controller = %controller, "unregistered watcher");
 }
 
-const WATCHER_ERROR_BACKOFF: Duration = Duration::from_secs(2);
-
 /// Watch a Deployment and update its ClusterIntent on changes.
 async fn run_deployment_watcher(
     client: &Client,
@@ -187,9 +174,8 @@ async fn run_deployment_watcher(
                         warn!(
                             controller = %controller,
                             error = %e,
-                            "deployment watcher error, backing off before retry"
+                            "deployment watcher error, stream will retry"
                         );
-                        tokio::time::sleep(WATCHER_ERROR_BACKOFF).await;
                     }
                     None => {
                         info!(controller = %controller, "deployment watcher stream ended");
@@ -410,9 +396,8 @@ async fn run_statefulset_watcher(
                         warn!(
                             controller = %controller,
                             error = %e,
-                            "statefulset watcher error, backing off before retry"
+                            "statefulset watcher error, stream will retry"
                         );
-                        tokio::time::sleep(WATCHER_ERROR_BACKOFF).await;
                     }
                     None => {
                         info!(controller = %controller, "statefulset watcher stream ended");

--- a/rust/kafka-assigner/tests/k3s_integration.rs
+++ b/rust/kafka-assigner/tests/k3s_integration.rs
@@ -56,6 +56,13 @@ async fn setup_k3s() -> (
     let container = K3s::default()
         .with_conf_mount(tmp_dir.path())
         .with_privileged(true)
+        .with_cmd([
+            "server",
+            "--snapshotter=native",
+            "--disable=traefik",
+            "--disable=servicelb",
+            "--disable=metrics-server",
+        ])
         .start()
         .await
         .expect("failed to start k3s container");
@@ -328,18 +335,25 @@ async fn trigger_statefulset_rollout(client: &Client, name: &str) {
 /// testcontainer; this avoids burning the `wait_for_condition` budget on
 /// Connect errors.
 async fn wait_for_k3s_api_ready(client: &Client, timeout_dur: Duration) {
+    const REQUIRED_CONSECUTIVE: u32 = 3;
     let start = std::time::Instant::now();
     let pods: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), NAMESPACE);
+    let mut consecutive_ok: u32 = 0;
     loop {
         if tokio::time::timeout(Duration::from_secs(5), pods.list(&ListParams::default()))
             .await
             .map(|r| r.is_ok())
             .unwrap_or(false)
         {
-            return;
+            consecutive_ok += 1;
+            if consecutive_ok >= REQUIRED_CONSECUTIVE {
+                return;
+            }
+        } else {
+            consecutive_ok = 0;
         }
         if start.elapsed() > timeout_dur {
-            panic!("k3s API server did not recover within {timeout_dur:?}");
+            panic!("k3s API server did not stabilize within {timeout_dur:?}");
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
     }


### PR DESCRIPTION
## Problem


The `deployment_rollout_reassigns_partitions` k3s integration test in `kafka-assigner` flakes regularly in CI, timing out after 180s.
The root cause is resource pressure on the single-node k3s testcontainer during deployment rollouts.

By default, k3s runs traefik, servicelb, metrics-server, coredns, and local-path-provisioner alongside the full control plane — all in one container.
When the test triggers a rolling deployment, the API server becomes unreachable under load, which stalls consumer registration and the handoff cycle until the 180s budget runs out.


## Changes

- Disable unnecessary k3s components (`--disable=traefik,servicelb,metrics-server`) in `setup_k3s()` to free up CPU and memory for the actual test workload. These components aren't needed by the test and consume significant resources in the single-node cluster.
- Require 3 consecutive successful API calls in `wait_for_k3s_api_ready` before declaring the API server stable (previously only required 1), reducing the chance of proceeding while k3s is still flaky.


## How did you test this code?

- Verified `kafka-assigner` (including tests) compiles cleanly with `cargo check`.
- The k3s integration tests require a Docker environment with k3s, etcd, and Kafka, so they can only run in CI. The fix should be validated by observing the `deployment_rollout_reassigns_partitions` test pass rate in CI after merge.


