### PR TITLE
feat(alerts): add quota endpoint and alert limit logic

### DIFF
--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -152,6 +152,9 @@ tools:
     logs-alerts-partial-update:
         operation: logs_alerts_partial_update
         enabled: false
+    logs-alerts-quota-retrieve:
+        operation: logs_alerts_quota_retrieve
+        enabled: false
     logs-alerts-reset-create:
         operation: logs_alerts_reset_create
         enabled: false

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -58,6 +58,12 @@ MAX_ALERTS_PER_TEAM = 20
 UNCAPPED_ALERT_TEAM_IDS: frozenset[int] = frozenset(
     int(t) for x in os.environ.get("LOGS_ALERTS_UNCAPPED_TEAM_IDS", "").split(",") if (t := x.strip()).isdigit()
 )
+
+
+def alert_limit_for_team(team_id: int) -> int | None:
+    return None if team_id in UNCAPPED_ALERT_TEAM_IDS else MAX_ALERTS_PER_TEAM
+
+
 MAX_SIMULATE_LOOKBACK_DAYS = 30
 MAX_SIMULATE_BUCKETS = 15_000
 STATE_TIMELINE_LOOKBACK_HOURS = 24
@@ -498,10 +504,11 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             # Django optimises count() to SELECT COUNT(*). Locking the team
             # row instead serialises concurrent creates for this team.
             Team.objects.select_for_update().get(id=validated_data["team_id"])
-            if validated_data["team_id"] not in UNCAPPED_ALERT_TEAM_IDS:
+            limit = alert_limit_for_team(validated_data["team_id"])
+            if limit is not None:
                 count = LogsAlertConfiguration.objects.filter(team_id=validated_data["team_id"]).count()
-                if count >= MAX_ALERTS_PER_TEAM:
-                    raise ValidationError(f"Maximum number of alerts ({MAX_ALERTS_PER_TEAM}) reached for this team.")
+                if count >= limit:
+                    raise ValidationError(f"Maximum number of alerts ({limit}) reached for this team.")
             return super().create(validated_data)
 
 
@@ -633,6 +640,14 @@ class LogsAlertSimulateResponseSerializer(serializers.Serializer):
     total_buckets = serializers.IntegerField(help_text="Total number of buckets in the simulation window.")
     threshold_count = serializers.IntegerField(help_text="Threshold count used for evaluation.")
     threshold_operator = serializers.CharField(help_text="Threshold operator used for evaluation.")
+
+
+class LogsAlertQuotaSerializer(serializers.Serializer):
+    used = serializers.IntegerField(help_text="Number of alerts currently configured for the team.")
+    limit = serializers.IntegerField(
+        allow_null=True,
+        help_text="Maximum number of alerts allowed for the team. `null` means uncapped.",
+    )
 
 
 class LogsAlertCreateDestinationSerializer(serializers.Serializer):
@@ -991,6 +1006,16 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
         report_user_action(request.user, "logs alert reset", {"alert_id": str(alert.id)})
         return Response(self.get_serializer(alert).data)
+
+    @extend_schema(
+        request=None,
+        responses={200: LogsAlertQuotaSerializer},
+        description="Current alert count and configured limit for the team. `limit: null` means uncapped.",
+    )
+    @action(detail=False, methods=["GET"], url_path="quota")
+    def quota(self, request: Request, *args: object, **kwargs: object) -> Response:
+        used = LogsAlertConfiguration.objects.filter(team_id=self.team_id).count()
+        return Response(LogsAlertQuotaSerializer({"used": used, "limit": alert_limit_for_team(self.team_id)}).data)
 
     @extend_schema(
         request=LogsAlertSimulateRequestSerializer,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -447,6 +447,28 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == expected_status
         assert LogsAlertConfiguration.objects.filter(team=self.team).count() == expected_count
 
+    # --- Quota endpoint ---
+
+    def test_quota_endpoint_returns_used_and_limit(self):
+        for i in range(3):
+            LogsAlertConfiguration.objects.create(
+                team=self.team,
+                name=f"Alert {i}",
+                threshold_count=1,
+                created_by=self.user,
+                filters={"severityLevels": ["error"]},
+            )
+
+        response = self.client.get(f"{self.base_url}quota/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"used": 3, "limit": MAX_ALERTS_PER_TEAM}
+
+    def test_quota_endpoint_returns_null_limit_when_team_uncapped(self):
+        with patch("products.logs.backend.alerts_api.UNCAPPED_ALERT_TEAM_IDS", frozenset({self.team.id})):
+            response = self.client.get(f"{self.base_url}quota/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"used": 0, "limit": None}
+
     # --- Read-only fields ---
 
     def test_state_ignored_on_create(self):

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -14,7 +14,9 @@ import {
 import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
 import IconSlack from 'public/services/slack.png'
@@ -24,6 +26,7 @@ import {
     NotificationDestinationTypeEnumApi,
     LogsAlertConfigurationApi,
     LogsAlertConfigurationStateEnumApi,
+    LogsAlertQuotaApi,
     ThresholdOperatorEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
@@ -37,8 +40,35 @@ function formatThreshold(alert: LogsAlertConfigurationApi): string {
     return `${operator} ${alert.threshold_count} in ${alert.window_minutes}m`
 }
 
+function AlertQuotaWidget({ quota }: { quota: LogsAlertQuotaApi }): JSX.Element {
+    if (quota.limit === null) {
+        return <span className="text-muted text-xs">{quota.used} alerts</span>
+    }
+    const ratio = quota.used / quota.limit
+    return (
+        <Tooltip
+            title={
+                <>
+                    Need more? <Link to="mailto:sales@posthog.com?subject=Logs alerts limit">Contact us</Link> to raise
+                    the limit.
+                </>
+            }
+        >
+            <span
+                className={cn('text-xs cursor-help', {
+                    'text-danger': quota.used >= quota.limit,
+                    'text-warning': quota.used < quota.limit && ratio >= 0.8,
+                    'text-muted': ratio < 0.8,
+                })}
+            >
+                {quota.used} of {quota.limit} alerts
+            </span>
+        </Tooltip>
+    )
+}
+
 export function LogsAlertList(): JSX.Element {
-    const { alerts, alertsLoading, resettingAlertIds, creatingAlert } = useValues(logsAlertingLogic)
+    const { alerts, alertsLoading, resettingAlertIds, creatingAlert, quota } = useValues(logsAlertingLogic)
     const {
         setEditingAlert,
         deleteAlert,
@@ -246,14 +276,28 @@ export function LogsAlertList(): JSX.Element {
         return <SpinnerOverlay />
     }
 
+    const atLimit = quota !== null && quota.limit !== null && quota.used >= quota.limit
+
     return (
         <div className="space-y-2">
-            <div className="flex justify-end">
+            <div className="flex items-center gap-2">
+                {quota && <AlertQuotaWidget quota={quota} />}
                 <LemonButton
+                    className="ml-auto"
                     type="primary"
                     size="small"
                     onClick={() => createAlertAndOpen()}
                     loading={creatingAlert}
+                    disabledReason={
+                        atLimit ? (
+                            <>
+                                Reached the limit of {quota?.limit} alerts.{' '}
+                                <Link to="mailto:sales@posthog.com?subject=Logs alerts limit">Contact us</Link> to raise
+                                it.
+                            </>
+                        ) : undefined
+                    }
+                    disabledReasonInteractive
                     data-attr="logs-alerts-new"
                 >
                     New alert

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -13,9 +13,10 @@ import {
     logsAlertsDestroy,
     logsAlertsList,
     logsAlertsPartialUpdate,
+    logsAlertsQuotaRetrieve,
     logsAlertsResetCreate,
 } from 'products/logs/frontend/generated/api'
-import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+import { LogsAlertConfigurationApi, LogsAlertQuotaApi } from 'products/logs/frontend/generated/api.schemas'
 
 import type { logsAlertingLogicType } from './logsAlertingLogicType'
 import { alertFiltersForPreEnableCheck, dispatchPreEnableCheck, runPreEnableChecks } from './logsAlertUtils'
@@ -90,6 +91,15 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
                 },
             },
         ],
+        quota: [
+            null as LogsAlertQuotaApi | null,
+            {
+                loadQuota: async () => {
+                    const projectId = String(values.currentTeamId)
+                    return await logsAlertsQuotaRetrieve(projectId)
+                },
+            },
+        ],
     })),
 
     listeners(({ actions, values }) => ({
@@ -99,6 +109,7 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
                 await logsAlertsDestroy(projectId, id)
                 lemonToast.success('Alert deleted')
                 actions.loadAlerts()
+                actions.loadQuota()
             } catch {
                 lemonToast.error('Failed to delete alert')
             }
@@ -174,6 +185,7 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
                 const created = await logsAlertsCreate(projectId, { enabled: false })
                 router.actions.push(urls.logsAlertDetail(created.id))
                 actions.loadAlerts()
+                actions.loadQuota()
             } catch (e: any) {
                 lemonToast.error(e?.detail ?? e?.message ?? 'Failed to create alert')
             } finally {
@@ -184,6 +196,7 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
 
     afterMount(({ actions, values, cache }) => {
         actions.loadAlerts()
+        actions.loadQuota()
         cache.disposables.add(() => {
             const intervalId = window.setInterval(() => {
                 if (!values.isCreating && values.editingAlert === null && values.viewingHistoryAlert === null) {

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -463,6 +463,16 @@ export interface PaginatedLogsAlertEventListApi {
     results: LogsAlertEventApi[]
 }
 
+export interface LogsAlertQuotaApi {
+    /** Number of alerts currently configured for the team. */
+    used: number
+    /**
+     * Maximum number of alerts allowed for the team. `null` means uncapped.
+     * @nullable
+     */
+    limit: number | null
+}
+
 export interface LogsAlertSimulateRequestApi {
     /** Filter criteria — same format as LogsAlertConfiguration.filters. */
     filters: unknown

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -14,6 +14,7 @@ import type {
     LogsAlertCreateDestinationApi,
     LogsAlertDeleteDestinationApi,
     LogsAlertDestinationResponseApi,
+    LogsAlertQuotaApi,
     LogsAlertSimulateRequestApi,
     LogsAlertSimulateResponseApi,
     LogsAlertsEventsListParams,
@@ -406,6 +407,20 @@ export const logsAlertsResetCreate = async (
     return apiMutator<LogsAlertConfigurationApi>(getLogsAlertsResetCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
+    })
+}
+
+/**
+ * Current alert count and configured limit for the team. `limit: null` means uncapped.
+ */
+export const getLogsAlertsQuotaRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/alerts/quota/`
+}
+
+export const logsAlertsQuotaRetrieve = async (projectId: string, options?: RequestInit): Promise<LogsAlertQuotaApi> => {
+    return apiMutator<LogsAlertQuotaApi>(getLogsAlertsQuotaRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -169,6 +169,9 @@ tools:
                 - last_error_message
                 - created_at
                 - updated_at
+    logs-alerts-quota-retrieve:
+        operation: logs_alerts_quota_retrieve
+        enabled: false
     logs-alerts-reset-create:
         operation: logs_alerts_reset_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21478,6 +21478,16 @@ export namespace Schemas {
       readonly query_duration_ms: number | null;
     }
 
+    export interface LogsAlertQuota {
+      /** Number of alerts currently configured for the team. */
+      used: number;
+      /**
+       * Maximum number of alerts allowed for the team. `null` means uncapped.
+       * @nullable
+       */
+      limit: number | null;
+    }
+
     export interface LogsAlertSimulateBucket {
       /** Bucket start timestamp. */
       timestamp: string;


### PR DESCRIPTION
## Problem

Teams creating logs alerts had no visibility into how many alerts they'd used relative to their limit, and the "New alert" button would only fail at the point of creation rather than proactively communicating the constraint. There was also no programmatic way to query a team's alert quota.

## Changes  
  
![image.png](https://app.graphite.com/user-attachments/assets/c91faef1-f96e-49df-8e3a-79f539484d80.png)



**Backend**

- Extracted a `alert_limit_for_team(team_id)` helper that returns `None` for uncapped teams or `MAX_ALERTS_PER_TEAM` otherwise, replacing the inline `UNCAPPED_ALERT_TEAM_IDS` check in the create path.
- Added a `GET /api/projects/{projectId}/logs/alerts/quota/` endpoint that returns `{ used, limit }` — `limit: null` means uncapped.
- Added `LogsAlertQuotaSerializer` to back the new endpoint.

**Frontend**

- Loads quota on mount and after alert creation/deletion so the count stays current.
- Added an `AlertQuotaWidget` that shows current usage alongside the limit. It is colour-coded: muted when below 80 % capacity, warning-coloured from 80 %, and danger-coloured at the limit. A tooltip links to `sales@posthog.com` for teams that need a higher limit.
- The "New alert" button is disabled with an explanatory message (including a contact link) when the team is at its limit.
- Generated API client and schema types updated to include `logsAlertsQuotaRetrieve` and `LogsAlertQuotaApi`.

## How did you test this code?

Two automated tests cover the new endpoint:

- `test_quota_endpoint_returns_used_and_limit` — creates 3 alerts and asserts `{ used: 3, limit: MAX_ALERTS_PER_TEAM }`.
- `test_quota_endpoint_returns_null_limit_when_team_uncapped` — patches `UNCAPPED_ALERT_TEAM_IDS` and asserts `{ used: 0, limit: null }`.

The existing `test_per_team_limit` parameterised test continues to cover the enforcement path through the refactored `alert_limit_for_team` helper.

## Publish to changelog?

No