### PR TITLE
feat(taxonomy): remove 'taxonomy entry missing' frontend reporter

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -27,25 +27,16 @@ import {
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
 
-import { getCoreFilterDefinition, isCoreFilter } from '~/taxonomy/helpers'
-import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { CohortType, EventDefinition, GroupTypeIndex, PropertyType } from '~/types'
 
 import { teamLogic } from '../../../scenes/teamLogic'
 import { captureTimeToSeeData } from '../../internalMetrics'
 import { getItemGroup } from './InfiniteList'
 import type { infiniteListLogicType } from './infiniteListLogicType'
-
-function isTaxonomyTrackedListType(listGroupType: TaxonomicFilterGroupType): boolean {
-    return (
-        listGroupType in CORE_FILTER_DEFINITIONS_BY_GROUP ||
-        listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix)
-    )
-}
 
 function pinnedItemMatchesSearch(
     item: TaxonomicDefinitionTypes,
@@ -223,8 +214,6 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         actions: [
             taxonomicFilterLogic(props),
             ['setSearchQuery', 'setActiveTab', 'selectItem', 'infiniteListResultsReceived'],
-            eventUsageLogic,
-            ['reportMissingTaxonomyEntries'],
         ],
     })),
     actions({
@@ -978,30 +967,8 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 }
             }
         },
-        infiniteListResultsReceived: ({ results }) => {
+        infiniteListResultsReceived: () => {
             actions.reconcilePinnedRowState()
-            const listGroupType = props.listGroupType
-            if (!isTaxonomyTrackedListType(listGroupType)) {
-                return
-            }
-            const group = values.group
-            const missing: { name: string; groupType: TaxonomicFilterGroupType }[] = []
-            for (const item of results.results) {
-                if (isSkeletonItem(item) || isQuickFilterItem(item)) {
-                    continue
-                }
-                const name = group?.getName?.(item) ?? ('name' in item ? item.name : undefined)
-                if (!name || !name.startsWith('$')) {
-                    continue
-                }
-                if (getCoreFilterDefinition(name, listGroupType) !== null || isCoreFilter(name)) {
-                    continue
-                }
-                missing.push({ name, groupType: listGroupType })
-            }
-            if (missing.length > 0) {
-                actions.reportMissingTaxonomyEntries(missing)
-            }
         },
         applyInitialPinnedRow: ({ rowIndex }) => {
             actions.setIndex(rowIndex)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -322,8 +322,6 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
     return objectClean(payload)
 }
 
-const reportedMissingTaxonomyEntries = new Set<string>()
-
 export const eventUsageLogic = kea<eventUsageLogicType>([
     path(['lib', 'utils', 'eventUsageLogic']),
     connect(() => ({
@@ -776,9 +774,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             eventName,
         }),
         reportTaxonomicFilterAddFilterClicked: (eventName?: string) => ({ eventName }),
-        reportMissingTaxonomyEntries: (entries: { name: string; groupType: TaxonomicFilterGroupType }[]) => ({
-            entries,
-        }),
         // Definition Popover
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType, mediaPreviewCount?: number) => ({
             type,
@@ -1798,20 +1793,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportTaxonomicFilterAddFilterClicked: ({ eventName }) => {
             posthog.capture('taxonomic filter add filter clicked', { eventName })
-        },
-        reportMissingTaxonomyEntries: ({ entries }) => {
-            for (const { name, groupType } of entries) {
-                const key = `${groupType}::${name}`
-                if (reportedMissingTaxonomyEntries.has(key)) {
-                    continue
-                }
-                reportedMissingTaxonomyEntries.add(key)
-                posthog.capture('taxonomy entry missing', {
-                    name,
-                    group_type: groupType,
-                    source: 'taxonomic_filter',
-                })
-            }
         },
         reportDataManagementDefinitionHovered: ({ type, mediaPreviewCount }) => {
             posthog.capture('definition hovered', { type, media_preview_count: mediaPreviewCount ?? 0 })


### PR DESCRIPTION
## Problem

The TaxonomicFilter has been capturing a `taxonomy entry missing` event whenever it surfaces a `$`-prefixed property with no `CORE_FILTER_DEFINITIONS_BY_GROUP` entry. The intent was to surface taxonomy gaps so we could add labels for them. In practice, the captured firehose is dominated by noise rather than signal:

- **Same property reported across many irrelevant group lists.** A single key (`$pageleave event`) was reported under `events`, `person_properties`, `event_properties`, `session_properties`, `replay`, and even `groups_0` / `groups_1` — once per list it was rendered in.
- **SQL-injection / XSS scanner payloads.** Pen-test traffic captured event names like `$autocapture' or 7126=7126--`, `$pageview<esi:include src="http://bxss.me/rpb.png"/>`, and `$autocapture'"\`0&nslookup -q=cname …oastify.com.&\`'`. PostHog stored them in `event_definitions`, the picker rendered them, the reporter flagged them.
- **Test data with spaces in event names.** `$pageleave event 1`, `$feature_flag_called event 2`, `$identify event 1 - test` — manually-created event entries with spaces, treated as legitimate by the picker.
- **Internal mechanics that should not be in pickers at all.** `$snapshot_max_depth_exceeded`, `$elements`, `$elements_chain`, `$heatmap_data`, `$ai_clustering_*`, `$transformations_failed`, `$internal_or_test_user`, `$debug_images`.

A static comparison of `posthog/taxonomy/taxonomy.py` against the keys posthog-js v1.372.5 actually emits (via `getEventProperties`, `getPersonPropsFromInfo`, `getInitialPersonPropsFromInfo`, `getCampaignParams`, `getReferrerInfo`, `getSearchInfo`) found only two real gaps: `ph_keyword` and `$initial_ph_keyword`. The runtime reporter generated ~850k events / 15k users in the last 30 days; that volume is paying for ~2 useful signals.

A build-time SDK-vs-taxonomy diff (separate work) is a higher-signal way to keep the taxonomy in sync.

## Changes

Removes the runtime reporter end-to-end:

- `frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts`:
  - Drop `isTaxonomyTrackedListType` helper and the missing-property scan inside `infiniteListResultsReceived`.
  - Drop now-unused imports (`getCoreFilterDefinition`/`isCoreFilter` reduced to just `getCoreFilterDefinition`, `CORE_FILTER_DEFINITIONS_BY_GROUP`, `eventUsageLogic`).
  - Drop the `reportMissingTaxonomyEntries` action wiring on the connect block.
- `frontend/src/lib/utils/eventUsageLogic.ts`:
  - Drop the `reportMissingTaxonomyEntries` action, its listener, and the `reportedMissingTaxonomyEntries` dedup set.

The `taxonomic filter empty result` event (a different signal — empty search results — used elsewhere) is left untouched.

## How did you test this code?

I'm a PostHog Code agent. Automated checks I ran:

- `tsc --noEmit` against `frontend/tsconfig.json` shows no errors related to the removed symbols (`reportMissingTaxonomyEntries`, `isTaxonomyTrackedListType`, `reportedMissingTaxonomyEntries`).
- `grep` confirmed no remaining references to any of those symbols or to the literal event name `"taxonomy entry missing"` anywhere in `frontend/src`.

No manual UI testing. The TaxonomicFilter still renders results unchanged — the only behaviour change is that it stops calling `posthog.capture('taxonomy entry missing', ...)`.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code on behalf of @pauldambra.
- Decision: remove rather than try to filter the noise. The reporter would have to drop multi-group dupes, attacker payloads, names with whitespace, and properties marked `system`/`used_for_debug` to be useful — that filtering logic would re-create most of the picker's `getCoreFilterDefinition` work plus a heuristic layer on top. A static SDK-vs-taxonomy diff at CI time is simpler and catches real gaps with no false positives.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
