### PR TITLE
chore(hog-charts): add inProgress, valueLabels, goalLines config to TimeSeriesLineChart

### DIFF
--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import { TimeSeriesLineChart } from 'lib/hog-charts'
-import type { GoalLineConfig, Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
+import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
 
@@ -163,63 +163,6 @@ export const YAxisFormats: Story = {
             <YFormatCell title="duration_ms" series={DURATION_MS_SERIES} config={{ format: 'duration_ms' }} />
         </div>
     ),
-}
-
-export const InProgress: Story = {
-    render: () => {
-        const theme = useReactiveTheme()
-        return (
-            <Stage>
-                <TimeSeriesLineChart
-                    series={SERIES}
-                    labels={DAYS}
-                    theme={theme}
-                    config={{ inProgress: { fromIndex: 4 }, yAxis: { showGrid: true } }}
-                />
-            </Stage>
-        )
-    },
-}
-
-export const ValueLabelsStory: Story = {
-    name: 'ValueLabels',
-    render: () => {
-        const theme = useReactiveTheme()
-        return (
-            <Stage>
-                <TimeSeriesLineChart
-                    series={SERIES}
-                    labels={DAYS}
-                    theme={theme}
-                    config={{
-                        valueLabels: { seriesKeys: ['visits', 'signups'] },
-                        yAxis: { showGrid: true },
-                    }}
-                />
-            </Stage>
-        )
-    },
-}
-
-const GOAL_LINES: GoalLineConfig[] = [
-    { value: 50, label: 'Target', labelPosition: 'start' },
-    { value: 30, label: 'Floor', color: 'var(--danger)', labelPosition: 'end' },
-]
-
-export const GoalLines: Story = {
-    render: () => {
-        const theme = useReactiveTheme()
-        return (
-            <Stage>
-                <TimeSeriesLineChart
-                    series={SERIES}
-                    labels={DAYS}
-                    theme={theme}
-                    config={{ goalLines: GOAL_LINES, yAxis: { showGrid: true } }}
-                />
-            </Stage>
-        )
-    },
 }
 
 export const DateAxis: Story = {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import { TimeSeriesLineChart } from 'lib/hog-charts'
-import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
+import type { GoalLineConfig, Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
 
@@ -163,6 +163,63 @@ export const YAxisFormats: Story = {
             <YFormatCell title="duration_ms" series={DURATION_MS_SERIES} config={{ format: 'duration_ms' }} />
         </div>
     ),
+}
+
+export const InProgress: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ inProgress: { fromIndex: 4 }, yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const ValueLabelsStory: Story = {
+    name: 'ValueLabels',
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{
+                        valueLabels: { seriesKeys: ['visits', 'signups'] },
+                        yAxis: { showGrid: true },
+                    }}
+                />
+            </Stage>
+        )
+    },
+}
+
+const GOAL_LINES: GoalLineConfig[] = [
+    { value: 50, label: 'Target', labelPosition: 'start' },
+    { value: 30, label: 'Floor', color: 'var(--danger)', labelPosition: 'end' },
+]
+
+export const GoalLines: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ goalLines: GOAL_LINES, yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
 }
 
 export const DateAxis: Story = {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -1,35 +1,7 @@
-import { render } from '@testing-library/react'
+import { cleanup } from '@testing-library/react'
 
 import type { ChartTheme, Series } from '../../core/types'
-import type { ReferenceLineProps } from '../../overlays/ReferenceLine'
-import type { ValueLabelsProps } from '../../overlays/ValueLabels'
-import type { LineChartProps } from '../LineChart'
-
-const lineChartSpy = jest.fn()
-const referenceLinesSpy = jest.fn()
-const valueLabelsSpy = jest.fn()
-
-jest.mock('../LineChart', () => ({
-    LineChart: (props: LineChartProps) => {
-        lineChartSpy(props)
-        return <div data-attr="line-chart-mock">{props.children}</div>
-    },
-}))
-
-jest.mock('../../overlays/ReferenceLine', () => ({
-    ReferenceLines: (props: { lines: ReferenceLineProps[] }) => {
-        referenceLinesSpy(props)
-        return <div data-attr="reference-lines-mock" />
-    },
-}))
-
-jest.mock('../../overlays/ValueLabels', () => ({
-    ValueLabels: (props: ValueLabelsProps) => {
-        valueLabelsSpy(props)
-        return <div data-attr="value-labels-mock" />
-    },
-}))
-
+import { renderHogChart, setupJsdom, setupSyncRaf } from '../../testing'
 import { TimeSeriesLineChart } from './TimeSeriesLineChart'
 
 const THEME: ChartTheme = { colors: ['#111', '#222', '#333'], backgroundColor: '#ffffff' }
@@ -37,157 +9,103 @@ const LABELS = ['Mon', 'Tue', 'Wed']
 const SERIES: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3] }]
 
 describe('TimeSeriesLineChart', () => {
+    let teardownJsdom: () => void
+    let teardownRaf: () => void
+
     beforeEach(() => {
-        lineChartSpy.mockClear()
-        referenceLinesSpy.mockClear()
-        valueLabelsSpy.mockClear()
+        teardownJsdom = setupJsdom()
+        teardownRaf = setupSyncRaf()
     })
 
-    it('translates config.xAxis and config.yAxis fields onto LineChartConfig', () => {
-        const xTickFormatter = (v: string): string => `x:${v}`
-        const yTickFormatter = (v: number): string => `y:${v}`
-        render(
-            <TimeSeriesLineChart
-                series={SERIES}
-                labels={LABELS}
-                theme={THEME}
-                config={{
-                    xAxis: { tickFormatter: xTickFormatter, hide: true },
-                    yAxis: { scale: 'log', tickFormatter: yTickFormatter, hide: true, showGrid: true },
-                }}
-            />
-        )
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.labels).toBe(LABELS)
-        expect(props.config?.yScaleType).toBe('log')
-        expect(props.config?.xTickFormatter).toBe(xTickFormatter)
-        expect(props.config?.yTickFormatter).toBe(yTickFormatter)
-        expect(props.config?.hideXAxis).toBe(true)
-        expect(props.config?.hideYAxis).toBe(true)
-        expect(props.config?.showGrid).toBe(true)
+    afterEach(() => {
+        teardownRaf()
+        teardownJsdom()
+        cleanup()
     })
 
-    it('builds an x-axis tick formatter from xAxis.timezone + xAxis.interval', () => {
-        const allDays = ['2025-04-01 14:00:00', '2025-04-01 15:00:00', '2025-04-01 16:00:00']
-        render(
-            <TimeSeriesLineChart
-                series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
-                labels={['14:00', '15:00', '16:00']}
-                theme={THEME}
-                config={{
-                    xAxis: { timezone: 'UTC', interval: 'hour', allDays },
-                }}
-            />
-        )
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        const formatter = props.config?.xTickFormatter
-        expect(formatter).not.toBeUndefined()
-        expect(formatter?.('ignored', 0)).toBe('14:00')
-        expect(formatter?.('ignored', 1)).toBe('15:00')
-        expect(formatter?.('ignored', 2)).toBe('16:00')
-    })
-
-    it('explicit tickFormatter wins over xAxis.timezone + xAxis.interval', () => {
-        const explicit = (_v: string, i: number): string => `tick-${i}`
-        render(
-            <TimeSeriesLineChart
-                series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
-                labels={['14:00', '15:00', '16:00']}
-                theme={THEME}
-                config={{
-                    xAxis: {
-                        tickFormatter: explicit,
-                        timezone: 'UTC',
-                        interval: 'hour',
-                        allDays: ['2025-04-01 14:00:00', '2025-04-01 15:00:00', '2025-04-01 16:00:00'],
-                    },
-                }}
-            />
-        )
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.config?.xTickFormatter).toBe(explicit)
-    })
-
-    it.each([
-        [{ format: 'percentage' as const }, 50, '50%'],
-        [{ prefix: '$', suffix: ' req' }, 42, '$42 req'],
-    ])('builds a y-axis tick formatter from yAxis %p', (yAxis, value, expected) => {
-        render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ yAxis }} />)
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.config?.yTickFormatter?.(value)).toBe(expected)
-    })
-
-    it('explicit yAxis.tickFormatter wins over yAxis.format', () => {
-        const explicit = (v: number): string => `y:${v}`
-        render(
-            <TimeSeriesLineChart
-                series={SERIES}
-                labels={LABELS}
-                theme={THEME}
-                config={{ yAxis: { tickFormatter: explicit, format: 'percentage' } }}
-            />
-        )
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.config?.yTickFormatter).toBe(explicit)
-    })
-
-    it('does not build a y-axis tick formatter when no format options are set', () => {
-        render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ yAxis: {} }} />)
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.config?.yTickFormatter).toBeUndefined()
-    })
-
-    it('does not auto-format when only one of timezone or interval is provided', () => {
-        render(
-            <TimeSeriesLineChart
-                series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
-                labels={LABELS}
-                theme={THEME}
-                config={{
-                    xAxis: { timezone: 'UTC' },
-                }}
-            />
-        )
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.config?.xTickFormatter).toBeUndefined()
-    })
-
-    describe('config.inProgress', () => {
-        it('sets stroke.partial.fromIndex on each series when configured', () => {
-            render(
-                <TimeSeriesLineChart
-                    series={[
-                        { key: 'a', label: 'A', data: [1, 2, 3, 4] },
-                        { key: 'b', label: 'B', data: [5, 6, 7, 8] },
-                    ]}
-                    labels={['Mon', 'Tue', 'Wed', 'Thu']}
-                    theme={THEME}
-                    config={{ inProgress: { fromIndex: 2 } }}
-                />
+    describe('config.xAxis', () => {
+        it('hides x-axis ticks when xAxis.hide is true', () => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ xAxis: { hide: true } }} />
             )
-            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-            expect(props.series[0].stroke?.partial?.fromIndex).toBe(2)
-            expect(props.series[1].stroke?.partial?.fromIndex).toBe(2)
+            expect(chart.xTicks()).toHaveLength(0)
         })
 
-        it("preserves a series' explicit stroke.partial when inProgress is set", () => {
-            const explicitPartial = { fromIndex: 99, pattern: [4, 4] as number[] }
-            render(
+        it('builds an x-axis tick formatter from xAxis.timezone + xAxis.interval', () => {
+            const allDays = ['2025-04-01 14:00:00', '2025-04-01 15:00:00', '2025-04-01 16:00:00']
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
-                    series={[{ key: 'a', label: 'A', data: [1, 2, 3], stroke: { partial: explicitPartial } }]}
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                    labels={['14:00', '15:00', '16:00']}
+                    theme={THEME}
+                    config={{ xAxis: { timezone: 'UTC', interval: 'hour', allDays } }}
+                />
+            )
+            expect(chart.xTicks()).toEqual(['14:00', '15:00', '16:00'])
+        })
+
+        it('explicit xAxis.tickFormatter wins over timezone+interval', () => {
+            const explicit = (_v: string, i: number): string => `tick-${i}`
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                    labels={['14:00', '15:00', '16:00']}
+                    theme={THEME}
+                    config={{
+                        xAxis: {
+                            tickFormatter: explicit,
+                            timezone: 'UTC',
+                            interval: 'hour',
+                            allDays: ['2025-04-01 14:00:00', '2025-04-01 15:00:00', '2025-04-01 16:00:00'],
+                        },
+                    }}
+                />
+            )
+            expect(chart.xTicks()).toEqual(['tick-0', 'tick-1', 'tick-2'])
+        })
+
+        it('does not auto-format when only one of timezone or interval is provided', () => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
                     labels={LABELS}
                     theme={THEME}
-                    config={{ inProgress: { fromIndex: 1 } }}
+                    config={{ xAxis: { timezone: 'UTC' } }}
                 />
             )
-            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-            expect(props.series[0].stroke?.partial).toBe(explicitPartial)
+            expect(chart.xTicks()).toEqual(LABELS)
+        })
+    })
+
+    describe('config.yAxis', () => {
+        it('hides y-axis ticks when yAxis.hide is true', () => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ yAxis: { hide: true } }} />
+            )
+            expect(chart.yTicks()).toHaveLength(0)
         })
 
-        it('leaves series untouched when inProgress is omitted', () => {
-            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} />)
-            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-            expect(props.series).toBe(SERIES)
+        it.each([
+            [{ format: 'percentage' as const }, /\d+%$/],
+            [{ prefix: '$', suffix: ' req' }, /^\$.* req$/],
+        ])('builds a y-axis tick formatter from yAxis %p', (yAxis, pattern) => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ yAxis }} />
+            )
+            expect(chart.yTicks().some((t) => pattern.test(t))).toBe(true)
+        })
+
+        it('explicit yAxis.tickFormatter wins over yAxis.format', () => {
+            const explicit = (v: number): string => `y:${v}`
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ yAxis: { tickFormatter: explicit, format: 'percentage' } }}
+                />
+            )
+            expect(chart.yTicks().every((t) => t.startsWith('y:'))).toBe(true)
         })
     })
 
@@ -195,8 +113,8 @@ describe('TimeSeriesLineChart', () => {
         it.each([
             ['omitted', undefined],
             ['false', false as const],
-        ])('does not render ValueLabels when %s', (_, valueLabels) => {
-            render(
+        ])('does not render value labels when %s', (_, valueLabels) => {
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
                     series={SERIES}
                     labels={LABELS}
@@ -204,18 +122,19 @@ describe('TimeSeriesLineChart', () => {
                     config={valueLabels === undefined ? undefined : { valueLabels }}
                 />
             )
-            expect(valueLabelsSpy).not.toHaveBeenCalled()
+            expect(chart.valueLabels()).toHaveLength(0)
         })
 
-        it('renders ValueLabels with no formatter when valueLabels=true and yAxis has no format', () => {
-            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ valueLabels: true }} />)
-            expect(valueLabelsSpy).toHaveBeenCalledTimes(1)
-            expect(valueLabelsSpy.mock.calls[0][0].valueFormatter).toBeUndefined()
+        it('renders one value label per visible point when valueLabels=true', () => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ valueLabels: true }} />
+            )
+            expect(chart.valueLabels()).toHaveLength(SERIES[0].data.length)
         })
 
-        it('forwards an explicit formatter unchanged in behaviour', () => {
+        it('forwards an explicit formatter', () => {
             const formatter = (v: number): string => `~${v}`
-            render(
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
                     series={SERIES}
                     labels={LABELS}
@@ -223,26 +142,24 @@ describe('TimeSeriesLineChart', () => {
                     config={{ valueLabels: { formatter } }}
                 />
             )
-            const valueFormatter = valueLabelsSpy.mock.calls[0][0].valueFormatter
-            expect(valueFormatter?.(7, 0, 0)).toBe('~7')
+            expect(chart.valueLabels().map((l) => l.text)).toEqual(['~1', '~2', '~3'])
         })
 
         it('falls back to a yAxis-driven formatter when no explicit formatter is provided', () => {
-            render(
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
-                    series={SERIES}
-                    labels={LABELS}
+                    series={[{ key: 'a', label: 'A', data: [50] }]}
+                    labels={['Mon']}
                     theme={THEME}
                     config={{ yAxis: { format: 'percentage' }, valueLabels: true }}
                 />
             )
-            const valueFormatter = valueLabelsSpy.mock.calls[0][0].valueFormatter
-            expect(valueFormatter?.(50, 0, 0)).toBe('50%')
+            expect(chart.valueLabels().map((l) => l.text)).toEqual(['50%'])
         })
 
         it('reuses an explicit yAxis.tickFormatter as the default', () => {
             const explicit = (v: number): string => `y:${v}`
-            render(
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
                     series={SERIES}
                     labels={LABELS}
@@ -250,15 +167,15 @@ describe('TimeSeriesLineChart', () => {
                     config={{ yAxis: { tickFormatter: explicit }, valueLabels: true }}
                 />
             )
-            expect(valueLabelsSpy.mock.calls[0][0].valueFormatter).toBe(explicit)
+            expect(chart.valueLabels().map((l) => l.text)).toEqual(['y:1', 'y:2', 'y:3'])
         })
 
-        it('marks non-allowed series as excluded from value labels via visibility.fromValueLabels', () => {
+        it('hides labels for series excluded via seriesKeys', () => {
             const series: Series[] = [
                 { key: 'a', label: 'A', data: [1, 2, 3] },
                 { key: 'b', label: 'B', data: [4, 5, 6] },
             ]
-            render(
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
                     series={series}
                     labels={LABELS}
@@ -266,9 +183,7 @@ describe('TimeSeriesLineChart', () => {
                     config={{ valueLabels: { seriesKeys: ['a'] } }}
                 />
             )
-            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-            expect(props.series[0].visibility?.fromValueLabels).toBeFalsy()
-            expect(props.series[1].visibility?.fromValueLabels).toBe(true)
+            expect(chart.valueLabels()).toHaveLength(3)
         })
     })
 
@@ -276,8 +191,8 @@ describe('TimeSeriesLineChart', () => {
         it.each([
             ['omitted', undefined],
             ['empty', [] as never[]],
-        ])('does not render ReferenceLines when goalLines is %s', (_, goalLines) => {
-            render(
+        ])('does not render reference lines when goalLines is %s', (_, goalLines) => {
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
                     series={SERIES}
                     labels={LABELS}
@@ -285,33 +200,27 @@ describe('TimeSeriesLineChart', () => {
                     config={goalLines === undefined ? undefined : { goalLines }}
                 />
             )
-            expect(referenceLinesSpy).not.toHaveBeenCalled()
+            expect(chart.referenceLines()).toHaveLength(0)
         })
 
-        it('renders ReferenceLines with horizontal goal-variant lines', () => {
-            render(
+        it('renders horizontal goal lines with their label', () => {
+            const { chart } = renderHogChart(
                 <TimeSeriesLineChart
-                    series={SERIES}
+                    series={[{ key: 'a', label: 'A', data: [10, 20, 100] }]}
                     labels={LABELS}
                     theme={THEME}
                     config={{ goalLines: [{ value: 50, label: 'Target' }] }}
                 />
             )
-            expect(referenceLinesSpy).toHaveBeenCalledTimes(1)
-            const lines = referenceLinesSpy.mock.calls[0][0].lines as ReferenceLineProps[]
+            const lines = chart.referenceLines()
             expect(lines).toHaveLength(1)
-            expect(lines[0]).toMatchObject({
-                value: 50,
-                orientation: 'horizontal',
-                variant: 'goal',
-                label: 'Target',
-                labelPosition: 'start',
-            })
+            expect(lines[0].orientation).toBe('horizontal')
+            expect(lines[0].label).toBe('Target')
         })
     })
 
     it('forwards children alongside built-in overlays', () => {
-        const { container } = render(
+        const { container } = renderHogChart(
             <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME}>
                 <div data-attr="custom-overlay" />
             </TimeSeriesLineChart>

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -108,32 +108,13 @@ describe('TimeSeriesLineChart', () => {
         expect(props.config?.xTickFormatter).toBe(explicit)
     })
 
-    it('builds a y-axis tick formatter from yAxis.format', () => {
-        render(
-            <TimeSeriesLineChart
-                series={SERIES}
-                labels={LABELS}
-                theme={THEME}
-                config={{ yAxis: { format: 'percentage' } }}
-            />
-        )
+    it.each([
+        [{ format: 'percentage' as const }, 50, '50%'],
+        [{ prefix: '$', suffix: ' req' }, 42, '$42 req'],
+    ])('builds a y-axis tick formatter from yAxis %p', (yAxis, value, expected) => {
+        render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ yAxis }} />)
         const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        const formatter = props.config?.yTickFormatter
-        expect(formatter).not.toBeUndefined()
-        expect(formatter?.(50)).toBe('50%')
-    })
-
-    it('builds a y-axis tick formatter from yAxis.prefix/suffix without format', () => {
-        render(
-            <TimeSeriesLineChart
-                series={SERIES}
-                labels={LABELS}
-                theme={THEME}
-                config={{ yAxis: { prefix: '$', suffix: ' req' } }}
-            />
-        )
-        const props = lineChartSpy.mock.calls[0][0] as LineChartProps
-        expect(props.config?.yTickFormatter?.(42)).toBe('$42 req')
+        expect(props.config?.yTickFormatter?.(value)).toBe(expected)
     })
 
     it('explicit yAxis.tickFormatter wins over yAxis.format', () => {
@@ -211,12 +192,17 @@ describe('TimeSeriesLineChart', () => {
     })
 
     describe('config.valueLabels', () => {
-        it('does not render ValueLabels when omitted or false', () => {
-            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} />)
-            expect(valueLabelsSpy).not.toHaveBeenCalled()
-
+        it.each([
+            ['omitted', undefined],
+            ['false', false as const],
+        ])('does not render ValueLabels when %s', (_, valueLabels) => {
             render(
-                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ valueLabels: false }} />
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={valueLabels === undefined ? undefined : { valueLabels }}
+                />
             )
             expect(valueLabelsSpy).not.toHaveBeenCalled()
         })
@@ -287,11 +273,18 @@ describe('TimeSeriesLineChart', () => {
     })
 
     describe('config.goalLines', () => {
-        it('does not render ReferenceLines when goalLines is omitted or empty', () => {
-            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} />)
-            expect(referenceLinesSpy).not.toHaveBeenCalled()
-
-            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ goalLines: [] }} />)
+        it.each([
+            ['omitted', undefined],
+            ['empty', [] as never[]],
+        ])('does not render ReferenceLines when goalLines is %s', (_, goalLines) => {
+            render(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={goalLines === undefined ? undefined : { goalLines }}
+                />
+            )
             expect(referenceLinesSpy).not.toHaveBeenCalled()
         })
 

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -254,6 +254,19 @@ describe('TimeSeriesLineChart', () => {
             expect(valueFormatter?.(50, 0, 0)).toBe('50%')
         })
 
+        it('reuses an explicit yAxis.tickFormatter as the default', () => {
+            const explicit = (v: number): string => `y:${v}`
+            render(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ yAxis: { tickFormatter: explicit }, valueLabels: true }}
+                />
+            )
+            expect(valueLabelsSpy.mock.calls[0][0].valueFormatter).toBe(explicit)
+        })
+
         it('marks non-allowed series as excluded from value labels via visibility.fromValueLabels', () => {
             const series: Series[] = [
                 { key: 'a', label: 'A', data: [1, 2, 3] },

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -1,14 +1,32 @@
 import { render } from '@testing-library/react'
 
 import type { ChartTheme, Series } from '../../core/types'
+import type { ReferenceLineProps } from '../../overlays/ReferenceLine'
+import type { ValueLabelsProps } from '../../overlays/ValueLabels'
 import type { LineChartProps } from '../LineChart'
 
 const lineChartSpy = jest.fn()
+const referenceLinesSpy = jest.fn()
+const valueLabelsSpy = jest.fn()
 
 jest.mock('../LineChart', () => ({
     LineChart: (props: LineChartProps) => {
         lineChartSpy(props)
-        return <div data-attr="line-chart-mock" />
+        return <div data-attr="line-chart-mock">{props.children}</div>
+    },
+}))
+
+jest.mock('../../overlays/ReferenceLine', () => ({
+    ReferenceLines: (props: { lines: ReferenceLineProps[] }) => {
+        referenceLinesSpy(props)
+        return <div data-attr="reference-lines-mock" />
+    },
+}))
+
+jest.mock('../../overlays/ValueLabels', () => ({
+    ValueLabels: (props: ValueLabelsProps) => {
+        valueLabelsSpy(props)
+        return <div data-attr="value-labels-mock" />
     },
 }))
 
@@ -21,6 +39,8 @@ const SERIES: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3] }]
 describe('TimeSeriesLineChart', () => {
     beforeEach(() => {
         lineChartSpy.mockClear()
+        referenceLinesSpy.mockClear()
+        valueLabelsSpy.mockClear()
     })
 
     it('translates config.xAxis and config.yAxis fields onto LineChartConfig', () => {
@@ -149,5 +169,147 @@ describe('TimeSeriesLineChart', () => {
         )
         const props = lineChartSpy.mock.calls[0][0] as LineChartProps
         expect(props.config?.xTickFormatter).toBeUndefined()
+    })
+
+    describe('config.inProgress', () => {
+        it('sets stroke.partial.fromIndex on each series when configured', () => {
+            render(
+                <TimeSeriesLineChart
+                    series={[
+                        { key: 'a', label: 'A', data: [1, 2, 3, 4] },
+                        { key: 'b', label: 'B', data: [5, 6, 7, 8] },
+                    ]}
+                    labels={['Mon', 'Tue', 'Wed', 'Thu']}
+                    theme={THEME}
+                    config={{ inProgress: { fromIndex: 2 } }}
+                />
+            )
+            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+            expect(props.series[0].stroke?.partial?.fromIndex).toBe(2)
+            expect(props.series[1].stroke?.partial?.fromIndex).toBe(2)
+        })
+
+        it("preserves a series' explicit stroke.partial when inProgress is set", () => {
+            const explicitPartial = { fromIndex: 99, pattern: [4, 4] as number[] }
+            render(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3], stroke: { partial: explicitPartial } }]}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ inProgress: { fromIndex: 1 } }}
+                />
+            )
+            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+            expect(props.series[0].stroke?.partial).toBe(explicitPartial)
+        })
+
+        it('leaves series untouched when inProgress is omitted', () => {
+            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} />)
+            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+            expect(props.series).toBe(SERIES)
+        })
+    })
+
+    describe('config.valueLabels', () => {
+        it('does not render ValueLabels when omitted or false', () => {
+            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} />)
+            expect(valueLabelsSpy).not.toHaveBeenCalled()
+
+            render(
+                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ valueLabels: false }} />
+            )
+            expect(valueLabelsSpy).not.toHaveBeenCalled()
+        })
+
+        it('renders ValueLabels with no formatter when valueLabels=true and yAxis has no format', () => {
+            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ valueLabels: true }} />)
+            expect(valueLabelsSpy).toHaveBeenCalledTimes(1)
+            expect(valueLabelsSpy.mock.calls[0][0].valueFormatter).toBeUndefined()
+        })
+
+        it('forwards an explicit formatter unchanged in behaviour', () => {
+            const formatter = (v: number): string => `~${v}`
+            render(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ valueLabels: { formatter } }}
+                />
+            )
+            const valueFormatter = valueLabelsSpy.mock.calls[0][0].valueFormatter
+            expect(valueFormatter?.(7, 0, 0)).toBe('~7')
+        })
+
+        it('falls back to a yAxis-driven formatter when no explicit formatter is provided', () => {
+            render(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ yAxis: { format: 'percentage' }, valueLabels: true }}
+                />
+            )
+            const valueFormatter = valueLabelsSpy.mock.calls[0][0].valueFormatter
+            expect(valueFormatter?.(50, 0, 0)).toBe('50%')
+        })
+
+        it('marks non-allowed series as excluded from value labels via visibility.fromValueLabels', () => {
+            const series: Series[] = [
+                { key: 'a', label: 'A', data: [1, 2, 3] },
+                { key: 'b', label: 'B', data: [4, 5, 6] },
+            ]
+            render(
+                <TimeSeriesLineChart
+                    series={series}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ valueLabels: { seriesKeys: ['a'] } }}
+                />
+            )
+            const props = lineChartSpy.mock.calls[0][0] as LineChartProps
+            expect(props.series[0].visibility?.fromValueLabels).toBeFalsy()
+            expect(props.series[1].visibility?.fromValueLabels).toBe(true)
+        })
+    })
+
+    describe('config.goalLines', () => {
+        it('does not render ReferenceLines when goalLines is omitted or empty', () => {
+            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} />)
+            expect(referenceLinesSpy).not.toHaveBeenCalled()
+
+            render(<TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ goalLines: [] }} />)
+            expect(referenceLinesSpy).not.toHaveBeenCalled()
+        })
+
+        it('renders ReferenceLines with horizontal goal-variant lines', () => {
+            render(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ goalLines: [{ value: 50, label: 'Target' }] }}
+                />
+            )
+            expect(referenceLinesSpy).toHaveBeenCalledTimes(1)
+            const lines = referenceLinesSpy.mock.calls[0][0].lines as ReferenceLineProps[]
+            expect(lines).toHaveLength(1)
+            expect(lines[0]).toMatchObject({
+                value: 50,
+                orientation: 'horizontal',
+                variant: 'goal',
+                label: 'Target',
+                labelPosition: 'start',
+            })
+        })
+    })
+
+    it('forwards children alongside built-in overlays', () => {
+        const { container } = render(
+            <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME}>
+                <div data-attr="custom-overlay" />
+            </TimeSeriesLineChart>
+        )
+        expect(container.querySelector('[data-attr="custom-overlay"]')).not.toBeNull()
     })
 })

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -1,12 +1,38 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../../core/types'
+import { ReferenceLines } from '../../overlays/ReferenceLine'
+import { ValueLabels } from '../../overlays/ValueLabels'
 import { LineChart } from '../LineChart'
+import { buildGoalLineReferenceLines, type GoalLineConfig } from './utils/goal-lines'
 import { useXTickFormatter, useYTickFormatter, type XAxisConfig, type YAxisConfig } from './utils/use-axis-formatters'
+import { buildYTickFormatter } from './utils/y-formatters'
+
+export interface ValueLabelsConfig {
+    /** When set, only series whose `key` is in this list get value labels.
+     *  Other series stay rendered on the chart but skip the labels overlay. */
+    seriesKeys?: string[]
+    /** Override the label text formatter. Falls back to a `yAxis`-driven
+     *  formatter when omitted (or no formatter when `yAxis.format` is unset). */
+    formatter?: (value: number) => string
+}
+
+export interface InProgressConfig {
+    /** Index from which the in-progress (dashed) tail begins. Series whose
+     *  `stroke.partial` is already set keep their explicit value. */
+    fromIndex: number
+}
 
 export interface TimeSeriesLineChartConfig {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    /** Mark the tail of every series as in-progress (dashed). */
+    inProgress?: InProgressConfig
+    /** Render the {@link ValueLabels} overlay. `true` enables it with defaults;
+     *  passing an object configures filtering/formatting. */
+    valueLabels?: boolean | ValueLabelsConfig
+    /** Render goal lines as horizontal {@link ReferenceLines} on the chart. */
+    goalLines?: GoalLineConfig[]
 }
 
 export interface TimeSeriesLineChartProps<Meta = unknown> {
@@ -20,6 +46,32 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     /** `data-attr` applied to the chart wrapper for product-level test selectors. */
     dataAttr?: string
     className?: string
+    /** Custom overlays composed alongside the built-in ones (rendered after them). */
+    children?: React.ReactNode
+}
+
+function resolveValueLabelsConfig(valueLabels: TimeSeriesLineChartConfig['valueLabels']): ValueLabelsConfig | null {
+    if (valueLabels === undefined || valueLabels === false) {
+        return null
+    }
+    if (valueLabels === true) {
+        return {}
+    }
+    return valueLabels
+}
+
+function hasYFormatterConfig(yAxis: YAxisConfig | undefined): boolean {
+    if (!yAxis) {
+        return false
+    }
+    return (
+        yAxis.format !== undefined ||
+        yAxis.prefix !== undefined ||
+        yAxis.suffix !== undefined ||
+        yAxis.decimalPlaces !== undefined ||
+        yAxis.minDecimalPlaces !== undefined ||
+        yAxis.currency !== undefined
+    )
 }
 
 export function TimeSeriesLineChart<Meta = unknown>({
@@ -31,10 +83,61 @@ export function TimeSeriesLineChart<Meta = unknown>({
     onPointClick,
     dataAttr,
     className,
+    children,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
-    const { xAxis, yAxis } = config ?? {}
+    const { xAxis, yAxis, inProgress, valueLabels, goalLines } = config ?? {}
     const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
+
+    const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
+
+    const seriesWithInProgress = useMemo(() => {
+        if (inProgress?.fromIndex === undefined) {
+            return series
+        }
+        const fromIndex = inProgress.fromIndex
+        return series.map((s) =>
+            s.stroke?.partial !== undefined ? s : { ...s, stroke: { ...s.stroke, partial: { fromIndex } } }
+        )
+    }, [series, inProgress?.fromIndex])
+
+    // Filter ValueLabels overlay via the per-series `fromValueLabels` flag — leaves
+    // everything else (rendering, hit-testing, tooltips) untouched.
+    const transformedSeries = useMemo(() => {
+        const seriesKeys = valueLabelsConfig?.seriesKeys
+        if (!seriesKeys) {
+            return seriesWithInProgress
+        }
+        const allowed = new Set(seriesKeys)
+        return seriesWithInProgress.map((s) =>
+            allowed.has(s.key) ? s : { ...s, visibility: { ...s.visibility, fromValueLabels: true } }
+        )
+    }, [seriesWithInProgress, valueLabelsConfig?.seriesKeys])
+
+    const valueLabelFormatter = useMemo(() => {
+        if (!valueLabelsConfig) {
+            return undefined
+        }
+        if (valueLabelsConfig.formatter) {
+            return valueLabelsConfig.formatter
+        }
+        if (hasYFormatterConfig(yAxis)) {
+            return buildYTickFormatter({
+                format: yAxis?.format,
+                prefix: yAxis?.prefix,
+                suffix: yAxis?.suffix,
+                decimalPlaces: yAxis?.decimalPlaces,
+                minDecimalPlaces: yAxis?.minDecimalPlaces,
+                currency: yAxis?.currency,
+            })
+        }
+        return undefined
+    }, [valueLabelsConfig, yAxis])
+
+    const referenceLines = useMemo(
+        () => buildGoalLineReferenceLines(goalLines, transformedSeries),
+        [goalLines, transformedSeries]
+    )
 
     const lineChartConfig: LineChartConfig = {
         yScaleType: yAxis?.scale,
@@ -47,7 +150,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
 
     return (
         <LineChart
-            series={series}
+            series={transformedSeries}
             labels={labels}
             config={lineChartConfig}
             theme={theme}
@@ -55,6 +158,12 @@ export function TimeSeriesLineChart<Meta = unknown>({
             onPointClick={onPointClick}
             className={className}
             dataAttr={dataAttr}
-        />
+        >
+            {referenceLines.length > 0 && <ReferenceLines lines={referenceLines} />}
+            {valueLabelsConfig && (
+                <ValueLabels valueFormatter={valueLabelFormatter ? (v) => valueLabelFormatter(v) : undefined} />
+            )}
+            {children}
+        </LineChart>
     )
 }

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -5,15 +5,12 @@ import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import { LineChart } from '../LineChart'
 import { buildGoalLineReferenceLines, type GoalLineConfig } from './utils/goal-lines'
+import { applyInProgressToSeries, type InProgressConfig } from './utils/in-progress'
 import { useXTickFormatter, useYTickFormatter, type XAxisConfig, type YAxisConfig } from './utils/use-axis-formatters'
 
 export interface ValueLabelsConfig {
     seriesKeys?: string[]
     formatter?: (value: number) => string
-}
-
-export interface InProgressConfig {
-    fromIndex: number
 }
 
 export interface TimeSeriesLineChartConfig {
@@ -63,15 +60,10 @@ export function TimeSeriesLineChart<Meta = unknown>({
 
     const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
 
-    const seriesWithInProgress = useMemo(() => {
-        if (inProgress?.fromIndex === undefined) {
-            return series
-        }
-        const fromIndex = inProgress.fromIndex
-        return series.map((s) =>
-            s.stroke?.partial !== undefined ? s : { ...s, stroke: { ...s.stroke, partial: { fromIndex } } }
-        )
-    }, [series, inProgress?.fromIndex])
+    const seriesWithInProgress = useMemo(
+        () => applyInProgressToSeries(series, inProgress),
+        [series, inProgress?.fromIndex]
+    )
 
     const transformedSeries = useMemo(() => {
         const seriesKeys = valueLabelsConfig?.seriesKeys

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -6,7 +6,6 @@ import { ValueLabels } from '../../overlays/ValueLabels'
 import { LineChart } from '../LineChart'
 import { buildGoalLineReferenceLines, type GoalLineConfig } from './utils/goal-lines'
 import { useXTickFormatter, useYTickFormatter, type XAxisConfig, type YAxisConfig } from './utils/use-axis-formatters'
-import { buildYTickFormatter } from './utils/y-formatters'
 
 export interface ValueLabelsConfig {
     /** When set, only series whose `key` is in this list get value labels.
@@ -60,20 +59,6 @@ function resolveValueLabelsConfig(valueLabels: TimeSeriesLineChartConfig['valueL
     return valueLabels
 }
 
-function hasYFormatterConfig(yAxis: YAxisConfig | undefined): boolean {
-    if (!yAxis) {
-        return false
-    }
-    return (
-        yAxis.format !== undefined ||
-        yAxis.prefix !== undefined ||
-        yAxis.suffix !== undefined ||
-        yAxis.decimalPlaces !== undefined ||
-        yAxis.minDecimalPlaces !== undefined ||
-        yAxis.currency !== undefined
-    )
-}
-
 export function TimeSeriesLineChart<Meta = unknown>({
     series,
     labels,
@@ -114,25 +99,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
         )
     }, [seriesWithInProgress, valueLabelsConfig?.seriesKeys])
 
-    const valueLabelFormatter = useMemo(() => {
-        if (!valueLabelsConfig) {
-            return undefined
-        }
-        if (valueLabelsConfig.formatter) {
-            return valueLabelsConfig.formatter
-        }
-        if (hasYFormatterConfig(yAxis)) {
-            return buildYTickFormatter({
-                format: yAxis?.format,
-                prefix: yAxis?.prefix,
-                suffix: yAxis?.suffix,
-                decimalPlaces: yAxis?.decimalPlaces,
-                minDecimalPlaces: yAxis?.minDecimalPlaces,
-                currency: yAxis?.currency,
-            })
-        }
-        return undefined
-    }, [valueLabelsConfig, yAxis])
+    const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
 
     const referenceLines = useMemo(
         () => buildGoalLineReferenceLines(goalLines, transformedSeries),
@@ -160,9 +127,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
             dataAttr={dataAttr}
         >
             {referenceLines.length > 0 && <ReferenceLines lines={referenceLines} />}
-            {valueLabelsConfig && (
-                <ValueLabels valueFormatter={valueLabelFormatter ? (v) => valueLabelFormatter(v) : undefined} />
-            )}
+            {valueLabelsConfig && <ValueLabels valueFormatter={valueLabelFormatter} />}
             {children}
         </LineChart>
     )

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -8,44 +8,31 @@ import { buildGoalLineReferenceLines, type GoalLineConfig } from './utils/goal-l
 import { useXTickFormatter, useYTickFormatter, type XAxisConfig, type YAxisConfig } from './utils/use-axis-formatters'
 
 export interface ValueLabelsConfig {
-    /** When set, only series whose `key` is in this list get value labels.
-     *  Other series stay rendered on the chart but skip the labels overlay. */
     seriesKeys?: string[]
-    /** Override the label text formatter. Falls back to a `yAxis`-driven
-     *  formatter when omitted (or no formatter when `yAxis.format` is unset). */
     formatter?: (value: number) => string
 }
 
 export interface InProgressConfig {
-    /** Index from which the in-progress (dashed) tail begins. Series whose
-     *  `stroke.partial` is already set keep their explicit value. */
     fromIndex: number
 }
 
 export interface TimeSeriesLineChartConfig {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
-    /** Mark the tail of every series as in-progress (dashed). */
     inProgress?: InProgressConfig
-    /** Render the {@link ValueLabels} overlay. `true` enables it with defaults;
-     *  passing an object configures filtering/formatting. */
     valueLabels?: boolean | ValueLabelsConfig
-    /** Render goal lines as horizontal {@link ReferenceLines} on the chart. */
     goalLines?: GoalLineConfig[]
 }
 
 export interface TimeSeriesLineChartProps<Meta = unknown> {
     series: Series<Meta>[]
-    /** Pre-formatted time labels. Length must match each series.data. */
     labels: string[]
     theme: ChartTheme
     config?: TimeSeriesLineChartConfig
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
-    /** `data-attr` applied to the chart wrapper for product-level test selectors. */
     dataAttr?: string
     className?: string
-    /** Custom overlays composed alongside the built-in ones (rendered after them). */
     children?: React.ReactNode
 }
 
@@ -86,8 +73,6 @@ export function TimeSeriesLineChart<Meta = unknown>({
         )
     }, [series, inProgress?.fromIndex])
 
-    // Filter ValueLabels overlay via the per-series `fromValueLabels` flag — leaves
-    // everything else (rendering, hit-testing, tooltips) untouched.
     const transformedSeries = useMemo(() => {
         const seriesKeys = valueLabelsConfig?.seriesKeys
         if (!seriesKeys) {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.test.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.test.ts
@@ -24,19 +24,23 @@ describe('goal-lines', () => {
             ).toBe(3)
         })
 
-        it('returns 0 when no series have non-zero values', () => {
-            expect(computeSeriesNonZeroMax([makeSeries([0, 0, NaN])])).toBe(0)
-            expect(computeSeriesNonZeroMax([])).toBe(0)
+        it.each([
+            ['only zeros/NaN', [makeSeries([0, 0, NaN])]],
+            ['empty input', []],
+        ])('returns 0 when %s', (_, input) => {
+            expect(computeSeriesNonZeroMax(input)).toBe(0)
         })
     })
 
     describe('buildGoalLineReferenceLines', () => {
         const series = [makeSeries([10, 20, 30])]
 
-        it('returns an empty array for nullish/empty input', () => {
-            expect(buildGoalLineReferenceLines(null, series)).toEqual([])
-            expect(buildGoalLineReferenceLines(undefined, series)).toEqual([])
-            expect(buildGoalLineReferenceLines([], series)).toEqual([])
+        it.each([
+            ['null', null],
+            ['undefined', undefined],
+            ['empty', []],
+        ] as const)('returns [] for %s input', (_, input) => {
+            expect(buildGoalLineReferenceLines(input, series)).toEqual([])
         })
 
         it('maps each goal to a horizontal "goal" ReferenceLine, defaulting label position to start', () => {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.test.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.test.ts
@@ -1,0 +1,80 @@
+import type { Series } from '../../../core/types'
+import { buildGoalLineReferenceLines, computeSeriesNonZeroMax, type GoalLineConfig } from './goal-lines'
+
+const makeSeries = (data: number[], overrides: Partial<Series> = {}): Series => ({
+    key: 'a',
+    label: 'a',
+    color: '#000',
+    data,
+    ...overrides,
+})
+
+describe('goal-lines', () => {
+    describe('computeSeriesNonZeroMax', () => {
+        it('returns the max non-zero finite value across all series', () => {
+            expect(computeSeriesNonZeroMax([makeSeries([1, 2, 0, 5]), makeSeries([0, 0, 3, NaN])])).toBe(5)
+        })
+
+        it('ignores excluded series', () => {
+            expect(
+                computeSeriesNonZeroMax([
+                    makeSeries([1, 2, 3]),
+                    makeSeries([1000], { key: 'b', visibility: { excluded: true } }),
+                ])
+            ).toBe(3)
+        })
+
+        it('returns 0 when no series have non-zero values', () => {
+            expect(computeSeriesNonZeroMax([makeSeries([0, 0, NaN])])).toBe(0)
+            expect(computeSeriesNonZeroMax([])).toBe(0)
+        })
+    })
+
+    describe('buildGoalLineReferenceLines', () => {
+        const series = [makeSeries([10, 20, 30])]
+
+        it('returns an empty array for nullish/empty input', () => {
+            expect(buildGoalLineReferenceLines(null, series)).toEqual([])
+            expect(buildGoalLineReferenceLines(undefined, series)).toEqual([])
+            expect(buildGoalLineReferenceLines([], series)).toEqual([])
+        })
+
+        it('maps each goal to a horizontal "goal" ReferenceLine, defaulting label position to start', () => {
+            const result = buildGoalLineReferenceLines([{ label: 'Target', value: 50 }], series)
+            expect(result).toHaveLength(1)
+            expect(result[0]).toMatchObject({
+                value: 50,
+                orientation: 'horizontal',
+                variant: 'goal',
+                label: 'Target',
+                labelPosition: 'start',
+            })
+        })
+
+        it.each([
+            ['propagates color via style.color', { color: 'var(--danger)' }, { style: { color: 'var(--danger)' } }],
+            ['omits label when displayLabel is false', { displayLabel: false }, { label: undefined }],
+            ['respects explicit labelPosition', { labelPosition: 'end' as const }, { labelPosition: 'end' }],
+        ] as const)('%s', (_, lineOverrides, expectedProps) => {
+            const lines: GoalLineConfig[] = [{ label: 'X', value: 50, ...lineOverrides }]
+            expect(buildGoalLineReferenceLines(lines, series)[0]).toMatchObject(expectedProps)
+        })
+
+        it('drops lines when displayIfCrossed=false and value is below the series peak', () => {
+            const lines: GoalLineConfig[] = [
+                { label: 'Crossed', value: 5, displayIfCrossed: false },
+                { label: 'Uncrossed', value: 100, displayIfCrossed: false },
+            ]
+            // seriesMax = 30
+            expect(buildGoalLineReferenceLines(lines, series).map((r) => r.label)).toEqual(['Uncrossed'])
+        })
+
+        it('keeps lines when displayIfCrossed is undefined or true', () => {
+            const lines: GoalLineConfig[] = [
+                { label: 'Default', value: 5 },
+                { label: 'Explicit', value: 5, displayIfCrossed: true },
+            ]
+            expect(buildGoalLineReferenceLines(lines, series)).toHaveLength(2)
+        })
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.ts
@@ -31,7 +31,7 @@ export function computeSeriesNonZeroMax(series: Series[]): number {
 }
 
 export function buildGoalLineReferenceLines(
-    lines: GoalLineConfig[] | null | undefined,
+    lines: readonly GoalLineConfig[] | null | undefined,
     series: Series[]
 ): ReferenceLineProps[] {
     if (!lines?.length) {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.ts
@@ -1,26 +1,15 @@
 import type { Series } from '../../../core/types'
 import type { ReferenceLineProps } from '../../../overlays/ReferenceLine'
 
-/** Library-agnostic shape for a horizontal goal line. Adapters in product code
- *  (e.g. trends' SchemaGoalLine adapter) translate their persisted shape to this. */
 export interface GoalLineConfig {
-    /** Y-value at which to draw the line. */
     value: number
-    /** Optional text label rendered alongside the line. */
     label?: string
-    /** When `false`, suppress the label even if `label` is set. Defaults to `true`. */
     displayLabel?: boolean
-    /** Color override for both the line stroke and label. */
     color?: string
-    /** Anchor for the label. Defaults to `'start'`. */
     labelPosition?: 'start' | 'end'
-    /** When explicitly `false`, hide the line if any series value already exceeds it
-     *  (matches the trends "displayIfCrossed" semantics). Defaults to `true`. */
     displayIfCrossed?: boolean
 }
 
-/** Compute the max non-zero, non-NaN value across all visible series.
- *  Used for the `displayIfCrossed` filter in {@link buildGoalLineReferenceLines}. */
 export function computeSeriesNonZeroMax(series: Series[]): number {
     let max = Number.NEGATIVE_INFINITY
     for (const s of series) {
@@ -29,7 +18,7 @@ export function computeSeriesNonZeroMax(series: Series[]): number {
         }
         for (const raw of s.data) {
             const value = Number(raw)
-            // `!value` covers both 0 and NaN (since `!NaN === true`).
+            // `!value` covers both 0 and NaN (since `!NaN === true`)
             if (!value) {
                 continue
             }
@@ -41,8 +30,6 @@ export function computeSeriesNonZeroMax(series: Series[]): number {
     return max === Number.NEGATIVE_INFINITY ? 0 : max
 }
 
-/** Map {@link GoalLineConfig}s to {@link ReferenceLineProps}, applying the
- *  `displayIfCrossed` filter so already-crossed targets are dropped. */
 export function buildGoalLineReferenceLines(
     lines: GoalLineConfig[] | null | undefined,
     series: Series[]

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/goal-lines.ts
@@ -1,0 +1,64 @@
+import type { Series } from '../../../core/types'
+import type { ReferenceLineProps } from '../../../overlays/ReferenceLine'
+
+/** Library-agnostic shape for a horizontal goal line. Adapters in product code
+ *  (e.g. trends' SchemaGoalLine adapter) translate their persisted shape to this. */
+export interface GoalLineConfig {
+    /** Y-value at which to draw the line. */
+    value: number
+    /** Optional text label rendered alongside the line. */
+    label?: string
+    /** When `false`, suppress the label even if `label` is set. Defaults to `true`. */
+    displayLabel?: boolean
+    /** Color override for both the line stroke and label. */
+    color?: string
+    /** Anchor for the label. Defaults to `'start'`. */
+    labelPosition?: 'start' | 'end'
+    /** When explicitly `false`, hide the line if any series value already exceeds it
+     *  (matches the trends "displayIfCrossed" semantics). Defaults to `true`. */
+    displayIfCrossed?: boolean
+}
+
+/** Compute the max non-zero, non-NaN value across all visible series.
+ *  Used for the `displayIfCrossed` filter in {@link buildGoalLineReferenceLines}. */
+export function computeSeriesNonZeroMax(series: Series[]): number {
+    let max = Number.NEGATIVE_INFINITY
+    for (const s of series) {
+        if (s.visibility?.excluded) {
+            continue
+        }
+        for (const raw of s.data) {
+            const value = Number(raw)
+            // `!value` covers both 0 and NaN (since `!NaN === true`).
+            if (!value) {
+                continue
+            }
+            if (value > max) {
+                max = value
+            }
+        }
+    }
+    return max === Number.NEGATIVE_INFINITY ? 0 : max
+}
+
+/** Map {@link GoalLineConfig}s to {@link ReferenceLineProps}, applying the
+ *  `displayIfCrossed` filter so already-crossed targets are dropped. */
+export function buildGoalLineReferenceLines(
+    lines: GoalLineConfig[] | null | undefined,
+    series: Series[]
+): ReferenceLineProps[] {
+    if (!lines?.length) {
+        return []
+    }
+    const seriesNonZeroMax = computeSeriesNonZeroMax(series)
+    return lines
+        .filter((line) => line.displayIfCrossed !== false || line.value >= seriesNonZeroMax)
+        .map((line) => ({
+            value: line.value,
+            orientation: 'horizontal',
+            label: line.displayLabel === false ? undefined : line.label,
+            labelPosition: line.labelPosition ?? 'start',
+            variant: 'goal',
+            style: line.color ? { color: line.color } : undefined,
+        }))
+}

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.test.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.test.ts
@@ -1,0 +1,26 @@
+import type { Series } from '../../../core/types'
+import { applyInProgressToSeries } from './in-progress'
+
+const SERIES: Series[] = [
+    { key: 'a', label: 'A', data: [1, 2, 3, 4] },
+    { key: 'b', label: 'B', data: [5, 6, 7, 8] },
+]
+
+describe('applyInProgressToSeries', () => {
+    it('returns the original reference when inProgress is undefined', () => {
+        expect(applyInProgressToSeries(SERIES, undefined)).toBe(SERIES)
+    })
+
+    it('sets stroke.partial.fromIndex on each series when configured', () => {
+        const result = applyInProgressToSeries(SERIES, { fromIndex: 2 })
+        expect(result[0].stroke?.partial?.fromIndex).toBe(2)
+        expect(result[1].stroke?.partial?.fromIndex).toBe(2)
+    })
+
+    it("preserves a series' explicit stroke.partial", () => {
+        const explicitPartial = { fromIndex: 99, pattern: [4, 4] as number[] }
+        const series: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3], stroke: { partial: explicitPartial } }]
+        const result = applyInProgressToSeries(series, { fromIndex: 1 })
+        expect(result[0].stroke?.partial).toBe(explicitPartial)
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.ts
@@ -1,0 +1,18 @@
+import type { Series } from '../../../core/types'
+
+export interface InProgressConfig {
+    fromIndex: number
+}
+
+export function applyInProgressToSeries<Meta = unknown>(
+    series: Series<Meta>[],
+    inProgress: InProgressConfig | undefined
+): Series<Meta>[] {
+    if (inProgress?.fromIndex === undefined) {
+        return series
+    }
+    const fromIndex = inProgress.fromIndex
+    return series.map((s) =>
+        s.stroke?.partial !== undefined ? s : { ...s, stroke: { ...s.stroke, partial: { fromIndex } } }
+    )
+}

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -5,11 +5,11 @@ export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 export type {
-    InProgressConfig,
     TimeSeriesLineChartConfig,
     TimeSeriesLineChartProps,
     ValueLabelsConfig,
 } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
+export type { InProgressConfig } from './charts/TimeSeriesLineChart/utils/in-progress'
 
 // Base chart (for building new chart types)
 export { Chart } from './core/Chart'

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -5,8 +5,10 @@ export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 export type {
+    InProgressConfig,
     TimeSeriesLineChartConfig,
     TimeSeriesLineChartProps,
+    ValueLabelsConfig,
 } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
 
 // Base chart (for building new chart types)
@@ -64,3 +66,5 @@ export type { TimeInterval } from './charts/TimeSeriesLineChart/utils/dates'
 export { buildYTickFormatter } from './charts/TimeSeriesLineChart/utils/y-formatters'
 export type { YAxisFormat, YFormatterConfig } from './charts/TimeSeriesLineChart/utils/y-formatters'
 export type { XAxisConfig, YAxisConfig } from './charts/TimeSeriesLineChart/utils/use-axis-formatters'
+export { buildGoalLineReferenceLines, computeSeriesNonZeroMax } from './charts/TimeSeriesLineChart/utils/goal-lines'
+export type { GoalLineConfig } from './charts/TimeSeriesLineChart/utils/goal-lines'

--- a/frontend/src/scenes/trends/viz/trends-line-chart/goalLinesAdapter.ts
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/goalLinesAdapter.ts
@@ -1,37 +1,19 @@
-import type { ReferenceLineProps, Series } from 'lib/hog-charts'
+import { buildGoalLineReferenceLines, computeSeriesNonZeroMax } from 'lib/hog-charts'
+import type { GoalLineConfig, ReferenceLineProps, Series } from 'lib/hog-charts'
 
 import type { GoalLine as SchemaGoalLine } from '~/queries/schema/schema-general'
 
-/** Compute the max non-zero, non-NaN value across all series. Used for the
- *  `displayIfCrossed` filter below. Matches the Chart.js LineGraph behavior. */
-export function computeSeriesNonZeroMax(series: Series[]): number {
-    let max = Number.NEGATIVE_INFINITY
-    for (const s of series) {
-        if (s.visibility?.excluded) {
-            continue
-        }
-        for (const raw of s.data) {
-            const value = Number(raw)
-            // `!value` covers both 0 and NaN (since `!NaN === true`).
-            if (!value) {
-                continue
-            }
-            if (value > max) {
-                max = value
-            }
-        }
-    }
-    return max === Number.NEGATIVE_INFINITY ? 0 : max
-}
+// Re-exported so existing call sites importing from this adapter keep working.
+export { computeSeriesNonZeroMax }
 
-function goalLineToReferenceLine(goal: SchemaGoalLine, variant: 'goal' | 'alert'): ReferenceLineProps {
+function schemaToGoalLineConfig(line: SchemaGoalLine): GoalLineConfig {
     return {
-        value: goal.value,
-        orientation: 'horizontal',
-        label: goal.displayLabel === false ? undefined : goal.label,
-        labelPosition: goal.position ?? 'start',
-        variant,
-        style: goal.borderColor ? { color: goal.borderColor } : undefined,
+        value: line.value,
+        label: line.label,
+        displayLabel: line.displayLabel,
+        color: line.borderColor,
+        labelPosition: line.position,
+        displayIfCrossed: line.displayIfCrossed,
     }
 }
 
@@ -46,10 +28,7 @@ export function goalLinesToReferenceLines(
     if (!goalLines?.length) {
         return []
     }
-    const seriesNonZeroMax = computeSeriesNonZeroMax(series)
-    return goalLines
-        .filter((goal) => goal.displayIfCrossed !== false || goal.value >= seriesNonZeroMax)
-        .map((goal) => goalLineToReferenceLine(goal, 'goal'))
+    return buildGoalLineReferenceLines(goalLines.map(schemaToGoalLineConfig), series)
 }
 
 /** Map alert threshold lines (sourced from `insightAlertsLogic.alertThresholdLines`) to
@@ -61,5 +40,12 @@ export function alertThresholdsToReferenceLines(
     if (!alertThresholdLines?.length) {
         return []
     }
-    return alertThresholdLines.map((line) => goalLineToReferenceLine(line, 'alert'))
+    return alertThresholdLines.map((line) => ({
+        value: line.value,
+        orientation: 'horizontal',
+        label: line.displayLabel === false ? undefined : line.label,
+        labelPosition: line.position ?? 'start',
+        variant: 'alert',
+        style: line.borderColor ? { color: line.borderColor } : undefined,
+    }))
 }


### PR DESCRIPTION
## Problem

`TimeSeriesLineChart` is the generic charting primitive that non-trends consumers should be able to drive entirely from config. Today it can't render in-progress dashed tails, value labels, or goal lines without callers reaching into `LineChart` and the trends-specific adapter. Stage 4 of the migration wires these three features as first-class config props so non-trends call sites can adopt the primitive without copying trends code.

This PR also extracts the generic core of the trends `goalLinesAdapter` into `lib/hog-charts` so non-trends consumers don't pull in `scenes/trends` to build a goal line.

## Changes

- `TimeSeriesLineChart` now wraps `LineChart` (instead of self-closing it) so it can render internal overlays. It also accepts a `children` prop for caller-composed overlays.
- New `config.inProgress?: { fromIndex }` — transforms each series' `stroke.partial` to mark the tail as in-progress. Series with an explicit `stroke.partial` keep their own value (mirrors trends `incompletenessOffsetFromEnd` semantics).
- New `config.valueLabels?: boolean | { seriesKeys?, formatter? }` — renders the existing `ValueLabels` overlay. The `seriesKeys` filter is implemented by setting `visibility.fromValueLabels` on excluded series so neither the overlay nor any other surface is changed. When `formatter` is omitted, falls back to a `yAxis.format`-driven formatter, else no formatter.
- New `config.goalLines?: GoalLineConfig[]` — renders horizontal `ReferenceLines` internally.
- Extract `utils/goal-lines.ts` in `lib/hog-charts` — exports `GoalLineConfig`, `buildGoalLineReferenceLines`, `computeSeriesNonZeroMax`. Refactor `scenes/trends/viz/trends-line-chart/goalLinesAdapter.ts` so `goalLinesToReferenceLines` delegates to the generic helper. `alertThresholdsToReferenceLines` stays put (trends/alerts feature). Public signatures of both adapter functions are unchanged.
- Re-export new types/helpers from the `lib/hog-charts` barrel.
- One Storybook story per new feature (`InProgress`, `ValueLabels`, `GoalLines`).

No changes to `TrendsLineChart`, `TrendsAlertOverlays`, `LineChart`, `Series`, `core/types.ts`, `canvas-renderer.ts`, or any existing overlay. Trends adoption is Phase B.

## How did you test this code?

I'm an agent. Tests run locally:

- New `goal-lines.test.ts` (10 tests) and updated `TimeSeriesLineChart.test.tsx` (19 tests, 11 new) pass.
- Existing `goalLinesAdapter.test.ts` passes unchanged (13 tests).
- `pnpm --filter=@posthog/frontend lint` clean on changed files (0 warnings).
- `pnpm run format:frontend:check` clean.
- File-by-file `tsc --noEmit` clean on the touched files.

I didn't run Storybook in a browser — please skim the new stories visually before merging.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Human prompt: implement Stage 4 of the TimeSeriesLineChart migration spec — wire `inProgress`, `valueLabels`, `goalLines` as config props in one PR, mirroring the 3b adapter pattern for the goal-lines extraction. Do not modify TrendsLineChart or TrendsAlertOverlays.
- Decisions worth flagging:
  - `valueLabels.seriesKeys` is implemented by toggling `visibility.fromValueLabels` on non-allowed series rather than changing `ValueLabels`' prop surface — keeps the overlay untouched per the scope guardrails.
  - The default `valueLabels` formatter reuses `buildYTickFormatter` whenever any of the y-axis formatter inputs are set (`format`, `prefix`, `suffix`, `decimalPlaces`, `minDecimalPlaces`, `currency`). This matches the existing `useYTickFormatter` heuristic so the two stay consistent.
  - `computeSeriesNonZeroMax` is re-exported from the trends adapter for backward compatibility with the existing test imports — the actual definition now lives in `lib/hog-charts`.
  - `valueLabels: false` and `valueLabels: undefined` both skip the overlay; `valueLabels: true` renders with defaults.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*