### PR TITLE
feat(hog-charts): add inProgress and valueLabels config to TimeSeriesLineChart

### DIFF
--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -109,6 +109,84 @@ describe('TimeSeriesLineChart', () => {
         })
     })
 
+    describe('config.valueLabels', () => {
+        it.each([
+            ['omitted', undefined],
+            ['false', false as const],
+        ])('does not render value labels when %s', (_, valueLabels) => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={valueLabels === undefined ? undefined : { valueLabels }}
+                />
+            )
+            expect(chart.valueLabels()).toHaveLength(0)
+        })
+
+        it('renders one value label per visible point when valueLabels=true', () => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart series={SERIES} labels={LABELS} theme={THEME} config={{ valueLabels: true }} />
+            )
+            expect(chart.valueLabels()).toHaveLength(SERIES[0].data.length)
+        })
+
+        it('forwards an explicit formatter', () => {
+            const formatter = (v: number): string => `~${v}`
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ valueLabels: { formatter } }}
+                />
+            )
+            expect(chart.valueLabels().map((l) => l.text)).toEqual(['~1', '~2', '~3'])
+        })
+
+        it('falls back to a yAxis-driven formatter when no explicit formatter is provided', () => {
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [50] }]}
+                    labels={['Mon']}
+                    theme={THEME}
+                    config={{ yAxis: { format: 'percentage' }, valueLabels: true }}
+                />
+            )
+            expect(chart.valueLabels().map((l) => l.text)).toEqual(['50%'])
+        })
+
+        it('reuses an explicit yAxis.tickFormatter as the default', () => {
+            const explicit = (v: number): string => `y:${v}`
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ yAxis: { tickFormatter: explicit }, valueLabels: true }}
+                />
+            )
+            expect(chart.valueLabels().map((l) => l.text)).toEqual(['y:1', 'y:2', 'y:3'])
+        })
+
+        it('hides labels for series excluded via seriesKeys', () => {
+            const series: Series[] = [
+                { key: 'a', label: 'A', data: [1, 2, 3] },
+                { key: 'b', label: 'B', data: [4, 5, 6] },
+            ]
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={series}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ valueLabels: { seriesKeys: ['a'] } }}
+                />
+            )
+            expect(chart.valueLabels()).toHaveLength(3)
+        })
+    })
+
     describe('config.goalLines', () => {
         it.each([
             ['omitted', undefined],

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -65,6 +65,9 @@ export function TimeSeriesLineChart<Meta = unknown>({
         [series, inProgress?.fromIndex]
     )
 
+    // Stable primitive key so callers can pass `valueLabels: { seriesKeys: ['a'] }` inline
+    // without re-running the transform on every render.
+    const seriesKeysSignature = valueLabelsConfig?.seriesKeys?.join(' ')
     const transformedSeries = useMemo(() => {
         const seriesKeys = valueLabelsConfig?.seriesKeys
         if (!seriesKeys) {
@@ -74,7 +77,8 @@ export function TimeSeriesLineChart<Meta = unknown>({
         return seriesWithInProgress.map((s) =>
             allowed.has(s.key) ? s : { ...s, visibility: { ...s.visibility, fromValueLabels: true } }
         )
-    }, [seriesWithInProgress, valueLabelsConfig?.seriesKeys])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [seriesWithInProgress, seriesKeysSignature])
 
     const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
 

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -2,13 +2,22 @@ import React, { useMemo } from 'react'
 
 import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../../core/types'
 import { ReferenceLines } from '../../overlays/ReferenceLine'
+import { ValueLabels } from '../../overlays/ValueLabels'
 import { LineChart } from '../LineChart'
 import { buildGoalLineReferenceLines, type GoalLineConfig } from './utils/goal-lines'
+import { applyInProgressToSeries, type InProgressConfig } from './utils/in-progress'
 import { useXTickFormatter, useYTickFormatter, type XAxisConfig, type YAxisConfig } from './utils/use-axis-formatters'
+
+export interface ValueLabelsConfig {
+    seriesKeys?: string[]
+    formatter?: (value: number) => string
+}
 
 export interface TimeSeriesLineChartConfig {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    inProgress?: InProgressConfig
+    valueLabels?: boolean | ValueLabelsConfig
     goalLines?: GoalLineConfig[]
 }
 
@@ -24,6 +33,16 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     children?: React.ReactNode
 }
 
+function resolveValueLabelsConfig(valueLabels: TimeSeriesLineChartConfig['valueLabels']): ValueLabelsConfig | null {
+    if (valueLabels === undefined || valueLabels === false) {
+        return null
+    }
+    if (valueLabels === true) {
+        return {}
+    }
+    return valueLabels
+}
+
 export function TimeSeriesLineChart<Meta = unknown>({
     series,
     labels,
@@ -35,11 +54,34 @@ export function TimeSeriesLineChart<Meta = unknown>({
     className,
     children,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
-    const { xAxis, yAxis, goalLines } = config ?? {}
+    const { xAxis, yAxis, inProgress, valueLabels, goalLines } = config ?? {}
     const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
 
-    const referenceLines = useMemo(() => buildGoalLineReferenceLines(goalLines, series), [goalLines, series])
+    const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
+
+    const seriesWithInProgress = useMemo(
+        () => applyInProgressToSeries(series, inProgress),
+        [series, inProgress?.fromIndex]
+    )
+
+    const transformedSeries = useMemo(() => {
+        const seriesKeys = valueLabelsConfig?.seriesKeys
+        if (!seriesKeys) {
+            return seriesWithInProgress
+        }
+        const allowed = new Set(seriesKeys)
+        return seriesWithInProgress.map((s) =>
+            allowed.has(s.key) ? s : { ...s, visibility: { ...s.visibility, fromValueLabels: true } }
+        )
+    }, [seriesWithInProgress, valueLabelsConfig?.seriesKeys])
+
+    const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
+
+    const referenceLines = useMemo(
+        () => buildGoalLineReferenceLines(goalLines, transformedSeries),
+        [goalLines, transformedSeries]
+    )
 
     const lineChartConfig: LineChartConfig = {
         yScaleType: yAxis?.scale,
@@ -52,7 +94,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
 
     return (
         <LineChart
-            series={series}
+            series={transformedSeries}
             labels={labels}
             config={lineChartConfig}
             theme={theme}
@@ -62,6 +104,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
             dataAttr={dataAttr}
         >
             {referenceLines.length > 0 && <ReferenceLines lines={referenceLines} />}
+            {valueLabelsConfig && <ValueLabels valueFormatter={valueLabelFormatter} />}
             {children}
         </LineChart>
     )

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.test.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.test.ts
@@ -1,0 +1,26 @@
+import type { Series } from '../../../core/types'
+import { applyInProgressToSeries } from './in-progress'
+
+const SERIES: Series[] = [
+    { key: 'a', label: 'A', data: [1, 2, 3, 4] },
+    { key: 'b', label: 'B', data: [5, 6, 7, 8] },
+]
+
+describe('applyInProgressToSeries', () => {
+    it('returns the original reference when inProgress is undefined', () => {
+        expect(applyInProgressToSeries(SERIES, undefined)).toBe(SERIES)
+    })
+
+    it('sets stroke.partial.fromIndex on each series when configured', () => {
+        const result = applyInProgressToSeries(SERIES, { fromIndex: 2 })
+        expect(result[0].stroke?.partial?.fromIndex).toBe(2)
+        expect(result[1].stroke?.partial?.fromIndex).toBe(2)
+    })
+
+    it("preserves a series' explicit stroke.partial", () => {
+        const explicitPartial = { fromIndex: 99, pattern: [4, 4] as number[] }
+        const series: Series[] = [{ key: 'a', label: 'A', data: [1, 2, 3], stroke: { partial: explicitPartial } }]
+        const result = applyInProgressToSeries(series, { fromIndex: 1 })
+        expect(result[0].stroke?.partial).toBe(explicitPartial)
+    })
+})

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/in-progress.ts
@@ -1,0 +1,18 @@
+import type { Series } from '../../../core/types'
+
+export interface InProgressConfig {
+    fromIndex: number
+}
+
+export function applyInProgressToSeries<Meta = unknown>(
+    series: Series<Meta>[],
+    inProgress: InProgressConfig | undefined
+): Series<Meta>[] {
+    if (inProgress?.fromIndex === undefined) {
+        return series
+    }
+    const fromIndex = inProgress.fromIndex
+    return series.map((s) =>
+        s.stroke?.partial !== undefined ? s : { ...s, stroke: { ...s.stroke, partial: { fromIndex } } }
+    )
+}

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -7,7 +7,9 @@ export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLine
 export type {
     TimeSeriesLineChartConfig,
     TimeSeriesLineChartProps,
+    ValueLabelsConfig,
 } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'
+export type { InProgressConfig } from './charts/TimeSeriesLineChart/utils/in-progress'
 
 // Base chart (for building new chart types)
 export { Chart } from './core/Chart'


### PR DESCRIPTION
## Problem

`TimeSeriesLineChart` had no way to render the dashed in-progress tail or the `<ValueLabels>` overlay declaratively — adapters had to either set `stroke.partial` per series themselves or compose the `ValueLabels` overlay at the call site. This is the second half of #57412 (stacked on #57435).

## Changes

- New `inProgress?: { fromIndex: number }` field on `TimeSeriesLineChartConfig`. Sets `stroke.partial.fromIndex` on every series that doesn't already declare one.
- New `valueLabels?: boolean | { seriesKeys?, formatter? }` field. `true` enables the overlay with defaults (formatter falls back to the resolved `yTickFormatter`); the object form lets consumers narrow which series get labels and override the formatter.
- New `utils/in-progress.ts` (+ test) housing `applyInProgressToSeries`. Extracted from the component so the `stroke.partial` merge — which isn't observable through the DOM accessor — can be unit-tested directly.
- New `describe('config.valueLabels')` block in `TimeSeriesLineChart.test.tsx` covering the `boolean` / object branches, formatter fallback, `seriesKeys` filtering, and the empty cases.
- Index exports: `InProgressConfig`, `ValueLabelsConfig`.

## How did you test this code?

I'm an agent (Claude). Automated tests only:
- \`hogli test frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/\` — 357 passed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code, split from #57412 at the user's request. Stacks on #57435 (\`goalLines\` config). Notable decisions:

- \`InProgressConfig\` is intentionally a single-field type today — extending it later is a deliberate change, not something that should sneak in via the merge call.
- Kept the \`seriesKeys\` filter inline in the component (rather than extracting a third helper) since it's a 4-line transform that's exercised through the DOM accessor by counting rendered labels.