### PR TITLE
perf(observability): cache positive get_default_event_info per team

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -407,6 +407,50 @@ class TestDefaultEventName(BaseTest):
         assert args[0] == _default_event_info_cache_key(self.team.id)
         assert kwargs["timeout"] == expected_ttl
 
+    def test_cache_invalidated_when_default_event_definition_deleted(self):
+        ed = EventDefinition.objects.create(name="$pageview", team=self.team)
+        # warm the cache
+        assert get_default_event_info(self.team)["has_pageview"] is True
+        with self.assertNumQueries(0):
+            assert get_default_event_info(self.team)["has_pageview"] is True
+
+        ed.delete()
+        # cache should now be cold and reflect the new ground truth
+        assert get_default_event_info(self.team)["has_pageview"] is False
+
+    def test_cache_invalidated_when_default_event_definition_renamed_away(self):
+        ed = EventDefinition.objects.create(name="$pageview", team=self.team)
+        assert get_default_event_info(self.team)["has_pageview"] is True
+
+        ed.name = "pageview_legacy"
+        ed.save()
+        # rename of the cached default event must bust the cache
+        assert get_default_event_info(self.team)["has_pageview"] is False
+
+    def test_cache_invalidated_when_default_event_definition_renamed_in(self):
+        ed = EventDefinition.objects.create(name="legacy_event", team=self.team)
+        assert get_default_event_info(self.team)["has_pageview"] is False
+
+        ed.name = "$pageview"
+        ed.save()
+        # renaming an event into one of the defaults must bust the cache
+        assert get_default_event_info(self.team)["has_pageview"] is True
+
+    def test_cache_not_invalidated_when_unrelated_event_definition_changed(self):
+        EventDefinition.objects.create(name="$pageview", team=self.team)
+        EventDefinition.objects.create(name="$screen", team=self.team)
+        # warm the both-present cache
+        assert get_default_event_info(self.team) == {
+            "default_event_name": "$pageview",
+            "has_pageview": True,
+            "has_screen": True,
+        }
+
+        # creating an unrelated event definition should NOT bust the cache
+        EventDefinition.objects.create(name="custom_event", team=self.team)
+        with self.assertNumQueries(0):
+            get_default_event_info(self.team)
+
 
 class TestLoadDataFromRequest(TestCase):
     def _create_request_with_headers(self, origin: str, referer: str) -> WSGIRequest:

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import call, patch
 
+from django.core.cache import cache
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest
 from django.test import TestCase
@@ -309,6 +310,10 @@ class TestRelativeDateParse(TestCase):
 
 
 class TestDefaultEventName(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
     def test_no_events_returns_pageview_default(self):
         # When team has no events at all, default to $pageview (most common for new teams)
         self.assertEqual(get_default_event_name(self.team), "$pageview")
@@ -361,6 +366,21 @@ class TestDefaultEventName(BaseTest):
         if create_screen:
             EventDefinition.objects.create(name="$screen", team=self.team)
         self.assertEqual(get_default_event_name(self.team), expected)
+
+    def test_negative_result_is_not_cached(self):
+        # Empty teams may simply not have ingested events yet — caching the
+        # negative would block them from ever updating to the positive answer.
+        with self.assertNumQueries(2):
+            get_default_event_info(self.team)
+        with self.assertNumQueries(2):
+            get_default_event_info(self.team)
+
+    def test_positive_result_is_cached(self):
+        EventDefinition.objects.create(name="$pageview", team=self.team)
+        with self.assertNumQueries(1):
+            get_default_event_info(self.team)
+        with self.assertNumQueries(0):
+            get_default_event_info(self.team)
 
 
 class TestLoadDataFromRequest(TestCase):

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -382,6 +382,32 @@ class TestDefaultEventName(BaseTest):
         with self.assertNumQueries(0):
             get_default_event_info(self.team)
 
+    @parameterized.expand(
+        [
+            ("only_pageview", True, False, 30 * 60),
+            ("only_screen", False, True, 30 * 60),
+            ("both", True, True, 24 * 60 * 60),
+        ]
+    )
+    def test_cache_ttl_depends_on_completeness(
+        self, _name: str, create_pageview: bool, create_screen: bool, expected_ttl: int
+    ):
+        from posthog.utils import _default_event_info_cache_key
+
+        if create_pageview:
+            EventDefinition.objects.create(name="$pageview", team=self.team)
+        if create_screen:
+            EventDefinition.objects.create(name="$screen", team=self.team)
+
+        with patch("posthog.utils.safe_cache_set") as mock_set:
+            get_default_event_info(self.team)
+
+        mock_set.assert_called_once()
+        _, kwargs = mock_set.call_args
+        args, _ = mock_set.call_args
+        assert args[0] == _default_event_info_cache_key(self.team.id)
+        assert kwargs["timeout"] == expected_ttl
+
 
 class TestLoadDataFromRequest(TestCase):
     def _create_request_with_headers(self, origin: str, referer: str) -> WSGIRequest:

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -403,8 +403,7 @@ class TestDefaultEventName(BaseTest):
             get_default_event_info(self.team)
 
         mock_set.assert_called_once()
-        _, kwargs = mock_set.call_args
-        args, _ = mock_set.call_args
+        args, kwargs = mock_set.call_args
         assert args[0] == _default_event_info_cache_key(self.team.id)
         assert kwargs["timeout"] == expected_ttl
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -646,12 +646,12 @@ async def initialize_self_capture_api_token():
         posthoganalytics.host = settings.SITE_URL
 
 
-DEFAULT_EVENT_INFO_FULLY_POSITIVE_TTL_SECONDS = 24 * 60 * 60
-DEFAULT_EVENT_INFO_PARTIALLY_POSITIVE_TTL_SECONDS = 30 * 60
+BOTH_DEFAULTS_PRESENT_TTL_SECONDS = 24 * 60 * 60
+ONE_DEFAULT_PRESENT_TTL_SECONDS = 30 * 60
 
 
 def _default_event_info_cache_key(team_id: int) -> str:
-    return f"default_event_info:positive:{team_id}"
+    return f"default_event_info:{team_id}"
 
 
 def get_default_event_info(team: "Team") -> dict:
@@ -687,12 +687,19 @@ def get_default_event_info(team: "Team") -> dict:
     # been ingested yet. With both true the answer is fully monotonic so we can
     # cache for a day; with only one true the team might still be setting up the
     # other surface (e.g. wired up web, later wires up mobile) so cap the TTL.
-    if has_pageview and has_screen:
-        safe_cache_set(cache_key, result, timeout=DEFAULT_EVENT_INFO_FULLY_POSITIVE_TTL_SECONDS)
-    elif has_pageview or has_screen:
-        safe_cache_set(cache_key, result, timeout=DEFAULT_EVENT_INFO_PARTIALLY_POSITIVE_TTL_SECONDS)
+    ttl = _default_event_info_ttl(has_pageview=has_pageview, has_screen=has_screen)
+    if ttl is not None:
+        safe_cache_set(cache_key, result, timeout=ttl)
 
     return result
+
+
+def _default_event_info_ttl(*, has_pageview: bool, has_screen: bool) -> int | None:
+    if has_pageview and has_screen:
+        return BOTH_DEFAULTS_PRESENT_TTL_SECONDS
+    if has_pageview or has_screen:
+        return ONE_DEFAULT_PRESENT_TTL_SECONDS
+    return None
 
 
 def get_default_event_name(team: "Team") -> str | None:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -646,7 +646,8 @@ async def initialize_self_capture_api_token():
         posthoganalytics.host = settings.SITE_URL
 
 
-DEFAULT_EVENT_INFO_CACHE_TTL_SECONDS = 24 * 60 * 60
+DEFAULT_EVENT_INFO_FULLY_POSITIVE_TTL_SECONDS = 24 * 60 * 60
+DEFAULT_EVENT_INFO_PARTIALLY_POSITIVE_TTL_SECONDS = 30 * 60
 
 
 def _default_event_info_cache_key(team_id: int) -> str:
@@ -682,10 +683,14 @@ def get_default_event_info(team: "Team") -> dict:
         "has_screen": has_screen,
     }
 
-    # Only cache positive answers: once a team has $pageview or $screen the answer is
-    # monotonic, but a negative result might just mean events haven't been ingested yet.
-    if has_pageview or has_screen:
-        safe_cache_set(cache_key, result, timeout=DEFAULT_EVENT_INFO_CACHE_TTL_SECONDS)
+    # Only cache positive answers: a negative result might just mean events haven't
+    # been ingested yet. With both true the answer is fully monotonic so we can
+    # cache for a day; with only one true the team might still be setting up the
+    # other surface (e.g. wired up web, later wires up mobile) so cap the TTL.
+    if has_pageview and has_screen:
+        safe_cache_set(cache_key, result, timeout=DEFAULT_EVENT_INFO_FULLY_POSITIVE_TTL_SECONDS)
+    elif has_pageview or has_screen:
+        safe_cache_set(cache_key, result, timeout=DEFAULT_EVENT_INFO_PARTIALLY_POSITIVE_TTL_SECONDS)
 
     return result
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -702,6 +702,10 @@ def _default_event_info_ttl(*, has_pageview: bool, has_screen: bool) -> int | No
     return None
 
 
+def invalidate_default_event_info_cache(team_id: int) -> None:
+    safe_cache_delete(_default_event_info_cache_key(team_id))
+
+
 def get_default_event_name(team: "Team") -> str | None:
     return get_default_event_info(team)["default_event_name"]
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -646,8 +646,20 @@ async def initialize_self_capture_api_token():
         posthoganalytics.host = settings.SITE_URL
 
 
+DEFAULT_EVENT_INFO_CACHE_TTL_SECONDS = 24 * 60 * 60
+
+
+def _default_event_info_cache_key(team_id: int) -> str:
+    return f"default_event_info:positive:{team_id}"
+
+
 def get_default_event_info(team: "Team") -> dict:
     from posthog.models import EventDefinition
+
+    cache_key = _default_event_info_cache_key(team.id)
+    cached = get_safe_cache(cache_key)
+    if cached is not None:
+        return cached
 
     existing_names = set(
         EventDefinition.objects.filter(team=team, name__in=["$pageview", "$screen"]).values_list("name", flat=True)
@@ -664,11 +676,18 @@ def get_default_event_info(team: "Team") -> dict:
     else:
         default_event_name = "$pageview"
 
-    return {
+    result = {
         "default_event_name": default_event_name,
         "has_pageview": has_pageview,
         "has_screen": has_screen,
     }
+
+    # Only cache positive answers: once a team has $pageview or $screen the answer is
+    # monotonic, but a negative result might just mean events haven't been ingested yet.
+    if has_pageview or has_screen:
+        safe_cache_set(cache_key, result, timeout=DEFAULT_EVENT_INFO_CACHE_TTL_SECONDS)
+
+    return result
 
 
 def get_default_event_name(team: "Team") -> str | None:

--- a/products/event_definitions/backend/models/event_definition.py
+++ b/products/event_definitions/backend/models/event_definition.py
@@ -1,8 +1,13 @@
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
+from django.db.models.signals import post_delete, post_save, pre_save
+from django.dispatch import receiver
 from django.utils import timezone
 
 from posthog.models.utils import UniqueConstraintByExpression, UUIDTModel
+from posthog.utils import invalidate_default_event_info_cache
+
+DEFAULT_EVENT_INFO_NAMES: frozenset[str] = frozenset({"$pageview", "$screen"})
 
 
 class SchemaEnforcementMode(models.TextChoices):
@@ -64,3 +69,29 @@ class EventDefinition(UUIDTModel):
 
     def __str__(self) -> str:
         return f"{self.name} / {self.team.name}"
+
+
+@receiver(pre_save, sender=EventDefinition)
+def _capture_event_definition_old_name(sender: type[EventDefinition], instance: EventDefinition, **kwargs) -> None:
+    if instance.pk:
+        try:
+            instance._old_name = EventDefinition.objects.get(pk=instance.pk).name  # type: ignore[attr-defined]
+        except EventDefinition.DoesNotExist:
+            instance._old_name = None  # type: ignore[attr-defined]
+    else:
+        instance._old_name = None  # type: ignore[attr-defined]
+
+
+@receiver(post_save, sender=EventDefinition)
+def _invalidate_default_event_info_on_save(sender: type[EventDefinition], instance: EventDefinition, **kwargs) -> None:
+    old_name: str | None = getattr(instance, "_old_name", None)
+    if instance.name in DEFAULT_EVENT_INFO_NAMES or old_name in DEFAULT_EVENT_INFO_NAMES:
+        invalidate_default_event_info_cache(instance.team_id)
+
+
+@receiver(post_delete, sender=EventDefinition)
+def _invalidate_default_event_info_on_delete(
+    sender: type[EventDefinition], instance: EventDefinition, **kwargs
+) -> None:
+    if instance.name in DEFAULT_EVENT_INFO_NAMES:
+        invalidate_default_event_info_cache(instance.team_id)


### PR DESCRIPTION
## Problem

The home view (\`get_context_for_template\`) calls \`get_default_event_info\` once per request. The underlying query

\`\`\`sql
SELECT name FROM posthog_eventdefinition WHERE name IN ('\$pageview', '\$screen') AND team_id = X
\`\`\`

is per pganalyze the largest single read on prod-us writer: **740 ms average over ~104k calls/day, 7.3% of all read runtime**. Single biggest fixable target on the home view.

The answer is monotonic in practice — once a team has a \`\$pageview\` or \`\$screen\` event definition, it always will. So most calls do work that has been done before.

## Changes

Cache the result for 24 hours, but **only when \`has_pageview or has_screen\` is true**. A negative answer might just mean events have not been ingested yet, so caching it would block teams from ever flipping to the positive answer.

Cache key is per team. Uses existing \`get_safe_cache\` / \`safe_cache_set\` helpers so a Redis blip during an incident degrades gracefully.

## How did you test this code?

I'm an agent. Added two tests:

- \`test_negative_result_is_not_cached\` — empty team runs the query on every call
- \`test_positive_result_is_cached\` — team with \`\$pageview\` runs it once, subsequent calls hit cache (\`assertNumQueries(0)\`)

Plus the existing parameterized \`TestDefaultEventName\` suite, which still passes after adding a \`cache.clear()\` to setUp so cache state does not leak between cases.

\`hogli test posthog/test/test_utils.py -- -k TestDefaultEventName\` — 13 cases pass.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

PostHog Code session investigating slow home view (\`/project/<id>/insights\` showed 2.75 s TTFB with 1.22 s pg_max). User specifically asked to cache only positive results since a fresh team with no events might just not have ingested yet. Sister PR adds a btree index on \`(team_id, name)\` so the residual misses are also fast.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*