### PR TITLE
fix(taxonomic-filter): stop closed and empty result events from over-firing

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -439,6 +439,58 @@ describe('TaxonomicFilter', () => {
         })
     })
 
+    describe('`taxonomic filter closed` capture', () => {
+        // The TaxonomicFilter logic mounts in many contexts where the picker isn't visibly opened
+        // (popovers that render before the popover opens, side panels tied to scene lifecycle...).
+        // Without gating, every involuntary mount/unmount fires the close event with
+        // hadSelection=false and inflates the abandonment metric. These tests pin the gate.
+        it('does not fire when the logic mounts and unmounts with no user interaction', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture')
+            const { unmount } = renderFilter()
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+            })
+
+            unmount()
+
+            const closedCalls = captureSpy.mock.calls.filter((c) => c[0] === 'taxonomic filter closed')
+            expect(closedCalls).toHaveLength(0)
+        })
+
+        it.each([
+            {
+                name: 'fires when the user typed in the search input before closing',
+                interact: async () => {
+                    await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'event')
+                },
+                expected: { hadSelection: false },
+            },
+            {
+                name: 'fires when the user selected an item before closing',
+                interact: async () => {
+                    await userEvent.click(screen.getByTestId('prop-filter-events-0'))
+                },
+                expected: { hadSelection: true },
+            },
+        ])('$name', async ({ interact, expected }) => {
+            const captureSpy = jest.spyOn(posthog, 'capture')
+            const { unmount } = renderFilter()
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+            })
+
+            await interact()
+
+            unmount()
+
+            const closedCall = captureSpy.mock.calls.find((c) => c[0] === 'taxonomic filter closed')
+            expect(closedCall).not.toBeUndefined()
+            expect(closedCall?.[1]).toMatchObject(expected)
+        })
+    })
+
     describe('keyboard navigation', () => {
         it('search narrows results and arrow down + enter selects from filtered list', async () => {
             renderFilter()

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -487,7 +487,11 @@ describe('TaxonomicFilter', () => {
 
             const closedCall = captureSpy.mock.calls.find((c) => c[0] === 'taxonomic filter closed')
             expect(closedCall).not.toBeUndefined()
-            expect(closedCall?.[1]).toMatchObject(expected)
+            expect(closedCall?.[1]).toMatchObject({
+                ...expected,
+                dwellMs: expect.any(Number),
+                groupType: expect.any(String),
+            })
         })
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -204,6 +204,7 @@ export const TaxonomicFilterSearchInput = forwardRef<
     const { searchQuery, searchPlaceholder, showNumericalPropsOnly } = useValues(taxonomicFilterLogic)
     const {
         setSearchQuery: setTaxonomicSearchQuery,
+        markUserInteraction,
         recordPaste,
         moveUp,
         moveDown,
@@ -213,6 +214,7 @@ export const TaxonomicFilterSearchInput = forwardRef<
     } = useActions(taxonomicFilterLogic)
 
     const _onChange = (query: string): void => {
+        markUserInteraction()
         setTaxonomicSearchQuery(query)
         onChange?.(query)
     }

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -214,6 +214,9 @@ export const TaxonomicFilterSearchInput = forwardRef<
     } = useActions(taxonomicFilterLogic)
 
     const _onChange = (query: string): void => {
+        // Only the input's onChange path counts as user interaction. The controlled-prop
+        // useEffect above also calls setSearchQuery directly, but that's programmatic and
+        // shouldn't unmute the `taxonomic filter closed` capture — keep this dispatch separate.
         markUserInteraction()
         setTaxonomicSearchQuery(query)
         onChange?.(query)

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1,6 +1,7 @@
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic, partial } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
@@ -14,6 +15,7 @@ import { AppContext, PropertyDefinition, PropertyType } from '~/types'
 import { joinsLogic } from 'products/data_warehouse/frontend/shared/logics/joinsLogic'
 
 import { infiniteListLogic } from './infiniteListLogic'
+import { taxonomicFilterLogic } from './taxonomicFilterLogic'
 
 window.POSTHOG_APP_CONTEXT = {
     current_team: { id: MOCK_TEAM_ID },
@@ -813,6 +815,56 @@ describe('infiniteListLogic', () => {
                 .toMatchValues({
                     keywordShortcutItems: [],
                 })
+        })
+    })
+
+    describe('`taxonomic filter empty result` capture', () => {
+        // Every list runs the same search in parallel — without an active-tab gate, one keystroke
+        // can fire 4-8 empty events from background tabs the user never sees. Pin the gate.
+        const taxonomicFilterLogicKey = 'emptyResultGateTest'
+        const props = {
+            taxonomicFilterLogicKey,
+            taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.EventProperties],
+            showNumericalPropsOnly: false,
+        }
+
+        it.each([
+            {
+                name: 'fires when the empty list is the active tab',
+                activeTab: TaxonomicFilterGroupType.Events,
+                listGroupType: TaxonomicFilterGroupType.Events,
+                expectFire: true,
+            },
+            {
+                name: 'does not fire when the empty list is a background tab',
+                activeTab: TaxonomicFilterGroupType.EventProperties,
+                listGroupType: TaxonomicFilterGroupType.Events,
+                expectFire: false,
+            },
+        ])('$name', async ({ activeTab, listGroupType, expectFire }) => {
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            const parent = taxonomicFilterLogic(props)
+            parent.mount()
+            parent.actions.setActiveTab(activeTab)
+
+            const listLogic = infiniteListLogic({ ...props, listGroupType })
+            listLogic.mount()
+
+            await expectLogic(listLogic, () => listLogic.actions.setSearchQuery('mcp tool call'))
+                .toDispatchActions(['setSearchQuery', 'loadRemoteItems', 'loadRemoteItemsSuccess'])
+                .toFinishAllListeners()
+
+            const emptyCalls = captureSpy.mock.calls.filter((c) => c[0] === 'taxonomic filter empty result')
+            if (expectFire) {
+                expect(emptyCalls).toHaveLength(1)
+                expect(emptyCalls[0][1]).toMatchObject({
+                    groupType: listGroupType,
+                    searchQuery: 'mcp tool call',
+                })
+            } else {
+                expect(emptyCalls).toHaveLength(0)
+            }
         })
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -851,6 +851,11 @@ describe('infiniteListLogic', () => {
             const listLogic = infiniteListLogic({ ...props, listGroupType })
             listLogic.mount()
 
+            // Tripwire: the gate reads `isActiveTab` from the parent. If anyone refactors
+            // `isActiveTab` to be self-contained, this assertion catches it before the
+            // empty-result expectations silently start passing for the wrong reason.
+            expect(listLogic.values.isActiveTab).toBe(activeTab === listGroupType)
+
             await expectLogic(listLogic, () => listLogic.actions.setSearchQuery('mcp tool call'))
                 .toDispatchActions(['setSearchQuery', 'loadRemoteItems', 'loadRemoteItemsSuccess'])
                 .toFinishAllListeners()

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -959,7 +959,15 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
 
             const trimmedQuery = (remoteItems.searchQuery ?? '').trim()
             const queryReachedBackend = trimmedQuery.length >= values.minSearchQueryLength
-            if (trimmedQuery.length > 0 && queryReachedBackend && remoteItems.results.length === 0) {
+            // Only fire on the tab the user is actually looking at — every list runs the same
+            // search in parallel, so without this gate one keystroke can fire 4-8 empty events
+            // from background tabs the user never sees, inflating the dead-end metric.
+            if (
+                values.isActiveTab &&
+                trimmedQuery.length > 0 &&
+                queryReachedBackend &&
+                remoteItems.results.length === 0
+            ) {
                 const dedupeKey = `${props.listGroupType}::${trimmedQuery}`
                 if (cache.lastEmptyResultDedupeKey !== dedupeKey) {
                     cache.lastEmptyResultDedupeKey = dedupeKey

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1703,20 +1703,18 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         }
     }),
     beforeUnmount(({ values, cache }) => {
-        // The logic mounts in many contexts where the picker isn't visibly opened — e.g. inside a
-        // popover whose contents render before the popover is shown, or as part of a side panel
-        // whose lifecycle is tied to the surrounding scene rather than to user intent. Without a
-        // gate, every involuntary mount/unmount fires `taxonomic filter closed` with
-        // hadSelection=false, inflating the abandonment metric well beyond actual user behaviour
-        // (top sessions hit 100+ closes, far more than any human would generate).
-        if (!cache.hadInteraction && !cache.hadSelection) {
-            return
+        // Only capture when there's evidence the user actually engaged with the picker. The logic
+        // mounts in many places where the picker isn't visibly opened (popover contents rendered
+        // before the popover shows, side panels tied to scene lifecycle, route transitions), so
+        // without this gate every involuntary mount/unmount fires a close with hadSelection=false
+        // and inflates the abandonment metric (top sessions hit 100+ closes pre-gate).
+        if (cache.hadInteraction || cache.hadSelection) {
+            posthog.capture('taxonomic filter closed', {
+                dwellMs: Date.now() - (cache.openedAt ?? Date.now()),
+                hadSelection: !!cache.hadSelection,
+                groupType: values.activeTab,
+            })
         }
-        posthog.capture('taxonomic filter closed', {
-            dwellMs: Date.now() - (cache.openedAt ?? Date.now()),
-            hadSelection: !!cache.hadSelection,
-            groupType: values.activeTab,
-        })
     }),
     propsChanged(({ actions, props }, oldProps) => {
         // When the in-context events change (e.g. an insight series swaps event), ask the model

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -410,6 +410,22 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 enableMouseInteractions: () => true,
             },
         ],
+        hadInteraction: [
+            // Any genuine user-driven action flips this. Read in `beforeUnmount` to gate the
+            // `taxonomic filter closed` capture so involuntary mounts (popovers/side panels
+            // rendered before the picker is shown, route transitions) don't fire phantom closes.
+            // New interaction sources should be added here, not by mutating cache from listeners.
+            false,
+            {
+                moveUp: () => true,
+                moveDown: () => true,
+                tabLeft: () => true,
+                tabRight: () => true,
+                setActiveTab: () => true,
+                selectItem: () => true,
+                markUserInteraction: () => true,
+            },
+        ],
         topMatchItems: [
             [] as (TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType })[],
             {
@@ -1696,7 +1712,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
     afterMount(({ actions, props, cache }) => {
         cache.openedAt = Date.now()
         cache.hadSelection = false
-        cache.hadInteraction = false
         // Initial fire — the model dedupes against taxonomy defaults and already-loaded names.
         if (props.eventNames?.length) {
             actions.ensureLoadedForEvents(props.eventNames)
@@ -1708,7 +1723,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         // before the popover shows, side panels tied to scene lifecycle, route transitions), so
         // without this gate every involuntary mount/unmount fires a close with hadSelection=false
         // and inflates the abandonment metric (top sessions hit 100+ closes pre-gate).
-        if (cache.hadInteraction || cache.hadSelection) {
+        if (values.hadInteraction) {
             posthog.capture('taxonomic filter closed', {
                 dwellMs: Date.now() - (cache.openedAt ?? Date.now()),
                 hadSelection: !!cache.hadSelection,
@@ -1798,7 +1813,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         moveUp: async (_, breakpoint) => {
-            cache.hadInteraction = true
             if (values.activeTab) {
                 infiniteListLogic({
                     ...props,
@@ -1810,7 +1824,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         moveDown: async (_, breakpoint) => {
-            cache.hadInteraction = true
             if (values.activeTab) {
                 infiniteListLogic({
                     ...props,
@@ -1833,7 +1846,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         tabLeft: () => {
-            cache.hadInteraction = true
             const { currentTabIndex, taxonomicGroupTypes, infiniteListCounts } = values
             for (let i = 1; i < taxonomicGroupTypes.length; i++) {
                 const newIndex = (currentTabIndex - i + taxonomicGroupTypes.length) % taxonomicGroupTypes.length
@@ -1845,7 +1857,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         tabRight: () => {
-            cache.hadInteraction = true
             const { currentTabIndex, taxonomicGroupTypes, infiniteListCounts } = values
             for (let i = 1; i < taxonomicGroupTypes.length; i++) {
                 const newIndex = (currentTabIndex + i) % taxonomicGroupTypes.length
@@ -1854,14 +1865,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     return
                 }
             }
-        },
-
-        setActiveTab: () => {
-            cache.hadInteraction = true
-        },
-
-        markUserInteraction: () => {
-            cache.hadInteraction = true
         },
 
         recordPaste: ({ pastedLength }) => {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -351,6 +351,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         tabLeft: true,
         tabRight: true,
         setSearchQuery: (searchQuery: string) => ({ searchQuery }),
+        markUserInteraction: true,
         recordPaste: (pastedLength: number) => ({ pastedLength }),
         setActiveTab: (activeTab: TaxonomicFilterGroupType) => ({ activeTab }),
         selectItem: (
@@ -1695,12 +1696,22 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
     afterMount(({ actions, props, cache }) => {
         cache.openedAt = Date.now()
         cache.hadSelection = false
+        cache.hadInteraction = false
         // Initial fire — the model dedupes against taxonomy defaults and already-loaded names.
         if (props.eventNames?.length) {
             actions.ensureLoadedForEvents(props.eventNames)
         }
     }),
     beforeUnmount(({ values, cache }) => {
+        // The logic mounts in many contexts where the picker isn't visibly opened — e.g. inside a
+        // popover whose contents render before the popover is shown, or as part of a side panel
+        // whose lifecycle is tied to the surrounding scene rather than to user intent. Without a
+        // gate, every involuntary mount/unmount fires `taxonomic filter closed` with
+        // hadSelection=false, inflating the abandonment metric well beyond actual user behaviour
+        // (top sessions hit 100+ closes, far more than any human would generate).
+        if (!cache.hadInteraction && !cache.hadSelection) {
+            return
+        }
         posthog.capture('taxonomic filter closed', {
             dwellMs: Date.now() - (cache.openedAt ?? Date.now()),
             hadSelection: !!cache.hadSelection,
@@ -1789,6 +1800,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         moveUp: async (_, breakpoint) => {
+            cache.hadInteraction = true
             if (values.activeTab) {
                 infiniteListLogic({
                     ...props,
@@ -1800,6 +1812,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         moveDown: async (_, breakpoint) => {
+            cache.hadInteraction = true
             if (values.activeTab) {
                 infiniteListLogic({
                     ...props,
@@ -1822,6 +1835,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         tabLeft: () => {
+            cache.hadInteraction = true
             const { currentTabIndex, taxonomicGroupTypes, infiniteListCounts } = values
             for (let i = 1; i < taxonomicGroupTypes.length; i++) {
                 const newIndex = (currentTabIndex - i + taxonomicGroupTypes.length) % taxonomicGroupTypes.length
@@ -1833,6 +1847,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         },
 
         tabRight: () => {
+            cache.hadInteraction = true
             const { currentTabIndex, taxonomicGroupTypes, infiniteListCounts } = values
             for (let i = 1; i < taxonomicGroupTypes.length; i++) {
                 const newIndex = (currentTabIndex + i) % taxonomicGroupTypes.length
@@ -1841,6 +1856,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     return
                 }
             }
+        },
+
+        setActiveTab: () => {
+            cache.hadInteraction = true
+        },
+
+        markUserInteraction: () => {
+            cache.hadInteraction = true
         },
 
         recordPaste: ({ pastedLength }) => {


### PR DESCRIPTION
## Problem

Paul flagged that the new TaxonomicFilter health dashboard's headline numbers — ~67% picker abandonment, 82% of search users hitting a dead-end — looked too high to be real user behaviour. Investigation confirmed two analytics over-fires inflating both metrics; this PR fixes them at the source.

## Changes

**1. `taxonomic filter closed` was firing on every kea logic mount/unmount.** `taxonomicFilterLogic` mounts in many contexts where the picker isn't visibly opened (popover content rendered before the popover opens, side panels tied to scene lifecycle, route transitions). Every involuntary mount fired a close with `hadSelection=false`, inflating the abandonment metric. The smoking gun: top sessions in production had 100+ closes — not human behaviour. ~8k closes in 3d had `dwellMs<1s` with no selection vs only 133 selected closes <1s.

Gate the capture on a new `cache.hadInteraction` flag set by real user-driven actions:
- keyboard nav: `moveUp` / `moveDown` / `tabLeft` / `tabRight`
- tab clicks: `setActiveTab` listener (covers the UI clicks from `CategoryDropdown` and `InfiniteSelectResults`)
- search input typing/clearing: a new `markUserInteraction` action wired into the input's `_onChange` — distinguishes from the controlled-prop `useEffect` path which calls `setSearchQuery` directly without going through `_onChange`
- existing `hadSelection` (selection counts as interaction)

**2. `taxonomic filter empty result` was firing per list, not per search.** Every tab runs the same search in parallel, so typing "email" commonly fires 4-8 empty events from background tabs the user can't even see. A single "email" search fires empty events from up to 8 different `groupType`s — counting "82% of users hitting a dead-end" is really "82% had at least one background tab return zero results". Gate on the existing `isActiveTab` selector so empties only fire from the visible tab.


## Metric semantics — read before consuming the existing events downstream

Both gates change the meaning of the events for any dashboard or insight that already consumes them:

- taxonomic filter closed shifts from "any open/close cycle" to "engaged open/close cycle". A user who opens, scrolls or hovers without typing/keyboard-navigating/selecting, then closes, no longer fires the event. Expected effect: total volume of the event drops sharply (much of the prior ~282k events/month was phantom mounts), and the hadSelection=false cohort shrinks the most.
- taxonomic filter empty result shifts from "any list returned empty for this query" to "the visible tab returned empty". A typed search like email previously fired one empty event per group whose list returned zero — typically 4-8 events per keystroke. Expected effect: total volume drops by roughly the multiplier of how many tabs return empty for a typical query (3-6x is realistic).

If you have any alerts or insights pinned on absolute event volumes, expect a step change once this lands. Rates and ratios computed from these events should land closer to actual user behaviour after the change.

## How did you test this code?

I'm an agent (PostHog Code) — no manual UI testing. Automated coverage added:

- **`taxonomic filter closed` gate** (in `TaxonomicFilter.test.tsx`): parameterised tests covering (a) bare mount/unmount fires nothing, (b) typing then unmount fires with `hadSelection=false`, (c) selecting then unmount fires with `hadSelection=true`.
- **`taxonomic filter empty result` gate** (in `infiniteListLogic.test.ts`): parameterised tests covering (a) empty list on the active tab fires the event, (b) empty list on a background tab does not fire.

Both files have a pre-existing `@posthog/hogvm` resolution failure on my local machine that prevents Jest from running locally — same blocker called out in PR #56660. Documenting this honestly: CI will exercise the tests.

`pnpm typescript:check` is clean for these files (only pre-existing `@posthog/hogvm` / `@posthog/quill` resolution warnings unrelated to this change), and `oxlint` is clean (0 errors).

## Publish to changelog?

no — analytics correctness fix, no user-facing change

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Authored by the PostHog Code agent on behalf of @pauldambra during a session that started with adding tiles to dashboard 1514607 ([Taxonomic filter health](https://us.posthog.com/project/2/dashboard/1514607)) using events shipped in PRs #56514, #56515, #56516, #56517, #56660.
- Key human prompt that drove this work: Paul read the AI-generated weekly summary, saw the abandonment + dead-end numbers, and asked "is this an analytics error? are users opening and closing just to explore?" That question shaped the entire investigation.
- Decisions:
  - For the closed event, considered just gating on `dwellMs > 250ms` to filter out programmatic remounts. Rejected — a misclick (real user, low dwell) would be silently dropped. Settled on the `hadInteraction || hadSelection` gate which keeps misclicks visible (low dwell + had typing/keyboard) while suppressing involuntary mounts (no interaction at all).
  - For the search input wiring, considered marking `hadInteraction` directly in the `setSearchQuery` listener. Rejected — `TaxonomicFilter.tsx` line 116 calls `setSearchQuery(controlledSearchQuery)` from a `useEffect` watching a parent prop, which would falsely register as user interaction. The dedicated `markUserInteraction` action wired only into the input's `_onChange` handler avoids that confound.
  - For the empty-result fix, the `isActiveTab` selector already existed in `infiniteListLogic` (used elsewhere for ranking) — re-used it rather than introducing a new value.
- Requires human review before merging.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
