### PR TITLE
chore(taxonomic-filter): remove orphaned useVerticalLayout prop

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -91,12 +91,6 @@ export interface TaxonomicFilterProps {
     showNumericalPropsOnly?: boolean
     dataWarehousePopoverFields?: DataWarehousePopoverField[]
     maxContextOptions?: MaxContextTaxonomicFilterOption[]
-    /**
-     * Controls the layout of taxonomic groups.
-     * When undefined (default), vertical/columnar layout is automatically used when there are more than VERTICAL_LAYOUT_THRESHOLD (4) groups.
-     * Set to true to force vertical/columnar layout, or false to force horizontal layout.
-     */
-    useVerticalLayout?: boolean
     initialSearchQuery?: string
     /** Allow users to select events that haven't been captured yet (default: false) */
     allowNonCapturedEvents?: boolean


### PR DESCRIPTION
## Problem

`TaxonomicFilterProps.useVerticalLayout` has no readers. PR #53366 removed the runtime use of the prop but left the type and its docstring in place. The docstring even references `VERTICAL_LAYOUT_THRESHOLD`, a constant that was deleted in the same cleanup. Net effect: the type promises behavior the component does not deliver, and any caller setting it gets a silent no-op.

## Changes

Removed `useVerticalLayout?: boolean` and its 5-line docstring from `TaxonomicFilterProps` in `frontend/src/lib/components/TaxonomicFilter/types.ts`. No other change needed — `rg useVerticalLayout` returns nothing across `frontend/` and `products/` after the deletion.

## How did you test this code?

I'm an agent (PostHog Code). No automated tests apply — this is a 6-line type deletion. Verified by ripgrep across `frontend/` and `products/` that the symbol has no remaining references.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

Spotted while updating the `modifying-taxonomic-filter` skill (PR #57378). The skill draft initially carried a "don't reintroduce as a runtime flag" warning bullet; on a second pass that bullet failed the "is it load-bearing?" test — there's no risk of reintroduction because no caller is setting the prop, so the bullet was documenting dead code. Cleaning the prop is the right fix. Split out from the skill PR so each change stays focused.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*