### PR TITLE
fix(logs-alerting): align evaluator window to next_check_at, not clock

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -59,6 +59,28 @@ def _build_logs_query(alert: LogsAlertConfiguration, date_range: DateRange) -> L
     )
 
 
+def _period_ranges(
+    date_from: dt.datetime, period_minutes: int, period_count: int
+) -> list[tuple[dt.datetime, dt.datetime]]:
+    return [
+        (
+            date_from + dt.timedelta(minutes=i * period_minutes),
+            date_from + dt.timedelta(minutes=(i + 1) * period_minutes),
+        )
+        for i in range(period_count)
+    ]
+
+
+def _timestamp_in_range(start: dt.datetime, end: dt.datetime) -> ast.Expr:
+    # Compare raw `timestamp`, not `toStartOfMinute(timestamp)`: `date_from` can carry
+    # sub-minute fractions from a DateTime64(6) checkpoint, and a minute-floor wrap
+    # would drop up to 60s of data at the lower boundary.
+    return parse_expr(
+        "timestamp >= {start} AND timestamp < {end}",
+        placeholders={"start": ast.Constant(value=start), "end": ast.Constant(value=end)},
+    )
+
+
 def _tag_alert_query(*, team: Team, alert_config_id: str, source: str) -> None:
     tag_queries(
         product=Product.LOGS,
@@ -140,6 +162,8 @@ class AlertCheckQuery:
             raise ValueError(f"Alert {alert.id} belongs to team {alert.team_id}, not {team.id}")
         self.team = team
         self.alert = alert
+        self.date_from = date_from
+        self.date_to = date_to
         self.date_range = DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat())
         self.where_expr = build_alert_where_expr(team=team, alert=alert, date_from=date_from, date_to=date_to)
 
@@ -209,6 +233,28 @@ class AlertCheckQuery:
         response = self._run_query(query)
         return [BucketedCount(timestamp=row[0], count=row[1]) for row in response.results]
 
+    def execute_periods(self, period_minutes: int, period_count: int) -> list[BucketedCount]:
+        """Per-period counts anchored to `date_from`, oldest-first."""
+        self._tag()
+
+        ranges = _period_ranges(self.date_from, period_minutes, period_count)
+        select_columns: list[ast.Expr] = [
+            ast.Alias(
+                alias=f"period_{i}",
+                expr=ast.Call(name="countIf", args=[_timestamp_in_range(start, end)]),
+            )
+            for i, (start, end) in enumerate(ranges)
+        ]
+
+        query = ast.SelectQuery(
+            select=select_columns,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["logs"])),
+            where=self.where_expr,
+        )
+        response = self._run_query(query)
+        row = response.results[0] if response.results else [0] * period_count
+        return [BucketedCount(timestamp=start, count=count) for (start, _), count in zip(ranges, row)]
+
     def _run_query(self, query: ast.SelectQuery | ast.SelectSetQuery) -> HogQLQueryResponse:
         if not isinstance(query, ast.SelectQuery):
             raise ValueError("Failed to build alert check query")
@@ -267,6 +313,8 @@ class BatchedAlertCheckQuery:
             raise ValueError("All alerts in a batch must belong to the same team")
         self.team = team
         self.alerts = list(alerts)
+        self.date_from = date_from
+        self.date_to = date_to
         self._alert_where_exprs: list[ast.Expr] = [
             build_alert_where_expr(team=team, alert=alert, date_from=date_from, date_to=date_to)
             for alert in self.alerts
@@ -344,6 +392,45 @@ class BatchedAlertCheckQuery:
             bucket_ts = row[0]
             for i, alert in enumerate(self.alerts):
                 per_alert[str(alert.id)].append(BucketedCount(timestamp=bucket_ts, count=row[i + 1]))
+        return BatchedBucketedResult(per_alert=per_alert, query_duration_ms=duration_ms)
+
+    def execute_periods(self, period_minutes: int, period_count: int) -> BatchedBucketedResult:
+        """Per-alert per-period counts anchored to `date_from` (cohort version of `AlertCheckQuery.execute_periods`)."""
+        self._tag()
+
+        ranges = _period_ranges(self.date_from, period_minutes, period_count)
+        select_columns: list[ast.Expr] = [
+            ast.Alias(
+                alias=f"alert_{alert_i}_period_{period_i}",
+                expr=ast.Call(
+                    name="countIf",
+                    args=[ast.And(exprs=[alert_expr, _timestamp_in_range(start, end)])],
+                ),
+            )
+            for alert_i, alert_expr in enumerate(self._alert_where_exprs)
+            for period_i, (start, end) in enumerate(ranges)
+        ]
+
+        query = ast.SelectQuery(
+            select=select_columns,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["logs"])),
+            where=self._outer_where,
+        )
+
+        start_ms = time.monotonic_ns() // 1_000_000
+        response = self._run_query(query)
+        duration_ms = time.monotonic_ns() // 1_000_000 - start_ms
+
+        # Cells are laid out alert-major: row[0..M-1] = alert 0's M periods,
+        # row[M..2M-1] = alert 1's, etc. Empty result = all zeros.
+        row = response.results[0] if response.results else [0] * (len(self.alerts) * len(ranges))
+        per_alert: dict[str, list[BucketedCount]] = {}
+        for alert_i, alert in enumerate(self.alerts):
+            offset = alert_i * len(ranges)
+            per_alert[str(alert.id)] = [
+                BucketedCount(timestamp=start, count=row[offset + period_i])
+                for period_i, (start, _) in enumerate(ranges)
+            ]
         return BatchedBucketedResult(per_alert=per_alert, query_duration_ms=duration_ms)
 
     def _run_query(self, query: ast.SelectQuery) -> HogQLQueryResponse:

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -435,7 +435,7 @@ def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
         date_from=cohort.date_from,
         date_to=cohort.date_to,
         projection_eligible=cohort.projection_eligible,
-    ).execute_bucketed(interval_minutes=cohort.window_minutes, limit=cohort.evaluation_periods)
+    ).execute_periods(period_minutes=cohort.window_minutes, period_count=cohort.evaluation_periods)
 
 
 def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
@@ -448,7 +448,7 @@ def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
                 alert=alert,
                 date_from=cohort.date_from,
                 date_to=cohort.date_to,
-            ).execute_bucketed(interval_minutes=cohort.window_minutes, limit=cohort.evaluation_periods)
+            ).execute_periods(period_minutes=cohort.window_minutes, period_count=cohort.evaluation_periods)
             duration_ms = (time.monotonic_ns() - start) // 1_000_000
             per_alert[str(alert.id)] = _PrefetchedQuery(buckets=buckets, query_duration_ms=duration_ms)
         except Exception as e:
@@ -922,13 +922,11 @@ def _evaluate_single_alert(
                 alert=alert,
                 date_from=date_from,
                 date_to=date_to,
-            ).execute_bucketed(interval_minutes=alert.window_minutes, limit=alert.evaluation_periods)
+            ).execute_periods(period_minutes=alert.window_minutes, period_count=alert.evaluation_periods)
             query_duration_ms = int((time.perf_counter() - query_start) * 1000)
 
-        # execute_bucketed returns ASC (oldest first); state machine wants newest first.
-        # Buckets that are entirely empty are absent from the result, so a sparse window
-        # naturally produces a shorter breaches tuple — same behavior as today's
-        # get_recent_breaches when fewer than M CHECK rows exist.
+        # `execute_periods` returns one entry per evaluation period in ASC order;
+        # the state machine wants newest-first, which `_derive_breaches` reverses.
         breaches = _derive_breaches(buckets, alert.threshold_count, alert.threshold_operator, alert.evaluation_periods)
         latest_count = buckets[-1].count if buckets else 0
         check_result = CheckResult(

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -626,6 +626,138 @@ class TestAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
                 query.execute()
 
 
+class TestEvaluatorWindowAccuracy(ClickhouseTestMixin, APIBaseTest):
+    """`execute_periods` counts must be invariant to `next_check_at` clock offset."""
+
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Window accuracy test",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 60,
+            "filters": {"serviceNames": ["window_accuracy_test"]},
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    def _seed_one_log_per_minute(self, start_hour_utc: int, hours: int = 3) -> None:
+        rows = []
+        for h in range(hours):
+            for m in range(60):
+                rows.append(
+                    {
+                        "uuid": f"window-{h:02d}-{m:02d}",
+                        "team_id": self.team.id,
+                        "timestamp": f"2025-12-16 {start_hour_utc + h:02d}:{m:02d}:00",
+                        "body": "",
+                        "severity_text": "info",
+                        "severity_number": 9,
+                        "service_name": "window_accuracy_test",
+                        "resource_attributes": {},
+                        "attributes_map_str": {},
+                    }
+                )
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+    @parameterized.expand(
+        [
+            ("offset_0_clock_aligned", 0),
+            ("offset_5", 5),
+            ("offset_10", 10),
+            ("offset_15", 15),
+            ("offset_20", 20),
+            ("offset_30", 30),
+            ("offset_45", 45),
+            ("offset_55", 55),
+        ]
+    )
+    @freeze_time("2025-12-16T13:30:00Z")
+    def test_m_equals_1_full_window_count_is_independent_of_nca_offset(self, _name: str, offset_minutes: int):
+        # 1 log/min × 60-min window = 60.
+        self._seed_one_log_per_minute(start_hour_utc=10, hours=3)
+        alert = self._make_alert(window_minutes=60, evaluation_periods=1)
+
+        nca = datetime(2025, 12, 16, 12, 0, tzinfo=UTC) + dt.timedelta(minutes=offset_minutes)
+        date_from = nca - dt.timedelta(minutes=alert.window_minutes * alert.evaluation_periods)
+
+        result = AlertCheckQuery(team=self.team, alert=alert, date_from=date_from, date_to=nca).execute_periods(
+            period_minutes=alert.window_minutes, period_count=alert.evaluation_periods
+        )
+
+        assert len(result) == 1
+        assert result[0].count == 60, (
+            f"NCA {nca.time()}: window [{date_from.time()}, {nca.time()}) has 60 logs by construction; "
+            f"got {result[0].count}"
+        )
+
+    @parameterized.expand(
+        [
+            ("offset_0_clock_aligned", 0),
+            ("offset_5", 5),
+            ("offset_10", 10),
+            ("offset_25", 25),
+            ("offset_55", 55),
+        ]
+    )
+    @freeze_time("2025-12-16T13:30:00Z")
+    def test_m_of_n_each_period_reports_full_window_count(self, _name: str, offset_minutes: int):
+        # 1 log/min × 3 × 20-min periods = 20 each.
+        self._seed_one_log_per_minute(start_hour_utc=10, hours=3)
+        alert = self._make_alert(window_minutes=20, evaluation_periods=3)
+
+        nca = datetime(2025, 12, 16, 12, 0, tzinfo=UTC) + dt.timedelta(minutes=offset_minutes)
+        date_from = nca - dt.timedelta(minutes=alert.window_minutes * alert.evaluation_periods)
+
+        result = AlertCheckQuery(team=self.team, alert=alert, date_from=date_from, date_to=nca).execute_periods(
+            period_minutes=alert.window_minutes, period_count=alert.evaluation_periods
+        )
+
+        assert len(result) == 3
+        # Every period must contain exactly 20 logs (1/min × 20 min).
+        for i, period in enumerate(result):
+            assert period.count == 20, (
+                f"Period {i} (offset {offset_minutes}min) at {period.timestamp.time()} should have 20 logs; "
+                f"got {period.count}. Per-period counts: {[p.count for p in result]}"
+            )
+        # Total across all periods = 60 logs.
+        assert sum(p.count for p in result) == 60
+
+    @freeze_time("2025-12-16T13:30:00Z")
+    def test_m_equals_1_steady_rate_does_not_oscillate_across_hour(self):
+        self._seed_one_log_per_minute(start_hour_utc=10, hours=3)
+        alert = self._make_alert(window_minutes=60, evaluation_periods=1)
+
+        counts_by_offset = {}
+        for offset in (0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55):
+            nca = datetime(2025, 12, 16, 12, 0, tzinfo=UTC) + dt.timedelta(minutes=offset)
+            result = AlertCheckQuery(
+                team=self.team, alert=alert, date_from=nca - dt.timedelta(minutes=60), date_to=nca
+            ).execute_periods(period_minutes=60, period_count=1)
+            counts_by_offset[offset] = result[0].count
+
+        unique_counts = set(counts_by_offset.values())
+        assert unique_counts == {60}, (
+            f"Reported counts vary across NCA offsets within the same hour, despite constant log rate. "
+            f"Per-offset counts: {counts_by_offset}"
+        )
+
+    @freeze_time("2025-12-16T13:30:00Z")
+    def test_m_of_n_steady_rate_does_not_oscillate_across_hour(self):
+        self._seed_one_log_per_minute(start_hour_utc=10, hours=3)
+        alert = self._make_alert(window_minutes=20, evaluation_periods=3)
+
+        for offset in (0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55):
+            nca = datetime(2025, 12, 16, 12, 0, tzinfo=UTC) + dt.timedelta(minutes=offset)
+            result = AlertCheckQuery(
+                team=self.team, alert=alert, date_from=nca - dt.timedelta(minutes=60), date_to=nca
+            ).execute_periods(period_minutes=20, period_count=3)
+            counts = [p.count for p in result]
+            assert counts == [20, 20, 20], (
+                f"NCA offset {offset}min: M-of-N period counts diverge from constant 20/period; got {counts}"
+            )
+
+
 class TestBatchedAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
     """Per-team batching: run N alerts in one CH query via `countIf(<predicate>)`.
 
@@ -817,6 +949,82 @@ class TestBatchedAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
         ):
             with self.assertRaisesRegex(Exception, "ClickHouse timeout"):
                 query.execute_bucketed(interval_minutes=5)
+
+    @parameterized.expand(
+        [
+            ("offset_0_clock_aligned", 0),
+            ("offset_5", 5),
+            ("offset_25", 25),
+            ("offset_55", 55),
+        ]
+    )
+    @freeze_time("2025-12-16T13:30:00Z")
+    def test_execute_periods_per_alert_per_period_indexing_is_correct(self, _name: str, offset_minutes: int):
+        # service_a: 1 log/min. service_b: 2 logs/min. Expected: A=[20,20,20], B=[40,40,40] for any NCA offset.
+        rows = []
+        for h in range(3):
+            for m in range(60):
+                # service_a: 1 log/min. service_b: 2 logs/min (a 'left' and a 'right' variant).
+                rows.append(
+                    {
+                        "uuid": f"a-{h:02d}-{m:02d}",
+                        "team_id": self.team.id,
+                        "timestamp": f"2025-12-16 {11 + h:02d}:{m:02d}:00",
+                        "body": "",
+                        "severity_text": "info",
+                        "severity_number": 9,
+                        "service_name": "batched_window_a",
+                        "resource_attributes": {},
+                        "attributes_map_str": {},
+                    }
+                )
+                rows.append(
+                    {
+                        "uuid": f"b1-{h:02d}-{m:02d}",
+                        "team_id": self.team.id,
+                        "timestamp": f"2025-12-16 {11 + h:02d}:{m:02d}:10",
+                        "body": "",
+                        "severity_text": "info",
+                        "severity_number": 9,
+                        "service_name": "batched_window_b",
+                        "resource_attributes": {},
+                        "attributes_map_str": {},
+                    }
+                )
+                rows.append(
+                    {
+                        "uuid": f"b2-{h:02d}-{m:02d}",
+                        "team_id": self.team.id,
+                        "timestamp": f"2025-12-16 {11 + h:02d}:{m:02d}:40",
+                        "body": "",
+                        "severity_text": "info",
+                        "severity_number": 9,
+                        "service_name": "batched_window_b",
+                        "resource_attributes": {},
+                        "attributes_map_str": {},
+                    }
+                )
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+        alert_a = self._make_alert(name="A", filters={"serviceNames": ["batched_window_a"]})
+        alert_b = self._make_alert(name="B", filters={"serviceNames": ["batched_window_b"]})
+
+        nca = datetime(2025, 12, 16, 13, 0, tzinfo=UTC) + dt.timedelta(minutes=offset_minutes)
+        date_from = nca - dt.timedelta(minutes=60)
+
+        result = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert_a, alert_b], date_from=date_from, date_to=nca
+        ).execute_periods(period_minutes=20, period_count=3)
+
+        # Every period for A: 20 logs (1/min × 20 min). Every period for B: 40 logs (2/min × 20 min).
+        a_counts = [b.count for b in result.per_alert[str(alert_a.id)]]
+        b_counts = [b.count for b in result.per_alert[str(alert_b.id)]]
+        assert a_counts == [20, 20, 20], (
+            f"NCA offset {offset_minutes}min: alert A per-period counts diverge from constant 20; got {a_counts}"
+        )
+        assert b_counts == [40, 40, 40], (
+            f"NCA offset {offset_minutes}min: alert B per-period counts diverge from constant 40; got {b_counts}"
+        )
 
     @freeze_time("2025-12-16T11:00:00Z")
     def test_per_alert_results_match_single_query_across_random_inputs(self):

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -75,13 +75,13 @@ def _bucket_counts_for(counts: list[int]) -> list[BucketedCount]:
 
 
 def _mock_buckets(mock_query_cls: MagicMock, counts: list[int]) -> None:
-    """Set AlertCheckQuery().execute_bucketed to return `counts` (oldest-first).
+    """Set AlertCheckQuery().execute_periods to return `counts` (oldest-first).
 
     Used for tests that call `_evaluate_single_alert` directly without prefetched
-    buckets — the per-alert path still goes through `AlertCheckQuery`. For the
-    cohort/sync path see `_mock_batched_buckets`.
+    buckets — the per-alert path goes through `AlertCheckQuery.execute_periods`.
+    For the cohort/sync path see `_mock_batched_buckets`.
     """
-    mock_query_cls.return_value.execute_bucketed.return_value = _bucket_counts_for(counts)
+    mock_query_cls.return_value.execute_periods.return_value = _bucket_counts_for(counts)
 
 
 def _mock_batched_buckets(mock_run_batched: MagicMock, counts: list[int]) -> None:
@@ -588,9 +588,9 @@ class TestRunCohortQueryFallback(unittest.TestCase):
         def make_query_instance(*, team, alert, **_kwargs):
             instance = MagicMock()
             if alert.id == "alert-1":
-                instance.execute_bucketed.side_effect = RuntimeError("alert-1 also bad")
+                instance.execute_periods.side_effect = RuntimeError("alert-1 also bad")
             else:
-                instance.execute_bucketed.return_value = [
+                instance.execute_periods.return_value = [
                     BucketedCount(timestamp=datetime(2025, 1, 1, 0, 0, tzinfo=UTC), count=42)
                 ]
             return instance
@@ -777,14 +777,14 @@ class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Selectively fail the per-alert query for bad_alert; let good_alert hit real CH.
-        original_execute_bucketed = AlertCheckQuery.execute_bucketed
+        original_execute_periods = AlertCheckQuery.execute_periods
 
         def maybe_fail(self, *args, **kwargs):
             if self.alert.id == bad_alert.id:
                 raise RuntimeError("simulated per-alert query failure")
-            return original_execute_bucketed(self, *args, **kwargs)
+            return original_execute_periods(self, *args, **kwargs)
 
-        with patch.object(AlertCheckQuery, "execute_bucketed", maybe_fail):
+        with patch.object(AlertCheckQuery, "execute_periods", maybe_fail):
             result = _run_cohort_query(cohort)
 
         # Good alert: real buckets, no error.
@@ -926,7 +926,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         # Force the classifier to treat this as a performance error so the assertion
         # doesn't depend on whether the raw message hits one of the shared classifier's
         # recognized shapes.
-        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
+        mock_query_cls.return_value.execute_periods.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         alert = self._make_alert()
@@ -1199,7 +1199,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             consecutive_failures=initial_failures,
             state=initial_state,
         )
-        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
+        mock_query_cls.return_value.execute_periods.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
 
@@ -1315,7 +1315,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_check_errors,
     ):
-        mock_query_cls.return_value.execute_bucketed.side_effect = Exception("boom")
+        mock_query_cls.return_value.execute_periods.side_effect = Exception("boom")
         self._make_alert()
 
         with patch(
@@ -1438,7 +1438,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_errored_notification_emitted_on_first_error(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
+        mock_query_cls.return_value.execute_periods.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         alert = self._make_alert()
@@ -1463,7 +1463,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_errored_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.side_effect = RuntimeError("CH down")
+        mock_query_cls.return_value.execute_periods.side_effect = RuntimeError("CH down")
         alert = self._make_alert()
         now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
@@ -1487,7 +1487,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
+        mock_query_cls.return_value.execute_periods.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         # 4 prior failures — one more pushes consecutive_failures to MAX (5) → BROKEN.
@@ -1538,7 +1538,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_notif_failures,
     ):
-        mock_query_cls.return_value.execute_bucketed.side_effect = Exception(
+        mock_query_cls.return_value.execute_periods.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         self._make_alert(state=initial_state, consecutive_failures=initial_failures)
@@ -1661,11 +1661,11 @@ class TestDeriveBreachesProperties(unittest.TestCase):
 class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
     """End-to-end coverage of `_evaluate_single_alert` against real ClickHouse.
 
-    Sibling tests above mock `execute_bucketed` and verify the activity's logic
-    in isolation. This class drives the full hot path — bucketed CH query →
-    activity reverses → state machine → PG state update — against seeded log
-    data, catching seam bugs (ASC/DESC handling, BucketedCount tzinfo, threshold
-    sign) that mocked-bucket tests can't see.
+    Sibling tests above mock `execute_periods` and verify the activity's logic
+    in isolation. This class drives the full hot path — periods CH query →
+    state machine → PG state update — against seeded log data, catching seam
+    bugs (BucketedCount tzinfo, threshold sign) that mocked-bucket tests can't
+    see.
     """
 
     @freeze_time("2025-12-16T10:33:00Z")
@@ -1824,13 +1824,11 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2025-12-16T10:33:00Z")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_below_operator_fires_on_truly_silent_service(self, _mock_produce):
-        # Pre-PR behavior: `execute()` always runs, returns count=0 for a silent
-        # service, so `0 < threshold` evaluates True → breach → fires.
-        # Post-PR risk: `execute_bucketed()` returns NO buckets for a silent
-        # service (CH GROUP BY only emits buckets with data). If the activity
-        # treats absent buckets as "no breach", `below` alerts on truly silent
-        # services would silently never fire — exactly the case the [TEST] Web
-        # Service Silent prod alert is built to catch.
+        # `execute_periods` always returns exactly `period_count` entries (zero
+        # counts for silent services, since each period is a fixed-width
+        # `countIf` column rather than a `GROUP BY` over data), so
+        # `0 < threshold` evaluates True → breach → fires. Regression guard
+        # for the [TEST] Web Service Silent prod alert.
         alert = self._make_alert(
             filters={"serviceNames": ["truly_silent_service_no_logs"]},
             threshold_count=1,


### PR DESCRIPTION
## Problem

Alert evaluation was using `execute_bucketed`, which buckets log counts via `toStartOfInterval` — a clock-aligned grid. When `next_check_at` (NCA) doesn't fall on an exact bucket boundary, the first and last buckets in the evaluation window get truncated, causing alerts to report incorrect counts and potentially oscillate between firing and resolving based on the clock rather than the actual data.

For example, with a 60-minute window and 1 log/minute, an alert should always report 60 logs. With `execute_bucketed`, the reported count could vary depending on where NCA falls within the hour.

## Changes

Introduces `execute_periods` on both `AlertCheckQuery` and `BatchedAlertCheckQuery` as a replacement for `execute_bucketed` in the alert evaluation path.

Instead of clock-aligned `toStartOfInterval` bucketing, `execute_periods` generates one `countIf(timestamp >= start AND timestamp < end)` column per evaluation period, with boundaries anchored precisely to `date_from + i * period_minutes`. This ensures each period always covers exactly `period_minutes` of data regardless of where NCA falls on the clock.

Key implementation details:
- `_period_ranges` computes the half-open `[start, end)` boundaries for each period.
- `_timestamp_in_range` builds the per-period predicate using raw `timestamp` (not `toStartOfMinute`) to correctly handle sub-minute `date_from` precision from `resolve_alert_date_to` checkpoints.
- The batched path (`BatchedAlertCheckQuery.execute_periods`) generates `len(alerts) × period_count` `countIf` columns in alert-major order.
- All alert evaluation call sites (`_run_batched_query`, `_run_per_alert_queries`, `_evaluate_single_alert`) are switched from `execute_bucketed` to `execute_periods`.

## How did you test this code?

New `TestEvaluatorWindowAccuracy` test class exercises `execute_periods` against a real ClickHouse instance with parameterized NCA offsets (0, 5, 10, 15, 20, 25, 30, 45, 55 minutes):

- **M=1**: Verifies a full 60-minute window always reports exactly 60 logs regardless of NCA offset.
- **M-of-N (M=3, window=20)**: Verifies each of the 3 periods reports exactly 20 logs at every NCA offset, confirming no period is truncated.
- **Steady-rate oscillation tests**: Confirms that with a constant log rate, all NCA offsets within an hour produce identical counts (no clock-driven oscillation).
- **Batched path**: `test_execute_periods_per_alert_per_period_indexing_is_correct` verifies the alert-major column layout is parsed correctly for two alerts at distinct rates across multiple NCA offsets.

All existing unit tests updated to mock `execute_periods` instead of `execute_bucketed`.

## Publish to changelog?

No