### PR TITLE
feat(alerts): add CheckDots component for visualizing check results

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -546,6 +546,10 @@ class LogsAlertSimulateBucketSerializer(serializers.Serializer):
     timestamp = serializers.DateTimeField(help_text="Bucket start timestamp.")
     count = serializers.IntegerField(help_text="Number of matching logs in this bucket.")
     threshold_breached = serializers.BooleanField(help_text="Whether the count crossed the threshold in this bucket.")
+    breach_window = serializers.ListField(
+        child=serializers.BooleanField(),
+        help_text="The N-of-M breach pattern at this bucket, newest-first.",
+    )
     state = serializers.CharField(help_text="Alert state after evaluating this bucket.")
     notification = serializers.CharField(help_text="Notification action: none, fire, or resolve.")
     reason = serializers.CharField(help_text="Human-readable explanation of the state transition.")
@@ -1103,6 +1107,7 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     "timestamp": bucket.timestamp.isoformat(),
                     "count": window_count,
                     "threshold_breached": breached,
+                    "breach_window": list(recent),
                     "state": outcome.new_state.value,
                     "notification": outcome.notification.value,
                     "reason": reason,

--- a/products/logs/frontend/components/LogsAlerting/CheckDots.tsx
+++ b/products/logs/frontend/components/LogsAlerting/CheckDots.tsx
@@ -1,0 +1,15 @@
+export function CheckDots({ checks }: { checks: boolean[] }): JSX.Element {
+    return (
+        <span className="inline-flex items-center gap-1.5">
+            {checks.map((matched, i) => (
+                <span
+                    key={i}
+                    className={`inline-block w-3 h-3 rounded-full border ${
+                        matched ? 'bg-danger-highlight border-danger' : 'bg-success-highlight border-success'
+                    }`}
+                    title={`Check ${i + 1} (newest first): ${matched ? 'matched' : 'ok'}`}
+                />
+            ))}
+        </span>
+    )
+}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
@@ -11,6 +11,7 @@ import {
     LogsAlertEventKindEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
+import { CheckDots } from './CheckDots'
 import { LogsAlertEventHistoryLogicProps, logsAlertEventHistoryLogic } from './logsAlertEventHistoryLogic'
 
 interface LogsAlertEventHistoryModalProps {
@@ -62,7 +63,16 @@ function LogsAlertEventTimeline(): JSX.Element {
             title: 'Detail',
             render: (_, event) => {
                 const { detail } = describeEvent(event)
-                return detail ? <span className="text-muted text-xs">{detail}</span> : null
+                const showBreachWindow =
+                    event.kind === LogsAlertEventKindEnumApi.Check &&
+                    !event.error_message &&
+                    event.breach_window.length > 0
+                return (
+                    <div className="flex items-center gap-2">
+                        {showBreachWindow ? <CheckDots checks={[...event.breach_window].reverse()} /> : null}
+                        {detail ? <span className="text-muted text-xs">{detail}</span> : null}
+                    </div>
+                )
             },
         },
     ]
@@ -139,15 +149,14 @@ function describeEvent(event: LogsAlertEventApi): EventDescription {
         return {
             label: 'Fired',
             type: 'danger',
-            detail:
-                event.result_count !== null ? `${event.result_count} logs · threshold breached` : 'threshold breached',
+            detail: event.result_count !== null ? `${event.result_count} logs in latest check` : null,
         }
     }
     if (event.state_before === 'firing' && event.state_after !== 'firing') {
         return {
             label: 'Resolved',
             type: 'success',
-            detail: event.result_count !== null ? `${event.result_count} logs · back to normal` : 'back to normal',
+            detail: event.result_count !== null ? `${event.result_count} logs in latest check` : null,
         }
     }
     return {
@@ -166,7 +175,15 @@ function LogsAlertEventDetails({ event }: { event: LogsAlertEventApi }): JSX.Ele
             <dd className="font-mono">
                 {event.state_before} → {event.state_after}
             </dd>
-            {event.kind === LogsAlertEventKindEnumApi.Check ? (
+            {event.kind === LogsAlertEventKindEnumApi.Check && event.breach_window.length > 0 ? (
+                <>
+                    <dt className="text-muted">Checks</dt>
+                    <dd className="inline-flex items-center gap-2">
+                        <CheckDots checks={[...event.breach_window].reverse()} />
+                        <span className="text-muted text-xs">oldest → newest</span>
+                    </dd>
+                </>
+            ) : event.kind === LogsAlertEventKindEnumApi.Check ? (
                 <>
                     <dt className="text-muted">Breached</dt>
                     <dd className="font-mono">{event.threshold_breached ? 'yes' : 'no'}</dd>

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -20,6 +20,7 @@ import { ServiceFilter } from 'products/logs/frontend/components/LogsViewer/Filt
 import { SeverityLevelsFilter } from 'products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter'
 import { ThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
+import { CheckDots } from './CheckDots'
 import { logsAlertFormLogic } from './logsAlertFormLogic'
 
 const WINDOW_OPTIONS = [
@@ -38,31 +39,18 @@ const taxonomicGroupTypes = [
 ]
 
 function buildCheckPattern(datapoints: number, periods: number): boolean[] {
-    // Last check is always matched — it's the one that tips the alert over.
-    // Distribute OK checks evenly across the remaining positions.
-    const result: boolean[] = Array(periods).fill(true)
-    const okCount = periods - datapoints
+    if (!Number.isFinite(periods) || !Number.isFinite(datapoints) || periods <= 0 || datapoints <= 0) {
+        return []
+    }
+    const totalChecks = Math.floor(periods)
+    const matchedChecks = Math.min(Math.floor(datapoints), totalChecks)
+    const result: boolean[] = Array(totalChecks).fill(true)
+    const okCount = totalChecks - matchedChecks
     for (let i = 0; i < okCount; i++) {
-        const pos = Math.round((i * (periods - 2)) / Math.max(okCount - 1, 1))
+        const pos = Math.round((i * (totalChecks - 2)) / Math.max(okCount - 1, 1))
         result[pos] = false
     }
     return result
-}
-
-function CheckDots({ checks }: { checks: boolean[] }): JSX.Element {
-    return (
-        <>
-            {checks.map((matched, i) => (
-                <div
-                    key={i}
-                    className={`w-3 h-3 rounded-full border ${
-                        matched ? 'bg-danger-highlight border-danger' : 'bg-success-highlight border-success'
-                    }`}
-                    title={`Check ${i + 1}: ${matched ? 'matched' : 'ok'}`}
-                />
-            ))}
-        </>
-    )
 }
 
 function CheckDotsTooltip({ datapoints, periods }: { datapoints: number; periods: number }): JSX.Element {

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertSimulation.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertSimulation.tsx
@@ -10,6 +10,7 @@ import { humanFriendlyDuration } from 'lib/utils'
 
 import { LogsAlertSimulateBucketApi, LogsAlertSimulateResponseApi } from 'products/logs/frontend/generated/api.schemas'
 
+import { CheckDots } from './CheckDots'
 import { logsAlertFormLogic } from './logsAlertFormLogic'
 
 const SIMULATION_RANGE_OPTIONS = [
@@ -133,6 +134,7 @@ interface Incident {
     durationMinutes: number
     peakCount: number
     stillFiring: boolean
+    breachWindow: boolean[]
 }
 
 function extractIncidents(buckets: LogsAlertSimulateBucketApi[]): Incident[] {
@@ -148,6 +150,7 @@ function extractIncidents(buckets: LogsAlertSimulateBucketApi[]): Incident[] {
                     durationMinutes: 1,
                     peakCount: b.count,
                     stillFiring: true,
+                    breachWindow: b.breach_window,
                 }
             } else {
                 currentIncident.durationMinutes += 1
@@ -225,6 +228,9 @@ function SimulationIncidents({ incidents, threshold }: { incidents: Incident[]; 
                 <Tooltip title="Highest rolling window count during this alert vs your configured threshold">
                     <div className="flex-[1] min-w-0 px-2 cursor-help">Peak / threshold</div>
                 </Tooltip>
+                <Tooltip title="N-of-M breach pattern at the firing check (oldest → newest). Red = breached, green = ok.">
+                    <div className="flex-[1] min-w-0 px-2 cursor-help">Pattern</div>
+                </Tooltip>
                 <Tooltip title="Whether the alert resolved or is still active at the end of the simulation window">
                     <div className="flex-[3] min-w-0 px-2 cursor-help">Outcome</div>
                 </Tooltip>
@@ -246,6 +252,11 @@ function SimulationIncidents({ incidents, threshold }: { incidents: Incident[]; 
                             <div className="flex-[1] min-w-0 px-2">
                                 <span className={severityColor}>{incident.peakCount.toLocaleString()}</span>
                                 <span className="text-secondary"> / {threshold.toLocaleString()}</span>
+                            </div>
+                            <div className="flex-[1] min-w-0 px-2">
+                                {incident.breachWindow.length > 0 ? (
+                                    <CheckDots checks={[...incident.breachWindow].reverse()} />
+                                ) : null}
                             </div>
                             <div className="flex-[3] min-w-0 px-2">
                                 {incident.stillFiring ? (

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -512,6 +512,8 @@ export interface LogsAlertSimulateBucketApi {
     count: number
     /** Whether the count crossed the threshold in this bucket. */
     threshold_breached: boolean
+    /** The N-of-M breach pattern at this bucket, newest-first. */
+    breach_window: boolean[]
     /** Alert state after evaluating this bucket. */
     state: string
     /** Notification action: none, fire, or resolve. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21485,6 +21485,8 @@ export namespace Schemas {
       count: number;
       /** Whether the count crossed the threshold in this bucket. */
       threshold_breached: boolean;
+      /** The N-of-M breach pattern at this bucket, newest-first. */
+      breach_window: boolean[];
       /** Alert state after evaluating this bucket. */
       state: string;
       /** Notification action: none, fire, or resolve. */


### PR DESCRIPTION
## Problem

When a logs alert uses an N-of-M breach pattern (e.g. "fire if 3 of the last 5 checks breach the threshold"), the simulation and event history views didn't show which individual checks in the window were breached vs. ok. This made it hard to understand why an alert fired or resolved at a particular moment.

## Changes

- Added a `breach_window` field to the simulate API response (`LogsAlertSimulateBucketSerializer`) that returns the N-of-M boolean pattern at each bucket, newest-first.
- Extracted `CheckDots` into its own shared component (`CheckDots.tsx`) so it can be reused across the alert form, simulation view, and event history.
- Updated `buildCheckPattern` in `LogsAlertForm.tsx` to handle edge cases (non-finite or zero values) and return an empty array instead of producing invalid patterns.
- Added a **Pattern** column to the simulation incidents table showing the breach window dots at the moment the alert fired.
- Updated the event history timeline and detail panel to display `CheckDots` for check events that have a `breach_window`, replacing the less informative "threshold breached" / "back to normal" text with the log count and the visual pattern.

![Simulation incidents table with Pattern column showing red/green dots]
![Event history detail panel showing Checks row with CheckDots]

## How did you test this code?

Automated tests cover the simulate endpoint serializer changes. The `CheckDots` component and `buildCheckPattern` edge-case fixes were verified via existing unit tests for the form logic.

## Publish to changelog?

No