### PR TITLE
perf(event-definitions): index posthog_eventdefinition on (team_id, name)

### DIFF
--- a/products/event_definitions/backend/migrations/0004_eventdefinition_team_name_idx.py
+++ b/products/event_definitions/backend/migrations/0004_eventdefinition_team_name_idx.py
@@ -1,0 +1,17 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0003_eventdefinition_promoted_property"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="eventdefinition",
+            index=models.Index(fields=["team_id", "name"], name="posthog_eventdef_team_name_idx"),
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/max_migration.txt
+++ b/products/event_definitions/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_eventdefinition_promoted_property
+0004_eventdefinition_team_name_idx

--- a/products/event_definitions/backend/models/event_definition.py
+++ b/products/event_definitions/backend/models/event_definition.py
@@ -53,6 +53,7 @@ class EventDefinition(UUIDTModel):
                 name="posthog_eventdef_enforce_idx",
                 condition=models.Q(enforcement_mode="reject"),
             ),
+            models.Index(fields=["team_id", "name"], name="posthog_eventdef_team_name_idx"),
         ]
         constraints = [
             UniqueConstraintByExpression(


### PR DESCRIPTION
## Problem

The hot home-view query

```sql
SELECT name FROM posthog_eventdefinition
WHERE name IN ('\$pageview', '\$screen') AND team_id = X
```

is the largest single read on prod-us writer (~7.3% of all read time, **740 ms average over ~104k calls/day** per pganalyze). None of the existing indexes match this filter shape:

- `(project_id)` does not cover `team_id` lookups
- the GIN index on `name` is fuzzy-search optimized
- the partial `team_id` index requires `enforcement_mode='reject'`
- the unique expression on `(coalesce(project_id, team_id), name)` does not match a plain `team_id = X` predicate

## Changes

Add a regular btree on `(team_id, name)` so the planner has an exact match for the common shape.

- `products/event_definitions/backend/models/event_definition.py` — add the index to `EventDefinition.Meta.indexes`
- `products/event_definitions/backend/migrations/0004_eventdefinition_team_name_idx.py` — `AddIndexConcurrently` with `atomic = False`. Generated SQL: `CREATE INDEX CONCURRENTLY "posthog_eventdef_team_name_idx" ON "posthog_eventdefinition" ("team_id", "name");`

Sister PR caches the home-view caller of this query when the answer is positive, so most page loads will skip the query entirely. This index covers the misses and any other call sites that filter by team_id + name.

## How did you test this code?

I'm an agent. Verified:

- \`./manage.py makemigrations --check --dry-run\` reports "No changes detected"
- \`./manage.py sqlmigrate event_definitions 0004\` produces the expected \`CREATE INDEX CONCURRENTLY\` statement

No prod / staging verification.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

PostHog Code session investigating slow home view (\`/project/<id>/insights\` showed 2.75 s TTFB with 1.22 s pg_max). pganalyze identified \`get_default_event_info\` query as the dominant reader. Two-pronged fix: cache positive answers (sister PR) so most calls skip the query, and index for the residual calls.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*