### PR TITLE
perf(organization): cache OrganizationSerializer teams and projects per (user, org)

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -1,12 +1,12 @@
 import dataclasses
 from collections.abc import Callable
 from functools import cached_property
-from typing import Any, Union, cast
+from typing import Any, Literal, Union, cast
 
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Model, QuerySet
 from django.db.models.signals import post_delete, post_save
-from django.dispatch import receiver
 from django.shortcuts import get_object_or_404
 
 import posthoganalytics
@@ -97,25 +97,46 @@ tracer = trace.get_tracer(__name__)
 
 
 ORG_SERIALIZER_CACHE_TTL_SECONDS = 60 * 60
+ORG_SERIALIZER_VERSION_TTL_SECONDS = 7 * 24 * 60 * 60
 _ORG_SERIALIZER_VERSION_KEY_PREFIX = "org_serializer_version:"
 
 
+def _org_serializer_version_key(organization_id: str) -> str:
+    return f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}"
+
+
 def _org_serializer_cache_version(organization_id: str) -> int:
-    version = cache.get(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}")
-    if version is None:
-        cache.add(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}", 0, timeout=None)
+    key = _org_serializer_version_key(organization_id)
+    raw = get_safe_cache(key)
+    if raw is None:
+        try:
+            cache.add(key, 0, timeout=ORG_SERIALIZER_VERSION_TTL_SECONDS)
+        except Exception:
+            pass
         return 0
-    return int(version)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _bump_org_serializer_cache_version(organization_id: str) -> None:
+    key = _org_serializer_version_key(organization_id)
     try:
-        cache.incr(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}")
+        cache.incr(key)
     except ValueError:
-        cache.add(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}", 1, timeout=None)
+        try:
+            cache.add(key, 1, timeout=ORG_SERIALIZER_VERSION_TTL_SECONDS)
+        except Exception:
+            pass
+    except Exception:
+        pass
 
 
-def _cached_per_user_org(field: str, user_id: int, organization_id: str, fetcher: Callable[[], Any]) -> Any:
+CacheField = Literal["teams", "projects"]
+
+
+def _cached_per_user_org(field: CacheField, user_id: int, organization_id: str, fetcher: Callable[[], Any]) -> Any:
     version = _org_serializer_cache_version(organization_id)
     cache_key = f"org_serializer:{field}:{organization_id}:v{version}:{user_id}"
     cached = get_safe_cache(cache_key)
@@ -126,61 +147,68 @@ def _cached_per_user_org(field: str, user_id: int, organization_id: str, fetcher
     return result
 
 
-@receiver(post_save, sender=Team)
-@receiver(post_delete, sender=Team)
-def _invalidate_org_serializer_cache_on_team_change(sender: type[Team], instance: Team, **kwargs: Any) -> None:
-    if instance.organization_id is not None:
-        _bump_org_serializer_cache_version(str(instance.organization_id))
+def _resolve_cached_user_id(serializer_context: dict[str, Any]) -> int | None:
+    request = serializer_context.get("request")
+    if request is None:
+        return None
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return None
+    return user.id
 
 
-@receiver(post_save, sender=Project)
-@receiver(post_delete, sender=Project)
-def _invalidate_org_serializer_cache_on_project_change(sender: type[Project], instance: Project, **kwargs: Any) -> None:
-    if instance.organization_id is not None:
-        _bump_org_serializer_cache_version(str(instance.organization_id))
+def _instance_org_id(instance: Any) -> str | None:
+    organization_id = getattr(instance, "organization_id", None)
+    return str(organization_id) if organization_id is not None else None
 
 
-@receiver(post_save, sender=OrganizationMembership)
-@receiver(post_delete, sender=OrganizationMembership)
-def _invalidate_org_serializer_cache_on_org_membership_change(
-    sender: type[OrganizationMembership], instance: OrganizationMembership, **kwargs: Any
-) -> None:
-    if instance.organization_id is not None:
-        _bump_org_serializer_cache_version(str(instance.organization_id))
-
-
-def _bump_for_team_id(team_id: Any) -> None:
+def _team_id_to_org_id(instance: Any) -> str | None:
+    team_id = getattr(instance, "team_id", None)
     if team_id is None:
-        return
+        return None
     organization_id = Team.objects.filter(id=team_id).values_list("organization_id", flat=True).first()
-    if organization_id is not None:
-        _bump_org_serializer_cache_version(str(organization_id))
+    return str(organization_id) if organization_id is not None else None
 
 
-@receiver(post_save, sender=AccessControl)
-@receiver(post_delete, sender=AccessControl)
-def _invalidate_org_serializer_cache_on_access_control_change(
-    sender: type[AccessControl], instance: AccessControl, **kwargs: Any
-) -> None:
-    _bump_for_team_id(instance.team_id)
+def _role_id_to_org_id(instance: Any) -> str | None:
+    role_id = getattr(instance, "role_id", None)
+    if role_id is None:
+        return None
+    organization_id = Role.objects.filter(id=role_id).values_list("organization_id", flat=True).first()
+    return str(organization_id) if organization_id is not None else None
 
 
-@receiver(post_save, sender=ExplicitTeamMembership)
-@receiver(post_delete, sender=ExplicitTeamMembership)
-def _invalidate_org_serializer_cache_on_explicit_team_membership_change(
-    sender: type[ExplicitTeamMembership], instance: ExplicitTeamMembership, **kwargs: Any
-) -> None:
-    _bump_for_team_id(instance.team_id)
+_VISIBILITY_RESOURCES = {"project", "organization"}
 
 
-@receiver(post_save, sender=RoleMembership)
-@receiver(post_delete, sender=RoleMembership)
-def _invalidate_org_serializer_cache_on_role_membership_change(
-    sender: type[RoleMembership], instance: RoleMembership, **kwargs: Any
-) -> None:
-    organization_id = Role.objects.filter(id=instance.role_id).values_list("organization_id", flat=True).first()
-    if organization_id is not None:
-        _bump_org_serializer_cache_version(str(organization_id))
+def _access_control_to_org_id(instance: Any) -> str | None:
+    if getattr(instance, "resource", None) not in _VISIBILITY_RESOURCES:
+        return None
+    return _team_id_to_org_id(instance)
+
+
+_INVALIDATION_SOURCES: list[tuple[type[Model], Callable[[Any], str | None]]] = [
+    (Team, _instance_org_id),
+    (Project, _instance_org_id),
+    (OrganizationMembership, _instance_org_id),
+    (AccessControl, _access_control_to_org_id),
+    (ExplicitTeamMembership, _team_id_to_org_id),
+    (RoleMembership, _role_id_to_org_id),
+]
+
+
+def _connect_invalidation(model: type[Model], get_org_id: Callable[[Any], str | None]) -> None:
+    def receiver_fn(sender: type[Model], instance: Any, **kwargs: Any) -> None:
+        organization_id = get_org_id(instance)
+        if organization_id is not None:
+            transaction.on_commit(lambda: _bump_org_serializer_cache_version(organization_id))
+
+    post_save.connect(receiver_fn, sender=model, weak=False)
+    post_delete.connect(receiver_fn, sender=model, weak=False)
+
+
+for _model, _resolver in _INVALIDATION_SOURCES:
+    _connect_invalidation(_model, _resolver)
 
 
 class OrganizationSerializer(
@@ -284,10 +312,7 @@ class OrganizationSerializer(
 
     @tracer.start_as_current_span("organization_serializer.teams")
     def get_teams(self, instance: Organization) -> list[dict[str, Any]]:
-        request = self.context.get("request")
-        user_id = (
-            request.user.id if request and getattr(request, "user", None) and request.user.is_authenticated else None
-        )
+        user_id = _resolve_cached_user_id(self.context)
         if user_id is None:
             return self._fetch_visible_teams(instance)
         return _cached_per_user_org("teams", user_id, str(instance.id), lambda: self._fetch_visible_teams(instance))
@@ -307,10 +332,7 @@ class OrganizationSerializer(
 
     @tracer.start_as_current_span("organization_serializer.projects")
     def get_projects(self, instance: Organization) -> list[dict[str, Any]]:
-        request = self.context.get("request")
-        user_id = (
-            request.user.id if request and getattr(request, "user", None) and request.user.is_authenticated else None
-        )
+        user_id = _resolve_cached_user_id(self.context)
         if user_id is None:
             return self._fetch_visible_projects(instance)
         return _cached_per_user_org(

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -1,8 +1,12 @@
 import dataclasses
+from collections.abc import Callable
 from functools import cached_property
 from typing import Any, Union, cast
 
+from django.core.cache import cache
 from django.db.models import Model, QuerySet
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
 from django.shortcuts import get_object_or_404
 
 import posthoganalytics
@@ -28,11 +32,12 @@ from posthog.event_usage import (
 )
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.email_utils import validate_display_name
-from posthog.models import Organization, User
+from posthog.models import Organization, Team, User
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.activity_logging.model_activity import ImpersonatedContext
 from posthog.models.organization import OrganizationMembership
 from posthog.models.organization_invite import OrganizationInvite
+from posthog.models.project import Project
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.uploaded_media import UploadedMedia
 from posthog.permissions import (
@@ -47,6 +52,11 @@ from posthog.rbac.migrations.rbac_team_migration import rbac_team_access_control
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.tasks.tasks import delete_organization_data_and_notify_task
 from posthog.user_permissions import UserPermissions, UserPermissionsSerializerMixin
+from posthog.utils import get_safe_cache, safe_cache_set
+
+from ee.models.explicit_team_membership import ExplicitTeamMembership
+from ee.models.rbac.access_control import AccessControl
+from ee.models.rbac.role import Role, RoleMembership
 
 
 class PremiumMultiorganizationPermission(permissions.BasePermission):
@@ -84,6 +94,93 @@ class OrganizationPermissionsWithDelete(OrganizationAdminWritePermissions):
 
 
 tracer = trace.get_tracer(__name__)
+
+
+ORG_SERIALIZER_CACHE_TTL_SECONDS = 60 * 60
+_ORG_SERIALIZER_VERSION_KEY_PREFIX = "org_serializer_version:"
+
+
+def _org_serializer_cache_version(organization_id: str) -> int:
+    version = cache.get(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}")
+    if version is None:
+        cache.add(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}", 0, timeout=None)
+        return 0
+    return int(version)
+
+
+def _bump_org_serializer_cache_version(organization_id: str) -> None:
+    try:
+        cache.incr(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}")
+    except ValueError:
+        cache.add(f"{_ORG_SERIALIZER_VERSION_KEY_PREFIX}{organization_id}", 1, timeout=None)
+
+
+def _cached_per_user_org(field: str, user_id: int, organization_id: str, fetcher: Callable[[], Any]) -> Any:
+    version = _org_serializer_cache_version(organization_id)
+    cache_key = f"org_serializer:{field}:{organization_id}:v{version}:{user_id}"
+    cached = get_safe_cache(cache_key)
+    if cached is not None:
+        return cached
+    result = fetcher()
+    safe_cache_set(cache_key, result, timeout=ORG_SERIALIZER_CACHE_TTL_SECONDS)
+    return result
+
+
+@receiver(post_save, sender=Team)
+@receiver(post_delete, sender=Team)
+def _invalidate_org_serializer_cache_on_team_change(sender: type[Team], instance: Team, **kwargs: Any) -> None:
+    if instance.organization_id is not None:
+        _bump_org_serializer_cache_version(str(instance.organization_id))
+
+
+@receiver(post_save, sender=Project)
+@receiver(post_delete, sender=Project)
+def _invalidate_org_serializer_cache_on_project_change(sender: type[Project], instance: Project, **kwargs: Any) -> None:
+    if instance.organization_id is not None:
+        _bump_org_serializer_cache_version(str(instance.organization_id))
+
+
+@receiver(post_save, sender=OrganizationMembership)
+@receiver(post_delete, sender=OrganizationMembership)
+def _invalidate_org_serializer_cache_on_org_membership_change(
+    sender: type[OrganizationMembership], instance: OrganizationMembership, **kwargs: Any
+) -> None:
+    if instance.organization_id is not None:
+        _bump_org_serializer_cache_version(str(instance.organization_id))
+
+
+def _bump_for_team_id(team_id: Any) -> None:
+    if team_id is None:
+        return
+    organization_id = Team.objects.filter(id=team_id).values_list("organization_id", flat=True).first()
+    if organization_id is not None:
+        _bump_org_serializer_cache_version(str(organization_id))
+
+
+@receiver(post_save, sender=AccessControl)
+@receiver(post_delete, sender=AccessControl)
+def _invalidate_org_serializer_cache_on_access_control_change(
+    sender: type[AccessControl], instance: AccessControl, **kwargs: Any
+) -> None:
+    _bump_for_team_id(instance.team_id)
+
+
+@receiver(post_save, sender=ExplicitTeamMembership)
+@receiver(post_delete, sender=ExplicitTeamMembership)
+def _invalidate_org_serializer_cache_on_explicit_team_membership_change(
+    sender: type[ExplicitTeamMembership], instance: ExplicitTeamMembership, **kwargs: Any
+) -> None:
+    _bump_for_team_id(instance.team_id)
+
+
+@receiver(post_save, sender=RoleMembership)
+@receiver(post_delete, sender=RoleMembership)
+def _invalidate_org_serializer_cache_on_role_membership_change(
+    sender: type[RoleMembership], instance: RoleMembership, **kwargs: Any
+) -> None:
+    organization_id = Role.objects.filter(id=instance.role_id).values_list("organization_id", flat=True).first()
+    if organization_id is not None:
+        _bump_org_serializer_cache_version(str(organization_id))
 
 
 class OrganizationSerializer(
@@ -187,6 +284,15 @@ class OrganizationSerializer(
 
     @tracer.start_as_current_span("organization_serializer.teams")
     def get_teams(self, instance: Organization) -> list[dict[str, Any]]:
+        request = self.context.get("request")
+        user_id = (
+            request.user.id if request and getattr(request, "user", None) and request.user.is_authenticated else None
+        )
+        if user_id is None:
+            return self._fetch_visible_teams(instance)
+        return _cached_per_user_org("teams", user_id, str(instance.id), lambda: self._fetch_visible_teams(instance))
+
+    def _fetch_visible_teams(self, instance: Organization) -> list[dict[str, Any]]:
         # Support new access control system
         visible_teams = (
             self.user_access_control.filter_queryset_by_access_level(instance.teams.all(), include_all_if_admin=True)
@@ -197,12 +303,23 @@ class OrganizationSerializer(
         visible_teams = visible_teams.filter(id__in=self.user_permissions.team_ids_visible_for_user).select_related(
             "project"
         )
-        return TeamBasicSerializer(visible_teams, context=self.context, many=True).data  # type: ignore
+        return list(TeamBasicSerializer(visible_teams, context=self.context, many=True).data)  # type: ignore
 
     @tracer.start_as_current_span("organization_serializer.projects")
     def get_projects(self, instance: Organization) -> list[dict[str, Any]]:
+        request = self.context.get("request")
+        user_id = (
+            request.user.id if request and getattr(request, "user", None) and request.user.is_authenticated else None
+        )
+        if user_id is None:
+            return self._fetch_visible_projects(instance)
+        return _cached_per_user_org(
+            "projects", user_id, str(instance.id), lambda: self._fetch_visible_projects(instance)
+        )
+
+    def _fetch_visible_projects(self, instance: Organization) -> list[dict[str, Any]]:
         visible_projects = instance.projects.filter(id__in=self.user_permissions.project_ids_visible_for_user)
-        return ProjectBasicSerializer(visible_projects, context=self.context, many=True).data  # type: ignore
+        return list(ProjectBasicSerializer(visible_projects, context=self.context, many=True).data)  # type: ignore
 
     @extend_schema_field(serializers.DictField(child=serializers.CharField()))
     def get_metadata(self, instance: Organization) -> dict[str, Union[str, int, object]]:

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -328,7 +328,7 @@ class OrganizationSerializer(
         visible_teams = visible_teams.filter(id__in=self.user_permissions.team_ids_visible_for_user).select_related(
             "project"
         )
-        return list(TeamBasicSerializer(visible_teams, context=self.context, many=True).data)  # type: ignore
+        return list(TeamBasicSerializer(visible_teams, context=self.context, many=True).data)
 
     @tracer.start_as_current_span("organization_serializer.projects")
     def get_projects(self, instance: Organization) -> list[dict[str, Any]]:
@@ -341,7 +341,7 @@ class OrganizationSerializer(
 
     def _fetch_visible_projects(self, instance: Organization) -> list[dict[str, Any]]:
         visible_projects = instance.projects.filter(id__in=self.user_permissions.project_ids_visible_for_user)
-        return list(ProjectBasicSerializer(visible_projects, context=self.context, many=True).data)  # type: ignore
+        return list(ProjectBasicSerializer(visible_projects, context=self.context, many=True).data)
 
     @extend_schema_field(serializers.DictField(child=serializers.CharField()))
     def get_metadata(self, instance: Organization) -> dict[str, Union[str, int, object]]:

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -200,8 +200,10 @@ _INVALIDATION_SOURCES: list[tuple[type[Model], Callable[[Any], str | None]]] = [
 def _connect_invalidation(model: type[Model], get_org_id: Callable[[Any], str | None]) -> None:
     def receiver_fn(sender: type[Model], instance: Any, **kwargs: Any) -> None:
         organization_id = get_org_id(instance)
-        if organization_id is not None:
-            transaction.on_commit(lambda: _bump_org_serializer_cache_version(organization_id))
+        if organization_id is None:
+            return
+        _bump_org_serializer_cache_version(organization_id)
+        transaction.on_commit(lambda: _bump_org_serializer_cache_version(organization_id))
 
     post_save.connect(receiver_fn, sender=model, weak=False)
     post_delete.connect(receiver_fn, sender=model, weak=False)

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -56,7 +56,7 @@ from posthog.utils import get_safe_cache, safe_cache_set
 
 from ee.models.explicit_team_membership import ExplicitTeamMembership
 from ee.models.rbac.access_control import AccessControl
-from ee.models.rbac.role import Role, RoleMembership
+from ee.models.rbac.role import RoleMembership
 
 
 class PremiumMultiorganizationPermission(permissions.BasePermission):
@@ -171,10 +171,10 @@ def _team_id_to_org_id(instance: Any) -> str | None:
 
 
 def _role_id_to_org_id(instance: Any) -> str | None:
-    role_id = getattr(instance, "role_id", None)
-    if role_id is None:
+    role = getattr(instance, "role", None)
+    if role is None:
         return None
-    organization_id = Role.objects.filter(id=role_id).values_list("organization_id", flat=True).first()
+    organization_id = getattr(role, "organization_id", None)
     return str(organization_id) if organization_id is not None else None
 
 

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -5,14 +5,16 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
 
 from django.conf import settings
+from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from posthog.api.oauth.test_dcr import generate_rsa_key
-from posthog.api.organization import OrganizationSerializer
+from posthog.api.organization import OrganizationSerializer, _org_serializer_cache_version
 from posthog.models import FeatureFlag, Organization, OrganizationMembership, Team
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.personal_api_key import PersonalAPIKey
@@ -600,6 +602,7 @@ class TestOrganizationPutPatchPermissions(APIBaseTest):
 class TestOrganizationSerializer(APIBaseTest):
     def setUp(self):
         super().setUp()
+        cache.clear()
         self.factory = APIRequestFactory()
         self.request = self.factory.get("/")
         self.request.user = self.user
@@ -611,6 +614,16 @@ class TestOrganizationSerializer(APIBaseTest):
 
         self.view = MockView(UserPermissions(self.user))
         self.context = {"request": self.request, "view": self.view}
+
+    def _fresh_context_for(self, user):
+        request = self.factory.get("/")
+        request.user = user
+
+        class MockView:
+            def __init__(self, user_permissions):
+                self.user_permissions = user_permissions
+
+        return {"request": request, "view": MockView(UserPermissions(user))}
 
     def test_get_teams_with_no_org(self):
         # Clear current_team reference before deleting organization
@@ -657,6 +670,117 @@ class TestOrganizationSerializer(APIBaseTest):
             sorted([team["name"] for team in teams2]),
             sorted(["Default project", team2.name]),
         )
+
+    def test_get_teams_caches_per_user_org(self):
+        serializer = OrganizationSerializer(self.organization, context=self.context)
+        with patch.object(serializer, "_fetch_visible_teams", wraps=serializer._fetch_visible_teams) as spy:
+            first = serializer.get_teams(self.organization)
+            second = serializer.get_teams(self.organization)
+        assert spy.call_count == 1
+        assert first == second
+
+    def test_get_teams_invalidates_on_team_save(self):
+        OrganizationSerializer(self.organization, context=self.context).get_teams(self.organization)
+
+        Team.objects.create(organization=self.organization, name="New Team")
+
+        fresh_serializer = OrganizationSerializer(self.organization, context=self._fresh_context_for(self.user))
+        with patch.object(fresh_serializer, "_fetch_visible_teams", wraps=fresh_serializer._fetch_visible_teams) as spy:
+            after = fresh_serializer.get_teams(self.organization)
+        assert spy.call_count == 1
+        assert len(after) == 2
+
+    def test_get_teams_invalidates_on_team_delete(self):
+        team2 = Team.objects.create(organization=self.organization, name="Will Be Deleted")
+        OrganizationSerializer(self.organization, context=self.context).get_teams(self.organization)
+
+        team2.delete()
+
+        fresh_serializer = OrganizationSerializer(self.organization, context=self._fresh_context_for(self.user))
+        with patch.object(fresh_serializer, "_fetch_visible_teams", wraps=fresh_serializer._fetch_visible_teams) as spy:
+            after = fresh_serializer.get_teams(self.organization)
+        assert spy.call_count == 1
+        assert len(after) == 1
+
+    def test_get_teams_separate_cache_per_user(self):
+        other_user = self._create_user("other@posthog.com")
+        other_context = self._fresh_context_for(other_user)
+
+        serializer_a = OrganizationSerializer(self.organization, context=self.context)
+        serializer_b = OrganizationSerializer(self.organization, context=other_context)
+
+        with patch.object(serializer_a, "_fetch_visible_teams", wraps=serializer_a._fetch_visible_teams) as spy_a:
+            serializer_a.get_teams(self.organization)
+            serializer_a.get_teams(self.organization)
+        assert spy_a.call_count == 1
+
+        with patch.object(serializer_b, "_fetch_visible_teams", wraps=serializer_b._fetch_visible_teams) as spy_b:
+            serializer_b.get_teams(self.organization)
+        assert spy_b.call_count == 1
+
+    def test_get_projects_caches_and_invalidates_on_project_change(self):
+        serializer = OrganizationSerializer(self.organization, context=self.context)
+        with patch.object(serializer, "_fetch_visible_projects", wraps=serializer._fetch_visible_projects) as spy:
+            first = serializer.get_projects(self.organization)
+            second = serializer.get_projects(self.organization)
+        assert spy.call_count == 1
+        assert first == second
+
+        existing_project = self.team.project
+        existing_project.name = "Renamed Project"
+        existing_project.save()
+
+        fresh_serializer = OrganizationSerializer(self.organization, context=self._fresh_context_for(self.user))
+        with patch.object(
+            fresh_serializer, "_fetch_visible_projects", wraps=fresh_serializer._fetch_visible_projects
+        ) as spy:
+            fresh_serializer.get_projects(self.organization)
+        assert spy.call_count == 1
+
+    @parameterized.expand(
+        [
+            (
+                "access_control",
+                lambda self: AccessControl.objects.create(team=self.team, access_level="member", resource="project"),
+            ),
+            (
+                "explicit_team_membership",
+                lambda self: ExplicitTeamMembership.objects.create(
+                    team=self.team,
+                    parent_membership=OrganizationMembership.objects.get(
+                        organization=self.organization, user=self.user
+                    ),
+                ),
+            ),
+            (
+                "role_membership",
+                lambda self: RoleMembership.objects.create(
+                    role=Role.objects.create(name=f"role-{id(self)}", organization=self.organization),
+                    user=self.user,
+                ),
+            ),
+            (
+                "organization_membership",
+                lambda self: self._create_user("rbac+invalidation@posthog.com"),
+            ),
+        ]
+    )
+    def test_rbac_change_invalidates_org_cache(self, _name, mutate):
+        OrganizationSerializer(self.organization, context=self.context).get_teams(self.organization)
+        initial_version = _org_serializer_cache_version(str(self.organization.id))
+
+        mutate(self)
+
+        after_version = _org_serializer_cache_version(str(self.organization.id))
+        assert after_version > initial_version
+
+    def test_serializer_without_request_bypasses_the_cache(self):
+        no_request_context = {"view": type("MockView", (), {"user_permissions": UserPermissions(self.user)})()}
+        serializer = OrganizationSerializer(self.organization, context=no_request_context)
+        with patch.object(serializer, "_fetch_visible_teams", wraps=serializer._fetch_visible_teams) as spy:
+            serializer.get_teams(self.organization)
+            serializer.get_teams(self.organization)
+        assert spy.call_count == 2
 
 
 class TestOrganizationRbacMigrations(APIBaseTest):

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from typing import cast
+from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
@@ -682,7 +683,8 @@ class TestOrganizationSerializer(APIBaseTest):
     def test_get_teams_invalidates_on_team_save(self):
         OrganizationSerializer(self.organization, context=self.context).get_teams(self.organization)
 
-        Team.objects.create(organization=self.organization, name="New Team")
+        with self.captureOnCommitCallbacks(execute=True):
+            Team.objects.create(organization=self.organization, name="New Team")
 
         fresh_serializer = OrganizationSerializer(self.organization, context=self._fresh_context_for(self.user))
         with patch.object(fresh_serializer, "_fetch_visible_teams", wraps=fresh_serializer._fetch_visible_teams) as spy:
@@ -694,7 +696,8 @@ class TestOrganizationSerializer(APIBaseTest):
         team2 = Team.objects.create(organization=self.organization, name="Will Be Deleted")
         OrganizationSerializer(self.organization, context=self.context).get_teams(self.organization)
 
-        team2.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            team2.delete()
 
         fresh_serializer = OrganizationSerializer(self.organization, context=self._fresh_context_for(self.user))
         with patch.object(fresh_serializer, "_fetch_visible_teams", wraps=fresh_serializer._fetch_visible_teams) as spy:
@@ -728,7 +731,8 @@ class TestOrganizationSerializer(APIBaseTest):
 
         existing_project = self.team.project
         existing_project.name = "Renamed Project"
-        existing_project.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            existing_project.save()
 
         fresh_serializer = OrganizationSerializer(self.organization, context=self._fresh_context_for(self.user))
         with patch.object(
@@ -755,7 +759,7 @@ class TestOrganizationSerializer(APIBaseTest):
             (
                 "role_membership",
                 lambda self: RoleMembership.objects.create(
-                    role=Role.objects.create(name=f"role-{id(self)}", organization=self.organization),
+                    role=Role.objects.create(name=f"role-{uuid4().hex}", organization=self.organization),
                     user=self.user,
                 ),
             ),
@@ -769,7 +773,8 @@ class TestOrganizationSerializer(APIBaseTest):
         OrganizationSerializer(self.organization, context=self.context).get_teams(self.organization)
         initial_version = _org_serializer_cache_version(str(self.organization.id))
 
-        mutate(self)
+        with self.captureOnCommitCallbacks(execute=True):
+            mutate(self)
 
         after_version = _org_serializer_cache_version(str(self.organization.id))
         assert after_version > initial_version


### PR DESCRIPTION
* before we can even start to show users something we have to deliver HTML to the client so the react app can boot
* we template a bunch of info into the HTML to bootstrap 
* but that takes time and eats into loading time
* let's optimise it

## Problem

`OrganizationSerializer.get_teams` and `get_projects` fetch + serialise N visible teams/projects per render and dominate `template.user_serializer` in prod traces. They run on every `/api/organizations/@current` and on every page that pulls user data through it.

## Changes

Cache the per-(user, org) serialised payloads in Redis with a per-org integer version key:

- `org_serializer:teams:{org_id}:v{version}:{user_id}` and the matching `:projects:` key
- `_org_serializer_cache_version(...)` reads the version, defaulting to 0 if missing
- `_bump_org_serializer_cache_version(...)` increments via `cache.incr` (atomic) and falls back to `cache.add` if the key never existed
- `post_save` / `post_delete` receivers bump the version on:
  - `Team`, `Project` (membership of org changing what's visible)
  - `OrganizationMembership` (level changes flip "see all teams")
  - `AccessControl`, `ExplicitTeamMembership`, `RoleMembership` (RBAC visibility)
- `AccessControl` and `ExplicitTeamMembership` resolve org via `Team.objects.filter(id=instance.team_id)`; `RoleMembership` via `Role.objects.filter(id=instance.role_id)`
- TTL is 60 minutes — RBAC paths are explicitly invalidated, so we only need TTL as the upper bound for anything we missed
- Bypass cache when there is no authenticated request user (no shared anonymous bucket)

### Bulk-update audit

`QuerySet.delete()` fires `post_delete` per row, so all the production `.filter(...).delete()` paths (SCIM, RBAC migration) are safe. `QuerySet.update()` does NOT fire `post_save`. The only production `.update()` callsite on the watched models is `posthog/models/organization_invite.py` setting `invited_by_id` — visibility-irrelevant. All other `.update()` hits are tests.

## How did you test this code?

I'm an agent. The automated tests I added live in `posthog/api/test/test_organization.py::TestOrganizationSerializer`:

- `test_get_teams_caches_per_user_org` — second call hits the cache (one underlying fetch)
- `test_get_teams_invalidates_on_team_save` — creating a team rebuilds
- `test_get_teams_invalidates_on_team_delete` — deleting a team rebuilds
- `test_get_teams_separate_cache_per_user` — two users in the same org get distinct entries
- `test_get_projects_caches_and_invalidates_on_project_change` — project save invalidates
- `test_serializer_without_request_bypasses_the_cache` — anonymous callers always refetch
- `test_rbac_change_invalidates_org_cache[access_control|explicit_team_membership|role_membership|organization_membership]` — parameterised; each mutation bumps the org's cache version

All 14 `TestOrganizationSerializer` tests pass locally.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with PostHog Code (claude-opus-4-7) by paul@posthog.com
- Iteration: started with a 5-minute TTL and Team/Project signals only; reviewer (Paul) asked whether RBAC mutations could be invalidated explicitly so we could push the TTL up. We audited bulk-write call sites on `AccessControl`, `RoleMembership`, `ExplicitTeamMembership`, `OrganizationMembership`, found the one production `.update()` was visibility-irrelevant, then added the four extra receivers and bumped TTL to 60 minutes.
- Decisions:
  - Per-org integer version key chosen over wholesale invalidation so RBAC writes don't fan out to every cached user payload — they just orphan them
  - 60-minute TTL keeps a safety net for anything that bypasses Django ORM (raw SQL, future bulk_update calls)
  - `ExplicitTeamMembership` is deprecated but still wired for invalidation completeness

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*