### PR TITLE
feat(insights): add hide_on_dashboard filter to saved insights list

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -376,7 +376,7 @@ export function SavedInsights(): JSX.Element {
                         setFilters={setSavedInsightsFilters}
                         quickFilters={
                             tab === SavedInsightsTabs.Yours
-                                ? ['insightType', 'tags', 'favorites', 'featureFlags']
+                                ? ['insightType', 'tags', 'favorites', 'featureFlags', 'dashboardMembership']
                                 : undefined
                         }
                     />

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -376,7 +376,7 @@ export function SavedInsights(): JSX.Element {
                         setFilters={setSavedInsightsFilters}
                         quickFilters={
                             tab === SavedInsightsTabs.Yours
-                                ? ['insightType', 'tags', 'favorites', 'featureFlags', 'dashboardMembership']
+                                ? ['insightType', 'tags', 'favorites', 'featureFlags', 'notOnAnyDashboard']
                                 : undefined
                         }
                     />

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
@@ -134,11 +134,11 @@ describe('SavedInsightsFilters Created by dropdown', () => {
         expect(setFilters).toHaveBeenCalledWith({ createdBy: [MOCK_SECOND_BASIC_USER.id] })
     })
 
-    it('toggles hideOnDashboard when the dashboard membership filter is clicked', async () => {
-        renderFilters({ hideOnDashboard: false })
+    it('toggles notOnAnyDashboard when the dashboard membership filter is clicked', async () => {
+        renderFilters({ notOnAnyDashboard: false })
 
-        await userEvent.click(screen.getByText(/Hide insights on dashboards/))
+        await userEvent.click(screen.getByText(/Not on any dashboard/))
 
-        expect(setFilters).toHaveBeenCalledWith({ hideOnDashboard: true })
+        expect(setFilters).toHaveBeenCalledWith({ notOnAnyDashboard: true })
     })
 })

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
@@ -133,4 +133,12 @@ describe('SavedInsightsFilters Created by dropdown', () => {
 
         expect(setFilters).toHaveBeenCalledWith({ createdBy: [MOCK_SECOND_BASIC_USER.id] })
     })
+
+    it('toggles hideOnDashboard when the dashboard membership filter is clicked', async () => {
+        renderFilters({ hideOnDashboard: false })
+
+        await userEvent.click(screen.getByText(/Hide insights on dashboards/))
+
+        expect(setFilters).toHaveBeenCalledWith({ hideOnDashboard: true })
+    })
 })

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -1,6 +1,6 @@
 import posthog from 'posthog-js'
 
-import { IconFlag, IconHeart, IconHeartFilled } from '@posthog/icons'
+import { IconDashboard, IconFlag, IconHeart, IconHeartFilled } from '@posthog/icons'
 
 import { MemberSelectMultiplePopover } from 'lib/components/MemberSelectMultiplePopover'
 import { TagSelect } from 'lib/components/TagSelect'
@@ -13,8 +13,21 @@ import { cn } from 'lib/utils/css-classes'
 import { INSIGHT_TYPE_OPTIONS } from 'scenes/saved-insights/SavedInsights'
 import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
 
-export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags'
-const ALL_QUICK_FILTERS: QuickFilterKind[] = ['insightType', 'tags', 'createdBy', 'favorites', 'featureFlags']
+export type QuickFilterKind =
+    | 'insightType'
+    | 'tags'
+    | 'createdBy'
+    | 'favorites'
+    | 'featureFlags'
+    | 'dashboardMembership'
+const ALL_QUICK_FILTERS: QuickFilterKind[] = [
+    'insightType',
+    'tags',
+    'createdBy',
+    'favorites',
+    'featureFlags',
+    'dashboardMembership',
+]
 
 export function SavedInsightsFilters({
     filters,
@@ -28,7 +41,7 @@ export function SavedInsightsFilters({
     /** When true, inactive filters appear borderless. */
     borderless?: boolean
 }): JSX.Element {
-    const { search, hideFeatureFlagInsights, favorited, tags, insightType, createdBy } = filters
+    const { search, hideFeatureFlagInsights, hideOnDashboard, favorited, tags, insightType, createdBy } = filters
     const quickFilterSet = new Set(quickFilters)
     const hasInsightTypeSelection = !!insightType && insightType !== 'All types'
 
@@ -116,6 +129,18 @@ export function SavedInsightsFilters({
                             onToggle={(checked) => setFilters({ hideFeatureFlagInsights: checked })}
                         />
                     )}
+                    {quickFilterSet.has('dashboardMembership') && (
+                        <DashboardMembershipToggle
+                            hideOnDashboard={hideOnDashboard ?? undefined}
+                            onToggle={(checked) => {
+                                setFilters({ hideOnDashboard: checked })
+                                posthog.capture('saved insights filtered', {
+                                    filter_type: 'hide_on_dashboard',
+                                    value: checked,
+                                })
+                            }}
+                        />
+                    )}
                 </div>
             )}
         </div>
@@ -151,6 +176,40 @@ const FeatureFlagInsightsToggle = ({
                 size="small"
             >
                 Hide feature flag insights: <LemonSwitch checked={hideFeatureFlagInsights || false} className="ml-1" />
+            </LemonButton>
+        </Tooltip>
+    )
+}
+
+const DashboardMembershipToggle = ({
+    hideOnDashboard,
+    onToggle,
+}: {
+    hideOnDashboard?: boolean
+    onToggle: (checked: boolean) => void
+}): JSX.Element => {
+    return (
+        <Tooltip
+            title={
+                <div>
+                    <p>
+                        Hide insights that are already attached to a dashboard, so you can focus on insights that
+                        aren't on any dashboard yet.
+                    </p>
+                    <p className="mb-0">
+                        Useful for cleaning up forgotten insights or finding ones worth promoting to a dashboard.
+                    </p>
+                </div>
+            }
+            placement="top"
+        >
+            <LemonButton
+                icon={<IconDashboard />}
+                onClick={() => onToggle(!hideOnDashboard)}
+                type="tertiary"
+                size="small"
+            >
+                Hide insights on dashboards: <LemonSwitch checked={hideOnDashboard || false} className="ml-1" />
             </LemonButton>
         </Tooltip>
     )

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -19,14 +19,14 @@ export type QuickFilterKind =
     | 'createdBy'
     | 'favorites'
     | 'featureFlags'
-    | 'dashboardMembership'
+    | 'notOnAnyDashboard'
 const ALL_QUICK_FILTERS: QuickFilterKind[] = [
     'insightType',
     'tags',
     'createdBy',
     'favorites',
     'featureFlags',
-    'dashboardMembership',
+    'notOnAnyDashboard',
 ]
 
 export function SavedInsightsFilters({
@@ -41,7 +41,7 @@ export function SavedInsightsFilters({
     /** When true, inactive filters appear borderless. */
     borderless?: boolean
 }): JSX.Element {
-    const { search, hideFeatureFlagInsights, hideOnDashboard, favorited, tags, insightType, createdBy } = filters
+    const { search, hideFeatureFlagInsights, notOnAnyDashboard, favorited, tags, insightType, createdBy } = filters
     const quickFilterSet = new Set(quickFilters)
     const hasInsightTypeSelection = !!insightType && insightType !== 'All types'
 
@@ -129,13 +129,13 @@ export function SavedInsightsFilters({
                             onToggle={(checked) => setFilters({ hideFeatureFlagInsights: checked })}
                         />
                     )}
-                    {quickFilterSet.has('dashboardMembership') && (
-                        <DashboardMembershipToggle
-                            hideOnDashboard={hideOnDashboard ?? undefined}
+                    {quickFilterSet.has('notOnAnyDashboard') && (
+                        <NotOnAnyDashboardToggle
+                            notOnAnyDashboard={notOnAnyDashboard ?? undefined}
                             onToggle={(checked) => {
-                                setFilters({ hideOnDashboard: checked })
+                                setFilters({ notOnAnyDashboard: checked })
                                 posthog.capture('saved insights filtered', {
-                                    filter_type: 'hide_on_dashboard',
+                                    filter_type: 'not_on_any_dashboard',
                                     value: checked,
                                 })
                             }}
@@ -181,11 +181,11 @@ const FeatureFlagInsightsToggle = ({
     )
 }
 
-const DashboardMembershipToggle = ({
-    hideOnDashboard,
+const NotOnAnyDashboardToggle = ({
+    notOnAnyDashboard,
     onToggle,
 }: {
-    hideOnDashboard?: boolean
+    notOnAnyDashboard?: boolean
     onToggle: (checked: boolean) => void
 }): JSX.Element => {
     return (
@@ -205,11 +205,11 @@ const DashboardMembershipToggle = ({
         >
             <LemonButton
                 icon={<IconDashboard />}
-                onClick={() => onToggle(!hideOnDashboard)}
+                onClick={() => onToggle(!notOnAnyDashboard)}
                 type="tertiary"
                 size="small"
             >
-                Hide insights on dashboards: <LemonSwitch checked={hideOnDashboard || false} className="ml-1" />
+                Not on any dashboard: <LemonSwitch checked={notOnAnyDashboard || false} className="ml-1" />
             </LemonButton>
         </Tooltip>
     )

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
@@ -327,6 +327,48 @@ describe('savedInsightsLogic', () => {
         })
     })
 
+    describe('hideOnDashboard filter', () => {
+        it('defaults to false and preserves true through cleanFilters', () => {
+            expect(cleanFilters({}).hideOnDashboard).toBe(false)
+            expect(cleanFilters({ hideOnDashboard: true }).hideOnDashboard).toBe(true)
+            expect(cleanFilters({ hideOnDashboard: false }).hideOnDashboard).toBe(false)
+        })
+
+        it('sends hide_on_dashboard=true query param when filter is enabled', async () => {
+            let lastSearchParams: URLSearchParams | null = null
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/insights/': (req) => {
+                        lastSearchParams = req.url.searchParams
+                        return [200, createSavedInsights('', 0)]
+                    },
+                },
+            })
+
+            logic.actions.setSavedInsightsFilters({ hideOnDashboard: true })
+            await expectLogic(logic).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+
+            expect(lastSearchParams?.get('hide_on_dashboard')).toBe('true')
+        })
+
+        it('omits hide_on_dashboard query param when filter is disabled', async () => {
+            let lastSearchParams: URLSearchParams | null = null
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/insights/': (req) => {
+                        lastSearchParams = req.url.searchParams
+                        return [200, createSavedInsights('', 0)]
+                    },
+                },
+            })
+
+            logic.actions.setSavedInsightsFilters({ search: 'noop' })
+            await expectLogic(logic).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+
+            expect(lastSearchParams?.has('hide_on_dashboard')).toBe(false)
+        })
+    })
+
     describe('reacts to external updates', () => {
         it('loads insights when a dashboard is duplicated', async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
@@ -328,10 +328,12 @@ describe('savedInsightsLogic', () => {
     })
 
     describe('hideOnDashboard filter', () => {
-        it('defaults to false and preserves true through cleanFilters', () => {
-            expect(cleanFilters({}).hideOnDashboard).toBe(false)
-            expect(cleanFilters({ hideOnDashboard: true }).hideOnDashboard).toBe(true)
-            expect(cleanFilters({ hideOnDashboard: false }).hideOnDashboard).toBe(false)
+        it.each([
+            [undefined, false],
+            [true, true],
+            [false, false],
+        ])('cleanFilters({ hideOnDashboard: %s }).hideOnDashboard === %s', (input, expected) => {
+            expect(cleanFilters({ hideOnDashboard: input as boolean | undefined }).hideOnDashboard).toBe(expected)
         })
 
         it('sends hide_on_dashboard=true query param when filter is enabled', async () => {

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
@@ -327,16 +327,16 @@ describe('savedInsightsLogic', () => {
         })
     })
 
-    describe('hideOnDashboard filter', () => {
+    describe('notOnAnyDashboard filter', () => {
         it.each([
             [undefined, false],
             [true, true],
             [false, false],
-        ])('cleanFilters({ hideOnDashboard: %s }).hideOnDashboard === %s', (input, expected) => {
-            expect(cleanFilters({ hideOnDashboard: input as boolean | undefined }).hideOnDashboard).toBe(expected)
+        ])('cleanFilters({ notOnAnyDashboard: %s }).notOnAnyDashboard === %s', (input, expected) => {
+            expect(cleanFilters({ notOnAnyDashboard: input as boolean | undefined }).notOnAnyDashboard).toBe(expected)
         })
 
-        it('sends hide_on_dashboard=true query param when filter is enabled', async () => {
+        it('sends not_on_any_dashboard=true query param when filter is enabled', async () => {
             let lastSearchParams: URLSearchParams | null = null
             useMocks({
                 get: {
@@ -347,13 +347,13 @@ describe('savedInsightsLogic', () => {
                 },
             })
 
-            logic.actions.setSavedInsightsFilters({ hideOnDashboard: true })
+            logic.actions.setSavedInsightsFilters({ notOnAnyDashboard: true })
             await expectLogic(logic).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
 
-            expect(lastSearchParams?.get('hide_on_dashboard')).toBe('true')
+            expect(lastSearchParams?.get('not_on_any_dashboard')).toBe('true')
         })
 
-        it('omits hide_on_dashboard query param when filter is disabled', async () => {
+        it('omits not_on_any_dashboard query param when filter is disabled', async () => {
             let lastSearchParams: URLSearchParams | null = null
             useMocks({
                 get: {
@@ -367,7 +367,7 @@ describe('savedInsightsLogic', () => {
             logic.actions.setSavedInsightsFilters({ search: 'noop' })
             await expectLogic(logic).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
 
-            expect(lastSearchParams?.has('hide_on_dashboard')).toBe(false)
+            expect(lastSearchParams?.has('not_on_any_dashboard')).toBe(false)
         })
     })
 

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -67,7 +67,7 @@ export interface SavedInsightFilters {
     dashboardId: number | undefined | null
     events: string[] | undefined | null
     hideFeatureFlagInsights: boolean | undefined | null
-    hideOnDashboard: boolean | undefined | null
+    notOnAnyDashboard: boolean | undefined | null
     favorited: boolean | undefined | null
 }
 
@@ -90,7 +90,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         dashboardId: values.dashboardId,
         events: values.events,
         hideFeatureFlagInsights: values.hideFeatureFlagInsights || false,
-        hideOnDashboard: values.hideOnDashboard || false,
+        notOnAnyDashboard: values.notOnAnyDashboard || false,
         favorited: values.favorited || false,
     }
 }
@@ -132,7 +132,7 @@ function insightsListParams(filters: SavedInsightFilters): Record<string, any> {
             dashboards: [filters.dashboardId],
         }),
         ...(filters.hideFeatureFlagInsights && { hide_feature_flag_insights: true }),
-        ...(filters.hideOnDashboard && { hide_on_dashboard: true }),
+        ...(filters.notOnAnyDashboard && { not_on_any_dashboard: true }),
     }
 }
 

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -67,6 +67,7 @@ export interface SavedInsightFilters {
     dashboardId: number | undefined | null
     events: string[] | undefined | null
     hideFeatureFlagInsights: boolean | undefined | null
+    hideOnDashboard: boolean | undefined | null
     favorited: boolean | undefined | null
 }
 
@@ -89,6 +90,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         dashboardId: values.dashboardId,
         events: values.events,
         hideFeatureFlagInsights: values.hideFeatureFlagInsights || false,
+        hideOnDashboard: values.hideOnDashboard || false,
         favorited: values.favorited || false,
     }
 }
@@ -130,6 +132,7 @@ function insightsListParams(filters: SavedInsightFilters): Record<string, any> {
             dashboards: [filters.dashboardId],
         }),
         ...(filters.hideFeatureFlagInsights && { hide_feature_flag_insights: true }),
+        ...(filters.hideOnDashboard && { hide_on_dashboard: true }),
     }
 }
 

--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -2081,14 +2081,14 @@ class InsightViewSet(
                     )
             elif key == "hide_on_dashboard":
                 if str_to_bool(request.GET["hide_on_dashboard"]):
-                    # Exclude insights that are attached to any active dashboard.
+                    # Mirrors the `saved` filter above: an insight is considered
+                    # "on a dashboard" only if it has a tile on a non-unlisted dashboard.
                     # DashboardTile.objects (default manager) already excludes soft-deleted tiles
                     # and tiles whose dashboard is soft-deleted.
-                    queryset = queryset.exclude(
-                        id__in=DashboardTile.objects.filter(insight__isnull=False).values_list(
-                            "insight_id", flat=True
-                        )
+                    visible_tile_for_insight = DashboardTile.objects.filter(insight=OuterRef("pk")).exclude(
+                        dashboard__creation_mode="unlisted"
                     )
+                    queryset = queryset.exclude(Exists(visible_tile_for_insight))
             elif key == "date_from":
                 queryset = queryset.filter(
                     last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)

--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -1751,6 +1751,11 @@ Background calculation can be tracked using the `query_status` response field.""
                 description="JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).",
             ),
             OpenApiParameter(
+                name="not_on_any_dashboard",
+                type=OpenApiTypes.BOOL,
+                description="When truthy, restricts results to insights that aren't tiled on any dashboard.",
+            ),
+            OpenApiParameter(
                 name="tags",
                 type=OpenApiTypes.STR,
                 description="JSON-encoded array of tag names. Returns insights with any of the listed tags.",
@@ -2079,8 +2084,8 @@ class InsightViewSet(
                     queryset = queryset.exclude(
                         name__in=[FEATURE_FLAG_TOTAL_VOLUME_INSIGHT_NAME, FEATURE_FLAG_UNIQUE_USERS_INSIGHT_NAME]
                     )
-            elif key == "hide_on_dashboard":
-                if str_to_bool(request.GET["hide_on_dashboard"]):
+            elif key == "not_on_any_dashboard":
+                if str_to_bool(request.GET["not_on_any_dashboard"]):
                     # Mirrors the `saved` filter above: an insight is considered
                     # "on a dashboard" only if it has a tile on a non-unlisted dashboard.
                     # DashboardTile.objects (default manager) already excludes soft-deleted tiles

--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -2079,6 +2079,16 @@ class InsightViewSet(
                     queryset = queryset.exclude(
                         name__in=[FEATURE_FLAG_TOTAL_VOLUME_INSIGHT_NAME, FEATURE_FLAG_UNIQUE_USERS_INSIGHT_NAME]
                     )
+            elif key == "hide_on_dashboard":
+                if str_to_bool(request.GET["hide_on_dashboard"]):
+                    # Exclude insights that are attached to any active dashboard.
+                    # DashboardTile.objects (default manager) already excludes soft-deleted tiles
+                    # and tiles whose dashboard is soft-deleted.
+                    queryset = queryset.exclude(
+                        id__in=DashboardTile.objects.filter(insight__isnull=False).values_list(
+                            "insight_id", flat=True
+                        )
+                    )
             elif key == "date_from":
                 queryset = queryset.filter(
                     last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)

--- a/products/product_analytics/backend/tests/api/test_insight.py
+++ b/products/product_analytics/backend/tests/api/test_insight.py
@@ -502,6 +502,54 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(len(response.json()["results"]), 1)
         self.assertEqual(response.json()["results"][0]["name"], "Regular Insight")
 
+    def test_hide_on_dashboard_filter(self) -> None:
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
+
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "the dashboard"})
+
+        # Insight attached to a dashboard via the `dashboards` write path,
+        # which creates a DashboardTile under the hood.
+        self.dashboard_api.create_insight(
+            {"filters": filter_dict, "name": "On dashboard", "dashboards": [dashboard_id], "saved": True}
+        )
+
+        # Orphan insight — no DashboardTile.
+        Insight.objects.create(
+            name="Not on dashboard",
+            filters=Filter(data=filter_dict).to_dict(),
+            saved=True,
+            team=self.team,
+            created_by=self.user,
+        )
+
+        # Insight whose only DashboardTile was soft-deleted — should be treated
+        # as not on a dashboard, since the default DashboardTile manager hides
+        # soft-deleted rows.
+        soft_deleted_insight = Insight.objects.create(
+            name="Soft-deleted tile",
+            filters=Filter(data=filter_dict).to_dict(),
+            saved=True,
+            team=self.team,
+            created_by=self.user,
+        )
+        DashboardTile.objects_including_soft_deleted.create(
+            dashboard_id=dashboard_id, insight=soft_deleted_insight, deleted=True
+        )
+
+        # Without filter: all 3 saved insights returned.
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 3)
+
+        # With filter: only the two insights with no active dashboard tile.
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true&hide_on_dashboard=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = sorted(r["name"] for r in response.json()["results"])
+        self.assertEqual(names, ["Not on dashboard", "Soft-deleted tile"])
+
     def test_get_insight_in_dashboard_context(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard(
             {"name": "the dashboard", "filters": {"date_from": "-180d"}}

--- a/products/product_analytics/backend/tests/api/test_insight.py
+++ b/products/product_analytics/backend/tests/api/test_insight.py
@@ -539,16 +539,30 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             dashboard_id=dashboard_id, insight=soft_deleted_insight, deleted=True
         )
 
-        # Without filter: all 3 saved insights returned.
+        # Insight on an unlisted (system-generated) dashboard — should be treated
+        # as not on a dashboard, mirroring the `saved` filter's semantics.
+        unlisted_dashboard = Dashboard.objects.create(
+            name="d-unlisted", team=self.team, creation_mode="unlisted"
+        )
+        on_unlisted_insight = Insight.objects.create(
+            name="On unlisted dashboard",
+            filters=Filter(data=filter_dict).to_dict(),
+            saved=True,
+            team=self.team,
+            created_by=self.user,
+        )
+        DashboardTile.objects.create(dashboard=unlisted_dashboard, insight=on_unlisted_insight)
+
+        # Without filter: all 4 saved insights returned.
         response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.json()["results"]), 3)
+        self.assertEqual(len(response.json()["results"]), 4)
 
-        # With filter: only the two insights with no active dashboard tile.
+        # With filter: insights with no active non-unlisted dashboard tile.
         response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true&hide_on_dashboard=true")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         names = sorted(r["name"] for r in response.json()["results"])
-        self.assertEqual(names, ["Not on dashboard", "Soft-deleted tile"])
+        self.assertEqual(names, ["Not on dashboard", "On unlisted dashboard", "Soft-deleted tile"])
 
     def test_get_insight_in_dashboard_context(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard(

--- a/products/product_analytics/backend/tests/api/test_insight.py
+++ b/products/product_analytics/backend/tests/api/test_insight.py
@@ -502,7 +502,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(len(response.json()["results"]), 1)
         self.assertEqual(response.json()["results"][0]["name"], "Regular Insight")
 
-    def test_hide_on_dashboard_filter(self) -> None:
+    def test_not_on_any_dashboard_filter(self) -> None:
         filter_dict = {
             "events": [{"id": "$pageview"}],
             "properties": [{"key": "$browser", "value": "Mac OS X"}],
@@ -559,7 +559,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(len(response.json()["results"]), 4)
 
         # With filter: insights with no active non-unlisted dashboard tile.
-        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true&hide_on_dashboard=true")
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true&not_on_any_dashboard=true")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         names = sorted(r["name"] for r in response.json()["results"])
         self.assertEqual(names, ["Not on dashboard", "On unlisted dashboard", "Soft-deleted tile"])


### PR DESCRIPTION
## Problem

Closes #26621

The Saved insights list lets users filter by tags, owner, type, favorites, and more, but there's no way to surface insights that aren't attached to any dashboard yet. The issue describes the orphan-insights case: users want to find forgotten insights worth promoting (or cleaning up), and a couple of users have already +1'd on the issue (one of them was redirected from support).

## Changes

**Frontend** (`frontend/src/scenes/saved-insights/`):

- `SavedInsightFilters.hideOnDashboard` boolean added to the interface + `cleanFilters` default + outgoing `hide_on_dashboard` query param wiring in `savedInsightsLogic.ts`.
- New `'dashboardMembership'` `QuickFilterKind` and matching `DashboardMembershipToggle` sub-component (`LemonSwitch` inside a tooltip-wrapped `LemonButton` with `IconDashboard`). Mirrors the existing `FeatureFlagInsightsToggle` shape exactly.
- Added `'dashboardMembership'` to the `Yours`-tab quick filter list in `SavedInsights.tsx`.

**Backend** (`posthog/api/insight.py`):

- New `elif key == "hide_on_dashboard"` handler placed right after `hide_feature_flag_insights` for symmetry. Excludes insights that have any active `DashboardTile` via:

  ```python
  queryset.exclude(
      id__in=DashboardTile.objects.filter(insight__isnull=False)
                                  .values_list("insight_id", flat=True)
  )
  ```

  `DashboardTile.objects` is the default manager that already filters out soft-deleted tiles and tiles whose dashboard is soft-deleted, so the filter naturally treats those as "not on a dashboard" without re-implementing that logic. The pattern (subquery + `id__in`) mirrors an existing usage at `insight.py:1557`.

## How did you test this code?

> Agent disclosure: I'm an agent (Claude). I did **not** run the dev environment locally — see Agent context for the blocker. The tests below are written but not executed by me; I'm relying on PostHog CI for full verification.

**Automated tests added:**

- `posthog/api/test/test_insight.py::TestInsight::test_hide_on_dashboard_filter` — sets up 3 saved insights (one on a dashboard, one orphan, one whose only `DashboardTile` was soft-deleted). Asserts the default list returns all 3, and `?hide_on_dashboard=true` returns exactly the orphan + the soft-deleted-tile pair.
- `frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts` — three cases under `describe('hideOnDashboard filter')`: `cleanFilters` default + preserve behavior, query-param presence when enabled, query-param absence when disabled.
- `frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx` — clicks the toggle and asserts `setFilters({ hideOnDashboard: true })`.

No UI screenshot included for the same reason as above. Happy to add one in a follow-up commit once I have a working local env (or if a maintainer can quickly point me to a working dev-env recipe for this codebase that doesn't require everything-on-host).

## Publish to changelog?

do not publish to changelog

## Docs update

No docs change needed — existing saved-insights docs don't enumerate quick filters.

## 🤖 Agent context

- **Tools/agent:** Claude Code (Claude Opus 4.7), single session.
- **Key human prompts that shaped this work:**
  - "Implement the saved insights filter from issue #26621, mirror the existing `hideFeatureFlagInsights` pattern."
  - User explicitly approved naming `hideOnDashboard` / `hide_on_dashboard` (chosen for parity with `hideFeatureFlagInsights` / `hide_feature_flag_insights`).
  - User confirmed UI label "Hide insights on dashboards" (matches the "Hide feature flag insights" voice on the sibling toggle).
- **Decisions made along the way:**
  - **ORM choice:** picked `queryset.exclude(id__in=DashboardTile.objects.filter(insight__isnull=False).values_list("insight_id", flat=True))` over a naive `dashboards__isnull=True` (Insight ↔ Dashboard isn't a direct M2M, it goes through `DashboardTile`) and over a manual `Exists()` subquery (the `id__in` pattern is already used at `insight.py:1557`, keeping the file consistent).
  - **Soft-delete handling:** chose to lean on `DashboardTile.objects`'s default-manager filtering (excludes `deleted=True` and `dashboard__deleted=True`) instead of duplicating the conditions in the new handler. Backend test explicitly covers the soft-deleted-tile case.
  - **Analytics event:** added `posthog.capture('saved insights filtered', { filter_type: 'hide_on_dashboard', value: checked })` to match the broader file convention (the other filter handlers all `posthog.capture`). The existing `FeatureFlagInsightsToggle` doesn't `posthog.capture`, so this is technically inconsistent with the immediate sibling — happy to drop it for parity if reviewers prefer.
- **Local verification blocker (full disclosure):** I tried `docker-compose.dev-full.yml` because I was constrained to "everything in Docker". The production-targeted `Dockerfile` builds an image that excludes the ~70 dev dependencies under `[dependency-groups]` in `pyproject.toml`. With `DEBUG=1` set by `dev-full.yml`, the web container immediately fails with `ModuleNotFoundError: No module named 'django_linear_migrations'`. The packaged Python runtime at `/python-runtime/` doesn't ship `pip` either, so I couldn't patch deps in at runtime. The standard PostHog dev path (`flox` + `bin/start` natively on the host) wasn't available in this session.
- I read every file change end-to-end myself before submitting and own the code. All changes follow patterns already in the file (`hideFeatureFlagInsights` for the FE shape, `DashboardTile.objects` subquery for the BE shape, `FeatureFlagInsightsToggle` for the sub-component layout).