### PR TITLE
fix(experiments): Drop duplicated prepositions in activity log

### DIFF
--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -69,11 +69,11 @@ export const getExperimentChangeDescription = (
                     const duration = dayjs.duration(Math.abs(diff), 'minute')
                     const sign = diff > 0 ? 'moved the start date forward' : 'moved the start date back'
 
-                    return `${sign} by ${duration.humanize()} on`
+                    return `${sign} by ${duration.humanize()}`
                 }
             }
 
-            return 'updated the start date of'
+            return 'changed the start date'
         })
         .with({ field: 'end_date' }, ({ action, before, after }) => {
             /**
@@ -83,7 +83,7 @@ export const getExperimentChangeDescription = (
                 return 'stopped experiment'
             }
 
-            return 'updated the end date of'
+            return 'changed the end date'
         })
         .with({ field: 'conclusion' }, ({ action, before, after }) => {
             /**
@@ -102,12 +102,11 @@ export const getExperimentChangeDescription = (
                 return (
                     <span>
                         changed the conclusion to <ExperimentConclusionTag conclusion={after as ExperimentConclusion} />
-                        &nbsp;for
                     </span>
                 )
             }
 
-            return 'updated conclusion for'
+            return 'changed the conclusion'
         })
         .with({ field: 'metrics', action: 'created', before: null }, () => 'added the first metric to')
         .with({ field: 'metrics', action: 'changed' }, ({ before, after }) =>

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -46,8 +46,26 @@ const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element =
     )
 }
 
+// Recursively pull plain text out of a string / JSX node so getPreposition can
+// inspect its keywords. The conclusion matcher returns JSX whose leading verb
+// ("changed") would otherwise be invisible to the keyword check.
+const extractText = (node: string | JSX.Element | null | undefined): string => {
+    if (node === null || node === undefined || typeof node === 'boolean') {
+        return ''
+    }
+    if (typeof node === 'string' || typeof node === 'number') {
+        return String(node)
+    }
+    if (Array.isArray(node)) {
+        return node.map(extractText).join(' ')
+    }
+    const children = (node as JSX.Element).props?.children
+    return children !== undefined ? extractText(children) : ''
+}
+
 // Helper to determine the right preposition based on the action text
-const getPreposition = (text: string): string => {
+const getPreposition = (item: string | JSX.Element): string => {
+    const text = extractText(item)
     if (text.includes('added') || text.includes('set')) {
         return 'to'
     }
@@ -63,76 +81,30 @@ const getPreposition = (text: string): string => {
     return 'on'
 }
 
-/**
- * Formats the result from getExperimentChangeDescription into a human-readable string
- * Handles arrays by joining with commas and "and" for the last item
- * Adds appropriate preposition (to/for/on) based on the action
- */
+// Flatten the result of getExperimentChangeDescription into the parts that
+// SentenceList will join. Prepositions are NOT appended here — the outer
+// updated branch attaches a single preposition to the last list part so the
+// joined sentence reads naturally (e.g. "changed A, changed B, and changed C
+// for Experiment Name").
 const humanizeExperimentChange = (
     result: string | JSX.Element | (string | JSX.Element)[] | null
-): string | JSX.Element | null => {
+): (string | JSX.Element)[] => {
     if (result === null) {
-        return null
+        return []
     }
-
     if (Array.isArray(result)) {
-        // Filter out null/undefined values
-        const validItems = result.filter(Boolean)
-
-        if (validItems.length === 0) {
-            return null
-        }
-
-        if (validItems.length === 1) {
-            const item = validItems[0]
-            const itemText = typeof item === 'string' ? item : ''
-            const preposition = getPreposition(itemText)
-            return (
-                <span>
-                    {item} {preposition}
-                </span>
-            )
-        }
-
-        // Join with commas and "and" for the last item
-        const lastItem = validItems[validItems.length - 1]
-        const otherItems = validItems.slice(0, -1)
-
-        // Determine preposition based on first item (they should all be similar actions)
-        const firstItemText = typeof otherItems[0] === 'string' ? otherItems[0] : ''
-        const preposition = getPreposition(firstItemText)
-
-        // If all items are strings, return a string
-        const allStrings = validItems.every((item) => typeof item === 'string')
-        if (allStrings) {
-            return `${otherItems.join(', ')} and ${lastItem} ${preposition}`
-        }
-
-        // If mixed or JSX elements, return a span
-        return (
-            <span>
-                {otherItems.map((item, index) => (
-                    <span key={index}>
-                        {item}
-                        {index < otherItems.length - 1 ? ', ' : ' and '}
-                    </span>
-                ))}
-                {lastItem} {preposition}
-            </span>
-        )
+        return result.filter(Boolean) as (string | JSX.Element)[]
     }
+    return [result]
+}
 
-    // Single string or JSX element
-    const itemText = typeof result === 'string' ? result : ''
-    const preposition = getPreposition(itemText)
-
-    if (typeof result === 'string') {
-        return `${result} ${preposition}`
-    }
-
-    return (
+const appendPreposition = (item: string | JSX.Element): string | JSX.Element => {
+    const preposition = getPreposition(item)
+    return typeof item === 'string' ? (
+        `${item} ${preposition}`
+    ) : (
         <span>
-            {result} {preposition}
+            {item} {preposition}
         </span>
     )
 }
@@ -252,17 +224,34 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
              */
             const changes = updateLogDetail.changes || []
 
-            const listParts =
-                changes.length === 0
-                    ? ['updated']
-                    : changes
-                          .map((change) =>
-                              match(updateLogDetail.type)
-                                  .with('shared_metric', () => getSharedMetricChangeDescription(change))
-                                  .with('holdout', () => getHoldoutChangeDescription(change))
-                                  .otherwise(() => humanizeExperimentChange(getExperimentChangeDescription(change)))
-                          )
-                          .filter((part) => part !== null)
+            const isExperiment = updateLogDetail.type !== 'shared_metric' && updateLogDetail.type !== 'holdout'
+
+            let listParts: (string | JSX.Element)[]
+            if (changes.length === 0) {
+                listParts = ['updated']
+            } else if (isExperiment) {
+                // Flatten each change into one or more parts. The preposition is appended
+                // exactly once below — to the final part — so the SentenceList reads
+                // "changed A, changed B, and changed C for Experiment Name" instead of
+                // duplicating prepositions inside each clause.
+                listParts = changes.flatMap((change) =>
+                    humanizeExperimentChange(getExperimentChangeDescription(change))
+                )
+            } else {
+                listParts = changes
+                    .map((change) =>
+                        match(updateLogDetail.type)
+                            .with('shared_metric', () => getSharedMetricChangeDescription(change))
+                            .with('holdout', () => getHoldoutChangeDescription(change))
+                            .otherwise(() => null)
+                    )
+                    .filter((part): part is string | JSX.Element => part !== null)
+            }
+
+            if (isExperiment && listParts.length > 0) {
+                const lastIndex = listParts.length - 1
+                listParts[lastIndex] = appendPreposition(listParts[lastIndex])
+            }
 
             const suffix = match(updateLogDetail.type)
                 .with('shared_metric', () => nameOrLinkToSharedMetric(updateLogDetail.name, item_id))

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -248,7 +248,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                     .filter((part): part is string | JSX.Element => part !== null)
             }
 
-            if (isExperiment && listParts.length > 0) {
+            if (isExperiment && changes.length > 0 && listParts.length > 0) {
                 const lastIndex = listParts.length - 1
                 listParts[lastIndex] = appendPreposition(listParts[lastIndex])
             }


### PR DESCRIPTION
## Problem

Resetting a launched/stopped experiment clears `start_date`, `end_date`, and `conclusion` together, producing activity-log entries like:

> Employee 427 changed the start date for, changed the end date for, updated status on, changed the conclusion for, and removed conclusion comment from Team collaboration boost

Two issues stacked: several matchers in `getExperimentChangeDescription` ended in a preposition while `humanizeExperimentChange` always appended one based on a keyword scan, and the appended preposition was attached per-clause instead of once at the end of the joined sentence.

## Changes

- Matchers in `experimentChangeDescription.tsx` (`start_date`, `end_date`, `conclusion`) return raw phrases without trailing prepositions.
- The conclusion-changed JSX no longer appends `&nbsp;for`.
- `experimentActivityDescriber.tsx` flattens all change parts into one `listParts` array, then appends the preposition exactly once — to the final part — so `SentenceList` reads naturally.
- `getPreposition` now reads text out of JSX children too, so the conclusion-changed JSX resolves to `for` instead of falling back to `on`.

After:
> Employee 427 changed the start date, changed the end date, updated status, and changed the conclusion for Team collaboration boost

## How did you test this code?
|Before|After|
|----|----|
|<img width="1041" height="74" alt="image" src="https://github.com/user-attachments/assets/aae4d8e7-7d8f-4fc4-9691-ec16d410eadb" />|<img width="968" height="72" alt="image" src="https://github.com/user-attachments/assets/581db45c-7281-4781-ae90-1b2022738401" />|