### PR TITLE
feat(alerts): implement rolling checks and refactor date calculations

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -71,6 +71,26 @@ def _period_ranges(
     ]
 
 
+def rolling_check_lookback_minutes(window_minutes: int, cadence_minutes: int, period_count: int) -> int:
+    """Total minutes of history covered by M cadence-stepped rolling windows."""
+    return window_minutes + (period_count - 1) * cadence_minutes
+
+
+def _rolling_check_ranges(
+    nca: dt.datetime,
+    window_minutes: int,
+    cadence_minutes: int,
+    period_count: int,
+) -> list[tuple[dt.datetime, dt.datetime]]:
+    """M cadence-stepped rolling windows ending at NCA, oldest-first."""
+    ranges: list[tuple[dt.datetime, dt.datetime]] = []
+    for k in range(period_count - 1, -1, -1):
+        end = nca - dt.timedelta(minutes=k * cadence_minutes)
+        start = end - dt.timedelta(minutes=window_minutes)
+        ranges.append((start, end))
+    return ranges
+
+
 def _timestamp_in_range(start: dt.datetime, end: dt.datetime) -> ast.Expr:
     # Compare raw `timestamp`, not `toStartOfMinute(timestamp)`: `date_from` can carry
     # sub-minute fractions from a DateTime64(6) checkpoint, and a minute-floor wrap
@@ -236,8 +256,22 @@ class AlertCheckQuery:
     def execute_periods(self, period_minutes: int, period_count: int) -> list[BucketedCount]:
         """Per-period counts anchored to `date_from`, oldest-first."""
         self._tag()
-
         ranges = _period_ranges(self.date_from, period_minutes, period_count)
+        return self._execute_count_per_range(ranges)
+
+    def execute_rolling_checks(
+        self,
+        nca: dt.datetime,
+        window_minutes: int,
+        cadence_minutes: int,
+        period_count: int,
+    ) -> list[BucketedCount]:
+        """Per-check counts for M cadence-stepped rolling windows ending at NCA, oldest-first."""
+        self._tag()
+        ranges = _rolling_check_ranges(nca, window_minutes, cadence_minutes, period_count)
+        return self._execute_count_per_range(ranges)
+
+    def _execute_count_per_range(self, ranges: list[tuple[dt.datetime, dt.datetime]]) -> list[BucketedCount]:
         select_columns: list[ast.Expr] = [
             ast.Alias(
                 alias=f"period_{i}",
@@ -252,7 +286,7 @@ class AlertCheckQuery:
             where=self.where_expr,
         )
         response = self._run_query(query)
-        row = response.results[0] if response.results else [0] * period_count
+        row = response.results[0] if response.results else [0] * len(ranges)
         return [BucketedCount(timestamp=start, count=count) for (start, _), count in zip(ranges, row)]
 
     def _run_query(self, query: ast.SelectQuery | ast.SelectSetQuery) -> HogQLQueryResponse:
@@ -395,10 +429,24 @@ class BatchedAlertCheckQuery:
         return BatchedBucketedResult(per_alert=per_alert, query_duration_ms=duration_ms)
 
     def execute_periods(self, period_minutes: int, period_count: int) -> BatchedBucketedResult:
-        """Per-alert per-period counts anchored to `date_from` (cohort version of `AlertCheckQuery.execute_periods`)."""
+        """Per-alert per-period counts anchored to `date_from`."""
         self._tag()
-
         ranges = _period_ranges(self.date_from, period_minutes, period_count)
+        return self._execute_count_per_range(ranges)
+
+    def execute_rolling_checks(
+        self,
+        nca: dt.datetime,
+        window_minutes: int,
+        cadence_minutes: int,
+        period_count: int,
+    ) -> BatchedBucketedResult:
+        """Per-alert per-check counts for M cadence-stepped rolling windows ending at NCA."""
+        self._tag()
+        ranges = _rolling_check_ranges(nca, window_minutes, cadence_minutes, period_count)
+        return self._execute_count_per_range(ranges)
+
+    def _execute_count_per_range(self, ranges: list[tuple[dt.datetime, dt.datetime]]) -> BatchedBucketedResult:
         select_columns: list[ast.Expr] = [
             ast.Alias(
                 alias=f"alert_{alert_i}_period_{period_i}",

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -25,6 +25,7 @@ from products.logs.backend.alert_check_query import (
     fetch_live_logs_checkpoint,
     is_projection_eligible,
     resolve_alert_date_to,
+    rolling_check_lookback_minutes,
 )
 from products.logs.backend.alert_error_classifier import (
     AlertErrorCode,
@@ -114,12 +115,8 @@ class CheckAlertsInput:
 class _AlertCohort:
     """Group of alerts that share team + bucket grid and can be batched into one CH query.
 
-    Cohort key (implicit, derived in `_build_cohorts`):
-    `(team_id, window_minutes, evaluation_periods, projection_eligible, date_to)`.
-
-    All five must match for two alerts to share a query. `date_to` matters because
-    checkpoint clamping can pull alerts with different `next_check_at` values onto
-    the same window, and we want them to share the scan when that happens.
+    Cohort key (built in `_build_cohorts`): (team_id, window_minutes,
+    evaluation_periods, check_interval_minutes, projection_eligible, date_to).
     """
 
     alerts: tuple[LogsAlertConfiguration, ...]
@@ -143,8 +140,16 @@ class _AlertCohort:
         return self.alerts[0].evaluation_periods
 
     @property
+    def check_interval_minutes(self) -> int:
+        return self.alerts[0].check_interval_minutes
+
+    @property
     def date_from(self) -> datetime:
-        return self.date_to - timedelta(minutes=self.window_minutes * self.evaluation_periods)
+        return self.date_to - timedelta(
+            minutes=rolling_check_lookback_minutes(
+                self.window_minutes, self.check_interval_minutes, self.evaluation_periods
+            )
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -402,29 +407,25 @@ def _build_cohorts(
     now: datetime,
     checkpoint: datetime | None,
 ) -> list[_AlertCohort]:
-    """Group alerts into cohorts that can share a batched CH query.
-
-    Cohort key: (team_id, window_minutes, evaluation_periods, projection_eligible, date_to).
-    A single-alert "cohort" is fine — `BatchedAlertCheckQuery` with N=1 has the
-    same shape as `AlertCheckQuery.execute_bucketed`, so we don't bother
-    bypassing the batched path for cohorts of one.
-    """
-    grouped: dict[tuple, list[LogsAlertConfiguration]] = {}
+    """Group alerts into cohorts that can share a batched CH query."""
+    grouped: dict[tuple, tuple[list[LogsAlertConfiguration], datetime, bool]] = {}
     for alert in alerts:
         nca = alert.next_check_at if alert.next_check_at is not None else now
         date_to = resolve_alert_date_to(nca, checkpoint)
+        projection_eligible = is_projection_eligible(alert.filters)
         key = (
             alert.team_id,
             alert.window_minutes,
             alert.evaluation_periods,
-            is_projection_eligible(alert.filters),
+            alert.check_interval_minutes,
+            projection_eligible,
             date_to,
         )
-        grouped.setdefault(key, []).append(alert)
+        grouped.setdefault(key, ([], date_to, projection_eligible))[0].append(alert)
 
     return [
-        _AlertCohort(alerts=tuple(members), date_to=key[4], projection_eligible=key[3])
-        for key, members in grouped.items()
+        _AlertCohort(alerts=tuple(members), date_to=date_to, projection_eligible=projection_eligible)
+        for (members, date_to, projection_eligible) in grouped.values()
     ]
 
 
@@ -435,7 +436,12 @@ def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
         date_from=cohort.date_from,
         date_to=cohort.date_to,
         projection_eligible=cohort.projection_eligible,
-    ).execute_periods(period_minutes=cohort.window_minutes, period_count=cohort.evaluation_periods)
+    ).execute_rolling_checks(
+        nca=cohort.date_to,
+        window_minutes=cohort.window_minutes,
+        cadence_minutes=cohort.check_interval_minutes,
+        period_count=cohort.evaluation_periods,
+    )
 
 
 def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
@@ -448,7 +454,12 @@ def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
                 alert=alert,
                 date_from=cohort.date_from,
                 date_to=cohort.date_to,
-            ).execute_periods(period_minutes=cohort.window_minutes, period_count=cohort.evaluation_periods)
+            ).execute_rolling_checks(
+                nca=cohort.date_to,
+                window_minutes=cohort.window_minutes,
+                cadence_minutes=cohort.check_interval_minutes,
+                period_count=cohort.evaluation_periods,
+            )
             duration_ms = (time.monotonic_ns() - start) // 1_000_000
             per_alert[str(alert.id)] = _PrefetchedQuery(buckets=buckets, query_duration_ms=duration_ms)
         except Exception as e:
@@ -898,13 +909,13 @@ def _evaluate_single_alert(
     """
     original_next_check_at = alert.next_check_at
 
-    # First-run alerts (`next_check_at` still null after enable) anchor on `now`;
-    # from the second eval onward, `next_check_at` is set and idempotence holds.
     nca = alert.next_check_at if alert.next_check_at is not None else now
     date_to = resolve_alert_date_to(nca, checkpoint)
-    # Each bucket represents one historical "what the alert query would have
-    # returned" — window_minutes of data. M buckets cover M * window_minutes total.
-    date_from = date_to - timedelta(minutes=alert.window_minutes * alert.evaluation_periods)
+    date_from = date_to - timedelta(
+        minutes=rolling_check_lookback_minutes(
+            alert.window_minutes, alert.check_interval_minutes, alert.evaluation_periods
+        )
+    )
 
     check_result: CheckResult
     recent_breaches: tuple[bool, ...] = ()
@@ -922,11 +933,14 @@ def _evaluate_single_alert(
                 alert=alert,
                 date_from=date_from,
                 date_to=date_to,
-            ).execute_periods(period_minutes=alert.window_minutes, period_count=alert.evaluation_periods)
+            ).execute_rolling_checks(
+                nca=date_to,
+                window_minutes=alert.window_minutes,
+                cadence_minutes=alert.check_interval_minutes,
+                period_count=alert.evaluation_periods,
+            )
             query_duration_ms = int((time.perf_counter() - query_start) * 1000)
 
-        # `execute_periods` returns one entry per evaluation period in ASC order;
-        # the state machine wants newest-first, which `_derive_breaches` reverses.
         breaches = _derive_breaches(buckets, alert.threshold_count, alert.threshold_operator, alert.evaluation_periods)
         latest_count = buckets[-1].count if buckets else 0
         check_result = CheckResult(

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -75,13 +75,8 @@ def _bucket_counts_for(counts: list[int]) -> list[BucketedCount]:
 
 
 def _mock_buckets(mock_query_cls: MagicMock, counts: list[int]) -> None:
-    """Set AlertCheckQuery().execute_periods to return `counts` (oldest-first).
-
-    Used for tests that call `_evaluate_single_alert` directly without prefetched
-    buckets — the per-alert path goes through `AlertCheckQuery.execute_periods`.
-    For the cohort/sync path see `_mock_batched_buckets`.
-    """
-    mock_query_cls.return_value.execute_periods.return_value = _bucket_counts_for(counts)
+    """Set AlertCheckQuery().execute_rolling_checks to return `counts` (oldest-first)."""
+    mock_query_cls.return_value.execute_rolling_checks.return_value = _bucket_counts_for(counts)
 
 
 def _mock_batched_buckets(mock_run_batched: MagicMock, counts: list[int]) -> None:
@@ -565,6 +560,7 @@ class TestRunCohortQueryFallback(unittest.TestCase):
         for a in alerts:
             a.window_minutes = 5
             a.evaluation_periods = 1
+            a.check_interval_minutes = 5
         return _AlertCohort(
             alerts=alerts,
             date_to=datetime(2025, 1, 1, 0, 5, 0, tzinfo=UTC),
@@ -588,9 +584,9 @@ class TestRunCohortQueryFallback(unittest.TestCase):
         def make_query_instance(*, team, alert, **_kwargs):
             instance = MagicMock()
             if alert.id == "alert-1":
-                instance.execute_periods.side_effect = RuntimeError("alert-1 also bad")
+                instance.execute_rolling_checks.side_effect = RuntimeError("alert-1 also bad")
             else:
-                instance.execute_periods.return_value = [
+                instance.execute_rolling_checks.return_value = [
                     BucketedCount(timestamp=datetime(2025, 1, 1, 0, 0, tzinfo=UTC), count=42)
                 ]
             return instance
@@ -777,14 +773,14 @@ class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Selectively fail the per-alert query for bad_alert; let good_alert hit real CH.
-        original_execute_periods = AlertCheckQuery.execute_periods
+        original_execute_rolling_checks = AlertCheckQuery.execute_rolling_checks
 
         def maybe_fail(self, *args, **kwargs):
             if self.alert.id == bad_alert.id:
                 raise RuntimeError("simulated per-alert query failure")
-            return original_execute_periods(self, *args, **kwargs)
+            return original_execute_rolling_checks(self, *args, **kwargs)
 
-        with patch.object(AlertCheckQuery, "execute_periods", maybe_fail):
+        with patch.object(AlertCheckQuery, "execute_rolling_checks", maybe_fail):
             result = _run_cohort_query(cohort)
 
         # Good alert: real buckets, no error.
@@ -926,7 +922,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         # Force the classifier to treat this as a performance error so the assertion
         # doesn't depend on whether the raw message hits one of the shared classifier's
         # recognized shapes.
-        mock_query_cls.return_value.execute_periods.side_effect = Exception(
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         alert = self._make_alert()
@@ -1199,7 +1195,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
             consecutive_failures=initial_failures,
             state=initial_state,
         )
-        mock_query_cls.return_value.execute_periods.side_effect = Exception(
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
 
@@ -1315,7 +1311,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_check_errors,
     ):
-        mock_query_cls.return_value.execute_periods.side_effect = Exception("boom")
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception("boom")
         self._make_alert()
 
         with patch(
@@ -1407,17 +1403,16 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @parameterized.expand(
         [
-            # M=1/window=5 covered by `test_query_uses_now_when_checkpoint_is_none` above.
             ("M=3_window=5", 5, 3, 15),
             ("M=10_window=5", 5, 10, 50),
-            ("M=3_window=10", 10, 3, 30),
-            ("M=10_window=60_worst_case", 60, 10, 600),
+            ("M=3_window=10", 10, 3, 20),
+            ("M=10_window=60_worst_case", 60, 10, 105),
         ]
     )
     @freeze_time("2025-01-01T05:00:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
-    def test_date_from_scales_with_window_times_evaluation_periods(
+    def test_date_from_covers_full_rolling_check_lookback(
         self, _name, window_minutes, evaluation_periods, expected_range_minutes, _mock_produce, mock_query_cls
     ):
         _mock_buckets(mock_query_cls, [0])
@@ -1438,7 +1433,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_errored_notification_emitted_on_first_error(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute_periods.side_effect = Exception(
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         alert = self._make_alert()
@@ -1463,7 +1458,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_errored_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute_periods.side_effect = RuntimeError("CH down")
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = RuntimeError("CH down")
         alert = self._make_alert()
         now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
@@ -1487,7 +1482,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute_periods.side_effect = Exception(
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         # 4 prior failures — one more pushes consecutive_failures to MAX (5) → BROKEN.
@@ -1538,7 +1533,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_notif_failures,
     ):
-        mock_query_cls.return_value.execute_periods.side_effect = Exception(
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
         )
         self._make_alert(state=initial_state, consecutive_failures=initial_failures)
@@ -1661,7 +1656,7 @@ class TestDeriveBreachesProperties(unittest.TestCase):
 class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
     """End-to-end coverage of `_evaluate_single_alert` against real ClickHouse.
 
-    Sibling tests above mock `execute_periods` and verify the activity's logic
+    Sibling tests above mock `execute_rolling_checks` and verify the activity's logic
     in isolation. This class drives the full hot path — periods CH query →
     state machine → PG state update — against seeded log data, catching seam
     bugs (BucketedCount tzinfo, threshold sign) that mocked-bucket tests can't
@@ -1824,7 +1819,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2025-12-16T10:33:00Z")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_below_operator_fires_on_truly_silent_service(self, _mock_produce):
-        # `execute_periods` always returns exactly `period_count` entries (zero
+        # `execute_rolling_checks` always returns exactly `period_count` entries (zero
         # counts for silent services, since each period is a fixed-width
         # `countIf` column rather than a `GROUP BY` over data), so
         # `0 < threshold` evaluates True → breach → fires. Regression guard


### PR DESCRIPTION
## Problem

Alert evaluation periods were anchored as fixed, non-overlapping windows (each period = one `window_minutes` block), meaning M evaluation periods always covered `M × window_minutes` of history. This doesn't correctly model rolling check semantics, where each check looks back `window_minutes` from its own scheduled time, and checks are spaced `check_interval_minutes` apart. The correct lookback is `window_minutes + (M - 1) × check_interval_minutes`, not `M × window_minutes`.

## Changes

- Added `rolling_check_lookback_minutes(window_minutes, cadence_minutes, period_count)` to compute the correct total history span for M rolling windows.
- Added `_rolling_check_ranges(nca, window_minutes, cadence_minutes, period_count)` to generate M cadence-stepped rolling windows ending at NCA, oldest-first.
- Introduced `execute_rolling_checks(nca, window_minutes, cadence_minutes, period_count)` on both `AlertCheckQuery` and `BatchedAlertCheckQuery`, replacing `execute_periods` for alert evaluation.
- Refactored the shared range-execution logic into `_execute_count_per_range` on both query classes to eliminate duplication.
- Updated `_AlertCohort` to include `check_interval_minutes` in its cohort key and use `rolling_check_lookback_minutes` for `date_from` computation.
- Updated `_build_cohorts` to include `check_interval_minutes` in the grouping key.
- Fixed the fallback count in `_execute_count_per_range` to use `len(ranges)` instead of the previously hardcoded `period_count`.
- Updated test expected lookback values to reflect the corrected formula (e.g. `M=3/window=10` is now `20` minutes, not `30`).

## How did you test this code?

Existing unit and integration tests were updated to use `execute_rolling_checks` and to assert the corrected `date_from` ranges. The parameterized `test_date_from_covers_full_rolling_check_lookback` test cases were updated to reflect the new formula. End-to-end tests against real ClickHouse in `TestEvaluateSingleAlertEndToEnd` continue to exercise the full evaluation path.

## Publish to changelog?

No