### PR TITLE
fix(llma): default $geoip_disable for otel ai traces

### DIFF
--- a/rust/capture/src/otel/fan_out.rs
+++ b/rust/capture/src/otel/fan_out.rs
@@ -94,6 +94,17 @@ fn filter_resource_attributes(attrs: &[KeyValue]) -> serde_json::Map<String, Val
         .collect()
 }
 
+fn apply_geoip_default(properties: &mut serde_json::Map<String, Value>) {
+    if properties.contains_key("$geoip_disable") {
+        return;
+    }
+    let alias = properties.remove("posthog.geoip_disable");
+    properties.insert(
+        "$geoip_disable".to_string(),
+        alias.unwrap_or(Value::Bool(true)),
+    );
+}
+
 fn nanos_to_datetime(nanos: u64) -> Option<DateTime<Utc>> {
     if nanos == 0 {
         return None;
@@ -142,6 +153,8 @@ pub fn expand_into_events(
 
                 let mut properties = resource_attrs.clone();
                 properties.extend(span_attrs);
+
+                apply_geoip_default(&mut properties);
 
                 properties.insert(
                     "$ai_trace_id".to_string(),
@@ -641,5 +654,92 @@ mod tests {
         };
         let events = expand_into_events(&request, "fallback-id");
         assert_eq!(events[0].distinct_id, "fallback-id");
+    }
+
+    fn make_minimal_request(
+        extra_resource_attrs: Vec<KeyValue>,
+        extra_span_attrs: Vec<KeyValue>,
+    ) -> ExportTraceServiceRequest {
+        let mut span_attrs = vec![make_kv(
+            "gen_ai.request.model",
+            any_value::Value::StringValue("gpt-4".to_string()),
+        )];
+        span_attrs.extend(extra_span_attrs);
+
+        ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: extra_resource_attrs,
+                    dropped_attributes_count: 0,
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![make_span(
+                        vec![0; 16],
+                        vec![0; 8],
+                        vec![],
+                        0,
+                        0,
+                        "",
+                        span_attrs,
+                    )],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_geoip_disabled_by_default() {
+        let request = make_minimal_request(vec![], vec![]);
+        let events = expand_into_events(&request, "user");
+        let props = events[0].properties.as_object().unwrap();
+        assert_eq!(props["$geoip_disable"], Value::Bool(true));
+        assert!(!props.contains_key("posthog.geoip_disable"));
+    }
+
+    #[test]
+    fn test_user_can_opt_into_geoip_via_canonical_property() {
+        let request = make_minimal_request(
+            vec![],
+            vec![make_kv(
+                "$geoip_disable",
+                any_value::Value::BoolValue(false),
+            )],
+        );
+        let events = expand_into_events(&request, "user");
+        let props = events[0].properties.as_object().unwrap();
+        assert_eq!(props["$geoip_disable"], Value::Bool(false));
+    }
+
+    #[test]
+    fn test_user_can_opt_into_geoip_via_otel_alias() {
+        let request = make_minimal_request(
+            vec![make_kv(
+                "posthog.geoip_disable",
+                any_value::Value::BoolValue(false),
+            )],
+            vec![],
+        );
+        let events = expand_into_events(&request, "user");
+        let props = events[0].properties.as_object().unwrap();
+        assert_eq!(props["$geoip_disable"], Value::Bool(false));
+        // Alias is consumed so it doesn't leak as a duplicate property.
+        assert!(!props.contains_key("posthog.geoip_disable"));
+    }
+
+    #[test]
+    fn test_canonical_property_wins_over_alias() {
+        let request = make_minimal_request(
+            vec![make_kv(
+                "posthog.geoip_disable",
+                any_value::Value::BoolValue(false),
+            )],
+            vec![make_kv("$geoip_disable", any_value::Value::BoolValue(true))],
+        );
+        let events = expand_into_events(&request, "user");
+        let props = events[0].properties.as_object().unwrap();
+        assert_eq!(props["$geoip_disable"], Value::Bool(true));
     }
 }

--- a/rust/capture/src/otel/fan_out.rs
+++ b/rust/capture/src/otel/fan_out.rs
@@ -95,10 +95,10 @@ fn filter_resource_attributes(attrs: &[KeyValue]) -> serde_json::Map<String, Val
 }
 
 fn apply_geoip_default(properties: &mut serde_json::Map<String, Value>) {
+    let alias = properties.remove("posthog.geoip_disable");
     if properties.contains_key("$geoip_disable") {
         return;
     }
-    let alias = properties.remove("posthog.geoip_disable");
     properties.insert(
         "$geoip_disable".to_string(),
         alias.unwrap_or(Value::Bool(true)),
@@ -211,6 +211,7 @@ mod tests {
     use opentelemetry_proto::tonic::common::v1::AnyValue;
     use opentelemetry_proto::tonic::resource::v1::Resource;
     use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+    use rstest::rstest;
 
     fn make_kv(key: &str, value: any_value::Value) -> KeyValue {
         KeyValue {
@@ -690,56 +691,33 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_geoip_disabled_by_default() {
-        let request = make_minimal_request(vec![], vec![]);
+    #[rstest]
+    // Default: no attributes set; $geoip_disable defaults to true.
+    #[case::default_disabled(vec![], vec![], true)]
+    // Canonical $geoip_disable on span wins.
+    #[case::canonical_opt_in(vec![], vec![("$geoip_disable", false)], false)]
+    // posthog.geoip_disable alias on resource is copied into $geoip_disable.
+    #[case::alias_opt_in(vec![("posthog.geoip_disable", false)], vec![], false)]
+    // Both set: canonical wins, alias is consumed (not duplicated).
+    #[case::canonical_wins_over_alias(
+        vec![("posthog.geoip_disable", false)],
+        vec![("$geoip_disable", true)],
+        true
+    )]
+    fn test_geoip_default_behavior(
+        #[case] resource_attrs: Vec<(&str, bool)>,
+        #[case] span_attrs: Vec<(&str, bool)>,
+        #[case] expected_geoip_disable: bool,
+    ) {
+        let to_kv = |(k, v): &(&str, bool)| make_kv(k, any_value::Value::BoolValue(*v));
+        let request = make_minimal_request(
+            resource_attrs.iter().map(to_kv).collect(),
+            span_attrs.iter().map(to_kv).collect(),
+        );
         let events = expand_into_events(&request, "user");
         let props = events[0].properties.as_object().unwrap();
-        assert_eq!(props["$geoip_disable"], Value::Bool(true));
+        assert_eq!(props["$geoip_disable"], Value::Bool(expected_geoip_disable));
+        // Alias must always be consumed so it doesn't leak as a duplicate property.
         assert!(!props.contains_key("posthog.geoip_disable"));
-    }
-
-    #[test]
-    fn test_user_can_opt_into_geoip_via_canonical_property() {
-        let request = make_minimal_request(
-            vec![],
-            vec![make_kv(
-                "$geoip_disable",
-                any_value::Value::BoolValue(false),
-            )],
-        );
-        let events = expand_into_events(&request, "user");
-        let props = events[0].properties.as_object().unwrap();
-        assert_eq!(props["$geoip_disable"], Value::Bool(false));
-    }
-
-    #[test]
-    fn test_user_can_opt_into_geoip_via_otel_alias() {
-        let request = make_minimal_request(
-            vec![make_kv(
-                "posthog.geoip_disable",
-                any_value::Value::BoolValue(false),
-            )],
-            vec![],
-        );
-        let events = expand_into_events(&request, "user");
-        let props = events[0].properties.as_object().unwrap();
-        assert_eq!(props["$geoip_disable"], Value::Bool(false));
-        // Alias is consumed so it doesn't leak as a duplicate property.
-        assert!(!props.contains_key("posthog.geoip_disable"));
-    }
-
-    #[test]
-    fn test_canonical_property_wins_over_alias() {
-        let request = make_minimal_request(
-            vec![make_kv(
-                "posthog.geoip_disable",
-                any_value::Value::BoolValue(false),
-            )],
-            vec![make_kv("$geoip_disable", any_value::Value::BoolValue(true))],
-        );
-        let events = expand_into_events(&request, "user");
-        let props = events[0].properties.as_object().unwrap();
-        assert_eq!(props["$geoip_disable"], Value::Bool(true));
     }
 }


### PR DESCRIPTION
## Problem

OTel AI traces (events posted to `/i/v0/ai/otel`) are always emitted from server-side LLM calls — Vercel AI SDK, Convex agents, Pydantic AI, Traceloop, etc. The capture handler stamps the request's IP onto every event (`rust/capture/src/otel/mod.rs:179-181`, then `filtering.rs:105`), and the GeoIP CDP transformation runs on that IP unless the event carries `$geoip_disable: true`. The result: every server-side AI event currently gets geo-enriched against the application server's egress IP rather than the end user's location, surfacing misleading geo properties on dashboards.

This is also inconsistent with our other server-side SDKs:
- `posthog-python` — `client.py` defaults the constructor option `disable_geoip=True` and stamps `geoip_disable: True` on the payload.
- `posthog-node` / `posthog-js-lite` — `posthog-core/src/index.ts` defaults `disableGeoip = true` for the stateless (server) client and writes `$geoip_disable: true` into properties.

The OTel AI ingestion path was the odd one out.

This was raised by a customer using `@posthog/ai`'s OTel exporter via Convex who noticed every AI event was geo-tagged with their server's location.

## Changes

`rust/capture/src/otel/fan_out.rs`: a small `apply_geoip_default` helper called once per span while properties are being assembled.

- Default `$geoip_disable: true` on every AI event built from an OTel span.
- Honor `$geoip_disable` if set directly on a span/resource attribute (canonical PostHog property name).
- Honor `posthog.geoip_disable` as an OTel-idiomatic alias and copy its value into `$geoip_disable`. Mirrors how `posthog.distinct_id` is treated. The alias is consumed so it doesn't leak as a duplicate property.

Net effect: server-side OTel AI events stop getting geo-enriched against the application server's IP. Users who genuinely want geo (e.g. they're forwarding the real end-user IP via `$ip`) opt back in by setting `posthog.geoip_disable: false`.

## How did you test this code?

I'm an agent. Carlos reviewed the change before commit. I ran:

- `cargo test -p capture --lib otel::fan_out` — 19 tests pass, including 4 new ones covering: default-on, opt-out via `$geoip_disable`, opt-out via `posthog.geoip_disable` alias, canonical-wins-over-alias.
- `cargo test -p capture --test integration_otel_endpoint` — all 21 OTel integration tests pass; nothing in the existing assertions broke from the new default property.
- `cargo fmt -p capture --check` — clean.
- `cargo clippy -p capture --lib --tests` — clean.

No manual end-to-end testing through the live ingestion pipeline.

## Publish to changelog?

no

## Docs update

Worth a follow-up to mention the new default and the `posthog.geoip_disable` opt-in attribute in `docs/onboarding/llm-analytics/opentelemetry.tsx`. Not in this PR to keep it minimal.

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Human prompt that shaped this: Carlos asked to investigate what IP data ends up on OTel AI events after a customer support thread flagged that server-side OTel AI traces were being geo-enriched with the server's location. We traced the IP capture flow (`rust/capture/src/otel/mod.rs` → `filtering.rs::build_events` sets `event.ip` from the request IP; downstream plugin-server lifts it to `$ip` and runs GeoIP unless `$geoip_disable` is set). We confirmed that other server-side PostHog SDKs (`posthog-python`, `posthog-node`/`posthog-js-lite`) default to sending `$geoip_disable: true`, but the OTel AI path didn't.
- Decisions:
  - Set the default at the OTel ingestion layer rather than in `@posthog/ai` exporters — covers direct OTLP collectors and other-language exporters too, not just users of our SDK helper.
  - Mirror the `posthog.distinct_id` aliasing convention (`posthog.geoip_disable`) so the OTel-idiomatic flat-namespace key works alongside the canonical `$geoip_disable`. Consume the alias so it doesn't double-stamp.
  - Did not strip the request IP itself — only disable geo enrichment. Matches what the server SDKs do (they send `$geoip_disable: true` but don't nullify `$ip`), and matches the customer's actual concern, which was specifically about geo not raw IP.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
