### PR TITLE
feat(experiments): ship conversion window filter to everyone

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -301,7 +301,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
-    EXPERIMENTS_MATURED_USERS_FILTER: 'experiments-matured-users-filter', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments
     EXPERIMENTS_TEMPLATES: 'experiments-templates', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -4,7 +4,6 @@ import { IconPencil } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, Link } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { urls } from 'scenes/urls'
@@ -20,7 +19,6 @@ export function SettingsTab(): JSX.Element {
     const { updateExperiment } = useActions(experimentLogic)
     const { openStatsEngineModal } = useActions(modalsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const showMaturedUsersOption = useFeatureFlag('EXPERIMENTS_MATURED_USERS_FILTER')
 
     const isBayesian = statsMethod === ExperimentStatsMethod.Bayesian
 
@@ -46,28 +44,26 @@ export function SettingsTab(): JSX.Element {
                 </div>
                 <StatsMethodModal />
             </div>
-            {showMaturedUsersOption && (
-                <div>
-                    <h2 className="font-semibold text-lg">Conversion windows</h2>
-                    <div className="flex items-center gap-2">
-                        <LemonCheckbox
-                            label="Require completed conversion window"
-                            checked={experiment.only_count_matured_users ?? false}
-                            onChange={(checked) => {
-                                updateExperiment({ only_count_matured_users: checked })
-                            }}
-                        />
-                    </div>
-                    <p className="text-muted text-xs mt-1">
-                        Only count participants whose full conversion window has elapsed. Applies to metrics with a
-                        custom time window. Default is set in{' '}
-                        <Link to={urls.settings('environment-experiments', 'environment-experiment-matured-users')}>
-                            environment settings
-                        </Link>
-                        .
-                    </p>
+            <div>
+                <h2 className="font-semibold text-lg">Conversion windows</h2>
+                <div className="flex items-center gap-2">
+                    <LemonCheckbox
+                        label="Require completed conversion window"
+                        checked={experiment.only_count_matured_users ?? false}
+                        onChange={(checked) => {
+                            updateExperiment({ only_count_matured_users: checked })
+                        }}
+                    />
                 </div>
-            )}
+                <p className="text-muted text-xs mt-1">
+                    Only count participants whose full conversion window has elapsed. Applies to metrics with a custom
+                    time window. Default is set in{' '}
+                    <Link to={urls.settings('environment-experiments', 'environment-experiment-matured-users')}>
+                        environment settings
+                    </Link>
+                    .
+                </p>
+            </div>
             {shouldShowSignificanceAlerts && (
                 <div>
                     <h2 className="font-semibold text-lg">Notifications</h2>

--- a/frontend/src/scenes/experiments/ExperimentsSettings.tsx
+++ b/frontend/src/scenes/experiments/ExperimentsSettings.tsx
@@ -1,6 +1,5 @@
 import { useValues } from 'kea'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner'
 import { DefaultExperimentConfidenceLevel } from 'scenes/settings/environment/DefaultExperimentConfidenceLevel'
@@ -15,7 +14,6 @@ import { experimentsConfigLogic } from 'scenes/settings/environment/experimentsC
  */
 export function ExperimentsSettings(): JSX.Element {
     const { experimentsConfig, experimentsConfigLoading } = useValues(experimentsConfigLogic)
-    const showMaturedUsersOption = useFeatureFlag('EXPERIMENTS_MATURED_USERS_FILTER')
 
     if (experimentsConfigLoading && !experimentsConfig) {
         return <SpinnerOverlay sceneLevel />
@@ -47,16 +45,14 @@ export function ExperimentsSettings(): JSX.Element {
                 </p>
                 <ExperimentRecalculationTime />
             </div>
-            {showMaturedUsersOption && (
-                <div>
-                    <LemonLabel className="text-base">Default conversion window filter</LemonLabel>
-                    <p className="text-secondary mt-2">
-                        When enabled, new experiments will only count participants whose full conversion window has
-                        elapsed. Can be overridden per experiment.
-                    </p>
-                    <DefaultOnlyCountMaturedUsers />
-                </div>
-            )}
+            <div>
+                <LemonLabel className="text-base">Default conversion window filter</LemonLabel>
+                <p className="text-secondary mt-2">
+                    When enabled, new experiments will only count participants whose full conversion window has elapsed.
+                    Can be overridden per experiment.
+                </p>
+                <DefaultOnlyCountMaturedUsers />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/settings/environment/DefaultOnlyCountMaturedUsers.tsx
+++ b/frontend/src/scenes/settings/environment/DefaultOnlyCountMaturedUsers.tsx
@@ -4,23 +4,17 @@ import { LemonCheckbox } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TeamMembershipLevel } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import { experimentsConfigLogic } from './experimentsConfigLogic'
 
 export function DefaultOnlyCountMaturedUsers(): JSX.Element | null {
     const { experimentsConfig, experimentsConfigLoading } = useValues(experimentsConfigLogic)
     const { updateExperimentsConfig } = useActions(experimentsConfigLogic)
-    const showOption = useFeatureFlag('EXPERIMENTS_MATURED_USERS_FILTER')
 
     const restrictionReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
-
-    if (!showOption) {
-        return null
-    }
 
     return (
         <LemonCheckbox


### PR DESCRIPTION
## Problem

The 'Require completed conversion window' setting (and its team-level default) was gated behind the `EXPERIMENTS_MATURED_USERS_FILTER` flag.

## Changes

Remove the flag and its three usage guards. The setting is now visible to all users on both the experiment Settings tab and the environment-level Experiments settings.

## How did you test this code?

I'm an agent. No manual testing or new automated tests; relied on the existing lint/format hooks that ran on commit.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code at the user's request to remove the gate.
- Prompt: "remove this flag, i.e. let's ship it to everyone".