### PR TITLE
perf(preflight): pre-warm timezone offsets cache at app startup

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -10,7 +10,13 @@ from posthoganalytics.client import Client
 
 from posthog.git import get_git_branch, get_git_commit_short
 from posthog.tasks.tasks import sync_all_organization_available_product_features
-from posthog.utils import get_instance_region, get_machine_id, initialize_self_capture_api_token, str_to_bool
+from posthog.utils import (
+    get_available_timezones_with_offsets,
+    get_instance_region,
+    get_machine_id,
+    initialize_self_capture_api_token,
+    str_to_bool,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -23,6 +29,7 @@ class PostHogConfig(AppConfig):
         import posthog.storage.team_access_cache_signal_handlers  # noqa: F401
 
         self._setup_lazy_admin()
+        self._prewarm_timezone_offsets_cache()
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"  # ty: ignore[invalid-assignment]
         # Fall back to DEV_API_KEY in debug so feature flags work locally without manual env setup.
         # DEV_API_KEY lives in ee/settings.py — getattr returns None in OSS mode.
@@ -107,6 +114,19 @@ class PostHogConfig(AppConfig):
             queue_sync_hog_function_templates()
 
         file_system_registrations.register_core_file_system_types()
+
+    def _prewarm_timezone_offsets_cache(self):
+        # The pytz walk in get_available_timezones_with_offsets is hourly-cached but
+        # the cache is per-process. Without pre-warming, every fresh pod pays ~580ms
+        # on its first preflight (the home view). Run it once at startup so the cache
+        # is hot before any request lands. Skip during tests / static collection where
+        # this would just slow setup with no benefit.
+        if settings.TEST or settings.STATIC_COLLECTION:
+            return
+        try:
+            get_available_timezones_with_offsets()
+        except Exception:
+            logger.warning("prewarm_timezone_offsets_cache_failure", exc_info=True)
 
     def _setup_lazy_admin(self):
         """Set up lazy loading of admin classes to avoid importing all at startup."""


### PR DESCRIPTION
## Problem

#57418 made \`get_available_timezones_with_offsets\` hourly-cached via \`@lru_cache(maxsize=2)\`, but that's a per-process cache. Production traces from 2026-05-04 09:14-09:53 UTC show **four separate home-view requests landing on four freshly-started pods**, each paying **490-637ms** in \`preflight.available_timezones\`:

| trace | pod | pod start | trace | dt | dominant span |
| --- | --- | --- | --- | --- | --- |
| thCu8U | wgj4b | 09:13:02 | 09:23:55 | +10m | 637 ms |
| OG0vvE | tx2pt | 09:29:22 | 09:45:04 | +16m | 539 ms |
| xT7kQi | 92bjd | 09:29:24 | 09:36:07 |  +7m | 530 ms |
| UiJ6cz | hx7f9 | 09:13:01 | 09:20:13 |  +7m | 490 ms |

The lru_cache works as designed but only saves the second call onwards on each pod. With many pods and modest home-view traffic per pod, most pods don't get a second call within an hour, so every pod's first home-view trace looks slow.

## Changes

\`PostHogConfig.ready()\` now calls \`get_available_timezones_with_offsets()\` once at startup so every new pod populates its lru_cache before serving traffic.

- Skip during \`settings.TEST\` (don't slow test setup)
- Skip during \`settings.STATIC_COLLECTION\` (Dockerfile build step has no runtime services)
- Swallow exceptions (\`logger.warning\` only) so a pre-warm failure can't block app startup

## How did you test this code?

I'm an agent.

- \`ruff check\` clean
- \`hogli test posthog/test/test_utils.py::TestGeneralUtils\` — 5 tests pass

Once deployed, the next freshly-started pod's first home-view request should show \`preflight.available_timezones\` in single-digit ms instead of 500-600ms — meaning the cost moves from request path to startup, where users don't see it.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with PostHog Code (claude-opus-4-7)
- Follow-up to #57418, motivated by a batch of seven slow home-view traces from this morning where 4 of them were all cold-pod first-calls of the timezone walk

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*