### PR TITLE
chore(hog-charts): add stories for inProgress, valueLabels, goalLines

### DIFF
--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import { TimeSeriesLineChart } from 'lib/hog-charts'
-import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
+import type { GoalLineConfig, Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
 
@@ -163,6 +163,63 @@ export const YAxisFormats: Story = {
             <YFormatCell title="duration_ms" series={DURATION_MS_SERIES} config={{ format: 'duration_ms' }} />
         </div>
     ),
+}
+
+export const InProgress: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ inProgress: { fromIndex: 4 }, yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
+}
+
+export const ValueLabelsStory: Story = {
+    name: 'ValueLabels',
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{
+                        valueLabels: { seriesKeys: ['visits', 'signups'] },
+                        yAxis: { showGrid: true },
+                    }}
+                />
+            </Stage>
+        )
+    },
+}
+
+const GOAL_LINES: GoalLineConfig[] = [
+    { value: 50, label: 'Target', labelPosition: 'start' },
+    { value: 30, label: 'Floor', color: 'var(--danger)', labelPosition: 'end' },
+]
+
+export const GoalLines: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        return (
+            <Stage>
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={DAYS}
+                    theme={theme}
+                    config={{ goalLines: GOAL_LINES, yAxis: { showGrid: true } }}
+                />
+            </Stage>
+        )
+    },
 }
 
 export const DateAxis: Story = {


### PR DESCRIPTION
## Problem

Stage 4 of the hog-charts migration added `inProgress`, `valueLabels`, and `goalLines` config props to `TimeSeriesLineChart` (#57412). The corresponding Storybook stories were originally bundled in that PR — splitting them out keeps #57412 focused on the API change.

## Changes

- One Storybook story per new feature (`InProgress`, `ValueLabels`, `GoalLines`) in `TimeSeriesLineChart.stories.tsx`.

Stacked on top of #57412 — depends on the new config props and the `GoalLineConfig` re-export from `lib/hog-charts`.

## How did you test this code?

I'm an agent. I haven't run Storybook in a browser — please skim the new stories visually before merging. The stories file passes lint and format checks.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Human prompt: split the stories out of the Stage 4 PR (#57412) into a separate PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*