### PR TITLE
fix(common-kafka): apply client.id and client.rack to producer

### DIFF
--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -90,6 +90,14 @@ where
         client_config.set("sticky.partitioning.linger.ms", v.to_string());
     }
 
+    if !config.kafka_client_rack.is_empty() {
+        client_config.set("client.rack", &config.kafka_client_rack);
+    }
+
+    if !config.kafka_client_id.is_empty() {
+        client_config.set("client.id", &config.kafka_client_id);
+    }
+
     if config.kafka_tls {
         client_config
             .set("security.protocol", "ssl")


### PR DESCRIPTION
## Problem

The Rust Kafka producer in [common-kafka](rust/common/kafka/src/kafka_producer.rs) reads `kafka_client_id` and `kafka_client_rack` from `KafkaConfig` but never applies them — only the consumer does. WarpStream parses `warpstream_proxy_target` and `warpstream_az` from `client.id` to route producers to AZ-local agents. Without this, every produce connection lands on a random AZ agent — adding cross-AZ data charges and worse tail latency.

This is a prerequisite for migrating cyclotron-janitor's `app_metrics2` producer to WarpStream.

## Changes

- `create_kafka_producer` now sets `client.rack` and `client.id` on the librdkafka client config when the corresponding `KafkaConfig` fields are non-empty, mirroring the existing logic in `kafka_consumer.rs`.

## How did you test this code?

## Publish to changelog?

no
