### PR TITLE
chore(experiments): Simplify total-row percentage in exposures table

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -438,27 +438,9 @@ export function Exposures(): JSX.Element {
                                                 key: 'percentage',
                                                 render: function Percentage(_, series) {
                                                     if (series.isTotal) {
-                                                        let totalPercentage = 0
-                                                        let total = 0
-                                                        if (exposures?.total_exposures) {
-                                                            for (const [_, value] of Object.entries(
-                                                                exposures.total_exposures
-                                                            )) {
-                                                                total += Number(value)
-                                                            }
-                                                            if (total > 0) {
-                                                                for (const [_, count] of Object.entries(
-                                                                    exposures.total_exposures
-                                                                )) {
-                                                                    totalPercentage += (Number(count) / total) * 100
-                                                                }
-                                                            }
-                                                        }
                                                         return (
                                                             <span className="font-semibold">
-                                                                {totalPercentage
-                                                                    ? `${totalPercentage.toFixed(1)}%`
-                                                                    : '-%'}
+                                                                {totalExposures > 0 ? '100.0%' : '-%'}
                                                             </span>
                                                         )
                                                     }


### PR DESCRIPTION
## Problem

The Total row's `%` column in the experiment Exposures table iterates `total_exposures` to compute the sum, then iterates again to sum `(count_i / total) * 100`. By construction this always equals `100.0%` (or `'-%'` when total is 0). ~20 lines of nested conditionals to render a constant.

## Changes

Replace the Total branch with a direct `totalExposures > 0 ? '100.0%' : '-%'` using the already-computed `totalExposures` variable. Per-variant branch untouched.

## How did you test this code?

Agent-authored. No manual testing performed. The change is a pure simplification — the previous code's output is mathematically `100.0%` whenever `total > 0` and `'-%'` otherwise, which is what the new code returns directly.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Change identified during a code-quality scan of the Experiments exposures UI; flagged as low-impact but potentially misleading to future readers who might assume the math is meaningful.