### PR TITLE
chore(observability): split slack config preflight spans + instrument db hit

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -25,6 +25,7 @@ from disposable_email_domains import blocklist as disposable_email_domains_list
 from free_email_domains import whitelist as free_email_domains_list
 from google.auth.transport.requests import Request as GoogleRequest
 from google.oauth2 import service_account
+from opentelemetry import trace
 from prometheus_client import Counter
 from requests.auth import HTTPBasicAuth
 from rest_framework.exceptions import ValidationError
@@ -51,6 +52,7 @@ from posthog.utils import get_instance_region
 from products.workflows.backend.providers import SESProvider, TwilioProvider
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 def _decode_jwt_payload(token: str) -> dict | None:
@@ -1194,13 +1196,17 @@ class SlackIntegration:
     @classmethod
     @cache_for(timedelta(minutes=5))
     def slack_config(cls):
-        config = get_instance_settings(
-            [
-                "SLACK_APP_CLIENT_ID",
-                "SLACK_APP_CLIENT_SECRET",
-                "SLACK_APP_SIGNING_SECRET",
-            ]
-        )
+        # Span only fires on cache miss (cache_for is process-local in-memory).
+        # If preflight.slack_config_main is fast in production traces, this span
+        # will be absent; if it appears, it tells us the DB hit was slow.
+        with tracer.start_as_current_span("slack_integration.slack_config_db"):
+            config = get_instance_settings(
+                [
+                    "SLACK_APP_CLIENT_ID",
+                    "SLACK_APP_CLIENT_SECRET",
+                    "SLACK_APP_SIGNING_SECRET",
+                ]
+            )
 
         return config
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -177,8 +177,9 @@ def render_query(request: HttpRequest) -> HttpResponse:
 
 @never_cache
 def preflight_check(request: HttpRequest) -> JsonResponse:
-    with tracer.start_as_current_span("preflight.slack_config"):
+    with tracer.start_as_current_span("preflight.slack_config_main"):
         slack_client_id = SlackIntegration.slack_config().get("SLACK_APP_CLIENT_ID")
+    with tracer.start_as_current_span("preflight.posthog_code_slack_config"):
         posthog_code_slack_config = SlackIntegration.posthog_code_slack_config()
         posthog_code_slack_client_id = posthog_code_slack_config.get("SLACK_POSTHOG_CODE_CLIENT_ID")
         posthog_code_slack_signing_secret = posthog_code_slack_config.get("SLACK_POSTHOG_CODE_SIGNING_SECRET")


### PR DESCRIPTION
## Problem

Per-step preflight spans (#57404) localized one of the home-view spikes to **\`preflight.slack_config\` = 510ms**. That single span covers two distinct calls though, so we can't tell which is the slow one:

- \`SlackIntegration.slack_config()\` — \`@cache_for(timedelta(minutes=5))\`-decorated; on cache miss queries \`get_instance_settings(["SLACK_APP_CLIENT_ID", "SLACK_APP_CLIENT_SECRET", "SLACK_APP_SIGNING_SECRET"])\` against the \`posthog_instancesetting\` table.
- \`SlackIntegration.posthog_code_slack_config()\` — pure \`settings.SLACK_POSTHOG_CODE_*\` dict, should be ~free.

## Changes

- Split the wrapping span in \`posthog/views.py\` into \`preflight.slack_config_main\` and \`preflight.posthog_code_slack_config\` so we can see which side dominates.
- Add an inner span \`slack_integration.slack_config_db\` inside the \`@cache_for\`-decorated \`SlackIntegration.slack_config()\` body in \`posthog/models/integration.py\`. It only emits on cache miss (process start, 5-min expiry, or new pod), so its presence in a trace tells us the DB hit was the slow path.

No behavior change — purely additive instrumentation. \`hogli test posthog/api/test/test_preflight.py\` (13 tests) passes.

## Why instrumentation rather than a fix

Three reasons to look before leaping:

1. \`@cache_for(timedelta(minutes=5))\` already exists. If it's actually warming on every pod and serving 99% of requests, raising the TTL or moving to Redis isn't the right answer.
2. The DB query is on \`posthog_instancesetting\` filtered by 3 keys. That table is small and the \`key\` column is the primary key — should be ~ms-fast. If it's spiking to 500ms+, that's a connection-pool / DB-saturation signal worth understanding before "fixing" by adding more cache.
3. \`posthog_code_slack_config()\` is "just a settings dict" but if it's the spiking side, that's a different bug entirely.

Once the next slow trace shows up with these spans deployed, we'll know whether to (a) fix \`slack_config\` cache misses, (b) cache \`posthog_code_slack_config\`, or (c) chase a deeper DB issue.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with PostHog Code (claude-opus-4-7)
- Sister investigation to #57418 (timezone offsets cache, separate finding from the same trace batch)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*