### PR TITLE
feat(experiments): Filter slowest queries by team or experiment

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -38,8 +38,11 @@ export function QueryPerformance(): JSX.Element {
         slowestQueries,
         slowestQueriesLoading,
         hoursBack,
+        teamIdFilter,
+        experimentIdFilter,
     } = useValues(queryPerformanceLogic)
-    const { setSearch, setPrecomputation, setHoursBack, loadSlowestQueries } = useActions(queryPerformanceLogic)
+    const { setSearch, setPrecomputation, setHoursBack, loadSlowestQueries, setTeamIdFilter, setExperimentIdFilter } =
+        useActions(queryPerformanceLogic)
 
     if (!user?.is_staff) {
         return (
@@ -222,7 +225,7 @@ export function QueryPerformance(): JSX.Element {
                         content: (
                             <>
                                 <h2>Slowest queries</h2>
-                                <div className="flex gap-2 mb-4 items-center">
+                                <div className="flex flex-wrap gap-2 mb-4 items-center">
                                     {TIME_RANGE_OPTIONS.map(({ label, hours }) => (
                                         <LemonButton
                                             key={hours}
@@ -233,6 +236,24 @@ export function QueryPerformance(): JSX.Element {
                                             {label}
                                         </LemonButton>
                                     ))}
+                                    <LemonInput
+                                        type="number"
+                                        min={1}
+                                        size="small"
+                                        placeholder="Team ID"
+                                        value={teamIdFilter ? Number(teamIdFilter) : undefined}
+                                        onChange={(value) => setTeamIdFilter(value != null ? String(value) : '')}
+                                        className="w-32"
+                                    />
+                                    <LemonInput
+                                        type="number"
+                                        min={1}
+                                        size="small"
+                                        placeholder="Experiment ID"
+                                        value={experimentIdFilter ? Number(experimentIdFilter) : undefined}
+                                        onChange={(value) => setExperimentIdFilter(value != null ? String(value) : '')}
+                                        className="w-36"
+                                    />
                                     <LemonButton
                                         type="secondary"
                                         size="small"

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -40,6 +40,8 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
         setSearch: (search: string) => ({ search }),
         setPrecomputation: (teamId: number, enabled: boolean) => ({ teamId, enabled }),
         setHoursBack: (hours: number) => ({ hours }),
+        setTeamIdFilter: (teamId: string) => ({ teamId }),
+        setExperimentIdFilter: (experimentId: string) => ({ experimentId }),
     }),
     reducers({
         search: [
@@ -52,6 +54,18 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             1,
             {
                 setHoursBack: (_, { hours }) => hours,
+            },
+        ],
+        teamIdFilter: [
+            '',
+            {
+                setTeamIdFilter: (_, { teamId }) => teamId,
+            },
+        ],
+        experimentIdFilter: [
+            '',
+            {
+                setExperimentIdFilter: (_, { experimentId }) => experimentId,
             },
         ],
     }),
@@ -85,7 +99,14 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             [] as SlowestQuery[],
             {
                 loadSlowestQueries: async () => {
-                    return await api.get(`api/debug_ch_queries/slowest_queries/?hours=${values.hoursBack}`)
+                    const params = new URLSearchParams({ hours: String(values.hoursBack) })
+                    if (values.teamIdFilter) {
+                        params.append('team_id', values.teamIdFilter)
+                    }
+                    if (values.experimentIdFilter) {
+                        params.append('experiment_id', values.experimentIdFilter)
+                    }
+                    return await api.get(`api/debug_ch_queries/slowest_queries/?${params.toString()}`)
                 },
             },
         ],
@@ -96,6 +117,14 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             actions.loadPrecomputationTeams()
         },
         setHoursBack: () => {
+            actions.loadSlowestQueries()
+        },
+        setTeamIdFilter: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadSlowestQueries()
+        },
+        setExperimentIdFilter: async (_, breakpoint) => {
+            await breakpoint(300)
             actions.loadSlowestQueries()
         },
     })),

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -350,8 +350,35 @@ class DebugCHQueries(viewsets.ViewSet):
             raise exceptions.ValidationError("hours must be an integer.")
         hours = max(1, min(hours, 168))  # clamp to 1h–7d
 
-        response = sync_execute(
-            """
+        team_id_filter: Optional[int] = None
+        if request.query_params.get("team_id"):
+            try:
+                team_id_filter = int(request.query_params["team_id"])
+            except (TypeError, ValueError):
+                raise exceptions.ValidationError("team_id must be an integer.")
+
+        experiment_id_filter: Optional[int] = None
+        if request.query_params.get("experiment_id"):
+            try:
+                experiment_id_filter = int(request.query_params["experiment_id"])
+            except (TypeError, ValueError):
+                raise exceptions.ValidationError("experiment_id must be an integer.")
+
+        params: dict = {
+            "cluster": CLICKHOUSE_CLUSTER,
+            "hours": hours,
+            "not_query": "%request:_api_debug_ch_queries_%",
+        }
+        extra_filters = ""
+        if team_id_filter is not None:
+            extra_filters += " AND JSONExtractInt(log_comment, 'team_id') = %(team_id)s"
+            params["team_id"] = team_id_filter
+        if experiment_id_filter is not None:
+            extra_filters += " AND JSONExtractInt(log_comment, 'experiment_id') = %(experiment_id)s"
+            params["experiment_id"] = experiment_id_filter
+
+        # nosemgrep: clickhouse-fstring-param-audit - extra_filters is built from hardcoded SQL fragments; user values flow through params
+        sql_query = f"""
             SELECT
                 query_id,
                 argMax(query, type) AS query,
@@ -376,18 +403,15 @@ class DebugCHQueries(viewsets.ViewSet):
                     AND JSONExtractString(log_comment, 'product') = 'experiments'
                     AND is_initial_query
                     AND query NOT LIKE %(not_query)s
+                    {extra_filters}
                 SETTINGS skip_unavailable_shards=1
             )
             GROUP BY query_id
             ORDER BY query_duration_ms DESC
             LIMIT 100
-            """,
-            {
-                "cluster": CLICKHOUSE_CLUSTER,
-                "hours": hours,
-                "not_query": "%request:_api_debug_ch_queries_%",
-            },
-        )
+            """
+
+        response = sync_execute(sql_query, params)
 
         # Batch-fetch team and org names from Postgres
         team_ids = {row[6] for row in response if row[6]}

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -356,6 +356,8 @@ class DebugCHQueries(viewsets.ViewSet):
                 team_id_filter = int(request.query_params["team_id"])
             except (TypeError, ValueError):
                 raise exceptions.ValidationError("team_id must be an integer.")
+            if team_id_filter <= 0:
+                raise exceptions.ValidationError("team_id must be a positive integer.")
 
         experiment_id_filter: Optional[int] = None
         if request.query_params.get("experiment_id"):
@@ -363,6 +365,8 @@ class DebugCHQueries(viewsets.ViewSet):
                 experiment_id_filter = int(request.query_params["experiment_id"])
             except (TypeError, ValueError):
                 raise exceptions.ValidationError("experiment_id must be an integer.")
+            if experiment_id_filter <= 0:
+                raise exceptions.ValidationError("experiment_id must be a positive integer.")
 
         params: dict = {
             "cluster": CLICKHOUSE_CLUSTER,

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -313,6 +313,7 @@ export interface PaginatedTicketViewListApi {
  * `email` - Email
  * `slack` - Slack
  * `teams` - Microsoft Teams
+ * `github` - GitHub
  */
 export type ChannelSourceEnumApi = (typeof ChannelSourceEnumApi)[keyof typeof ChannelSourceEnumApi]
 
@@ -321,6 +322,7 @@ export const ChannelSourceEnumApi = {
     Email: 'email',
     Slack: 'slack',
     Teams: 'teams',
+    Github: 'github',
 } as const
 
 /**
@@ -331,6 +333,7 @@ export const ChannelSourceEnumApi = {
  * `teams_bot_mention` - Teams bot mention
  * `widget_embedded` - Widget
  * `widget_api` - API
+ * `github_issue` - GitHub issue
  */
 export type ChannelDetailEnumApi = (typeof ChannelDetailEnumApi)[keyof typeof ChannelDetailEnumApi]
 
@@ -342,6 +345,7 @@ export const ChannelDetailEnumApi = {
     TeamsBotMention: 'teams_bot_mention',
     WidgetEmbedded: 'widget_embedded',
     WidgetApi: 'widget_api',
+    GithubIssue: 'github_issue',
 } as const
 
 /**
@@ -472,6 +476,10 @@ export interface TicketApi {
     /** @nullable */
     readonly email_to: string | null
     readonly cc_participants: unknown
+    /** @nullable */
+    readonly github_repo: string | null
+    /** @nullable */
+    readonly github_issue_number: number | null
     readonly person: TicketPersonApi | null
     tags?: unknown[]
 }
@@ -546,6 +554,10 @@ export interface PatchedTicketApi {
     /** @nullable */
     readonly email_to?: string | null
     readonly cc_participants?: unknown
+    /** @nullable */
+    readonly github_repo?: string | null
+    /** @nullable */
+    readonly github_issue_number?: number | null
     readonly person?: TicketPersonApi | null
     tags?: unknown[]
 }
@@ -688,6 +700,7 @@ export type ConversationsTicketsListChannelDetail =
     (typeof ConversationsTicketsListChannelDetail)[keyof typeof ConversationsTicketsListChannelDetail]
 
 export const ConversationsTicketsListChannelDetail = {
+    GithubIssue: 'github_issue',
     SlackBotMention: 'slack_bot_mention',
     SlackChannelMessage: 'slack_channel_message',
     SlackEmojiReaction: 'slack_emoji_reaction',
@@ -702,6 +715,7 @@ export type ConversationsTicketsListChannelSource =
 
 export const ConversationsTicketsListChannelSource = {
     Email: 'email',
+    Github: 'github',
     Slack: 'slack',
     Teams: 'teams',
     Widget: 'widget',

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9947,13 +9947,13 @@ export type InsightsRetrieveParams = {
     filters_override?: string
     format?: InsightsRetrieveFormat
     /**
- *
+ * 
 Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
 When set, the specified dashboard's filters and date range override will be applied.
  */
     from_dashboard?: number
     /**
- *
+ * 
 Whether to refresh the insight, how aggresively, and if sync or async:
 - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
 - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache


### PR DESCRIPTION
## Problem

When debugging a noisy team or experiment in the Slowest queries panel, you have to scan up to 100 rows and read the team_id column to find the relevant ones.

## Changes

- `slowest_queries` endpoint accepts optional `team_id` and `experiment_id` query params and adds matching `JSONExtractInt(log_comment, ...)` filters via parameterized placeholders.
- Two `LemonInput` (number) fields next to the time-range buttons in `QueryPerformance.tsx`, wired through `setTeamIdFilter` / `setExperimentIdFilter` actions, debounced reducers, and the loader URL.

## How did you test this code?

Agent-authored. Verified `ruff check`, `ruff format`, `tsc --noEmit`, `kea-typegen write`, and `pnpm format` all pass. No manual browser testing performed.

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Prompt: implement contribution idea "No way to filter Slowest queries by team or experiment" — add optional `team_id`/`experiment_id` query params plus matching frontend inputs.
- Decisions: kept the existing string-typed reducer state (matches input value), debounced 300ms to mirror `setSearch`, added a single `nosemgrep` comment for the f-string SQL since the templated fragment is hardcoded server-side and user values flow through `%(...)s` params (same pattern as `_log_comment_filter` elsewhere in the file).