### PR TITLE
fix(logs-alerting): per-alert fallback when cohort query or save fails

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -60,7 +60,6 @@ def _build_logs_query(alert: LogsAlertConfiguration, date_range: DateRange) -> L
 
 
 def _tag_alert_query(*, team: Team, alert_config_id: str, source: str) -> None:
-    """Shared CH query tagging for both single-alert and batched alert checks."""
     tag_queries(
         product=Product.LOGS,
         feature=Feature.ALERTING,

--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -59,6 +59,17 @@ def _build_logs_query(alert: LogsAlertConfiguration, date_range: DateRange) -> L
     )
 
 
+def _tag_alert_query(*, team: Team, alert_config_id: str, source: str) -> None:
+    """Shared CH query tagging for both single-alert and batched alert checks."""
+    tag_queries(
+        product=Product.LOGS,
+        feature=Feature.ALERTING,
+        source=source,
+        alert_config_id=alert_config_id,
+        team_id=str(team.id),
+    )
+
+
 def build_alert_where_expr(
     *,
     team: Team,
@@ -214,13 +225,7 @@ class AlertCheckQuery:
         )
 
     def _tag(self) -> None:
-        tag_queries(
-            product=Product.LOGS,
-            feature=Feature.ALERTING,
-            source="logs_alert",
-            alert_config_id=str(self.alert.id),
-            team_id=str(self.team.id),
-        )
+        _tag_alert_query(team=self.team, alert_config_id=str(self.alert.id), source="logs_alert")
 
 
 @dataclass(frozen=True)
@@ -354,16 +359,14 @@ class BatchedAlertCheckQuery:
         )
 
     def _tag(self) -> None:
-        # `QueryTags` doesn't allow per-batch custom fields. We tag the first
-        # alert as the representative `alert_config_id` so single-alert tooling
-        # still works; ops can identify a batched query by `source` and read the
-        # full alert list from `query_log.query` if needed.
-        tag_queries(
-            product=Product.LOGS,
-            feature=Feature.ALERTING,
-            source="logs_alert_batched",
+        # `QueryTags` doesn't allow per-batch custom fields, so we tag the first
+        # alert as the representative `alert_config_id`. Ops can identify a
+        # batched query by `source` and read the full alert list from
+        # `query_log.query` if needed.
+        _tag_alert_query(
+            team=self.team,
             alert_config_id=str(self.alerts[0].id),
-            team_id=str(self.team.id),
+            source="logs_alert_batched",
         )
 
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -45,6 +45,7 @@ from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
     increment_checks_total,
+    increment_cohort_query_fallback,
     increment_cohort_save_fallback,
     increment_notification_failures,
     increment_state_transition,
@@ -62,6 +63,18 @@ from products.logs.backend.temporal.metrics import (
 )
 
 logger = structlog.get_logger(__name__)
+
+
+def _safe_record(label: str, fn, *args, **kwargs) -> None:
+    """Best-effort metric recording. Metric failures must never break alerting.
+
+    Use only when wrapping a single metric call. Multi-metric blocks should
+    keep their own grouped try/except so one failure doesn't skip the rest.
+    """
+    try:
+        fn(*args, **kwargs)
+    except Exception:
+        logger.exception("Failed to record %s", label)
 
 
 def _derive_breaches(
@@ -114,6 +127,14 @@ class _AlertCohort:
     projection_eligible: bool
 
     @property
+    def team(self):
+        return self.alerts[0].team
+
+    @property
+    def team_id(self) -> int:
+        return self.alerts[0].team_id
+
+    @property
     def window_minutes(self) -> int:
         return self.alerts[0].window_minutes
 
@@ -128,16 +149,36 @@ class _AlertCohort:
 
 @dataclasses.dataclass(frozen=True)
 class _PrefetchedQuery:
-    """Result of a batched query for one alert in a cohort.
+    """Result of a CH query for one alert in a cohort.
 
-    Either `buckets` is set (success path; `query_duration_ms` is the shared
-    batch duration) or `error` is set (failure — re-raised inside the per-alert
-    eval to flow through the same classification as a per-alert query failure).
+    Either `buckets` is set (success path; `query_duration_ms` carries the
+    relevant query wall time) or `error` is set (failure — re-raised inside the
+    per-alert eval to flow through the same classification as a per-alert query
+    failure). For batched queries `query_duration_ms` is the shared batch
+    duration; for the per-alert fallback path it's the individual alert's query
+    duration.
     """
 
     buckets: list[BucketedCount] | None = None
     query_duration_ms: int | None = None
     error: Exception | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _CohortQueryResult:
+    """Per-alert CH query results for a cohort.
+
+    Maps `alert_id -> _PrefetchedQuery`. The happy path populates this from a
+    single batched query (all entries share the batch's `query_duration_ms`,
+    none have `error` set). The fallback path runs per-alert queries and
+    populates each entry independently — alerts whose individual query failed
+    carry their error, others carry their successful buckets.
+    """
+
+    per_alert: dict[str, _PrefetchedQuery]
+
+    def for_alert(self, alert: LogsAlertConfiguration) -> _PrefetchedQuery:
+        return self.per_alert.get(str(alert.id), _PrefetchedQuery(buckets=[]))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -153,7 +194,6 @@ class _AlertEvaluation:
     check_result: CheckResult
     date_from: datetime
     date_to: datetime
-    error_category: AlertErrorCode | None
     state_before: str
 
 
@@ -210,7 +250,7 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
     # we run it as a sync list comprehension. Dispatch is Kafka I/O and gets
     # a thread-pool wrap + gather for actual concurrency.
     dispatch_async = database_sync_to_async_pool(_dispatch_for_alert)
-    batched_query_async = database_sync_to_async_pool(_run_batched_query)
+    cohort_query_async = database_sync_to_async_pool(_run_cohort_query)
     save_cohort_async = database_sync_to_async_pool(_save_cohort_outcomes)
 
     async def _bounded_cohort_eval(cohort: _AlertCohort) -> dict[str, int]:
@@ -218,30 +258,10 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
         local_stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         async with semaphore:
             wait_ms = int((time.perf_counter() - wait_start) * 1000)
-            try:
-                record_cohort_size(len(cohort.alerts))
-            except Exception:
-                logger.exception("Failed to record cohort_size histogram")
+            _safe_record("cohort_size histogram", record_cohort_size, len(cohort.alerts))
 
-            # Phase 1: batched CH query.
-            batched_result: BatchedBucketedResult | None
-            cohort_error: Exception | None = None
-            try:
-                batched_result = await batched_query_async(cohort)
-            except Exception as e:
-                # Propagate the cohort error to each alert in the cohort so they
-                # advance `consecutive_failures` independently. Re-raising per
-                # alert flows through the same classification as a per-alert
-                # query failure would.
-                logger.warning(
-                    "Batched alert query failed",
-                    team_id=cohort.alerts[0].team_id,
-                    cohort_size=len(cohort.alerts),
-                    error=str(e),
-                )
-                capture_exception(e, {"team_id": cohort.alerts[0].team_id, "cohort_size": len(cohort.alerts)})
-                batched_result = None
-                cohort_error = e
+            # Phase 1: cohort CH query (batched, with per-alert fallback on failure).
+            query_result = await cohort_query_async(cohort)
 
             # Phase 2a: evaluate all alerts (sync, in-memory).
             evaluations: list[_AlertEvaluation] = []
@@ -254,7 +274,7 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
                             alert,
                             now,
                             checkpoint=checkpoint,
-                            prefetched=_prefetch_for_alert(alert, batched_result, cohort_error),
+                            prefetched=query_result.for_alert(alert),
                         )
                     )
                     kept_eval_starts.append(eval_start)
@@ -301,10 +321,10 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
             except Exception as e:
                 logger.exception(
                     "Cohort bulk save failed (non-recoverable)",
-                    team_id=cohort.alerts[0].team_id,
+                    team_id=cohort.team_id,
                     cohort_size=len(dispatched),
                 )
-                capture_exception(e, {"team_id": cohort.alerts[0].team_id, "phase": "bulk_save"})
+                capture_exception(e, {"team_id": cohort.team_id, "phase": "bulk_save"})
                 # Saves failed — count alerts as errored so the cycle stat
                 # reflects that this cohort didn't advance state.
                 local_stats["errored"] += len(dispatched)
@@ -319,10 +339,7 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
                 # Alert's per-alert fallback save failed — count as errored.
                 local_stats["checked"] += 1
                 local_stats["errored"] += 1
-        try:
-            record_semaphore_wait(wait_ms)
-        except Exception:
-            logger.exception("Failed to record semaphore_wait histogram")
+        _safe_record("semaphore_wait histogram", record_semaphore_wait, wait_ms)
         return local_stats
 
     tasks: list[asyncio.Task[dict[str, int]]] = []
@@ -430,7 +447,7 @@ def _build_cohorts(
 
 def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
     return BatchedAlertCheckQuery(
-        team=cohort.alerts[0].team,
+        team=cohort.team,
         alerts=list(cohort.alerts),
         date_from=cohort.date_from,
         date_to=cohort.date_to,
@@ -438,17 +455,89 @@ def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
     ).execute_bucketed(interval_minutes=cohort.window_minutes, limit=cohort.evaluation_periods)
 
 
-def _prefetch_for_alert(
-    alert: LogsAlertConfiguration,
-    batched_result: BatchedBucketedResult | None,
-    cohort_error: Exception | None,
-) -> _PrefetchedQuery:
-    if batched_result is not None:
-        return _PrefetchedQuery(
-            buckets=batched_result.per_alert.get(str(alert.id), []),
-            query_duration_ms=batched_result.query_duration_ms,
+def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
+    """Fallback: run each alert's CH query individually.
+
+    Used when the batched cohort query fails (e.g., one alert's predicate is
+    expensive enough to time out the whole batch). Per-alert queries isolate
+    the bad alert: it fails its individual query and advances its own
+    `consecutive_failures`, while the rest of the cohort evaluates normally —
+    preserving the per-alert auto-disable semantics.
+    """
+    per_alert: dict[str, _PrefetchedQuery] = {}
+    for alert in cohort.alerts:
+        start = time.monotonic_ns()
+        try:
+            buckets = AlertCheckQuery(
+                team=alert.team,
+                alert=alert,
+                date_from=cohort.date_from,
+                date_to=cohort.date_to,
+            ).execute_bucketed(interval_minutes=cohort.window_minutes, limit=cohort.evaluation_periods)
+            duration_ms = (time.monotonic_ns() - start) // 1_000_000
+            per_alert[str(alert.id)] = _PrefetchedQuery(buckets=buckets, query_duration_ms=duration_ms)
+        except Exception as e:
+            per_alert[str(alert.id)] = _PrefetchedQuery(error=e)
+    return _CohortQueryResult(per_alert=per_alert)
+
+
+def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
+    """Run the cohort's batched CH query, falling back to per-alert on failure.
+
+    The fallback exists so a single bad-config alert can't poison the cohort:
+    its batched-query failure would otherwise propagate to all N alerts and
+    drive them all to BROKEN in lockstep — a regression from the pre-batching
+    per-alert auto-disable semantics.
+
+    We skip the fallback in two cases:
+      * Single-alert cohort: per-alert path would just hit the same error.
+      * Transient cluster errors (rate-limited, server busy, etc.): fallback
+        would hammer a struggling cluster with N more queries that are about
+        to fail the same way. Propagate as cohort-wide error; transient
+        errors typically clear by the next cycle so `consecutive_failures`
+        resets before anything hits BROKEN.
+    """
+    try:
+        batched = _run_batched_query(cohort)
+    except Exception as e:
+        team_id = cohort.team_id
+        cohort_size = len(cohort.alerts)
+
+        if cohort_size == 1:
+            return _CohortQueryResult(per_alert={str(cohort.alerts[0].id): _PrefetchedQuery(error=e)})
+
+        classified = classify_alert_error(e)
+        if classified.is_transient:
+            logger.warning(
+                "Batched cohort query failed (transient); skipping per-alert fallback",
+                team_id=team_id,
+                cohort_size=cohort_size,
+                error=str(e),
+                classification=classified.code,
+            )
+            _safe_record("cohort_query_fallback counter", increment_cohort_query_fallback, "transient_no_fallback")
+            return _CohortQueryResult(per_alert={str(a.id): _PrefetchedQuery(error=e) for a in cohort.alerts})
+
+        logger.warning(
+            "Batched cohort query failed; falling back to per-alert queries",
+            team_id=team_id,
+            cohort_size=cohort_size,
+            error=str(e),
+            classification=classified.code,
         )
-    return _PrefetchedQuery(error=cohort_error)
+        capture_exception(e, {"team_id": team_id, "cohort_size": cohort_size})
+        _safe_record("cohort_query_fallback counter", increment_cohort_query_fallback, "batched_failure")
+        return _run_per_alert_queries(cohort)
+
+    return _CohortQueryResult(
+        per_alert={
+            str(alert.id): _PrefetchedQuery(
+                buckets=batched.per_alert.get(str(alert.id), []),
+                query_duration_ms=batched.query_duration_ms,
+            )
+            for alert in cohort.alerts
+        }
+    )
 
 
 def _check_alerts_sync() -> CheckAlertsOutput:
@@ -462,26 +551,10 @@ def _check_alerts_sync() -> CheckAlertsOutput:
 
     stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
     for cohort in cohorts:
-        try:
-            record_cohort_size(len(cohort.alerts))
-        except Exception:
-            logger.exception("Failed to record cohort_size histogram")
+        _safe_record("cohort_size histogram", record_cohort_size, len(cohort.alerts))
 
-        # Phase 1
-        batched_result: BatchedBucketedResult | None
-        cohort_error: Exception | None = None
-        try:
-            batched_result = _run_batched_query(cohort)
-        except Exception as e:
-            logger.warning(
-                "Batched alert query failed",
-                team_id=cohort.alerts[0].team_id,
-                cohort_size=len(cohort.alerts),
-                error=str(e),
-            )
-            capture_exception(e, {"team_id": cohort.alerts[0].team_id, "cohort_size": len(cohort.alerts)})
-            batched_result = None
-            cohort_error = e
+        # Phase 1: cohort CH query (batched, with per-alert fallback on failure).
+        query_result = _run_cohort_query(cohort)
 
         # Phase 2a: evaluate all alerts.
         evaluations: list[_AlertEvaluation] = []
@@ -493,7 +566,7 @@ def _check_alerts_sync() -> CheckAlertsOutput:
                     alert,
                     now,
                     checkpoint=checkpoint,
-                    prefetched=_prefetch_for_alert(alert, batched_result, cohort_error),
+                    prefetched=query_result.for_alert(alert),
                 )
             except Exception:
                 logger.exception(
@@ -538,10 +611,10 @@ def _check_alerts_sync() -> CheckAlertsOutput:
         except Exception as e:
             logger.exception(
                 "Cohort bulk save failed (non-recoverable)",
-                team_id=cohort.alerts[0].team_id,
+                team_id=cohort.team_id,
                 cohort_size=len(dispatched),
             )
-            capture_exception(e, {"team_id": cohort.alerts[0].team_id, "phase": "bulk_save"})
+            capture_exception(e, {"team_id": cohort.team_id, "phase": "bulk_save"})
             stats["errored"] += len(dispatched)
             stats["checked"] += len(dispatched)
             continue
@@ -939,7 +1012,6 @@ def _evaluate_single_alert(
         check_result=check_result,
         date_from=date_from,
         date_to=date_to,
-        error_category=error_category,
         state_before=alert.state,
     )
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -4,6 +4,7 @@ import time
 import asyncio
 import dataclasses
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 
 from django.db import transaction
 from django.db.models import Q
@@ -62,15 +63,14 @@ from products.logs.backend.temporal.metrics import (
     record_semaphore_wait,
 )
 
+if TYPE_CHECKING:
+    from posthog.models import Team
+
 logger = structlog.get_logger(__name__)
 
 
 def _safe_record(label: str, fn, *args, **kwargs) -> None:
-    """Best-effort metric recording. Metric failures must never break alerting.
-
-    Use only when wrapping a single metric call. Multi-metric blocks should
-    keep their own grouped try/except so one failure doesn't skip the rest.
-    """
+    """Best-effort metric recording — failures must never break alerting."""
     try:
         fn(*args, **kwargs)
     except Exception:
@@ -127,7 +127,7 @@ class _AlertCohort:
     projection_eligible: bool
 
     @property
-    def team(self):
+    def team(self) -> "Team":
         return self.alerts[0].team
 
     @property
@@ -149,15 +149,7 @@ class _AlertCohort:
 
 @dataclasses.dataclass(frozen=True)
 class _PrefetchedQuery:
-    """Result of a CH query for one alert in a cohort.
-
-    Either `buckets` is set (success path; `query_duration_ms` carries the
-    relevant query wall time) or `error` is set (failure — re-raised inside the
-    per-alert eval to flow through the same classification as a per-alert query
-    failure). For batched queries `query_duration_ms` is the shared batch
-    duration; for the per-alert fallback path it's the individual alert's query
-    duration.
-    """
+    """CH query result for one alert: either `buckets` or `error` is set."""
 
     buckets: list[BucketedCount] | None = None
     query_duration_ms: int | None = None
@@ -166,15 +158,6 @@ class _PrefetchedQuery:
 
 @dataclasses.dataclass(frozen=True)
 class _CohortQueryResult:
-    """Per-alert CH query results for a cohort.
-
-    Maps `alert_id -> _PrefetchedQuery`. The happy path populates this from a
-    single batched query (all entries share the batch's `query_duration_ms`,
-    none have `error` set). The fallback path runs per-alert queries and
-    populates each entry independently — alerts whose individual query failed
-    carry their error, others carry their successful buckets.
-    """
-
     per_alert: dict[str, _PrefetchedQuery]
 
     def for_alert(self, alert: LogsAlertConfiguration) -> _PrefetchedQuery:
@@ -456,14 +439,6 @@ def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
 
 
 def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
-    """Fallback: run each alert's CH query individually.
-
-    Used when the batched cohort query fails (e.g., one alert's predicate is
-    expensive enough to time out the whole batch). Per-alert queries isolate
-    the bad alert: it fails its individual query and advances its own
-    `consecutive_failures`, while the rest of the cohort evaluates normally —
-    preserving the per-alert auto-disable semantics.
-    """
     per_alert: dict[str, _PrefetchedQuery] = {}
     for alert in cohort.alerts:
         start = time.monotonic_ns()
@@ -477,25 +452,16 @@ def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
             duration_ms = (time.monotonic_ns() - start) // 1_000_000
             per_alert[str(alert.id)] = _PrefetchedQuery(buckets=buckets, query_duration_ms=duration_ms)
         except Exception as e:
-            per_alert[str(alert.id)] = _PrefetchedQuery(error=e)
+            duration_ms = (time.monotonic_ns() - start) // 1_000_000
+            per_alert[str(alert.id)] = _PrefetchedQuery(error=e, query_duration_ms=duration_ms)
     return _CohortQueryResult(per_alert=per_alert)
 
 
 def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
-    """Run the cohort's batched CH query, falling back to per-alert on failure.
+    """Batched cohort CH query; per-alert fallback on non-transient failure.
 
-    The fallback exists so a single bad-config alert can't poison the cohort:
-    its batched-query failure would otherwise propagate to all N alerts and
-    drive them all to BROKEN in lockstep — a regression from the pre-batching
-    per-alert auto-disable semantics.
-
-    We skip the fallback in two cases:
-      * Single-alert cohort: per-alert path would just hit the same error.
-      * Transient cluster errors (rate-limited, server busy, etc.): fallback
-        would hammer a struggling cluster with N more queries that are about
-        to fail the same way. Propagate as cohort-wide error; transient
-        errors typically clear by the next cycle so `consecutive_failures`
-        resets before anything hits BROKEN.
+    Skip fallback for single-alert cohorts (would hit the same error) and transient cluster
+    errors (would hammer a struggling cluster with N more failing queries).
     """
     try:
         batched = _run_batched_query(cohort)

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -209,12 +209,33 @@ def record_cohort_size(size: int) -> None:
     )
 
 
-def increment_cohort_save_fallback(reason: str) -> None:
+CohortSaveFallbackReason = typing.Literal["integrity_error"]
+CohortQueryFallbackReason = typing.Literal["batched_failure", "transient_no_fallback"]
+
+
+def increment_cohort_save_fallback(reason: CohortSaveFallbackReason) -> None:
     """Counts cohort bulk-save failures that triggered the per-alert fallback path."""
     meter = get_metric_meter({"reason": reason})
     counter = meter.create_counter(
         "logs_alerting_cohort_save_fallback_total",
         "Cohort bulk-save fell back to per-alert UPDATEs (e.g. IntegrityError)",
+    )
+    counter.add(1)
+
+
+def increment_cohort_query_fallback(reason: CohortQueryFallbackReason) -> None:
+    """Counts batched CH query failures that triggered the per-alert query fallback path.
+
+    Sustained > 0 = at least one team has an alert whose predicate is taking down
+    its cohort's batched query. The fallback isolates the bad alert (its
+    consecutive_failures advances independently) so good alerts in the cohort
+    keep evaluating. If this fires regularly, investigate the team's alert
+    configs.
+    """
+    meter = get_metric_meter({"reason": reason})
+    counter = meter.create_counter(
+        "logs_alerting_cohort_query_fallback_total",
+        "Batched CH cohort query failed and fell back to per-alert queries",
     )
     counter.add(1)
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -559,14 +559,6 @@ class TestSaveCohortOutcomesFallback(APIBaseTest):
 
 
 class TestRunCohortQueryFallback(unittest.TestCase):
-    """Per-alert fallback when the batched cohort query fails.
-
-    Critical for auto-disable correctness: without the fallback, one alert with
-    a bad config would take down the whole cohort's batched query, propagating
-    `consecutive_failures += 1` to all N alerts and eventually disabling all of
-    them. The fallback isolates the failure to the alert that actually broke.
-    """
-
     @staticmethod
     def _make_cohort(n: int) -> _AlertCohort:
         alerts = tuple(MagicMock(id=f"alert-{i}", team_id=1, name=f"alert-{i}") for i in range(n))
@@ -687,11 +679,7 @@ class TestRunCohortQueryFallback(unittest.TestCase):
 
 
 class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):
-    """CH-backed integration test: when the batched cohort query fails, the
-    fallback runs real per-alert `AlertCheckQuery.execute_bucketed` calls
-    against test ClickHouse. Verifies that the per-alert results survive the
-    fallback path with correct bucket counts.
-    """
+    """CH-backed integration test for the per-alert fallback path."""
 
     def setUp(self):
         super().setUp()
@@ -810,6 +798,7 @@ class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):
         assert bad_prefetch.buckets is None
         assert bad_prefetch.error is not None
         assert "simulated per-alert query failure" in str(bad_prefetch.error)
+        assert bad_prefetch.query_duration_ms is not None and bad_prefetch.query_duration_ms >= 0
 
 
 class TestEvaluateSingleAlert(APIBaseTest):

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 from posthog.clickhouse.client import sync_execute
 from posthog.errors import QueryErrorCategory
 
-from products.logs.backend.alert_check_query import BatchedBucketedResult, BucketedCount
+from products.logs.backend.alert_check_query import AlertCheckQuery, BatchedBucketedResult, BucketedCount
 from products.logs.backend.alert_state_machine import AlertState, NotificationAction
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.activities import (
@@ -520,7 +520,6 @@ class TestSaveCohortOutcomesFallback(APIBaseTest):
             check_result=CheckResult(result_count=0, threshold_breached=False, query_duration_ms=10),
             date_from=datetime(2025, 1, 1, 0, 0, tzinfo=UTC),
             date_to=datetime(2025, 1, 1, 0, 5, tzinfo=UTC),
-            error_category=None,
             state_before=alert.state,
         )
         return _DispatchedAlert(evaluation=evaluation, notification_failed=False)
@@ -557,6 +556,260 @@ class TestSaveCohortOutcomesFallback(APIBaseTest):
 
         with self.assertRaises(OperationalError):
             _save_cohort_outcomes(dispatched, now)
+
+
+class TestRunCohortQueryFallback(unittest.TestCase):
+    """Per-alert fallback when the batched cohort query fails.
+
+    Critical for auto-disable correctness: without the fallback, one alert with
+    a bad config would take down the whole cohort's batched query, propagating
+    `consecutive_failures += 1` to all N alerts and eventually disabling all of
+    them. The fallback isolates the failure to the alert that actually broke.
+    """
+
+    @staticmethod
+    def _make_cohort(n: int) -> _AlertCohort:
+        alerts = tuple(MagicMock(id=f"alert-{i}", team_id=1, name=f"alert-{i}") for i in range(n))
+        for a in alerts:
+            a.window_minutes = 5
+            a.evaluation_periods = 1
+        return _AlertCohort(
+            alerts=alerts,
+            date_to=datetime(2025, 1, 1, 0, 5, 0, tzinfo=UTC),
+            projection_eligible=True,
+        )
+
+    @patch("products.logs.backend.temporal.activities.increment_cohort_query_fallback")
+    @patch("products.logs.backend.temporal.activities.classify_alert_error")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_falls_back_to_per_alert_on_non_transient_failure(
+        self, mock_batched, mock_alert_check_query_cls, mock_classify, mock_fallback_counter
+    ):
+        from products.logs.backend.temporal.activities import _run_cohort_query
+
+        # Non-transient classification → fallback runs.
+        mock_batched.side_effect = RuntimeError("query_performance error")
+        mock_classify.return_value = MagicMock(is_transient=False, code="query_performance")
+
+        # Per-alert AlertCheckQuery: alert-0 succeeds, alert-1 raises (the bad one).
+        def make_query_instance(*, team, alert, **_kwargs):
+            instance = MagicMock()
+            if alert.id == "alert-1":
+                instance.execute_bucketed.side_effect = RuntimeError("alert-1 also bad")
+            else:
+                instance.execute_bucketed.return_value = [
+                    BucketedCount(timestamp=datetime(2025, 1, 1, 0, 0, tzinfo=UTC), count=42)
+                ]
+            return instance
+
+        mock_alert_check_query_cls.side_effect = make_query_instance
+
+        cohort = self._make_cohort(2)
+        result = _run_cohort_query(cohort)
+
+        # Fallback counter fired with the "batched_failure" reason (non-transient → fallback ran).
+        mock_fallback_counter.assert_called_once_with("batched_failure")
+
+        # Good alert has buckets, bad alert has the per-alert error captured.
+        good = result.per_alert["alert-0"]
+        bad = result.per_alert["alert-1"]
+        assert good.buckets is not None and good.buckets[0].count == 42
+        assert good.error is None
+        assert bad.buckets is None
+        assert bad.error is not None and "alert-1 also bad" in str(bad.error)
+
+    @patch("products.logs.backend.temporal.activities.increment_cohort_query_fallback")
+    @patch("products.logs.backend.temporal.activities.classify_alert_error")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_skips_fallback_on_transient_error(
+        self, mock_batched, mock_alert_check_query_cls, mock_classify, mock_fallback_counter
+    ):
+        # Transient classification → no fallback. Don't hammer a sick cluster.
+        from products.logs.backend.temporal.activities import _run_cohort_query
+
+        mock_batched.side_effect = RuntimeError("server busy")
+        mock_classify.return_value = MagicMock(is_transient=True, code="server_busy")
+
+        cohort = self._make_cohort(3)
+        result = _run_cohort_query(cohort)
+
+        # Fallback counter fired with the "transient_no_fallback" reason.
+        mock_fallback_counter.assert_called_once_with("transient_no_fallback")
+        # AlertCheckQuery is never instantiated because we don't run the fallback.
+        mock_alert_check_query_cls.assert_not_called()
+
+        # Every alert in the cohort gets the same error — no isolation needed
+        # because the next cycle will retry once the cluster recovers.
+        for alert in cohort.alerts:
+            prefetched = result.per_alert[str(alert.id)]
+            assert prefetched.buckets is None
+            assert prefetched.error is not None and "server busy" in str(prefetched.error)
+
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_single_alert_cohort_skips_fallback(self, mock_batched, mock_alert_check_query_cls):
+        from products.logs.backend.temporal.activities import _run_cohort_query
+
+        mock_batched.side_effect = RuntimeError("query failed")
+
+        cohort = self._make_cohort(1)
+        result = _run_cohort_query(cohort)
+
+        # No fallback for single-alert cohorts — the per-alert path would just hit the same error.
+        mock_alert_check_query_cls.assert_not_called()
+        assert "alert-0" in result.per_alert
+        prefetched = result.per_alert["alert-0"]
+        assert prefetched.error is not None and "query failed" in str(prefetched.error)
+
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_batched_success_skips_fallback(self, mock_batched):
+        from products.logs.backend.alert_check_query import BatchedBucketedResult
+        from products.logs.backend.temporal.activities import _run_cohort_query
+
+        cohort = self._make_cohort(3)
+        mock_batched.return_value = BatchedBucketedResult(
+            per_alert={
+                str(a.id): [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=i)]
+                for i, a in enumerate(cohort.alerts)
+            },
+            query_duration_ms=42,
+        )
+
+        result = _run_cohort_query(cohort)
+
+        for i, alert in enumerate(cohort.alerts):
+            prefetched = result.per_alert[str(alert.id)]
+            assert prefetched.error is None
+            assert prefetched.buckets is not None and prefetched.buckets[0].count == i
+            assert prefetched.query_duration_ms == 42
+
+
+class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):
+    """CH-backed integration test: when the batched cohort query fails, the
+    fallback runs real per-alert `AlertCheckQuery.execute_bucketed` calls
+    against test ClickHouse. Verifies that the per-alert results survive the
+    fallback path with correct bucket counts.
+    """
+
+    def setUp(self):
+        super().setUp()
+        rows = [
+            {
+                "uuid": f"fallback-{i}",
+                "team_id": self.team.id,
+                "timestamp": ts,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": service,
+                "resource_attributes": {},
+                "attributes_map_str": {},
+            }
+            for i, (ts, service) in enumerate(
+                [
+                    ("2026-01-01 10:00:30", "fallback_service_a"),
+                    ("2026-01-01 10:01:00", "fallback_service_a"),
+                    ("2026-01-01 10:00:45", "fallback_service_a"),
+                    ("2026-01-01 10:02:30", "fallback_service_b"),
+                    ("2026-01-01 10:03:30", "fallback_service_b"),
+                ]
+            )
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+    def _make_alert(self, *, name: str, service: str) -> LogsAlertConfiguration:
+        return LogsAlertConfiguration.objects.create(
+            team=self.team,
+            name=name,
+            threshold_count=10,
+            threshold_operator="above",
+            window_minutes=5,
+            evaluation_periods=1,
+            filters={"serviceNames": [service]},
+        )
+
+    @freeze_time("2026-01-01T10:05:00Z")
+    @patch("products.logs.backend.temporal.activities.classify_alert_error")
+    @patch("products.logs.backend.temporal.activities.increment_cohort_query_fallback")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_fallback_runs_per_alert_queries_against_real_clickhouse(self, mock_batched, _mock_counter, mock_classify):
+        from products.logs.backend.temporal.activities import _AlertCohort, _run_cohort_query
+
+        # Non-transient classification → fallback runs against real CH.
+        mock_batched.side_effect = RuntimeError("batched query timed out")
+        mock_classify.return_value = MagicMock(is_transient=False, code="query_performance")
+
+        alert_a = self._make_alert(name="A", service="fallback_service_a")
+        alert_b = self._make_alert(name="B", service="fallback_service_b")
+        cohort = _AlertCohort(
+            alerts=(alert_a, alert_b),
+            date_to=datetime(2026, 1, 1, 10, 5, 0, tzinfo=UTC),
+            projection_eligible=True,
+        )
+
+        result = _run_cohort_query(cohort)
+
+        # Both alerts evaluated successfully via the per-alert fallback.
+        prefetch_a = result.per_alert[str(alert_a.id)]
+        prefetch_b = result.per_alert[str(alert_b.id)]
+        assert prefetch_a.error is None and prefetch_a.buckets is not None
+        assert prefetch_b.error is None and prefetch_b.buckets is not None
+
+        # Bucket counts match the seeded data: 3 logs for service_a, 2 for service_b.
+        assert sum(b.count for b in prefetch_a.buckets) == 3
+        assert sum(b.count for b in prefetch_b.buckets) == 2
+
+        # Per-alert query duration is captured (not the batched duration, which never
+        # ran). Should be a non-negative integer for each.
+        assert prefetch_a.query_duration_ms is not None and prefetch_a.query_duration_ms >= 0
+        assert prefetch_b.query_duration_ms is not None and prefetch_b.query_duration_ms >= 0
+
+    @freeze_time("2026-01-01T10:05:00Z")
+    @patch("products.logs.backend.temporal.activities.classify_alert_error")
+    @patch("products.logs.backend.temporal.activities.increment_cohort_query_fallback")
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_fallback_isolates_one_alerts_per_alert_failure(self, mock_batched, _mock_counter, mock_classify):
+        # Force batched to fail with a non-transient classification (so fallback
+        # runs); force ONE alert's per-alert query to also fail. Verify the other
+        # alert still evaluates correctly against real CH and the bad alert's
+        # error is captured per-alert (not propagated to the cohort).
+        from products.logs.backend.temporal.activities import _AlertCohort, _run_cohort_query
+
+        mock_batched.side_effect = RuntimeError("batched query timed out")
+        mock_classify.return_value = MagicMock(is_transient=False, code="query_performance")
+
+        good_alert = self._make_alert(name="good", service="fallback_service_a")
+        bad_alert = self._make_alert(name="bad", service="fallback_service_b")
+        cohort = _AlertCohort(
+            alerts=(good_alert, bad_alert),
+            date_to=datetime(2026, 1, 1, 10, 5, 0, tzinfo=UTC),
+            projection_eligible=True,
+        )
+
+        # Selectively fail the per-alert query for bad_alert; let good_alert hit real CH.
+        original_execute_bucketed = AlertCheckQuery.execute_bucketed
+
+        def maybe_fail(self, *args, **kwargs):
+            if self.alert.id == bad_alert.id:
+                raise RuntimeError("simulated per-alert query failure")
+            return original_execute_bucketed(self, *args, **kwargs)
+
+        with patch.object(AlertCheckQuery, "execute_bucketed", maybe_fail):
+            result = _run_cohort_query(cohort)
+
+        # Good alert: real buckets, no error.
+        good_prefetch = result.per_alert[str(good_alert.id)]
+        assert good_prefetch.error is None
+        assert good_prefetch.buckets is not None
+        assert sum(b.count for b in good_prefetch.buckets) == 3
+
+        # Bad alert: error captured per-alert, no buckets.
+        bad_prefetch = result.per_alert[str(bad_alert.id)]
+        assert bad_prefetch.buckets is None
+        assert bad_prefetch.error is not None
+        assert "simulated per-alert query failure" in str(bad_prefetch.error)
 
 
 class TestEvaluateSingleAlert(APIBaseTest):


### PR DESCRIPTION
## Problem

When a batched cohort query fails (e.g., one alert's predicate is expensive enough to time out the whole batch), the failure previously propagated to every alert in the cohort. This caused all N alerts to increment `consecutive_failures` in lockstep, eventually disabling all of them — even those whose individual queries would have succeeded. This was a regression from the pre-batching per-alert auto-disable semantics.

## Changes

**Per-alert fallback on batched query failure**

Introduces `_run_cohort_query` to replace the previous `_run_batched_query` call sites. On a batched query failure, it classifies the error and either:
- Runs per-alert `AlertCheckQuery` queries individually (non-transient errors, multi-alert cohorts), isolating the bad alert so only it accumulates `consecutive_failures`
- Propagates the error to all alerts without fallback (transient cluster errors like rate-limiting or server-busy, to avoid hammering a struggling cluster with N more queries; also skipped for single-alert cohorts where the fallback would hit the same error)

**`_CohortQueryResult` abstraction**

Replaces the `BatchedBucketedResult | None` + `cohort_error` pair with a `_CohortQueryResult` dataclass that maps `alert_id -> _PrefetchedQuery`. Both the batched success path and the per-alert fallback path produce this type, so downstream evaluation code is unchanged.

**`_PrefetchedQuery` updated**

The docstring now reflects that `query_duration_ms` carries the individual alert's query wall time on the fallback path, not just the shared batch duration.

**`increment_cohort_query_fallback` metric**

New counter tracking when the fallback fires, with reasons `batched_failure` (non-transient, fallback ran) and `transient_no_fallback` (transient, fallback skipped). Typed literal aliases added for both fallback counter reasons.

**`_tag_alert_query` helper**

Extracts the repeated `tag_queries(...)` call in `AlertCheckQuery._tag` and `BatchedAlertCheckQuery._tag` into a shared helper.

**`_safe_record` helper**

Wraps single metric calls so a metric failure never breaks alerting. Replaces several inline `try/except` blocks around histogram/counter calls.

**`_AlertCohort.team` / `team_id` properties**

Convenience properties to avoid repeated `cohort.alerts[0].team` / `cohort.alerts[0].team_id` access throughout the activity.

**`_AlertEvaluation.error_category` removed**

Field was unused after evaluation; removed from the dataclass and all construction sites.

## How did you test this code?

New unit tests in `TestRunCohortQueryFallback` cover:
- Non-transient batched failure → fallback runs, bad alert's per-alert query error is isolated, good alert gets real buckets
- Transient batched failure → fallback skipped, all alerts get the cohort error, `AlertCheckQuery` never instantiated
- Single-alert cohort → fallback skipped, error propagated directly
- Batched success → fallback never runs, all alerts get correct buckets and shared `query_duration_ms`

`TestRunCohortQueryFallbackEndToEnd` provides CH-backed integration tests:
- Fallback runs real `AlertCheckQuery.execute_bucketed` calls against test ClickHouse and returns correct per-service bucket counts
- One alert's per-alert query failure is isolated: the other alert still evaluates correctly against real CH