### PR TITLE
fix(devex): skip duplicate migrations on persons_db_reader alias

### DIFF
--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -129,7 +129,7 @@ class PersonDBRouter:
         don't run any migrations against the persons db, only against the default
         run all migrations against the default
         """
-        return db != "persons_db_writer"
+        return db not in ("persons_db_writer", "persons_db_reader")
 
     def is_persons_model(self, app_label, model_name):
         # only route posthog app models, not auth.Group (there is a name clash between posthog_group

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -313,6 +313,7 @@ export interface PaginatedTicketViewListApi {
  * `email` - Email
  * `slack` - Slack
  * `teams` - Microsoft Teams
+ * `github` - GitHub
  */
 export type ChannelSourceEnumApi = (typeof ChannelSourceEnumApi)[keyof typeof ChannelSourceEnumApi]
 
@@ -321,6 +322,7 @@ export const ChannelSourceEnumApi = {
     Email: 'email',
     Slack: 'slack',
     Teams: 'teams',
+    Github: 'github',
 } as const
 
 /**
@@ -331,6 +333,7 @@ export const ChannelSourceEnumApi = {
  * `teams_bot_mention` - Teams bot mention
  * `widget_embedded` - Widget
  * `widget_api` - API
+ * `github_issue` - GitHub issue
  */
 export type ChannelDetailEnumApi = (typeof ChannelDetailEnumApi)[keyof typeof ChannelDetailEnumApi]
 
@@ -342,6 +345,7 @@ export const ChannelDetailEnumApi = {
     TeamsBotMention: 'teams_bot_mention',
     WidgetEmbedded: 'widget_embedded',
     WidgetApi: 'widget_api',
+    GithubIssue: 'github_issue',
 } as const
 
 /**
@@ -472,6 +476,10 @@ export interface TicketApi {
     /** @nullable */
     readonly email_to: string | null
     readonly cc_participants: unknown
+    /** @nullable */
+    readonly github_repo: string | null
+    /** @nullable */
+    readonly github_issue_number: number | null
     readonly person: TicketPersonApi | null
     tags?: unknown[]
 }
@@ -546,6 +554,10 @@ export interface PatchedTicketApi {
     /** @nullable */
     readonly email_to?: string | null
     readonly cc_participants?: unknown
+    /** @nullable */
+    readonly github_repo?: string | null
+    /** @nullable */
+    readonly github_issue_number?: number | null
     readonly person?: TicketPersonApi | null
     tags?: unknown[]
 }
@@ -688,6 +700,7 @@ export type ConversationsTicketsListChannelDetail =
     (typeof ConversationsTicketsListChannelDetail)[keyof typeof ConversationsTicketsListChannelDetail]
 
 export const ConversationsTicketsListChannelDetail = {
+    GithubIssue: 'github_issue',
     SlackBotMention: 'slack_bot_mention',
     SlackChannelMessage: 'slack_channel_message',
     SlackEmojiReaction: 'slack_emoji_reaction',
@@ -702,6 +715,7 @@ export type ConversationsTicketsListChannelSource =
 
 export const ConversationsTicketsListChannelSource = {
     Email: 'email',
+    Github: 'github',
     Slack: 'slack',
     Teams: 'teams',
     Widget: 'widget',

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9947,13 +9947,13 @@ export type InsightsRetrieveParams = {
     filters_override?: string
     format?: InsightsRetrieveFormat
     /**
- *
+ * 
 Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
 When set, the specified dashboard's filters and date range override will be applied.
  */
     from_dashboard?: number
     /**
- *
+ * 
 Whether to refresh the insight, how aggresively, and if sync or async:
 - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
 - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache


### PR DESCRIPTION
## Problem

`PersonDBRouter.allow_migrate` only excluded `persons_db_writer`, so Django ran all migrations a second time against `persons_db_reader` — which points to the same physical database in test. This doubled the migration work during test DB setup for no benefit.

Found while investigating migration timing output from #57227, where 2334 migrations were reported applied in 529s. The real unique count is ~778 migrations × 3 aliases, with `persons_db_reader` doing redundant work.

## Changes

Exclude `persons_db_reader` from `allow_migrate` alongside `persons_db_writer`.

## How did you test this code?

One-line router change — CI will validate that test DB setup still works correctly. The timing branch (#57227) can confirm the migration count drops.

## 🤖 Agent context

Co-authored with Claude Code. Julian spotted the duplicate migration entries in the CI timing output from #57227 and asked why — traced it to the router returning `True` for `persons_db_reader`.