### PR TITLE
fix(devex): make openapi codegen exit non-zero on silent orval no-ops

### DIFF
--- a/frontend/bin/generate-openapi-types.mjs
+++ b/frontend/bin/generate-openapi-types.mjs
@@ -628,8 +628,44 @@ if (zodJobs.length > 0) {
 }
 console.log('')
 
+// Snapshot expected output mtimes so we can detect "fulfilled but didn't
+// write" — orval prints "🛑 Validation failed" then resolves cleanly, so a
+// silent no-op looks identical to success without this check. Any job whose
+// output file isn't newer after the run is reclassified as a failure.
+const expectedOutputs = allJobs.map((job) => {
+    const outputPath = job.kind === 'zod' ? path.join(job.outputDir, 'api.zod.ts') : path.join(job.outputDir, 'api.ts')
+    return {
+        path: outputPath,
+        preMtime: fs.existsSync(outputPath) ? fs.statSync(outputPath).mtimeMs : 0,
+    }
+})
+
 // Run all orval generations in parallel (in-process, no subprocess overhead)
 const results = await runOrvalParallel(allJobs.map((j) => ({ config: j.config, label: `${j.label}:${j.kind}` })))
+
+// Reclassify silent-no-op fulfilments as failures. CI's `git diff --exit-code`
+// gate in ci-backend.yml can't catch this on its own — when orval skips a
+// write, the disk matches HEAD and the diff comes back clean for the wrong
+// reason. Catching it here makes `hogli build:openapi` itself exit non-zero
+// before we ever reach the diff check.
+for (let i = 0; i < results.length; i++) {
+    if (results[i].status !== 'fulfilled') {
+        continue
+    }
+    const expected = expectedOutputs[i]
+    const exists = fs.existsSync(expected.path)
+    const mtime = exists ? fs.statSync(expected.path).mtimeMs : 0
+    if (!exists || mtime <= expected.preMtime) {
+        results[i] = {
+            status: 'rejected',
+            label: results[i].label,
+            reason: new Error(
+                `orval reported success but did not write ${path.relative(repoRoot, expected.path)} ` +
+                    `— check stderr above for "🛑 Validation failed" or other orval errors`
+            ),
+        }
+    }
+}
 
 // Report results and collect output dirs for formatting
 const outputDirs = []
@@ -688,4 +724,11 @@ if (generateAll) {
     console.log('')
     console.log('💡 Now run: node frontend/bin/find-type-overlaps.mjs')
     console.log('   to see which manual types overlap with generated types.')
+}
+
+// Exit non-zero on any failure so the wrapping `hogli build:openapi` gates
+// fail loudly. Without this, `git diff --exit-code` is the only signal
+// downstream — and it can't see silent no-op writes (see above).
+if (failed > 0) {
+    process.exit(1)
 }


### PR DESCRIPTION
## Problem

Companion follow-up to #57349.

orval's \`generate()\` resolves \"fulfilled\" even when a per-product slice fails OpenAPI validation (INVALID_REFERENCE on shared \`components.parameters\` $refs is the case that surfaced this). The script logged \`✓ <product>:fetch\` and exited 0 despite no file being written. CI's \`git diff --exit-code\` gate in \`ci-backend.yml\` couldn't see this either: orval no-op + stale committed files = no diff to detect, so the gate passed for the wrong reason. Master sat with stale generated types for two days and nobody noticed.

## Changes

Two layered checks in \`frontend/bin/generate-openapi-types.mjs\`:

**Snapshot expected output mtimes before the orval run, reclassify silent no-ops as failures.** Any job whose output file isn't newer after the run gets flipped from \`fulfilled\` to \`rejected\`. Catches both \"no file written\" and \"stale file untouched\" cases — anything where mtime didn't move past its pre-run value.

**Exit non-zero from the script when any job failed.** The existing \`failed\` counter was only printed in a summary line; nothing propagated up to the \`hogli build:openapi\` wrapper, so the diff gate was effectively the only signal. With \`process.exit(1)\`, \`hogli build:openapi\` itself fails before we ever reach the diff check.

Together, a future regression like #56865 (which broke per-product slicing for two days because the slicer was dropping \`components.parameters\`) would block CI on the introducing PR instead of slipping through and silently freezing all 50 products' types.

## How did you test this code?

I'm an agent. Verified locally:
- Without #57349 applied (master state, slicer broken): \`hogli build:openapi\` now reports 100 silent-no-op rejections and exits 1 (was: 0 reported, exit 0).
- With #57349 cherry-picked on top: \`hogli build:openapi\` runs clean, no false positives.

## Publish to changelog?

no

## 🤖 Agent context

This PR depends on #57349 to actually be green — without the slicer fix on master, the per-product slices fail validation and this PR's new check correctly fires. **Order matters: merge #57349 first, then this.** Once #57349 is on master, this PR's CI passes and it can land.

Considered making the orval wrapper in \`tools/openapi-codegen\` capture stdout/stderr to detect orval's \"🛑 Validation failed\" lines directly. Mtime-based detection is simpler, doesn't touch the shared package, and is robust against parallel jobs sharing \`process.stderr\`.