### PR TITLE
feat(visual-review): tighten snapshot overview card UX

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1996,6 +1996,11 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         full_universe_identifiers = universe_identifiers
 
     # 3a. Tolerate counts in 30d / 90d windows. Single grouped query each.
+    # Scope to HUMAN/AGENT reasons only — AUTO_THRESHOLD rows are auto-minted
+    # by the diff pipeline as a tolerated-hash cache for sub-threshold pixel
+    # jitter and don't represent a deliberate "we accept this drift" decision.
+    # Including them inflated the "Tolerated drift" tile with rendering noise.
+    intentional_tolerate_reasons = (ToleratedReason.HUMAN, ToleratedReason.AGENT)
     tolerate_30d_by_id: dict[str, int] = {}
     tolerate_90d_by_id: dict[str, int] = {}
     if universe_identifiers:
@@ -2005,6 +2010,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=universe_identifiers,
+                reason__in=intentional_tolerate_reasons,
                 created_at__gte=tol_30d_cutoff,
             )
             .values_list("identifier")
@@ -2016,6 +2022,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=universe_identifiers,
+                reason__in=intentional_tolerate_reasons,
                 created_at__gte=tol_90d_cutoff,
             )
             .values_list("identifier")
@@ -2118,8 +2125,9 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         totals_all = len(universe)
 
     # Recently / frequently tolerated — counts of distinct identifiers with
-    # ≥1 (or ≥3) tolerations in the rolling window. Scope across the *full*
-    # universe so the stat row stays correct under truncation.
+    # ≥1 (or ≥3) intentional tolerations in the rolling window. Scope across
+    # the *full* universe so the stat row stays correct under truncation, and
+    # match the per-entry counts above by excluding AUTO_THRESHOLD.
     recent_cutoff = now - timedelta(days=30)
     frequent_cutoff = now - timedelta(days=90)
     recent_ids: set[str] = set()
@@ -2129,6 +2137,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=full_universe_identifiers,
+                reason__in=intentional_tolerate_reasons,
                 created_at__gte=recent_cutoff,
             )
             .values_list("identifier", flat=True)
@@ -2138,6 +2147,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=full_universe_identifiers,
+                reason__in=intentional_tolerate_reasons,
                 created_at__gte=frequent_cutoff,
             )
             .values("identifier")

--- a/products/visual_review/backend/tests/test_baselines.py
+++ b/products/visual_review/backend/tests/test_baselines.py
@@ -257,6 +257,45 @@ class TestBaselinesOverview(APIBaseTest):
         assert result.totals.recently_tolerated == 1  # ≥1 in last 30d
         assert result.totals.frequently_tolerated == 1  # ≥3 in last 90d
 
+    def test_tolerate_counts_exclude_auto_threshold(self):
+        """AUTO_THRESHOLD rows are auto-minted by the diff pipeline for
+        sub-threshold pixel jitter — they're a system-judged tolerated-hash
+        cache, not a user/agent decision to accept drift. The Tolerated drift
+        tile and its inline `frequent` chip should reflect intent only.
+        """
+        run = _mk_run(self.repo)
+        _mk_snapshot(run, identifier="noisy")
+
+        # 5 auto-threshold rows in the last 30d — pure rendering noise.
+        for i in range(5):
+            ToleratedHash.objects.create(
+                repo=self.repo,
+                team_id=self.team.id,
+                identifier="noisy",
+                baseline_hash="b",
+                alternate_hash=f"auto-{i}",
+                reason=ToleratedReason.AUTO_THRESHOLD,
+            )
+        # 1 deliberate human tolerate.
+        ToleratedHash.objects.create(
+            repo=self.repo,
+            team_id=self.team.id,
+            identifier="noisy",
+            baseline_hash="b",
+            alternate_hash="human",
+            reason=ToleratedReason.HUMAN,
+        )
+
+        result = vr_api.get_baselines_overview(self.repo.id)
+        entry = next(e for e in result.entries if e.identifier == "noisy")
+
+        # Only the human row should count.
+        assert entry.tolerate_count_30d == 1
+        assert entry.tolerate_count_90d == 1
+        assert result.totals.recently_tolerated == 1
+        # 1 deliberate < 3, so this identifier is not "frequently tolerated".
+        assert result.totals.frequently_tolerated == 0
+
     def test_active_quarantine_counts_but_expired_does_not(self):
         run = _mk_run(self.repo)
         _mk_snapshot(run, identifier="active")

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -16,10 +16,22 @@ function formatDriftPct(value: number): string {
     return `${value.toFixed(1)}%`
 }
 
+// Anything below this rounds to "0.0%" via the formatter above, which would
+// render a misleading "no drift" chip on a card that does have drift. Hide
+// the chip entirely below this floor; the data is still in the API response
+// for anyone who wants the exact number.
+const DRIFT_DISPLAY_FLOOR_PCT = 0.05
+
 // Crossing this threshold tints the drift chip in the warning palette so the
-// eye lands on the loudest cards first. 1% pixel diff is the same boundary the
-// auto-threshold cache treats as "real change rather than render jitter".
+// eye lands on the loudest cards first. Picked for visual hierarchy, not
+// derived from the backend classifier — pixel/SSIM thresholds in
+// `diffing.py` are unrelated to this UI hook.
 const DRIFT_WARNING_THRESHOLD_PCT = 1
+
+// Mirrors `BASELINE_DRIFT_RECENT_RUN_COUNT` in
+// `products/visual_review/backend/facade/contracts.py`. Keep in sync — the
+// backend value drives `recent_drift_avg`, this constant drives the copy.
+export const RECENT_DRIFT_WINDOW = 10
 
 export function SnapshotCard({
     repoId,
@@ -34,6 +46,7 @@ export function SnapshotCard({
     const area = parseArea(entry.identifier)
     const tolerateCount = entry.tolerate_count_30d
     const driftPct = entry.recent_drift_avg ?? 0
+    const driftVisible = driftPct >= DRIFT_DISPLAY_FLOOR_PCT
     const driftLoud = driftPct >= DRIFT_WARNING_THRESHOLD_PCT
     // Only build the thumbnail URL when we know there's a thumbnail to fetch —
     // otherwise the endpoint 404s and browsers show the broken-image glyph.
@@ -42,7 +55,7 @@ export function SnapshotCard({
             ? `${thumbnailBasePath}/${encodeURIComponent(entry.identifier)}/`
             : null
     const href = urls.visualReviewSnapshotHistory(repoId, entry.run_type, entry.identifier)
-    const hasMeta = driftPct > 0 || tolerateCount > 0 || entry.baseline_change_count > 0
+    const hasMeta = driftVisible || tolerateCount > 0 || entry.baseline_change_count > 0
 
     return (
         <Link
@@ -99,9 +112,9 @@ export function SnapshotCard({
                     </LemonTag>
                     {hasMeta && (
                         <div className="flex items-center gap-2 shrink-0 tabular-nums leading-none">
-                            {driftPct > 0 && (
+                            {driftVisible && (
                                 <Tooltip
-                                    title={`Average pixel drift over the last 10 default-branch runs: ${driftPct.toFixed(
+                                    title={`Average pixel drift over the last ${RECENT_DRIFT_WINDOW} default-branch runs: ${driftPct.toFixed(
                                         2
                                     )}%`}
                                 >

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -1,4 +1,4 @@
-import { IconWarning } from '@posthog/icons'
+import { IconFlag, IconPulse, IconWarning } from '@posthog/icons'
 import { LemonTag, Link } from '@posthog/lemon-ui'
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -7,13 +7,19 @@ import { urls } from 'scenes/urls'
 import type { BaselineEntryApi } from '../generated/api.schemas'
 import { parseArea, parseTheme } from '../lib/parseIdentifier'
 
-// Shared base for the corner badges on a snapshot card. Both badges use the
-// same shape (capsule, fixed height, min-width matching height so single-glyph
-// content stays circular), centered content, and weight — only the bg colour
-// differs. Mismatched widths/shapes here looked broken when both badges were
-// present.
-const BADGE_BASE =
-    'inline-flex items-center justify-center h-5 min-w-5 px-1.5 rounded-full text-white text-[10px] font-semibold leading-none'
+// Drift is shown as a percentage with one decimal — anything less is sub-pixel
+// noise and not actionable; anything more on a thumbnail-sized card is illegible.
+function formatDriftPct(value: number): string {
+    if (value >= 10) {
+        return `${value.toFixed(0)}%`
+    }
+    return `${value.toFixed(1)}%`
+}
+
+// Crossing this threshold tints the drift chip in the warning palette so the
+// eye lands on the loudest cards first. 1% pixel diff is the same boundary the
+// auto-threshold cache treats as "real change rather than render jitter".
+const DRIFT_WARNING_THRESHOLD_PCT = 1
 
 export function SnapshotCard({
     repoId,
@@ -27,6 +33,8 @@ export function SnapshotCard({
     const { theme } = parseTheme(entry.identifier)
     const area = parseArea(entry.identifier)
     const tolerateCount = entry.tolerate_count_30d
+    const driftPct = entry.recent_drift_avg ?? 0
+    const driftLoud = driftPct >= DRIFT_WARNING_THRESHOLD_PCT
     // Only build the thumbnail URL when we know there's a thumbnail to fetch —
     // otherwise the endpoint 404s and browsers show the broken-image glyph.
     const thumbnailUrl =
@@ -34,6 +42,7 @@ export function SnapshotCard({
             ? `${thumbnailBasePath}/${encodeURIComponent(entry.identifier)}/`
             : null
     const href = urls.visualReviewSnapshotHistory(repoId, entry.run_type, entry.identifier)
+    const hasMeta = driftPct > 0 || tolerateCount > 0 || entry.baseline_change_count > 0
 
     return (
         <Link
@@ -65,20 +74,19 @@ export function SnapshotCard({
                 ) : (
                     <span className="text-muted text-xs my-auto">No thumbnail</span>
                 )}
-                <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
-                    {entry.is_quarantined && (
+                {/* Corner is reserved for severity-only signals: quarantine
+                    means "broken, system stopped trusting this". Activity
+                    metrics (tolerate / drift / baseline-change) live in the
+                    meta row below where they can be compared on the same axis. */}
+                {entry.is_quarantined && (
+                    <div className="absolute top-1.5 right-1.5">
                         <Tooltip title="Currently quarantined — excluded from gating">
-                            <span className={`${BADGE_BASE} bg-warning`}>
+                            <span className="inline-flex items-center justify-center h-5 min-w-5 px-1.5 rounded-full text-white text-[10px] font-semibold leading-none bg-warning">
                                 <IconWarning className="w-3 h-3" />
                             </span>
                         </Tooltip>
-                    )}
-                    {tolerateCount > 0 && (
-                        <Tooltip title={`${tolerateCount} tolerate${tolerateCount === 1 ? '' : 's'} in last 30 days`}>
-                            <span className={`${BADGE_BASE} bg-primary-3000`}>~{tolerateCount}</span>
-                        </Tooltip>
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
 
             <div className="p-2 flex flex-col gap-1 min-w-0">
@@ -89,16 +97,46 @@ export function SnapshotCard({
                     <LemonTag type="default" size="small">
                         {area}
                     </LemonTag>
-                    {entry.baseline_change_count > 0 && (
-                        <Tooltip
-                            title={`Baseline updated ${entry.baseline_change_count} time${
-                                entry.baseline_change_count === 1 ? '' : 's'
-                            } since inception`}
-                        >
-                            <span className="font-mono text-[10px] text-muted shrink-0">
-                                ↻ {entry.baseline_change_count}
-                            </span>
-                        </Tooltip>
+                    {hasMeta && (
+                        <div className="flex items-center gap-2 shrink-0 tabular-nums leading-none">
+                            {driftPct > 0 && (
+                                <Tooltip
+                                    title={`Average pixel drift over the last 10 default-branch runs: ${driftPct.toFixed(
+                                        2
+                                    )}%`}
+                                >
+                                    <span
+                                        className={`inline-flex items-center gap-0.5 ${
+                                            driftLoud ? 'text-warning-dark font-semibold' : ''
+                                        }`}
+                                    >
+                                        <IconPulse className="w-3 h-3" />
+                                        {formatDriftPct(driftPct)}
+                                    </span>
+                                </Tooltip>
+                            )}
+                            {tolerateCount > 0 && (
+                                <Tooltip
+                                    title={`Drift accepted ${tolerateCount} time${
+                                        tolerateCount === 1 ? '' : 's'
+                                    } in last 30 days (human or agent)`}
+                                >
+                                    <span className="inline-flex items-center gap-0.5">
+                                        <IconFlag className="w-3 h-3" />
+                                        {tolerateCount}
+                                    </span>
+                                </Tooltip>
+                            )}
+                            {entry.baseline_change_count > 0 && (
+                                <Tooltip
+                                    title={`Baseline updated ${entry.baseline_change_count} time${
+                                        entry.baseline_change_count === 1 ? '' : 's'
+                                    } since inception`}
+                                >
+                                    <span className="font-mono">↻ {entry.baseline_change_count}</span>
+                                </Tooltip>
+                            )}
+                        </div>
                     )}
                 </div>
             </div>

--- a/products/visual_review/frontend/components/SnapshotStatRow.tsx
+++ b/products/visual_review/frontend/components/SnapshotStatRow.tsx
@@ -1,3 +1,5 @@
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
 export type StatPreset = 'all' | 'tolerated_drift' | 'currently_quarantined'
 
 const COLOR_BY_PRESET: Record<StatPreset, string> = {
@@ -11,7 +13,10 @@ const STATS: Array<{ value: StatPreset; label: string; description: string }> = 
     {
         value: 'tolerated_drift',
         label: 'Tolerated drift',
-        description: 'At least one tolerate in the last 30 days',
+        // We deliberately exclude AUTO_THRESHOLD tolerations (rendering noise
+        // the diff pipeline auto-accepts) so this slice represents real "we
+        // chose to accept this drift" decisions, not pixel jitter.
+        description: 'At least one human or agent tolerate in the last 30 days',
     },
     {
         value: 'currently_quarantined',
@@ -68,9 +73,15 @@ export function SnapshotStatRow({
                             )}
                             <span className="truncate">{s.label}</span>
                             {s.value === 'tolerated_drift' && frequentlyToleratedCount > 0 && (
-                                <span className="ml-auto bg-primary-3000-button-bg text-primary-3000 text-[10px] font-semibold rounded px-1.5 py-0.5 shrink-0">
-                                    {frequentlyToleratedCount} frequent
-                                </span>
+                                <Tooltip
+                                    title={`${frequentlyToleratedCount} snapshot${
+                                        frequentlyToleratedCount === 1 ? '' : 's'
+                                    } accepted ≥3 times in the last 90 days — these have the most trust debt`}
+                                >
+                                    <span className="ml-auto bg-primary-3000-button-bg text-primary-3000 text-[10px] font-semibold rounded px-1.5 py-0.5 shrink-0">
+                                        {frequentlyToleratedCount} frequent
+                                    </span>
+                                </Tooltip>
                             )}
                         </div>
                         <div className="text-[11px] text-muted leading-tight">{s.description}</div>

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -10,7 +10,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { RepoSwitcher } from '../components/RepoSwitcher'
-import { SnapshotCard } from '../components/SnapshotCard'
+import { RECENT_DRIFT_WINDOW, SnapshotCard } from '../components/SnapshotCard'
 import { SnapshotFacetSidebar } from '../components/SnapshotFacetSidebar'
 import { SnapshotStatRow } from '../components/SnapshotStatRow'
 import { VisualReviewTabs } from '../components/VisualReviewTabs'
@@ -139,7 +139,7 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                 </span>
                 <span className="inline-flex items-center gap-1">
                     <IconPulse className="w-3 h-3" />
-                    Avg drift over last 10 default-branch runs
+                    Avg drift over last {RECENT_DRIFT_WINDOW} default-branch runs
                 </span>
                 <span className="inline-flex items-center gap-1">
                     <IconFlag className="w-3 h-3" />

--- a/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSnapshotOverviewScene.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconGear } from '@posthog/icons'
+import { IconFlag, IconGear, IconPulse, IconWarning } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonInput, LemonSegmentedButton, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { SceneExport } from 'scenes/sceneTypes'
@@ -32,11 +32,6 @@ export const scene: SceneExport = {
 // via `auto-fill, minmax(220px, 1fr)`.
 const CARD_MIN_WIDTH = 220
 
-// Mirror of the badge styling on `SnapshotCard` so the legend pills look
-// identical to the real badges.
-const BADGE_LEGEND_BASE =
-    'inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-white text-[10px] font-semibold leading-none'
-
 export function VisualReviewSnapshotOverviewScene(): JSX.Element {
     const {
         overview,
@@ -49,7 +44,6 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
         facetGroups,
         facetSelection,
         filters,
-        sortLabel,
         thumbnailBasePath,
     } = useValues(visualReviewSnapshotOverviewSceneLogic)
     const { setStatPreset, toggleType, toggleArea, toggleStability, setTheme, setSearch, clearAllFilters } = useActions(
@@ -115,8 +109,12 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                             Clear all
                         </button>
                     )}
-                    <div className="text-xs text-muted">
-                        Sorted by <span className="text-default">{sortLabel.label}</span>
+                    <div className="text-xs text-muted inline-flex items-center gap-1">
+                        Sorted by{' '}
+                        <span className="text-default inline-flex items-center gap-0.5">
+                            <IconPulse className="w-3 h-3" />
+                            drift (high → low)
+                        </span>
                     </div>
                 </div>
             </div>
@@ -128,18 +126,26 @@ export function VisualReviewSnapshotOverviewScene(): JSX.Element {
                 </LemonBanner>
             )}
 
-            {/* Legend lives above the grid so first-time viewers see what the
-                badges mean before they dive into hundreds of cards. */}
-            <div className="flex items-center gap-3 text-[11px] text-muted">
-                <span className="flex items-center gap-1">
-                    <span className={`${BADGE_LEGEND_BASE} bg-warning`}>!</span>
+            {/* Legend mirrors the card meta row: same icons, same order
+                (severity → trust debt → history). Lives above the grid so
+                first-time viewers see what each glyph means before they
+                dive into hundreds of cards. */}
+            <div className="flex items-center gap-4 text-[11px] text-muted flex-wrap">
+                <span className="inline-flex items-center gap-1">
+                    <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full bg-warning text-white">
+                        <IconWarning className="w-2.5 h-2.5" />
+                    </span>
                     Quarantined
                 </span>
-                <span className="flex items-center gap-1">
-                    <span className={`${BADGE_LEGEND_BASE} bg-primary-3000`}>~N</span>
-                    Tolerates in last 30 days
+                <span className="inline-flex items-center gap-1">
+                    <IconPulse className="w-3 h-3" />
+                    Avg drift over last 10 default-branch runs
                 </span>
-                <span className="flex items-center gap-1">
+                <span className="inline-flex items-center gap-1">
+                    <IconFlag className="w-3 h-3" />
+                    Drift accepted in last 30 days (human or agent)
+                </span>
+                <span className="inline-flex items-center gap-1">
                     <span className="font-mono">↻ N</span>
                     Baseline updates since inception
                 </span>

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotOverviewSceneLogic.ts
@@ -236,36 +236,23 @@ export const visualReviewSnapshotOverviewSceneLogic = kea<visualReviewSnapshotOv
                     _stability: entryStability(e),
                 })),
         ],
-        // The sort applied to filteredEntries depends on the active stat
-        // preset — alphabetical for the broad "All" view, severity-style
-        // ordering for the slices that highlight problems. Keeping it
-        // hardcoded per preset (rather than user-pickable) keeps the UX
-        // tight; the indicator label in the toolbar tells the user which
-        // sort is active.
-        sortLabel: [
-            (s) => [s.filters],
-            (filters): { kind: 'alpha' | 'drift'; label: string } => {
-                if (filters.statPreset === 'all') {
-                    return { kind: 'alpha', label: 'name (A → Z)' }
-                }
-                return { kind: 'drift', label: 'drift avg (high → low)' }
-            },
-        ],
+        // Single sort axis across every preset — drift severity descending
+        // with alphabetic tiebreak. Drift is what the visible meta row leads
+        // with on each card, so the toolbar indicator now matches what the
+        // user sees. Originally we had alpha for "All" and drift for the
+        // problem slices, but two axes meant the toolbar label had to keep
+        // re-explaining itself; one axis everywhere is calmer.
         filteredEntries: [
-            (s) => [s.decoratedEntries, s.filters, s.sortLabel],
-            (entries, filters, sortLabel) => {
+            (s) => [s.decoratedEntries, s.filters],
+            (entries, filters) => {
                 const filtered = applyFilters(entries, filters)
-                if (sortLabel.kind === 'alpha') {
-                    filtered.sort((a, b) => a.identifier.localeCompare(b.identifier))
-                } else {
-                    filtered.sort(
-                        (a, b) =>
-                            (b.recent_drift_avg ?? 0) - (a.recent_drift_avg ?? 0) ||
-                            b.baseline_change_count - a.baseline_change_count ||
-                            b.tolerate_count_30d - a.tolerate_count_30d ||
-                            a.identifier.localeCompare(b.identifier)
-                    )
-                }
+                filtered.sort(
+                    (a, b) =>
+                        (b.recent_drift_avg ?? 0) - (a.recent_drift_avg ?? 0) ||
+                        b.baseline_change_count - a.baseline_change_count ||
+                        b.tolerate_count_30d - a.tolerate_count_30d ||
+                        a.identifier.localeCompare(b.identifier)
+                )
                 return filtered
             },
         ],


### PR DESCRIPTION
## Problem

Snapshot overview cards mixed up severity vs activity signals — the corner badge held tolerate counts, drift % was sorted by but never displayed, and `Tolerated drift` totals were inflated by `AUTO_THRESHOLD` rows minted automatically by the diff pipeline (pixel jitter the system shrugged off, not deliberate human/agent decisions).

## Changes

**Backend**
- All four `ToleratedHash` aggregates (per-entry 30d/90d + recent/frequent totals) now filter `reason__in=[HUMAN, AGENT]` so counts reflect intent, not rendering noise.

**Card meta row** redesigned around data hierarchy:
- Corner badge reserved for severity (quarantine only).
- Drift % is now visible (`IconPulse`), tinted warning when ≥ 1%.
- Tolerate count moves into the meta row with `IconFlag`, alongside the baseline-change count.
- All three are zero-hidden, so clean cards stay clean.

**Sort** collapsed to drift-desc for every preset — toolbar's `Sorted by drift avg` stays honest across preset toggles.

**Stat-row** description + inline `frequent` chip get explicit human/agent wording and a tooltip explaining the ≥3-in-90d threshold.

## How did you test this code?

Agent-authored. Backend test added for `AUTO_THRESHOLD` exclusion (`test_baselines.py`). Local CH/zookeeper is broken so test wasn't run locally — relying on CI. Frontend not browser-verified yet.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Human prompts that shaped this:
  - "Tolerated drift includes auto toleration... should just include human+agent"
  - "page says sorted by drift avg but this drift is not displayed"
  - "the top right count is not immediately clear... apply best practice UX principles"
- Decisions:
  - Corner badge → severity-only (quarantine), tolerate moves inline.
  - Drift number rendered as primary chip with `IconPulse`; warning tint at ≥ 1%.
  - Sort axis unified to drift-desc across all presets to keep the toolbar indicator truthful.
  - Backend filter scoped to `HUMAN`/`AGENT` instead of negating `AUTO_THRESHOLD` — easier to reason about as new reasons get added.