### PR TITLE
fix(experiments): Render exposures chart inside its own component

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -130,6 +130,97 @@ function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
     )
 }
 
+interface ExposuresChartProps {
+    exposures: ExperimentExposureQueryResponse
+    axisLineColor: string
+}
+
+function ExposuresChart({ exposures, axisLineColor }: ExposuresChartProps): JSX.Element {
+    const { canvasRef } = useChart({
+        getConfig: () => {
+            if (!exposures?.timeseries?.length) {
+                return null
+            }
+
+            let labels = exposures.timeseries[0].days.map((day: string) => dayjs(day).format('MM/DD'))
+            let datasets = exposures.timeseries.map((series: ExperimentExposureTimeSeries, index: number) => ({
+                label: series.variant,
+                data: series.exposure_counts,
+                borderColor: getSeriesColor(index),
+                backgroundColor: getSeriesBackgroundColor(index),
+                fill: false,
+                tension: 0,
+                borderWidth: 2,
+                pointRadius: 0,
+            }))
+
+            if (exposures.timeseries[0].days.length === 1) {
+                const firstDay = dayjs(exposures.timeseries[0].days[0])
+                const previousDay = firstDay.subtract(1, 'day').format('MM/DD')
+
+                labels = [previousDay, ...labels]
+                datasets = datasets.map((dataset: ChartDataset) => ({
+                    ...dataset,
+                    data: [0, ...dataset.data],
+                }))
+            }
+
+            return {
+                type: 'line' as const,
+                data: { labels, datasets },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: {
+                        intersect: false,
+                        mode: 'nearest',
+                        axis: 'x',
+                    },
+                    scales: {
+                        x: {
+                            ticks: {
+                                maxTicksLimit: 8,
+                                autoSkip: true,
+                                maxRotation: 0,
+                                minRotation: 0,
+                            },
+                            grid: {
+                                display: true,
+                                color: axisLineColor,
+                            },
+                        },
+                        y: {
+                            beginAtZero: true,
+                            grid: {
+                                display: true,
+                                color: axisLineColor,
+                            },
+                        },
+                    },
+                    plugins: {
+                        legend: {
+                            display: false,
+                            labels: {
+                                boxWidth: 4,
+                                boxPadding: 20,
+                                pointStyle: 'dash',
+                            },
+                        },
+                        crosshair: false,
+                    },
+                },
+            }
+        },
+        deps: [exposures, axisLineColor],
+    })
+
+    return (
+        <div className="relative h-[200px]">
+            <canvas ref={canvasRef} />
+        </div>
+    )
+}
+
 function getExposureCriteriaLabel(exposureCriteria: ExperimentExposureCriteria | undefined): string {
     const exposureConfig = exposureCriteria?.exposure_config
     if (!exposureConfig) {
@@ -177,87 +268,6 @@ export function Exposures(): JSX.Element {
 
     // Detect sample ratio mismatch (p < 0.001 is significant)
     const hasSRM = exposures?.sample_ratio_mismatch != null && exposures.sample_ratio_mismatch.p_value < 0.001
-
-    const { canvasRef } = useChart({
-        getConfig: () => {
-            if (isCollapsed || !exposures?.timeseries?.length) {
-                return null
-            }
-
-            let labels = exposures.timeseries[0].days.map((day: string) => dayjs(day).format('MM/DD'))
-            let datasets = exposures.timeseries.map((series: ExperimentExposureTimeSeries, index: number) => ({
-                label: series.variant,
-                data: series.exposure_counts,
-                borderColor: getSeriesColor(index),
-                backgroundColor: getSeriesBackgroundColor(index),
-                fill: false,
-                tension: 0,
-                borderWidth: 2,
-                pointRadius: 0,
-            }))
-
-            if (exposures.timeseries[0].days.length === 1) {
-                const firstDay = dayjs(exposures.timeseries[0].days[0])
-                const previousDay = firstDay.subtract(1, 'day').format('MM/DD')
-
-                labels = [previousDay, ...labels]
-                datasets = datasets.map((dataset: ChartDataset) => ({
-                    ...dataset,
-                    data: [0, ...dataset.data],
-                }))
-            }
-
-            return {
-                type: 'line' as const,
-                data: {
-                    labels,
-                    datasets,
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    interaction: {
-                        intersect: false,
-                        mode: 'nearest',
-                        axis: 'x',
-                    },
-                    scales: {
-                        x: {
-                            ticks: {
-                                maxTicksLimit: 8,
-                                autoSkip: true,
-                                maxRotation: 0,
-                                minRotation: 0,
-                            },
-                            grid: {
-                                display: true,
-                                color: colors.EXPOSURES_AXIS_LINES,
-                            },
-                        },
-                        y: {
-                            beginAtZero: true,
-                            grid: {
-                                display: true,
-                                color: colors.EXPOSURES_AXIS_LINES,
-                            },
-                        },
-                    },
-                    plugins: {
-                        legend: {
-                            display: false,
-                            labels: {
-                                boxWidth: 4,
-                                boxPadding: 20,
-                                pointStyle: 'dash',
-                            },
-                        },
-                        crosshair: false,
-                    },
-                },
-            }
-        },
-        deps: [exposures, colors.EXPOSURES_AXIS_LINES, isCollapsed],
-    })
 
     const handleCollapseChange = useCallback((activeKey: string | null) => {
         const isOpen = activeKey === 'cumulative-exposures'
@@ -356,9 +366,7 @@ export function Exposures(): JSX.Element {
                                     </div>
                                 </div>
                             ) : (
-                                <div className="relative h-[200px]">
-                                    <canvas ref={canvasRef} />
-                                </div>
+                                <ExposuresChart exposures={exposures} axisLineColor={colors.EXPOSURES_AXIS_LINES} />
                             )}
 
                             {/* Exposure Criteria Section */}

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -159,7 +159,7 @@ function ExposuresChart({ exposures, axisLineColor }: ExposuresChartProps): JSX.
                 const previousDay = firstDay.subtract(1, 'day').format('MM/DD')
 
                 labels = [previousDay, ...labels]
-                datasets = datasets.map((dataset: ChartDataset) => ({
+                datasets = datasets.map((dataset) => ({
                     ...dataset,
                     data: [0, ...dataset.data],
                 }))


### PR DESCRIPTION
## Problem

The exposures chart in the experiment view stopped rendering — only a blank canvas appeared. The MicroChart in the header (same `useChart` hook, same data) kept working.

`LemonCollapse` switched from `react-transition-group`'s `<Transition mountOnEnter>` to `useAnimatedPresence` (#56360), which now mounts panel content one render *after* the open flip. The parent's `useChart` effect was running on the first render — when the canvas wasn't yet in the DOM — saw `canvasRef.current === null`, returned early, and never re-fired (none of its deps changed on the second render).

## Changes

Extracted the chart into a new `ExposuresChart` component that renders inside the collapse content. It mounts together with the panel, so `useChart`'s first effect run sees the canvas and creates the chart. Removed the now-redundant `isCollapsed` dep from the chart config.

## How did you test this code?
Verified manually in the running dev environment by expanding the exposures panel before and after the change — chart was blank before, renders correctly after.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Diagnosed regression by tracing the render/effect order between `LemonCollapse` (deferred-mount via `useAnimatedPresence`) and the parent `useChart` effect, then confirmed by temporarily patching `useAnimatedPresence` to mount synchronously on enter (chart rendered) — reverted that patch and adopted the local fix instead, since modifying a shared primitive has wider blast radius.
- Considered alternatives: (1) make `useChart` resilient to deferred canvas mounts via a callback ref + state, but that changes the returned `canvasRef` shape and breaks `LineGraph`/`BoxPlotChart` consumers that read `canvasRef.current`; (2) restore `mountOnEnter` semantics in `useAnimatedPresence` itself — correct but touches a widely-used primitive. Chose the local component-extraction fix as the smallest change that's obviously safe.