### PR TITLE
chore(observability): per-field spans inside team + user serializer

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -444,8 +444,8 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         with tracer.start_as_current_span("team_serializer.default_fields"):
             representation = super().to_representation(instance)
         # fallback to the default posthog data theme id, if the color feature isn't available e.g. after a downgrade
-        with tracer.start_as_current_span("team_serializer.default_data_theme_fallback"):
-            if not instance.organization.is_feature_available(AvailableFeature.DATA_COLOR_THEMES):
+        if not instance.organization.is_feature_available(AvailableFeature.DATA_COLOR_THEMES):
+            with tracer.start_as_current_span("team_serializer.default_data_theme_fallback"):
                 representation["default_data_theme"] = (
                     DataColorTheme.objects.filter(team_id__isnull=True).values_list("id", flat=True).first()
                 )
@@ -503,8 +503,8 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
     @extend_schema_field(
         serializers.ListField(child=serializers.ChoiceField(choices=[(e.value, e.value) for e in SetupTaskId]))
     )
-    @tracer.start_as_current_span("team_serializer.available_setup_task_ids")
     def get_available_setup_task_ids(self, obj) -> list[str]:
+        # Pure-compute - no span (matches the policy in the PR description).
         return [e.value for e in SetupTaskId]
 
     @staticmethod

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,6 +14,7 @@ from django.utils.dateparse import parse_datetime
 
 from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_view
 from loginas.utils import is_impersonated_session
+from opentelemetry import trace
 from rest_framework import exceptions, request, response, serializers, viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
@@ -73,6 +74,8 @@ from posthog.utils import get_instance_realm, get_instance_region, get_ip_addres
 from products.customer_analytics.backend.models.team_customer_analytics_config import TeamCustomerAnalyticsConfig
 from products.feature_flags.backend.models import TeamFeatureFlagDefaultsConfig
 from products.signals.backend.models import SignalSourceConfig
+
+tracer = trace.get_tracer(__name__)
 
 
 def _format_serializer_errors(serializer_errors: dict) -> str:
@@ -438,25 +441,31 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         )
 
     def to_representation(self, instance):
-        representation = super().to_representation(instance)
+        with tracer.start_as_current_span("team_serializer.default_fields"):
+            representation = super().to_representation(instance)
         # fallback to the default posthog data theme id, if the color feature isn't available e.g. after a downgrade
-        if not instance.organization.is_feature_available(AvailableFeature.DATA_COLOR_THEMES):
-            representation["default_data_theme"] = (
-                DataColorTheme.objects.filter(team_id__isnull=True).values_list("id", flat=True).first()
-            )
+        with tracer.start_as_current_span("team_serializer.default_data_theme_fallback"):
+            if not instance.organization.is_feature_available(AvailableFeature.DATA_COLOR_THEMES):
+                representation["default_data_theme"] = (
+                    DataColorTheme.objects.filter(team_id__isnull=True).values_list("id", flat=True).first()
+                )
 
         return representation
 
+    @tracer.start_as_current_span("team_serializer.effective_membership_level")
     def get_effective_membership_level(self, team: Team) -> OrganizationMembership.Level | None:
         # TODO: Map from user_access_controls
         return self.user_permissions.team(team).effective_membership_level
 
+    @tracer.start_as_current_span("team_serializer.has_group_types")
     def get_has_group_types(self, team: Team) -> bool:
         return bool(get_group_types_for_project(team.project_id))
 
+    @tracer.start_as_current_span("team_serializer.group_types")
     def get_group_types(self, team: Team) -> list[dict[str, Any]]:
         return get_group_types_for_project(team.project_id)
 
+    @tracer.start_as_current_span("team_serializer.live_events_token")
     def get_live_events_token(self, team: Team) -> str | None:
         request = self.context.get("request")
         user_id = request.user.id if request and hasattr(request, "user") and request.user.is_authenticated else None
@@ -473,6 +482,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         )
 
     @extend_schema_field(serializers.ListField(child=serializers.DictField()))
+    @tracer.start_as_current_span("team_serializer.product_intents")
     def get_product_intents(self, obj):
         calculate_product_activation.delay(obj.id, only_calc_if_days_since_last_checked=1)
         return ProductIntent.objects.filter(team=obj).values(
@@ -480,6 +490,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         )
 
     @extend_schema_field(serializers.DictField(child=serializers.BooleanField()))
+    @tracer.start_as_current_span("team_serializer.managed_viewsets")
     def get_managed_viewsets(self, obj):
         from products.data_warehouse.backend.models import DataWarehouseManagedViewSet
         from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
@@ -492,6 +503,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
     @extend_schema_field(
         serializers.ListField(child=serializers.ChoiceField(choices=[(e.value, e.value) for e in SetupTaskId]))
     )
+    @tracer.start_as_current_span("team_serializer.available_setup_task_ids")
     def get_available_setup_task_ids(self, obj) -> list[str]:
         return [e.value for e in SetupTaskId]
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -32,6 +32,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp.util import random_hex
 from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_view
 from loginas.utils import is_impersonated_session
+from opentelemetry import trace
 from prometheus_client import Counter
 from rest_framework import exceptions, mixins, serializers, viewsets
 from rest_framework.exceptions import NotFound
@@ -113,6 +114,7 @@ REDIRECT_TO_SITE_FAILED_COUNTER = Counter("posthog_redirect_to_site_failed", "Re
 NUM_2FA_BACKUP_CODES = 10
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 class ScenePersonalisationBasicSerializer(serializers.ModelSerializer):
@@ -335,12 +337,15 @@ class UserSerializer(serializers.ModelSerializer):
 
         return session_expiry_time.replace(tzinfo=UTC).isoformat()
 
+    @tracer.start_as_current_span("user_serializer.has_social_auth")
     def get_has_social_auth(self, instance: User) -> bool:
         return instance.social_auth.exists()
 
+    @tracer.start_as_current_span("user_serializer.is_2fa_enabled")
     def get_is_2fa_enabled(self, instance: User) -> bool:
         return default_device(instance) is not None
 
+    @tracer.start_as_current_span("user_serializer.has_sso_enforcement")
     def get_has_sso_enforcement(self, instance: User) -> bool:
         organization = instance.current_organization
         if not organization:
@@ -350,6 +355,7 @@ class UserSerializer(serializers.ModelSerializer):
             OrganizationDomain.objects.get_sso_enforcement_for_email_address(instance.email, organization=organization)
         )
 
+    @tracer.start_as_current_span("user_serializer.is_organization_first_user")
     def get_is_organization_first_user(self, instance: User) -> bool | None:
         # Only compute when the serialized user is the requesting user. Avoids paying an
         # extra membership query on every /api/users/@me/ hit for admin/staff flows that
@@ -375,6 +381,7 @@ class UserSerializer(serializers.ModelSerializer):
         return membership.invited_by_id is None
 
     @extend_schema_field(PendingInviteSerializer(many=True))
+    @tracer.start_as_current_span("user_serializer.pending_invites")
     def get_pending_invites(self, instance: User) -> list[dict]:
         """Non-expired organization invites matching the user's email for orgs they aren't already in.
 
@@ -607,7 +614,8 @@ class UserSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance: Any) -> Any:
         user_identify.identify_task.delay(user_id=instance.id)
-        data = super().to_representation(instance)
+        with tracer.start_as_current_span("user_serializer.default_fields"):
+            data = super().to_representation(instance)
 
         # Backfill shortcut_position default for frontend if null
         if data.get("shortcut_position") is None:


### PR DESCRIPTION
## Problem

Trace samples on the home view (#57369 added the parent `template.team_serializer` and `template.user_serializer` spans) show those two blocks can spike to 500–700 ms each — and the variance lives almost entirely in them. The lower-cost spans (rbac, preflight, frontend_apps, default_event_info, user_product_list) are stable. With only the parent span we are guessing at which field is the outlier.

Examples from prod traces:

| Span | Stable baseline | Outlier 1 | Outlier 2 |
|---|---|---|---|
| `template.team_serializer` | 33–39 ms | 64 ms | **512 ms** |
| `template.user_serializer` | 70–92 ms | **365 ms** | 76 ms |
| `template.preflight` | 47–53 ms | 50 ms | 51 ms |

Each big serializer can dominate independently — trace 1 is user-heavy, trace 2 is team-heavy.

## Changes

Add per-field spans inside both serializers using the existing \`tracer.start_as_current_span\` decorator-as-context-manager pattern (matches \`posthog/utils.py\` and \`posthog/models/remote_config.py\`).

**TeamSerializer**:
- \`team_serializer.default_fields\` (super().to_representation)
- \`team_serializer.default_data_theme_fallback\` (DataColorTheme PG hit)
- \`team_serializer.effective_membership_level\`
- \`team_serializer.has_group_types\` / \`.group_types\`
- \`team_serializer.live_events_token\` (JWT mint — already cached in #57375)
- \`team_serializer.product_intents\` (Celery enqueue + ProductIntent fetch — already debounced in #57376)
- \`team_serializer.managed_viewsets\` (DataWarehouseManagedViewSet PG hit)
- \`team_serializer.available_setup_task_ids\`

**UserSerializer**:
- \`user_serializer.default_fields\` — covers the nested \`team\` / \`organization\` / \`organizations(many=True)\` sub-serializers
- \`user_serializer.has_social_auth\` (PG)
- \`user_serializer.is_2fa_enabled\` (TOTPDevice PG)
- \`user_serializer.has_sso_enforcement\` (OrganizationDomain PG)
- \`user_serializer.is_organization_first_user\` (OrganizationMembership PG)
- \`user_serializer.pending_invites\` (OrganizationInvite PG)

Pure SerializerMethodFields that are pure-compute (\`has_password\`, \`is_impersonated*\`, \`sensitive_session_expires_at\`) are intentionally not wrapped — no value in a span around 5 µs of work.

## How did you test this code?

I'm an agent. Pure observability, no behaviour change. Smoke test: \`hogli test posthog/api/test/test_team.py -- -k test_retrieve_team_has_group_types\` — the integration test that exercises both \`has_group_types\` and \`group_types\` end-to-end still passes.

No prod / staging verification.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Continuing the home-view perf hunt. After #57369 added the block-level spans, prod traces showed \`template.team_serializer\` and \`template.user_serializer\` are the variance-dominant blocks — but a single span isn't enough to find which field is slow. This PR drops one level deeper. Sister follow-up will land the actual perf wins informed by the next set of traces.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*