### PR TITLE
chore(insights): unwire TrendsBarChart from Trends.tsx

### DIFF
--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -26,9 +26,6 @@ const BoxPlotChart = lazy(() => import('scenes/insights/views/BoxPlot').then((m)
 const TrendsLineChart = lazy(() =>
     import('./viz/trends-line-chart/TrendsLineChart').then((m) => ({ default: m.TrendsLineChart }))
 )
-const TrendsBarChart = lazy(() =>
-    import('./viz/trends-bar-chart/TrendsBarChart').then((m) => ({ default: m.TrendsBarChart }))
-)
 
 interface Props {
     view: InsightType
@@ -43,16 +40,8 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
     const showPersonsModal = insightLogicShowPersonsModal && !inSharedMode
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const {
-        display,
-        series,
-        breakdownFilter,
-        trendsFilter,
-        hasBreakdownMore,
-        breakdownValuesLoading,
-        isLifecycle,
-        isStickiness,
-    } = useValues(trendsDataLogic(insightProps))
+    const { display, series, breakdownFilter, hasBreakdownMore, breakdownValuesLoading, isLifecycle, isStickiness } =
+        useValues(trendsDataLogic(insightProps))
     const { updateBreakdownFilter } = useActions(trendsDataLogic(insightProps))
 
     const commonProps = {
@@ -61,15 +50,6 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
         inCardView: embedded && !inSharedMode,
         inSharedMode,
     }
-
-    // TrendsBarChart does not yet wire up showValuesOnSeries, goal lines, alert
-    // thresholds, or annotations — fall back to legacy when the insight needs them.
-    const canRouteThroughHogChartsBar =
-        featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS_BAR] &&
-        !isLifecycle &&
-        !isStickiness &&
-        !trendsFilter?.showValuesOnSeries &&
-        !trendsFilter?.goalLines?.length
 
     const renderViz = (): JSX.Element | undefined => {
         if (
@@ -84,9 +64,6 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
             return <ActionsLineGraph {...commonProps} />
         }
         if (display === ChartDisplayType.ActionsBar || display === ChartDisplayType.ActionsUnstackedBar) {
-            if (canRouteThroughHogChartsBar && display === ChartDisplayType.ActionsBar) {
-                return <TrendsBarChart context={context} />
-            }
             return <ActionsLineGraph {...commonProps} />
         }
         if (display === ChartDisplayType.BoldNumber) {
@@ -107,9 +84,6 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
             return <ActionsPie {...commonProps} />
         }
         if (display === ChartDisplayType.ActionsBarValue) {
-            if (canRouteThroughHogChartsBar) {
-                return <TrendsBarChart context={context} />
-            }
             return <ActionsHorizontalBar {...commonProps} />
         }
         if (display === ChartDisplayType.WorldMap) {

--- a/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.test.tsx
+++ b/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.test.tsx
@@ -25,7 +25,10 @@ const HOG_CHARTS_FLAG = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS_BAR]: true
 const trendsBar = (extra?: Parameters<typeof buildTrendsQuery>[0]): ReturnType<typeof buildTrendsQuery> =>
     buildTrendsQuery({ trendsFilter: { display: ChartDisplayType.ActionsBar }, ...extra })
 
-describe('TrendsBarChart (ActionsBar)', () => {
+// TODO(sam): re-enable when TrendsBarChart is wired back into Trends.tsx — the chart
+// isn't production-ready yet, so the route was removed and these integration tests
+// rely on the route via renderInsight().
+describe.skip('TrendsBarChart (ActionsBar)', () => {
     it.each([
         { name: 'one series for a single event', query: trendsBar(), expected: 1 },
         {
@@ -115,7 +118,7 @@ describe('TrendsBarChart (ActionsBar)', () => {
     })
 })
 
-describe('TrendsBarChart (ActionsBarValue)', () => {
+describe.skip('TrendsBarChart (ActionsBarValue)', () => {
     const aggregatedBar = (extra?: Parameters<typeof buildTrendsQuery>[0]): ReturnType<typeof buildTrendsQuery> =>
         buildTrendsQuery({ trendsFilter: { display: ChartDisplayType.ActionsBarValue }, ...extra })
 
@@ -188,7 +191,7 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
     })
 })
 
-describe('TrendsBarChart gate', () => {
+describe.skip('TrendsBarChart gate', () => {
     it.each([
         { name: 'showValuesOnSeries', filter: { display: ChartDisplayType.ActionsBar, showValuesOnSeries: true } },
         {


### PR DESCRIPTION
## Problem

`TrendsBarChart` (the hog-charts bar adapter) is wired into `Trends.tsx` behind `PRODUCT_ANALYTICS_HOG_CHARTS_BAR`, but it isn't production-ready yet — alert overlays, annotations, and other parity items aren't wired up. Removing the route avoids accidentally surfacing it to anyone who flips the flag.

## Changes

- Remove the lazy `TrendsBarChart` import and both `<TrendsBarChart>` returns from `Trends.tsx`.
- Drop the now-dead `canRouteThroughHogChartsBar` block and the unused `trendsFilter` destructure.
- Skip the three `describe` blocks in `TrendsBarChart.test.tsx` that drive the chart through `renderInsight()` — they all rely on the route. Left a TODO to re-enable when it's wired back up.

The `TrendsBarChart` component itself, the unit tests for `BarChart`/`ValueLabels`, and the feature flag constant all stay — easy to re-route once the missing pieces are in.

## How did you test this code?

I'm an agent. Ran `jest frontend/src/scenes/trends` locally — 194 passed, 14 skipped (the integration suite, as intended).

## Publish to changelog?
no

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code. Split out of #57403 at request — the unwire is unrelated to that PR's ValueLabels work.

Agent-authored PRs always require human review.