### PR TITLE
fix(tasks): handle deleted user in identify_task

### DIFF
--- a/posthog/tasks/test/test_user_identify.py
+++ b/posthog/tasks/test/test_user_identify.py
@@ -1,0 +1,28 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.models import User
+from posthog.tasks.user_identify import identify_task
+
+
+class TestIdentifyTask(BaseTest):
+    @patch("posthog.tasks.user_identify.posthoganalytics.capture")
+    def test_captures_user_properties_when_user_exists(self, mock_capture) -> None:
+        user = User.objects.create_user(email="exists@posthog.com", password="12345678", first_name="Test")
+
+        identify_task(user_id=user.id)
+
+        mock_capture.assert_called_once()
+        kwargs = mock_capture.call_args.kwargs
+        self.assertEqual(kwargs["distinct_id"], user.distinct_id)
+        self.assertEqual(kwargs["event"], "update user properties")
+
+    @patch("posthog.tasks.user_identify.posthoganalytics.capture")
+    def test_returns_silently_when_user_was_deleted(self, mock_capture) -> None:
+        user = User.objects.create_user(email="deleted@posthog.com", password="12345678", first_name="Test")
+        user_id = user.id
+        user.delete()
+
+        identify_task(user_id=user_id)
+
+        mock_capture.assert_not_called()

--- a/posthog/tasks/user_identify.py
+++ b/posthog/tasks/user_identify.py
@@ -6,7 +6,12 @@ from posthog.models import User
 
 @shared_task(ignore_result=True)
 def identify_task(user_id: int) -> None:
-    user = User.objects.get(id=user_id)
+    # The user can be deleted between scheduling and execution; treat as a no-op rather than crashing the worker.
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return
+
     posthoganalytics.capture(
         distinct_id=user.distinct_id,
         event="update user properties",


### PR DESCRIPTION
## Problem

\`identify_task\` is fired asynchronously after user updates, but if the user is deleted between scheduling and execution, the worker crashes with \`User.DoesNotExist\` and the task is marked as failed. This is a normal race condition for any deferred task and should be handled silently rather than surfaced as an error.

Closes #54525

## Changes

Wrap the \`User.objects.get\` lookup in a \`try / except User.DoesNotExist\` and return early — there's nothing to identify if the user no longer exists.

## How did you test this code?

Added \`posthog/tasks/test/test_user_identify.py\` with two tests:

1. \`test_captures_user_properties_when_user_exists\` — happy path, asserts \`posthoganalytics.capture\` is called with the right \`distinct_id\` and event name.
2. \`test_returns_silently_when_user_was_deleted\` — race condition path, deletes the user before invoking the task and asserts the task returns without raising and without calling \`capture\`.

Agent-authored — I have not run the full PostHog test suite locally; CI will exercise both tests.

## Publish to changelog?

No

## 🤖 Agent context

Agent-assisted PR. Claude Code was used to identify the right code path and implement the fix. The diff matches the one-line fix suggested in the original issue, plus tests covering both branches. Self-reviewed against AGENTS.md (comment explains *why* not *what*, no doc comments in tests, type annotations on test methods).