### PR TITLE
feat(agentic-provisioning): allow wizard-required scopes

### DIFF
--- a/ee/api/agentic_provisioning/test/test_scope_validation.py
+++ b/ee/api/agentic_provisioning/test/test_scope_validation.py
@@ -1,0 +1,32 @@
+import pytest
+
+from ee.api.agentic_provisioning.views import ALLOWED_PROVISIONING_SCOPES, _validate_scopes
+
+
+@pytest.mark.parametrize(
+    "scopes,expected",
+    [
+        ([], []),
+        (["query:read"], ["query:read"]),
+        (["llm_gateway:read", "project:read"], ["llm_gateway:read", "project:read"]),
+        (["dashboard:write", "insight:write", "introspection"], ["dashboard:write", "insight:write", "introspection"]),
+        (["query:read", "made_up_scope"], None),
+        (["dashboard:read"], None),
+        (["INSIGHT:READ"], None),
+    ],
+)
+def test_validate_scopes(scopes, expected):
+    assert _validate_scopes(scopes) == expected
+
+
+def test_allowlist_covers_wizard_required_scopes():
+    wizard_scopes = {
+        "user:read",
+        "project:read",
+        "introspection",
+        "llm_gateway:read",
+        "dashboard:write",
+        "insight:write",
+        "query:read",
+    }
+    assert wizard_scopes.issubset(ALLOWED_PROVISIONING_SCOPES)

--- a/ee/api/agentic_provisioning/test/test_scope_validation.py
+++ b/ee/api/agentic_provisioning/test/test_scope_validation.py
@@ -9,10 +9,12 @@ from ee.api.agentic_provisioning.views import ALLOWED_PROVISIONING_SCOPES, _vali
         ([], []),
         (["query:read"], ["query:read"]),
         (["llm_gateway:read", "project:read"], ["llm_gateway:read", "project:read"]),
-        (["dashboard:write", "insight:write", "introspection"], ["dashboard:write", "insight:write", "introspection"]),
+        (["dashboard:write", "insight:write"], ["dashboard:write", "insight:write"]),
         (["query:read", "made_up_scope"], None),
         (["dashboard:read"], None),
         (["INSIGHT:READ"], None),
+        # introspection is not a grantable OAuth scope (RFC 7662 endpoint, not a scope) — should be rejected.
+        (["introspection"], None),
     ],
 )
 def test_validate_scopes(scopes, expected):
@@ -23,7 +25,6 @@ def test_allowlist_covers_wizard_required_scopes():
     wizard_scopes = {
         "user:read",
         "project:read",
-        "introspection",
         "llm_gateway:read",
         "dashboard:write",
         "insight:write",

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -2040,7 +2040,6 @@ ALLOWED_PROVISIONING_SCOPES = {
     "feature_flag:read",
     "insight:read",
     "insight:write",
-    "introspection",
     "llm_gateway:read",
     "organization:read",
     "person:read",

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -2038,6 +2038,7 @@ ALLOWED_PROVISIONING_SCOPES = {
     "experiment:read",
     "feature_flag:read",
     "insight:read",
+    "llm_gateway:read",
     "organization:read",
     "person:read",
     "project:read",

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -2032,12 +2032,15 @@ def _verify_hmac_if_present(request: Request) -> Response | None:
 
 ALLOWED_PROVISIONING_SCOPES = {
     "customer_journey:read",
+    "dashboard:write",
     "query:read",
     "conversation:read",
     "conversation:write",
     "experiment:read",
     "feature_flag:read",
     "insight:read",
+    "insight:write",
+    "introspection",
     "llm_gateway:read",
     "organization:read",
     "person:read",


### PR DESCRIPTION
## Problem

Partner integrations using the agentic-provisioning OAuth flow issue scoped OAuth access tokens (`pha_` prefix) to end users. The list of scopes a partner can request is gated by `ALLOWED_PROVISIONING_SCOPES`. That allowlist was missing scopes the PostHog setup wizard (`@posthog/wizard`) needs in its interactive OAuth flow, so partner-issued tokens couldn't drive the wizard end-to-end.

User-facing symptom: a 401 from the LLM Gateway when the wizard tries to call its Claude agent through the gateway with a partner-provisioned token. The wizard's CI-mode error message in that case is misleading and is being fixed in a separate posthog-wizard PR.

## Changes

Add `llm_gateway:read`, `dashboard:write`, and `insight:write` to `ALLOWED_PROVISIONING_SCOPES` in `ee/api/agentic_provisioning/views.py`.

Add `ee/api/agentic_provisioning/test/test_scope_validation.py` with parameterized coverage for `_validate_scopes`: positive cases for the new scopes, negative cases for unknown scopes, case-sensitivity, and an explicit assertion that the allowlist covers the wizard's required scope set.

The set of writable scopes (`dashboard:write`, `insight:write`) is consistent with the existing write scopes already in the allowlist (`conversation:write`, `ticket:write`, `hog_flow:write`).

### What's NOT in this PR

The wizard's interactive OAuth currently also requests `introspection`, but per #56835 that's not a grantable scope — it's the OAuth token-introspection endpoint per RFC 7662, exposed as `introspection_endpoint` per RFC 8414, never as a scope. This PR explicitly does NOT add it to the allowlist, and includes a negative test case so it can't sneak back in. The wizard's stale `introspection` reference in `setup-utils.ts` is a separate cleanup.

## How did you test this code?

Agent-authored. Automated checks:

- `pytest ee/api/agentic_provisioning/test/test_scope_validation.py` — 9/9 pass (including the negative `introspection` case).
- `pytest ee/api/agentic_provisioning/` — 246 pass, 1 environmental failure (`test_full_a1_flow_with_token_exchange` requires `OIDC_RSA_PRIVATE_KEY`, fails identically on clean master, marked `requires_secrets`).
- `ruff check ee/api/agentic_provisioning/` and `ruff format` — clean.

No manual end-to-end testing.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude Opus 4.7 via Claude Code, working from a real partner-integration 401 where a `pha_` OAuth access token was rejected by the LLM Gateway. Initial scope was just `llm_gateway:read`; folded in `dashboard:write` and `insight:write` on a follow-up pass to cover the wizard's other required scopes. After #56835 was raised in review, dropped the originally-included `introspection` (it's not a grantable scope) and added a negative test for it.

The wizard-side fix (better error UX when a non-PAT token or wrong scope set is passed) is in a separate posthog-wizard PR.