### PR TITLE
refactor(experiments): Extract shared exposure dataset builder

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -29,15 +29,33 @@ interface MicroChartProps {
     exposures: ExperimentExposureQueryResponse
 }
 
-interface ChartDataset {
+interface ExposureSeries {
+    variant: string
     data: number[]
-    borderColor: string
-    fill: boolean
-    tension: number
-    borderWidth: number
-    pointRadius: number
-    label?: string
-    backgroundColor?: string
+}
+
+// Single-day timeseries get a synthetic prior day with 0 exposures so the chart
+// can draw a line instead of a single point.
+function buildExposureDatasets(timeseries: ExperimentExposureTimeSeries[]): {
+    labels: string[]
+    datasets: ExposureSeries[]
+} {
+    let labels = timeseries[0].days.map((day: string) => dayjs(day).format('MM/DD'))
+    let datasets: ExposureSeries[] = timeseries.map((series: ExperimentExposureTimeSeries) => ({
+        variant: series.variant,
+        data: series.exposure_counts,
+    }))
+
+    if (timeseries[0].days.length === 1) {
+        const previousDay = dayjs(timeseries[0].days[0]).subtract(1, 'day').format('MM/DD')
+        labels = [previousDay, ...labels]
+        datasets = datasets.map((dataset) => ({
+            ...dataset,
+            data: [0, ...dataset.data],
+        }))
+    }
+
+    return { labels, datasets }
 }
 
 function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
@@ -47,10 +65,9 @@ function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
                 return null
             }
 
-            const timeseries = exposures.timeseries
-
-            let datasets = timeseries.map((series: ExperimentExposureTimeSeries, index: number) => ({
-                data: series.exposure_counts,
+            const { datasets: rawDatasets } = buildExposureDatasets(exposures.timeseries)
+            const datasets = rawDatasets.map((series, index) => ({
+                data: series.data,
                 borderColor: getSeriesColor(index),
                 fill: false,
                 tension: 0.3,
@@ -58,17 +75,10 @@ function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
                 pointRadius: 0,
             }))
 
-            if (timeseries[0].days.length === 1) {
-                datasets = datasets.map((dataset: ChartDataset) => ({
-                    ...dataset,
-                    data: [0, ...dataset.data],
-                }))
-            }
-
             return {
                 type: 'line' as const,
                 data: {
-                    labels: datasets[0].data.map((_: any, i: number) => i),
+                    labels: datasets[0].data.map((_, i) => i),
                     datasets,
                 },
                 options: {
@@ -141,10 +151,10 @@ function ExposuresChart({ exposures, axisLineColor }: ExposuresChartProps): JSX.
                 return null
             }
 
-            let labels = exposures.timeseries[0].days.map((day: string) => dayjs(day).format('MM/DD'))
-            let datasets = exposures.timeseries.map((series: ExperimentExposureTimeSeries, index: number) => ({
+            const { labels, datasets: rawDatasets } = buildExposureDatasets(exposures.timeseries)
+            const datasets = rawDatasets.map((series, index) => ({
                 label: series.variant,
-                data: series.exposure_counts,
+                data: series.data,
                 borderColor: getSeriesColor(index),
                 backgroundColor: getSeriesBackgroundColor(index),
                 fill: false,
@@ -152,17 +162,6 @@ function ExposuresChart({ exposures, axisLineColor }: ExposuresChartProps): JSX.
                 borderWidth: 2,
                 pointRadius: 0,
             }))
-
-            if (exposures.timeseries[0].days.length === 1) {
-                const firstDay = dayjs(exposures.timeseries[0].days[0])
-                const previousDay = firstDay.subtract(1, 'day').format('MM/DD')
-
-                labels = [previousDay, ...labels]
-                datasets = datasets.map((dataset) => ({
-                    ...dataset,
-                    data: [0, ...dataset.data],
-                }))
-            }
 
             return {
                 type: 'line' as const,


### PR DESCRIPTION
## Problem

`MicroChart` and `ExposuresChart` in `Exposures.tsx` built datasets from `exposures.timeseries` with a near-identical mapping plus a single-day backfill that prepended a `0`. Any future change to the timeseries shape needed two edits.

## Changes

Extracted `buildExposureDatasets(timeseries)` returning `{ labels, datasets }`. Both charts call the helper and attach their own styling. Chart options stay inline since they diverge meaningfully (axis visibility, tooltips, line tension).

## How did you test this code?
Manually.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7) in response to a code review item.
- Prompt: address review comment that flagged duplicate dataset construction in `MicroChart` and `ExposuresChart` (single-day backfill happening in two places).
- Decision: matched the reviewer's suggested signature — helper returns `{ labels, datasets }`, options stay inline. `MicroChart` keeps index-based labels (its axes are hidden) so its visual output is unchanged.