### PR TITLE
chore(mcp): also sample 10% of worker invocations

### DIFF
--- a/services/mcp/wrangler.jsonc
+++ b/services/mcp/wrangler.jsonc
@@ -37,6 +37,7 @@
     },
     "observability": {
         "enabled": true,
+        "head_sampling_rate": 0.1,
         "logs": {
             "enabled": true,
             "destinations": ["posthog"],


### PR DESCRIPTION
## Problem

#57288 lowered `observability.logs.head_sampling_rate` for the `mcp1` Worker to 0.1, but the volume of invocation logs in the Cloudflare dashboard's longitudinal chart didn't drop. Root cause: the top-level `observability.head_sampling_rate` was unset, defaulting to 1 — so the dashboard's invocation/log volume view kept reading 100% of invocations even though the outbound logs pipeline was sampling at 10%.

## Changes

Set `observability.head_sampling_rate` to 0.1 to match `observability.logs.head_sampling_rate`. After deploy, the Cloudflare dashboard chart for `mcp1` should reflect ~10% of invocations.

## How did you test this code?

Agent-authored. No automated tests run — this is a one-line wrangler config change. Verification will be visual: after deploy, the Cloudflare dashboard's invocation log volume chart for `mcp1` should drop to ~10% of pre-change levels.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with Claude Code (Opus 4.7).
- Investigation: queried the live Cloudflare API for `mcp1` script-settings via the Cloudflare MCP and observed `observability.head_sampling_rate=1` alongside `observability.logs.head_sampling_rate=0.1`. The two rates are independent — the nested one governs the logs pipeline (and outbound `posthog` destination); the top-level one governs the in-dashboard invocation volume chart. Aligning both to 0.1 is the minimal fix.
- Decision: did not change `invocation_logs` or `persist` — the user wants logs to keep showing in the Cloudflare dashboard, just sampled.