### PR TITLE
feat(hog-charts): bar chart support in ValueLabels overlay

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { computeBarAtIndex, computeSeriesBars } from '../core/bar-layout'
+import { type BarChartPrivate, computeBarAtIndex, computeSeriesBars } from '../core/bar-layout'
 import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../core/canvas-renderer'
 import { Chart } from '../core/Chart'
 import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
 import {
-    type BarScaleSet,
     computePercentStackData,
     computeStackData,
     createBarScales,
@@ -26,14 +25,7 @@ import type {
 } from '../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../core/types'
 
-// Brand for the private ChartScales._private slot used by BarChart. The base Chart
-// and other chart types treat this as opaque; BarChart's draw callbacks narrow back to it.
-// Mirrors the LineChart pattern — see ARCHITECTURE.md "Passing chart-type-private state to drawStatic".
-interface BarChartPrivate {
-    __barChart: BarScaleSet
-}
-
-function bandCenter(scales: BarScaleSet, label: string): number | undefined {
+function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
     const start = scales.band(label)
     return start == null ? undefined : start + scales.band.bandwidth() / 2
 }
@@ -274,6 +266,7 @@ function BarChartInner<Meta = unknown>({
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}
+            isPercent={barLayout === 'percent'}
         >
             {children}
         </Chart>

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -239,6 +239,7 @@ function LineChartInner<Meta = unknown>({
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}
+            isPercent={percentStackView}
         >
             {children}
         </Chart>

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -86,6 +86,8 @@ export interface ChartProps<Meta = unknown> {
      *  axis (y in horizontal mode). Should be referentially stable; non-stable identities
      *  invalidate the interaction memo on every render. */
     labelToCoord?: (label: string) => number | undefined
+    /** Surfaced on layout context so overlays can default to a percent formatter. */
+    isPercent?: boolean
 }
 
 export function Chart<Meta = unknown>({
@@ -103,6 +105,7 @@ export function Chart<Meta = unknown>({
     children,
     resolveValue,
     labelToCoord,
+    isPercent = false,
 }: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
@@ -217,8 +220,10 @@ export function Chart<Meta = unknown>({
             theme,
             resolveValue: stableResolveValue,
             canvasBounds,
+            axisOrientation,
+            isPercent,
         }
-    }, [scales, dimensions, labels, coloredSeries, theme, stableResolveValue, canvasBounds])
+    }, [scales, dimensions, labels, coloredSeries, theme, stableResolveValue, canvasBounds, axisOrientation, isPercent])
 
     const hoverValue = useMemo<ChartHoverContextValue>(() => ({ hoverIndex }), [hoverIndex])
 

--- a/frontend/src/lib/hog-charts/core/bar-layout.ts
+++ b/frontend/src/lib/hog-charts/core/bar-layout.ts
@@ -1,6 +1,17 @@
 import type { BarRect, BarRoundedCorners } from './canvas-renderer'
 import type { BarScaleSet, StackedBand } from './scales'
-import type { Series } from './types'
+import type { ChartScales, Series } from './types'
+
+/** Brand for the BarChart `ChartScales._private` slot — populated by BarChart, narrowed
+ *  by its draw callbacks and by overlays that detect bar-chart presence (ValueLabels). */
+export interface BarChartPrivate {
+    __barChart: BarScaleSet
+}
+
+export function getBarChartPrivate(scales: ChartScales): BarChartPrivate | undefined {
+    const slot = scales._private as BarChartPrivate | undefined
+    return slot && '__barChart' in slot ? slot : undefined
+}
 
 export type SeriesBarLayout = (BarRect | null)[]
 

--- a/frontend/src/lib/hog-charts/core/chart-context.test.tsx
+++ b/frontend/src/lib/hog-charts/core/chart-context.test.tsx
@@ -15,6 +15,8 @@ const LAYOUT: ChartLayoutContextValue = {
     theme: THEME,
     resolveValue: (s, i) => s.data[i] ?? 0,
     canvasBounds: () => null,
+    axisOrientation: 'vertical',
+    isPercent: false,
 }
 
 describe('chart-context split', () => {

--- a/frontend/src/lib/hog-charts/core/chart-context.ts
+++ b/frontend/src/lib/hog-charts/core/chart-context.ts
@@ -24,6 +24,10 @@ export interface ChartLayoutContextValue<Meta = unknown> {
      *  This is a getter (not a value) because DOMRect changes on scroll. Useful for
      *  custom overlays that portal positioned content outside the chart wrapper. */
     canvasBounds: () => DOMRect | null
+    /** `horizontal` swaps which axis carries the value scale (`scales.y` returns x-pixels). */
+    axisOrientation: 'vertical' | 'horizontal'
+    /** True for BarChart `barLayout: 'percent'` / LineChart `percentStackView`. */
+    isPercent: boolean
 }
 
 /** Hover state isolated from layout so mousemoves don't invalidate every overlay.

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.test.tsx
@@ -32,6 +32,8 @@ const CONTEXT: BaseChartContext = {
     theme: THEME,
     resolveValue: (s, i) => s.data[i] ?? 0,
     canvasBounds: () => null,
+    axisOrientation: 'vertical',
+    isPercent: false,
     hoverIndex: -1,
 }
 

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -38,6 +38,8 @@ function makeContext(series: ResolvedSeries[], overrides: Partial<BaseChartConte
         theme: DEFAULT_THEME,
         resolveValue: DEFAULT_RESOLVE,
         canvasBounds: () => null,
+        axisOrientation: 'vertical',
+        isPercent: false,
         hoverIndex: -1,
         ...overrides,
     }
@@ -110,13 +112,13 @@ describe('ValueLabels', () => {
         const { container } = renderInChart(makeContext(series), <ValueLabels />)
         const divs = labelDivs(container)
         expect(divs).toHaveLength(5)
-        // positive values (50, 25, 75) render above → transform includes 'calc(-100%'
+        // positive values (50, 25, 75) render above → transform translates up by full height
         // negative values (-50, -25) render below → transform is plain translateX
         const values = [50, -50, 25, -25, 75]
         divs.forEach((d, i) => {
             const value = values[i]
             if (value >= 0) {
-                expect(d.style.transform).toContain('calc(-100%')
+                expect(d.style.transform).toBe('translate(-50%, -100%)')
             } else {
                 expect(d.style.transform).toBe('translateX(-50%)')
             }
@@ -246,5 +248,84 @@ describe('ValueLabels', () => {
         const divs = labelDivs(container)
         expect(divs).toHaveLength(1)
         expect(divs[0].style.borderColor).toBe('#222222')
+    })
+
+    it.each<[string, number, string, string]>([
+        ['positive value past the right edge', 50, '192px', 'translateY(-50%)'],
+        ['negative value past the left edge', -50, '544px', 'translate(-100%, -50%)'],
+    ])('horizontal: places %s', (_name, value, expectedLeft, expectedTransform) => {
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [value] }]
+        const ctx = makeContext(series, {
+            axisOrientation: 'horizontal',
+            labels: ['Mon'],
+            scales: { x: () => 60, y: yScale, yTicks: () => [0, 50, 100] },
+        })
+        const divs = labelDivs(renderInChart(ctx, <ValueLabels />).container)
+        expect(divs[0].style.left).toBe(expectedLeft)
+        expect(divs[0].style.transform).toBe(expectedTransform)
+    })
+
+    it('horizontal: drops vertically overlapping labels via per-series collision avoidance', () => {
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [40, 60] }]
+        const ctx = makeContext(series, {
+            axisOrientation: 'horizontal',
+            labels: ['A', 'B'],
+            scales: { x: () => 200, y: yScale, yTicks: () => [0, 50, 100] },
+        })
+        expect(labelDivs(renderInChart(ctx, <ValueLabels />).container)).toHaveLength(1)
+    })
+
+    describe('stack-total mode', () => {
+        it('sums visible series per band, skips zero totals and excluded series', () => {
+            const series: ResolvedSeries[] = [
+                { key: 'a', label: 'A', color: '#112233', data: [10, 0, 30] },
+                { key: 'b', label: 'B', color: '#445566', data: [5, 0, 5] },
+                { key: 'c', label: 'C', color: '#778899', data: [99, 99, 99], visibility: { fromValueLabels: true } },
+            ]
+            const ctx = makeContext(series, { labels: ['Mon', 'Tue', 'Wed'] })
+            const divs = labelDivs(renderInChart(ctx, <ValueLabels mode="stack-total" />).container)
+            expect(divs.map((d) => d.textContent)).toEqual(['15', '35'])
+            // Total label uses the topmost visible series color.
+            expect(divs[0].style.backgroundColor).toBe('rgb(68, 85, 102)')
+        })
+    })
+
+    describe('minBarSize', () => {
+        const barPrivate = { __barChart: { band: () => 0, value: () => 0 } as unknown }
+        const barScales = { x: xScale, y: yScale, yTicks: () => [0, 50, 100], _private: barPrivate }
+
+        it.each<[string, number[], string[], { minBarSize?: number; bar?: boolean; mode?: 'stack-total' }]>([
+            // segment sizes: 1→3.52 px, 2→7.04 px (filtered <16); 50→176 px kept
+            ['filters narrow segments by default on bar charts', [1, 2, 50, 1, 2], ['50'], { bar: true }],
+            ['minBarSize=0 keeps everything', [1, 50], ['1', '50'], { minBarSize: 0, bar: true }],
+            ['ignored on non-bar charts', [1, 2], ['1', '2'], {}],
+        ])('%s', (_name, data, expected, { minBarSize, bar }) => {
+            const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data }]
+            const labels = data.length === 5 ? LABELS : ['Mon', 'Tue']
+            const ctx = makeContext(series, bar ? { labels, scales: barScales } : { labels })
+            const { container } = renderInChart(ctx, <ValueLabels minBarSize={minBarSize} />)
+            expect(labelDivs(container).map((d) => d.textContent)).toEqual(expected)
+        })
+
+        it('drops bands whose stack-total size is below minBarSize', () => {
+            // Mon total=2 → 7 px (drop), Tue total=55 → 194 px (keep).
+            const series: ResolvedSeries[] = [
+                { key: 'a', label: 'A', color: '#a00', data: [1, 50] },
+                { key: 'b', label: 'B', color: '#0a0', data: [1, 5] },
+            ]
+            const ctx = makeContext(series, { labels: ['Mon', 'Tue'], scales: barScales })
+            const divs = labelDivs(renderInChart(ctx, <ValueLabels mode="stack-total" />).container)
+            expect(divs.map((d) => d.textContent)).toEqual(['55'])
+        })
+    })
+
+    it.each<[string, ((v: number) => string) | undefined, string[]]>([
+        ['default percent formatter', undefined, ['25%', '50%', '75%']],
+        ['consumer can still override', (v) => `${(v * 100).toFixed(1)}%`, ['25.0%', '50.0%', '75.0%']],
+    ])('isPercent: %s', (_name, valueFormatter, expected) => {
+        const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [0.25, 0.5, 0.75] }]
+        const ctx = makeContext(series, { isPercent: true, labels: ['Mon', 'Tue', 'Wed'] })
+        const { container } = renderInChart(ctx, <ValueLabels valueFormatter={valueFormatter} />)
+        expect(labelDivs(container).map((d) => d.textContent)).toEqual(expected)
     })
 })

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.test.tsx
@@ -276,6 +276,15 @@ describe('ValueLabels', () => {
     })
 
     describe('stack-total mode', () => {
+        it('honours maxPointsPerSeries against the number of bands', () => {
+            const series: ResolvedSeries[] = [{ key: 's', label: 'S', color: '#f00', data: [10, 20, 30, 40, 50] }]
+            const { container } = renderInChart(
+                makeContext(series),
+                <ValueLabels mode="stack-total" maxPointsPerSeries={3} />
+            )
+            expect(labelDivs(container)).toHaveLength(0)
+        })
+
         it('sums visible series per band, skips zero totals and excluded series', () => {
             const series: ResolvedSeries[] = [
                 { key: 'a', label: 'A', color: '#112233', data: [10, 0, 30] },

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -1,22 +1,31 @@
 import React, { useMemo } from 'react'
 
+import { getBarChartPrivate } from '../core/bar-layout'
 import { useChartLayout } from '../core/chart-context'
 import { DEFAULT_Y_AXIS_ID } from '../core/types'
 import type { ChartScales, ResolvedSeries, ResolveValueFn } from '../core/types'
 
+export type ValueLabelsMode = 'per-segment' | 'stack-total'
+
 export interface ValueLabelsProps {
-    /** Formats the value shown on each label. Defaults to `value.toLocaleString()`. */
     valueFormatter?: (value: number, seriesIndex: number, dataIndex: number) => string
-    /** Minimum horizontal gap (in px) required between adjacent labels. Defaults to 4. */
     minGap?: number
     /** Series with more than this many data points are skipped entirely to avoid
      *  rendering hundreds of DOM nodes on dense charts. Defaults to 100. */
     maxPointsPerSeries?: number
+    /** `stack-total`: one label per band placed at the topmost cap, summing visible series.
+     *  No effect on non-stacked layouts. Defaults to `per-segment`. */
+    mode?: ValueLabelsMode
+    /** On bar charts, skip labels whose bar size on the value axis is smaller than this
+     *  (CSS pixels). Defaults to 16; ignored on non-bar charts. */
+    minBarSize?: number
 }
 
 const LABEL_FONT =
     '600 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
-const LABEL_VERTICAL_OFFSET = 0
+const LABEL_HEIGHT = 22
+const STACK_TOTAL_KEY = '__stack_total__'
+const DEFAULT_MIN_BAR_SIZE = 16
 
 let measureCtx: CanvasRenderingContext2D | null = null
 function getMeasureCtx(): CanvasRenderingContext2D | null {
@@ -25,8 +34,6 @@ function getMeasureCtx(): CanvasRenderingContext2D | null {
     }
     return measureCtx
 }
-
-const LABEL_HEIGHT = 22
 
 interface Candidate {
     key: string
@@ -39,91 +46,185 @@ interface Candidate {
     above: boolean
 }
 
-function resolveYScale(s: ResolvedSeries, scales: ChartScales): (value: number) => number {
+function resolveYScale(s: { yAxisId?: string }, scales: ChartScales): (value: number) => number {
     const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
     return scales.yAxes?.[axisId]?.scale ?? scales.y
 }
 
-function buildCandidates(
-    series: ResolvedSeries[],
-    labels: string[],
-    scales: ChartScales,
-    resolveValue: ResolveValueFn,
-    valueFormatter: ValueLabelsProps['valueFormatter'],
+function defaultPercentFormatter(v: number): string {
+    return `${Math.round(v * 100)}%`
+}
+function defaultLocaleFormatter(v: number): string {
+    return v.toLocaleString()
+}
+
+interface BuildCandidatesArgs {
+    series: ResolvedSeries[]
+    labels: string[]
+    scales: ChartScales
+    resolveValue: ResolveValueFn
+    valueFormatter: NonNullable<ValueLabelsProps['valueFormatter']>
     maxPointsPerSeries: number
-): Candidate[] {
+    isHorizontal: boolean
+    mode: ValueLabelsMode
+    minBarSize: number
+    isBarChart: boolean
+}
+
+function pushCandidate(
+    out: Candidate[],
+    ctx: CanvasRenderingContext2D | null,
+    isHorizontal: boolean,
+    key: string,
+    seriesIndex: number,
+    color: string,
+    text: string,
+    categoricalCoord: number,
+    valueCoord: number,
+    above: boolean
+): void {
+    const width = ctx ? ctx.measureText(text).width : text.length * 6
+    out.push({
+        key,
+        seriesIndex,
+        text,
+        x: isHorizontal ? valueCoord : categoricalCoord,
+        y: isHorizontal ? categoricalCoord : valueCoord,
+        width,
+        color,
+        above,
+    })
+}
+
+function buildCandidates(args: BuildCandidatesArgs): Candidate[] {
     const ctx = getMeasureCtx()
     if (ctx) {
         ctx.font = LABEL_FONT
     }
+    const { series, labels, scales, resolveValue, valueFormatter, mode, isHorizontal, isBarChart, minBarSize } = args
+    const out: Candidate[] = []
 
-    const candidates: Candidate[] = []
+    if (mode === 'stack-total') {
+        const visible = series.filter((s) => !s.visibility?.excluded && !s.visibility?.fromValueLabels)
+        if (visible.length === 0) {
+            return out
+        }
+        const yScale = resolveYScale(visible[0], scales)
+        const topColor = visible[visible.length - 1].color
+        for (let dIdx = 0; dIdx < labels.length; dIdx++) {
+            let total = 0
+            let count = 0
+            for (const s of visible) {
+                const v = s.data[dIdx]
+                if (typeof v === 'number' && isFinite(v)) {
+                    total += v
+                    count++
+                }
+            }
+            if (count === 0 || total === 0 || !isFinite(total)) {
+                continue
+            }
+            const categoricalCoord = scales.x(labels[dIdx])
+            const valueCoord = yScale(total)
+            if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
+                continue
+            }
+            if (isBarChart && minBarSize > 0) {
+                const baseline = yScale(0)
+                if (isFinite(baseline) && Math.abs(valueCoord - baseline) < minBarSize) {
+                    continue
+                }
+            }
+            pushCandidate(
+                out,
+                ctx,
+                isHorizontal,
+                `${STACK_TOTAL_KEY}-${dIdx}`,
+                -1,
+                topColor,
+                valueFormatter(total, -1, dIdx),
+                categoricalCoord,
+                valueCoord,
+                total >= 0
+            )
+        }
+        return out
+    }
 
     for (let sIdx = 0; sIdx < series.length; sIdx++) {
         const s = series[sIdx]
-        if (s.visibility?.excluded || s.visibility?.fromValueLabels) {
-            continue
-        }
-        if (s.data.length > maxPointsPerSeries) {
+        if (s.visibility?.excluded || s.visibility?.fromValueLabels || s.data.length > args.maxPointsPerSeries) {
             continue
         }
         const yScale = resolveYScale(s, scales)
-
         for (let dIdx = 0; dIdx < s.data.length && dIdx < labels.length; dIdx++) {
             const rawValue = s.data[dIdx]
             if (typeof rawValue !== 'number' || !isFinite(rawValue) || rawValue === 0) {
                 continue
             }
             const yValue = resolveValue(s, dIdx)
-            if (typeof yValue !== 'number' || !isFinite(yValue)) {
+            const categoricalCoord = scales.x(labels[dIdx])
+            const valueCoord = isFinite(yValue) ? yScale(yValue) : NaN
+            if (
+                typeof yValue !== 'number' ||
+                !isFinite(yValue) ||
+                categoricalCoord == null ||
+                !isFinite(categoricalCoord) ||
+                !isFinite(valueCoord)
+            ) {
                 continue
             }
-            const x = scales.x(labels[dIdx])
-            if (x == null || !isFinite(x)) {
-                continue
+            if (isBarChart && minBarSize > 0) {
+                // For stacked: yValue is the segment top; bottom = top - rawValue.
+                // For grouped (no stacking): bottom = 0. Either way: |yScale(top) - yScale(top - raw)|.
+                const segmentBottom = yScale(yValue - rawValue)
+                if (isFinite(segmentBottom) && Math.abs(valueCoord - segmentBottom) < minBarSize) {
+                    continue
+                }
             }
-            const y = yScale(yValue)
-            if (!isFinite(y)) {
-                continue
-            }
-            const text = valueFormatter ? valueFormatter(rawValue, sIdx, dIdx) : rawValue.toLocaleString()
-            const width = ctx ? ctx.measureText(text).width : text.length * 6
-            candidates.push({
-                key: `${s.key}-${dIdx}`,
-                seriesIndex: sIdx,
-                text,
-                x,
-                y,
-                width,
-                color: s.color,
-                above: yValue >= 0,
-            })
+            pushCandidate(
+                out,
+                ctx,
+                isHorizontal,
+                `${s.key}-${dIdx}`,
+                sIdx,
+                s.color,
+                valueFormatter(rawValue, sIdx, dIdx),
+                categoricalCoord,
+                valueCoord,
+                yValue >= 0
+            )
         }
     }
-
-    return candidates
+    return out
 }
 
-function labelRect(c: Candidate): { left: number; right: number; top: number; bottom: number } {
+interface Rect {
+    left: number
+    right: number
+    top: number
+    bottom: number
+}
+
+function labelRect(c: Candidate, isHorizontal: boolean): Rect {
+    if (isHorizontal) {
+        const halfH = LABEL_HEIGHT / 2
+        const left = c.above ? c.x : c.x - c.width
+        return { left, right: left + c.width, top: c.y - halfH, bottom: c.y + halfH }
+    }
     const halfW = c.width / 2
     const top = c.above ? c.y - LABEL_HEIGHT : c.y
     return { left: c.x - halfW, right: c.x + halfW, top, bottom: top + LABEL_HEIGHT }
 }
 
-function rectsOverlap(
-    a: { left: number; right: number; top: number; bottom: number },
-    b: { left: number; right: number; top: number; bottom: number },
-    gap: number
-): boolean {
+function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
     return a.left < b.right + gap && a.right + gap > b.left && a.top < b.bottom + gap && a.bottom + gap > b.top
 }
 
-function applyCollisionAvoidance(candidates: Candidate[], minGap: number): Candidate[] {
+function applyCollisionAvoidance(candidates: Candidate[], minGap: number, isHorizontal: boolean): Candidate[] {
     if (candidates.length === 0) {
         return candidates
     }
-
-    // First pass: per-series horizontal dedup
     const bySeries: Map<number, Candidate[]> = new Map()
     for (const c of candidates) {
         const bucket = bySeries.get(c.seriesIndex)
@@ -134,27 +235,36 @@ function applyCollisionAvoidance(candidates: Candidate[], minGap: number): Candi
         }
     }
 
-    const afterHorizontal: Candidate[] = []
+    const afterPrimary: Candidate[] = []
     for (const group of bySeries.values()) {
-        group.sort((a, b) => a.x - b.x)
-        let lastRightEdge = -Infinity
-        for (const c of group) {
-            const halfWidth = c.width / 2
-            const leftEdge = c.x - halfWidth
-            if (leftEdge >= lastRightEdge + minGap) {
-                afterHorizontal.push(c)
-                lastRightEdge = c.x + halfWidth
+        if (isHorizontal) {
+            group.sort((a, b) => a.y - b.y)
+            const halfH = LABEL_HEIGHT / 2
+            let lastBottom = -Infinity
+            for (const c of group) {
+                if (c.y - halfH >= lastBottom + minGap) {
+                    afterPrimary.push(c)
+                    lastBottom = c.y + halfH
+                }
+            }
+        } else {
+            group.sort((a, b) => a.x - b.x)
+            let lastRight = -Infinity
+            for (const c of group) {
+                const halfW = c.width / 2
+                if (c.x - halfW >= lastRight + minGap) {
+                    afterPrimary.push(c)
+                    lastRight = c.x + halfW
+                }
             }
         }
     }
 
-    // Second pass: cross-series 2D overlap removal (earlier series win)
     const visible: Candidate[] = []
-    const placedRects: { left: number; right: number; top: number; bottom: number }[] = []
-    for (const c of afterHorizontal) {
-        const rect = labelRect(c)
-        const overlaps = placedRects.some((placed) => rectsOverlap(rect, placed, minGap))
-        if (!overlaps) {
+    const placedRects: Rect[] = []
+    for (const c of afterPrimary) {
+        const rect = labelRect(c, isHorizontal)
+        if (!placedRects.some((p) => rectsOverlap(rect, p, minGap))) {
             visible.push(c)
             placedRects.push(rect)
         }
@@ -176,17 +286,58 @@ const LABEL_STYLE_BASE: React.CSSProperties = {
     whiteSpace: 'nowrap',
 }
 
+function transformFor(c: Candidate, isHorizontal: boolean): string {
+    if (isHorizontal) {
+        return c.above ? 'translateY(-50%)' : 'translate(-100%, -50%)'
+    }
+    return c.above ? 'translate(-50%, -100%)' : 'translateX(-50%)'
+}
+
 export function ValueLabels({
     valueFormatter,
     minGap = 4,
     maxPointsPerSeries = 100,
+    mode = 'per-segment',
+    minBarSize = DEFAULT_MIN_BAR_SIZE,
 }: ValueLabelsProps): React.ReactElement | null {
-    const { series, scales, labels, theme, resolveValue } = useChartLayout()
+    const { series, scales, labels, theme, resolveValue, axisOrientation, isPercent } = useChartLayout()
+    const isHorizontal = axisOrientation === 'horizontal'
+    const isBarChart = !!getBarChartPrivate(scales)
 
-    const visible = useMemo(() => {
-        const candidates = buildCandidates(series, labels, scales, resolveValue, valueFormatter, maxPointsPerSeries)
-        return applyCollisionAvoidance(candidates, minGap)
-    }, [series, labels, scales, resolveValue, valueFormatter, minGap, maxPointsPerSeries])
+    const formatter = valueFormatter ?? (isPercent ? defaultPercentFormatter : defaultLocaleFormatter)
+
+    const visible = useMemo(
+        () =>
+            applyCollisionAvoidance(
+                buildCandidates({
+                    series,
+                    labels,
+                    scales,
+                    resolveValue,
+                    valueFormatter: formatter,
+                    maxPointsPerSeries,
+                    isHorizontal,
+                    mode,
+                    minBarSize,
+                    isBarChart,
+                }),
+                minGap,
+                isHorizontal
+            ),
+        [
+            series,
+            labels,
+            scales,
+            resolveValue,
+            formatter,
+            minGap,
+            maxPointsPerSeries,
+            isHorizontal,
+            mode,
+            minBarSize,
+            isBarChart,
+        ]
+    )
 
     if (visible.length === 0) {
         return null
@@ -196,23 +347,22 @@ export function ValueLabels({
 
     return (
         <>
-            {visible.map((c) => {
-                const style: React.CSSProperties = {
-                    ...LABEL_STYLE_BASE,
-                    backgroundColor: c.color,
-                    borderColor,
-                    left: Math.round(c.x),
-                    top: Math.round(c.above ? c.y : c.y + LABEL_VERTICAL_OFFSET),
-                    transform: c.above
-                        ? `translate(-50%, calc(-100% - ${LABEL_VERTICAL_OFFSET}px))`
-                        : 'translateX(-50%)',
-                }
-                return (
-                    <div key={c.key} data-attr="hog-chart-value-label" style={style}>
-                        {c.text}
-                    </div>
-                )
-            })}
+            {visible.map((c) => (
+                <div
+                    key={c.key}
+                    data-attr="hog-chart-value-label"
+                    style={{
+                        ...LABEL_STYLE_BASE,
+                        backgroundColor: c.color,
+                        borderColor,
+                        left: Math.round(c.x),
+                        top: Math.round(c.y),
+                        transform: transformFor(c, isHorizontal),
+                    }}
+                >
+                    {c.text}
+                </div>
+            ))}
         </>
     )
 }

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -106,6 +106,9 @@ function buildCandidates(args: BuildCandidatesArgs): Candidate[] {
     const out: Candidate[] = []
 
     if (mode === 'stack-total') {
+        if (labels.length > args.maxPointsPerSeries) {
+            return out
+        }
         const visible = series.filter((s) => !s.visibility?.excluded && !s.visibility?.fromValueLabels)
         if (visible.length === 0) {
             return out

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -102,58 +102,68 @@ function buildCandidates(args: BuildCandidatesArgs): Candidate[] {
     if (ctx) {
         ctx.font = LABEL_FONT
     }
-    const { series, labels, scales, resolveValue, valueFormatter, mode, isHorizontal, isBarChart, minBarSize } = args
-    const out: Candidate[] = []
+    return args.mode === 'stack-total' ? buildStackTotal(args, ctx) : buildPerSegment(args, ctx)
+}
 
-    if (mode === 'stack-total') {
-        if (labels.length > args.maxPointsPerSeries) {
-            return out
+function bandTotal(visible: ResolvedSeries[], dIdx: number): number | null {
+    let total = 0
+    let count = 0
+    for (const s of visible) {
+        const v = s.data[dIdx]
+        if (typeof v === 'number' && isFinite(v)) {
+            total += v
+            count++
         }
-        const visible = series.filter((s) => !s.visibility?.excluded && !s.visibility?.fromValueLabels)
-        if (visible.length === 0) {
-            return out
-        }
-        const yScale = resolveYScale(visible[0], scales)
-        const topColor = visible[visible.length - 1].color
-        for (let dIdx = 0; dIdx < labels.length; dIdx++) {
-            let total = 0
-            let count = 0
-            for (const s of visible) {
-                const v = s.data[dIdx]
-                if (typeof v === 'number' && isFinite(v)) {
-                    total += v
-                    count++
-                }
-            }
-            if (count === 0 || total === 0 || !isFinite(total)) {
-                continue
-            }
-            const categoricalCoord = scales.x(labels[dIdx])
-            const valueCoord = yScale(total)
-            if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
-                continue
-            }
-            if (isBarChart && minBarSize > 0) {
-                const baseline = yScale(0)
-                if (isFinite(baseline) && Math.abs(valueCoord - baseline) < minBarSize) {
-                    continue
-                }
-            }
-            pushCandidate(
-                out,
-                ctx,
-                isHorizontal,
-                `${STACK_TOTAL_KEY}-${dIdx}`,
-                -1,
-                topColor,
-                valueFormatter(total, -1, dIdx),
-                categoricalCoord,
-                valueCoord,
-                total >= 0
-            )
-        }
+    }
+    return count === 0 || total === 0 || !isFinite(total) ? null : total
+}
+
+function buildStackTotal(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2D | null): Candidate[] {
+    const { series, labels, scales, valueFormatter, isHorizontal, isBarChart, minBarSize } = args
+    const out: Candidate[] = []
+    if (labels.length > args.maxPointsPerSeries) {
         return out
     }
+    const visible = series.filter((s) => !s.visibility?.excluded && !s.visibility?.fromValueLabels)
+    if (visible.length === 0) {
+        return out
+    }
+    const yScale = resolveYScale(visible[0], scales)
+    const topColor = visible[visible.length - 1].color
+    const baseline = isBarChart && minBarSize > 0 ? yScale(0) : NaN
+
+    for (let dIdx = 0; dIdx < labels.length; dIdx++) {
+        const total = bandTotal(visible, dIdx)
+        if (total === null) {
+            continue
+        }
+        const categoricalCoord = scales.x(labels[dIdx])
+        const valueCoord = yScale(total)
+        if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
+            continue
+        }
+        if (isFinite(baseline) && Math.abs(valueCoord - baseline) < minBarSize) {
+            continue
+        }
+        pushCandidate(
+            out,
+            ctx,
+            isHorizontal,
+            `${STACK_TOTAL_KEY}-${dIdx}`,
+            -1,
+            topColor,
+            valueFormatter(total, -1, dIdx),
+            categoricalCoord,
+            valueCoord,
+            total >= 0
+        )
+    }
+    return out
+}
+
+function buildPerSegment(args: BuildCandidatesArgs, ctx: CanvasRenderingContext2D | null): Candidate[] {
+    const { series, labels, scales, resolveValue, valueFormatter, isHorizontal, isBarChart, minBarSize } = args
+    const out: Candidate[] = []
 
     for (let sIdx = 0; sIdx < series.length; sIdx++) {
         const s = series[sIdx]
@@ -167,15 +177,12 @@ function buildCandidates(args: BuildCandidatesArgs): Candidate[] {
                 continue
             }
             const yValue = resolveValue(s, dIdx)
+            if (typeof yValue !== 'number' || !isFinite(yValue)) {
+                continue
+            }
             const categoricalCoord = scales.x(labels[dIdx])
-            const valueCoord = isFinite(yValue) ? yScale(yValue) : NaN
-            if (
-                typeof yValue !== 'number' ||
-                !isFinite(yValue) ||
-                categoricalCoord == null ||
-                !isFinite(categoricalCoord) ||
-                !isFinite(valueCoord)
-            ) {
+            const valueCoord = yScale(yValue)
+            if (categoricalCoord == null || !isFinite(categoricalCoord) || !isFinite(valueCoord)) {
                 continue
             }
             if (isBarChart && minBarSize > 0) {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -8,6 +8,7 @@ import type { ChartScales, ResolvedSeries, ResolveValueFn } from '../core/types'
 export type ValueLabelsMode = 'per-segment' | 'stack-total'
 
 export interface ValueLabelsProps {
+    /** `seriesIndex` is `-1` for stack-total labels (no single source series). */
     valueFormatter?: (value: number, seriesIndex: number, dataIndex: number) => string
     minGap?: number
     /** Series with more than this many data points are skipped entirely to avoid

--- a/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.tsx
@@ -3,8 +3,9 @@ import posthog from 'posthog-js'
 import { useCallback, useMemo, type ErrorInfo } from 'react'
 
 import { buildTheme } from 'lib/charts/utils/theme'
-import { BarChart, buildYTickFormatter, createXAxisTickCallback } from 'lib/hog-charts'
+import { BarChart, buildYTickFormatter, createXAxisTickCallback, ValueLabels } from 'lib/hog-charts'
 import type { BarChartConfig, PointClickData, TooltipContext } from 'lib/hog-charts'
+import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -88,6 +89,7 @@ export function TrendsBarChart({ context }: TrendsBarChartProps): JSX.Element | 
         querySource,
         getTrendsColor,
         getTrendsHidden,
+        showValuesOnSeries,
     } = useValues(trendsDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
@@ -176,6 +178,11 @@ export function TrendsBarChart({ context }: TrendsBarChartProps): JSX.Element | 
         ]
     )
 
+    const valueLabelFormatter = useCallback(
+        (value: number) => formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency),
+        [trendsFilter, isPercentStackView, baseCurrency]
+    )
+
     const onPointClick = useCallback(
         (clickData: PointClickData) => {
             if (isAggregated) {
@@ -260,6 +267,8 @@ export function TrendsBarChart({ context }: TrendsBarChartProps): JSX.Element | 
             className="BarGraph"
             dataAttr={isAggregated ? 'trend-bar-value-graph' : 'trend-bar-graph'}
             onError={handleChartError}
-        />
+        >
+            {showValuesOnSeries && <ValueLabels valueFormatter={valueLabelFormatter} />}
+        </BarChart>
     )
 }


### PR DESCRIPTION
## Problem

The existing `<ValueLabels>` overlay landed correct labels for vertical bars by happy accident, but horizontal mode positioned them on the wrong axes, there was no stack-total mode, no narrow-bar collision avoidance, and percent-stacked bars showed raw `0.5`-style labels. `TrendsBarChart` also wasn't wired up to the overlay at all, so toggling "show values on series" did nothing for bar charts.

## Changes

- Surface `axisOrientation` and `isPercent` on `ChartLayoutContext`; `LineChart`/`BarChart` populate them from their configs so overlays don't read chart-specific config.
- Move `BarChartPrivate` to `core/bar-layout.ts` with a `getBarChartPrivate` narrowing helper so overlays can detect bar-chart presence without reaching into BarChart internals.
- Make `<ValueLabels>` orientation-aware: in horizontal mode, anchor on the bar's value-end side, dedupe along the categorical (y) axis.
- Add `mode: 'per-segment' | 'stack-total'` — stack-total renders one label per band at the topmost cap, summing visible series.
- Add `minBarSize` (default 16, bar charts only) to skip labels for bars too narrow on the value axis.
- Default the formatter to `${Math.round(v * 100)}%` when the parent chart is in a percent layout; consumers can still override via `valueFormatter`.
- Wire `<ValueLabels />` into `TrendsBarChart` under the same `showValuesOnSeries` gate `TrendsLineChart` uses, with the `formatPercentStackAxisValue` formatter mirroring the line adapter.
- Stories: split into a stacked PR (#57407) for the bar story coverage; #57415 unwires `TrendsBarChart` from `Trends.tsx` since it's not production-ready.

## How did you test this code?
tests, manually

## Publish to changelog?
no

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code. Stage 4 of an ongoing hog-charts migration; the prompt specified the desired API shape (orientation flag in context, `mode`/`minBarSize` props on `<ValueLabels>`, percent formatter default, TrendsBarChart wiring) and the implementation followed it. Notable decisions:

- Chose to surface orientation and percent-mode on `ChartLayoutContext` (a generic concept) rather than threading them through props or via `_private` (which is bar-chart-specific).
- Moved `BarChartPrivate` from a local interface in `BarChart.tsx` to `core/bar-layout.ts` so overlays can narrow `_private` without an import cycle.
- Used `seriesIndex = -1` for stack-total candidates so they all land in the same per-series collision-avoidance bucket and dedupe along the categorical axis.
- After review: `buildCandidates` was split into `buildPerSegment` and `buildStackTotal` (with an extracted `bandTotal` helper) for readability.