### PR TITLE
fix(visual-review): gate run scene UI on initial snapshot load

### DIFF
--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -288,6 +288,8 @@ export function VisualReviewRunScene(): JSX.Element {
         )
     }
 
+    const initialSnapshotsLoading = snapshotsLoading && snapshots.length === 0
+
     // Review summary (from loaded snapshots — paginated but covers actionable ones first)
     // Quarantined snapshots don't need review — exclude from pending count
     const reviewPending = snapshots.filter(
@@ -307,6 +309,7 @@ export function VisualReviewRunScene(): JSX.Element {
     // Predict whether recompute would flip the gate — uses client-side quarantine set
     // which updates immediately, unlike summary.unresolved which requires a recompute round-trip
     const allChangesResolved =
+        !initialSnapshotsLoading &&
         run.status === 'completed' &&
         !run.approved &&
         !run.is_stale &&
@@ -380,52 +383,65 @@ export function VisualReviewRunScene(): JSX.Element {
             <div className="border rounded-lg overflow-hidden">
                 {/* Header: summary + thumbnail strip */}
                 <div className="bg-bg-light border-b">
-                    <div className="flex items-center justify-between px-3 pt-3 pb-2">
-                        {/* Review summary (left) — what humans decided */}
-                        <span className="text-xs text-muted flex items-center gap-1.5">
-                            <span className="font-semibold text-default">Review</span>
-                            {[
-                                reviewPending > 0 && (
-                                    <span key="pend">
-                                        <span className="font-semibold">{reviewPending}</span>
-                                        {hasMore ? '+' : ''} pending
-                                    </span>
-                                ),
-                                reviewApproved > 0 && (
-                                    <span key="appr" className="text-success">
-                                        {reviewApproved} approved
-                                    </span>
-                                ),
-                                reviewTolerated > 0 && <span key="tol">{reviewTolerated} tolerated</span>,
-                            ]
-                                .filter(Boolean)
-                                .reduce<React.ReactNode[]>((acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]), [])}
-                        </span>
-                        {/* Diff summary (right) — what the system found */}
-                        <span className="text-xs text-muted flex items-center gap-1.5">
-                            <span className="font-semibold text-default">Diff</span>
-                            {[
-                                diffChanged > 0 && (
-                                    <span key="ch" className="text-warning-dark">
-                                        {diffChanged} changed
-                                    </span>
-                                ),
-                                diffNew > 0 && (
-                                    <span key="new" className="text-success">
-                                        {diffNew} added
-                                    </span>
-                                ),
-                                diffRemoved > 0 && (
-                                    <span key="rm" className="text-danger">
-                                        {diffRemoved} removed
-                                    </span>
-                                ),
-                                diffTolerated > 0 && <span key="tol">{diffTolerated} auto-tolerated</span>,
-                            ]
-                                .filter(Boolean)
-                                .reduce<React.ReactNode[]>((acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]), [])}
-                        </span>
-                    </div>
+                    {initialSnapshotsLoading ? (
+                        <div className="flex items-center justify-between px-3 pt-3 pb-2">
+                            <LemonSkeleton className="h-4 w-40" />
+                            <LemonSkeleton className="h-4 w-40" />
+                        </div>
+                    ) : (
+                        <div className="flex items-center justify-between px-3 pt-3 pb-2">
+                            {/* Review summary (left) — what humans decided */}
+                            <span className="text-xs text-muted flex items-center gap-1.5">
+                                <span className="font-semibold text-default">Review</span>
+                                {[
+                                    reviewPending > 0 && (
+                                        <span key="pend">
+                                            <span className="font-semibold">{reviewPending}</span>
+                                            {hasMore ? '+' : ''} pending
+                                        </span>
+                                    ),
+                                    reviewApproved > 0 && (
+                                        <span key="appr" className="text-success">
+                                            {reviewApproved} approved
+                                        </span>
+                                    ),
+                                    reviewTolerated > 0 && <span key="tol">{reviewTolerated} tolerated</span>,
+                                ]
+                                    .filter(Boolean)
+                                    .reduce<React.ReactNode[]>(
+                                        (acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]),
+                                        []
+                                    )}
+                            </span>
+                            {/* Diff summary (right) — what the system found */}
+                            <span className="text-xs text-muted flex items-center gap-1.5">
+                                <span className="font-semibold text-default">Diff</span>
+                                {[
+                                    diffChanged > 0 && (
+                                        <span key="ch" className="text-warning-dark">
+                                            {diffChanged} changed
+                                        </span>
+                                    ),
+                                    diffNew > 0 && (
+                                        <span key="new" className="text-success">
+                                            {diffNew} added
+                                        </span>
+                                    ),
+                                    diffRemoved > 0 && (
+                                        <span key="rm" className="text-danger">
+                                            {diffRemoved} removed
+                                        </span>
+                                    ),
+                                    diffTolerated > 0 && <span key="tol">{diffTolerated} auto-tolerated</span>,
+                                ]
+                                    .filter(Boolean)
+                                    .reduce<React.ReactNode[]>(
+                                        (acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]),
+                                        []
+                                    )}
+                            </span>
+                        </div>
+                    )}
 
                     {navSnapshots.length > 0 && (
                         <div className="flex gap-1.5 overflow-x-auto px-3 pb-3">

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -383,65 +383,67 @@ export function VisualReviewRunScene(): JSX.Element {
             <div className="border rounded-lg overflow-hidden">
                 {/* Header: summary + thumbnail strip */}
                 <div className="bg-bg-light border-b">
-                    {initialSnapshotsLoading ? (
-                        <div className="flex items-center justify-between px-3 pt-3 pb-2">
-                            <LemonSkeleton className="h-4 w-40" />
-                            <LemonSkeleton className="h-4 w-40" />
-                        </div>
-                    ) : (
-                        <div className="flex items-center justify-between px-3 pt-3 pb-2">
-                            {/* Review summary (left) — what humans decided */}
-                            <span className="text-xs text-muted flex items-center gap-1.5">
-                                <span className="font-semibold text-default">Review</span>
-                                {[
-                                    reviewPending > 0 && (
-                                        <span key="pend">
-                                            <span className="font-semibold">{reviewPending}</span>
-                                            {hasMore ? '+' : ''} pending
-                                        </span>
-                                    ),
-                                    reviewApproved > 0 && (
-                                        <span key="appr" className="text-success">
-                                            {reviewApproved} approved
-                                        </span>
-                                    ),
-                                    reviewTolerated > 0 && <span key="tol">{reviewTolerated} tolerated</span>,
-                                ]
-                                    .filter(Boolean)
-                                    .reduce<React.ReactNode[]>(
-                                        (acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]),
-                                        []
-                                    )}
-                            </span>
-                            {/* Diff summary (right) — what the system found */}
-                            <span className="text-xs text-muted flex items-center gap-1.5">
-                                <span className="font-semibold text-default">Diff</span>
-                                {[
-                                    diffChanged > 0 && (
-                                        <span key="ch" className="text-warning-dark">
-                                            {diffChanged} changed
-                                        </span>
-                                    ),
-                                    diffNew > 0 && (
-                                        <span key="new" className="text-success">
-                                            {diffNew} added
-                                        </span>
-                                    ),
-                                    diffRemoved > 0 && (
-                                        <span key="rm" className="text-danger">
-                                            {diffRemoved} removed
-                                        </span>
-                                    ),
-                                    diffTolerated > 0 && <span key="tol">{diffTolerated} auto-tolerated</span>,
-                                ]
-                                    .filter(Boolean)
-                                    .reduce<React.ReactNode[]>(
-                                        (acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]),
-                                        []
-                                    )}
-                            </span>
-                        </div>
-                    )}
+                    <div className="flex items-center justify-between px-3 pt-3 pb-2">
+                        {initialSnapshotsLoading ? (
+                            <>
+                                <LemonSkeleton className="h-4 w-40" />
+                                <LemonSkeleton className="h-4 w-40" />
+                            </>
+                        ) : (
+                            <>
+                                {/* Review summary (left) — what humans decided */}
+                                <span className="text-xs text-muted flex items-center gap-1.5">
+                                    <span className="font-semibold text-default">Review</span>
+                                    {[
+                                        reviewPending > 0 && (
+                                            <span key="pend">
+                                                <span className="font-semibold">{reviewPending}</span>
+                                                {hasMore ? '+' : ''} pending
+                                            </span>
+                                        ),
+                                        reviewApproved > 0 && (
+                                            <span key="appr" className="text-success">
+                                                {reviewApproved} approved
+                                            </span>
+                                        ),
+                                        reviewTolerated > 0 && <span key="tol">{reviewTolerated} tolerated</span>,
+                                    ]
+                                        .filter(Boolean)
+                                        .reduce<React.ReactNode[]>(
+                                            (acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]),
+                                            []
+                                        )}
+                                </span>
+                                {/* Diff summary (right) — what the system found */}
+                                <span className="text-xs text-muted flex items-center gap-1.5">
+                                    <span className="font-semibold text-default">Diff</span>
+                                    {[
+                                        diffChanged > 0 && (
+                                            <span key="ch" className="text-warning-dark">
+                                                {diffChanged} changed
+                                            </span>
+                                        ),
+                                        diffNew > 0 && (
+                                            <span key="new" className="text-success">
+                                                {diffNew} added
+                                            </span>
+                                        ),
+                                        diffRemoved > 0 && (
+                                            <span key="rm" className="text-danger">
+                                                {diffRemoved} removed
+                                            </span>
+                                        ),
+                                        diffTolerated > 0 && <span key="tol">{diffTolerated} auto-tolerated</span>,
+                                    ]
+                                        .filter(Boolean)
+                                        .reduce<React.ReactNode[]>(
+                                            (acc, el, i) => (i === 0 ? [el] : [...acc, ' · ', el]),
+                                            []
+                                        )}
+                                </span>
+                            </>
+                        )}
+                    </div>
 
                     {navSnapshots.length > 0 && (
                         <div className="flex gap-1.5 overflow-x-auto px-3 pb-3">


### PR DESCRIPTION
# fixes visual review scene loading state

## Problem

While the Visual review run scene is loading, two pieces of UI render with stale/empty info:

1. **"All changes are resolved" banner** flashes on incorrectly — `[].every(...)` returns `true` vacuously, so the gate calculation marks the run as resolved before any snapshots have arrived.
2. **Review/Diff summary header** shows an empty "Review" label next to a populated "Diff" side, because `run.summary` loads first and the snapshot-derived counts are still zero.

Both are missing a loading gate.

## Changes

- New `initialSnapshotsLoading = snapshotsLoading && snapshots.length === 0` derived value (true only on first load, not background refetches — preserves the existing behaviour of not flashing the whole scene to skeleton on mutations).
- `allChangesResolved` now requires `!initialSnapshotsLoading`, so the banner can only render once snapshots have actually loaded.
- Panel summary header renders twin `LemonSkeleton` placeholders during initial load instead of the half-populated Review/Diff row.

The body's diff-viewer skeleton was already gated correctly via `snapshotsLoading`, so no change there.

## How did you test this code?

Agent-authored. No automated tests added — there are no tests for this scene yet, and the bug is timing-dependent (server-side ordering of the run and snapshot responses). I have not manually loaded the affected scene.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- User report came with a screenshot showing the loading flash: title and tabs rendered, "All changes are resolved" banner visible, and skeleton placeholders below
- Considered gating on `quarantinedIdentifiersLoading` too, but that loader missing only makes the calc more conservative (would not falsely show the banner), so left it alone
- Considered extending the existing top-level `!run` skeleton path to also cover `initialSnapshotsLoading`, but rejected — the existing intent is to keep the scene structure stable across mutations, and gating just the affected sub-pieces preserves that

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*