### PR TITLE
fix(logs-alerts-api): use correct cadence in simulation

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -61,8 +61,9 @@ UNCAPPED_ALERT_TEAM_IDS: frozenset[int] = frozenset(
 MAX_SIMULATE_LOOKBACK_DAYS = 30
 MAX_SIMULATE_BUCKETS = 15_000
 STATE_TIMELINE_LOOKBACK_HOURS = 24
-# Mirrors LogsAlertConfiguration.check_interval_minutes' default — kept here so
-# the simulate endpoint evaluates at the same cadence production runs at.
+# Mirrors LogsAlertConfiguration.check_interval_minutes' default — used as the
+# simulate endpoint's default cadence so it matches production when callers
+# don't override it.
 DEFAULT_CHECK_INTERVAL_MINUTES = 5
 _SENTINEL: Final = object()
 _NOT_ANNOTATED: Final = object()
@@ -556,6 +557,12 @@ class LogsAlertSimulateRequestSerializer(serializers.Serializer):
     window_minutes = serializers.IntegerField(
         help_text="Window size in minutes — determines bucket interval.",
     )
+    check_interval_minutes = serializers.IntegerField(
+        default=DEFAULT_CHECK_INTERVAL_MINUTES,
+        min_value=1,
+        max_value=max(ALLOWED_WINDOW_MINUTES),
+        help_text="How often the alert is evaluated, in minutes.",
+    )
     evaluation_periods = serializers.IntegerField(
         default=1,
         min_value=1,
@@ -599,6 +606,8 @@ class LogsAlertSimulateRequestSerializer(serializers.Serializer):
     def validate(self, attrs: dict) -> dict:
         if attrs.get("datapoints_to_alarm", 1) > attrs.get("evaluation_periods", 1):
             raise ValidationError({"datapoints_to_alarm": "Cannot exceed evaluation_periods."})
+        if attrs["check_interval_minutes"] > attrs["window_minutes"]:
+            raise ValidationError({"check_interval_minutes": "Cannot exceed window_minutes."})
         return attrs
 
 
@@ -994,20 +1003,22 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             threshold_count=data["threshold_count"],
             threshold_operator=data["threshold_operator"],
             window_minutes=window_minutes,
+            check_interval_minutes=data["check_interval_minutes"],
         )
+        cadence_minutes = fake_alert.check_interval_minutes
 
         sparse_buckets: list[BucketedCount] = AlertCheckQuery(
             team=self.team,
             alert=fake_alert,
             date_from=date_from_dt,
             date_to=date_to_dt,
-        ).execute_bucketed(interval_minutes=DEFAULT_CHECK_INTERVAL_MINUTES, limit=MAX_SIMULATE_BUCKETS)
+        ).execute_bucketed(interval_minutes=cadence_minutes, limit=MAX_SIMULATE_BUCKETS)
 
-        cadence_buckets = _fill_empty_buckets(sparse_buckets, date_from_dt, date_to_dt, DEFAULT_CHECK_INTERVAL_MINUTES)
+        cadence_buckets = _fill_empty_buckets(sparse_buckets, date_from_dt, date_to_dt, cadence_minutes)
 
-        # ALLOWED_WINDOW_MINUTES is bounded below by DEFAULT_CHECK_INTERVAL_MINUTES,
+        # ALLOWED_WINDOW_MINUTES is bounded below by the configured cadence,
         # so integer division here is always >= 1.
-        buckets_per_window = window_minutes // DEFAULT_CHECK_INTERVAL_MINUTES
+        buckets_per_window = window_minutes // cadence_minutes
         counts = [b.count for b in cadence_buckets]
         rolling_counts: list[int] = []
         # Bucket i represents `[T_i, T_i + check_interval)`. The actual evaluator

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -477,6 +477,12 @@ export interface LogsAlertSimulateRequestApi {
     /** Window size in minutes — determines bucket interval. */
     window_minutes: number
     /**
+     * How often the alert is evaluated, in minutes.
+     * @minimum 1
+     * @maximum 60
+     */
+    check_interval_minutes?: number
+    /**
      * Total check periods in the N-of-M evaluation window (M).
      * @minimum 1
      * @maximum 10

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -315,6 +315,9 @@ export const LogsAlertsDestinationsDeleteCreateBody = /* @__PURE__ */ zod.object
  * Simulate a logs alert on historical data using the full state machine. Read-only — no alert check records are created.
  */
 
+export const logsAlertsSimulateCreateBodyCheckIntervalMinutesDefault = 5
+export const logsAlertsSimulateCreateBodyCheckIntervalMinutesMax = 60
+
 export const logsAlertsSimulateCreateBodyEvaluationPeriodsDefault = 1
 export const logsAlertsSimulateCreateBodyEvaluationPeriodsMax = 10
 
@@ -334,6 +337,12 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
             'Whether the alert fires when the count is above or below the threshold.\n\n* `above` - Above\n* `below` - Below'
         ),
     window_minutes: zod.number().describe('Window size in minutes — determines bucket interval.'),
+    check_interval_minutes: zod
+        .number()
+        .min(1)
+        .max(logsAlertsSimulateCreateBodyCheckIntervalMinutesMax)
+        .default(logsAlertsSimulateCreateBodyCheckIntervalMinutesDefault)
+        .describe('How often the alert is evaluated, in minutes.'),
     evaluation_periods: zod
         .number()
         .min(1)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21507,6 +21507,12 @@ export namespace Schemas {
       /** Window size in minutes — determines bucket interval. */
       window_minutes: number;
       /**
+       * How often the alert is evaluated, in minutes.
+       * @minimum 1
+       * @maximum 60
+       */
+      check_interval_minutes?: number;
+      /**
        * Total check periods in the N-of-M evaluation window (M).
        * @minimum 1
        * @maximum 10


### PR DESCRIPTION
## Problem

The alert simulation endpoint was hardcoded to use `DEFAULT_CHECK_INTERVAL_MINUTES` for bucketing, filling empty buckets, and calculating `buckets_per_window`. Callers had no way to override the evaluation cadence, so simulations for alerts with a non-default check interval produced inaccurate results.

## Changes

A `check_interval_minutes` field has been added to `LogsAlertSimulateRequestSerializer` (and the corresponding generated TypeScript schemas), allowing callers to specify the evaluation cadence. The simulation now derives `cadence_minutes` from `fake_alert.check_interval_minutes` and uses it consistently when executing bucketed queries, filling empty buckets, and computing `buckets_per_window`. A cross-field validation ensures `check_interval_minutes` cannot exceed `window_minutes`.

## How did you test this code?

Verified that passing a non-default `check_interval_minutes` to the simulate endpoint produces bucketing and rolling window calculations that match the specified cadence, and that omitting the field falls back to the existing default of 5 minutes.

## Publish to changelog?

No