### PR TITLE
feat(logs): add SQL view and editor to LogsScene

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -357,6 +357,7 @@ export const FEATURE_FLAGS = {
     LOGS_SETTINGS_PII_SCRUB: 'logs-settings-pii-scrub', // owner: #team-logs
     LOGS_SETTINGS_RETENTION: 'logs-settings-retention', // owner: #team-logs
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
+    LOGS_SQL_VIEW: 'logs-sql-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MARKETING_ANALYTICS_DRILL_DOWN: 'marketing-analytics-drill-down', // owner: @jabahamondes  #team-web-analytics

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -118,6 +118,7 @@ SCENE_TO_TAGS: dict[str, FallbackTags | None] = {
     "Cohort": {"product": Product.COHORTS, "feature": Feature.COHORT},
     "EndpointScene": {"product": Product.ENDPOINTS, "feature": Feature.QUERY},
     "EndpointsScene": {"product": Product.ENDPOINTS, "feature": Feature.QUERY},
+    "Logs": {"product": Product.LOGS, "feature": Feature.QUERY},
     "EventDefinition": {"product": Product.PRODUCT_ANALYTICS, "feature": Feature.EVENT_DEFINITION_SCENE},
     "EventDefinitionEdit": {"product": Product.PRODUCT_ANALYTICS, "feature": Feature.EVENT_DEFINITION_SCENE},
     "EventDefinitions": {"product": Product.PRODUCT_ANALYTICS, "feature": Feature.EVENT_DEFINITION_SCENE},

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -16,6 +16,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import { LogsAlertingSection } from 'products/logs/frontend/components/LogsAlerting/LogsAlertingSection'
 import { LogsServices } from 'products/logs/frontend/components/LogsServices/LogsServices'
+import { LogsSqlEditor } from 'products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { LogsViewerModal } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
@@ -92,11 +93,13 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
     const showAlerting = useFeatureFlag('LOGS_ALERTING')
+    const showSqlView = useFeatureFlag('LOGS_SQL_VIEW')
 
     const tabs: { key: LogsSceneActiveTab; label: string }[] = [
         { key: 'viewer', label: 'Viewer' },
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
         ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
+        ...(showSqlView ? [{ key: 'sql' as const, label: 'SQL' }] : []),
         { key: 'configuration', label: 'Configuration' },
     ]
 
@@ -142,6 +145,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 </>
             )}
             {activeTab === 'alerts' && showAlerting && <LogsAlertingSection />}
+            {activeTab === 'sql' && showSqlView && <LogsSqlEditor id={tabId} />}
             {activeTab === 'configuration' && (
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
             )}

--- a/products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor.tsx
+++ b/products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor.tsx
@@ -1,0 +1,50 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { SQLEditor } from 'scenes/data-warehouse/editor/SQLEditor'
+import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
+import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+
+import { logsSceneLogic } from 'products/logs/frontend/logsSceneLogic'
+
+const DEFAULT_LOGS_QUERY = 'SELECT * FROM logs LIMIT 10'
+
+export interface LogsSqlEditorProps {
+    id: string
+}
+
+export const LogsSqlEditor = ({ id }: LogsSqlEditorProps): JSX.Element => {
+    const sqlEditorTabId = `logs-sql-editor-${id}`
+    const { keepSqlEditorMounted } = useActions(logsSceneLogic)
+    const logic = sqlEditorLogic({ tabId: sqlEditorTabId, mode: SQLEditorMode.Embedded })
+    const { queryInput } = useValues(logic)
+    const { setQueryInput, setSourceQuery, runQuery } = useActions(logic)
+
+    useEffect(() => {
+        keepSqlEditorMounted(sqlEditorTabId)
+    }, [sqlEditorTabId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        if (queryInput === null) {
+            setQueryInput(DEFAULT_LOGS_QUERY)
+            setSourceQuery({
+                kind: NodeKind.DataVisualizationNode,
+                source: {
+                    kind: NodeKind.HogQLQuery,
+                    query: DEFAULT_LOGS_QUERY,
+                },
+                display: ChartDisplayType.ActionsLineGraph,
+            })
+            runQuery(DEFAULT_LOGS_QUERY)
+        }
+    }, [queryInput]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <div className="flex flex-col flex-1 min-h-0 min-w-0 border rounded overflow-hidden">
+            <SQLEditor tabId={sqlEditorTabId} mode={SQLEditorMode.Embedded} defaultShowDatabaseTree={false} />
+        </div>
+    )
+}

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -9,6 +9,8 @@ import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { parseTagsFilter } from 'lib/utils'
+import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
+import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
 import { Params } from 'scenes/sceneTypes'
 
 import {
@@ -33,8 +35,8 @@ import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/lo
 
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
-export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'configuration'
-const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'configuration']
+export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'sql', 'configuration']
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 const resolveActiveTabFromParams = (params: Params): LogsSceneActiveTab | null => {
@@ -240,6 +242,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         syncUrl: true,
         toggleAttributeBreakdown: (key: string) => ({ key }),
         setExpandedAttributeBreaksdowns: (expandedAttributeBreaksdowns: string[]) => ({ expandedAttributeBreaksdowns }),
+        keepSqlEditorMounted: (editorTabId: string) => ({ editorTabId }),
     }),
 
     reducers({
@@ -261,7 +264,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         tabId: [(_, p) => [p.tabId], (tabId: string) => tabId],
     }),
 
-    listeners(({ values, actions }) => ({
+    listeners(({ values, actions, cache }) => ({
         toggleAttributeBreakdown: ({ key }) => {
             const breakdowns = [...values.expandedAttributeBreaksdowns]
             const index = breakdowns.indexOf(key)
@@ -274,6 +277,16 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         },
         setOrderBy: () => {
             actions.syncUrl()
+        },
+        keepSqlEditorMounted: ({ editorTabId }) => {
+            if (cache.sqlEditorTabId === editorTabId) {
+                return
+            }
+            cache.unmountSqlEditor?.()
+            cache.sqlEditorTabId = editorTabId
+            // Intentionally not cleaned up in beforeUnmount: keeps the embedded sqlEditorLogic
+            // alive across navigation so the user's query survives leaving and re-entering /logs.
+            cache.unmountSqlEditor = sqlEditorLogic({ tabId: editorTabId, mode: SQLEditorMode.Embedded }).mount()
         },
     })),
 ])


### PR DESCRIPTION
## Problem

Users working with logs need a way to run custom SQL queries directly against log data without leaving the Logs scene. This provides a more flexible, power-user interface for exploring logs beyond the standard viewer.

## Changes  
  
![image.png](https://app.graphite.com/user-attachments/assets/7ff396c6-6667-4951-9431-1eab5ab98834.png)



Adds a new **SQL** tab to the Logs scene, gated behind the `LOGS_SQL_VIEW` feature flag. The tab renders an embedded SQL editor pre-populated with `SELECT * FROM logs LIMIT 10`, giving users a full HogQL editor experience.

- Added `LOGS_SQL_VIEW` feature flag constant
- Added `'sql'` as a valid `LogsSceneActiveTab`
- Added `LogsSqlEditor` component that initializes a `sqlEditorLogic` instance in embedded mode, pre-fills the query against the `logs` table, and keeps the editor mounted via `logsSceneLogic` cache to avoid re-initialization on tab switches
- Wired the SQL tab into `LogsSceneTabbedContent` behind the feature flag
- Added `keepSqlEditorMounted` action and corresponding `beforeUnmount` cleanup to properly manage the lifecycle of the embedded SQL editor logic
- Added `"Logs"` scene to query tagging so queries from this scene are correctly attributed to the logs product

## How did you test this code?

Enable the `logs-sql-view` feature flag and navigate to the Logs scene — a new **SQL** tab should appear. Clicking it renders the HogQL editor pre-filled with a query against the `logs` table.

## Publish to changelog?

Yes

## Docs update

Yes — explain that logs can be queried via SQL using the new SQL tab in the Logs scene.