### PR TITLE
fix(signals): List API fixes

### DIFF
--- a/posthog/api/test/test_user_integration.py
+++ b/posthog/api/test/test_user_integration.py
@@ -592,7 +592,7 @@ class TestUserIntegrationEndpoints(APIBaseTest):
 
 
 class TestGetGithubLoginPrecedence(APIBaseTest):
-    """User.get_github_login() precedence: UserIntegration > UserSocialAuth > team Integration."""
+    """User.get_github_login() precedence: UserIntegration > UserSocialAuth > team-level GitHub Integration."""
 
     def test_returns_none_when_no_source_present(self):
         self.assertIsNone(self.user.get_github_login())

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -390,14 +390,15 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
         """Resolve this user's GitHub login.
 
         Precedence:
-        1. `UserIntegration` (kind=github) - the user's own GitHub integration
-        2. `UserSocialAuth` (provider=github) - fallback for users who log in with GitHub but haven't set up a `UserIntegration` yet
-        3. Team `Integration` `connecting_user_github_login` - legacy fallback from before the user integration model existed
+        1. `UserIntegration` (kind=github) — user's own GitHub integration
+        2. `UserSocialAuth` (provider=github) — OAuth login linkage when no GitHub user integration exists
+        3. Team-level `Integration` (kind=github) `connecting_user_github_login` — identity stored on the
+           team's GitHub integration (e.g. captured at install). Still a supported integration path,
+           lowest precedence as an identity fallback when (1)/(2) do not yield a GitHub username.
         """
-        from posthog.models.integration import Integration
-        from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
+        from posthog.models.user_integration import UserGitHubIntegration
 
-        user_integration = UserIntegration.objects.filter(user=self, kind="github").first()
+        user_integration = self.integrations.filter(kind="github").first()
         if user_integration:
             login = UserGitHubIntegration(user_integration).github_login
             if login:
@@ -414,7 +415,7 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
                 if login:
                     return str(login)
 
-        # Fall back to team Integration identity captured at install time.
+        # Team-level GitHub integration: connecting_user_github_login from install / configuration.
         prefetched_integrations = getattr(self, "_prefetched_github_integrations", None)
         if prefetched_integrations is not None:
             for integration in prefetched_integrations:
@@ -422,14 +423,16 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
                 if login:
                     return str(login)
         else:
-            login = (
-                Integration.objects.filter(kind="github", created_by=self)
-                .values_list("config__connecting_user_github_login", flat=True)
+            team_github_integration = (
+                self.integration_set.filter(kind="github")
                 .exclude(config__connecting_user_github_login=None)
+                .only("config")
                 .first()
             )
-            if login:
-                return str(login)
+            if team_github_integration and isinstance(team_github_integration.config, dict):
+                login_val = team_github_integration.config.get("connecting_user_github_login")
+                if login_val:
+                    return str(login_val)
 
         return None
 

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -398,8 +398,13 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
         """
         from posthog.models.user_integration import UserGitHubIntegration
 
-        user_integration = self.integrations.filter(kind="github").first()
-        if user_integration:
+        prefetched_user_integrations = getattr(self, "_prefetched_github_user_integrations", None)
+        if prefetched_user_integrations is not None:
+            user_integrations = prefetched_user_integrations
+        else:
+            user_integrations = self.integrations.filter(kind="github")[:1]
+
+        for user_integration in user_integrations:
             login = UserGitHubIntegration(user_integration).github_login
             if login:
                 return login

--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -597,16 +597,19 @@ Read + delete + state transitions. Uses `IsAuthenticated` + `APIScopePermission`
 
 **Ordering:** Configurable via `?ordering=` with comma-separated fields. Supported fields: `status`, `is_suggested_reviewer`, `signal_count`, `total_weight`, `priority`, `created_at`, `updated_at`, `id`.
 
-The `status` ordering uses semantic pipeline stage ranking:
+The `status` clause sorts by annotated `pipeline_status_rank` (not lexicographic `status` text). Ascending rank lists earlier pipeline stages first. Ranks:
 
-- `ready=0`
-- `pending_input=1`
-- `in_progress=2`
-- `candidate=3`
-- `potential=4`
-- `failed=5`
-- `suppressed=6`
-- `deleted=7`
+- `0` — `ready` and actionable (includes reports with no actionability judgment yet)
+- `1` — `ready` and latest actionability judgment is `not_actionable`
+- `2` — `pending_input`
+- `3` — `in_progress`
+- `4` — `candidate`
+- `5` — `potential`
+- `6` — `failed`
+- `7` — `suppressed`
+- `8` — `deleted` (deleted rows are not returned by the API; rank exists for queryset consistency)
+
+So with `ordering=status`, **`failed` sorts after actionable `ready`**. With `ordering=-status`, **`failed` sorts before actionable `ready`**.
 
 Default ordering is **`-is_suggested_reviewer,status,-updated_at,id`**.
 
@@ -650,6 +653,7 @@ View + control API for the v2 grouping pipeline. Uses scope object `INTERNAL`.
   - `priority` comes from the latest `PRIORITY_JUDGMENT` artefact
   - `actionability` comes from the latest `ACTIONABILITY_JUDGMENT` artefact and supports both current (`actionability`) and legacy (`choice`) payloads
   - `already_addressed` also comes from the latest actionability artefact
+  - `is_suggested_reviewer`: list/detail annotate from the requesting user’s linked GitHub login against the `suggested_reviewers` artefact. Always **`false`** when there is nothing to review: `failed` reports, or `ready` with latest actionability `not_actionable` (even if the artefact names the user)
 - **`SignalReportArtefactSerializer`**
   - Exposes `id`, `type`, `content`, `created_at`
   - Parses JSON text into structured content

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -6,7 +6,8 @@ from collections import Counter
 from collections.abc import Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
+from uuid import UUID
 
 from django.db.models import Prefetch, QuerySet, Subquery
 from django.db.models.functions import Lower
@@ -27,6 +28,11 @@ logger = logging.getLogger(__name__)
 
 MAX_SUGGESTED_REVIEWERS = 3
 MAX_COMMIT_LOOKUPS = 15
+GitHubLoginFieldLookup = Literal[
+    "extra_data__login",
+    "config__github_user__login",
+    "config__connecting_user_github_login",
+]
 
 
 def enrich_reviewer_dicts_with_org_members(
@@ -48,7 +54,7 @@ def enrich_reviewer_dicts_with_org_members(
         resolved_map = login_to_user
     else:
         wanted = normalized_github_logins_from_reviewer_payloads(reviewer_dicts)
-        resolved_map = resolve_org_github_login_to_users(team_id, wanted) if wanted else dict[str, User]()
+        resolved_map = resolve_org_github_login_to_users(team_id, wanted) if wanted else {}
 
     enriched: list[dict] = []
     for r in reviewer_dicts:
@@ -263,7 +269,7 @@ def resolve_org_github_login_to_users(team_id: int, github_logins: Iterable[str]
     return login_to_user
 
 
-def _candidate_user_ids_for_organization(org_id: int) -> set[int]:
+def _candidate_user_ids_for_organization(org_id: UUID | str) -> set[int]:
     """Org member IDs that might have any GitHub identity."""
     mid_sq = Subquery(OrganizationMembership.objects.filter(organization_id=org_id).values("user_id"))
     candidates: set[int] = set()
@@ -283,7 +289,7 @@ def _candidate_user_ids_for_organization(org_id: int) -> set[int]:
     return candidates
 
 
-def _candidate_user_ids_for_org_and_logins(org_id: int, logins_lower: frozenset[str]) -> set[int]:
+def _candidate_user_ids_for_org_and_logins(org_id: UUID | str, logins_lower: frozenset[str]) -> set[int]:
     """Subset of org members whose stored GitHub identity might match one of ``logins_lower`` (case-insensitive)."""
     if not logins_lower:
         return set()
@@ -317,20 +323,22 @@ def _candidate_user_ids_for_org_and_logins(org_id: int, logins_lower: frozenset[
 
 def _filter_github_login_field_lc(
     qs: QuerySet,
-    login_field_lookup: str,
+    login_field_lookup: GitHubLoginFieldLookup,
     logins_lower: frozenset[str],
 ) -> QuerySet:
     """Case-insensitive match: ``Lower(login_field_lookup) ∈ logins_lower`` (expects lowercased logins)."""
-    alias = "_github_login_lc_lookup"
-    return qs.annotate(**{alias: Lower(login_field_lookup)}).filter(**{f"{alias}__in": sorted(logins_lower)})
+    return qs.annotate(_github_login_lc_lookup=Lower(login_field_lookup)).filter(
+        _github_login_lc_lookup__in=sorted(logins_lower)
+    )
 
 
 def _github_identity_prefetches() -> tuple[Prefetch, ...]:
-    """Prefetch relations read by `User.get_github_login()` (includes team `Integration` via `integration_set`)."""
+    """Prefetch relations read by `User.get_github_login()`."""
     return (
         Prefetch(
             "integrations",
             UserIntegration.objects.filter(kind=UserIntegration.IntegrationKind.GITHUB),
+            to_attr="_prefetched_github_user_integrations",
         ),
         Prefetch("social_auth", UserSocialAuth.objects.filter(provider="github")),
         Prefetch(
@@ -338,5 +346,6 @@ def _github_identity_prefetches() -> tuple[Prefetch, ...]:
             Integration.objects.filter(kind="github")
             .exclude(config__connecting_user_github_login=None)
             .only("config", "id", "created_by_id"),
+            to_attr="_prefetched_github_integrations",
         ),
     )

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any, Literal
-from uuid import UUID
 
 from django.db.models import Prefetch, QuerySet, Subquery
 from django.db.models.functions import Lower
@@ -189,7 +188,7 @@ def get_org_member_github_login_to_user_map(team_id: int) -> dict[str, User] | N
     Returns None if the team doesn't exist, otherwise a dict (possibly empty).
     """
     try:
-        org_id = Team.objects.values_list("organization_id", flat=True).get(id=team_id)
+        org_id = str(Team.objects.values_list("organization_id", flat=True).get(id=team_id))
     except Team.DoesNotExist:
         return None
 
@@ -214,7 +213,7 @@ def get_org_member_github_logins_by_user_uuid(team_id: int, user_uuids: list[str
         return {}
 
     try:
-        org_id = Team.objects.values_list("organization_id", flat=True).get(id=team_id)
+        org_id = str(Team.objects.values_list("organization_id", flat=True).get(id=team_id))
     except Team.DoesNotExist:
         return {}
 
@@ -248,7 +247,7 @@ def resolve_org_github_login_to_users(team_id: int, github_logins: Iterable[str]
         return {}
 
     try:
-        org_id = Team.objects.values_list("organization_id", flat=True).get(id=team_id)
+        org_id = str(Team.objects.values_list("organization_id", flat=True).get(id=team_id))
     except Team.DoesNotExist:
         return {}
 
@@ -269,7 +268,7 @@ def resolve_org_github_login_to_users(team_id: int, github_logins: Iterable[str]
     return login_to_user
 
 
-def _candidate_user_ids_for_organization(org_id: UUID | str) -> set[int]:
+def _candidate_user_ids_for_organization(org_id: str) -> set[int]:
     """Org member IDs that might have any GitHub identity."""
     mid_sq = Subquery(OrganizationMembership.objects.filter(organization_id=org_id).values("user_id"))
     candidates: set[int] = set()
@@ -289,7 +288,7 @@ def _candidate_user_ids_for_organization(org_id: UUID | str) -> set[int]:
     return candidates
 
 
-def _candidate_user_ids_for_org_and_logins(org_id: UUID | str, logins_lower: frozenset[str]) -> set[int]:
+def _candidate_user_ids_for_org_and_logins(org_id: str, logins_lower: frozenset[str]) -> set[int]:
     """Subset of org members whose stored GitHub identity might match one of ``logins_lower`` (case-insensitive)."""
     if not logins_lower:
         return set()

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
+import json
 import logging
 from collections import Counter
+from collections.abc import Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any
+
+from django.db.models import Prefetch, QuerySet, Subquery
+from django.db.models.functions import Lower
 
 from social_django.models import UserSocialAuth
 
 from posthog.schema import RelevantCommit
 
-from posthog.models.integration import GitHubIntegration
+from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
+from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
+
+from ..models import SignalReportArtefact
 
 logger = logging.getLogger(__name__)
 
@@ -20,14 +29,78 @@ MAX_SUGGESTED_REVIEWERS = 3
 MAX_COMMIT_LOOKUPS = 15
 
 
-@dataclass
-class _ResolvedReviewer:
-    """Intermediate result from commit resolution."""
+def enrich_reviewer_dicts_with_org_members(
+    team_id: int,
+    reviewer_dicts: list[dict],
+    *,
+    login_to_user: Mapping[str, User] | None = None,
+) -> list[dict]:
+    """Enrich reviewer dicts (from artefact content) with fresh PostHog user info.
 
-    login: str
-    name: str | None
-    commits: list[RelevantCommit]
-    weight: int
+    Called at read time so that users who connect their GitHub account after the
+    artefact was created show up properly.
+    """
+    if not reviewer_dicts:
+        return reviewer_dicts
+
+    resolved_map: Mapping[str, User]
+    if login_to_user is not None:
+        resolved_map = login_to_user
+    else:
+        wanted = normalized_github_logins_from_reviewer_payloads(reviewer_dicts)
+        resolved_map = resolve_org_github_login_to_users(team_id, wanted) if wanted else dict[str, User]()
+
+    enriched: list[dict] = []
+    for r in reviewer_dicts:
+        login = r.get("github_login", "")
+        user = resolved_map.get(login.lower()) if login else None
+        enriched.append(
+            {
+                **r,
+                "user": {
+                    "id": user.id,
+                    "uuid": str(user.uuid),
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
+                    "email": user.email,
+                }
+                if user
+                else None,
+            }
+        )
+
+    return enriched
+
+
+def normalized_github_logins_from_suggested_reviewer_artefacts(
+    artefacts: Iterable[SignalReportArtefact],
+) -> frozenset[str]:
+    out: set[str] = set()
+    for art in artefacts:
+        if art.type != SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS:
+            continue
+        try:
+            parsed_list = json.loads(art.content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if not isinstance(parsed_list, list):
+            continue
+        out.update(normalized_github_logins_from_reviewer_payloads(parsed_list))
+    return frozenset(out)
+
+
+def normalized_github_logins_from_reviewer_payloads(rows: Iterable[object]) -> frozenset[str]:
+    logins: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        raw = row.get("github_login")
+        if not raw:
+            continue
+        s = str(raw).strip().lower()
+        if s:
+            logins.add(s)
+    return frozenset(logins)
 
 
 def resolve_suggested_reviewers(
@@ -94,7 +167,17 @@ def resolve_suggested_reviewers(
     ]
 
 
-def get_org_member_github_login_to_user_map(team_id: int) -> dict[str, Any] | None:
+@dataclass
+class _ResolvedReviewer:
+    """Intermediate result from commit resolution."""
+
+    login: str
+    name: str | None
+    commits: list[RelevantCommit]
+    weight: int
+
+
+def get_org_member_github_login_to_user_map(team_id: int) -> dict[str, User] | None:
     """Build a mapping of GitHub login -> PostHog User for the team's org.
 
     Returns None if the team doesn't exist, otherwise a dict (possibly empty).
@@ -104,35 +187,17 @@ def get_org_member_github_login_to_user_map(team_id: int) -> dict[str, Any] | No
     except Team.DoesNotExist:
         return None
 
-    org_member_user_ids = OrganizationMembership.objects.filter(
-        organization_id=org_id,
-    ).values_list("user_id", flat=True)
+    candidate_ids = _candidate_user_ids_for_organization(org_id)
+    if not candidate_ids:
+        return {}
 
-    social_auths = (
-        UserSocialAuth.objects.filter(
-            provider="github",
-            user_id__in=org_member_user_ids,
-        )
-        .select_related("user")
-        .only(
-            "extra_data",
-            "user__id",
-            "user__uuid",
-            "user__first_name",
-            "user__last_name",
-            "user__email",
-        )
-    )
+    users = User.objects.filter(id__in=candidate_ids).prefetch_related(*_github_identity_prefetches()).order_by("id")
 
-    login_to_user: dict[str, Any] = {}
-    for sa in social_auths:
-        extra = sa.extra_data
-        if isinstance(extra, dict):
-            login = extra.get("login")
-        else:
-            continue
+    login_to_user: dict[str, User] = {}
+    for user in users:
+        login = user.get_github_login()
         if login:
-            login_to_user[login.lower()] = sa.user
+            login_to_user[login.lower()] = user
 
     return login_to_user
 
@@ -147,65 +212,131 @@ def get_org_member_github_logins_by_user_uuid(team_id: int, user_uuids: list[str
     except Team.DoesNotExist:
         return {}
 
-    org_member_user_ids = OrganizationMembership.objects.filter(
-        organization_id=org_id,
-        user__uuid__in=user_uuids,
-    ).values_list("user_id", flat=True)
-
-    social_auths = (
-        UserSocialAuth.objects.filter(
-            provider="github",
-            user_id__in=org_member_user_ids,
-        )
-        .only("extra_data", "user__uuid", "user_id")
-        .select_related("user")
-        .order_by("user_id", "-id")
-        .distinct("user_id")
+    org_member_user_ids = list(
+        OrganizationMembership.objects.filter(
+            organization_id=org_id,
+            user__uuid__in=user_uuids,
+        ).values_list("user_id", flat=True)
     )
+    if not org_member_user_ids:
+        return {}
+
+    users = User.objects.filter(id__in=org_member_user_ids).prefetch_related(*_github_identity_prefetches())
 
     user_uuid_to_login: dict[str, str] = {}
-    for sa in social_auths:
-        extra = sa.extra_data
-        if not isinstance(extra, dict):
-            continue
-        login = extra.get("login")
+    for user in users:
+        login = user.get_github_login()
         if login:
-            user_uuid_to_login[str(sa.user.uuid)] = login.lower()
+            user_uuid_to_login[str(user.uuid)] = login.lower()
 
     return user_uuid_to_login
 
 
-def enrich_reviewer_dicts_with_org_members(
-    team_id: int,
-    reviewer_dicts: list[dict],
-) -> list[dict]:
-    """Enrich reviewer dicts (from artefact content) with fresh PostHog user info.
+def resolve_org_github_login_to_users(team_id: int, github_logins: Iterable[str]) -> dict[str, User]:
+    """Map normalized GitHub login -> org member ``User`` (same identity rules as ``User.get_github_login()``).
 
-    Called at read time so that users who connect their GitHub account after the
-    artefact was created show up properly.
+    Restricts DB work to users that plausibly match the requested logins.
     """
-    if not reviewer_dicts:
-        return reviewer_dicts
+    logins_normalized = frozenset(s.strip().lower() for s in github_logins if s and str(s).strip())
+    if not logins_normalized:
+        return {}
 
-    login_to_user = get_org_member_github_login_to_user_map(team_id)
+    try:
+        org_id = Team.objects.values_list("organization_id", flat=True).get(id=team_id)
+    except Team.DoesNotExist:
+        return {}
 
-    enriched: list[dict] = []
-    for r in reviewer_dicts:
-        login = r.get("github_login", "")
-        user = login_to_user.get(login.lower()) if login_to_user and login else None
-        enriched.append(
-            {
-                **r,
-                "user": {
-                    "id": user.id,
-                    "uuid": str(user.uuid),
-                    "first_name": user.first_name,
-                    "last_name": user.last_name,
-                    "email": user.email,
-                }
-                if user
-                else None,
-            }
+    candidate_ids = _candidate_user_ids_for_org_and_logins(org_id, logins_normalized)
+    if not candidate_ids:
+        return {}
+
+    users = User.objects.filter(id__in=candidate_ids).prefetch_related(*_github_identity_prefetches()).order_by("id")
+
+    login_to_user: dict[str, User] = {}
+    for user in users:
+        gl = user.get_github_login()
+        if not gl:
+            continue
+        k = gl.lower()
+        if k in logins_normalized:
+            login_to_user[k] = user
+    return login_to_user
+
+
+def _candidate_user_ids_for_organization(org_id: int) -> set[int]:
+    """Org member IDs that might have any GitHub identity."""
+    mid_sq = Subquery(OrganizationMembership.objects.filter(organization_id=org_id).values("user_id"))
+    candidates: set[int] = set()
+    candidates.update(
+        UserSocialAuth.objects.filter(provider="github", user_id__in=mid_sq).values_list("user_id", flat=True)
+    )
+    candidates.update(
+        UserIntegration.objects.filter(kind=UserIntegration.IntegrationKind.GITHUB, user_id__in=mid_sq).values_list(
+            "user_id", flat=True
         )
+    )
+    candidates.update(
+        Integration.objects.filter(kind="github", created_by_id__in=mid_sq)
+        .exclude(config__connecting_user_github_login=None)
+        .values_list("created_by_id", flat=True)
+    )
+    return candidates
 
-    return enriched
+
+def _candidate_user_ids_for_org_and_logins(org_id: int, logins_lower: frozenset[str]) -> set[int]:
+    """Subset of org members whose stored GitHub identity might match one of ``logins_lower`` (case-insensitive)."""
+    if not logins_lower:
+        return set()
+    mid_sq = Subquery(OrganizationMembership.objects.filter(organization_id=org_id).values("user_id"))
+    candidates: set[int] = set()
+    candidates.update(
+        _filter_github_login_field_lc(
+            UserSocialAuth.objects.filter(provider="github", user_id__in=mid_sq),
+            "extra_data__login",
+            logins_lower,
+        ).values_list("user_id", flat=True)
+    )
+    candidates.update(
+        _filter_github_login_field_lc(
+            UserIntegration.objects.filter(kind=UserIntegration.IntegrationKind.GITHUB, user_id__in=mid_sq),
+            "config__github_user__login",
+            logins_lower,
+        ).values_list("user_id", flat=True)
+    )
+    candidates.update(
+        _filter_github_login_field_lc(
+            Integration.objects.filter(kind="github", created_by_id__in=mid_sq).exclude(
+                config__connecting_user_github_login=None
+            ),
+            "config__connecting_user_github_login",
+            logins_lower,
+        ).values_list("created_by_id", flat=True)
+    )
+    return candidates
+
+
+def _filter_github_login_field_lc(
+    qs: QuerySet,
+    login_field_lookup: str,
+    logins_lower: frozenset[str],
+) -> QuerySet:
+    """Case-insensitive match: ``Lower(login_field_lookup) ∈ logins_lower`` (expects lowercased logins)."""
+    alias = "_github_login_lc_lookup"
+    return qs.annotate(**{alias: Lower(login_field_lookup)}).filter(**{f"{alias}__in": sorted(logins_lower)})
+
+
+def _github_identity_prefetches() -> tuple[Prefetch, ...]:
+    """Prefetch relations read by `User.get_github_login()` (includes team `Integration` via `integration_set`)."""
+    return (
+        Prefetch(
+            "integrations",
+            UserIntegration.objects.filter(kind=UserIntegration.IntegrationKind.GITHUB),
+        ),
+        Prefetch("social_auth", UserSocialAuth.objects.filter(provider="github")),
+        Prefetch(
+            "integration_set",
+            Integration.objects.filter(kind="github")
+            .exclude(config__connecting_user_github_login=None)
+            .only("config", "id", "created_by_id"),
+        ),
+    )

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from collections.abc import Mapping
+from typing import cast
 
 from asgiref.sync import async_to_sync
 from rest_framework import serializers
@@ -298,6 +300,14 @@ class SignalReportArtefactSerializer(serializers.ModelSerializer):
 
         # Enrich suggested_reviewers with fresh PostHog user info at read time
         if obj.type == SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS and isinstance(parsed, list):
-            return enrich_reviewer_dicts_with_org_members(obj.team_id, parsed)
+            reviewer_login_map = cast(
+                Mapping[str, User] | None,
+                self.context.get("signals_github_login_to_user_map"),
+            )
+            return enrich_reviewer_dicts_with_org_members(
+                obj.team_id,
+                parsed,
+                login_to_user=reviewer_login_map,
+            )
 
         return parsed

--- a/products/signals/backend/temporal/agentic/report.py
+++ b/products/signals/backend/temporal/agentic/report.py
@@ -29,7 +29,7 @@ from products.signals.backend.report_generation.research import (
     run_multi_turn_research,
 )
 from products.signals.backend.report_generation.resolve_reviewers import (
-    get_org_member_github_login_to_user_map,
+    resolve_org_github_login_to_users,
     resolve_suggested_reviewers,
 )
 from products.signals.backend.report_generation.select_repo import RepoSelectionResult
@@ -223,7 +223,9 @@ def _resolve_autostart_assignee(
     whether the report's priority is high enough (lower rank = higher priority).
     Returns the first matching ``User``, or ``None`` if nobody qualifies.
     """
-    login_to_user = get_org_member_github_login_to_user_map(team_id) or {}
+    login_to_user = resolve_org_github_login_to_users(
+        team_id, (str(r["github_login"]) for r in reviewers_content if r.get("github_login"))
+    )
     report_rank = _priority_rank(report_priority)
 
     # Map reviewer github logins to user IDs (preserving reviewer order)

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -327,19 +327,45 @@ class TestSignalReportListAPI(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("not_actionable", "not_actionable", False),
-            ("immediately_actionable", "immediately_actionable", True),
-            ("requires_human_input", "requires_human_input", True),
+            ("ready_not_actionable", SignalReport.Status.READY, "ready", "not_actionable", False),
+            (
+                "ready_immediately_actionable",
+                SignalReport.Status.READY,
+                "ready",
+                "immediately_actionable",
+                True,
+            ),
+            (
+                "ready_requires_human_input",
+                SignalReport.Status.READY,
+                "ready",
+                "requires_human_input",
+                True,
+            ),
+            (
+                "failed_immediately_actionable",
+                SignalReport.Status.FAILED,
+                "failed",
+                "immediately_actionable",
+                False,
+            ),
         ]
     )
-    def test_is_suggested_reviewer_matches_actionability(self, _name, actionability: str, expected_suggested: bool):
+    def test_is_suggested_reviewer_matches_actionability(
+        self,
+        name: str,
+        report_status: str,
+        status_filter: str,
+        actionability: str,
+        expected_suggested: bool,
+    ):
         UserSocialAuth.objects.create(
             user=self.user,
             provider="github",
-            uid=f"github-test-suggested-{actionability}",
+            uid=f"github-test-suggested-{name}",
             extra_data={"login": "suggestedgh"},
         )
-        report = self._create_report()
+        report = self._create_report(status=report_status)
         self._actionability_artefact(report, actionability=actionability)
         SignalReportArtefact.objects.create(
             team=self.team,
@@ -348,7 +374,7 @@ class TestSignalReportListAPI(APIBaseTest):
             content=json.dumps([{"github_login": "suggestedgh"}]),
         )
 
-        response = self.client.get(self._list_url(status="ready"))
+        response = self.client.get(self._list_url(status=status_filter))
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["is_suggested_reviewer"] is expected_suggested
@@ -373,26 +399,6 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["is_suggested_reviewer"] is True
-
-    def test_is_suggested_reviewer_false_when_failed(self):
-        UserSocialAuth.objects.create(
-            user=self.user,
-            provider="github",
-            uid="github-test-suggested-failed",
-            extra_data={"login": "suggestedgh"},
-        )
-        report = self._create_report(status=SignalReport.Status.FAILED)
-        SignalReportArtefact.objects.create(
-            team=self.team,
-            report=report,
-            type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
-            content=json.dumps([{"github_login": "suggestedgh"}]),
-        )
-
-        response = self.client.get(self._list_url(status="failed"))
-        assert response.status_code == status.HTTP_200_OK
-        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
-        assert row["is_suggested_reviewer"] is False
 
     # --- implementation_pr_url ---
 

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -374,6 +374,26 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["is_suggested_reviewer"] is True
 
+    def test_is_suggested_reviewer_false_when_failed(self):
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider="github",
+            uid="github-test-suggested-failed",
+            extra_data={"login": "suggestedgh"},
+        )
+        report = self._create_report(status=SignalReport.Status.FAILED)
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
+            content=json.dumps([{"github_login": "suggestedgh"}]),
+        )
+
+        response = self.client.get(self._list_url(status="failed"))
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["is_suggested_reviewer"] is False
+
     # --- implementation_pr_url ---
 
     def _create_implementation_task_with_run(

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -62,6 +62,8 @@ from products.signals.backend.models import (
 from products.signals.backend.report_generation.resolve_reviewers import (
     get_org_member_github_login_to_user_map,
     get_org_member_github_logins_by_user_uuid,
+    normalized_github_logins_from_suggested_reviewer_artefacts,
+    resolve_org_github_login_to_users,
 )
 from products.signals.backend.serializers import (
     SignalReportArtefactSerializer,
@@ -522,6 +524,7 @@ class SignalReportViewSet(
         # and checking jsonb containment on the artefact content list. This stays fresh
         # even when a user connects their GitHub account after the report was generated.
         # Never true for ready + not_actionable — there is nothing actionable to review.
+        # Failed reports are excluded too — pipelines that errored should not bubble as "needs your review".
         github_login = self._get_github_login(self.request.user)
         if not github_login:
             return queryset.annotate(is_suggested_reviewer=Value(False))
@@ -540,6 +543,7 @@ class SignalReportViewSet(
         return queryset.annotate(
             is_suggested_reviewer=Case(
                 When(self._Q_READY_NOT_ACTIONABLE, then=Value(False)),
+                When(status=SignalReport.Status.FAILED, then=Value(False)),
                 default=suggested_exists,
                 output_field=BooleanField(),
             ),
@@ -771,14 +775,19 @@ class SignalReportViewSet(
     @action(detail=True, methods=["get"], url_path="artefacts", required_scopes=["task:read"])
     def artefacts(self, request, pk=None, **kwargs):
         report = cast(SignalReport, self.get_object())
-        artefacts = report.artefacts.all().order_by("-created_at")
-        serializer = SignalReportArtefactSerializer(artefacts, many=True)
-        return Response(
-            {
-                "results": serializer.data,
-                "count": len(serializer.data),
-            }
+        artefacts = list(report.artefacts.all().order_by("-created_at"))
+        logins_union = normalized_github_logins_from_suggested_reviewer_artefacts(artefacts)
+        login_map = resolve_org_github_login_to_users(self.team.id, logins_union) if logins_union else {}
+        serializer = SignalReportArtefactSerializer(
+            artefacts,
+            many=True,
+            context={
+                **self.get_serializer_context(),
+                "signals_github_login_to_user_map": login_map,
+            },
         )
+        results = serializer.data
+        return Response({"results": results, "count": len(results)})
 
     @extend_schema(exclude=True)
     @action(detail=True, methods=["get"], url_path="signals", required_scopes=["task:read"])


### PR DESCRIPTION
## Problem

**1. Inconsistent GitHub identity for suggested reviewers.**

`is_suggested_reviewer` followed `User.get_github_login()` (user GitHub integration → GitHub social auth → team-level GitHub integration), but list filtering and enrichment for suggested reviewers only considered social auth. Gave wrong results for people linked via user integrations or project-level integrations.

**2. Misleading review signal on failed reports.**

`is_suggested_reviewer` could stay true on `failed` reports when the artefact still named the viewer’s GitHub login, even though those reports appear as all red - a confusing experience.

## Changes

- **Single GH login resolution path**: Inbox-related code paths now resolve GitHub login → org member the same way as `User.get_github_login()`, with room to prefetch efficiently and to scope work when only a small set of logins matters.
- **Suggested reviewer API behavior**: `is_suggested_reviewer` is false for `failed` reports; the artefacts list avoids repeating full-org resolution where one batched map is enough; serializer context passes that map through for enrichment.

## How did you test this code?

One new test.

## Publish to changelog?

Do not publish to changelog.