### PR TITLE
chore(observability): instrument UserSerializer.to_representation outer steps

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -613,13 +613,15 @@ class UserSerializer(serializers.ModelSerializer):
         return instance
 
     def to_representation(self, instance: Any) -> Any:
-        user_identify.identify_task.delay(user_id=instance.id)
+        with tracer.start_as_current_span("user_serializer.identify_task_delay"):
+            user_identify.identify_task.delay(user_id=instance.id)
         with tracer.start_as_current_span("user_serializer.default_fields"):
             data = super().to_representation(instance)
 
         # Backfill shortcut_position default for frontend if null
-        if data.get("shortcut_position") is None:
-            data["shortcut_position"] = ShortcutPosition.ABOVE.value
+        with tracer.start_as_current_span("user_serializer.shortcut_position_backfill"):
+            if data.get("shortcut_position") is None:
+                data["shortcut_position"] = ShortcutPosition.ABOVE.value
 
         return data
 


### PR DESCRIPTION
## Problem

Slow home-view traces show \`template.user_serializer\` hitting **~600ms** while \`user_serializer.default_fields\` (the wrap around \`super().to_representation\`) is only **~55ms** of that. The remaining ~545ms is in the parts of \`UserSerializer.to_representation\` that aren't \`default_fields\` — currently invisible.

## Changes

\`posthog/api/user.py:615\` — wrap each non-\`default_fields\` step in its own span:

- \`user_serializer.identify_task_delay\` — wraps \`user_identify.identify_task.delay(user_id=instance.id)\`. Celery \`.delay()\` is supposed to be ~ms but spikes if the Redis broker is contended; this span will tell us when that's happening.
- \`user_serializer.shortcut_position_backfill\` — wraps the dict-mutation post-processing.

No behavior change. 12 existing user-API tests pass.

## How did you test this code?

I'm an agent.

- \`ruff check\` clean
- \`hogli test posthog/api/test/test_user.py::TestUserAPI -k "current_user or me"\` — 12 tests pass.

Once deployed, the next slow user_serializer trace will tell us which step (Celery enqueue, default-fields, or shortcut backfill) is dominating.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with PostHog Code (claude-opus-4-7)
- Sister investigation to #57418 (timezone offsets cache) and #57419 (slack config instrumentation), all triaged from the same batch of three slow home-view traces

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*