### PR TITLE
fix(experiments): wire bias banner button to first seen handling

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/MultiVariantBiasWarning.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/MultiVariantBiasWarning.tsx
@@ -33,19 +33,17 @@ export function MultiVariantBiasWarning(): JSX.Element | null {
     }
 
     return (
-        <LemonBanner type="warning" className="mb-4">
+        <LemonBanner type="warning" className="mt-4">
             <div className="flex items-start justify-between gap-4 flex-wrap">
                 <div className="flex-1 min-w-[300px]">
-                    <div>
-                        <strong>Setup likely introduced bias</strong>
-                    </div>
-                    <div>
+                    <div className="font-semibold">Setup likely introduced bias</div>
+                    <p className="m-0">
                         <strong>{risk.multiple_variant_percentage.toFixed(1)}%</strong> of users were exposed to
                         multiple variants. With your uneven variant split and the current <strong>Exclude</strong>{' '}
                         handling, users were disproportionately dropped from the smaller variant. If their behavior
                         differs from other users, the smaller variant's metrics will be biased.
-                    </div>
-                    <div className="mt-1">
+                    </p>
+                    <p className="m-0 mt-1">
                         We recommend using an <strong>even split</strong> and controlling exposure with the overall
                         rollout (uneven splits have further disadvantages). Alternatively use{' '}
                         <Link
@@ -55,13 +53,22 @@ export function MultiVariantBiasWarning(): JSX.Element | null {
                             <strong>First seen</strong>
                         </Link>{' '}
                         handling.
-                    </div>
+                    </p>
                 </div>
                 <div className="flex gap-2 items-center flex-shrink-0">
-                    <LemonButton type="secondary" onClick={() => openDistributionModal()}>
+                    <LemonButton size="small" type="secondary" onClick={() => openDistributionModal()}>
                         Adjust distribution
                     </LemonButton>
-                    <LemonButton type="secondary" onClick={() => openExposureCriteriaModal(exposureCriteria)}>
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        onClick={() =>
+                            openExposureCriteriaModal({
+                                ...exposureCriteria,
+                                multiple_variant_handling: 'first_seen',
+                            })
+                        }
+                    >
                         Use first seen variant
                     </LemonButton>
                 </div>


### PR DESCRIPTION
## Problem

The "Use first seen variant" button on the multi-variant bias warning banner only opened the exposure criteria modal — it did not pre-select `first_seen` handling. Users landed on a modal still defaulted to "Exclude from analysis" and had to re-discover the toggle the button just promised.

The banner itself sat flush against the Exposures component above it and used default-size buttons that felt heavy.

## Changes

- Pre-stage `multiple_variant_handling: 'first_seen'` when opening the modal from the banner, so the user just confirms by clicking Save.
- `mb-4` → `mt-4` on the banner so it has breathing room from Exposures (the wrapper in `ExperimentView.tsx` already supplies the bottom margin).
- `size="small"` on both CTAs.
- Title now uses `font-semibold`; body paragraphs use `<p>` with reset margins instead of bare `<div>`s. Copy unchanged.

## How did you test this code?
Manually

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude (Opus 4.7) at the user's direction.
- Origin: an audit item flagging that the banner button didn't fulfill its promise, plus a request to tighten the banner's UX without changing the copy.
- Rejected: a fuller copy rewrite — user asked to keep the original wording, so only structural/spacing changes were applied.