### PR TITLE
feat(alerts): implement chunked cohort query processing

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -166,7 +166,11 @@ class AlertCheckQuery:
 
     SETTINGS = HogQLGlobalSettings(
         max_execution_time=30,
-        max_bytes_to_read=50_000_000_000,  # 50GB
+        # Defence-in-depth against large-cohort batched queries: caps a single batched/per-alert
+        # query well below worker memory headroom. Cohort chunking (`MAX_COHORT_CHUNK_SIZE`)
+        # keeps per-query reads bounded at the source; this setting is the safety net if a
+        # chunk surprises us.
+        max_bytes_to_read=5_000_000_000,  # 5GB
         read_overflow_mode="throw",
     )
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -3,6 +3,7 @@
 import time
 import asyncio
 import dataclasses
+import concurrent.futures
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -42,7 +43,11 @@ from products.logs.backend.alert_state_machine import (
 from products.logs.backend.alert_utils import advance_next_check_at
 from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
-from products.logs.backend.temporal.constants import MAX_CONCURRENT_ALERT_EVALS
+from products.logs.backend.temporal.constants import (
+    MAX_CHUNK_CONCURRENCY,
+    MAX_COHORT_CHUNK_SIZE,
+    MAX_CONCURRENT_ALERT_EVALS,
+)
 from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
@@ -470,6 +475,38 @@ def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
 
 def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
     """Batched cohort CH query; per-alert fallback on non-transient failure.
+
+    Cohorts larger than `MAX_COHORT_CHUNK_SIZE` split into sub-queries whose
+    results merge into one `_CohortQueryResult`. Each chunk's batched query
+    and fallback are independent — a failure in one chunk doesn't trigger
+    per-alert fallback across the whole cohort. Chunks run with bounded
+    concurrency (`MAX_CHUNK_CONCURRENCY`); 1 = sequential.
+    """
+    if len(cohort.alerts) <= MAX_COHORT_CHUNK_SIZE:
+        return _run_cohort_chunk_query(cohort)
+
+    chunks = [
+        dataclasses.replace(cohort, alerts=cohort.alerts[start : start + MAX_COHORT_CHUNK_SIZE])
+        for start in range(0, len(cohort.alerts), MAX_COHORT_CHUNK_SIZE)
+    ]
+
+    if MAX_CHUNK_CONCURRENCY <= 1:
+        chunk_results = [_run_cohort_chunk_query(c) for c in chunks]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(MAX_CHUNK_CONCURRENCY, len(chunks)),
+            thread_name_prefix="logs-alerting-chunk",
+        ) as executor:
+            chunk_results = list(executor.map(_run_cohort_chunk_query, chunks))
+
+    merged: dict[str, _PrefetchedQuery] = {}
+    for r in chunk_results:
+        merged.update(r.per_alert)
+    return _CohortQueryResult(per_alert=merged)
+
+
+def _run_cohort_chunk_query(cohort: _AlertCohort) -> _CohortQueryResult:
+    """Single batched CH query for a cohort (or chunk); per-alert fallback on non-transient failure.
 
     Skip fallback for single-alert cohorts (would hit the same error) and transient cluster
     errors (would hammer a struggling cluster with N more failing queries).

--- a/products/logs/backend/temporal/constants.py
+++ b/products/logs/backend/temporal/constants.py
@@ -24,3 +24,15 @@ ACTIVITY_RETRY_POLICY = RetryPolicy(
 # the 60s cron interval past ~40 alerts at canonical-grid-aligned cadence.
 # Override via env when scaling the alert population without redeploying.
 MAX_CONCURRENT_ALERT_EVALS = int(os.environ.get("LOGS_ALERTING_MAX_CONCURRENT_EVALS", "5"))
+
+# Cap on alerts evaluated by a single batched ClickHouse query. Cohorts larger
+# than this run as multiple sub-queries whose results merge back into one cohort
+# result. Bounds CH read bytes and worker-side result materialization at high
+# cohort sizes; at the production per-team cap (20) this never triggers.
+MAX_COHORT_CHUNK_SIZE = int(os.environ.get("LOGS_ALERTING_MAX_COHORT_CHUNK_SIZE", "50"))
+
+# Concurrency for chunked cohort sub-queries. 1 = sequential. Worst-case CH load
+# from this worker is `MAX_CONCURRENT_ALERT_EVALS * MAX_CHUNK_CONCURRENCY`.
+# At production cap (20 alerts/team) cohorts never chunk, so this only affects
+# bypass-list teams. Override via env when CH has spare capacity.
+MAX_CHUNK_CONCURRENCY = int(os.environ.get("LOGS_ALERTING_MAX_CHUNK_CONCURRENCY", "5"))

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -673,6 +673,92 @@ class TestRunCohortQueryFallback(unittest.TestCase):
             assert prefetched.buckets is not None and prefetched.buckets[0].count == i
             assert prefetched.query_duration_ms == 42
 
+    @patch("products.logs.backend.temporal.activities.MAX_COHORT_CHUNK_SIZE", 2)
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_large_cohort_splits_into_chunks(self, mock_batched):
+        # 5 alerts at chunk size 2 → 3 batched calls (2, 2, 1) and one merged result.
+        from products.logs.backend.alert_check_query import BatchedBucketedResult
+        from products.logs.backend.temporal.activities import _run_cohort_query
+
+        cohort = self._make_cohort(5)
+
+        def make_result(sub_cohort):
+            return BatchedBucketedResult(
+                per_alert={
+                    str(a.id): [
+                        BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=int(a.id.split("-")[1]))
+                    ]
+                    for a in sub_cohort.alerts
+                },
+                query_duration_ms=1,
+            )
+
+        mock_batched.side_effect = make_result
+
+        result = _run_cohort_query(cohort)
+
+        # Each chunk is one batched call; cohort splits into ceil(5/2)=3 chunks.
+        # Sort because chunks may execute concurrently — call order on the mock is nondeterministic.
+        assert mock_batched.call_count == 3
+        chunk_sizes = sorted(len(call.args[0].alerts) for call in mock_batched.call_args_list)
+        assert chunk_sizes == [1, 2, 2]
+
+        # All 5 alerts present in the merged result with counts matching their index.
+        for i in range(5):
+            prefetched = result.per_alert[f"alert-{i}"]
+            assert prefetched.error is None
+            assert prefetched.buckets is not None and prefetched.buckets[0].count == i
+
+    @patch("products.logs.backend.temporal.activities.increment_cohort_query_fallback")
+    @patch("products.logs.backend.temporal.activities.classify_alert_error")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.MAX_COHORT_CHUNK_SIZE", 2)
+    @patch("products.logs.backend.temporal.activities._run_batched_query")
+    def test_chunk_failure_isolated_from_other_chunks(
+        self, mock_batched, mock_alert_check_query_cls, mock_classify, _mock_fallback_counter
+    ):
+        # First chunk succeeds; second chunk's batched query fails non-transient → only that
+        # chunk's alerts hit the per-alert fallback. Third chunk succeeds again.
+        from products.logs.backend.alert_check_query import BatchedBucketedResult
+        from products.logs.backend.temporal.activities import _run_cohort_query
+
+        cohort = self._make_cohort(5)
+        mock_classify.return_value = MagicMock(is_transient=False, code="query_performance")
+
+        good_result = BatchedBucketedResult(
+            per_alert={"will be replaced": [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=99)]},
+            query_duration_ms=1,
+        )
+
+        def batched_side_effect(sub_cohort):
+            ids = [a.id for a in sub_cohort.alerts]
+            if "alert-2" in ids:
+                raise RuntimeError("chunk 2 batched failure")
+            return BatchedBucketedResult(
+                per_alert={str(a.id): good_result.per_alert["will be replaced"] for a in sub_cohort.alerts},
+                query_duration_ms=1,
+            )
+
+        mock_batched.side_effect = batched_side_effect
+
+        # Per-alert fallback returns synthetic buckets so we can tell it ran.
+        def make_query_instance(*, team, alert, **_kwargs):
+            instance = MagicMock()
+            instance.execute_rolling_checks.return_value = [
+                BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=7)
+            ]
+            return instance
+
+        mock_alert_check_query_cls.side_effect = make_query_instance
+
+        result = _run_cohort_query(cohort)
+
+        # Chunks 0 and 2 returned batched results; chunk 1 hit per-alert fallback.
+        expected_counts = {"alert-0": 99, "alert-1": 99, "alert-2": 7, "alert-3": 7, "alert-4": 99}
+        for alert_id, expected in expected_counts.items():
+            prefetched = result.per_alert[alert_id]
+            assert prefetched.buckets is not None and prefetched.buckets[0].count == expected
+
 
 class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):
     """CH-backed integration test for the per-alert fallback path."""


### PR DESCRIPTION
## Problem

Large alert cohorts in the logs alerting pipeline can generate batched ClickHouse queries that read excessive amounts of data, risking worker memory exhaustion and cluster instability. A single batched query covering a very large cohort has no bounded upper limit on data reads beyond the previous 50GB cap, which is far too permissive.

## Changes

- Reduces the `max_bytes_to_read` ClickHouse setting from 50GB to 5GB as a safety net for per-alert/batched queries, complementing the new cohort chunking logic.
- Introduces `MAX_COHORT_CHUNK_SIZE` (default: 50) to split large cohorts into sub-queries, keeping per-query CH reads bounded at the source.
- Introduces `MAX_CHUNK_CONCURRENCY` (default: 5) to control how many chunk sub-queries run in parallel via a `ThreadPoolExecutor`. Worst-case CH load from one worker is `MAX_CONCURRENT_ALERT_EVALS × MAX_CHUNK_CONCURRENCY`.
- Renames the existing `_run_cohort_query` to `_run_cohort_chunk_query` (handles a single chunk or small cohort) and introduces a new `_run_cohort_query` that splits, dispatches, and merges chunk results.
- Chunk failures are isolated — a batched query failure in one chunk triggers per-alert fallback only for that chunk's alerts, leaving other chunks unaffected.
- Both new constants are overridable via environment variables (`LOGS_ALERTING_MAX_COHORT_CHUNK_SIZE`, `LOGS_ALERTING_MAX_CHUNK_CONCURRENCY`) without redeployment.

At the current production per-team alert cap (20 alerts), cohorts never exceed `MAX_COHORT_CHUNK_SIZE`, so chunking only activates for bypass-list teams.

## How did you test this code?

New unit tests cover:
- A 5-alert cohort at chunk size 2 splits into 3 batched calls (sizes 2, 2, 1) and merges all results correctly.
- A failure in the second chunk's batched query triggers per-alert fallback only for that chunk's alerts (alerts 2 and 3), while alerts in chunks 0 and 2 return their batched results unaffected.

## Publish to changelog?

No