### PR TITLE
chore(observability): restore per-field spans on TeamSerializer

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,6 +14,7 @@ from django.utils.dateparse import parse_datetime
 
 from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_view
 from loginas.utils import is_impersonated_session
+from opentelemetry import trace
 from rest_framework import exceptions, request, response, serializers, viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
@@ -73,6 +74,8 @@ from posthog.utils import get_instance_realm, get_instance_region, get_ip_addres
 from products.customer_analytics.backend.models.team_customer_analytics_config import TeamCustomerAnalyticsConfig
 from products.feature_flags.backend.models import TeamFeatureFlagDefaultsConfig
 from products.signals.backend.models import SignalSourceConfig
+
+tracer = trace.get_tracer(__name__)
 
 
 def _format_serializer_errors(serializer_errors: dict) -> str:
@@ -469,23 +472,29 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         )
 
     def to_representation(self, instance):
-        representation = super().to_representation(instance)
+        with tracer.start_as_current_span("team_serializer.default_fields"):
+            representation = super().to_representation(instance)
         # fallback to the default posthog data theme id, if the color feature isn't available e.g. after a downgrade
         if not instance.organization.is_feature_available(AvailableFeature.DATA_COLOR_THEMES):
-            representation["default_data_theme"] = _default_data_color_theme_id()
+            with tracer.start_as_current_span("team_serializer.default_data_theme_fallback"):
+                representation["default_data_theme"] = _default_data_color_theme_id()
 
         return representation
 
+    @tracer.start_as_current_span("team_serializer.effective_membership_level")
     def get_effective_membership_level(self, team: Team) -> OrganizationMembership.Level | None:
         # TODO: Map from user_access_controls
         return self.user_permissions.team(team).effective_membership_level
 
+    @tracer.start_as_current_span("team_serializer.has_group_types")
     def get_has_group_types(self, team: Team) -> bool:
         return bool(cached_group_types_for_team(team))
 
+    @tracer.start_as_current_span("team_serializer.group_types")
     def get_group_types(self, team: Team) -> list[dict[str, Any]]:
         return cached_group_types_for_team(team)
 
+    @tracer.start_as_current_span("team_serializer.live_events_token")
     def get_live_events_token(self, team: Team) -> str | None:
         request = self.context.get("request")
         user_id = request.user.id if request and hasattr(request, "user") and request.user.is_authenticated else None
@@ -502,6 +511,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         )
 
     @extend_schema_field(serializers.ListField(child=serializers.DictField()))
+    @tracer.start_as_current_span("team_serializer.product_intents")
     def get_product_intents(self, obj):
         calculate_product_activation.delay(obj.id, only_calc_if_days_since_last_checked=1)
         return ProductIntent.objects.filter(team=obj).values(
@@ -509,6 +519,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         )
 
     @extend_schema_field(serializers.DictField(child=serializers.BooleanField()))
+    @tracer.start_as_current_span("team_serializer.managed_viewsets")
     def get_managed_viewsets(self, obj):
         from products.data_warehouse.backend.models import DataWarehouseManagedViewSet
         from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind


### PR DESCRIPTION
## Problem

The per-field tracer spans on \`TeamSerializer\` were silently removed and aren't in production. \`#57382\` (\"per-field spans inside team + user serializer\") merged on Sun May 3, then \`#57381\` (\"two small home-view wins in TeamSerializer\") merged shortly after — but \`#57381\` was branched off master *before* \`#57382\` landed, so when it merged it overwrote \`posthog/api/team.py\` without picking up the new instrumentation.

\`user.py\` was untouched and its spans survived. \`team.py\` lost all of:

- \`team_serializer.default_fields\` / \`team_serializer.default_data_theme_fallback\`
- \`team_serializer.effective_membership_level\`
- \`team_serializer.has_group_types\` / \`team_serializer.group_types\`
- \`team_serializer.live_events_token\`
- \`team_serializer.product_intents\`
- \`team_serializer.managed_viewsets\`

In current production traces \`template.team_serializer\` shows up as a single ~500ms blob with no per-field children, so we can't see which field is the hot path.

## Changes

Re-apply the spans on top of the current code. The diff is small and matches what \`#57382\` did, with two cosmetic differences picked up since then:

- \`get_has_group_types\` / \`get_group_types\` now use \`cached_group_types_for_team(team)\` rather than \`get_group_types_for_project(team.project_id)\` — span placement unchanged
- \`get_product_intents\` now uses \`calculate_product_activation.delay(...)\` — span placement unchanged

## How did you test this code?

I'm an agent.

- \`ruff check posthog/api/team.py\` clean
- \`hogli test posthog/api/test/test_team.py -k test_retrieve\` (3 tests) pass

Once deployed I'll re-capture the home-view trace from #57399 conversation and we'll see which \`team_serializer.<field>\` span dominates the ~500ms — informs the next perf PR.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with PostHog Code (claude-opus-4-7)
- Found while investigating why a 524ms \`template.team_serializer\` blob in a production trace had no per-field children, expecting them from \`#57382\`
- \`git show 67714100a56 -- posthog/api/team.py\` confirmed the regression — that commit deleted every \`@tracer.start_as_current_span(\"team_serializer.*\")\` decorator

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*