### PR TITLE
feat(subscriptions): tag AI summary LLM calls with product=subscriptions

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -19,6 +19,7 @@ Product = Literal[
     "customer_archetype_classification",
     "slack-posthog-code",
     "product_analytics",
+    "subscriptions",
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 

--- a/posthog/temporal/subscriptions/llm_change_summary.py
+++ b/posthog/temporal/subscriptions/llm_change_summary.py
@@ -343,7 +343,7 @@ def generate_change_summary(
         user_message_length=attached.user_text_length,
     )
 
-    client = get_llm_client(product="product_analytics")
+    client = get_llm_client(product="subscriptions")
 
     instance_region = get_instance_region() or "HOBBY"
     user_tag = f"{instance_region}/subscription-summary-team-{team_id}"

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -126,6 +126,11 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID}),
         allow_api_keys=False,
     ),
+    "subscriptions": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=frozenset({"gpt-4.1-mini"}),
+        allow_api_keys=True,
+    ),
 }
 
 


### PR DESCRIPTION
## Problem

Right now every AI subscription summary goes through the LLM gateway tagged with `product=product_analytics`, which means LLMA traces and `$ai_generation` events for summaries are mixed in with chat, summarizer, and every other product-analytics-tagged LLM call. There's no way to ask LLMA "how much is the subscription summary feature costing us?" or "how many tokens are we burning per delivery?" without trying to filter by user-tag substrings, which is fragile.

## Changes

Adds a dedicated `subscriptions` product to the LLM gateway and switches the only call site to use it:

- `posthog/llm/gateway_client.py` — adds `"subscriptions"` to the `Product` literal so callers can pass it through `get_llm_client(product="subscriptions")`.
- `services/llm-gateway/src/llm_gateway/products/config.py` — registers `"subscriptions"` with the gateway, allowing only `gpt-4.1-mini` (the model we actually call) and API-key auth (matches the temporal worker's auth path).
- `posthog/temporal/subscriptions/llm_change_summary.py` — flips the single call site (covers both initial and change summaries — same call, different prompt template) from `product="product_analytics"` to `product="subscriptions"`.

After this lands, `$ai_generation` events from subscription summaries carry `$ai_product = subscriptions`, so we can build cost/usage insights that isolate this feature in LLMA.

## How did you test this code?

I'm an agent (PostHog Code). I have not run the code locally. I confirmed:

- The only LLM gateway call site under `posthog/temporal/subscriptions/` is `llm_change_summary.py:346` (one `get_llm_client` import, one usage).
- The model passed at the call site (`gpt-4.1-mini`, line 353) matches the new `allowed_models` set in the gateway config.
- The `Product` literal addition keeps the existing comment that requires sync with the gateway config file, and that file is updated in the same PR.

Existing test suite around `llm_change_summary.py` (`test_llm_change_summary.py`) all mock `get_llm_client`, so they don't depend on the product literal value. CI will run them.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs (internal observability change, no user-facing surface)

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) at the user's request: track subscription summary LLM cost via LLMA's `ai_product` tag.
- Decision: introduce a brand-new `subscriptions` product rather than rename `product_analytics`, so existing PA-tagged traffic is unaffected and we get a clean isolated feed.
- Decision: limit the new product to `gpt-4.1-mini` (the model we actually call today). Easy to widen later if we change models.
- Human review required before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*