### PR TITLE
chore(experiments/mcp): Add sandboxed eval for configuring-experiment-rollout skill load

### DIFF
--- a/ee/hogai/eval/sandboxed/experiments/eval_rollout_skill.py
+++ b/ee/hogai/eval/sandboxed/experiments/eval_rollout_skill.py
@@ -1,0 +1,56 @@
+"""Skill-load eval for ``configuring-experiment-rollout``.
+
+Asks the agent to change the variant split on a running experiment from
+50/50 to 70/30 and grades whether the ``configuring-experiment-rollout``
+skill auto-loaded before the agent took action. Single deterministic
+scorer (``SkillLoaded``) — no LLM judge — so the signal is binary and
+cheap to reproduce while iterating on the skill's description.
+
+Maps to stress-test finding #7 (skills rarely auto-load), specifically
+the variant-split rows (2.5, 5.3, 5.4, 5.5) in STEP_1_HARNESS.md. Uses
+``SandboxedPrivateEval`` so it runs without a Braintrust API key —
+local logs and PostHog ``$ai_trace`` events still emit.
+
+To run:
+    flox activate -- bash -c "set -a; source .env; set +a; \\
+        pytest -c ee/hogai/eval/pytest.ini \\
+        ee/hogai/eval/sandboxed/experiments/eval_rollout_skill.py \\
+        -v --mcp-mode tools --eval rollout"
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.hogai.eval.sandboxed.base import SandboxedPrivateEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.experiments.seeders import ROLLOUT_EXPERIMENT_NAME, seed_running_experiment
+from ee.hogai.eval.sandboxed.retrieval.scorers import SkillLoaded
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero
+
+SKILL_NAME = "configuring-experiment-rollout"
+
+
+@pytest.mark.django_db(transaction=True)
+async def eval_rollout_skill(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
+    cases: list[SandboxedEvalCase] = [
+        SandboxedEvalCase(
+            name="rollout_change_split_70_30",
+            prompt=(
+                f"Change the variant split on the running experiment '{ROLLOUT_EXPERIMENT_NAME}' from 50/50 to 70/30."
+            ),
+            setup=seed_running_experiment,
+        ),
+    ]
+
+    await SandboxedPrivateEval(
+        experiment_name=f"sandboxed-experiments-rollout-{mcp_mode}",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            SkillLoaded(skill_name=SKILL_NAME),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/ee/hogai/eval/sandboxed/experiments/eval_rollout_skill.py
+++ b/ee/hogai/eval/sandboxed/experiments/eval_rollout_skill.py
@@ -31,7 +31,7 @@ from ee.hogai.eval.sandboxed.scorers import ExitCodeZero
 SKILL_NAME = "configuring-experiment-rollout"
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 async def eval_rollout_skill(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
     cases: list[SandboxedEvalCase] = [
         SandboxedEvalCase(

--- a/ee/hogai/eval/sandboxed/experiments/seeders.py
+++ b/ee/hogai/eval/sandboxed/experiments/seeders.py
@@ -1,0 +1,85 @@
+"""Seeders for experiments-domain sandboxed eval cases.
+
+Each seeder is a synchronous callable that runs in a worker thread (via
+``asyncio.to_thread`` from ``base.py:task()``) and creates the entities
+the prompt references inside the per-case team. Returns a dict that's
+exposed to scorers as ``output["seed"]`` so deterministic scorers can
+reference the seeded IDs without round-tripping through ``expected``.
+"""
+
+from __future__ import annotations
+
+import uuid
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from products.tasks.backend.services.custom_prompt_runner import CustomPromptSandboxContext
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["seed_running_experiment", "ROLLOUT_EXPERIMENT_NAME"]
+
+
+# Deterministic name referenced verbatim by the rollout-skill prompt so the
+# agent's `experiment-list` / `experiment-get` calls can resolve the seeded
+# experiment by name.
+ROLLOUT_EXPERIMENT_NAME = "split test demo"
+
+
+def seed_running_experiment(context: CustomPromptSandboxContext) -> dict[str, Any]:
+    """Seed one running experiment with a 50/50 multivariate flag.
+
+    Designed for prompts that ask the agent to change variant split on a
+    *running* experiment — the canonical scenario the
+    ``configuring-experiment-rollout`` skill exists to handle.
+    """
+    from posthog.models import FeatureFlag
+
+    from products.experiments.backend.models.experiment import Experiment
+
+    team_id = context.team_id
+    user_id = context.user_id
+
+    flag = FeatureFlag.objects.create(
+        team_id=team_id,
+        created_by_id=user_id,
+        key=f"split-test-demo-{uuid.uuid4().hex[:6]}",
+        name=f"{ROLLOUT_EXPERIMENT_NAME} flag",
+        filters={
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "name": "Control", "rollout_percentage": 50},
+                    {"key": "test", "name": "Test", "rollout_percentage": 50},
+                ]
+            },
+        },
+        active=True,
+    )
+
+    experiment = Experiment.objects.create(
+        team_id=team_id,
+        created_by_id=user_id,
+        name=ROLLOUT_EXPERIMENT_NAME,
+        description="Seeded by eval — running experiment with 50/50 split.",
+        feature_flag=flag,
+        start_date=datetime.now(tz=UTC) - timedelta(days=7),
+        end_date=None,
+    )
+
+    payload: dict[str, Any] = {
+        "experiment_id": experiment.id,
+        "experiment_name": experiment.name,
+        "feature_flag_id": flag.id,
+        "feature_flag_key": flag.key,
+        "initial_split": {"control": 50, "test": 50},
+    }
+    logger.info(
+        "Seeded running experiment for team_id=%s: experiment_id=%s flag_key=%s",
+        team_id,
+        experiment.id,
+        flag.key,
+    )
+    return payload


### PR DESCRIPTION
## Problem

The experiments-domain skills had no automated regression test for skill auto-load behavior. Description rewrites or new skills could silently regress what's working today.

## Changes

Adds the first sandboxed eval for the experiments domain at `ee/hogai/eval/sandboxed/experiments/`:

- **`eval_rollout_skill.py`**: async pytest case prompting the agent and scoring result
- **`seeders.py`**: seed running experiment

## How did you test this code?

```bash
pytest -c ee/hogai/eval/pytest.ini \
       ee/hogai/eval/sandboxed/experiments/eval_rollout_skill.py \
       -v --mcp-mode tools --eval rollout
