### PR TITLE
fix: hide PostHog Code alpha reactivate action

### DIFF
--- a/frontend/src/scenes/billing/CodeSeatsSection.tsx
+++ b/frontend/src/scenes/billing/CodeSeatsSection.tsx
@@ -8,7 +8,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { billingLogic } from './billingLogic'
 import { CODE_PLAN_PRO } from './constants'
-import { isProPlanKey, seatBillingLogic, seatPriceFromPlanKey } from './seatBillingLogic'
+import { canReactivateSeat, isProPlanKey, seatBillingLogic, seatPriceFromPlanKey } from './seatBillingLogic'
 import type { SeatData, SeatStatus } from './types'
 
 function planLabel(planKey: string): string {
@@ -148,7 +148,7 @@ export function CodeSeatsSection(): JSX.Element {
                             }
                             const canUpgrade = seat.status === 'active' && !isProPlanKey(seat.plan_key)
                             const canCancel = seat.status === 'active'
-                            const canReactivate = seat.status === 'canceling'
+                            const canReactivate = canReactivateSeat(seat)
 
                             if (!canUpgrade && !canCancel && !canReactivate) {
                                 return null

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -29,6 +29,7 @@ export const CODE_PRODUCT_KEY = 'posthog_code'
 // TODO: Replace hardcoded plan keys with dynamic plan metadata from billing service
 export const CODE_PLAN_FREE = 'posthog-code-free-20260301'
 export const CODE_PLAN_PRO = 'posthog-code-pro-200-20260301'
+export const CODE_PLAN_ALPHA_PRO = 'posthog-code-pro-0-20260422'
 
 export const CODE_PRO_PLAN_PREFIX = 'posthog-code-pro-'
 export const CODE_FREE_PLAN_PREFIX = 'posthog-code-free'

--- a/frontend/src/scenes/billing/seatBillingLogic.spec.ts
+++ b/frontend/src/scenes/billing/seatBillingLogic.spec.ts
@@ -1,4 +1,4 @@
-import { isFreePlanKey, isProPlanKey, seatPriceFromPlanKey } from './seatBillingLogic'
+import { canReactivateSeat, isFreePlanKey, isProPlanKey, seatPriceFromPlanKey } from './seatBillingLogic'
 
 describe('seatBillingLogic plan key helpers', () => {
     describe('isProPlanKey', () => {
@@ -41,6 +41,19 @@ describe('seatBillingLogic plan key helpers', () => {
             ['unrecognized-plan', 0],
         ])('seatPriceFromPlanKey(%p) === %p', (planKey, expected) => {
             expect(seatPriceFromPlanKey(planKey)).toBe(expected)
+        })
+    })
+
+    describe('canReactivateSeat', () => {
+        it.each([
+            [{ status: 'canceling' as const, plan_key: 'posthog-code-pro-0-20260422' }, false],
+            [{ status: 'canceling' as const, plan_key: 'posthog-code-pro-200-20260301' }, true],
+            [{ status: 'canceling' as const, plan_key: 'posthog-code-free-20260301' }, true],
+            [{ status: 'active' as const, plan_key: 'posthog-code-pro-0-20260422' }, false],
+            [null, false],
+            [undefined, false],
+        ])('canReactivateSeat(%p) === %p', (seat, expected) => {
+            expect(canReactivateSeat(seat)).toBe(expected)
         })
     })
 })

--- a/frontend/src/scenes/billing/seatBillingLogic.ts
+++ b/frontend/src/scenes/billing/seatBillingLogic.ts
@@ -10,7 +10,7 @@ import { membersLogic } from 'scenes/organization/membersLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { CODE_FREE_PLAN_PREFIX, CODE_PRO_PLAN_PREFIX, CODE_PRODUCT_KEY } from './constants'
+import { CODE_FREE_PLAN_PREFIX, CODE_PLAN_ALPHA_PRO, CODE_PRO_PLAN_PREFIX, CODE_PRODUCT_KEY } from './constants'
 import type { seatBillingLogicType } from './seatBillingLogicType'
 import type { SeatData } from './types'
 
@@ -20,6 +20,10 @@ export function isProPlanKey(planKey: string | null | undefined): boolean {
 
 export function isFreePlanKey(planKey: string | null | undefined): boolean {
     return !!planKey && planKey.startsWith(CODE_FREE_PLAN_PREFIX)
+}
+
+export function canReactivateSeat(seat: Pick<SeatData, 'plan_key' | 'status'> | null | undefined): boolean {
+    return !!seat && seat.status === 'canceling' && seat.plan_key !== CODE_PLAN_ALPHA_PRO
 }
 
 // TODO: Replace with `seat.price` once billing exposes it via SeatSerializer
@@ -112,7 +116,7 @@ export const seatBillingLogic = kea<seatBillingLogicType>([
             (mySeat): boolean => !!mySeat && mySeat.status === 'active' && isFreePlanKey(mySeat.plan_key),
         ],
         canCancel: [(s) => [s.mySeat], (mySeat): boolean => !!mySeat && mySeat.status === 'active'],
-        canReactivate: [(s) => [s.mySeat], (mySeat): boolean => !!mySeat && mySeat.status === 'canceling'],
+        canReactivate: [(s) => [s.mySeat], (mySeat): boolean => canReactivateSeat(mySeat)],
         displaySeats: [
             (s) => [s.orgSeats],
             (orgSeats): SeatData[] => {


### PR DESCRIPTION
## Problem

PostHog/billing#1871 listed a follow-up to hide the Reactivate action for PostHog Code alpha Pro seats. Those seats use a free alpha plan and are meant to expire into the follow-on free seat, so offering Reactivate would be confusing.

## Changes

- Add a named constant for the alpha Pro plan key.
- Centralize Reactivate eligibility in `canReactivateSeat`.
- Hide Reactivate for canceling alpha Pro seats in the Code seats table and my-seat selector.
- Add focused coverage for Reactivate eligibility.

## How did you test this code?

Added and ran frontend tests covering Reactivate eligibility for alpha Pro, paid Pro, free, active, null, and undefined seats.

## Publish to changelog?

No.

## Docs update

No docs update needed.
