### PR TITLE
fix(replay): drop event-less sessions in summarization sweep

### DIFF
--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -6,6 +6,9 @@ SESSION_SUMMARIES_REASONING_EFFORT = "medium"
 BASE_LLM_CALL_TIMEOUT_S = 600.0
 
 # Summarization
+# Shared by `get_session_events` (workflow) and `filter_session_ids_with_events` (sweep);
+# they must stay in lockstep or recording-only sessions loop on the sweep tick.
+SESSION_SUMMARY_EVENT_BLOCKLIST: tuple[str, ...] = ("$feature_flag_called",)
 MAX_SESSIONS_TO_SUMMARIZE = 100  # Maximum number of sessions to summarize at once
 HALLUCINATED_EVENTS_MIN_RATIO = 0.15  # If more than 15% of events in the summary hallucinated, fail the summarization
 # Minimum number of sessions to use group summary logic (find patterns) instead of summarizing them separately

--- a/ee/hogai/session_summaries/session/input_data.py
+++ b/ee/hogai/session_summaries/session/input_data.py
@@ -10,7 +10,7 @@ from posthog.session_recordings.constants import COLUMNS_TO_REMOVE_FROM_LLM_CONT
 from posthog.session_recordings.models.metadata import RecordingMetadata
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 
-from ee.hogai.session_summaries.constants import SESSION_EVENTS_REPLAY_CUTOFF_MS
+from ee.hogai.session_summaries.constants import SESSION_EVENTS_REPLAY_CUTOFF_MS, SESSION_SUMMARY_EVENT_BLOCKLIST
 from ee.hogai.session_summaries.local.input_data import (
     _get_production_session_events_locally,
     _get_production_session_metadata_locally,
@@ -53,7 +53,7 @@ def get_session_events(
     Get session events with pagination to handle large sessions.
     Returns combined results from all pages up to max_pages.
     """
-    events_to_ignore = ["$feature_flag_called"]
+    events_to_ignore = list(SESSION_SUMMARY_EVENT_BLOCKLIST)
     extra_fields = EXTRA_SUMMARY_EVENT_FIELDS
     # Collect all events and columns from all pages
     all_events = []

--- a/posthog/temporal/session_replay/summarization_sweep/activities.py
+++ b/posthog/temporal/session_replay/summarization_sweep/activities.py
@@ -14,6 +14,7 @@ from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_FINGERPRI
 from posthog.temporal.session_replay.rasterize_recording.activities.stuck_counter import read_stuck_session_ids
 from posthog.temporal.session_replay.summarization_sweep.constants import (
     CH_QUERY_MAX_EXECUTION_SECONDS,
+    EVENTS_PREFILTER_QUERY_MAX_EXECUTION_SECONDS,
     SCHEDULE_ID_PREFIX,
     SCHEDULE_TYPE,
     STUCK_RASTERIZE_THRESHOLD,
@@ -22,6 +23,7 @@ from posthog.temporal.session_replay.summarization_sweep.constants import (
 from posthog.temporal.session_replay.summarization_sweep.session_candidates import (
     coerce_sample_rate,
     fetch_recent_session_ids,
+    filter_session_ids_with_events,
 )
 from posthog.temporal.session_replay.summarization_sweep.types import (
     DeleteTeamScheduleInput,
@@ -120,6 +122,15 @@ async def find_sessions_for_team_activity(inputs: FindSessionsInput) -> FindSess
         extra_summary_context=None,
     )
     sessions_to_summarize = [sid for sid in session_ids if not existing_summaries.get(sid)]
+    # Recording-only sessions never write a summary row, so summaries_exist can't dedup them.
+    if sessions_to_summarize:
+        sessions_with_events = await database_sync_to_async_pool(filter_session_ids_with_events)(
+            team=team,
+            session_ids=sessions_to_summarize,
+            lookback_minutes=inputs.lookback_minutes,
+            max_execution_time_seconds=EVENTS_PREFILTER_QUERY_MAX_EXECUTION_SECONDS,
+        )
+        sessions_to_summarize = [sid for sid in sessions_to_summarize if sid in sessions_with_events]
     stuck = await _stuck_session_ids(inputs.team_id, sessions_to_summarize)
     sessions_to_summarize = [sid for sid in sessions_to_summarize if sid not in stuck]
 

--- a/posthog/temporal/session_replay/summarization_sweep/constants.py
+++ b/posthog/temporal/session_replay/summarization_sweep/constants.py
@@ -25,6 +25,8 @@ STUCK_RASTERIZE_THRESHOLD = 3
 STUCK_RASTERIZE_LOOKBACK = timedelta(hours=2)
 
 CH_QUERY_MAX_EXECUTION_SECONDS = 180
+# Two CH queries fire under FIND_ACTIVITY_TIMEOUT; the second must fit in what's left.
+EVENTS_PREFILTER_QUERY_MAX_EXECUTION_SECONDS = 60
 
 # Must exceed FIND_ACTIVITY_TIMEOUT + child-start fan-out. Children are
 # ABANDONED so their execution does not count against this budget.

--- a/posthog/temporal/session_replay/summarization_sweep/session_candidates.py
+++ b/posthog/temporal/session_replay/summarization_sweep/session_candidates.py
@@ -4,12 +4,14 @@ from django.conf import settings
 
 from temporalio.exceptions import ApplicationError
 
-from posthog.schema import PropertyOperator, RecordingPropertyFilter, RecordingsQuery
+from posthog.schema import HogQLQuery, PropertyOperator, RecordingPropertyFilter, RecordingsQuery
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
 
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.models.team import Team
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
@@ -19,6 +21,7 @@ from posthog.temporal.session_replay.summarization_sweep.constants import DEFAUL
 from ee.hogai.session_summaries.constants import (
     MAX_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S,
     MIN_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S,
+    SESSION_SUMMARY_EVENT_BLOCKLIST,
 )
 
 MAX_CANDIDATE_SESSIONS = 10_000
@@ -137,3 +140,35 @@ def fetch_recent_session_ids(
         ).run()
 
     return [recording["session_id"] for recording in result.results]
+
+
+def filter_session_ids_with_events(
+    team: Team,
+    session_ids: list[str],
+    lookback_minutes: int,
+    max_execution_time_seconds: int = HOGQL_INCREASED_MAX_EXECUTION_TIME,
+) -> set[str]:
+    """Subset of `session_ids` that have at least one summarizable event in their recording window."""
+    if not session_ids:
+        return set()
+    # Covers candidate sessions started within lookback and active up to MAX_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S.
+    events_window_minutes = lookback_minutes + MAX_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S // 60 + 5
+    query = HogQLQuery(
+        query=(
+            "SELECT DISTINCT $session_id FROM events "
+            "WHERE timestamp >= now() - toIntervalMinute({events_window_minutes}) "
+            "AND $session_id IN {session_ids} "
+            "AND event NOT IN {events_to_ignore} "
+            "LIMIT {limit}"
+        ),
+        values={
+            "events_window_minutes": events_window_minutes,
+            "session_ids": session_ids,
+            "events_to_ignore": list(SESSION_SUMMARY_EVENT_BLOCKLIST),
+            "limit": len(session_ids),
+        },
+    )
+    hogql_settings = HogQLGlobalSettings(enable_analyzer=True, max_execution_time=max_execution_time_seconds)
+    with tags_context(product=Product.SESSION_SUMMARY, feature=Feature.ENRICHMENT):
+        result = HogQLQueryRunner(team=team, query=query, settings=hogql_settings).calculate()
+    return {row[0] for row in (result.results or []) if row and row[0]}

--- a/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py
@@ -72,6 +72,10 @@ async def test_find_sessions_filters_summarized(activity_environment, organizati
                 "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
                 return_value=existing,
             ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                return_value={"s2"},
+            ),
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
@@ -103,6 +107,10 @@ async def test_find_sessions_dispatches_all_unsummarized_candidates(activity_env
             patch(
                 "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
                 return_value=existing,
+            ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                return_value={"s3", "s4", "s5", "s6", "s7"},
             ),
         ):
             result = await activity_environment.run(
@@ -137,6 +145,10 @@ async def test_find_sessions_passes_sample_rate_to_fetch(activity_environment, o
             patch(
                 "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
                 return_value={"only-1": False},
+            ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                return_value={"only-1"},
             ),
         ):
             result = await activity_environment.run(
@@ -231,6 +243,10 @@ async def test_find_sessions_prefers_created_by_user(activity_environment, organ
                 "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
                 return_value={"s1": False},
             ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                return_value={"s1"},
+            ),
         ):
             result = await activity_environment.run(
                 find_sessions_for_team_activity,
@@ -258,6 +274,10 @@ async def test_find_sessions_falls_back_when_created_by_is_null(activity_environ
             patch(
                 "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
                 return_value={"s1": False},
+            ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                return_value={"s1"},
             ),
         ):
             result = await activity_environment.run(
@@ -311,6 +331,10 @@ async def test_find_sessions_skips_recordings_with_too_many_failures(activity_en
                 return_value={},
             ),
             patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                return_value=set(candidate_ids),
+            ),
+            patch(
                 "posthog.temporal.session_replay.summarization_sweep.activities._stuck_session_ids",
                 return_value={"stuck-2"},
             ),
@@ -322,6 +346,104 @@ async def test_find_sessions_skips_recordings_with_too_many_failures(activity_en
         assert sorted(result.session_ids) == ["good-1", "good-3"]
     finally:
         await sync_to_async(user.delete)()
+
+
+@pytest.mark.parametrize(
+    "candidate_ids,sessions_with_events,expected_kept",
+    [
+        (["has-events", "snapshot-only-1", "snapshot-only-2"], {"has-events"}, ["has-events"]),
+        (["s1", "s2", "s3"], {"s1", "s2", "s3"}, ["s1", "s2", "s3"]),
+        (["s1", "s2", "s3"], set(), []),
+    ],
+    ids=["mixed", "all_have_events", "none_have_events"],
+)
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_find_sessions_drops_sessions_without_events(
+    activity_environment, organization, team, candidate_ids, sessions_with_events, expected_kept
+):
+    from typing import Any
+
+    from posthog.models.user import User
+
+    await sync_to_async(enable_signal_source)(team)
+    user = await sync_to_async(User.objects.create_and_join)(organization, "events@posthog.com", "pw", "Events")
+    try:
+        captured: dict[str, Any] = {}
+
+        def _fake_filter(*, team, session_ids, lookback_minutes, max_execution_time_seconds):
+            captured["session_ids"] = list(session_ids)
+            captured["lookback_minutes"] = lookback_minutes
+            captured["max_execution_time_seconds"] = max_execution_time_seconds
+            return sessions_with_events
+
+        with (
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.fetch_recent_session_ids",
+                return_value=candidate_ids,
+            ),
+            patch(
+                "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
+                return_value={},
+            ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+                side_effect=_fake_filter,
+            ),
+        ):
+            result = await activity_environment.run(
+                find_sessions_for_team_activity,
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
+            )
+        from posthog.temporal.session_replay.summarization_sweep.constants import (
+            EVENTS_PREFILTER_QUERY_MAX_EXECUTION_SECONDS,
+        )
+
+        assert sorted(result.session_ids) == sorted(expected_kept)
+        assert sorted(captured["session_ids"]) == sorted(candidate_ids)
+        assert captured["lookback_minutes"] == 30
+        assert captured["max_execution_time_seconds"] == EVENTS_PREFILTER_QUERY_MAX_EXECUTION_SECONDS
+    finally:
+        await sync_to_async(user.delete)()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_find_sessions_skips_events_filter_when_all_summarized(activity_environment, organization, team):
+    from posthog.models.user import User
+
+    await sync_to_async(enable_signal_source)(team)
+    user = await sync_to_async(User.objects.create_and_join)(organization, "skipfilter@posthog.com", "pw", "Skip")
+    try:
+        candidate_ids = ["s1", "s2"]
+        with (
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.fetch_recent_session_ids",
+                return_value=candidate_ids,
+            ),
+            patch(
+                "ee.models.session_summaries.SingleSessionSummary.objects.summaries_exist",
+                return_value={"s1": True, "s2": True},
+            ),
+            patch(
+                "posthog.temporal.session_replay.summarization_sweep.activities.filter_session_ids_with_events",
+            ) as mock_filter,
+        ):
+            result = await activity_environment.run(
+                find_sessions_for_team_activity,
+                FindSessionsInput(team_id=team.id, lookback_minutes=30),
+            )
+        assert result.session_ids == []
+        mock_filter.assert_not_called()
+    finally:
+        await sync_to_async(user.delete)()
+
+
+@pytest.mark.asyncio
+async def test_filter_session_ids_with_events_returns_empty_for_empty_input():
+    from posthog.temporal.session_replay.summarization_sweep.session_candidates import filter_session_ids_with_events
+
+    assert filter_session_ids_with_events(team=None, session_ids=[], lookback_minutes=30) == set()  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The summarization sweep finds candidate sessions from `session_replay_events` and only filters them by `summaries_exist` before fanning out a `summarize-session` per session. Recording-only sessions (replay snapshots but no analytics events) never get a summary row written, so the sweep re-discovers them every tick and the workflow short-circuits at the no-events guard. Production data from a recent 6h window in `posthog-prod-us`: **68,226 `summarize-session` workflows across 1,100 unique session IDs** — ~62 starts per session-id over 6h.

## Changes

- New `filter_session_ids_with_events` helper in `session_candidates.py`. Single HogQL query against `events` with `$session_id IN ids AND event NOT IN ignore_list AND timestamp >= now() - (lookback_minutes + MAX_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S/60 + 5)`. Wider window than the sweep's candidate window to leave headroom for any session in the candidate set.
- Wired into `find_sessions_for_team_activity` after `summaries_exist`, skipped when the candidate list is already empty.
- Lifted the per-session `events_to_ignore = ["$feature_flag_called"]` literal out of `input_data.py` into a shared `SESSION_SUMMARY_EVENT_BLOCKLIST` constant, consumed by both the workflow's per-session fetcher and the new sweep filter so they can't drift.

## How did you test this code?

I am Claude Code (an agent). No manual production testing was done.

- `hogli test posthog/temporal/tests/session_replay/summarization_sweep/test_activities.py` (19 passed)
- `hogli test posthog/temporal/tests/session_replay/summarization_sweep/test_session_candidates.py` (19 passed)
- `hogli test ee/hogai/session_summaries/tests/test_input_data.py` (33 passed)
- `ruff check`, `ruff format`, `mypy` clean

No real-CH integration test for the new HogQL — reviewers please sanity-check the query plan on a production cluster.

## Publish to changelog?

No.

## Docs update

No docs changes.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Discovered by inspecting workflow volume after #57072 deployed: 67k `summarize-session` runs vs ~770 `rasterize-recording` runs — couldn't be explained by event-based vs video-based since the sweep always passes `video_based=True`. Sampled completed workflows: most ran only `fetch_session_data_activity` and exited.

Considered writing a sentinel `SingleSessionSummary` row instead of pre-filtering. Rejected because late-arriving events would get permanently blacklisted; pre-filter re-checks freshly each tick.

First version of the filter used `now() - lookback_minutes` for the events `timestamp` predicate. Code-review caught that this was tighter than the sweep's own candidate window. Widened to `lookback_minutes + MAX_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S/60 + 5` to give headroom over the candidate set.