### PR TITLE
chore(flags): clean up flag-bucketing-identifier flag and device beta badge

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -314,7 +314,6 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation
     FEATURE_FLAGS_ACROSS_PROJECTS_INDEX: 'feature-flags-across-projects-index', // owner: #team-platform-features
     FEATURE_FLAGS_V2: 'feature-flags-v2', // owner: @dmarticus #team-feature-flags
-    FLAG_BUCKETING_IDENTIFIER: 'flag-bucketing-identifier', // owner: @andehen #team-experiments
     FLAG_EVALUATION_RUNTIMES: 'flag-evaluation-runtimes', // owner: @dmarticus #team-feature-flags
     FLAG_EVALUATION_TAGS: 'flag-evaluation-tags', // owner: @dmarticus #team-feature-flags
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -1013,7 +1013,6 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                           label: 'Device',
                                           description:
                                               'Stable assignment per device. Good fit for experiments on anonymous users.',
-                                          badge: { type: 'warning' as const, text: 'BETA' },
                                           learnMoreUrl: 'https://posthog.com/docs/feature-flags/device-bucketing',
                                       },
                                   ]


### PR DESCRIPTION
## Problem

The `flag-bucketing-identifier` feature flag is no longer needed — the `Device` bucketing identifier option is gated by the `onBucketingIdentifierChange` prop in code, not by a runtime feature flag, and the constant is unused. The `BETA` badge on the Device option is also no longer warranted.

## Changes

- Remove unused `FLAG_BUCKETING_IDENTIFIER` constant from `frontend/src/lib/constants.tsx`.
- Remove the `BETA` badge on the `Device` identifier option in `FeatureFlagReleaseConditionsCollapsible.tsx`.

## How did you test this code?

I'm an agent. I made textual edits only:
- Verified `FLAG_BUCKETING_IDENTIFIER` had no other references in the codebase before removing it.
- Lint-staged pre-commit hooks ran cleanly.
- No automated tests were added or run for this change.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Code (Opus 4.7) at the user's request. Two trivial edits: drop an unused feature flag constant and a `BETA` badge. No behavior change beyond the badge no longer rendering.