### PR TITLE
fix(tabs): reverse tab mount/unmount order to prevent logic deallocation

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1145,15 +1145,12 @@ export const sceneLogic = kea<sceneLogicType>([
                 try {
                     const builtLogicProps = { tabId, ...exportedScene?.paramsToProps?.(params) }
                     const builtLogic = exportedScene?.logic(builtLogicProps)
-                    // cache.mountedTabLogic[tabId] = builtLogic.mount()
                     newUnmount = builtLogic.mount()
                 } catch (error) {
                     // Scene logic builders (e.g. dashboardLogic.key()) can throw on malformed
                     // route params like `/dashboard/abc`. Capture so regressions surface, then
                     // route to Error404 so the user sees a proper 404 instead of a blank crash.
                     posthog.captureException(error, { extra: { sceneId, sceneKey, tabId } })
-                    // actions.loadScene(Scene.Error404, undefined, tabId, emptySceneParams, 'REPLACE')
-                    // return
                     newLogicErrored = true
                 }
             }

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1135,28 +1135,46 @@ export const sceneLogic = kea<sceneLogicType>([
                 }
             }
 
-            const unmount = cache.mountedTabLogic[tabId]
-            if (unmount) {
-                try {
-                    unmount()
-                } catch (error) {
-                    console.error('Error unmounting previous tab logic:', error)
-                }
-                delete cache.mountedTabLogic[tabId]
-            }
+            // Mount the new scene logic *before* unmounting the previous one. When the new
+            // mount uses the same logic key (tab switch back to the same scene with the same
+            // params), kea's reference count goes 1 → 2 → 1 and reducer state is preserved.
+            // Unmount-then-mount would briefly drop the count to 0 and destroy the instance.
+            let newUnmount: (() => void) | undefined
+            let newLogicErrored = false
             if (exportedScene?.logic) {
                 try {
                     const builtLogicProps = { tabId, ...exportedScene?.paramsToProps?.(params) }
                     const builtLogic = exportedScene?.logic(builtLogicProps)
-                    cache.mountedTabLogic[tabId] = builtLogic.mount()
+                    // cache.mountedTabLogic[tabId] = builtLogic.mount()
+                    newUnmount = builtLogic.mount()
                 } catch (error) {
                     // Scene logic builders (e.g. dashboardLogic.key()) can throw on malformed
                     // route params like `/dashboard/abc`. Capture so regressions surface, then
                     // route to Error404 so the user sees a proper 404 instead of a blank crash.
                     posthog.captureException(error, { extra: { sceneId, sceneKey, tabId } })
-                    actions.loadScene(Scene.Error404, undefined, tabId, emptySceneParams, 'REPLACE')
-                    return
+                    // actions.loadScene(Scene.Error404, undefined, tabId, emptySceneParams, 'REPLACE')
+                    // return
+                    newLogicErrored = true
                 }
+            }
+
+            const previousUnmount = cache.mountedTabLogic[tabId]
+            if (newUnmount) {
+                cache.mountedTabLogic[tabId] = newUnmount
+            } else {
+                delete cache.mountedTabLogic[tabId]
+            }
+            if (previousUnmount) {
+                try {
+                    previousUnmount()
+                } catch (error) {
+                    console.error('Error unmounting previous tab logic:', error)
+                }
+            }
+
+            if (newLogicErrored) {
+                actions.loadScene(Scene.Error404, undefined, tabId, emptySceneParams, 'REPLACE')
+                return
             }
 
             const trackingKey = tabId || '__default__'


### PR DESCRIPTION
## Problem

Fix 1 to make the `/persons/:uuid` scene not loose filters after tab changes. Repro:

1. Open anything in a PostHog tab
2. Open a person profile in another PostHog tab
3. Go to events sub-tab
4. Change the date range e.g. 30 days
5. Go to the other tab, and back again
-> the date range is reset to the default (24 hours)

Note: Property filters are still unset with a tab change, indicating another issues, that I'm fixing subsequently.
---

kea logics are reference counted; unmounting before remounting can cause the reference count to drop to 0; this causes a deallocation of the logic


## Changes

Reverses the order to mount before unmount, making the reference count never drop to zero.

## How did you test this code?

Manually performed the repro before and after