### PR TITLE
perf(insights): upgrade search to pg_trgm word similarity

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1316,7 +1316,13 @@ class InsightViewSet(
         span.set_attribute("posthog.basic", self._is_basic_request())
         span.set_attribute("posthog.saved", str_to_bool(request.query_params.get("saved", "0")))
         span.set_attribute("posthog.order", request.query_params.get("order", ""))
-        return super().list(request, *args, **kwargs)
+        response = super().list(request, *args, **kwargs)
+        if request.query_params.get("search"):
+            data = response.data if isinstance(response.data, dict) else {}
+            results_len = len(data.get("results", [])) if "results" in data else 0
+            span.set_attribute("insight.search.result_count", results_len)
+            span.set_attribute("insight.search.empty", results_len == 0)
+        return response
 
     def paginate_queryset(self, queryset):
         page = super().paginate_queryset(queryset)
@@ -1526,8 +1532,11 @@ class InsightViewSet(
         return Response(data=data, status=status.HTTP_200_OK)
 
     @staticmethod
+    @tracer.start_as_current_span("InsightViewSet._apply_search")
     def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
         search = search.replace("\x00", "").strip()
+        span = trace.get_current_span()
+        span.set_attribute("insight.search.length", len(search))
         if not search:
             return queryset
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1429,6 +1429,8 @@ class InsightViewSet(
     def order_queryset(self, queryset: QuerySet) -> QuerySet:
         order = self.request.GET.get("order", None)
         if not order:
+            if self.request.GET.get("search"):
+                return queryset
             return queryset.order_by("order")
 
         if order == "-last_viewed_at":

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -67,6 +67,13 @@ from posthog.errors import ExposedCHQueryError
 from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
+from posthog.helpers.trigram_search import (
+    DESCRIPTION_SCORE_WEIGHT,
+    MAX_SEARCH_LENGTH,
+    MIN_DESCRIPTION_TRIGRAM_SIMILARITY,
+    MIN_NAME_TRIGRAM_SIMILARITY,
+    normalize_search_term,
+)
 from posthog.hogql_queries.apply_dashboard_filters import (
     WRAPPER_NODE_KINDS,
     apply_dashboard_filters_to_dict,
@@ -129,11 +136,6 @@ from common.hogvm.python.utils import HogVMException
 
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
-
-MIN_NAME_TRIGRAM_SIMILARITY = 0.3
-MIN_DESCRIPTION_TRIGRAM_SIMILARITY = 0.4
-DESCRIPTION_SCORE_WEIGHT = 0.5
-MAX_SEARCH_LENGTH = 200
 
 LEGACY_INSIGHT_ENDPOINTS_BLOCKED_FLAG = "legacy-insight-endpoints-disabled"
 LEGACY_INSIGHT_FILTERS_BLOCKED_FLAG = "legacy-insight-filters-disabled"
@@ -1534,7 +1536,7 @@ class InsightViewSet(
     @staticmethod
     @tracer.start_as_current_span("InsightViewSet._apply_search")
     def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
-        search = search.replace("\x00", "").strip()
+        search = normalize_search_term(search)
         span = trace.get_current_span()
         span.set_attribute("insight.search.length", len(search))
         if not search:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1321,7 +1321,7 @@ class InsightViewSet(
         response = super().list(request, *args, **kwargs)
         if request.query_params.get("search"):
             data = response.data if isinstance(response.data, dict) else {}
-            results_len = len(data.get("results", [])) if "results" in data else 0
+            results_len = data.get("count", len(data.get("results", [])))
             span.set_attribute("insight.search.result_count", results_len)
             span.set_attribute("insight.search.empty", results_len == 0)
         return response

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -132,6 +132,7 @@ tracer = trace.get_tracer(__name__)
 
 MIN_NAME_TRIGRAM_SIMILARITY = 0.3
 MIN_DESCRIPTION_TRIGRAM_SIMILARITY = 0.4
+DESCRIPTION_SCORE_WEIGHT = 0.5
 MAX_SEARCH_LENGTH = 200
 
 LEGACY_INSIGHT_ENDPOINTS_BLOCKED_FLAG = "legacy-insight-endpoints-disabled"
@@ -1536,7 +1537,7 @@ class InsightViewSet(
         derived_name_word_score = Coalesce(TrigramWordSimilarity(search, "derived_name"), zero)
         description_word_score = Coalesce(TrigramWordSimilarity(search, "description"), zero)
 
-        tag_match = queryset.filter(tagged_items__tag__name__icontains=search).values("id")
+        matching_tag_ids = queryset.filter(tagged_items__tag__name__icontains=search).values("id")
 
         return (
             queryset.annotate(
@@ -1549,7 +1550,7 @@ class InsightViewSet(
                 Q(_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY)
                 | Q(_derived_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY)
                 | Q(_description_word__gt=MIN_DESCRIPTION_TRIGRAM_SIMILARITY)
-                | Q(id__in=tag_match)
+                | Q(id__in=matching_tag_ids)
             )
             .annotate(
                 _name_match_score=F("_name_word") + F("_name_full"),
@@ -1559,7 +1560,7 @@ class InsightViewSet(
             .annotate(
                 _search_score=F("_name_match_score")
                 + F("_derived_name_match_score")
-                + F("_description_match_score") * 0.5
+                + F("_description_match_score") * DESCRIPTION_SCORE_WEIGHT
             )
             .order_by("-_search_score", "name")
             .distinct()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -5,8 +5,10 @@ from datetime import UTC, datetime, timedelta
 from functools import lru_cache
 from typing import Any, Union, cast
 
+from django.contrib.postgres.search import TrigramSimilarity, TrigramWordSimilarity
 from django.db import transaction
-from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, QuerySet, Subquery
+from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, QuerySet, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
 from django.utils.text import slugify
@@ -127,6 +129,10 @@ from common.hogvm.python.utils import HogVMException
 
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
+
+MIN_NAME_TRIGRAM_SIMILARITY = 0.3
+MIN_DESCRIPTION_TRIGRAM_SIMILARITY = 0.4
+MAX_SEARCH_LENGTH = 200
 
 LEGACY_INSIGHT_ENDPOINTS_BLOCKED_FLAG = "legacy-insight-endpoints-disabled"
 LEGACY_INSIGHT_FILTERS_BLOCKED_FLAG = "legacy-insight-filters-disabled"
@@ -1516,6 +1522,47 @@ class InsightViewSet(
 
         return Response(data=data, status=status.HTTP_200_OK)
 
+    @staticmethod
+    def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
+        search = search.replace("\x00", "").strip()
+        if not search:
+            return queryset
+
+        zero = Value(0.0)
+        name_word_score = Coalesce(TrigramWordSimilarity(search, "name"), zero)
+        name_full_score = Coalesce(TrigramSimilarity("name", search), zero)
+        derived_name_word_score = Coalesce(TrigramWordSimilarity(search, "derived_name"), zero)
+        description_word_score = Coalesce(TrigramWordSimilarity(search, "description"), zero)
+
+        tag_match = queryset.filter(tagged_items__tag__name__icontains=search).values("id")
+
+        return (
+            queryset.annotate(
+                _name_word=name_word_score,
+                _name_full=name_full_score,
+                _derived_name_word=derived_name_word_score,
+                _description_word=description_word_score,
+            )
+            .filter(
+                Q(_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY)
+                | Q(_derived_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY)
+                | Q(_description_word__gt=MIN_DESCRIPTION_TRIGRAM_SIMILARITY)
+                | Q(id__in=tag_match)
+            )
+            .annotate(
+                _name_match_score=F("_name_word") + F("_name_full"),
+                _derived_name_match_score=F("_derived_name_word"),
+                _description_match_score=F("_description_word"),
+            )
+            .annotate(
+                _search_score=F("_name_match_score")
+                + F("_derived_name_match_score")
+                + F("_description_match_score") * 0.5
+            )
+            .order_by("-_search_score", "name")
+            .distinct()
+        )
+
     def _filter_request(self, request: request.Request, queryset: QuerySet) -> QuerySet:
         filters = request.GET.dict()
 
@@ -1599,12 +1646,10 @@ class InsightViewSet(
                 else:
                     queryset = queryset.filter(legacy_filter)
             elif key == "search":
-                queryset = queryset.filter(
-                    Q(name__icontains=request.GET["search"])
-                    | Q(derived_name__icontains=request.GET["search"])
-                    | Q(tagged_items__tag__name__icontains=request.GET["search"])
-                    | Q(description__icontains=request.GET["search"])
-                ).distinct()
+                term = request.GET["search"]
+                if len(term) > MAX_SEARCH_LENGTH:
+                    raise ValidationError({"search": f"Search query must be {MAX_SEARCH_LENGTH} characters or fewer."})
+                queryset = self._apply_search(queryset, term)
             elif key == "dashboards":
                 dashboards_filter = request.GET["dashboards"]
                 if dashboards_filter:

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -739,6 +739,135 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             f"got {len(matching_short_ids)} copies."
         )
 
+    @parameterized.expand(
+        [
+            (
+                "exact match wins over partial matches",
+                ["Ad Sales", "Email Sales", "Sales", "Sales Funnel", "Weekly Sales", "Unrelated"],
+                "Sales",
+                "Sales",
+                ["Unrelated"],
+            ),
+            (
+                "typo / transposition still matches via trigram",
+                ["Dashboard overview", "Unrelated"],
+                "dahsboard",
+                "Dashboard overview",
+                ["Unrelated"],
+            ),
+            (
+                "prefix-as-you-type",
+                ["Marketing funnel", "Engineering metrics"],
+                "Marke",
+                "Marketing funnel",
+                ["Engineering metrics"],
+            ),
+            (
+                "case-insensitive: lower",
+                ["Revenue by region", "Engineering metrics"],
+                "revenue",
+                "Revenue by region",
+                ["Engineering metrics"],
+            ),
+            (
+                "case-insensitive: upper",
+                ["Revenue by region", "Engineering metrics"],
+                "REVENUE",
+                "Revenue by region",
+                ["Engineering metrics"],
+            ),
+        ]
+    )
+    def test_list_filter_by_search_relevance(self, _name, insight_names, search, expected_first, excluded):
+        for name in insight_names:
+            Insight.objects.create(name=name, team=self.team, filters={"events": [{"id": "$pageview"}]})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?search={search}")
+        assert response.status_code == status.HTTP_200_OK
+        result_names = [r["name"] for r in response.json()["results"]]
+
+        assert result_names, f"expected at least one match for {search!r}, got nothing"
+        assert result_names[0] == expected_first, f"expected {expected_first!r} first, got {result_names}"
+        for name in excluded:
+            assert name not in result_names, f"expected {name!r} excluded, got {result_names}"
+
+    def test_list_filter_by_search_matches_derived_name(self):
+        named = Insight.objects.create(
+            name="Marketing funnel", team=self.team, filters={"events": [{"id": "$pageview"}]}
+        )
+        derived = Insight.objects.create(
+            name=None, derived_name="Signup conversion", team=self.team, filters={"events": [{"id": "$pageview"}]}
+        )
+        Insight.objects.create(name="Unrelated", team=self.team, filters={"events": [{"id": "$pageview"}]})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?search=signup")
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = [r["id"] for r in response.json()["results"]]
+
+        assert derived.id in result_ids
+        assert named.id not in result_ids
+
+    def test_list_filter_by_search_matches_description_with_lower_rank_than_name(self):
+        name_match = Insight.objects.create(name="revenue", team=self.team, filters={"events": [{"id": "$pageview"}]})
+        description_match = Insight.objects.create(
+            name="Q4 review",
+            description="Quarterly revenue breakdown",
+            team=self.team,
+            filters={"events": [{"id": "$pageview"}]},
+        )
+        Insight.objects.create(name="Unrelated", team=self.team, filters={"events": [{"id": "$pageview"}]})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?search=revenue")
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = [r["id"] for r in response.json()["results"]]
+
+        assert result_ids[:2] == [name_match.id, description_match.id]
+        assert all(r["name"] != "Unrelated" for r in response.json()["results"])
+
+    @parameterized.expand(
+        [
+            ("whitespace-only", "   "),
+            ("empty", ""),
+        ]
+    )
+    def test_list_filter_by_search_blank_returns_all(self, _name, search):
+        a = Insight.objects.create(name="Alpha", team=self.team, filters={"events": [{"id": "$pageview"}]})
+        b = Insight.objects.create(name="Beta", team=self.team, filters={"events": [{"id": "$pageview"}]})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?search={search}")
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = {r["id"] for r in response.json()["results"]}
+
+        assert {a.id, b.id}.issubset(result_ids)
+
+    @parameterized.expand(
+        [
+            ("plain symbols", "&|!"),
+            ("sql-injection-shaped", "'; DROP TABLE--"),
+        ]
+    )
+    def test_list_filter_by_search_pathological_input_does_not_500(self, _name, search):
+        Insight.objects.create(name="Dashboard overview", team=self.team, filters={"events": [{"id": "$pageview"}]})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/", {"search": search})
+        assert response.status_code == status.HTTP_200_OK
+
+    @parameterized.expand(
+        [
+            ("at cap (200)", 200, status.HTTP_200_OK),
+            ("just over cap (201)", 201, status.HTTP_400_BAD_REQUEST),
+            ("very long (10k)", 10_000, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_list_filter_by_search_enforces_length_cap(self, _name, length, expected_status):
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/", {"search": "a" * length})
+        assert response.status_code == expected_status
+
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            body = response.json()
+            assert body["attr"] == "search", f"expected error scoped to 'search', got {body}"
+            assert "200 characters" in body["detail"], f"expected error detail to mention the cap, got {body['detail']}"
+
     # :KLUDGE: avoid making extra queries that are explicitly not cached in tests. Avoids false N+1-s.
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @snapshot_postgres_queries

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -868,6 +868,22 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             assert body["attr"] == "search", f"expected error scoped to 'search', got {body}"
             assert "200 characters" in body["detail"], f"expected error detail to mention the cap, got {body['detail']}"
 
+    def test_list_filter_by_search_nul_bytes_do_not_500(self):
+        Insight.objects.create(name="Alpha", team=self.team, filters={"events": [{"id": "$pageview"}]})
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/", {"search": "\x00\x00\x00"})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_list_filter_by_search_explicit_order_overrides_relevance(self):
+        older = Insight.objects.create(name="revenue funnel", team=self.team, filters={"events": [{"id": "$pageview"}]})
+        newer = Insight.objects.create(name="revenue trends", team=self.team, filters={"events": [{"id": "$pageview"}]})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/", {"search": "revenue", "order": "-id"})
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = [r["id"] for r in response.json()["results"]]
+        assert result_ids.index(newer.id) < result_ids.index(older.id), (
+            "explicit order=-id should override relevance ranking and put newer insight first"
+        )
+
     # :KLUDGE: avoid making extra queries that are explicitly not cached in tests. Avoids false N+1-s.
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @snapshot_postgres_queries

--- a/posthog/helpers/trigram_search.py
+++ b/posthog/helpers/trigram_search.py
@@ -1,0 +1,19 @@
+# Minimum trigram word similarity for a name match. Calibrated against the
+# `test_list_filter_by_search_*` tests in posthog/api/test/dashboards/test_dashboard.py.
+# Tighten it and typo cases stop matching, loosen it and unrelated rows leak in.
+MIN_NAME_TRIGRAM_SIMILARITY = 0.3
+# Description thresholds run higher because descriptions are freeform prose where short
+# queries (3-5 chars) can clear a 0.3 threshold against any sufficiently long passage.
+MIN_DESCRIPTION_TRIGRAM_SIMILARITY = 0.4
+# Description matches contribute less than name matches to the relevance score so that
+# a row matched only on description ranks below a row matched on name.
+DESCRIPTION_SCORE_WEIGHT = 0.5
+# Hard cap on the `?search=` query parameter — protects against pathological inputs
+# burning CPU on trigram comparisons against a long string. Both `Dashboard.name` and
+# `Insight.name` are bounded at 400 chars so 200 covers any realistic prefix-as-you-type.
+MAX_SEARCH_LENGTH = 200
+
+
+def normalize_search_term(search: str) -> str:
+    # Postgres rejects NUL bytes in text parameters; strip before they hit the query.
+    return search.replace("\x00", "").strip()

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1104,7 +1104,7 @@ class DashboardsViewSet(
         # telemetry — flag empty results (loosen) and high counts (tighten).
         if request.query_params.get("search"):
             data = response.data if isinstance(response.data, dict) else {}
-            results_len = len(data.get("results", [])) if "results" in data else 0
+            results_len = data.get("count", len(data.get("results", [])))
             span = trace.get_current_span()
             span.set_attribute("dashboard.search.result_count", results_len)
             span.set_attribute("dashboard.search.empty", results_len == 0)

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -48,6 +48,13 @@ from posthog.constants import GENERATED_DASHBOARD_PREFIX
 from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.helpers.dashboard_templates import create_from_template, dashboard_template_from_creation_payload
+from posthog.helpers.trigram_search import (
+    DESCRIPTION_SCORE_WEIGHT,
+    MAX_SEARCH_LENGTH,
+    MIN_DESCRIPTION_TRIGRAM_SIMILARITY,
+    MIN_NAME_TRIGRAM_SIMILARITY,
+    normalize_search_term,
+)
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Insight
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
@@ -140,18 +147,6 @@ FILTERS_OVERRIDE_PARAM = OpenApiParameter(
 
 
 tracer = trace.get_tracer(__name__)
-
-# Minimum trigram word similarity for a name match. Calibrated against the
-# `test_list_filter_by_search_*` tests in posthog/api/test/dashboards/test_dashboard.py.
-# Tighten it and typo cases stop matching, loosen it and unrelated rows leak in.
-MIN_NAME_TRIGRAM_SIMILARITY = 0.3
-# Description thresholds run higher because descriptions are freeform prose where short
-# queries (3-5 chars) can clear a 0.3 threshold against any sufficiently long passage.
-MIN_DESCRIPTION_TRIGRAM_SIMILARITY = 0.4
-# Hard cap on the `?search=` query parameter — protects against pathological inputs
-# burning CPU on trigram comparisons against a long string (and against operational
-# `dashboard.name` is bounded at 400 chars so 200 covers any realistic prefix-as-you-type).
-MAX_SEARCH_LENGTH = 200
 
 
 def serialize_tile_with_context(tile, order: int, context: dict) -> tuple[int, dict]:
@@ -1118,8 +1113,7 @@ class DashboardsViewSet(
     @staticmethod
     @tracer.start_as_current_span("DashboardViewSet._apply_search")
     def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
-        # Postgres rejects NUL bytes in text parameters; strip before they hit the query.
-        search = search.replace("\x00", "").strip()
+        search = normalize_search_term(search)
         span = trace.get_current_span()
         span.set_attribute("dashboard.search.length", len(search))
         if not search:
@@ -1150,7 +1144,7 @@ class DashboardsViewSet(
                 _name_match_score=F("_name_word") + F("_name_full"),
                 _description_match_score=F("_description_word"),
             )
-            .annotate(_search_score=F("_name_match_score") + F("_description_match_score") * 0.5)
+            .annotate(_search_score=F("_name_match_score") + F("_description_match_score") * DESCRIPTION_SCORE_WEIGHT)
             .order_by("-_search_score", "-pinned", "name")
         )
 


### PR DESCRIPTION
## Summary

- Replaces the four-field `icontains` OR filter on `?search=` with trigram word similarity, matching the approach shipped for dashboards in #57106
- `name` and `derived_name` scored via `TrigramWordSimilarity` + `TrigramSimilarity` (typo-tolerant, prefix-as-you-type)
- `description` scored via `TrigramWordSimilarity` with a higher threshold (0.4 vs 0.3) to avoid short queries matching long freeform prose
- Tags kept as `icontains` via subquery — exact label matching is preferable for short tag strings
- Adds a 200-char cap on `?search=` returning 400, consistent with the dashboards endpoint
- Results ordered by relevance score descending, then name; `distinct()` preserved so multi-tag insights don't duplicate

## Test plan

- [ ] `pytest posthog/api/test/test_insight.py -k "search" -x -q`
- [ ] Manual: search saved insights with typos, partial words, and terms matching description-only insights

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*