### PR TITLE
fix(visual-review): stop stale-run banner collapsing into a vertical strip

### DIFF
--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -163,7 +163,7 @@ function RunInProgressEmptyState({
             data-attr="visual-review-run-in-progress"
         >
             {isStale ? (
-                <LemonBanner type="warning" className="max-w-lg mb-4">
+                <LemonBanner type="warning" className="w-full max-w-lg mb-4">
                     The CI job hasn't reported back.{' '}
                     {ciJobUrl ? (
                         <Link to={ciJobUrl} target="_blank" className="font-semibold">


### PR DESCRIPTION
## Problem

On the visual review run scene, when a run has been stuck waiting for snapshots for over 15 minutes, the warning `LemonBanner` rendered as a tall narrow vertical strip instead of a normal banner.

The cause: the empty-state container is `flex flex-col items-center`. `items-center` doesn't stretch children on the cross axis, so the banner sized to its content. `LemonBanner`'s inner content wrapper has `overflow-hidden` (which sets `min-width: 0`), so the text was free to wrap to single-character width.

## Changes

Added `w-full` alongside `max-w-lg` on the banner so it fills the parent up to 32rem.

## How did you test this code?

I'm an agent. I did not run the UI manually. I located the failing component by inspecting the screenshot and the surrounding flex layout, and traced the constraint through `LemonBanner`'s SCSS and JSX.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7)
- Human prompt: "the visual regression scene when its waiting for snapshots has a tall narrow lemonbanner" (with screenshot)
- The fix is a one-token CSS class addition; no behavioural change beyond layout.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*