### PR TITLE
feat(metrics): add garbage collection tracking for worker memory

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -1,5 +1,6 @@
 """Temporal activities for logs alerting."""
 
+import gc
 import time
 import asyncio
 import dataclasses
@@ -67,6 +68,7 @@ from products.logs.backend.temporal.metrics import (
     record_pending_alerts,
     record_scheduler_lag,
     record_semaphore_wait,
+    record_worker_memory_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -81,6 +83,15 @@ def _safe_record(label: str, fn, *args, **kwargs) -> None:
         fn(*args, **kwargs)
     except Exception:
         logger.exception("Failed to record %s", label)
+
+
+def _post_cohort_memory_cleanup() -> None:
+    """gc.collect() then snapshot the post-GC live-object count. Called after each cohort."""
+    try:
+        gc.collect()
+    except Exception:
+        logger.exception("gc.collect failed in post-cohort cleanup")
+    _safe_record("worker_gc_objects gauge", record_worker_memory_snapshot)
 
 
 def _derive_breaches(
@@ -322,6 +333,8 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
                 # reflects that this cohort didn't advance state.
                 local_stats["errored"] += len(dispatched)
                 local_stats["checked"] += len(dispatched)
+                # Off-thread: gc.collect() is CPU-bound and would block the event loop.
+                await asyncio.to_thread(_post_cohort_memory_cleanup)
                 return local_stats
 
             # Phase 4 (serial): finalize stats + per-alert post-save metrics.
@@ -332,6 +345,7 @@ async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
                 # Alert's per-alert fallback save failed — count as errored.
                 local_stats["checked"] += 1
                 local_stats["errored"] += 1
+            await asyncio.to_thread(_post_cohort_memory_cleanup)
         _safe_record("semaphore_wait histogram", record_semaphore_wait, wait_ms)
         return local_stats
 
@@ -631,6 +645,7 @@ def _check_alerts_sync() -> CheckAlertsOutput:
             capture_exception(e, {"team_id": cohort.team_id, "phase": "bulk_save"})
             stats["errored"] += len(dispatched)
             stats["checked"] += len(dispatched)
+            _post_cohort_memory_cleanup()
             continue
 
         # Phase 4: finalize stats + per-alert post-save metrics.
@@ -640,6 +655,7 @@ def _check_alerts_sync() -> CheckAlertsOutput:
         for _ in failed:
             stats["checked"] += 1
             stats["errored"] += 1
+        _post_cohort_memory_cleanup()
 
     if stats["checked"] > 0:
         logger.info("Alert check cycle complete", **stats)

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -1,11 +1,13 @@
 """Prometheus metrics and Temporal interceptor for logs alerting."""
 
+import gc
 import time
 import typing
 import datetime as dt
 
 from django.conf import settings
 
+from prometheus_client import Gauge
 from temporalio import activity, workflow
 from temporalio.common import MetricMeter
 from temporalio.worker import ActivityInboundInterceptor, ExecuteActivityInput, Interceptor
@@ -238,6 +240,32 @@ def increment_cohort_query_fallback(reason: CohortQueryFallbackReason) -> None:
         "Batched CH cohort query failed and fell back to per-alert queries",
     )
     counter.add(1)
+
+
+# `prometheus_client`'s default REGISTRY auto-registers `ProcessCollector` and
+# `GCCollector`, so the worker's /metrics endpoint already exposes
+# `process_resident_memory_bytes`, `process_virtual_memory_bytes`,
+# `process_open_fds`, and `python_gc_collections_total{generation}` on Linux pods.
+# This gauge is the one signal those built-ins don't cover: the count of objects
+# currently tracked by Python's GC, sampled post-collection. Diverging RSS while
+# this stays flat = native (CH driver, librdkafka) retention; both rising = Python
+# heap retention.
+WORKER_GC_OBJECTS = Gauge(
+    "logs_alerting_worker_gc_objects",
+    "Live Python objects tracked by the garbage collector, sampled per cohort post-gc.collect().",
+)
+
+
+def record_worker_memory_snapshot() -> None:
+    """Set `WORKER_GC_OBJECTS` to the current live-object count. Best-effort.
+
+    `gc.get_objects()` materialises a list (~13MB transient at 1.6M objects) but
+    `sum(gc.get_count())` is not a substitute — count1/count2 are *collection*
+    counters, not object counts, and post-`gc.collect()` they're all ~0. Caller
+    runs this in a worker thread (`asyncio.to_thread`) so the allocation is off
+    the event loop.
+    """
+    WORKER_GC_OBJECTS.set(len(gc.get_objects()))
 
 
 def record_scheduler_lag(lag_ms: int) -> None:


### PR DESCRIPTION
## Problem

Memory retention in the logs alerting worker is difficult to diagnose because existing metrics (`process_resident_memory_bytes`, `process_virtual_memory_bytes`) don't distinguish between Python heap growth and native library retention (e.g. ClickHouse driver, librdkafka). Without a per-cohort GC object count, it's hard to tell whether rising RSS is caused by Python objects or native allocations.

## Changes

Adds a new Prometheus gauge `logs_alerting_worker_gc_objects` that tracks the number of live Python objects tracked by the garbage collector, sampled after each cohort evaluation. A `gc.collect()` is triggered before each snapshot to ensure the count reflects actual retained objects rather than uncollected garbage.

- `_post_cohort_memory_cleanup()` runs `gc.collect()` then records the live-object gauge after every cohort, in both the async (`_bounded_cohort_eval`) and sync (`_check_alerts_sync`) evaluation paths — including early-exit error branches.
- `record_worker_memory_snapshot()` sets the gauge to `len(gc.get_objects())` and is called best-effort via the existing `_safe_record` wrapper.

If RSS rises while this gauge stays flat, the retention is in native code. If both rise together, it points to Python heap growth.

## How did you test this code?

No manual testing performed. The gauge registration and `gc.collect()` call are straightforward, and the metric is wired into the existing `_safe_record` error-handling path so failures are logged but non-fatal.

## Publish to changelog?

No