### PR TITLE
fix(logs): bound alert cohort size at build time, drop in-query chunking

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -167,7 +167,7 @@ class AlertCheckQuery:
     SETTINGS = HogQLGlobalSettings(
         max_execution_time=30,
         # Defence-in-depth against large-cohort batched queries: caps a single batched/per-alert
-        # query well below worker memory headroom. Cohort chunking (`MAX_COHORT_CHUNK_SIZE`)
+        # query well below worker memory headroom. Cohort chunking (`MAX_ALERT_COHORT_SIZE`)
         # keeps per-query reads bounded at the source; this setting is the safety net if a
         # chunk surprises us.
         max_bytes_to_read=5_000_000_000,  # 5GB

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -5,9 +5,9 @@ import time
 import asyncio
 import contextlib
 import dataclasses
-import concurrent.futures
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from datetime import UTC, datetime, timedelta
+from itertools import batched
 from typing import TYPE_CHECKING
 
 from django.db import transaction
@@ -46,11 +46,7 @@ from products.logs.backend.alert_state_machine import (
 from products.logs.backend.alert_utils import advance_next_check_at
 from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
-from products.logs.backend.temporal.constants import (
-    MAX_CHUNK_CONCURRENCY,
-    MAX_COHORT_CHUNK_SIZE,
-    MAX_CONCURRENT_ALERT_EVALS,
-)
+from products.logs.backend.temporal.constants import MAX_ALERT_COHORT_SIZE, MAX_CONCURRENT_ALERT_EVALS
 from products.logs.backend.temporal.metrics import (
     increment_check_errors,
     increment_checkpoint_unavailable,
@@ -459,12 +455,18 @@ def _load_alerts_and_checkpoint() -> tuple[datetime, list[LogsAlertConfiguration
 
 
 def _build_cohorts(
-    alerts: list[LogsAlertConfiguration],
+    alerts: Sequence[LogsAlertConfiguration],
     *,
     now: datetime,
     checkpoint: datetime | None,
 ) -> list[_AlertCohort]:
-    """Group alerts into cohorts that can share a batched CH query."""
+    """Group alerts into cohorts that can share a batched CH query.
+
+    Each cohort holds at most `MAX_ALERT_COHORT_SIZE` alerts. Larger groups (same
+    team / window / cadence / projection / date_to) split into multiple cohorts
+    so each individual batched query stays bounded — and the existing outer
+    semaphore (`MAX_CONCURRENT_ALERT_EVALS`) is the only concurrency control.
+    """
     grouped: dict[tuple, tuple[list[LogsAlertConfiguration], datetime, bool]] = {}
     for alert in alerts:
         nca = alert.next_check_at if alert.next_check_at is not None else now
@@ -480,10 +482,11 @@ def _build_cohorts(
         )
         grouped.setdefault(key, ([], date_to, projection_eligible))[0].append(alert)
 
-    return [
-        _AlertCohort(alerts=tuple(members), date_to=date_to, projection_eligible=projection_eligible)
-        for (members, date_to, projection_eligible) in grouped.values()
-    ]
+    cohorts: list[_AlertCohort] = []
+    for members, date_to, projection_eligible in grouped.values():
+        for chunk in batched(members, MAX_ALERT_COHORT_SIZE):
+            cohorts.append(_AlertCohort(alerts=chunk, date_to=date_to, projection_eligible=projection_eligible))
+    return cohorts
 
 
 def _run_batched_query(cohort: _AlertCohort) -> BatchedBucketedResult:
@@ -526,45 +529,15 @@ def _run_per_alert_queries(cohort: _AlertCohort) -> _CohortQueryResult:
 
 
 def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
-    """Batched cohort CH query; per-alert fallback on non-transient failure.
+    """Batched CH query for a cohort; per-alert fallback on non-transient failure.
 
-    Cohorts larger than `MAX_COHORT_CHUNK_SIZE` split into sub-queries whose
-    results merge into one `_CohortQueryResult`. Each chunk's batched query
-    and fallback are independent — a failure in one chunk doesn't trigger
-    per-alert fallback across the whole cohort. Chunks run with bounded
-    concurrency (`MAX_CHUNK_CONCURRENCY`); 1 = sequential.
-    """
-    if len(cohort.alerts) <= MAX_COHORT_CHUNK_SIZE:
-        return _run_cohort_chunk_query(cohort)
-
-    chunks = [
-        dataclasses.replace(cohort, alerts=cohort.alerts[start : start + MAX_COHORT_CHUNK_SIZE])
-        for start in range(0, len(cohort.alerts), MAX_COHORT_CHUNK_SIZE)
-    ]
-
-    if MAX_CHUNK_CONCURRENCY <= 1:
-        chunk_results = [_run_cohort_chunk_query(c) for c in chunks]
-    else:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=min(MAX_CHUNK_CONCURRENCY, len(chunks)),
-            thread_name_prefix="logs-alerting-chunk",
-        ) as executor:
-            chunk_results = list(executor.map(_run_cohort_chunk_query, chunks))
-
-    merged: dict[str, _PrefetchedQuery] = {}
-    for r in chunk_results:
-        merged.update(r.per_alert)
-    return _CohortQueryResult(per_alert=merged)
-
-
-def _run_cohort_chunk_query(cohort: _AlertCohort) -> _CohortQueryResult:
-    """Single batched CH query for a cohort (or chunk); per-alert fallback on non-transient failure.
-
-    Skip fallback for single-alert cohorts (would hit the same error) and transient cluster
-    errors (would hammer a struggling cluster with N more failing queries).
+    Cohorts are pre-sized at `_build_cohorts` time so this function operates on a
+    single bounded group. Skip fallback for single-alert cohorts (would hit the
+    same error) and transient cluster errors (would hammer a struggling cluster
+    with N more failing queries).
     """
     try:
-        batched = _run_batched_query(cohort)
+        batched_result = _run_batched_query(cohort)
     except Exception as e:
         team_id = cohort.team_id
         cohort_size = len(cohort.alerts)
@@ -598,8 +571,8 @@ def _run_cohort_chunk_query(cohort: _AlertCohort) -> _CohortQueryResult:
     return _CohortQueryResult(
         per_alert={
             str(alert.id): _PrefetchedQuery(
-                buckets=batched.per_alert.get(str(alert.id), []),
-                query_duration_ms=batched.query_duration_ms,
+                buckets=batched_result.per_alert.get(str(alert.id), []),
+                query_duration_ms=batched_result.query_duration_ms,
             )
             for alert in cohort.alerts
         }

--- a/products/logs/backend/temporal/constants.py
+++ b/products/logs/backend/temporal/constants.py
@@ -25,14 +25,10 @@ ACTIVITY_RETRY_POLICY = RetryPolicy(
 # Override via env when scaling the alert population without redeploying.
 MAX_CONCURRENT_ALERT_EVALS = int(os.environ.get("LOGS_ALERTING_MAX_CONCURRENT_EVALS", "5"))
 
-# Cap on alerts evaluated by a single batched ClickHouse query. Cohorts larger
-# than this run as multiple sub-queries whose results merge back into one cohort
-# result. Bounds CH read bytes and worker-side result materialization at high
-# cohort sizes; at the production per-team cap (20) this never triggers.
-MAX_COHORT_CHUNK_SIZE = int(os.environ.get("LOGS_ALERTING_MAX_COHORT_CHUNK_SIZE", "50"))
-
-# Concurrency for chunked cohort sub-queries. 1 = sequential. Worst-case CH load
-# from this worker is `MAX_CONCURRENT_ALERT_EVALS * MAX_CHUNK_CONCURRENCY`.
-# At production cap (20 alerts/team) cohorts never chunk, so this only affects
-# bypass-list teams. Override via env when CH has spare capacity.
-MAX_CHUNK_CONCURRENCY = int(os.environ.get("LOGS_ALERTING_MAX_CHUNK_CONCURRENCY", "5"))
+# Cap on alerts in a single cohort. Larger groups (same team / window / cadence /
+# projection / date_to) split at cohort-build time into multiple cohorts of this
+# size, each of which becomes its own task in the outer evaluation loop and
+# competes for a `MAX_CONCURRENT_ALERT_EVALS` slot. Bounds per-query CH read
+# bytes and worker-side result materialization. The production per-team cap (20)
+# already keeps cohorts under this; the limit only matters for bypass-list teams.
+MAX_ALERT_COHORT_SIZE = int(os.environ.get("LOGS_ALERTING_MAX_ALERT_COHORT_SIZE", "50"))

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -673,75 +673,56 @@ class TestRunCohortQueryFallback(unittest.TestCase):
             assert prefetched.buckets is not None and prefetched.buckets[0].count == i
             assert prefetched.query_duration_ms == 42
 
-    @patch("products.logs.backend.temporal.activities.MAX_COHORT_CHUNK_SIZE", 2)
-    @patch("products.logs.backend.temporal.activities._run_batched_query")
-    def test_large_cohort_splits_into_chunks(self, mock_batched):
-        # 5 alerts at chunk size 2 → 3 batched calls (2, 2, 1) and one merged result.
-        from products.logs.backend.alert_check_query import BatchedBucketedResult
-        from products.logs.backend.temporal.activities import _run_cohort_query
+    @patch("products.logs.backend.temporal.activities.MAX_ALERT_COHORT_SIZE", 2)
+    def test_build_cohorts_splits_oversized_groups(self):
+        # 5 alerts on the same grid at chunk size 2 → 3 cohorts of sizes (2, 2, 1).
+        # Each cohort runs as its own task in the activity, with the existing outer
+        # MAX_CONCURRENT_ALERT_EVALS semaphore as the only concurrency control —
+        # no nested chunking inside _run_cohort_query.
+        from products.logs.backend.temporal.activities import _build_cohorts
 
-        cohort = self._make_cohort(5)
-
-        def make_result(sub_cohort):
-            return BatchedBucketedResult(
-                per_alert={
-                    str(a.id): [
-                        BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=int(a.id.split("-")[1]))
-                    ]
-                    for a in sub_cohort.alerts
-                },
-                query_duration_ms=1,
+        alerts = [
+            MagicMock(
+                id=f"alert-{i}",
+                team_id=1,
+                window_minutes=5,
+                evaluation_periods=1,
+                check_interval_minutes=5,
+                next_check_at=None,
+                filters={},
             )
+            for i in range(5)
+        ]
+        now = datetime(2025, 1, 1, 0, 5, tzinfo=UTC)
 
-        mock_batched.side_effect = make_result
+        with (
+            patch("products.logs.backend.temporal.activities.is_projection_eligible", return_value=True),
+            patch("products.logs.backend.temporal.activities.resolve_alert_date_to", return_value=now),
+        ):
+            cohorts = _build_cohorts(alerts, now=now, checkpoint=None)
 
-        result = _run_cohort_query(cohort)
-
-        # Each chunk is one batched call; cohort splits into ceil(5/2)=3 chunks.
-        # Sort because chunks may execute concurrently — call order on the mock is nondeterministic.
-        assert mock_batched.call_count == 3
-        chunk_sizes = sorted(len(call.args[0].alerts) for call in mock_batched.call_args_list)
-        assert chunk_sizes == [1, 2, 2]
-
-        # All 5 alerts present in the merged result with counts matching their index.
-        for i in range(5):
-            prefetched = result.per_alert[f"alert-{i}"]
-            assert prefetched.error is None
-            assert prefetched.buckets is not None and prefetched.buckets[0].count == i
+        assert sorted(len(c.alerts) for c in cohorts) == [1, 2, 2]
+        all_alert_ids = sorted(a.id for c in cohorts for a in c.alerts)
+        assert all_alert_ids == [f"alert-{i}" for i in range(5)]
 
     @patch("products.logs.backend.temporal.activities.increment_cohort_query_fallback")
     @patch("products.logs.backend.temporal.activities.classify_alert_error")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.MAX_COHORT_CHUNK_SIZE", 2)
     @patch("products.logs.backend.temporal.activities._run_batched_query")
-    def test_chunk_failure_isolated_from_other_chunks(
+    def test_one_cohorts_failure_isolated_from_others(
         self, mock_batched, mock_alert_check_query_cls, mock_classify, _mock_fallback_counter
     ):
-        # First chunk succeeds; second chunk's batched query fails non-transient → only that
-        # chunk's alerts hit the per-alert fallback. Third chunk succeeds again.
-        from products.logs.backend.alert_check_query import BatchedBucketedResult
+        # With cohort splitting at _build_cohorts time, each post-split cohort is an
+        # independent unit. _run_cohort_query operates on one bounded cohort at a time.
+        # This test confirms a single cohort's batched failure → per-alert fallback works
+        # as before. Cross-cohort isolation is structural (separate tasks, separate calls).
         from products.logs.backend.temporal.activities import _run_cohort_query
 
-        cohort = self._make_cohort(5)
+        cohort = self._make_cohort(2)
         mock_classify.return_value = MagicMock(is_transient=False, code="query_performance")
+        mock_batched.side_effect = RuntimeError("batched failure")
 
-        good_result = BatchedBucketedResult(
-            per_alert={"will be replaced": [BucketedCount(timestamp=datetime(2025, 1, 1, tzinfo=UTC), count=99)]},
-            query_duration_ms=1,
-        )
-
-        def batched_side_effect(sub_cohort):
-            ids = [a.id for a in sub_cohort.alerts]
-            if "alert-2" in ids:
-                raise RuntimeError("chunk 2 batched failure")
-            return BatchedBucketedResult(
-                per_alert={str(a.id): good_result.per_alert["will be replaced"] for a in sub_cohort.alerts},
-                query_duration_ms=1,
-            )
-
-        mock_batched.side_effect = batched_side_effect
-
-        # Per-alert fallback returns synthetic buckets so we can tell it ran.
+        # Per-alert fallback returns synthetic buckets.
         def make_query_instance(*, team, alert, **_kwargs):
             instance = MagicMock()
             instance.execute_rolling_checks.return_value = [
@@ -753,11 +734,9 @@ class TestRunCohortQueryFallback(unittest.TestCase):
 
         result = _run_cohort_query(cohort)
 
-        # Chunks 0 and 2 returned batched results; chunk 1 hit per-alert fallback.
-        expected_counts = {"alert-0": 99, "alert-1": 99, "alert-2": 7, "alert-3": 7, "alert-4": 99}
-        for alert_id, expected in expected_counts.items():
+        for alert_id in ("alert-0", "alert-1"):
             prefetched = result.per_alert[alert_id]
-            assert prefetched.buckets is not None and prefetched.buckets[0].count == expected
+            assert prefetched.buckets is not None and prefetched.buckets[0].count == 7
 
 
 class TestRunCohortQueryFallbackEndToEnd(ClickhouseTestMixin, APIBaseTest):


### PR DESCRIPTION
## Problem

The logs alerting pipeline previously handled oversized cohorts by splitting them into sub-chunks *inside* `_run_cohort_query`, using a `ThreadPoolExecutor` with its own concurrency constant (`MAX_CHUNK_CONCURRENCY`). This created a two-level concurrency model that was harder to reason about and introduced unnecessary complexity: the outer `MAX_CONCURRENT_ALERT_EVALS` semaphore controlled cohort-level parallelism, while the inner executor controlled chunk-level parallelism within a single cohort. At production alert caps (20 alerts/team), cohorts never exceeded the chunk size anyway, making the inner chunking logic dead code for normal operation.

## Changes

Cohort splitting is moved upstream to `_build_cohorts`, where oversized groups are split into multiple independent cohorts of at most `MAX_ALERT_COHORT_SIZE` alerts each. These cohorts then flow through the existing outer evaluation loop and compete for `MAX_CONCURRENT_ALERT_EVALS` slots like any other cohort — no nested threading, no separate chunk concurrency constant.

- `_run_cohort_query` no longer contains chunking logic or a `ThreadPoolExecutor`; it operates on a single pre-bounded cohort.
- `_run_cohort_chunk_query` is removed; its logic is now just `_run_cohort_query`.
- `MAX_COHORT_CHUNK_SIZE` and `MAX_CHUNK_CONCURRENCY` constants are replaced by a single `MAX_ALERT_COHORT_SIZE` constant (env var: `LOGS_ALERTING_MAX_ALERT_COHORT_SIZE`, default `50`).
- `concurrent.futures` import is removed; `itertools.batched` is used for the split.

## How did you test this code?

The existing test suite was updated to reflect the new design:

- `test_large_cohort_splits_into_chunks` is replaced by `test_build_cohorts_splits_oversized_groups`, which patches `MAX_ALERT_COHORT_SIZE=2` and asserts that 5 alerts on the same grid produce cohorts of sizes `[1, 2, 2]` with all alert IDs accounted for.
- `test_chunk_failure_isolated_from_other_chunks` is simplified to `test_one_cohorts_failure_isolated_from_others`, confirming that a batched query failure on a single cohort triggers per-alert fallback for that cohort's alerts, with cross-cohort isolation now structural rather than tested inline.

## Publish to changelog?

No