### PR TITLE
feat(mcp): accept object form for *_override params on all insight/dashboard tools

### DIFF
--- a/posthog/api/openapi_parameters.py
+++ b/posthog/api/openapi_parameters.py
@@ -17,6 +17,15 @@ posthog/api/insight_variable.py, so they're documented once here:
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 
+# OpenAPI extension marking a query parameter whose wire format is a stringified
+# JSON object. Consumers (currently the MCP codegen at
+# services/mcp/scripts/generate-tools.ts) widen the input schema to accept either
+# a pre-encoded JSON string or a plain object; the runtime then JSON.stringify-s
+# objects before placing them on the URL. The extension is intentionally generic
+# rather than MCP-scoped — frontend codegen and any other downstream consumer
+# can read the same fact about the param.
+ACCEPTS_STRINGIFIED_JSON = {"x-accepts-stringified-json": True}
+
 
 def make_variables_override_param(*, subject_label: str, tool_name: str) -> OpenApiParameter:
     """OpenAPI definition for `variables_override`.
@@ -31,12 +40,13 @@ def make_variables_override_param(*, subject_label: str, tool_name: str) -> Open
         "variables_override",
         OpenApiTypes.STR,
         description=(
-            f"JSON object to override {subject_label} variables for this request only (not persisted). "
+            f"Object (or pre-encoded JSON string) to override {subject_label} variables for this request only (not persisted). "
             'Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. '
             "Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is "
             f"to call `{tool_name}` first, copy the matching entry from the response, and mutate `value`. "
             "Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         ),
+        extensions=ACCEPTS_STRINGIFIED_JSON,
     )
 
 
@@ -51,9 +61,10 @@ def make_filters_override_param(*, subject_label: str) -> OpenApiParameter:
         "filters_override",
         OpenApiTypes.STR,
         description=(
-            f"JSON object to override {subject_label} filters for this request only (not persisted). "
+            f"Object (or pre-encoded JSON string) to override {subject_label} filters for this request only (not persisted). "
             "Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. "
             "Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). "
             "Ignored when accessed via a sharing token."
         ),
+        extensions=ACCEPTS_STRINGIFIED_JSON,
     )

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -602,12 +602,12 @@ export const DashboardsCreateFormat = {
 
 export type DashboardsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string
     format?: DashboardsRetrieveFormat
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string
 }
@@ -703,7 +703,7 @@ export const DashboardsReorderTilesCreateFormat = {
 
 export type DashboardsRunInsightsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string
     format?: DashboardsRunInsightsRetrieveFormat
@@ -716,7 +716,7 @@ export type DashboardsRunInsightsRetrieveParams = {
      */
     refresh?: DashboardsRunInsightsRetrieveRefresh
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string
 }
@@ -760,7 +760,7 @@ export const DashboardsSnapshotCreateFormat = {
 
 export type DashboardsStreamTilesRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string
     format?: DashboardsStreamTilesRetrieveFormat
@@ -769,7 +769,7 @@ export type DashboardsStreamTilesRetrieveParams = {
      */
     layoutSize?: DashboardsStreamTilesRetrieveLayoutSize
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string
 }

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9942,7 +9942,7 @@ export const InsightsCreateFormat = {
 
 export type InsightsRetrieveParams = {
     /**
-     * JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string
     format?: InsightsRetrieveFormat
@@ -9965,7 +9965,7 @@ Background calculation can be tracked using the `query_status` response field.
  */
     refresh?: InsightsRetrieveRefresh
     /**
-     * JSON object to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string
 }

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -858,12 +858,34 @@
                     "enum": ["optimized", "json"]
                 },
                 "variables_override": {
-                    "description": "JSON object to override the insight's HogQL variables for this run only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response's query variables, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.",
-                    "type": "string"
+                    "description": "Object (or pre-encoded JSON string) to override the insight's HogQL variables for this run only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response's query variables, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object",
+                            "propertyNames": {
+                                "type": "string"
+                            },
+                            "additionalProperties": {}
+                        }
+                    ]
                 },
                 "filters_override": {
-                    "description": "JSON object to override the insight's filters for this run only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.",
-                    "type": "string"
+                    "description": "Object (or pre-encoded JSON string) to override the insight's filters for this run only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object",
+                            "propertyNames": {
+                                "type": "string"
+                            },
+                            "additionalProperties": {}
+                        }
+                    ]
                 }
             },
             "required": ["insightId"]

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -51,6 +51,13 @@ interface OpenApiParam {
     required?: boolean
     description?: string
     schema: OpenApiSchema
+    /**
+     * Set by the Django factories in posthog/api/openapi_parameters.py for
+     * params whose wire format is a URL-encoded JSON string but whose semantic
+     * shape is an object (e.g. variables_override / filters_override). The
+     * codegen widens these into z.union([z.string(), z.record(...)]).
+     */
+    'x-accepts-stringified-json'?: boolean
 }
 
 interface OpenApiSchema {
@@ -265,6 +272,16 @@ function toPascalCase(str: string): string {
 function toCamelCase(str: string): string {
     const pascal = toPascalCase(str)
     return pascal.charAt(0).toLowerCase() + pascal.slice(1)
+}
+
+/**
+ * Escape a description string for embedding inside a single-quoted Zod
+ * `.describe('...')` call. Backslashes first, then single quotes, then collapse
+ * line breaks to spaces. Order matters — escape the escape character before
+ * anything else.
+ */
+function escapeForDescribe(desc: string): string {
+    return desc.trim().replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n\s*/g, ' ')
 }
 
 /**
@@ -512,12 +529,7 @@ function composeToolSchema(
                         expr += `.default(${JSON.stringify(override.default)}).optional()`
                     }
                     if (override.description) {
-                        const escaped = override.description
-                            .trim()
-                            .replace(/\\/g, '\\\\')
-                            .replace(/'/g, "\\'")
-                            .replace(/\n\s*/g, ' ')
-                        expr += `.describe('${escaped}')`
+                        expr += `.describe('${escapeForDescribe(override.description)}')`
                     }
                     if (override.optional) {
                         expr += '.optional()'
@@ -544,22 +556,29 @@ function composeToolSchema(
         }
     }
 
-    // *_override query params accept either a pre-encoded JSON string or a plain
-    // object. LLM agents reading insight/dashboard responses see these values as
-    // objects (variables, filters), so requiring JSON.stringify before sending is
-    // friction that frequently breaks (escaping, double-encoding). The runtime
-    // request() helper JSON-stringify-s object query params automatically, so the
-    // schema-side union is sufficient — no handler changes required.
-    const overrideQueryParams = queryParams.filter(
-        (p) => p.name.endsWith('_override') && queryParamNames.includes(p.name)
+    // Query params marked `x-accepts-stringified-json` (set by Django factories
+    // in posthog/api/openapi_parameters.py) are stringified-JSON-objects on the
+    // wire but conceptually objects. Widen the schema to accept either shape so
+    // LLM agents can pass the object literal they just read from a sibling
+    // tool's response, without a JSON.stringify round-trip that frequently
+    // breaks on escaping. The runtime request() helper at
+    // services/mcp/src/api/client.ts:141-145 JSON-stringify-s object query
+    // params automatically, so the schema-side union is sufficient — no handler
+    // changes required. Skipped when the YAML config also defines a
+    // param_overrides entry for the field, so explicit YAML always wins.
+    const explicitOverrideKeys = new Set(Object.keys(config.param_overrides ?? {}))
+    const stringifiedJsonQueryParams = queryParams.filter(
+        (p) =>
+            p['x-accepts-stringified-json'] === true &&
+            queryParamNames.includes(p.name) &&
+            !explicitOverrideKeys.has(p.name)
     )
-    if (overrideQueryParams.length > 0) {
-        const overrideEntries = overrideQueryParams.map((p) => {
+    if (stringifiedJsonQueryParams.length > 0) {
+        const overrideEntries = stringifiedJsonQueryParams.map((p) => {
             let expr = 'z.union([z.string(), z.record(z.string(), z.unknown())]).optional()'
             const desc = p.description ?? p.schema?.description
             if (desc) {
-                const escaped = desc.trim().replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n\s*/g, ' ')
-                expr += `.describe('${escaped}')`
+                expr += `.describe('${escapeForDescribe(desc)}')`
             }
             return `${p.name}: ${expr}`
         })

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -561,15 +561,17 @@ function composeToolSchema(
     // wire but conceptually objects. Widen the schema to accept either shape so
     // LLM agents can pass the object literal they just read from a sibling
     // tool's response, without a JSON.stringify round-trip that frequently
-    // breaks on escaping. The runtime request() helper at
-    // services/mcp/src/api/client.ts:141-145 JSON-stringify-s object query
-    // params automatically, so the schema-side union is sufficient — no handler
-    // changes required. Skipped when the YAML config also defines a
-    // param_overrides entry for the field, so explicit YAML always wins.
+    // breaks on escaping. ApiClient.request() in services/mcp/src/api/client.ts
+    // JSON-stringify-s object query params automatically, so the schema-side
+    // union is sufficient — no handler changes required. Skipped when the YAML
+    // config also defines a param_overrides entry for the field, so explicit
+    // YAML always wins.
     const explicitOverrideKeys = new Set(Object.keys(config.param_overrides ?? {}))
     const stringifiedJsonQueryParams = queryParams.filter(
         (p) =>
             p['x-accepts-stringified-json'] === true &&
+            // queryParamNames is the post-include/exclude set, so this drops
+            // params the YAML excluded via include_params / exclude_params.
             queryParamNames.includes(p.name) &&
             !explicitOverrideKeys.has(p.name)
     )

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -544,6 +544,28 @@ function composeToolSchema(
         }
     }
 
+    // *_override query params accept either a pre-encoded JSON string or a plain
+    // object. LLM agents reading insight/dashboard responses see these values as
+    // objects (variables, filters), so requiring JSON.stringify before sending is
+    // friction that frequently breaks (escaping, double-encoding). The runtime
+    // request() helper JSON-stringify-s object query params automatically, so the
+    // schema-side union is sufficient — no handler changes required.
+    const overrideQueryParams = queryParams.filter(
+        (p) => p.name.endsWith('_override') && queryParamNames.includes(p.name)
+    )
+    if (overrideQueryParams.length > 0) {
+        const overrideEntries = overrideQueryParams.map((p) => {
+            let expr = 'z.union([z.string(), z.record(z.string(), z.unknown())]).optional()'
+            const desc = p.description ?? p.schema?.description
+            if (desc) {
+                const escaped = desc.trim().replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n\s*/g, ' ')
+                expr += `.describe('${escaped}')`
+            }
+            return `${p.name}: ${expr}`
+        })
+        schemaExpr = `(${schemaExpr}).extend({ ${overrideEntries.join(', ')} })`
+    }
+
     return {
         orvalImports,
         toolInputsImports,

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -38153,12 +38153,12 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsDashboardsRetrieveFormat;
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -38257,7 +38257,7 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsRunInsightsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsDashboardsRunInsightsRetrieveFormat;
@@ -38270,7 +38270,7 @@ export namespace Schemas {
      */
     refresh?: EnvironmentsDashboardsRunInsightsRetrieveRefresh;
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -38314,7 +38314,7 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsStreamTilesRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsDashboardsStreamTilesRetrieveFormat;
@@ -38323,7 +38323,7 @@ export namespace Schemas {
      */
     layoutSize?: EnvironmentsDashboardsStreamTilesRetrieveLayoutSize;
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -39359,7 +39359,7 @@ export namespace Schemas {
 
     export type EnvironmentsInsightsRetrieveParams = {
     /**
-     * JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: EnvironmentsInsightsRetrieveFormat;
@@ -39382,7 +39382,7 @@ export namespace Schemas {
      */
     refresh?: EnvironmentsInsightsRetrieveRefresh;
     /**
-     * JSON object to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -42298,12 +42298,12 @@ export namespace Schemas {
 
     export type DashboardsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: DashboardsRetrieveFormat;
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -42402,7 +42402,7 @@ export namespace Schemas {
 
     export type DashboardsRunInsightsRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: DashboardsRunInsightsRetrieveFormat;
@@ -42415,7 +42415,7 @@ export namespace Schemas {
      */
     refresh?: DashboardsRunInsightsRetrieveRefresh;
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -42459,7 +42459,7 @@ export namespace Schemas {
 
     export type DashboardsStreamTilesRetrieveParams = {
     /**
-     * JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: DashboardsStreamTilesRetrieveFormat;
@@ -42468,7 +42468,7 @@ export namespace Schemas {
      */
     layoutSize?: DashboardsStreamTilesRetrieveLayoutSize;
     /**
-     * JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };
@@ -43809,7 +43809,7 @@ export namespace Schemas {
 
     export type InsightsRetrieveParams = {
     /**
-     * JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.
      */
     filters_override?: string;
     format?: InsightsRetrieveFormat;
@@ -43832,7 +43832,7 @@ export namespace Schemas {
      */
     refresh?: InsightsRetrieveRefresh;
     /**
-     * JSON object to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
+     * Object (or pre-encoded JSON string) to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
     };

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -88,14 +88,14 @@ export const DashboardsRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
+            'Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
         ),
     format: zod.enum(['json', 'txt']).optional(),
     variables_override: zod
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            'Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
         ),
 })
 
@@ -197,7 +197,7 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
+            'Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
         ),
     format: zod.enum(['json', 'txt']).optional(),
     output_format: zod
@@ -216,6 +216,6 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .string()
         .optional()
         .describe(
-            'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            'Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
         ),
 })

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -188,7 +188,7 @@ export const InsightsRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            "JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+            "Object (or pre-encoded JSON string) to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         ),
     format: zod.enum(['csv', 'json']).optional(),
     from_dashboard: zod
@@ -215,7 +215,7 @@ export const InsightsRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'JSON object to override the insight\'s HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            'Object (or pre-encoded JSON string) to override the insight\'s HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
         ),
 })
 

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -335,16 +335,16 @@ export const InsightQueryInputSchema = z.object({
             'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
         ),
     variables_override: z
-        .string()
+        .union([z.string(), z.record(z.string(), z.unknown())])
         .optional()
         .describe(
-            'JSON object to override the insight\'s HogQL variables for this run only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response\'s query variables, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            'Object (or pre-encoded JSON string) to override the insight\'s HogQL variables for this run only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response\'s query variables, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
         ),
     filters_override: z
-        .string()
+        .union([z.string(), z.record(z.string(), z.unknown())])
         .optional()
         .describe(
-            "JSON object to override the insight's filters for this run only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+            "Object (or pre-encoded JSON string) to override the insight's filters for this run only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         ),
 })
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -123,9 +123,22 @@ const dashboardDelete = (): ToolBase<typeof DashboardDeleteSchema, Schemas.Dashb
     },
 })
 
-const DashboardGetSchema = DashboardsRetrieveParams.omit({ project_id: true }).extend(
-    DashboardsRetrieveQueryParams.omit({ format: true }).shape
-)
+const DashboardGetSchema = DashboardsRetrieveParams.omit({ project_id: true })
+    .extend(DashboardsRetrieveQueryParams.omit({ format: true }).shape)
+    .extend({
+        filters_override: z
+            .union([z.string(), z.record(z.string(), z.unknown())])
+            .optional()
+            .describe(
+                'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
+            ),
+        variables_override: z
+            .union([z.string(), z.record(z.string(), z.unknown())])
+            .optional()
+            .describe(
+                'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            ),
+    })
 
 const dashboardGet = (): ToolBase<typeof DashboardGetSchema, WithPostHogUrl<Schemas.Dashboard>> => ({
     name: 'dashboard-get',
@@ -181,9 +194,22 @@ const dashboardGet = (): ToolBase<typeof DashboardGetSchema, WithPostHogUrl<Sche
     },
 })
 
-const DashboardInsightsRunSchema = DashboardsRunInsightsRetrieveParams.omit({ project_id: true }).extend(
-    DashboardsRunInsightsRetrieveQueryParams.omit({ format: true }).shape
-)
+const DashboardInsightsRunSchema = DashboardsRunInsightsRetrieveParams.omit({ project_id: true })
+    .extend(DashboardsRunInsightsRetrieveQueryParams.omit({ format: true }).shape)
+    .extend({
+        filters_override: z
+            .union([z.string(), z.record(z.string(), z.unknown())])
+            .optional()
+            .describe(
+                'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
+            ),
+        variables_override: z
+            .union([z.string(), z.record(z.string(), z.unknown())])
+            .optional()
+            .describe(
+                'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            ),
+    })
 
 const dashboardInsightsRun = (): ToolBase<
     typeof DashboardInsightsRunSchema,

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -130,13 +130,13 @@ const DashboardGetSchema = DashboardsRetrieveParams.omit({ project_id: true })
             .union([z.string(), z.record(z.string(), z.unknown())])
             .optional()
             .describe(
-                'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
+                'Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
             ),
         variables_override: z
             .union([z.string(), z.record(z.string(), z.unknown())])
             .optional()
             .describe(
-                'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+                'Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
             ),
     })
 
@@ -201,13 +201,13 @@ const DashboardInsightsRunSchema = DashboardsRunInsightsRetrieveParams.omit({ pr
             .union([z.string(), z.record(z.string(), z.unknown())])
             .optional()
             .describe(
-                'JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
+                'Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
             ),
         variables_override: z
             .union([z.string(), z.record(z.string(), z.unknown())])
             .optional()
             .describe(
-                'JSON object to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+                'Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
             ),
     })
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -165,9 +165,22 @@ const insightDelete = (): ToolBase<typeof InsightDeleteSchema, Schemas.Insight> 
     },
 })
 
-const InsightGetSchema = InsightsRetrieveParams.omit({ project_id: true }).extend(
-    InsightsRetrieveQueryParams.omit({ format: true, from_dashboard: true, refresh: true }).shape
-)
+const InsightGetSchema = InsightsRetrieveParams.omit({ project_id: true })
+    .extend(InsightsRetrieveQueryParams.omit({ format: true, from_dashboard: true, refresh: true }).shape)
+    .extend({
+        filters_override: z
+            .union([z.string(), z.record(z.string(), z.unknown())])
+            .optional()
+            .describe(
+                "JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+            ),
+        variables_override: z
+            .union([z.string(), z.record(z.string(), z.unknown())])
+            .optional()
+            .describe(
+                'JSON object to override the insight\'s HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+            ),
+    })
 
 const insightGet = (): ToolBase<typeof InsightGetSchema, WithPostHogUrl<Schemas.Insight>> => ({
     name: 'insight-get',

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -172,13 +172,13 @@ const InsightGetSchema = InsightsRetrieveParams.omit({ project_id: true })
             .union([z.string(), z.record(z.string(), z.unknown())])
             .optional()
             .describe(
-                "JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+                "Object (or pre-encoded JSON string) to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
             ),
         variables_override: z
             .union([z.string(), z.record(z.string(), z.unknown())])
             .optional()
             .describe(
-                'JSON object to override the insight\'s HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
+                'Object (or pre-encoded JSON string) to override the insight\'s HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.'
             ),
     })
 

--- a/services/mcp/src/tools/insights/query.ts
+++ b/services/mcp/src/tools/insights/query.ts
@@ -19,6 +19,13 @@ type Result = WithPostHogUrl<{ query: unknown; insight: Insight & { url: string 
 // object, so requiring them to JSON.stringify before sending is friction that
 // frequently breaks (escaping, double-encoding). Normalising here lets either
 // shape reach the backend as a properly-encoded query-string value.
+//
+// Transitional: the auto-generated tools rely on ApiClient.request() in
+// services/mcp/src/api/client.ts, which already JSON-stringify-s object query
+// params automatically. This helper exists because the bespoke insights().get()
+// in client.ts builds its own URLSearchParams and types the override params as
+// `string`. Once that endpoint migrates onto request(), normalizeOverride can
+// be deleted.
 function normalizeOverride(value: string | Record<string, unknown> | undefined): string | undefined {
     if (value === undefined) {
         return undefined

--- a/services/mcp/src/tools/insights/query.ts
+++ b/services/mcp/src/tools/insights/query.ts
@@ -14,6 +14,18 @@ type Params = z.infer<typeof schema>
 
 type Result = WithPostHogUrl<{ query: unknown; insight: Insight & { url: string }; results: unknown }>
 
+// Accept either a pre-encoded JSON string or a plain object for the override
+// params. LLM agents reading the insight-get response see `variables` as an
+// object, so requiring them to JSON.stringify before sending is friction that
+// frequently breaks (escaping, double-encoding). Normalising here lets either
+// shape reach the backend as a properly-encoded query-string value.
+function normalizeOverride(value: string | Record<string, unknown> | undefined): string | undefined {
+    if (value === undefined) {
+        return undefined
+    }
+    return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
 export const queryHandler: ToolBase<typeof schema, Result>['handler'] = async (context: Context, params: Params) => {
     const { insightId, output_format, variables_override, filters_override } = params
     const projectId = await context.stateManager.getProjectId()
@@ -23,9 +35,11 @@ export const queryHandler: ToolBase<typeof schema, Result>['handler'] = async (c
     // apply_dashboard_filters_to_dict). The merged query is then POSTed to /query/
     // as-is, so insight-query results reflect the overridden values without
     // mutating the saved insight.
-    const insightResult = await context.api
-        .insights({ projectId })
-        .get({ insightId, variables_override, filters_override })
+    const insightResult = await context.api.insights({ projectId }).get({
+        insightId,
+        variables_override: normalizeOverride(variables_override),
+        filters_override: normalizeOverride(filters_override),
+    })
 
     if (!insightResult.success) {
         throw new Error(`Failed to get insight: ${insightResult.error.message}`)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
@@ -14,7 +14,7 @@
                     "type": "object"
                 }
             ],
-            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+            "description": "Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
@@ -33,7 +33,7 @@
                     "type": "object"
                 }
             ],
-            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
+            "description": "Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-get.json
@@ -2,16 +2,38 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "filters_override": {
-            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
         "variables_override": {
-            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
@@ -14,7 +14,7 @@
                     "type": "object"
                 }
             ],
-            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+            "description": "Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
@@ -43,7 +43,7 @@
                     "type": "object"
                 }
             ],
-            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
+            "description": "Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/dashboard-insights-run.json
@@ -2,8 +2,19 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "filters_override": {
-            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "JSON object to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
@@ -20,8 +31,19 @@
             "type": "string"
         },
         "variables_override": {
-            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "JSON object to override dashboard variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-get.json
@@ -2,8 +2,19 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "filters_override": {
-            "description": "JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "id": {
             "anyOf": [
@@ -17,8 +28,19 @@
             "description": "Numeric primary key or 8-character `short_id` (for example `AaVQ8Ijw`) identifying the insight."
         },
         "variables_override": {
-            "description": "JSON object to override the insight's HogQL variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "JSON object to override the insight's HogQL variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-get.json
@@ -14,7 +14,7 @@
                     "type": "object"
                 }
             ],
-            "description": "JSON object to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
+            "description": "Object (or pre-encoded JSON string) to override the insight's filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "id": {
             "anyOf": [
@@ -40,7 +40,7 @@
                     "type": "object"
                 }
             ],
-            "description": "JSON object to override the insight's HogQL variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
+            "description": "Object (or pre-encoded JSON string) to override the insight's HogQL variables for this request only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-query.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-query.json
@@ -2,8 +2,19 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "filters_override": {
-            "description": "JSON object to override the insight's filters for this run only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "Object (or pre-encoded JSON string) to override the insight's filters for this run only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token."
         },
         "insightId": {
             "description": "The insight ID or short_id to run.",
@@ -16,8 +27,19 @@
             "type": "string"
         },
         "variables_override": {
-            "description": "JSON object to override the insight's HogQL variables for this run only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response's query variables, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.",
-            "type": "string"
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "Object (or pre-encoded JSON string) to override the insight's HogQL variables for this run only (not persisted). Format: {\"<variable_id>\": {\"code_name\": \"<code_name>\", \"variableId\": \"<variable_id>\", \"value\": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response's query variables, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token."
         }
     },
     "required": ["insightId"],

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -622,6 +622,126 @@ describe('rename_params', () => {
     })
 })
 
+describe('x-accepts-stringified-json query params', () => {
+    function resolvedWith(parameters: NonNullable<ResolvedOperation['operation']['parameters']>): ResolvedOperation {
+        return makeResolved({
+            operation: {
+                operationId: 'things_list',
+                parameters,
+            },
+        })
+    }
+
+    it('widens schema for params marked x-accepts-stringified-json', () => {
+        const config: ToolConfig = { operation: 'things_list', enabled: true }
+        const resolved = resolvedWith([
+            {
+                in: 'query',
+                name: 'filters_override',
+                schema: { type: 'string' },
+                description: 'Filters override.',
+                'x-accepts-stringified-json': true,
+            },
+        ])
+
+        const result = composeToolSchema(config, resolved, makeSpec(), stubGetQuerySchema)
+
+        expect(result.schemaExpr).toContain(
+            "filters_override: z.union([z.string(), z.record(z.string(), z.unknown())]).optional().describe('Filters override.')"
+        )
+    })
+
+    it('does not widen sibling params that lack the extension', () => {
+        const config: ToolConfig = { operation: 'things_list', enabled: true }
+        const resolved = resolvedWith([
+            {
+                in: 'query',
+                name: 'filters_override',
+                schema: { type: 'string' },
+                'x-accepts-stringified-json': true,
+            },
+            {
+                in: 'query',
+                name: 'plain_string',
+                schema: { type: 'string' },
+            },
+        ])
+
+        const result = composeToolSchema(config, resolved, makeSpec(), stubGetQuerySchema)
+
+        expect(result.schemaExpr).toContain('filters_override: z.union([z.string()')
+        expect(result.schemaExpr).not.toContain('plain_string: z.union(')
+    })
+
+    it('does not widen params named *_override without the extension', () => {
+        const config: ToolConfig = { operation: 'things_list', enabled: true }
+        const resolved = resolvedWith([
+            {
+                in: 'query',
+                name: 'filters_override',
+                schema: { type: 'string' },
+                // no x-accepts-stringified-json — magic naming alone must not trigger widening
+            },
+        ])
+
+        const result = composeToolSchema(config, resolved, makeSpec(), stubGetQuerySchema)
+
+        expect(result.schemaExpr).not.toContain('z.union([z.string()')
+    })
+
+    it('skips widening when the YAML config also defines a param_override for the same field', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            param_overrides: {
+                filters_override: { description: 'Custom YAML description' },
+            },
+        }
+        const resolved = resolvedWith([
+            {
+                in: 'query',
+                name: 'filters_override',
+                schema: { type: 'string' },
+                description: 'OpenAPI description',
+                'x-accepts-stringified-json': true,
+            },
+        ])
+
+        const result = composeToolSchema(config, resolved, makeSpec(), stubGetQuerySchema)
+
+        // YAML wins — describe() comes through, no union extension afterwards.
+        expect(result.schemaExpr).toContain('Custom YAML description')
+        expect(result.schemaExpr).not.toContain('z.union([z.string()')
+    })
+
+    it('respects exclude_params — excluded fields are not widened', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            exclude_params: ['filters_override'],
+        }
+        const resolved = resolvedWith([
+            {
+                in: 'query',
+                name: 'filters_override',
+                schema: { type: 'string' },
+                'x-accepts-stringified-json': true,
+            },
+            {
+                in: 'query',
+                name: 'variables_override',
+                schema: { type: 'string' },
+                'x-accepts-stringified-json': true,
+            },
+        ])
+
+        const result = composeToolSchema(config, resolved, makeSpec(), stubGetQuerySchema)
+
+        expect(result.schemaExpr).not.toContain('filters_override: z.union(')
+        expect(result.schemaExpr).toContain('variables_override: z.union([z.string()')
+    })
+})
+
 describe('QueryWrapperToolConfigSchema validation', () => {
     it.each([true, false] as const)('accepts use_optimized_output: %s', (value) => {
         const result = QueryWrapperToolConfigSchema.safeParse({

--- a/services/mcp/tests/unit/insights-query-handler.test.ts
+++ b/services/mcp/tests/unit/insights-query-handler.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { queryHandler } from '@/tools/insights/query'
+import type { Context } from '@/tools/types'
+
+const filtersOverrideObject = { date_from: '-7d' }
+const variablesOverrideObject = {
+    '019d4838-1da4-0000-33c7-2561bf01f1c9': {
+        code_name: 'eventname',
+        variableId: '019d4838-1da4-0000-33c7-2561bf01f1c9',
+        value: 'signed_up',
+    },
+}
+
+interface InsightsCallArgs {
+    insightId: string
+    variables_override?: string
+    filters_override?: string
+}
+
+interface MockHandles {
+    context: Context
+    insightsGet: ReturnType<typeof vi.fn>
+    insightsQuery: ReturnType<typeof vi.fn>
+}
+
+function createContext(): MockHandles {
+    const insightsGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+            id: 42,
+            short_id: 'abc12345',
+            query: { kind: 'HogQLQuery', query: 'select 1' },
+        },
+    })
+    const insightsQuery = vi.fn().mockResolvedValue({
+        success: true,
+        data: { columns: ['c'], results: [[1]] },
+    })
+    const context = {
+        api: {
+            insights: vi.fn().mockReturnValue({
+                get: insightsGet,
+                query: insightsQuery,
+            }),
+            request: vi.fn(),
+            getProjectBaseUrl: vi.fn().mockReturnValue('https://us.posthog.com/project/1'),
+        },
+        stateManager: {
+            getProjectId: vi.fn().mockResolvedValue('1'),
+            getOrgID: vi.fn(),
+            getRegion: vi.fn().mockResolvedValue('us'),
+        },
+        env: { POSTHOG_BASE_URL: 'https://us.posthog.com' },
+        sessionManager: {},
+        cache: {},
+        getDistinctId: async () => 'test',
+    } as unknown as Context
+
+    return { context, insightsGet, insightsQuery }
+}
+
+describe('queryHandler — overrides forwarding', () => {
+    it('forwards a string variables_override unchanged', async () => {
+        const { context, insightsGet } = createContext()
+        const variables_override = JSON.stringify(variablesOverrideObject)
+
+        await queryHandler(context, { insightId: '42', output_format: 'json', variables_override })
+
+        const call = insightsGet.mock.calls[0]![0] as InsightsCallArgs
+        expect(call.variables_override).toBe(variables_override)
+        expect(call.filters_override).toBeUndefined()
+    })
+
+    it('JSON.stringify-s an object variables_override before forwarding', async () => {
+        const { context, insightsGet } = createContext()
+
+        await queryHandler(context, {
+            insightId: '42',
+            output_format: 'json',
+            // Cast through unknown — at runtime this is what an LLM sends; the
+            // tool schema accepts it, but the inner client typing is string-only.
+            variables_override: variablesOverrideObject as unknown as string,
+        })
+
+        const call = insightsGet.mock.calls[0]![0] as InsightsCallArgs
+        expect(call.variables_override).toBe(JSON.stringify(variablesOverrideObject))
+    })
+
+    it('JSON.stringify-s an object filters_override before forwarding', async () => {
+        const { context, insightsGet } = createContext()
+
+        await queryHandler(context, {
+            insightId: '42',
+            output_format: 'json',
+            filters_override: filtersOverrideObject as unknown as string,
+        })
+
+        const call = insightsGet.mock.calls[0]![0] as InsightsCallArgs
+        expect(call.filters_override).toBe(JSON.stringify(filtersOverrideObject))
+    })
+
+    it('handles undefined overrides without coercing them to "undefined"', async () => {
+        const { context, insightsGet } = createContext()
+
+        await queryHandler(context, { insightId: '42', output_format: 'json' })
+
+        const call = insightsGet.mock.calls[0]![0] as InsightsCallArgs
+        expect(call.variables_override).toBeUndefined()
+        expect(call.filters_override).toBeUndefined()
+    })
+
+    it('forwards mixed string + object overrides correctly', async () => {
+        const { context, insightsGet } = createContext()
+        const filters_override = JSON.stringify(filtersOverrideObject)
+
+        await queryHandler(context, {
+            insightId: '42',
+            output_format: 'json',
+            variables_override: variablesOverrideObject as unknown as string,
+            filters_override,
+        })
+
+        const call = insightsGet.mock.calls[0]![0] as InsightsCallArgs
+        expect(call.variables_override).toBe(JSON.stringify(variablesOverrideObject))
+        expect(call.filters_override).toBe(filters_override)
+    })
+})


### PR DESCRIPTION
## Problem

Follow-up to #57257. LLM agents reading `insight-get` / `dashboard-get` responses see `variables` and `filters` as objects; requiring them to `JSON.stringify` before passing them back as overrides on the next call is friction that frequently breaks on escaping. Accepting an object literal directly removes the conversion.

## Changes

1. **Backend (`posthog/api/openapi_parameters.py`)** — adds an `x-accepts-stringified-json: true` OpenAPI extension on the shared `make_variables_override_param` / `make_filters_override_param` factories, plus updates their description to "Object (or pre-encoded JSON string) to override...". The contract about wire shape now lives where the parameter is defined.

2. **MCP codegen (`services/mcp/scripts/generate-tools.ts`)** — when a query param carries `x-accepts-stringified-json`, emits a `.extend({...})` clause widening it to `z.union([z.string(), z.record(z.string(), z.unknown())])`, preserving the OpenAPI description. Applies today to `insight-get`, `dashboard-get`, `dashboard-insights-run`, and `insight-query` (and any future param that opts in via the factory). Skips the widening when the YAML config already defines a `param_overrides` entry for the same field, so explicit YAML always wins.

3. **Hand-written `insight-query`** — restores the union schema + `normalizeOverride` helper (lost in the parent PR's squash-merge). The helper bridges the union to the bespoke `insights().get()` typing; the comment marks it as transitional, to be deleted once that endpoint migrates onto the generic `request()` helper, which already JSON-stringify-s object query params (`services/mcp/src/api/client.ts:141-145`).

Backward-compatible — pre-encoded JSON strings continue to parse through the union.

## How did you test this code?

✅ Manually invoking the MCP works as expected

Prompt:

```
Use the posthog-local MCP. For each of the four tools that accept filters_override / variables_override (insight-get, dashboard-get, dashboard-insights-run, insight-query), run a three-call comparison:

1. Baseline: call the tool with no overrides.
2. String-form override: call the tool with filters_override: '{"date_from":"-7d"}' (a JSON-encoded string).
3. Object-form override: call the tool with filters_override: {date_from: "-7d"} (a plain object literal).

Pick a real insight via insight-list (limit 1) and a real dashboard via dashboard-list (limit 1) for the first two; reuse them for the others. If the chosen insight/dashboard has variables, also do the three-call sweep with variables_override (use the actual variable id and code_name from the response — copy from the baseline's variables field).

For each tool, compare the relevant response field:
- insight-get and dashboard-get: compare query.dateRange.date_from (or whatever path the override touches).
- dashboard-insights-run: compare the per-tile result arrays for at least one tile.
- insight-query: compare the top-level results array.

Report PASS/FAIL per tool with this rubric:
- PASS if (a) string-form result differs from baseline in the expected direction (override applied), AND (b) object-form result is byte-equal to string-form result. Both must hold.
 - FAIL if the object-form call errors, or if the override is silently ignored, or if string-form and object-form results diverge.

End with a summary table: tool | baseline_OK | string_form | object_form | overall.
```

Outcome:

<img width="846" height="1367" alt="CleanShot 2026-05-04 at 12 40 19" src="https://github.com/user-attachments/assets/8b8c633a-9506-47f1-a08b-ea9ae9f0725b" />


## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7).
- An earlier iteration used suffix-matching (`endsWith('_override')`) to detect which params to widen; replaced with the OpenAPI extension after a local review-swarm pass flagged the hardcoding as a smell. The extension keeps the contract on the backend (one place), removes the magic naming convention, and frontend type generation is unaffected because `schema.type` stays `string` (the extension is metadata).
- Greptile's initial review on the first commit flagged the description inconsistency and the `param_overrides` precedence trap; both are addressed by the follow-up commits and covered by the new tests.