### PR TITLE
fix(cyclotron): skip janitor cleanup when jobs table is absent

### DIFF
--- a/rust/cyclotron-core/src/error.rs
+++ b/rust/cyclotron-core/src/error.rs
@@ -16,6 +16,21 @@ pub enum QueueError {
     CsvError(&'static str, csv::Error),
 }
 
+impl QueueError {
+    pub fn is_missing_relation(&self, relation: &str) -> bool {
+        match self {
+            QueueError::SqlxError(sqlx::Error::Database(db_error)) => {
+                is_missing_relation_error(db_error.code().as_deref(), db_error.message(), relation)
+            }
+            _ => false,
+        }
+    }
+}
+
+fn is_missing_relation_error(code: Option<&str>, message: &str, relation: &str) -> bool {
+    code == Some("42P01") && message.contains(relation)
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum JobError {
     #[error("Unknown job id: {0}")]
@@ -30,4 +45,32 @@ pub enum JobError {
     UpdateDropped,
     #[error("vm_state compression error: {0}")]
     CompressionError(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_missing_relation_error;
+
+    #[test]
+    fn detects_missing_relation_error_for_named_table() {
+        assert!(is_missing_relation_error(
+            Some("42P01"),
+            "relation \"cyclotron_jobs\" does not exist",
+            "cyclotron_jobs"
+        ));
+    }
+
+    #[test]
+    fn ignores_other_tables_and_error_codes() {
+        assert!(!is_missing_relation_error(
+            Some("42P01"),
+            "relation \"some_other_table\" does not exist",
+            "cyclotron_jobs"
+        ));
+        assert!(!is_missing_relation_error(
+            Some("23505"),
+            "duplicate key value violates unique constraint",
+            "cyclotron_jobs"
+        ));
+    }
 }

--- a/rust/cyclotron-core/src/error.rs
+++ b/rust/cyclotron-core/src/error.rs
@@ -28,7 +28,8 @@ impl QueueError {
 }
 
 fn is_missing_relation_error(code: Option<&str>, message: &str, relation: &str) -> bool {
-    code == Some("42P01") && message.contains(relation)
+    let quoted_relation = format!("\"{relation}\"");
+    code == Some("42P01") && message.contains(&quoted_relation)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -52,25 +53,40 @@ mod tests {
     use super::is_missing_relation_error;
 
     #[test]
-    fn detects_missing_relation_error_for_named_table() {
-        assert!(is_missing_relation_error(
-            Some("42P01"),
-            "relation \"cyclotron_jobs\" does not exist",
-            "cyclotron_jobs"
-        ));
-    }
+    fn detects_missing_relation_error_cases() {
+        let cases = [
+            (
+                Some("42P01"),
+                "relation \"cyclotron_jobs\" does not exist",
+                "cyclotron_jobs",
+                true,
+            ),
+            (
+                Some("42P01"),
+                "relation \"some_other_table\" does not exist",
+                "cyclotron_jobs",
+                false,
+            ),
+            (
+                Some("23505"),
+                "duplicate key value violates unique constraint",
+                "cyclotron_jobs",
+                false,
+            ),
+            (
+                None,
+                "relation \"cyclotron_jobs\" does not exist",
+                "cyclotron_jobs",
+                false,
+            ),
+        ];
 
-    #[test]
-    fn ignores_other_tables_and_error_codes() {
-        assert!(!is_missing_relation_error(
-            Some("42P01"),
-            "relation \"some_other_table\" does not exist",
-            "cyclotron_jobs"
-        ));
-        assert!(!is_missing_relation_error(
-            Some("23505"),
-            "duplicate key value violates unique constraint",
-            "cyclotron_jobs"
-        ));
+        for (code, message, relation, expected) in cases {
+            assert_eq!(
+                is_missing_relation_error(code, message, relation),
+                expected,
+                "unexpected result for code={code:?}, message={message}, relation={relation}"
+            );
+        }
     }
 }

--- a/rust/cyclotron-janitor/src/janitor.rs
+++ b/rust/cyclotron-janitor/src/janitor.rs
@@ -68,7 +68,24 @@ impl Janitor {
 
         let aggregated_deletes = {
             let _time = common_metrics::timing_guard(CLEANUP_TIME, &self.metrics_labels);
-            self.inner.delete_completed_and_failed_jobs().await?
+            match self.inner.delete_completed_and_failed_jobs().await {
+                Ok(aggregated_deletes) => aggregated_deletes,
+                Err(error) if error.is_missing_relation("cyclotron_jobs") => {
+                    warn!(
+                        "Skipping janitor cleanup because cyclotron_jobs does not exist on this deployment"
+                    );
+                    common_metrics::inc(RUN_ENDS, &self.metrics_labels, 1);
+                    info!("Janitor loop skipped");
+                    return Ok(CleanupResult {
+                        completed: 0,
+                        failed: 0,
+                        canceled: 0,
+                        poisoned: 0,
+                        stalled: 0,
+                    });
+                }
+                Err(error) => return Err(error),
+            }
         };
 
         let mut completed_count = 0u64;


### PR DESCRIPTION

  ## Summary

  This makes cyclotron-janitor fail open on self-hosted deployments where the Cyclotron tables have not been created.

  Right now, the janitor loop keeps trying to run cleanup queries against cyclotron_jobs, and if that table is missing
  it logs the same Postgres error on every interval. That creates noisy logs in hobby/self-hosted setups where the
  janitor container may be running even though the Cyclotron schema is not present.

  ## What changed

  - added a small Postgres error classifier in cyclotron-core for missing relation errors
  - updated cyclotron-janitor to treat a missing cyclotron_jobs table as a skipped cleanup run instead of a hard failure
  - kept all other database errors unchanged, so unexpected janitor failures still surface normally
  - added focused unit coverage for the missing-relation error detection

  ## Why

  The issue here is not that cleanup failed for an active Cyclotron installation. It’s that the janitor keeps reporting
  hard errors in environments where the backing table does not exist at all. In that case, repeatedly logging failures
  is just noise.

  This change makes the janitor behave more gracefully in that scenario while preserving the existing behavior for real
  operational errors.

  Fixes #57363

  ## Validation

  Passed:

  - cargo fmt --package cyclotron-core --package cyclotron-janitor
  - cargo test -p cyclotron-core error --lib

  I wasn’t able to complete a full cyclotron-janitor build locally on this Windows machine because unrelated
  dependencies (rdkafka-sys and pprof2) hit platform-specific build issues here, so CI should be the final verification.