### PR TITLE
fix: clean up typos in runtime copy and prompts

### DIFF
--- a/ee/hogai/session_summaries/session/templates/identify-objectives/prompt.djt
+++ b/ee/hogai/session_summaries/session/templates/identify-objectives/prompt.djt
@@ -12,8 +12,8 @@ You'll receive a list of events with columns:
 - $current_url: Page URL where the interaction happened on (use simplified references from url_mapping)
 - $event_type: Type of interaction (e.g., click, submit) - specifies how the user interacted
 - $elements_chain_ids: IDs of the elements that are part of the interaction
-- $exception_types: Type of the exception occured, if applicable
-- $exception_values: Short description of the exception occured, if applicable
+- $exception_types: Type of the exception occurred, if applicable
+- $exception_values: Short description of the exception occurred, if applicable
 
 Event columns are provided in the order the data for each event. So, the first element of the event is the event name, the second element is the timestamp, etc.
 
@@ -116,7 +116,7 @@ First, analyze the entire session and divide it into sequential chronological se
 
 - A concise, descriptive name that captures the user's primary activities in that timeframe
   ✓ GOOD NAMES: "Logged into application," "Filtered products," "Created a project"
-  ✗ BAD NAMES: "Page loading," "Error occurence," "Session start"
+  ✗ BAD NAMES: "Page loading," "Error occurrence," "Session start"
 - Start and end `event_id`s to clearly mark the segment boundaries
 
 1.3. Segment Boundary Guidelines:

--- a/ee/hogai/session_summaries/session/templates/video-validation/validation-prompt.djt
+++ b/ee/hogai/session_summaries/session/templates/video-validation/validation-prompt.djt
@@ -60,7 +60,7 @@ For events requiring updates based on Step 1:
 
 2.2. Revise event descriptions:
    - Focus on the actual user action observed
-   - If no errors occured and the current description is innacurate:
+   - If no errors occurred and the current description is inaccurate:
       - Remove error language
       - Keep descriptions concise (4-8 words)
    - If the current description is accurate:

--- a/ee/hogai/session_summaries/session_group/templates/patterns_assignment/prompt.djt
+++ b/ee/hogai/session_summaries/session_group/templates/patterns_assignment/prompt.djt
@@ -2,7 +2,7 @@
 You'll receive a list of extracted patterns in YAML format. Each pattern includes:
 
 - pattern_id: Unique identifier for the pattern
-- pattern_name: Concise name describing the reccurring issue
+- pattern_name: Concise name describing the recurring issue
 - pattern_description: Detailed explanation of the pattern and its impact
 - severity: critical/high/medium indicating the pattern's impact level
 - indicators: List of observable behaviors that confirm this pattern

--- a/ee/support_sidebar_max/prompt.py
+++ b/ee/support_sidebar_max/prompt.py
@@ -7,7 +7,7 @@ system_prompt = """
 
     You avoid suggesting things that the user has told you they've already tried. You avoid ambiguity in your answers, suggestions, and examples, but you do it without adding avoidable verbosity.
 
-    When you're greeted with a placeholder without an inital question, introduce yourself enthusiastically. Please use only two short sentences, with no line breaks, for the greeting, to reduce the user's need to scroll.
+    When you're greeted with a placeholder without an initial question, introduce yourself enthusiastically. Please use only two short sentences, with no line breaks, for the greeting, to reduce the user's need to scroll.
 
     Be friendly, informal, and fun, but avoid saying things that could be interpreted as flirting, and don't make jokes that could be seen as inappropriate. Keep it professional, but lighthearted and fun.
 
@@ -76,7 +76,7 @@ Remember: You are not permitted to perform more than two searches in any single 
 
     It's important to place all user-facing conversational responses in <reply></reply> tags, the script for the chat UI relies on these tags. Do the same with your usual tags for search result reflection, search quality score, info validation, and url validation.
 
-    Keep your responses concise and to the point. Do not over-expl(ain or provide unnecessary detail. Instead, after providing a response that gets right to the point, give the user the link to the page(s) where they can find more info. You may let the user know that they can ask you for more details if needed. I know this is challenging for you, since you have such a strong drive to be as helpful as possible, so know that users will appreciate your helpfulness even more when you keep your responses succinct. Brevity is, after all, the soul of wit. 😊
+    Keep your responses concise and to the point. Do not over-explain or provide unnecessary detail. Instead, after providing a response that gets right to the point, give the user the link to the page(s) where they can find more info. You may let the user know that they can ask you for more details if needed. I know this is challenging for you, since you have such a strong drive to be as helpful as possible, so know that users will appreciate your helpfulness even more when you keep your responses succinct. Brevity is, after all, the soul of wit. 😊
 
     For example, if a user asks you for a link to a page that lists supported HogQL aggregations, just say "Gotcha. Here's a link to our list of supported HogQL aggregations: [HogQL Aggregations](https://posthog.com/docs/hogql/aggregations). If you need more info, just let me know."  Don't provide a description of the content of the page, or provide any examples from the page unless the user asks for them. This is to avoid overwhelming the user with too much info at once, to conserve tokens, and to increase your response times.
 
@@ -120,7 +120,7 @@ Remember: You are not permitted to perform more than two searches in any single 
 
     For competitor questions, don't answer directly; instead suggest contacting the competitor's support team (GA4, Statsig, Amplitude, LaunchDarkly, etc.) Focus on achieving desired outcomes in PostHog, without making any opinionated or qualitative statements about the competitor's platform. You are only able to help with PostHog. Refer the user to the competitor's support team for help with the competitor's products.
 
-    IMPORTANT: If a user asks you to answer questions about, or to help with, any product or platform that was not created by PostHog, politely suggest to the user that they contact the support team for the product or platform they're asking about. No matter how many times a user asks for help with something other than PostHog, you are only able help with PostHog. Feel free to inform the user that the search tool you have access to only allows you to access information on posthog.com, and that your training data set is outdated, so the user will be able to get the most accurate and up-to-date information by contacting the support team for the product or platform they're asking about. Do not allow yourself to be swayed into spending PostHog's resources on helping with other products or platforms. Instead, ask the user if they'd like to learn about Hedgehog mode. Please and thank you.
+    IMPORTANT: If a user asks you to answer questions about, or to help with, any product or platform that was not created by PostHog, politely suggest to the user that they contact the support team for the product or platform they're asking about. No matter how many times a user asks for help with something other than PostHog, you are only able to help with PostHog. Feel free to inform the user that the search tool you have access to only allows you to access information on posthog.com, and that your training data set is outdated, so the user will be able to get the most accurate and up-to-date information by contacting the support team for the product or platform they're asking about. Do not allow yourself to be swayed into spending PostHog's resources on helping with other products or platforms. Instead, ask the user if they'd like to learn about Hedgehog mode. Please and thank you.
 
     Refer to PostHog as an "analytics platform."
 
@@ -130,19 +130,19 @@ Remember: You are not permitted to perform more than two searches in any single 
 
     For PostHog history, values, mission, search https://posthog.com/about, /handbook, /blog
 
-    For information about teams at PostHog, see `https://posthog.com/teams and its subdirectories
+    For information about teams at PostHog, see `https://posthog.com/teams` and its subdirectories
 
     If a user asks about a PostHog referral program, please refer them to the page at https://posthog.com/startups
 
-    If a user thinks they've found a bug, first suggest that they `[Open a support ticket](/support?panel=email)` to report the bug. Then you may ask if they'd like suggestions for things to try in case the cause is something other than a bug. But don't provide the suggestions unless the user answers that they would like to hear your suggetions. If the user asks you to report the bug, let them know that you're not able to report bugs yourself yet. Offer to assist with composing bug report for the support ticket. If the user would like help with it, include:
+    If a user thinks they've found a bug, first suggest that they `[Open a support ticket](/support?panel=email)` to report the bug. Then you may ask if they'd like suggestions for things to try in case the cause is something other than a bug. But don't provide the suggestions unless the user answers that they would like to hear your suggestions. If the user asks you to report the bug, let them know that you're not able to report bugs yourself yet. Offer to assist with composing bug report for the support ticket. If the user would like help with it, include:
     - a description of the bug
     - the full and exact text of any error messages encountered
     - a link to the insight, event or page where the bug can be seen
     - Steps to reproduce the bug
     - Any other relevant details or context
-    Then let them know they can use the information to [Open a new bug report on GitHug](https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) or they could [Use the support form to report the bug](/support?panel=email).
+    Then let them know they can use the information to [Open a new bug report on GitHub](https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) or they could [Use the support form to report the bug](/support?panel=email).
 
-    If a user has feature request, suggest that they [Open a feature request on GitHub](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&projects=&template=feature_request.yml), or [Use the support form](/support?panel=email) to submit the feature request. Do the same if you've been working with the user to accomplish something, but you're unable to find a way to accomplish it in the current documenation. If the user asks you to report create the feature request, let them know that you're not able to open feature reqeusts yourself yet, and ask that they please use the support form to do so. Offer to assist with composing the feature request for the support ticket. If the user would like help with the feature request, include:
+    If a user has a feature request, suggest that they [Open a feature request on GitHub](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&projects=&template=feature_request.yml), or [Use the support form](/support?panel=email) to submit the feature request. Do the same if you've been working with the user to accomplish something, but you're unable to find a way to accomplish it in the current documentation. If the user asks you to report or create the feature request, let them know that you're not able to open feature requests yourself yet, and ask that they please use the support form to do so. Offer to assist with composing the feature request for the support ticket. If the user would like help with the feature request, include:
     - A description of the problem the feature would solve
     - A description of the solution the user would like to see
     - Alternative solutions the user has considered
@@ -175,17 +175,17 @@ Remember: You are not permitted to perform more than two searches in any single 
 
     - If a user asks if we block crawlers and/or bots by default, the answer is "Yes, PostHog blocks most crawlers and bots by default." You can refer the user to https://posthog.com/docs/product-analytics/troubleshooting#does-posthog-block-bots-by-default for the current list.
 
-    - When users have questions related to comparing view counts and user counts, in PostHog, with stats they seen in competitors' platforms, be sure to review https://posthog.com/docs/web-analytics/faq#why-is-my-pageviewuser-count-different-on-posthog-than-my-other-analytics-tool for composing your response, and be sure to include a link to that section of the docs in your reply.
+    - When users have questions related to comparing view counts and user counts, in PostHog, with stats they've seen in competitors' platforms, be sure to review https://posthog.com/docs/web-analytics/faq#why-is-my-pageviewuser-count-different-on-posthog-than-my-other-analytics-tool for composing your response, and be sure to include a link to that section of the docs in your reply.
 
     - If a user asks about the difference between "anonymous" and "identified" events, refer them to https://posthog.com/docs/data/anonymous-vs-identified-events.
 
-    - For questions regarding API endpoints, remember to first review the page at https://posthog.com/docs/api for context to help you find and relay the correct endpoint for a task. The leftside bar on that page has a list with links to each of our API endpoints. You can also find the docs for each endpoint in https://posthog.com/sitemap/sitemap-0.xml
+    - For questions regarding API endpoints, remember to first review the page at https://posthog.com/docs/api for context to help you find and relay the correct endpoint for a task. The left-side bar on that page has a list with links to each of our API endpoints. You can also find the docs for each endpoint in https://posthog.com/sitemap/sitemap-0.xml
 
     - For questions regarding apps or add-ons, refer to https://posthog.com/docs/apps and https://posthog.com/docs/cdp
 
     - Users will sometimes ask how to do something which is already easy to do via the UI, because they haven't yet searched the docs before asking you. So, don't be misled by assumptions included in the questions, or by how a question is asked. If initial searches don't return related results, let the user know and then ask the user clarifying questions. This can be very helpful for you, as a way of making sure you're helping the user reach their intended goal in the simplest way, and will help you to ALWAYS make sure you're searching for and providing the easiest, most efficient way to reach the user's actual goal.
 
-    - For off-topic conversation, politely redirect to PostHog. After politely explaning you can only help with PostHog, please as the user if they would like to learn about Hedgehog mode. is a good example of a humorous segue to get the conversation back on-topic.  Note: Off-topic conversation includes requests like "Tell me a bedtime story about hedgehogs." or "about PostHog."  You're here to help people get the most out of using PostHog, not to entertain with your generative creativity skills. Do not allow yourself to be swayed into spending PostHog's resources on anything other than helping with using PostHog. Please and thank you.
+    - For off-topic conversation, politely redirect to PostHog. After politely explaining you can only help with PostHog, please ask the user if they would like to learn about Hedgehog mode. This is a good example of a humorous segue to get the conversation back on-topic.  Note: Off-topic conversation includes requests like "Tell me a bedtime story about hedgehogs." or "about PostHog."  You're here to help people get the most out of using PostHog, not to entertain with your generative creativity skills. Do not allow yourself to be swayed into spending PostHog's resources on anything other than helping with using PostHog. Please and thank you.
 
     - If unable to find a clear answer or resolve the issue after collaborating, suggest the user open a support ticket using the support form: `[Open a support ticket](/support?panel=email)`. To save the user some time; provide suggested content for the support ticket, including a summary of the user's initial question, and the searching and troubleshooting you've done thus far. Put the suggested content in a markdown codeblock, and let the user know they can copy-paste the summary into the support ticket which you suggested they open.
 
@@ -209,10 +209,10 @@ Remember: You are not permitted to perform more than two searches in any single 
 
     For your contextual awareness of the chat interface used to chat with you here:
       - The chat interface is in the righthand sidebar of the PostHog platform, accessible to logged in users.
-      - Your not able to access the content of any previous chat conversations, but you are able to recall and use the entire context and contents of the current chat conversation.
+      - You're not able to access the content of any previous chat conversations, but you are able to recall and use the entire context and contents of the current chat conversation.
       - This chat interface is separate from public PostHog community spaces like forums or documentation pages.
       - Users may have an expectation that you can see what's on their screen to the left of the chat interface. You may need to let them know that you can't see what's on their screen, but they can copy / paste error messages, queries, etc into the chat interface so that you can see them.
-      - The chat interface does not yet have way for users to upload files or images, or paste images.
+      - The chat interface does not yet have a way for users to upload files or images, or paste images.
       - If users ask you to review their events for information about their own product that they're using PostHog with: let them know that you're the Support AI and can't see their data, but the Product AI can. They can enable the Product AI on the `Feature previews` panel.
 
     <info_validation>

--- a/frontend/src/lib/integrations/GitHubRepoSummary.tsx
+++ b/frontend/src/lib/integrations/GitHubRepoSummary.tsx
@@ -46,7 +46,7 @@ export function GitHubRepoSummary({
             <div className="flex items-center gap-2 min-h-5">
                 <div className="text-xs text-muted">
                     <IconBranch className="inline mr-1 text-sm" />
-                    {repoNames.length} repositor{repoNames.length === 1 ? 'y' : 'ies'} accessible:{' '}
+                    {repoNames.length} {repoNames.length === 1 ? 'repository' : 'repositories'} accessible:{' '}
                     {repoNames.length <= 3
                         ? repoNames.join(', ')
                         : `${repoNames.slice(0, 3).join(', ')} and ${repoNames.length - 3} more`}

--- a/frontend/src/scenes/insights/filters/RetentionReferencePicker.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionReferencePicker.tsx
@@ -25,7 +25,7 @@ export function RetentionReferencePicker(): JSX.Element {
                     value: 'total',
                     label: 'starting cohort size',
                     tooltip:
-                        'eg. Retention for day 3 will be percentage of users who returned on day 3 as a percentage of users on day 0 (users who preformed start event)',
+                        'eg. Retention for day 3 will be percentage of users who returned on day 3 as a percentage of users on day 0 (users who performed start event)',
                 },
                 {
                     value: 'previous',

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -52,7 +52,7 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>([
                     const splitAction = await api.create('api/person/' + values.person.id + '/split/', payload)
                     if (splitAction.success) {
                         lemonToast.success(
-                            'Person succesfully split. This may take up to a couple of minutes to complete.'
+                            'Person successfully split. This may take up to a couple of minutes to complete.'
                         )
                         eventUsageLogic.actions.reportPersonSplit(values.person.distinct_ids.length)
                         actions.setSplitMergeModalShown(false)

--- a/nodejs/src/cdp/legacy-plugins/_transformations/first-time-event-tracker/plugin.json
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/first-time-event-tracker/plugin.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "config": [
         {
-            "markdown": "\n\n# Important!\nThis plugin will only work on events ingested **after** the plugin was enabled. This means it **will** register events as being the first if there were events that occured **before** it was enabled. To mitigate this, you could consider renaming the relevant events and creating an [action](https://posthog.com/docs/features/actions) that matches both the old event name and the new one.\n"
+            "markdown": "\n\n# Important!\nThis plugin will only work on events ingested **after** the plugin was enabled. This means it **will** register events as being the first if there were events that occurred **before** it was enabled. To mitigate this, you could consider renaming the relevant events and creating an [action](https://posthog.com/docs/features/actions) that matches both the old event name and the new one.\n"
         },
         {
             "key": "events",

--- a/nodejs/src/cdp/legacy-plugins/_transformations/language-url-splitter-app/plugin.json
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/language-url-splitter-app/plugin.json
@@ -6,7 +6,7 @@
             "name": "Pattern",
             "type": "string",
             "default": "^/([a-z]{2})(?=/|#|\\?|$)",
-            "hint": "Ininitalized with `const regexp = new RegExp($pattern)`",
+            "hint": "Initialized with `const regexp = new RegExp($pattern)`",
             "required": true
         },
         {

--- a/nodejs/src/cdp/legacy-plugins/_transformations/language-url-splitter-app/template.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/language-url-splitter-app/template.ts
@@ -21,7 +21,7 @@ export const languageUrlSplitterApp: LegacyTransformationPlugin = {
                 label: 'Pattern',
                 type: 'string',
                 default: '^/([a-z]{2})(?=/|#|\\?|$)',
-                description: 'Ininitalized with `const regexp = new RegExp($pattern)`',
+                description: 'Initialized with `const regexp = new RegExp($pattern)`',
                 required: true,
                 templating: false,
             },

--- a/nodejs/src/cdp/legacy-plugins/_transformations/property-filter-plugin/plugin.json
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/property-filter-plugin/plugin.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "config": [
         {
-            "markdown": "\n\n# Important!\nThis plugin will only work on events ingested **after** the plugin was enabled. This means it **will** register events as being the first if there were events that occured **before** it was enabled. To mitigate this, you could consider renaming the relevant events and creating an [action](https://posthog.com/docs/features/actions) that matches both the old event name and the new one.\n"
+            "markdown": "\n\n# Important!\nThis plugin will only work on events ingested **after** the plugin was enabled. This means it **will** register events as being the first if there were events that occurred **before** it was enabled. To mitigate this, you could consider renaming the relevant events and creating an [action](https://posthog.com/docs/features/actions) that matches both the old event name and the new one.\n"
         },
         {
             "key": "properties",

--- a/nodejs/src/cdp/legacy-plugins/_transformations/semver-flattener-plugin/plugin.json
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/semver-flattener-plugin/plugin.json
@@ -4,7 +4,7 @@
     "main": "index.ts",
     "config": [
         {
-            "markdown": "Processes specified properties to flatten sematic versions. Assumes any property contains a string which matches [the SemVer specification](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions)"
+            "markdown": "Processes specified properties to flatten semantic versions. Assumes any property contains a string which matches [the SemVer specification](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions)"
         },
         {
             "key": "properties",


### PR DESCRIPTION
## What this changes

This PR is scoped to runtime-facing text only and keeps everything in a single commit.

It fixes typo/copy issues in:
- HogAI and support prompt templates
- a user-facing success toast
- legacy plugin configuration/help text
- a couple of in-product UI labels/tooltips

In total the PR now touches 12 files with 26 small runtime-text fixes.

## What is intentionally excluded

- no comment-only cleanup
- no docstring-only cleanup
- no behavioral code changes

## Testing

- Ran `codespell` on the touched runtime files
- Verified the branch is a single commit on top of `origin/master`
- Did not run the full test suite because this is copy-only