### PR TITLE
chore(hog-charts): use the testing module internally + add LineChart tests

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render } from '@testing-library/react'
 import { drawBars } from '../core/canvas-renderer'
 import type { BarRect } from '../core/canvas-renderer'
 import type { ChartTheme, ResolvedSeries, Series } from '../core/types'
-import { setupJsdom, setupSyncRaf } from '../testing'
+import { renderHogChart, setupJsdom, setupSyncRaf } from '../testing'
 import { BarChart } from './BarChart'
 
 jest.mock('../core/canvas-renderer', () => {
@@ -70,8 +70,8 @@ describe('BarChart', () => {
     })
 
     it('renders empty state without crashing', () => {
-        const { container } = render(<BarChart series={[]} labels={[]} theme={THEME} />)
-        expect(container.querySelector('canvas')).not.toBeNull()
+        const { chart } = renderHogChart(<BarChart series={[]} labels={[]} theme={THEME} />)
+        expect(chart.seriesCount).toBe(0)
     })
 
     it('skips excluded series in stacked layout', () => {
@@ -80,10 +80,10 @@ describe('BarChart', () => {
             { key: 'b', label: 'B', data: [5, 15, 25], visibility: { excluded: true } },
             { key: 'c', label: 'C', data: [3, 6, 9] },
         ]
-        const { container } = render(
+        const { chart } = renderHogChart(
             <BarChart series={series} labels={LABELS} theme={THEME} config={{ barLayout: 'stacked' }} />
         )
-        expect(container.querySelector('canvas')).not.toBeNull()
+        expect(chart.seriesCount).toBe(2)
     })
 
     it('renders custom percent formatter when consumer supplies one', () => {
@@ -102,12 +102,10 @@ describe('BarChart', () => {
     })
 
     it('applies a default percent formatter when consumer omits one', () => {
-        const { container } = render(
+        const { chart } = renderHogChart(
             <BarChart series={SERIES} labels={LABELS} theme={THEME} config={{ barLayout: 'percent' }} />
         )
-        // AxisLabels renders tick text into divs; default percent formatter emits values like "50%".
-        const text = container.textContent ?? ''
-        expect(text).toMatch(/\d+%/)
+        expect(chart.yTicks().some((t) => /\d+%/.test(t))).toBe(true)
     })
 
     it('tolerates NaN data values without throwing', () => {

--- a/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render } from '@testing-library/react'
+
+import type { ChartTheme, Series } from '../core/types'
+import { renderHogChart, setupJsdom, setupSyncRaf } from '../testing'
+import { LineChart } from './LineChart'
+
+const THEME: ChartTheme = {
+    colors: ['#1f77b4', '#ff7f0e', '#2ca02c'],
+    backgroundColor: '#ffffff',
+    gridColor: '#eeeeee',
+    crosshairColor: '#888888',
+}
+
+const SERIES: Series[] = [
+    { key: 'a', label: 'A', data: [10, 20, 30] },
+    { key: 'b', label: 'B', data: [5, 15, 25] },
+]
+
+const LABELS = ['Mon', 'Tue', 'Wed']
+
+describe('LineChart', () => {
+    let teardownJsdom: () => void
+    let teardownRaf: () => void
+
+    beforeEach(() => {
+        teardownJsdom = setupJsdom()
+        teardownRaf = setupSyncRaf()
+    })
+
+    afterEach(() => {
+        teardownRaf()
+        teardownJsdom()
+        cleanup()
+    })
+
+    it('renders a canvas without throwing for default config', () => {
+        const { container } = render(<LineChart series={SERIES} labels={LABELS} theme={THEME} />)
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+
+    it('renders area mode without throwing', () => {
+        const series: Series[] = [{ key: 'a', label: 'A', data: [10, 20, 30], fill: {} }]
+        const { container } = render(<LineChart series={series} labels={LABELS} theme={THEME} />)
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+
+    it('renders percent stack mode without throwing', () => {
+        const { container } = render(
+            <LineChart series={SERIES} labels={LABELS} theme={THEME} config={{ percentStackView: true }} />
+        )
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+
+    it('renders empty state without crashing', () => {
+        const { chart } = renderHogChart(<LineChart series={[]} labels={[]} theme={THEME} />)
+        expect(chart.seriesCount).toBe(0)
+    })
+
+    it('skips excluded series', () => {
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [10, 20, 30] },
+            { key: 'b', label: 'B', data: [5, 15, 25], visibility: { excluded: true } },
+            { key: 'c', label: 'C', data: [3, 6, 9] },
+        ]
+        const { chart } = renderHogChart(<LineChart series={series} labels={LABELS} theme={THEME} />)
+        expect(chart.seriesCount).toBe(2)
+    })
+
+    it('forwards `dataAttr` to the chart wrapper for product-test selection', () => {
+        const { container } = render(
+            <LineChart series={SERIES} labels={LABELS} theme={THEME} dataAttr="line-chart-instance" />
+        )
+        expect(container.querySelector('[data-attr="line-chart-instance"]')).not.toBeNull()
+    })
+
+    it('applies a default percent formatter when consumer omits one in percent stack mode', () => {
+        const { chart } = renderHogChart(
+            <LineChart series={SERIES} labels={LABELS} theme={THEME} config={{ percentStackView: true }} />
+        )
+        expect(chart.yTicks().some((t) => /\d+%/.test(t))).toBe(true)
+    })
+
+    it('uses custom yTickFormatter when supplied in percent stack mode', () => {
+        const formatter = jest.fn((v: number) => `${Math.round(v * 1000) / 10}‰`)
+        const { chart } = renderHogChart(
+            <LineChart
+                series={SERIES}
+                labels={LABELS}
+                theme={THEME}
+                config={{ percentStackView: true, yTickFormatter: formatter }}
+            />
+        )
+        expect(formatter).toHaveBeenCalled()
+        expect(chart.yTicks().some((t) => t.endsWith('‰'))).toBe(true)
+    })
+
+    it('tolerates NaN data values without throwing', () => {
+        const broken: Series[] = [{ key: 'a', label: 'A', data: [Number.NaN, Number.NaN, Number.NaN] }]
+        const { container } = render(<LineChart series={broken} labels={LABELS} theme={THEME} />)
+        expect(container.querySelector('canvas')).not.toBeNull()
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.test.tsx
@@ -33,22 +33,13 @@ describe('LineChart', () => {
         cleanup()
     })
 
-    it('renders a canvas without throwing for default config', () => {
-        const { container } = render(<LineChart series={SERIES} labels={LABELS} theme={THEME} />)
-        expect(container.querySelector('canvas')).not.toBeNull()
-    })
-
-    it('renders area mode without throwing', () => {
-        const series: Series[] = [{ key: 'a', label: 'A', data: [10, 20, 30], fill: {} }]
-        const { container } = render(<LineChart series={series} labels={LABELS} theme={THEME} />)
-        expect(container.querySelector('canvas')).not.toBeNull()
-    })
-
-    it('renders percent stack mode without throwing', () => {
-        const { container } = render(
-            <LineChart series={SERIES} labels={LABELS} theme={THEME} config={{ percentStackView: true }} />
-        )
-        expect(container.querySelector('canvas')).not.toBeNull()
+    it.each([
+        ['default config', SERIES, undefined],
+        ['area mode', [{ key: 'a', label: 'A', data: [10, 20, 30], fill: {} }] as Series[], undefined],
+        ['percent stack mode', SERIES, { percentStackView: true }],
+    ] as const)('renders without throwing in %s', (_, series, config) => {
+        const { chart } = renderHogChart(<LineChart series={series} labels={LABELS} theme={THEME} config={config} />)
+        expect(chart.seriesCount).toBeGreaterThan(0)
     })
 
     it('renders empty state without crashing', () => {

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -1,20 +1,8 @@
 import * as d3 from 'd3'
 
+import { dimensions, makeSeries } from '../testing'
 import { composeDrawHoverWithCrosshair, drawArea, drawGrid, drawLine, type DrawContext } from './canvas-renderer'
-import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, ResolvedSeries, Series } from './types'
-
-const dimensions: ChartDimensions = {
-    width: 800,
-    height: 400,
-    plotLeft: 48,
-    plotTop: 16,
-    plotWidth: 736,
-    plotHeight: 352,
-}
-
-function makeSeries(overrides: Partial<Series> & { key: string; data: number[] }): ResolvedSeries {
-    return { label: overrides.key, color: '#f00', ...overrides }
-}
+import type { ChartDrawArgs, ChartScales, ChartTheme } from './types'
 
 function mockCanvasContext(): jest.Mocked<CanvasRenderingContext2D> {
     return {

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -1,17 +1,9 @@
 import { renderHook, type RenderHookResult } from '@testing-library/react'
 import { act } from 'react'
 
-import type { ChartDimensions, ChartScales } from '../types'
+import { dimensions } from '../../testing'
+import type { ChartScales } from '../types'
 import { useChartInteraction } from './useChartInteraction'
-
-const dimensions: ChartDimensions = {
-    width: 800,
-    height: 400,
-    plotLeft: 48,
-    plotTop: 16,
-    plotWidth: 736,
-    plotHeight: 352,
-}
 
 const scales: ChartScales = {
     x: (label: string) => ({ Mon: 100, Tue: 200, Wed: 300 })[label],

--- a/frontend/src/lib/hog-charts/testing/index.ts
+++ b/frontend/src/lib/hog-charts/testing/index.ts
@@ -2,6 +2,7 @@ export { dimensions, makeSeries, mockRect, setupJsdom, setupSyncRaf } from './js
 export { clickAtIndex, hoverAtIndex } from './interactions'
 export { getHogChart } from './accessor'
 export type { HogChart } from './accessor'
+export { renderHogChart } from './render'
 export {
     createHogChartTooltip,
     getHogChartTooltip,

--- a/frontend/src/lib/hog-charts/testing/render.ts
+++ b/frontend/src/lib/hog-charts/testing/render.ts
@@ -1,0 +1,12 @@
+import { render, type RenderResult } from '@testing-library/react'
+import type { ReactElement } from 'react'
+
+import { getHogChart, type HogChart } from './accessor'
+
+/** Render a hog-charts component and return Testing Library's `RenderResult`
+ *  with a `chart` accessor attached. Throws if the rendered component doesn't
+ *  emit a hog-charts canvas — use plain `render` for non-chart components. */
+export function renderHogChart(ui: ReactElement): RenderResult & { chart: HogChart } {
+    const result = render(ui)
+    return { ...result, chart: getHogChart(result.container) }
+}

--- a/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom'
 import { cleanup, screen, waitFor } from '@testing-library/react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { setupJsdom } from 'lib/hog-charts/test-helpers'
+import { setupJsdom } from 'lib/hog-charts/testing'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildTrendsQuery, chart, renderInsight } from '~/test/insight-testing'


### PR DESCRIPTION
## Problem

Phase 1 (#57348) shipped `lib/hog-charts/testing` and a deprecation path for the old shims. A few internal hog-charts test files still hand-rolled the same fixtures (`dimensions`, `makeSeries`) the testing module already exports, several `BarChart.test.tsx` assertions were just "canvas exists" rather than actual behavior, and there was no focused test file for `LineChart` — its specific behaviors (percent-stack auto-formatter, area-fill detection, stack composition) were only covered indirectly via Trends integration tests.

## Changes

- New `lib/hog-charts/testing/render.ts` — `renderHogChart` helper that returns Testing Library's `RenderResult` with a `chart` accessor attached, so chart tests don't have to call `getHogChart(container)` separately.
- Strengthen three `BarChart.test.tsx` assertions: empty state and excluded-series tests now assert `seriesCount` instead of "canvas exists"; the default percent-formatter test reads y-axis ticks from the accessor instead of regex-sweeping `container.textContent`.
- Drop the locally-duplicated `dimensions` and `makeSeries` fixtures from `core/canvas-renderer.test.ts` and `core/hooks/useChartInteraction.test.ts`; both now import from the testing module.
- New `charts/LineChart.test.tsx` mirroring BarChart's coverage shape: smoke per mode (default / area / percent-stack), empty state, excluded series, `dataAttr` forwarding, default vs custom percent formatter, NaN tolerance.

Skipped intentionally: `ReferenceLine.test.tsx` and `ValueLabels.test.tsx` use a different `plotWidth` (720 vs the canonical 736) — leaving those alone until someone confirms whether the divergence was deliberate.

## How did you test this code?

I'm an agent. Ran the four affected jest suites locally:

- `hogli test frontend/src/lib/hog-charts/charts/LineChart.test.tsx` — 9/9 (new)
- `hogli test frontend/src/lib/hog-charts/charts/BarChart.test.tsx` — 13/13
- `hogli test frontend/src/lib/hog-charts/core/canvas-renderer.test.ts` — 50/50
- `hogli test frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts` — 15/15

Total 87/87 passing. No manual UI testing — this is a pure refactor + new test file.

## Publish to changelog?

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7, 1M context)
- Follow-up to #57348. The original ask was to ship the testing module; once that landed, the next pass was to actually use it internally and close the asymmetry between BarChart (had a focused test file) and LineChart (didn't).
- Decisions:
  - Subpath helper (`renderHogChart`) returns `RenderResult & { chart }` rather than just `chart` — keeps `rerender` / `unmount` / `getByText` available without adding API surface
  - Did not expose `canvas` on the result: in hog-charts the wrapper is the event target, not the canvas, so the win was negligible
  - Did not include `hover` / `click` shortcuts: `totalLabels` can't be inferred from the rendered DOM (post-collision-avoidance `xTicks()` may be a subset), so the ergonomic win is one variable name
  - Skipped the parameterized "renders without throwing" smoke tests in BarChart — the test name promises smoke, not behavior, and `seriesCount === 2` would be thin noise