### PR TITLE
perf(team): debounce calculate_product_activation enqueue per team

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -44,7 +44,7 @@ from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.product_intent.product_intent import (
     ProductIntent,
     ProductIntentSerializer,
-    calculate_product_activation,
+    enqueue_product_activation_calc_debounced,
 )
 from posthog.models.project import Project
 from posthog.models.team.setup_tasks import SetupTaskId
@@ -385,7 +385,7 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
     def get_product_intents(self, obj):
         project = obj
         team = project.passthrough_team
-        calculate_product_activation.delay(team.id, only_calc_if_days_since_last_checked=1)
+        enqueue_product_activation_calc_debounced(team.id)
         return ProductIntent.objects.filter(team=team).values(
             "product_type", "created_at", "onboarding_completed_at", "updated_at"
         )

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -42,7 +42,10 @@ from posthog.models.evaluation_context import EvaluationContext, TeamDefaultEval
 from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
 from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.organization import OrganizationMembership
-from posthog.models.product_intent.product_intent import ProductIntentSerializer, calculate_product_activation
+from posthog.models.product_intent.product_intent import (
+    ProductIntentSerializer,
+    enqueue_product_activation_calc_debounced,
+)
 from posthog.models.project import Project
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.team.setup_tasks import SetupTaskId
@@ -474,7 +477,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
     @extend_schema_field(serializers.ListField(child=serializers.DictField()))
     def get_product_intents(self, obj):
-        calculate_product_activation.delay(obj.id, only_calc_if_days_since_last_checked=1)
+        enqueue_product_activation_calc_debounced(obj.id)
         return ProductIntent.objects.filter(team=obj).values(
             "product_type", "created_at", "onboarding_completed_at", "updated_at"
         )

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1622,7 +1622,7 @@ def team_api_test_factory():
                 team=self.team,
             )
 
-        @patch("posthog.api.team.calculate_product_activation.delay", MagicMock())
+        @patch("posthog.api.team.enqueue_product_activation_calc_debounced", MagicMock())
         @patch("posthog.models.product_intent.ProductIntent.check_and_update_activation", return_value=False)
         @patch("posthog.event_usage.report_user_action")
         @freeze_time("2024-01-01T00:00:00Z")

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from typing import Optional
 
+from django.core.cache import cache
 from django.db import models
 
 from celery import shared_task
@@ -328,3 +329,22 @@ def calculate_product_activation(team_id: int, only_calc_if_days_since_last_chec
         ):
             continue
         product_intent.check_and_update_activation()
+
+
+PRODUCT_ACTIVATION_DEBOUNCE_TTL_SECONDS = 24 * 60 * 60
+
+
+def enqueue_product_activation_calc_debounced(team_id: int) -> bool:
+    """Enqueue `calculate_product_activation` for this team at most once per 24h.
+
+    The task itself already short-circuits with `only_calc_if_days_since_last_checked=1`,
+    so enqueueing on every page render was wasted broker traffic. This guard skips the
+    Celery enqueue when we've already enqueued for this team within the debounce window.
+
+    Returns True when the task was enqueued, False when the call was debounced.
+    """
+    debounce_key = f"product_activation_enqueued:{team_id}"
+    if cache.add(debounce_key, "1", timeout=PRODUCT_ACTIVATION_DEBOUNCE_TTL_SECONDS):
+        calculate_product_activation.delay(team_id, only_calc_if_days_since_last_checked=1)
+        return True
+    return False

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -331,20 +331,39 @@ def calculate_product_activation(team_id: int, only_calc_if_days_since_last_chec
         product_intent.check_and_update_activation()
 
 
+# Intentionally matches the default of `only_calc_if_days_since_last_checked=1`
+# in `calculate_product_activation` above. The two together define the
+# activation re-check cadence — tune them together.
 PRODUCT_ACTIVATION_DEBOUNCE_TTL_SECONDS = 24 * 60 * 60
 
 
 def enqueue_product_activation_calc_debounced(team_id: int) -> bool:
     """Enqueue `calculate_product_activation` for this team at most once per 24h.
 
-    The task itself already short-circuits with `only_calc_if_days_since_last_checked=1`,
-    so enqueueing on every page render was wasted broker traffic. This guard skips the
-    Celery enqueue when we've already enqueued for this team within the debounce window.
+    The Celery task itself already short-circuits each not-yet-activated intent with
+    `only_calc_if_days_since_last_checked=1`, so enqueueing on every page render was
+    wasted broker traffic that the worker would no-op. This guard skips the enqueue
+    when we've already done it for this team within the debounce window.
+
+    Failure mode: if the cache backend errors (e.g. Redis blip), fail open and
+    enqueue anyway — better to take the broker round-trip than to 500 the team
+    list endpoint. The inner task's per-intent short-circuit limits the cost.
+
+    Best-effort: the debounce key is set unconditionally before enqueueing, so a
+    Celery enqueue or worker failure leaves the team debounced for up to 24h. The
+    primary activation path is `ProductIntent.register()` which calls
+    `check_and_update_activation()` synchronously; this helper exists only for the
+    periodic re-check of criteria that became met after registration.
 
     Returns True when the task was enqueued, False when the call was debounced.
     """
     debounce_key = f"product_activation_enqueued:{team_id}"
-    if cache.add(debounce_key, "1", timeout=PRODUCT_ACTIVATION_DEBOUNCE_TTL_SECONDS):
+    try:
+        was_added = cache.add(debounce_key, "1", timeout=PRODUCT_ACTIVATION_DEBOUNCE_TTL_SECONDS)
+    except Exception:
+        # Cache error must not block the enqueue path; fall through to .delay().
+        was_added = True
+    if was_added:
         calculate_product_activation.delay(team_id, only_calc_if_days_since_last_checked=1)
         return True
     return False

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.core.cache import cache
 from django.db import models
 
+import structlog
 from celery import shared_task
 from rest_framework import serializers
 
@@ -25,6 +26,8 @@ from products.event_definitions.backend.models.event_definition import EventDefi
 from products.experiments.backend.models.experiment import Experiment
 from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.models import Survey
+
+logger = structlog.get_logger(__name__)
 
 """
 How to use this model:
@@ -360,8 +363,13 @@ def enqueue_product_activation_calc_debounced(team_id: int) -> bool:
     debounce_key = f"product_activation_enqueued:{team_id}"
     try:
         was_added = cache.add(debounce_key, "1", timeout=PRODUCT_ACTIVATION_DEBOUNCE_TTL_SECONDS)
-    except Exception:
+    except Exception as e:
         # Cache error must not block the enqueue path; fall through to .delay().
+        # Log + capture so a chronic Redis problem still surfaces in monitoring
+        # rather than silently degrading to "every render enqueues" (which would
+        # otherwise look identical to working code).
+        logger.warning("product_activation_debounce_cache_failure", team_id=team_id, exc_info=True)
+        capture_exception(e)
         was_added = True
     if was_added:
         calculate_product_activation.delay(team_id, only_calc_if_days_since_last_checked=1)

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -5,13 +5,21 @@ from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.core.cache import cache
+
+from parameterized import parameterized
+
 from posthog.schema import ProductIntentContext, ProductKey
 
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.file_system.user_product_list import UserProductList
 from posthog.models.hog_flow.hog_flow import HogFlow
 from posthog.models.insight import Insight
-from posthog.models.product_intent.product_intent import ProductIntent, calculate_product_activation
+from posthog.models.product_intent.product_intent import (
+    ProductIntent,
+    calculate_product_activation,
+    enqueue_product_activation_calc_debounced,
+)
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.utils import get_instance_realm
 
@@ -790,30 +798,32 @@ class TestProductIntent(BaseTest):
 class TestEnqueueProductActivationCalcDebounced(BaseTest):
     def setUp(self):
         super().setUp()
-        from django.core.cache import cache
-
         cache.clear()
 
-    def test_first_call_enqueues_the_celery_task(self):
-        from posthog.models.product_intent.product_intent import enqueue_product_activation_calc_debounced
-
+    @parameterized.expand(
+        [
+            # name, team_id_offsets (called as self.team.id + offset), expected_returns, expected_delay_calls
+            ("first call enqueues", [0], [True], 1),
+            ("second call same team debounced", [0, 0], [True, False], 1),
+            ("third call same team still debounced", [0, 0, 0], [True, False, False], 1),
+            ("different team is not debounced", [0, 9999], [True, True], 2),
+            ("same team twice then different team", [0, 0, 9999], [True, False, True], 2),
+        ]
+    )
+    def test_debounce_behaviour(
+        self, _name: str, team_id_offsets: list[int], expected_returns: list[bool], expected_delay_calls: int
+    ):
         with patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay:
+            results = [enqueue_product_activation_calc_debounced(self.team.id + offset) for offset in team_id_offsets]
+        assert results == expected_returns
+        assert mock_delay.call_count == expected_delay_calls
+
+    def test_cache_failure_falls_open_and_still_enqueues(self):
+        # Redis blip must not 500 the team list endpoint. The helper falls open:
+        # treat a cache exception as "we haven't enqueued recently" and proceed.
+        with (
+            patch("posthog.models.product_intent.product_intent.cache.add", side_effect=Exception("redis is sad")),
+            patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay,
+        ):
             assert enqueue_product_activation_calc_debounced(self.team.id) is True
         mock_delay.assert_called_once_with(self.team.id, only_calc_if_days_since_last_checked=1)
-
-    def test_subsequent_calls_within_window_are_debounced(self):
-        from posthog.models.product_intent.product_intent import enqueue_product_activation_calc_debounced
-
-        with patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay:
-            assert enqueue_product_activation_calc_debounced(self.team.id) is True
-            assert enqueue_product_activation_calc_debounced(self.team.id) is False
-            assert enqueue_product_activation_calc_debounced(self.team.id) is False
-        assert mock_delay.call_count == 1
-
-    def test_other_teams_are_not_debounced(self):
-        from posthog.models.product_intent.product_intent import enqueue_product_activation_calc_debounced
-
-        with patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay:
-            assert enqueue_product_activation_calc_debounced(self.team.id) is True
-            assert enqueue_product_activation_calc_debounced(self.team.id + 9999) is True
-        assert mock_delay.call_count == 2

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -785,3 +785,35 @@ class TestProductIntent(BaseTest):
         self.product_intent.save()
 
         assert self.product_intent.has_activated_workflows() is False
+
+
+class TestEnqueueProductActivationCalcDebounced(BaseTest):
+    def setUp(self):
+        super().setUp()
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_first_call_enqueues_the_celery_task(self):
+        from posthog.models.product_intent.product_intent import enqueue_product_activation_calc_debounced
+
+        with patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay:
+            assert enqueue_product_activation_calc_debounced(self.team.id) is True
+        mock_delay.assert_called_once_with(self.team.id, only_calc_if_days_since_last_checked=1)
+
+    def test_subsequent_calls_within_window_are_debounced(self):
+        from posthog.models.product_intent.product_intent import enqueue_product_activation_calc_debounced
+
+        with patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay:
+            assert enqueue_product_activation_calc_debounced(self.team.id) is True
+            assert enqueue_product_activation_calc_debounced(self.team.id) is False
+            assert enqueue_product_activation_calc_debounced(self.team.id) is False
+        assert mock_delay.call_count == 1
+
+    def test_other_teams_are_not_debounced(self):
+        from posthog.models.product_intent.product_intent import enqueue_product_activation_calc_debounced
+
+        with patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay:
+            assert enqueue_product_activation_calc_debounced(self.team.id) is True
+            assert enqueue_product_activation_calc_debounced(self.team.id + 9999) is True
+        assert mock_delay.call_count == 2

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -818,12 +818,21 @@ class TestEnqueueProductActivationCalcDebounced(BaseTest):
         assert results == expected_returns
         assert mock_delay.call_count == expected_delay_calls
 
-    def test_cache_failure_falls_open_and_still_enqueues(self):
+    def test_cache_failure_falls_open_logs_and_still_enqueues(self):
         # Redis blip must not 500 the team list endpoint. The helper falls open:
         # treat a cache exception as "we haven't enqueued recently" and proceed.
+        # We also log + capture so a chronic Redis problem still shows up rather
+        # than silently degrading to "every render enqueues".
         with (
             patch("posthog.models.product_intent.product_intent.cache.add", side_effect=Exception("redis is sad")),
             patch("posthog.models.product_intent.product_intent.calculate_product_activation.delay") as mock_delay,
+            patch("posthog.models.product_intent.product_intent.logger.warning") as mock_log,
+            patch("posthog.models.product_intent.product_intent.capture_exception") as mock_capture,
         ):
             assert enqueue_product_activation_calc_debounced(self.team.id) is True
+
         mock_delay.assert_called_once_with(self.team.id, only_calc_if_days_since_last_checked=1)
+        mock_log.assert_called_once()
+        assert mock_log.call_args.args == ("product_activation_debounce_cache_failure",)
+        assert mock_log.call_args.kwargs == {"team_id": self.team.id, "exc_info": True}
+        mock_capture.assert_called_once()


### PR DESCRIPTION
* before we can even start to show users something we have to deliver HTML to the client so the react app can boot
* we template a bunch of info into the HTML to bootstrap 
* but that takes time and eats into loading time
* let's optimise it

## Problem

\`TeamSerializer.get_product_intents\` calls
\`calculate_product_activation.delay(team_id, only_calc_if_days_since_last_checked=1)\` on every authenticated page load via \`get_context_for_template\`. The Celery task itself short-circuits when it's been less than a day since the last check — so the work is correctly skipped — but the \`.delay()\` round-trip to the broker still happens on every render. Thousands of enqueues per minute that the worker no-ops.

This is one of the items uncovered by the \`template.team_serializer\` span (33–39 ms total) added in #57369. Sister PR #57375 takes care of the JWT cache in the same serializer.

## Changes

Add \`enqueue_product_activation_calc_debounced(team_id)\` in \`posthog/models/product_intent/product_intent.py\` that uses \`cache.add(..., timeout=24h)\` (atomic SETNX EX) to debounce the enqueue itself. Matches the task's own \`only_calc_if_days_since_last_checked=1\` threshold so we never miss a window the task would actually act on.

Returns \`True\` when the task was enqueued, \`False\` when debounced — useful for assertions in tests, and matches the existing return contract of \`cache.add\`.

Both \`TeamSerializer.get_product_intents\` and \`ProjectBackwardCompatSerializer.get_product_intents\` now call this helper.

## How did you test this code?

I'm an agent. Added 3 unit tests in \`posthog/models/test/test_product_intent.py::TestEnqueueProductActivationCalcDebounced\`:

- first call enqueues the Celery task
- subsequent calls within the 24h window are debounced
- different teams are not debounced together

Updated the existing patch in \`posthog/api/test/test_team.py::test_can_update_product_intent_if_already_exists\` to point at the new helper name. Re-ran that test — passes.

\`hogli test posthog/models/test/test_product_intent.py -- -k TestEnqueueProductActivationCalcDebounced\` — 3 pass.
\`hogli test posthog/api/test/test_team.py -- -k test_can_update_product_intent_if_already_exists\` — 1 pass.

No prod / staging verification.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

PostHog Code session continuing the home-view perf investigation. Trace dump from #57369's spans showed \`template.team_serializer\` at 33–39 ms, with \`product_intents\` enqueueing a Celery task every render even though the task has its own daily debounce. Fix: short-circuit at the call site too. Sister PR #57375 caches the JWT in the same serializer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*