### PR TITLE
chore(observability): one more level of spans on the home view

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 
 import posthoganalytics
 from drf_spectacular.utils import extend_schema, extend_schema_field
+from opentelemetry import trace
 from rest_framework import exceptions, permissions, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -80,6 +81,9 @@ class OrganizationPermissionsWithDelete(OrganizationAdminWritePermissions):
             OrganizationMembership.objects.get(user=cast(User, request.user), organization=organization).level
             >= min_level
         )
+
+
+tracer = trace.get_tracer(__name__)
 
 
 class OrganizationSerializer(
@@ -176,10 +180,12 @@ class OrganizationSerializer(
         organization, _, _ = Organization.objects.bootstrap(user, **validated_data)
         return organization
 
+    @tracer.start_as_current_span("organization_serializer.membership_level")
     def get_membership_level(self, organization: Organization) -> OrganizationMembership.Level | None:
         membership = self.user_permissions.organization_memberships.get(organization.pk)
         return OrganizationMembership.Level(membership.level) if membership is not None else None
 
+    @tracer.start_as_current_span("organization_serializer.teams")
     def get_teams(self, instance: Organization) -> list[dict[str, Any]]:
         # Support new access control system
         visible_teams = (
@@ -193,6 +199,7 @@ class OrganizationSerializer(
         )
         return TeamBasicSerializer(visible_teams, context=self.context, many=True).data  # type: ignore
 
+    @tracer.start_as_current_span("organization_serializer.projects")
     def get_projects(self, instance: Organization) -> list[dict[str, Any]]:
         visible_projects = instance.projects.filter(id__in=self.user_permissions.project_ids_visible_for_user)
         return ProjectBasicSerializer(visible_projects, context=self.context, many=True).data  # type: ignore
@@ -240,6 +247,7 @@ class OrganizationSerializer(
         return value
 
     @extend_schema_field(serializers.IntegerField())
+    @tracer.start_as_current_span("organization_serializer.member_count")
     def get_member_count(self, organization: Organization):
         return (
             OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
@@ -249,6 +257,10 @@ class OrganizationSerializer(
             .filter(organization=organization)
             .count()
         )
+
+    @tracer.start_as_current_span("organization_serializer.to_representation")
+    def to_representation(self, instance):
+        return super().to_representation(instance)
 
 
 @extend_schema(tags=["platform_features"])

--- a/posthog/api/shared.py
+++ b/posthog/api/shared.py
@@ -5,6 +5,7 @@ This module contains serializers that are used across other serializers for nest
 import copy
 from typing import Any, Optional
 
+from opentelemetry import trace
 from rest_framework import serializers
 from rest_framework.fields import SkipField
 from rest_framework.relations import PKOnlyObject
@@ -13,6 +14,8 @@ from rest_framework.utils import model_meta
 from posthog.models import Organization, Team, User
 from posthog.models.organization import OrganizationMembership
 from posthog.models.project import Project
+
+tracer = trace.get_tracer(__name__)
 
 
 class UserBasicSerializer(serializers.ModelSerializer):
@@ -202,6 +205,10 @@ class TeamBasicSerializer(serializers.ModelSerializer):
         )
         read_only_fields = fields
 
+    @tracer.start_as_current_span("team_basic_serializer.to_representation")
+    def to_representation(self, instance):
+        return super().to_representation(instance)
+
 
 class TeamPublicSerializer(serializers.ModelSerializer):
     """
@@ -241,6 +248,10 @@ class OrganizationBasicSerializer(serializers.ModelSerializer):
             organization=organization, user=self.context["request"].user
         ).first()
         return OrganizationMembership.Level(membership.level) if membership is not None else None
+
+    @tracer.start_as_current_span("organization_basic_serializer.to_representation")
+    def to_representation(self, instance):
+        return super().to_representation(instance)
 
 
 class FilterBaseSerializer(serializers.Serializer):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -488,15 +488,17 @@ def get_context_for_template(
             user_permissions = UserPermissions(user=user, team=user.team)
             user_access_control = UserAccessControl(user=user, team=user.team)
             with tracer.start_as_current_span("template.rbac.effective"):
-                posthog_app_context["effective_resource_access_control"] = {
-                    resource: user_access_control.effective_access_level_for_resource(resource)
-                    for resource in ACCESS_CONTROL_RESOURCES
-                }
+                effective_access: dict[str, Any] = {}
+                for resource in ACCESS_CONTROL_RESOURCES:
+                    with tracer.start_as_current_span(f"template.rbac.effective.{resource}"):
+                        effective_access[resource] = user_access_control.effective_access_level_for_resource(resource)
+                posthog_app_context["effective_resource_access_control"] = effective_access
             with tracer.start_as_current_span("template.rbac.levels"):
-                posthog_app_context["resource_access_control"] = {
-                    resource: user_access_control.access_level_for_resource(resource)
-                    for resource in ACCESS_CONTROL_RESOURCES
-                }
+                resource_access: dict[str, Any] = {}
+                for resource in ACCESS_CONTROL_RESOURCES:
+                    with tracer.start_as_current_span(f"template.rbac.levels.{resource}"):
+                        resource_access[resource] = user_access_control.access_level_for_resource(resource)
+                posthog_app_context["resource_access_control"] = resource_access
 
             with tracer.start_as_current_span("template.user_serializer"):
                 user_serialized = UserSerializer(


### PR DESCRIPTION
## Problem

After the per-field spans in #57382 landed, prod traces showed two remaining mysteries:

1. **\`user_serializer.default_fields\` is 74–100 ms** — most of \`user_serializer\` (93–124 ms total). This is \`super().to_representation\` which serialises 30+ scalar fields plus three nested serialisers — \`team\` (TeamBasicSerializer), \`organization\` (OrganizationSerializer — itself heavy: teams, projects, member_count), and \`organizations\` (OrganizationBasicSerializer(many=True), N orgs per render). One span can't tell us which nested call is the cost.
2. **\`template.rbac.effective\` spiked to 60–67 ms** in some traces (was 3–13 ms earlier). The dict comp over 18 \`ACCESS_CONTROL_RESOURCES\` lets a single slow resource hide inside one combined span.

## Changes

Add the next level of spans:

- \`team_basic_serializer.to_representation\`
- \`organization_basic_serializer.to_representation\`
- \`organization_serializer.to_representation\`
- \`organization_serializer.membership_level\` / \`.teams\` / \`.projects\` / \`.member_count\`
- \`template.rbac.effective.<resource>\` for each of 18 resources
- \`template.rbac.levels.<resource>\` for each of 18 resources

The basic-serializer spans appear under any caller (team-list endpoints etc.), not just the home view — that's fine, more data points.

Per-resource RBAC spans expand the dict comp into a for loop with one span per resource.

Pure observability, no behaviour change. Same shape as the spans landed in #57369 + #57382.

## How did you test this code?

I'm an agent. Smoke test: \`hogli test posthog/api/test/test_team.py -- -k test_retrieve_team_has_group_types\` — the integration test that exercises the team serialization (which uses TeamBasicSerializer transitively) still passes.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Continuing the home-view perf hunt. Per-block spans (#57369) → per-field spans (#57382) → per-nested-serializer + per-resource spans (this PR). The next outlier trace will tell us whether the cost in user_serializer is the nested OrganizationSerializer or the organizations list, and whether one specific RBAC resource is the slow path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*