### PR TITLE
feat(hog-charts): bar value-labels storybook coverage

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { BarChart } from 'lib/hog-charts'
+import { BarChart, ValueLabels } from 'lib/hog-charts'
 import type { BarChartConfig, Series } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../story-helpers'
@@ -27,6 +27,29 @@ export const StackedMixedSign: Story = {
         return (
             <Stage>
                 <BarChart series={series} labels={DAYS} config={config} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
+/** Pins the regression that ValueLabels swaps placement axes when horizontal. */
+export const WithValueLabelsHorizontal: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const series: Series[] = [
+            { key: 'desktop', label: 'Desktop', color: '', data: [40, 38, 44, 41, 45, 47, 46] },
+            { key: 'mobile', label: 'Mobile', color: '', data: [22, 25, 18, 24, 26, 28, 27] },
+        ]
+        const config: BarChartConfig = {
+            showGrid: true,
+            barLayout: 'grouped',
+            axisOrientation: 'horizontal',
+        }
+        return (
+            <Stage>
+                <BarChart series={series} labels={DAYS} config={config} theme={theme}>
+                    <ValueLabels />
+                </BarChart>
             </Stage>
         )
     },

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.stories.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { LineChart, ValueLabels } from 'lib/hog-charts'
-import type { LineChartConfig, Series } from 'lib/hog-charts'
+import { BarChart, LineChart, ValueLabels } from 'lib/hog-charts'
+import type { BarChartConfig, LineChartConfig, Series } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../story-helpers'
 
@@ -155,6 +155,36 @@ export const CrossSeriesOverlapRemoval: Story = {
         )
     },
 }
+
+const BAR_SERIES: Series[] = [
+    { key: 'desktop', label: 'Desktop', color: '', data: [40, 38, 44, 41, 45, 47, 46] },
+    { key: 'mobile', label: 'Mobile', color: '', data: [22, 25, 18, 24, 26, 28, 27] },
+    { key: 'tablet', label: 'Tablet', color: '', data: [10, 12, 9, 11, 13, 14, 12] },
+]
+
+function makeBarStory(config: BarChartConfig, mode?: 'per-segment' | 'stack-total'): Story {
+    return {
+        render: () => {
+            const theme = useReactiveTheme()
+            return (
+                <Stage>
+                    <BarChart series={BAR_SERIES} labels={LABELS} config={config} theme={theme}>
+                        <ValueLabels mode={mode} />
+                    </BarChart>
+                </Stage>
+            )
+        },
+    }
+}
+
+export const VerticalStackedBars = makeBarStory({ showGrid: true, barLayout: 'stacked' })
+export const VerticalStackedBarsTotal = makeBarStory({ showGrid: true, barLayout: 'stacked' }, 'stack-total')
+export const HorizontalStackedBars = makeBarStory({
+    showGrid: true,
+    barLayout: 'stacked',
+    axisOrientation: 'horizontal',
+})
+export const PercentStackBars = makeBarStory({ showGrid: true, barLayout: 'percent' })
 
 export const WithCustomFormatter: Story = {
     render: () => {


### PR DESCRIPTION
## Problem

Stacked on #57403. Adds Storybook coverage for the bar-chart paths in `<ValueLabels>` so the snapshot suite catches regressions.

## Changes

- Four new `ValueLabels` bar stories: vertical stacked, vertical stacked-total, horizontal stacked, percent stack — all driven through a small `makeBarStory` helper that shares the series/data so each story is one line.
- One new `BarChart` story (`WithValueLabelsHorizontal`) — pins the regression that ValueLabels swaps placement axes when the parent chart is horizontal.

## How did you test this code?

I'm an agent. No new tests — this PR is Storybook stories only. The functionality they exercise is covered by the Jest tests in #57403.

## Publish to changelog?

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code. Split out of #57403 to keep that PR under the LOC budget.

Agent-authored PRs always require human review.