### PR TITLE
fix(persons): preserve event filter overrides on tab remount

### DIFF
--- a/frontend/src/queries/nodes/DataTable/TableView/tableViewLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/TableView/tableViewLogic.ts
@@ -12,7 +12,8 @@ import { PERSON_EVENTS_CONTEXT_KEY } from 'scenes/persons/personsLogic'
 import { PEOPLE_LIST_CONTEXT_KEY, PEOPLE_LIST_DEFAULT_QUERY } from 'scenes/persons/personsSceneLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { ActorsQuery, EventsQuery, GroupsQuery } from '~/queries/schema/schema-general'
+import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
+import { ActorsQuery, EventsQuery, GroupsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { isEventsQuery } from '~/queries/utils'
 import { AnyPropertyFilter, PropertyOperator } from '~/types'
 
@@ -59,6 +60,14 @@ function getViewData(
         columns: props.query.select,
         filters: [...(props.query.properties || []), event, events],
     }
+}
+
+function isInitialPersonEventsQuery(query: TableViewSupportedQueryType): boolean {
+    if (!isEventsQuery(query)) {
+        return false
+    }
+    const defaultColumns = defaultDataTableColumns(NodeKind.EventsQuery)
+    return equal(query.select, defaultColumns) && !query.properties?.length && !query.event && !query.events?.length
 }
 
 function getQueryFromView(
@@ -307,7 +316,10 @@ export const tableViewLogic = kea<tableViewLogicType>([
                 }
                 break
             case PERSON_EVENTS_CONTEXT_KEY:
-                actions.applyView(values.currentView)
+                if (isInitialPersonEventsQuery(props.query)) {
+                    actions.applyView(values.currentView)
+                }
+                break
         }
     }),
 ])


### PR DESCRIPTION
## Problem

On the Persons page Events sub-tab (e.g. `/project/<id>/persons/<uuid>#activeTab=events`),
switching to a different PostHog scene tab and back wipes the user's `properties`,
`event`, and `events` filters on the events query. The date range (`after`) survives,
which is a useful clue: the four wiped fields are exactly the ones controlled by the
saved-table-view machinery.

`tableViewLogic.afterMount` was unconditionally calling `applyView(currentView)` for
the `PERSON_EVENTS_CONTEXT_KEY` case. Every time the events sub-tab remounted, that
call ran `getQueryFromView` and overwrote the user's in-progress overrides with the
saved view's snapshot. The other context keys (`PEOPLE_LIST_CONTEXT_KEY`, the
`group-N-list` keys) already gate the same call on "query is still at default", but
that guard was missing here.

## Changes

- `frontend/src/queries/nodes/DataTable/TableView/tableViewLogic.ts`
  - Added `isInitialPersonEventsQuery` helper that returns true only when the events
    query is still at its `createInitialEventsPayload` defaults (default columns,
    no properties / event / events).
  - Guarded the `PERSON_EVENTS_CONTEXT_KEY` branch in `afterMount` with that check,
    matching the existing pattern for the other context keys.
  - `getQueryFromView` itself is unchanged — the `applyView` listener (explicit
    user-driven view selection / reset) and "Update current view with changes"
    (which reads live `props.query` via `getViewData`) keep their existing
    override-replacing semantics.

## How did you test this code?

Agent-authored PR. Automated checks I ran:

- [x] `pnpm --filter=@posthog/frontend typescript:check` — no new type errors in the
      modified file (pre-existing failures in unrelated `visual_review` and
      `workflows` files only).

I have **not** manually verified the UI flow. Suggested manual test plan for the
human reviewer:

- [x] Open a person → Events sub-tab. Confirm a saved view (if any) auto-applies on
      first load.
- [x] Add a property filter and pick an event, switch to another PostHog scene tab,
      and switch back. Filters should be preserved (along with the date range,
      which already worked).
- [x] With a saved view applied, add an extra override on top, click "Update current
      view with changes", reload, and confirm the view now contains the override.
- [x] Apply a view → modify → re-select the same view in the picker. Overrides
      should be discarded (this path goes through the `applyView` listener,
      unchanged by the fix).

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7).
- Human prompt described the symptom on the persons events sub-tab and pointed at
  `getQueryFromView` as the suspected area, with the constraint that "Update current
  view with changes" must keep working with overrides.
- Considered gating inside `getQueryFromView` itself, but rejected: that function is
  also used by the `applyView` listener, where overwriting overrides is the desired
  behavior (e.g. selecting a different saved view). The right place to gate is the
  `afterMount` decision point, mirroring the existing `PEOPLE_LIST_CONTEXT_KEY` and
  `group-N-list` patterns.
- Considered adding a persisted "view already applied" flag, but rejected as more
  state than necessary; the "query is at initial default" check is enough and stays
  consistent with the rest of the file.
