### PR TITLE
chore(llma): type LLM judge eval result dict with TypedDict

### DIFF
--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, NotRequired, TypedDict
+from typing import Any, NotRequired, Required, TypedDict
 
 from django.conf import settings
 from django.db import models
@@ -63,23 +63,26 @@ LLM_JUDGE_RETRY_POLICY = RetryPolicy(
 
 
 class LLMJudgeResult(TypedDict, total=False):
-    """Result produced by `execute_llm_judge_activity` and `_build_errored_trace_result`.
+    """Result produced by `execute_llm_judge_activity`, `_build_errored_trace_result`, and
+    `execute_hog_eval_activity`.
 
-    `total=False` is used because the dict is constructed across paths whose shapes overlap
-    but are not identical, and `NotRequired` markers document the truly conditional fields:
+    `total=False` is used as the default so individual fields opt in via `Required` /
+    `NotRequired`, making the contract honest about which keys every path actually sets:
 
+    - `verdict`, `reasoning`, `allows_na` are set on every path (LLM judge success, errored-
+      trace skip, hog eval) and are `Required`.
     - `applicable` is set only when `allows_na=True`.
     - `skipped` and `skip_reason` are set only on the skip path (e.g. errored source trace).
     - `model`, `provider`, `key_id`, `is_byok`, and the `*_tokens` fields come from the LLM
-      judge success path; the skip path omits `model`/`provider` so downstream cost
+      judge success path. The skip path omits `model`/`provider` so downstream cost
       attribution doesn't credit phantom calls, and `execute_hog_eval_activity` (whose
       output also flows into `emit_evaluation_event_activity`) emits only `verdict`,
       `reasoning`, `allows_na`, and optionally `applicable`.
     """
 
-    verdict: bool | None
-    reasoning: str
-    allows_na: bool
+    verdict: Required[bool | None]
+    reasoning: Required[str]
+    allows_na: Required[bool]
     input_tokens: NotRequired[int]
     output_tokens: NotRequired[int]
     total_tokens: NotRequired[int]
@@ -95,16 +98,18 @@ class LLMJudgeResult(TypedDict, total=False):
 class WorkflowResult(TypedDict, total=False):
     """Result returned by `RunEvaluationWorkflow.run`.
 
-    Composes a subset of `LLMJudgeResult` with workflow-level identifiers. The skip-on-error
-    branch (e.g. `trial_limit_reached`, `key_invalid`) omits `reasoning` and `is_byok` and
-    adds `message`; the normal-completion branch carries those fields through from the
-    activity result. `skip_reason` is set only when `skipped=True`.
+    Composes a subset of `LLMJudgeResult` with workflow-level identifiers. Both branches
+    that build this dict — the skip-on-error branch (e.g. `trial_limit_reached`,
+    `key_invalid`) and the normal-completion branch — always set `verdict`, `evaluation_id`,
+    `evaluation_type`, and `skipped`, so those four are `Required`. The skip-on-error branch
+    omits `reasoning` and `is_byok` and adds `message`; `skip_reason` is set only when
+    `skipped=True`.
     """
 
-    verdict: bool | None
-    evaluation_id: str
-    evaluation_type: str
-    skipped: bool
+    verdict: Required[bool | None]
+    evaluation_id: Required[str]
+    evaluation_type: Required[str]
+    skipped: Required[bool]
     reasoning: NotRequired[str]
     is_byok: NotRequired[bool]
     skip_reason: NotRequired[str]

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from django.conf import settings
 from django.db import models
@@ -60,6 +60,55 @@ LLM_JUDGE_RETRY_POLICY = RetryPolicy(
     maximum_interval=timedelta(seconds=60),
     backoff_coefficient=2.0,
 )
+
+
+class LLMJudgeResult(TypedDict, total=False):
+    """Result produced by `execute_llm_judge_activity` and `_build_errored_trace_result`.
+
+    `total=False` is used because the dict is constructed across paths whose shapes overlap
+    but are not identical, and `NotRequired` markers document the truly conditional fields:
+
+    - `applicable` is set only when `allows_na=True`.
+    - `skipped` and `skip_reason` are set only on the skip path (e.g. errored source trace).
+    - `model`, `provider`, `key_id`, `is_byok`, and the `*_tokens` fields come from the LLM
+      judge success path; the skip path omits `model`/`provider` so downstream cost
+      attribution doesn't credit phantom calls, and `execute_hog_eval_activity` (whose
+      output also flows into `emit_evaluation_event_activity`) emits only `verdict`,
+      `reasoning`, `allows_na`, and optionally `applicable`.
+    """
+
+    verdict: bool | None
+    reasoning: str
+    allows_na: bool
+    input_tokens: NotRequired[int]
+    output_tokens: NotRequired[int]
+    total_tokens: NotRequired[int]
+    is_byok: NotRequired[bool]
+    key_id: NotRequired[str | None]
+    model: NotRequired[str]
+    provider: NotRequired[str]
+    applicable: NotRequired[bool]
+    skipped: NotRequired[bool]
+    skip_reason: NotRequired[str]
+
+
+class WorkflowResult(TypedDict, total=False):
+    """Result returned by `RunEvaluationWorkflow.run`.
+
+    Composes a subset of `LLMJudgeResult` with workflow-level identifiers. The skip-on-error
+    branch (e.g. `trial_limit_reached`, `key_invalid`) omits `reasoning` and `is_byok` and
+    adds `message`; the normal-completion branch carries those fields through from the
+    activity result. `skip_reason` is set only when `skipped=True`.
+    """
+
+    verdict: bool | None
+    evaluation_id: str
+    evaluation_type: str
+    skipped: bool
+    reasoning: NotRequired[str]
+    is_byok: NotRequired[bool]
+    skip_reason: NotRequired[str]
+    message: NotRequired[str]
 
 
 class BooleanEvalResult(BaseModel):
@@ -445,18 +494,17 @@ def _is_errored_trace(properties: dict[str, Any]) -> bool:
     return False
 
 
-def _build_errored_trace_result(allows_na: bool) -> dict[str, Any]:
+def _build_errored_trace_result(allows_na: bool) -> LLMJudgeResult:
     """Result returned when the source trace errored — skips the LLM call entirely.
 
-    Keep the keys here in sync with the success-path result built around the bottom of
-    `execute_llm_judge_activity`; `emit_evaluation_event_activity` and the workflow downstream
-    both branch on the same shape. `model` and `provider` are deliberately omitted so the
-    `.get(..., DEFAULT_JUDGE_MODEL)` defaults don't silently attribute phantom calls to a model
-    that was never invoked — the emit activity instead detects the `skipped` flag and drops
-    cost / model attribution entirely.
+    `model` and `provider` are deliberately omitted so the `.get(..., DEFAULT_JUDGE_MODEL)`
+    defaults in downstream activities don't silently attribute phantom calls to a model that
+    was never invoked — the emit activity instead detects the `skipped` flag and drops cost
+    and model attribution entirely. The `LLMJudgeResult` TypedDict expresses the shape
+    contract previously enforced by convention.
     """
     reasoning = "Source trace errored before producing output; evaluation skipped."
-    result: dict[str, Any] = {
+    result: LLMJudgeResult = {
         "verdict": None if allows_na else False,
         "reasoning": reasoning,
         "input_tokens": 0,
@@ -474,7 +522,7 @@ def _build_errored_trace_result(allows_na: bool) -> dict[str, Any]:
 
 
 @temporalio.activity.defn
-async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str, Any]:
+async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> LLMJudgeResult:
     """Execute LLM judge to evaluate the target event.
 
     Fetches API key configuration internally to avoid passing sensitive data between activities.
@@ -722,7 +770,7 @@ Output: {output_data}"""
         bind_contextvars(provider=provider, model=model)
 
     # Build result dict based on allows_na config
-    result_dict: dict[str, Any] = {
+    result_dict: LLMJudgeResult = {
         "verdict": result.verdict,
         "reasoning": result.reasoning,
         "input_tokens": usage.input_tokens if usage else 0,
@@ -830,8 +878,14 @@ def run_hog_eval(bytecode: list, event_data: dict[str, Any], allows_na: bool = F
 
 
 @temporalio.activity.defn
-async def execute_hog_eval_activity(evaluation: dict[str, Any], event_data: dict[str, Any]) -> dict[str, Any]:
-    """Execute Hog code to evaluate the target event."""
+async def execute_hog_eval_activity(evaluation: dict[str, Any], event_data: dict[str, Any]) -> LLMJudgeResult:
+    """Execute Hog code to evaluate the target event.
+
+    Returns a strict subset of `LLMJudgeResult` (verdict, reasoning, allows_na, optionally
+    applicable). The shared TypedDict lets both this activity and `execute_llm_judge_activity`
+    feed `EmitEvaluationEventInputs.result` without a wider union — downstream code already
+    branches on `evaluation_type` and `result.get("skipped")` before reading LLM-only keys.
+    """
     if evaluation["evaluation_type"] != "hog":
         raise ApplicationError(
             f"Unsupported evaluation type: {evaluation['evaluation_type']}",
@@ -857,7 +911,7 @@ async def execute_hog_eval_activity(evaluation: dict[str, Any], event_data: dict
             non_retryable=True,
         )
 
-    activity_result: dict[str, Any] = {
+    activity_result: LLMJudgeResult = {
         "verdict": result["verdict"],
         "reasoning": result["reasoning"],
         "allows_na": allows_na,
@@ -872,7 +926,7 @@ async def execute_hog_eval_activity(evaluation: dict[str, Any], event_data: dict
 class EmitEvaluationEventInputs:
     evaluation: dict[str, Any]
     event_data: dict[str, Any]
-    result: dict[str, Any]
+    result: LLMJudgeResult
     start_time: datetime
 
     @property
@@ -976,7 +1030,7 @@ async def emit_evaluation_event_activity(inputs: EmitEvaluationEventInputs) -> N
 class EmitInternalTelemetryInputs:
     evaluation: dict[str, Any]
     team_id: int
-    result: dict[str, Any]
+    result: LLMJudgeResult
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -1030,7 +1084,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
         )
 
     @temporalio.workflow.run
-    async def run(self, inputs: RunEvaluationInputs) -> dict[str, Any]:
+    async def run(self, inputs: RunEvaluationInputs) -> WorkflowResult:
         start_time = temporalio.workflow.now()
         evaluation = await temporalio.workflow.execute_activity(
             fetch_evaluation_activity,
@@ -1119,7 +1173,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                                             evaluation_id=evaluation["id"],
                                             team_id=evaluation["team_id"],
                                         )
-                        return {
+                        skip_result: WorkflowResult = {
                             "verdict": None,
                             "skipped": True,
                             "skip_reason": error_type,
@@ -1127,6 +1181,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                             "evaluation_id": evaluation["id"],
                             "evaluation_type": evaluation_type,
                         }
+                        return skip_result
 
                     # Update key state for API-related errors
                     key_id = details.get("key_id")
@@ -1260,7 +1315,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                         team_id=evaluation["team_id"],
                     )
 
-        workflow_result: dict[str, Any] = {
+        workflow_result: WorkflowResult = {
             "verdict": result["verdict"],
             "reasoning": result["reasoning"],
             "evaluation_id": evaluation["id"],
@@ -1272,5 +1327,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
         # above) so consumers can group skipped workflows by reason without special-casing the
         # source of the skip.
         if result.get("skipped"):
-            workflow_result["skip_reason"] = result.get("skip_reason")
+            skip_reason = result.get("skip_reason")
+            if skip_reason is not None:
+                workflow_result["skip_reason"] = skip_reason
         return workflow_result

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -22,6 +22,7 @@ from .run_evaluation import (
     BooleanWithNAEvalResult,
     EmitEvaluationEventInputs,
     ExecuteLLMJudgeInputs,
+    LLMJudgeResult,
     RunEvaluationInputs,
     RunEvaluationWorkflow,
     SendEvaluationDisabledEmailInputs,
@@ -160,7 +161,7 @@ class TestRunEvaluationWorkflow:
 
         event_data = create_mock_event_data(team.id, properties={})
 
-        result = {
+        result: LLMJudgeResult = {
             "verdict": True,
             "reasoning": "Test passed",
             "model": "gpt-5-mini",
@@ -213,7 +214,7 @@ class TestRunEvaluationWorkflow:
 
         event_data = create_mock_event_data(team.id, properties={})
 
-        result = {
+        result: LLMJudgeResult = {
             "verdict": False,
             "reasoning": "Source trace errored before producing output; evaluation skipped.",
             "input_tokens": 0,
@@ -520,7 +521,7 @@ class TestRunEvaluationWorkflow:
 
         event_data = create_mock_event_data(team.id, properties={})
 
-        result = {
+        result: LLMJudgeResult = {
             "verdict": True,
             "reasoning": "Test passed",
             "applicable": True,
@@ -561,7 +562,7 @@ class TestRunEvaluationWorkflow:
 
         event_data = create_mock_event_data(team.id, properties={})
 
-        result = {
+        result: LLMJudgeResult = {
             "verdict": None,
             "reasoning": "Not applicable",
             "applicable": False,

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -164,6 +164,7 @@ class TestRunEvaluationWorkflow:
         result: LLMJudgeResult = {
             "verdict": True,
             "reasoning": "Test passed",
+            "allows_na": False,
             "model": "gpt-5-mini",
             "provider": "openai",
             "input_tokens": 42,


### PR DESCRIPTION
## Problem

The eval result dict produced by `execute_llm_judge_activity` in `posthog/temporal/llm_analytics/run_evaluation.py` is consumed by several downstream activities and the workflow return. There were two construction sites — the success path at the bottom of `execute_llm_judge_activity` and `_build_errored_trace_result` for the skipped path — both built as free-form `dict[str, Any]`. Keeping them aligned by convention has bitten the codebase before (`model`/`provider`/`key_id`/`is_byok`/`skipped`/`skip_reason` were all added over time). [#56883](https://github.com/PostHog/posthog/pull/56883) added a comment pointing the two paths at each other but explicitly deferred the typed shape — this is the follow-up.

## Changes

- New `LLMJudgeResult` TypedDict (`total=False` with explicit `Required` markers on fields every path sets and `NotRequired` markers on the conditional ones) captures every key produced by the LLM judge success path, the errored-trace skip path, and the hog eval path (which emits a strict subset).
  - `Required`: `verdict`, `reasoning`, `allows_na`.
  - `NotRequired`: token counts, `is_byok`, `key_id`, `model`, `provider`, `applicable`, `skipped`, `skip_reason`.
- New `WorkflowResult` TypedDict captures the workflow-level return shape, composing a subset of `LLMJudgeResult` with `evaluation_id` / `evaluation_type` and the skip-on-error-only `message` field.
  - `Required`: `verdict`, `evaluation_id`, `evaluation_type`, `skipped`.
  - `NotRequired`: `reasoning`, `is_byok`, `skip_reason`, `message`.
- `execute_llm_judge_activity`, `_build_errored_trace_result`, `execute_hog_eval_activity` return types tightened to `LLMJudgeResult`.
- `EmitEvaluationEventInputs.result` and `EmitInternalTelemetryInputs.result` now take `LLMJudgeResult` instead of `dict[str, Any]`.
- `RunEvaluationWorkflow.run` returns `WorkflowResult`, with both the skip-error branch and the normal-completion branch annotated against it.
- Test result-dict literals in `test_run_evaluation.py` are annotated as `LLMJudgeResult` for clarity. The new `Required[allows_na]` marker exposed one stale fixture missing the key — fixed in the same commit.

`dict[str, Any]` is preserved at the JSON / Temporal payload boundaries (event data, evaluation rows, `properties_to_log`, `capture_internal` payloads) — none leaks back into the typed activity bodies.

This is a typing-only refactor; the same keys land on the same events.

## How did you test this code?

I'm an agent; here is what I ran:

- `ruff check` / `ruff format` — clean
- `uv run ty check posthog/temporal/llm_analytics/run_evaluation.py posthog/temporal/llm_analytics/test_run_evaluation.py` — clean (the `Required` markers caught a real test-fixture gap that I then fixed)
- `mypy posthog/temporal/llm_analytics/run_evaluation.py posthog/temporal/llm_analytics/test_run_evaluation.py` — clean, no new baseline entries
- `pytest …test_emit_evaluation_event_activity*` — couldn't run locally (Postgres not up); CI runs the full suite

I did not exercise this in a running worker — TypedDict serializes via the same dataclass JSON converter as `dict[str, Any]`, so over the Temporal gRPC boundary the wire format is unchanged.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7). Two rounds:

1. **Initial typing pass** — human prompt set the scope precisely: define a `LLMJudgeResult` TypedDict capturing every key currently produced, annotate the activity return types, update the consumer dataclasses, and either compose or define a separate `WorkflowResult` for the workflow's final return (which carries different keys like `evaluation_id` / `evaluation_type`).
2. **Required-marker follow-up** — addressed Greptile review feedback. With `total=False` and no `Required` wrappers, fields like `verdict`/`reasoning`/`allows_na` (always set by every path) and `verdict`/`evaluation_id`/`evaluation_type`/`skipped` (always set by both `WorkflowResult` branches) were typed as optional, weakening the contract the refactor was meant to encode. Wrapped them in `Required[…]`. The marker also caught a stale test fixture missing `allows_na` — fixed in the same commit.

Decisions along the way:

- Kept the TypedDicts in `run_evaluation.py` rather than splitting into a sibling `types.py` — they're tightly coupled to a single file's contracts and a sibling module would only add an indirection.
- Annotated `execute_hog_eval_activity` with the same `LLMJudgeResult` type even though it produces a strict subset of keys. This avoids a `LLMJudgeResult | HogEvalResult` union on the consumer dataclasses; downstream code already branches on `evaluation_type` / `result.get("skipped")` before reading LLM-only keys, so a single dict shape is accurate.
- Defined `WorkflowResult` separately rather than composing via `TypedDict.__or__` / inheritance — the skip-on-error branch omits `reasoning` / `is_byok` and adds `message`, so a single flat shape with `Required` + `NotRequired` markers reads more honestly than a union or an inheritance chain.