### PR TITLE
chore(experiments): Remove EXPERIMENTS_SAMPLE_RATIO_MISMATCH flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -302,7 +302,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_MATURED_USERS_FILTER: 'experiments-matured-users-filter', // owner: @jurajmajerik #team-experiments
-    EXPERIMENTS_SAMPLE_RATIO_MISMATCH: 'experiments-sample-ratio-mismatch', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments
     EXPERIMENTS_TEMPLATES: 'experiments-templates', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -5,7 +5,6 @@ import { IconCheckCircle, IconCorrelationAnalysis, IconInfo, IconPencil, IconWar
 import { LemonButton, LemonCollapse, LemonTable, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { getSeriesBackgroundColor, getSeriesColor } from 'lib/colors'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { useChart } from 'lib/hooks/useChart'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
@@ -141,8 +140,7 @@ function getExposureCriteriaLabel(exposureCriteria: ExperimentExposureCriteria |
 }
 
 export function Exposures(): JSX.Element {
-    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft, featureFlags } =
-        useValues(experimentLogic)
+    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft } = useValues(experimentLogic)
     const { openExposureCriteriaModal } = useActions(exposureCriteriaModalLogic)
     const colors = useChartColors()
 
@@ -307,7 +305,7 @@ export function Exposures(): JSX.Element {
                                         ))}
                                     </div>
                                 )}
-                                {featureFlags[FEATURE_FLAGS.EXPERIMENTS_SAMPLE_RATIO_MISMATCH] && hasSRM && (
+                                {hasSRM && (
                                     <Tooltip title={srmFailureTooltipText}>
                                         <IconWarning className="text-warning text-lg" />
                                     </Tooltip>
@@ -490,41 +488,39 @@ export function Exposures(): JSX.Element {
                                             },
                                         ]}
                                     />
-                                    {featureFlags[FEATURE_FLAGS.EXPERIMENTS_SAMPLE_RATIO_MISMATCH] &&
-                                        exposures?.sample_ratio_mismatch != null && (
-                                            <div className="flex items-center gap-1 text-xs mt-2">
-                                                {hasSRM ? (
-                                                    <>
-                                                        <Tooltip title={srmFailureTooltipText}>
-                                                            <span className="flex items-center gap-1 text-warning cursor-pointer">
-                                                                <IconWarning className="text-sm" />
-                                                                <span className="font-semibold">
-                                                                    Sample ratio mismatch detected
-                                                                </span>
+                                    {exposures?.sample_ratio_mismatch != null && (
+                                        <div className="flex items-center gap-1 text-xs mt-2">
+                                            {hasSRM ? (
+                                                <>
+                                                    <Tooltip title={srmFailureTooltipText}>
+                                                        <span className="flex items-center gap-1 text-warning cursor-pointer">
+                                                            <IconWarning className="text-sm" />
+                                                            <span className="font-semibold">
+                                                                Sample ratio mismatch detected
                                                             </span>
-                                                        </Tooltip>
-                                                        <span className="text-muted">
-                                                            (p ={' '}
-                                                            {exposures.sample_ratio_mismatch.p_value.toExponential(2)})
                                                         </span>
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        <Tooltip title="No sample ratio mismatch detected. The difference between actual and expected exposures is within normal random variation.">
-                                                            <span className="flex items-center gap-1 text-success cursor-pointer">
-                                                                <IconCheckCircle className="text-sm" />
-                                                                <span>
-                                                                    Exposure distribution matches rollout percentages
-                                                                </span>
+                                                    </Tooltip>
+                                                    <span className="text-muted">
+                                                        (p = {exposures.sample_ratio_mismatch.p_value.toExponential(2)})
+                                                    </span>
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <Tooltip title="No sample ratio mismatch detected. The difference between actual and expected exposures is within normal random variation.">
+                                                        <span className="flex items-center gap-1 text-success cursor-pointer">
+                                                            <IconCheckCircle className="text-sm" />
+                                                            <span>
+                                                                Exposure distribution matches rollout percentages
                                                             </span>
-                                                        </Tooltip>
-                                                        <span className="text-muted">
-                                                            (p = {exposures.sample_ratio_mismatch.p_value.toFixed(3)})
                                                         </span>
-                                                    </>
-                                                )}
-                                            </div>
-                                        )}
+                                                    </Tooltip>
+                                                    <span className="text-muted">
+                                                        (p = {exposures.sample_ratio_mismatch.p_value.toFixed(3)})
+                                                    </span>
+                                                </>
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
## Problem

The `EXPERIMENTS_SAMPLE_RATIO_MISMATCH` feature flag gated the SRM warning icon and the "sample ratio mismatch detected" detail row in the Exposures view. The feature has shipped and the gate is dead weight.

## Changes

- Dropped both flag gates in `frontend/src/scenes/experiments/ExperimentView/Exposures.tsx` so SRM signals always render when `exposures.sample_ratio_mismatch` is present.
- Removed the now-unused `featureFlags` value and `FEATURE_FLAGS` import from the file.
- Deleted the `EXPERIMENTS_SAMPLE_RATIO_MISMATCH` entry from `frontend/src/lib/constants.tsx`.

## How did you test this code?

Agent-authored. No manual testing performed. Verified via grep that no other references to `EXPERIMENTS_SAMPLE_RATIO_MISMATCH` / `experiments-sample-ratio-mismatch` remain in the repo.

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Prompt: remove the `EXPERIMENTS_SAMPLE_RATIO_MISMATCH` flag, identified as dead-weight gating around SRM UI (owner @jurajmajerik).
- Decision: removed the flag outright rather than ramping — owner is on-team and the SRM signal is broadly useful.