### PR TITLE
feat(data-warehouse): add Instagram source for organic content

### DIFF
--- a/posthog/migrations/1141_alter_integration_kind.py
+++ b/posthog/migrations/1141_alter_integration_kind.py
@@ -1,0 +1,54 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1140_integrationrepositorycacheentry"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="integration",
+            name="kind",
+            field=models.CharField(
+                choices=[
+                    ("apns", "Apple Push"),
+                    ("azure-blob", "Azure Blob"),
+                    ("bing-ads", "Bing Ads"),
+                    ("clickup", "Clickup"),
+                    ("customerio-app", "Customerio App"),
+                    ("customerio-track", "Customerio Track"),
+                    ("customerio-webhook", "Customerio Webhook"),
+                    ("databricks", "Databricks"),
+                    ("email", "Email"),
+                    ("firebase", "Firebase"),
+                    ("github", "Github"),
+                    ("gitlab", "Gitlab"),
+                    ("google-ads", "Google Ads"),
+                    ("google-cloud-service-account", "Google Cloud Service Account"),
+                    ("google-cloud-storage", "Google Cloud Storage"),
+                    ("google-pubsub", "Google Pubsub"),
+                    ("google-sheets", "Google Sheets"),
+                    ("hubspot", "Hubspot"),
+                    ("instagram", "Instagram"),
+                    ("intercom", "Intercom"),
+                    ("jira", "Jira"),
+                    ("linear", "Linear"),
+                    ("linkedin-ads", "Linkedin Ads"),
+                    ("meta-ads", "Meta Ads"),
+                    ("pinterest-ads", "Pinterest Ads"),
+                    ("postgresql", "Postgresql"),
+                    ("reddit-ads", "Reddit Ads"),
+                    ("salesforce", "Salesforce"),
+                    ("slack", "Slack"),
+                    ("slack-posthog-code", "Slack Posthog Code"),
+                    ("snapchat", "Snapchat"),
+                    ("stripe", "Stripe"),
+                    ("tiktok-ads", "Tiktok Ads"),
+                    ("twilio", "Twilio"),
+                    ("vercel", "Vercel"),
+                ],
+                max_length=32,
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1140_integrationrepositorycacheentry
+1141_alter_integration_kind

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -162,6 +162,7 @@ class Integration(models.Model):
         GOOGLE_PUBSUB = "google-pubsub"
         GOOGLE_SHEETS = "google-sheets"
         HUBSPOT = "hubspot"
+        INSTAGRAM = "instagram"
         INTERCOM = "intercom"
         JIRA = "jira"
         LINEAR = "linear"
@@ -298,6 +299,7 @@ class OauthIntegration:
         "tiktok-ads",
         "bing-ads",
         "meta-ads",
+        "instagram",
         "intercom",
         "linear",
         "clickup",
@@ -521,6 +523,25 @@ class OauthIntegration:
                 client_id=settings.META_ADS_APP_CLIENT_ID,
                 client_secret=settings.META_ADS_APP_CLIENT_SECRET,
                 scope="ads_read",
+                id_path="id",
+                name_path="name",
+            )
+        elif kind == "instagram":
+            # Reuses the same Meta/Facebook app credentials as meta-ads, but requests
+            # the Instagram Graph API content scopes instead of ads_read. Meta Ads
+            # already covers paid Instagram activity; this integration covers organic
+            # content (posts, stories, account insights).
+            if not settings.META_ADS_APP_CLIENT_ID or not settings.META_ADS_APP_CLIENT_SECRET:
+                raise NotImplementedError("Meta Ads app (used for Instagram OAuth) not configured")
+
+            return OauthConfig(
+                authorize_url=f"https://www.facebook.com/{InstagramIntegration.api_version}/dialog/oauth",
+                token_url=f"https://graph.facebook.com/{InstagramIntegration.api_version}/oauth/access_token",
+                token_info_url=f"https://graph.facebook.com/{InstagramIntegration.api_version}/me",
+                token_info_config_fields=["id", "name", "email"],
+                client_id=settings.META_ADS_APP_CLIENT_ID,
+                client_secret=settings.META_ADS_APP_CLIENT_SECRET,
+                scope="instagram_basic instagram_manage_insights pages_show_list pages_read_engagement business_management",
                 id_path="id",
                 name_path="name",
             )
@@ -2992,6 +3013,52 @@ class MetaAdsIntegration:
             self.integration.config["refreshed_at"] = int(time.time())
             # not used in CDP yet
             # reload_integrations_on_workers(self.integration.team_id, [self.integration.id])
+            oauth_refresh_counter.labels(self.integration.kind, "success").inc()
+        self.integration.save()
+
+
+class InstagramIntegration:
+    integration: Integration
+    api_version: str = "v23.0"
+
+    def __init__(self, integration: Integration) -> None:
+        if integration.kind != "instagram":
+            raise Exception("InstagramIntegration init called with Integration with wrong 'kind'")
+        self.integration = integration
+
+    def refresh_access_token(self):
+        oauth_config = OauthIntegration.oauth_config_for_kind(self.integration.kind)
+
+        if self.integration.config.get("expires_in") and self.integration.config.get("refreshed_at"):
+            if (
+                time.time()
+                > self.integration.config.get("refreshed_at") + self.integration.config.get("expires_in") - 604800
+            ):
+                return
+
+        res = requests.post(
+            oauth_config.token_url,
+            data={
+                "client_id": oauth_config.client_id,
+                "client_secret": oauth_config.client_secret,
+                "fb_exchange_token": self.integration.sensitive_config["access_token"],
+                "grant_type": "fb_exchange_token",
+                "set_token_expires_in_60_days": True,
+            },
+        )
+
+        config: dict = res.json()
+
+        if res.status_code != 200 or not config.get("access_token"):
+            logger.warning(f"Failed to refresh token for {self}", response=res.text)
+            self.integration.errors = ERROR_TOKEN_REFRESH_FAILED
+            oauth_refresh_counter.labels(self.integration.kind, "failed").inc()
+        else:
+            logger.info(f"Refreshed access token for {self}")
+            self.integration.sensitive_config["access_token"] = config["access_token"]
+            self.integration.errors = ""
+            self.integration.config["expires_in"] = config.get("expires_in")
+            self.integration.config["refreshed_at"] = int(time.time())
             oauth_refresh_counter.labels(self.integration.kind, "success").inc()
         self.integration.save()
 

--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -58,6 +58,7 @@ the row lists both.
 | google_ads    | gRPC                        | google-ads (googleads.client)                                   | ➖                          |
 | google_sheets | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
 | hubspot       | HTTP                        | requests                                                        | ✅                          |
+| instagram     | HTTP                        | requests                                                        | ✅                          |
 | klaviyo       | HTTP                        | requests                                                        | ✅                          |
 | linear        | HTTP                        | requests                                                        | ✅                          |
 | linkedin_ads  | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
@@ -109,7 +110,7 @@ ashby, auth0, azure_blob, bamboohr, bigcommerce, box, braintree, braze, brevo, c
 chartmogul, circleci, clickup, close, cockroachdb, confluence, convertkit, copper, datadog,
 drip, dynamodb, elasticsearch, eventbrite, facebook_pages, firebase, freshdesk, freshsales, front,
 fullstory, gitlab, gong, google_analytics, google_drive, gorgias, granola, greenhouse, helpscout,
-instagram, intercom, iterable, jira, kafka, launchdarkly, lever, mailerlite, mailjet, marketo,
+intercom, iterable, jira, kafka, launchdarkly, lever, mailerlite, mailjet, marketo,
 microsoft_teams, mixpanel, monday, netsuite, notion, okta, omnisend, onedrive, oracle, outreach,
 pagerduty, pardot, paypal, pendo, pipedrive, plaid, polar, postmark, productboard, quickbooks, recharge,
 recurly, revenuecat, ringcentral, salesloft, sendgrid, servicenow, sftp, sharepoint, shortcut, smartsheet,

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -412,7 +412,9 @@ class HubspotSourceConfig(config.Config):
 
 @config.config
 class InstagramSourceConfig(config.Config):
-    pass
+    ig_user_id: str
+    instagram_integration_id: int = config.value(converter=config.str_to_int)
+    sync_lookback_days: int | None = config.value(converter=config.str_to_optional_int, default_factory=lambda: None)
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/instagram/instagram.py
+++ b/posthog/temporal/data_imports/sources/instagram/instagram.py
@@ -2,6 +2,7 @@ import typing
 import datetime as dt
 import collections.abc
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from requests import Response
@@ -334,14 +335,14 @@ def instagram_source(
         kind = schema_def["kind"]
 
         if kind == "single":
-            params = {"fields": ",".join(schema_def["field_names"])}
-            response = _fetch_url(formatted_url, access_token, params)
+            single_params: dict[str, Any] = {"fields": ",".join(schema_def["field_names"])}
+            response = _fetch_url(formatted_url, access_token, single_params)
             payload = _check_response(response)
             yield [payload]
             return
 
         if kind == "list":
-            params = {
+            params: dict[str, Any] = {
                 "fields": ",".join(schema_def["field_names"]),
                 "limit": DEFAULT_PAGE_LIMIT,
                 **schema_def["extra_params"],

--- a/posthog/temporal/data_imports/sources/instagram/instagram.py
+++ b/posthog/temporal/data_imports/sources/instagram/instagram.py
@@ -1,0 +1,398 @@
+import typing
+import datetime as dt
+import collections.abc
+from dataclasses import dataclass
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from requests import Response
+
+from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, InstagramIntegration, Integration
+from posthog.temporal.data_imports.naming_convention import NamingConvention
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import InstagramSourceConfig
+from posthog.temporal.data_imports.sources.instagram.schemas import RESOURCE_SCHEMAS, InstagramResource
+
+from products.data_warehouse.backend.types import IncrementalFieldType
+
+# Instagram Graph API supports up to 2 years of insights history; we cap a touch
+# under that to stay safe.
+INSTAGRAM_MAX_HISTORY_DAYS = 2 * 365 - 30
+DEFAULT_SYNC_LOOKBACK_DAYS = 90
+
+# How many media/story rows to fetch per page on the parent listing endpoints.
+DEFAULT_PAGE_LIMIT = 100
+
+# user_insights only supports a max 30-day window per request.
+USER_INSIGHTS_MAX_DAYS_PER_REQUEST = 30
+
+
+@dataclass
+class InstagramResumeConfig:
+    """Resume state for an Instagram sync.
+
+    Three shapes are encoded here, distinguished by which fields are set:
+
+    - Simple cursor pagination (``media``, ``stories``): only ``next_url`` is
+      set. It is a ``paging.next`` URL with ``access_token`` stripped (see
+      ``_strip_access_token``); a fresh token is re-attached at request time on
+      resume.
+    - Time-windowed pagination (``user_insights``): ``end_date`` acts as the
+      discriminator. ``chunk_since`` describes where to restart the outer chunk
+      loop. ``chunk_next_url`` is set when the crash happened mid-chunk.
+    - Fan-out endpoints (``media_insights``, ``story_insights``): only
+      ``parent_next_url`` is set, pointing at the next page of parents to
+      iterate. We finish all child insight fetches for each parent batch before
+      saving — there's no mid-parent resume in v1.
+
+    All persisted URLs have ``access_token`` stripped.
+    """
+
+    next_url: str | None = None
+    end_date: str | None = None
+    chunk_since: str | None = None
+    chunk_next_url: str | None = None
+    parent_next_url: str | None = None
+
+
+def _strip_access_token(url: str) -> str:
+    """Remove the ``access_token`` query parameter from a URL.
+
+    Meta's ``paging.next`` URLs embed the caller's access token. We never want
+    that token at rest in Redis or in logs — it's re-attached at request time.
+    """
+    parts = urlsplit(url)
+    if not parts.query:
+        return url
+    filtered = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != "access_token"]
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(filtered), parts.fragment))
+
+
+def _fetch_url(url: str, access_token: str, params: dict | None = None) -> Response:
+    """Fetch a Graph API URL with a freshly injected access token.
+
+    Saved URLs always have ``access_token`` stripped; the token is provided via
+    ``params`` so it never persists in Redis or debug logs.
+    """
+    merged_params = {**(params or {}), "access_token": access_token}
+    return make_tracked_session().get(url, params=merged_params)
+
+
+def get_integration(config: InstagramSourceConfig, team_id: int) -> Integration:
+    integration = Integration.objects.get(id=config.instagram_integration_id, team_id=team_id)
+    instagram_integration = InstagramIntegration(integration)
+    instagram_integration.refresh_access_token()
+
+    if instagram_integration.integration.errors == ERROR_TOKEN_REFRESH_FAILED:
+        raise Exception("Failed to refresh token for Instagram integration. Please re-authorize the integration.")
+
+    return instagram_integration.integration
+
+
+def _check_response(response: Response) -> dict:
+    if response.status_code != 200:
+        raise Exception(f"Instagram API request failed: {response.status_code} - {response.text}")
+    return response.json()
+
+
+def _iter_simple_cursor(
+    initial_url: str,
+    initial_params: dict,
+    access_token: str,
+    resume_config: InstagramResumeConfig | None,
+    resumable_source_manager: ResumableSourceManager[InstagramResumeConfig],
+) -> collections.abc.Generator[list[dict], None, None]:
+    """Iterate a Graph API list endpoint via ``paging.next`` URLs.
+
+    On resume, ``resume_config.next_url`` is used as the starting point and the
+    initial request is skipped.
+    """
+    if resume_config is not None and resume_config.next_url and resume_config.end_date is None:
+        response = _fetch_url(resume_config.next_url, access_token)
+    else:
+        response = _fetch_url(initial_url, access_token, initial_params)
+
+    while True:
+        payload = _check_response(response)
+        yield payload.get("data", [])
+
+        next_url = payload.get("paging", {}).get("next")
+        if not next_url:
+            return
+
+        stripped = _strip_access_token(next_url)
+        resumable_source_manager.save_state(InstagramResumeConfig(next_url=stripped))
+        response = _fetch_url(stripped, access_token)
+
+
+def _flatten_insights(
+    raw_insights: list[dict],
+    parent_id: str,
+    parent_id_key: str,
+    parent_timestamp: str | None,
+) -> list[dict]:
+    """The /insights edge returns one row per metric, each row carrying a
+    ``values`` array. We flatten to one row per metric value, attaching the
+    parent ID (and parent ``timestamp`` for media/stories so partitioning works).
+    """
+    rows: list[dict] = []
+    for metric in raw_insights:
+        name = metric.get("name")
+        period = metric.get("period")
+        title = metric.get("title")
+        description = metric.get("description")
+        for value in metric.get("values", []):
+            row = {
+                parent_id_key: parent_id,
+                "name": name,
+                "period": period,
+                "title": title,
+                "description": description,
+                "value": value.get("value"),
+                "end_time": value.get("end_time"),
+            }
+            if parent_timestamp is not None:
+                row["timestamp"] = parent_timestamp
+            rows.append(row)
+    return rows
+
+
+def _iter_fanout_insights(
+    parent_url: str,
+    parent_fields: list[str],
+    metrics: list[str],
+    parent_id_key: str,
+    access_token: str,
+    resume_config: InstagramResumeConfig | None,
+    resumable_source_manager: ResumableSourceManager[InstagramResumeConfig],
+) -> collections.abc.Generator[list[dict], None, None]:
+    """Iterate parent media/stories, then fetch /insights per parent.
+
+    For each page of parents, yield one batch of flattened insight rows for all
+    parents in that page. Resume state captures the next *parent* page URL only;
+    if a crash happens mid-page the worst case is we re-fetch insights for at
+    most ``DEFAULT_PAGE_LIMIT`` parents — merge dedupes on
+    ``(parent_id, name)``.
+    """
+    if resume_config is not None and resume_config.parent_next_url:
+        parent_response = _fetch_url(resume_config.parent_next_url, access_token)
+    else:
+        parent_response = _fetch_url(
+            parent_url,
+            access_token,
+            {"fields": "id,timestamp", "limit": DEFAULT_PAGE_LIMIT},
+        )
+
+    while True:
+        parent_payload = _check_response(parent_response)
+        parents: list[dict] = parent_payload.get("data", [])
+
+        batch: list[dict] = []
+        for parent in parents:
+            parent_id = parent.get("id")
+            parent_timestamp = parent.get("timestamp")
+            if not parent_id:
+                continue
+            insight_url = f"https://graph.facebook.com/{InstagramIntegration.api_version}/{parent_id}/insights"
+            insight_response = _fetch_url(insight_url, access_token, {"metric": ",".join(metrics)})
+            # Some media types don't support some metrics — Graph API returns 400
+            # for those. Skip the parent rather than failing the whole sync.
+            if insight_response.status_code == 400:
+                continue
+            insight_payload = _check_response(insight_response)
+            batch.extend(
+                _flatten_insights(
+                    insight_payload.get("data", []),
+                    parent_id=parent_id,
+                    parent_id_key=parent_id_key,
+                    parent_timestamp=parent_timestamp,
+                )
+            )
+
+        if batch:
+            yield batch
+
+        next_parent_url = parent_payload.get("paging", {}).get("next")
+        if not next_parent_url:
+            return
+
+        stripped = _strip_access_token(next_parent_url)
+        resumable_source_manager.save_state(InstagramResumeConfig(parent_next_url=stripped))
+        parent_response = _fetch_url(stripped, access_token)
+
+
+def _iter_user_insights(
+    base_url: str,
+    metrics: list[str],
+    period: str,
+    ig_user_id: str,
+    start_date: dt.date,
+    end_date: dt.date,
+    access_token: str,
+    resume_config: InstagramResumeConfig | None,
+    resumable_source_manager: ResumableSourceManager[InstagramResumeConfig],
+) -> collections.abc.Generator[list[dict], None, None]:
+    """Iterate /me/insights in 30-day-or-smaller chunks (Graph API max).
+
+    Resume captures ``chunk_since`` for the outer loop and ``chunk_next_url``
+    for mid-chunk pagination state.
+    """
+    chunk_size_days = USER_INSIGHTS_MAX_DAYS_PER_REQUEST
+    current_start = start_date
+    pending_next_url: str | None = None
+
+    if resume_config is not None and resume_config.end_date is not None and resume_config.chunk_since is not None:
+        current_start = dt.datetime.strptime(resume_config.chunk_since, "%Y-%m-%d").date()
+        pending_next_url = resume_config.chunk_next_url
+
+    end_date_iso = end_date.strftime("%Y-%m-%d")
+
+    def _save(since: dt.date, next_url_in_chunk: str | None) -> None:
+        sanitised = _strip_access_token(next_url_in_chunk) if next_url_in_chunk else None
+        resumable_source_manager.save_state(
+            InstagramResumeConfig(
+                end_date=end_date_iso,
+                chunk_since=since.strftime("%Y-%m-%d"),
+                chunk_next_url=sanitised,
+            )
+        )
+
+    while current_start <= end_date:
+        current_end = min(current_start + dt.timedelta(days=chunk_size_days - 1), end_date)
+
+        if pending_next_url:
+            response = _fetch_url(pending_next_url, access_token)
+            pending_next_url = None
+        else:
+            since_ts = int(dt.datetime.combine(current_start, dt.time.min).timestamp())
+            until_ts = int(dt.datetime.combine(current_end + dt.timedelta(days=1), dt.time.min).timestamp())
+            response = _fetch_url(
+                base_url,
+                access_token,
+                {
+                    "metric": ",".join(metrics),
+                    "period": period,
+                    "since": since_ts,
+                    "until": until_ts,
+                },
+            )
+
+        while True:
+            payload = _check_response(response)
+            rows = _flatten_insights(
+                payload.get("data", []),
+                parent_id=ig_user_id,
+                parent_id_key="ig_user_id",
+                parent_timestamp=None,
+            )
+            if rows:
+                yield rows
+
+            next_url = payload.get("paging", {}).get("next")
+            if not next_url:
+                break
+
+            stripped = _strip_access_token(next_url)
+            _save(current_start, stripped)
+            response = _fetch_url(stripped, access_token)
+
+        current_start = current_end + dt.timedelta(days=1)
+        _save(current_start, None)
+
+
+def instagram_source(
+    resource_name: str,
+    config: InstagramSourceConfig,
+    team_id: int,
+    resumable_source_manager: ResumableSourceManager[InstagramResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: typing.Any = None,
+    incremental_field: str | None = None,
+    incremental_field_type: IncrementalFieldType | None = None,
+) -> SourceResponse:
+    """A data warehouse Instagram source."""
+    name = NamingConvention.normalize_identifier(resource_name)
+    schema_def = RESOURCE_SCHEMAS[InstagramResource(resource_name)]
+
+    sync_lookback_days = getattr(config, "sync_lookback_days", None)
+    if sync_lookback_days is None or sync_lookback_days < 1:
+        sync_lookback_days = DEFAULT_SYNC_LOOKBACK_DAYS
+    sync_lookback_days = min(sync_lookback_days, INSTAGRAM_MAX_HISTORY_DAYS)
+
+    ig_user_id = (config.ig_user_id or "").strip()
+
+    def get_rows():
+        integration = get_integration(config, team_id)
+        access_token = integration.access_token
+        if access_token is None:
+            raise ValueError("Access token is required for Instagram integration")
+
+        resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+        formatted_url = schema_def["url"].format(API_VERSION=InstagramIntegration.api_version, ig_user_id=ig_user_id)
+        kind = schema_def["kind"]
+
+        if kind == "single":
+            params = {"fields": ",".join(schema_def["field_names"])}
+            response = _fetch_url(formatted_url, access_token, params)
+            payload = _check_response(response)
+            yield [payload]
+            return
+
+        if kind == "list":
+            params = {
+                "fields": ",".join(schema_def["field_names"]),
+                "limit": DEFAULT_PAGE_LIMIT,
+                **schema_def["extra_params"],
+            }
+            yield from _iter_simple_cursor(formatted_url, params, access_token, resume_config, resumable_source_manager)
+            return
+
+        if kind in ("media_insights_fanout", "story_insights_fanout"):
+            parent_id_key = "media_id" if kind == "media_insights_fanout" else "story_id"
+            yield from _iter_fanout_insights(
+                parent_url=formatted_url,
+                parent_fields=["id", "timestamp"],
+                metrics=schema_def["metrics"],
+                parent_id_key=parent_id_key,
+                access_token=access_token,
+                resume_config=resume_config,
+                resumable_source_manager=resumable_source_manager,
+            )
+            return
+
+        if kind == "user_insights":
+            if should_use_incremental_field and db_incremental_field_last_value is not None:
+                if isinstance(db_incremental_field_last_value, dt.datetime):
+                    start_date = db_incremental_field_last_value.date()
+                elif isinstance(db_incremental_field_last_value, dt.date):
+                    start_date = db_incremental_field_last_value
+                else:
+                    start_date = dt.date.today() - dt.timedelta(days=sync_lookback_days)
+            else:
+                start_date = dt.date.today() - dt.timedelta(days=sync_lookback_days)
+            end_date = dt.date.today()
+            yield from _iter_user_insights(
+                base_url=formatted_url,
+                metrics=schema_def["metrics"],
+                period=schema_def["extra_params"].get("period", "day"),
+                ig_user_id=ig_user_id,
+                start_date=start_date,
+                end_date=end_date,
+                access_token=access_token,
+                resume_config=resume_config,
+                resumable_source_manager=resumable_source_manager,
+            )
+            return
+
+        raise ValueError(f"Unknown Instagram resource kind: {kind}")
+
+    return SourceResponse(
+        name=name,
+        items=get_rows,
+        primary_keys=schema_def["primary_keys"],
+        partition_mode=schema_def["partition_mode"],
+        partition_format=schema_def["partition_format"],
+        partition_keys=schema_def["partition_keys"],
+    )

--- a/posthog/temporal/data_imports/sources/instagram/schemas.py
+++ b/posthog/temporal/data_imports/sources/instagram/schemas.py
@@ -1,0 +1,191 @@
+from enum import StrEnum
+from typing import Any
+
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+
+class InstagramResource(StrEnum):
+    Users = "users"
+    Media = "media"
+    MediaInsights = "media_insights"
+    Stories = "stories"
+    StoryInsights = "story_insights"
+    UserInsights = "user_insights"
+
+
+ENDPOINTS = (
+    InstagramResource.Users,
+    InstagramResource.Media,
+    InstagramResource.MediaInsights,
+    InstagramResource.Stories,
+    InstagramResource.StoryInsights,
+    InstagramResource.UserInsights,
+)
+
+INCREMENTAL_ENDPOINTS = (InstagramResource.UserInsights,)
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    InstagramResource.UserInsights: [
+        {
+            "label": "end_time",
+            "type": IncrementalFieldType.DateTime,
+            "field": "end_time",
+            "field_type": IncrementalFieldType.DateTime,
+        }
+    ],
+}
+
+
+# Fields requested for the IG Business/Creator account profile.
+USERS_FIELDS = [
+    "id",
+    "username",
+    "name",
+    "biography",
+    "website",
+    "profile_picture_url",
+    "followers_count",
+    "follows_count",
+    "media_count",
+]
+
+# Fields requested per media object.
+MEDIA_FIELDS = [
+    "id",
+    "caption",
+    "media_type",
+    "media_product_type",
+    "media_url",
+    "thumbnail_url",
+    "permalink",
+    "timestamp",
+    "username",
+    "like_count",
+    "comments_count",
+    "is_comment_enabled",
+    "owner",
+    "shortcode",
+]
+
+# Fields requested per story object. Stories are a subset of media with a 24h TTL.
+STORIES_FIELDS = [
+    "id",
+    "caption",
+    "media_type",
+    "media_product_type",
+    "media_url",
+    "thumbnail_url",
+    "permalink",
+    "timestamp",
+    "username",
+    "owner",
+]
+
+# Per-media insight metric names. Reels and feed posts share most of these;
+# the Graph API silently drops unsupported metrics per media-type, so we ask
+# for the union and let the API filter.
+MEDIA_INSIGHTS_METRICS = [
+    "impressions",
+    "reach",
+    "saved",
+    "video_views",
+    "likes",
+    "comments",
+    "shares",
+    "total_interactions",
+    "profile_visits",
+    "follows",
+]
+
+# Per-story insight metric names.
+STORY_INSIGHTS_METRICS = [
+    "impressions",
+    "reach",
+    "replies",
+    "exits",
+    "taps_forward",
+    "taps_back",
+]
+
+# Account-level daily metrics. These come from the /insights edge with period=day.
+USER_INSIGHTS_METRICS = [
+    "impressions",
+    "reach",
+    "profile_views",
+    "website_clicks",
+    "follower_count",
+    "email_contacts",
+    "phone_call_clicks",
+    "text_message_clicks",
+    "get_directions_clicks",
+]
+
+
+RESOURCE_SCHEMAS: dict[InstagramResource, dict[str, Any]] = {
+    InstagramResource.Users: {
+        "primary_keys": ["id"],
+        "url": "https://graph.facebook.com/{API_VERSION}/{ig_user_id}",
+        "extra_params": {},
+        "field_names": USERS_FIELDS,
+        "partition_mode": None,
+        "partition_format": None,
+        "partition_keys": [],
+        "kind": "single",
+    },
+    InstagramResource.Media: {
+        "primary_keys": ["id"],
+        "url": "https://graph.facebook.com/{API_VERSION}/{ig_user_id}/media",
+        "extra_params": {},
+        "field_names": MEDIA_FIELDS,
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "partition_keys": ["timestamp"],
+        "kind": "list",
+    },
+    InstagramResource.Stories: {
+        "primary_keys": ["id"],
+        "url": "https://graph.facebook.com/{API_VERSION}/{ig_user_id}/stories",
+        "extra_params": {},
+        "field_names": STORIES_FIELDS,
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "partition_keys": ["timestamp"],
+        "kind": "list",
+    },
+    InstagramResource.MediaInsights: {
+        "primary_keys": ["media_id", "name"],
+        "url": "https://graph.facebook.com/{API_VERSION}/{ig_user_id}/media",
+        "extra_params": {},
+        "field_names": [],
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "partition_keys": ["timestamp"],
+        "kind": "media_insights_fanout",
+        "metrics": MEDIA_INSIGHTS_METRICS,
+        "is_stats": True,
+    },
+    InstagramResource.StoryInsights: {
+        "primary_keys": ["story_id", "name"],
+        "url": "https://graph.facebook.com/{API_VERSION}/{ig_user_id}/stories",
+        "extra_params": {},
+        "field_names": [],
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "partition_keys": ["timestamp"],
+        "kind": "story_insights_fanout",
+        "metrics": STORY_INSIGHTS_METRICS,
+        "is_stats": True,
+    },
+    InstagramResource.UserInsights: {
+        "primary_keys": ["ig_user_id", "name", "end_time"],
+        "url": "https://graph.facebook.com/{API_VERSION}/{ig_user_id}/insights",
+        "extra_params": {"period": "day"},
+        "field_names": [],
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "partition_keys": ["end_time"],
+        "kind": "user_insights",
+        "metrics": USER_INSIGHTS_METRICS,
+        "is_stats": True,
+    },
+}

--- a/posthog/temporal/data_imports/sources/instagram/source.py
+++ b/posthog/temporal/data_imports/sources/instagram/source.py
@@ -122,6 +122,7 @@ class InstagramSource(ResumableSource[InstagramSourceConfig, InstagramResumeConf
                         label="Instagram account",
                         required=True,
                         kind="instagram",
+                        requiredScopes="instagram_basic instagram_manage_insights pages_show_list pages_read_engagement business_management",
                     ),
                     SourceFieldInputConfig(
                         name="sync_lookback_days",

--- a/posthog/temporal/data_imports/sources/instagram/source.py
+++ b/posthog/temporal/data_imports/sources/instagram/source.py
@@ -1,29 +1,136 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SourceFieldOauthConfig,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.exceptions_capture import capture_exception
+from posthog.models.integration import Integration
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import InstagramSourceConfig
+from posthog.temporal.data_imports.sources.instagram.instagram import InstagramResumeConfig, instagram_source
+from posthog.temporal.data_imports.sources.instagram.schemas import ENDPOINTS, INCREMENTAL_FIELDS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class InstagramSource(SimpleSource[InstagramSourceConfig]):
+class InstagramSource(ResumableSource[InstagramSourceConfig, InstagramResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.INSTAGRAM
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "Failed to refresh token for Instagram integration. Please re-authorize the integration.": None,
+            "(#10) Application does not have permission for this action": "Your Instagram integration is missing required scopes. Please reconnect.",
+            "Error validating access token": "Your Instagram access token is invalid or expired. Please reconnect.",
+            "Instagram account not found": None,
+        }
+
+    def validate_credentials(
+        self, config: InstagramSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if not config.ig_user_id or not config.instagram_integration_id:
+            return False, "Instagram Business Account ID and Instagram integration are required"
+
+        try:
+            Integration.objects.get(id=config.instagram_integration_id, team_id=team_id)
+            return True, None
+        except Integration.DoesNotExist:
+            return False, "Instagram integration not found. Please re-authenticate."
+        except Exception as e:
+            capture_exception(e)
+            return False, f"Failed to validate Instagram credentials: {str(e)}"
+
+    def get_schemas(
+        self,
+        config: InstagramSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None,
+                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[InstagramResumeConfig]:
+        return ResumableSourceManager[InstagramResumeConfig](inputs, InstagramResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: InstagramSourceConfig,
+        resumable_source_manager: ResumableSourceManager[InstagramResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return instagram_source(
+            resource_name=inputs.schema_name,
+            config=config,
+            team_id=inputs.team_id,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            incremental_field=inputs.incremental_field if inputs.should_use_incremental_field else None,
+            incremental_field_type=inputs.incremental_field_type if inputs.should_use_incremental_field else None,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
+        )
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.INSTAGRAM,
             label="Instagram",
+            caption="Sync your Instagram Business or Creator account profile, media, stories, and account insights. Note: paid Instagram ad activity is covered by the separate Meta Ads source.",
             iconPath="/static/services/instagram.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/instagram",
+            releaseStatus="alpha",
+            featureFlag="dwh-instagram",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="ig_user_id",
+                        label="Instagram Business Account ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="17841400000000000",
+                        secret=False,
+                    ),
+                    SourceFieldOauthConfig(
+                        name="instagram_integration_id",
+                        label="Instagram account",
+                        required=True,
+                        kind="instagram",
+                    ),
+                    SourceFieldInputConfig(
+                        name="sync_lookback_days",
+                        label="Sync history for insights (days) - applies to user_insights",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=False,
+                        placeholder="90",
+                        secret=False,
+                    ),
+                ],
+            ),
         )

--- a/posthog/temporal/data_imports/sources/instagram/test_instagram.py
+++ b/posthog/temporal/data_imports/sources/instagram/test_instagram.py
@@ -1,0 +1,293 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.instagram.instagram import (
+    InstagramResumeConfig,
+    _flatten_insights,
+    _iter_fanout_insights,
+    _iter_simple_cursor,
+    _strip_access_token,
+)
+from posthog.temporal.data_imports.sources.instagram.schemas import (
+    INCREMENTAL_FIELDS,
+    RESOURCE_SCHEMAS,
+    InstagramResource,
+)
+
+
+def _mock_response(status: int, body: dict) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status
+    response.json.return_value = body
+    response.text = ""
+    return response
+
+
+def _build_manager(*, can_resume: bool = False, state: InstagramResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = can_resume
+    manager.load_state.return_value = state
+    return manager
+
+
+class TestStripAccessToken:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (
+                "https://graph.facebook.com/v23.0/next?access_token=secret&cursor=abc",
+                "https://graph.facebook.com/v23.0/next?cursor=abc",
+            ),
+            (
+                "https://graph.facebook.com/v23.0/next?cursor=abc&access_token=secret",
+                "https://graph.facebook.com/v23.0/next?cursor=abc",
+            ),
+            (
+                "https://graph.facebook.com/v23.0/next?access_token=secret",
+                "https://graph.facebook.com/v23.0/next",
+            ),
+            (
+                "https://graph.facebook.com/v23.0/next?cursor=abc",
+                "https://graph.facebook.com/v23.0/next?cursor=abc",
+            ),
+            (
+                "https://graph.facebook.com/v23.0/next",
+                "https://graph.facebook.com/v23.0/next",
+            ),
+            (
+                "https://example/path?access_token=a&foo=1&access_token=b",
+                "https://example/path?foo=1",
+            ),
+        ],
+    )
+    def test_strips(self, url: str, expected: str) -> None:
+        assert _strip_access_token(url) == expected
+
+
+class TestFlattenInsights:
+    def test_flattens_one_metric_one_value(self):
+        rows = _flatten_insights(
+            [
+                {
+                    "name": "impressions",
+                    "period": "day",
+                    "title": "Impressions",
+                    "description": "Total impressions",
+                    "values": [{"value": 42, "end_time": "2026-04-01T07:00:00+0000"}],
+                }
+            ],
+            parent_id="ig_123",
+            parent_id_key="ig_user_id",
+            parent_timestamp=None,
+        )
+        assert rows == [
+            {
+                "ig_user_id": "ig_123",
+                "name": "impressions",
+                "period": "day",
+                "title": "Impressions",
+                "description": "Total impressions",
+                "value": 42,
+                "end_time": "2026-04-01T07:00:00+0000",
+            }
+        ]
+
+    def test_attaches_parent_timestamp_when_provided(self):
+        rows = _flatten_insights(
+            [{"name": "reach", "period": "lifetime", "values": [{"value": 100}]}],
+            parent_id="m1",
+            parent_id_key="media_id",
+            parent_timestamp="2026-01-01T00:00:00+0000",
+        )
+        assert len(rows) == 1
+        assert rows[0]["media_id"] == "m1"
+        assert rows[0]["timestamp"] == "2026-01-01T00:00:00+0000"
+
+    def test_one_metric_many_values(self):
+        rows = _flatten_insights(
+            [
+                {
+                    "name": "impressions",
+                    "values": [
+                        {"value": 1, "end_time": "2026-04-01T00:00:00+0000"},
+                        {"value": 2, "end_time": "2026-04-02T00:00:00+0000"},
+                    ],
+                }
+            ],
+            parent_id="x",
+            parent_id_key="ig_user_id",
+            parent_timestamp=None,
+        )
+        assert len(rows) == 2
+        assert rows[0]["value"] == 1
+        assert rows[1]["value"] == 2
+
+
+class TestSimpleCursorPagination:
+    INITIAL_URL = "https://graph.facebook.com/v23.0/ig_123/media"
+    INITIAL_PARAMS: dict[str, Any] = {"fields": "id,timestamp", "limit": 100}
+
+    def test_fresh_run_follows_paging_next(self):
+        manager = _build_manager()
+        responses = [
+            _mock_response(
+                200,
+                {
+                    "data": [{"id": "1"}, {"id": "2"}],
+                    "paging": {"next": "https://graph.facebook.com/v23.0/next?access_token=tok&cursor=abc"},
+                },
+            ),
+            _mock_response(200, {"data": [{"id": "3"}], "paging": {}}),
+        ]
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.instagram.instagram.make_tracked_session"
+        ) as mock_session:
+            mock_session.return_value.get.side_effect = responses
+            batches = list(
+                _iter_simple_cursor(
+                    self.INITIAL_URL,
+                    self.INITIAL_PARAMS,
+                    "tok",
+                    None,
+                    manager,
+                )
+            )
+
+        assert batches == [[{"id": "1"}, {"id": "2"}], [{"id": "3"}]]
+        # State should have been saved exactly once — after the first batch, with
+        # the access_token-stripped next URL.
+        assert manager.save_state.call_count == 1
+        saved = manager.save_state.call_args.args[0]
+        assert isinstance(saved, InstagramResumeConfig)
+        assert saved.next_url == "https://graph.facebook.com/v23.0/next?cursor=abc"
+
+    def test_resume_skips_initial_request(self):
+        manager = _build_manager(
+            can_resume=True,
+            state=InstagramResumeConfig(next_url="https://graph.facebook.com/v23.0/next?cursor=abc"),
+        )
+        response = _mock_response(200, {"data": [{"id": "9"}], "paging": {}})
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.instagram.instagram.make_tracked_session"
+        ) as mock_session:
+            mock_session.return_value.get.return_value = response
+            batches = list(
+                _iter_simple_cursor(
+                    self.INITIAL_URL,
+                    self.INITIAL_PARAMS,
+                    "tok",
+                    manager.load_state(),
+                    manager,
+                )
+            )
+
+        assert batches == [[{"id": "9"}]]
+        # The first (and only) GET should have been to the saved URL, not the initial URL.
+        first_call = mock_session.return_value.get.call_args_list[0]
+        assert first_call.args[0] == "https://graph.facebook.com/v23.0/next?cursor=abc"
+
+    def test_non_200_raises(self):
+        manager = _build_manager()
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.instagram.instagram.make_tracked_session"
+        ) as mock_session:
+            mock_session.return_value.get.return_value = _mock_response(401, {"error": "bad token"})
+            with pytest.raises(Exception, match="Instagram API request failed"):
+                list(
+                    _iter_simple_cursor(
+                        self.INITIAL_URL,
+                        self.INITIAL_PARAMS,
+                        "tok",
+                        None,
+                        manager,
+                    )
+                )
+
+
+class TestFanoutInsights:
+    PARENT_URL = "https://graph.facebook.com/v23.0/ig_123/media"
+
+    def test_fans_out_per_parent_and_skips_400(self):
+        manager = _build_manager()
+
+        # Parent page returns two media rows; second media's insights endpoint
+        # returns 400 (e.g. metric not supported for that media type) and should
+        # be silently skipped, not crash the sync.
+        parent_response = _mock_response(
+            200,
+            {
+                "data": [
+                    {"id": "m1", "timestamp": "2026-04-01T00:00:00+0000"},
+                    {"id": "m2", "timestamp": "2026-04-02T00:00:00+0000"},
+                ],
+                "paging": {},
+            },
+        )
+        m1_insights = _mock_response(
+            200,
+            {"data": [{"name": "impressions", "values": [{"value": 5}]}]},
+        )
+        m2_insights_400 = _mock_response(400, {"error": "(#100) metric not supported"})
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.instagram.instagram.make_tracked_session"
+        ) as mock_session:
+            mock_session.return_value.get.side_effect = [parent_response, m1_insights, m2_insights_400]
+            batches = list(
+                _iter_fanout_insights(
+                    parent_url=self.PARENT_URL,
+                    parent_fields=["id", "timestamp"],
+                    metrics=["impressions"],
+                    parent_id_key="media_id",
+                    access_token="tok",
+                    resume_config=None,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert len(batches) == 1
+        rows = batches[0]
+        assert len(rows) == 1
+        assert rows[0]["media_id"] == "m1"
+        assert rows[0]["timestamp"] == "2026-04-01T00:00:00+0000"
+        assert rows[0]["name"] == "impressions"
+
+
+class TestSchemaCatalog:
+    def test_all_endpoints_have_required_fields(self):
+        for _resource, schema in RESOURCE_SCHEMAS.items():
+            assert "primary_keys" in schema
+            assert isinstance(schema["primary_keys"], list)
+            assert len(schema["primary_keys"]) >= 1
+            assert "url" in schema
+            assert schema["url"].startswith("https://graph.facebook.com/")
+            assert "kind" in schema
+
+    @pytest.mark.parametrize(
+        "resource,expected_pk",
+        [
+            (InstagramResource.Users, ["id"]),
+            (InstagramResource.Media, ["id"]),
+            (InstagramResource.Stories, ["id"]),
+            (InstagramResource.MediaInsights, ["media_id", "name"]),
+            (InstagramResource.StoryInsights, ["story_id", "name"]),
+            (InstagramResource.UserInsights, ["ig_user_id", "name", "end_time"]),
+        ],
+    )
+    def test_primary_key_for_each_endpoint(self, resource: InstagramResource, expected_pk: list[str]):
+        assert RESOURCE_SCHEMAS[resource]["primary_keys"] == expected_pk
+
+    def test_only_user_insights_is_in_incremental_fields(self):
+        assert set(INCREMENTAL_FIELDS.keys()) == {InstagramResource.UserInsights}
+
+    def test_partition_keys_use_stable_fields(self):
+        # Picking a stable partition key (timestamp/end_time) is critical — using
+        # an updated_at would cause partition rewrites on every sync.
+        for resource, schema in RESOURCE_SCHEMAS.items():
+            for key in schema.get("partition_keys") or []:
+                assert key in {"timestamp", "end_time"}, f"{resource}: unstable partition key {key}"

--- a/posthog/temporal/data_imports/sources/instagram/test_instagram_source.py
+++ b/posthog/temporal/data_imports/sources/instagram/test_instagram_source.py
@@ -1,0 +1,110 @@
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import InstagramSourceConfig
+from posthog.temporal.data_imports.sources.instagram.instagram import InstagramResumeConfig
+from posthog.temporal.data_imports.sources.instagram.schemas import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.instagram.source import InstagramSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestInstagramSource:
+    def setup_method(self):
+        self.source = InstagramSource()
+        self.team_id = 123
+        self.config = InstagramSourceConfig(
+            ig_user_id="17841400000000000",
+            instagram_integration_id=456,
+        )
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.INSTAGRAM
+
+    def test_get_source_config_basics(self):
+        config = self.source.get_source_config
+        assert config.label == "Instagram"
+        assert config.iconPath == "/static/services/instagram.png"
+        assert config.releaseStatus == "alpha"
+        assert config.featureFlag == "dwh-instagram"
+        # Three fields: ig_user_id, instagram_integration_id (OAuth), sync_lookback_days.
+        names = [getattr(f, "name", None) for f in config.fields]
+        assert "ig_user_id" in names
+        assert "instagram_integration_id" in names
+        assert "sync_lookback_days" in names
+
+    def test_get_schemas_returns_all_endpoints(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == {e.value for e in ENDPOINTS}
+
+    def test_get_schemas_filters_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["users", "media"])
+        assert {s.name for s in schemas} == {"users", "media"}
+
+    def test_only_user_insights_supports_incremental(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        incremental_names = {s.name for s in schemas if s.supports_incremental}
+        assert incremental_names == set(INCREMENTAL_FIELDS.keys())
+        assert incremental_names == {"user_insights"}
+
+    def test_validate_credentials_missing_ig_user_id(self):
+        invalid_config = InstagramSourceConfig(ig_user_id="", instagram_integration_id=456)
+        ok, error = self.source.validate_credentials(invalid_config, self.team_id)
+        assert ok is False
+        assert error is not None
+        assert "Instagram" in error
+
+    @mock.patch("posthog.temporal.data_imports.sources.instagram.source.Integration")
+    def test_validate_credentials_integration_missing(self, mock_integration):
+        class MockDoesNotExist(Exception):
+            pass
+
+        mock_integration.DoesNotExist = MockDoesNotExist
+        mock_integration.objects.get.side_effect = MockDoesNotExist()
+
+        ok, error = self.source.validate_credentials(self.config, self.team_id)
+        assert ok is False
+        assert error is not None
+        assert "Instagram integration not found" in error
+
+    @mock.patch("posthog.temporal.data_imports.sources.instagram.source.Integration")
+    def test_validate_credentials_success(self, mock_integration):
+        mock_integration.DoesNotExist = type("MockDoesNotExist", (Exception,), {})
+        mock_integration.objects.get.return_value = mock.MagicMock()
+        ok, error = self.source.validate_credentials(self.config, self.team_id)
+        assert ok is True
+        assert error is None
+
+    def test_get_resumable_source_manager_returns_manager_bound_to_resume_config(self):
+        inputs = mock.MagicMock()
+        manager = self.source.get_resumable_source_manager(inputs)
+        assert isinstance(manager, ResumableSourceManager)
+        # The manager is parameterized over InstagramResumeConfig — saving/loading state
+        # should round-trip through that dataclass. Smoke-check the binding via the
+        # private attribute set at construction time.
+        assert manager._data_class is InstagramResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.instagram.source.instagram_source")
+    def test_source_for_pipeline_passes_through(self, mock_source_fn):
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+        inputs = mock.MagicMock()
+        inputs.schema_name = "media"
+        inputs.team_id = 7
+        inputs.should_use_incremental_field = False
+        inputs.incremental_field = None
+        inputs.incremental_field_type = None
+        inputs.db_incremental_field_last_value = None
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_source_fn.assert_called_once()
+        call_kwargs = mock_source_fn.call_args.kwargs
+        assert call_kwargs["resource_name"] == "media"
+        assert call_kwargs["team_id"] == 7
+        assert call_kwargs["resumable_source_manager"] is manager
+        assert call_kwargs["should_use_incremental_field"] is False
+
+    def test_get_non_retryable_errors_includes_token_failure(self):
+        errors = self.source.get_non_retryable_errors()
+        assert any("re-authorize" in key for key in errors)
+        assert any("Error validating access token" in key for key in errors)

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -171,6 +171,7 @@ export interface RoleLookupResponseApi {
  * `google-pubsub` - Google Pubsub
  * `google-sheets` - Google Sheets
  * `hubspot` - Hubspot
+ * `instagram` - Instagram
  * `intercom` - Intercom
  * `jira` - Jira
  * `linear` - Linear
@@ -209,6 +210,7 @@ export const IntegrationKindEnumApi = {
     GooglePubsub: 'google-pubsub',
     GoogleSheets: 'google-sheets',
     Hubspot: 'hubspot',
+    Instagram: 'instagram',
     Intercom: 'intercom',
     Jira: 'jira',
     Linear: 'linear',

--- a/products/integrations/frontend/generated/api.zod.ts
+++ b/products/integrations/frontend/generated/api.zod.ts
@@ -80,6 +80,7 @@ export const IntegrationsCreateBody = /* @__PURE__ */ zod
                 'google-pubsub',
                 'google-sheets',
                 'hubspot',
+                'instagram',
                 'intercom',
                 'jira',
                 'linear',
@@ -98,7 +99,7 @@ export const IntegrationsCreateBody = /* @__PURE__ */ zod
                 'vercel',
             ])
             .describe(
-                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `instagram` - Instagram\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
             ),
         config: zod.unknown().optional(),
     })
@@ -126,6 +127,7 @@ export const IntegrationsEmailPartialUpdateBody = /* @__PURE__ */ zod
                 'google-pubsub',
                 'google-sheets',
                 'hubspot',
+                'instagram',
                 'intercom',
                 'jira',
                 'linear',
@@ -145,7 +147,7 @@ export const IntegrationsEmailPartialUpdateBody = /* @__PURE__ */ zod
             ])
             .optional()
             .describe(
-                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `instagram` - Instagram\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
             ),
         config: zod.unknown().optional(),
     })
@@ -173,6 +175,7 @@ export const IntegrationsEmailVerifyCreateBody = /* @__PURE__ */ zod
                 'google-pubsub',
                 'google-sheets',
                 'hubspot',
+                'instagram',
                 'intercom',
                 'jira',
                 'linear',
@@ -191,7 +194,7 @@ export const IntegrationsEmailVerifyCreateBody = /* @__PURE__ */ zod
                 'vercel',
             ])
             .describe(
-                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `instagram` - Instagram\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
             ),
         config: zod.unknown().optional(),
     })
@@ -226,6 +229,7 @@ export const IntegrationsDomainConnectApplyUrlCreateBody = /* @__PURE__ */ zod
                 'google-pubsub',
                 'google-sheets',
                 'hubspot',
+                'instagram',
                 'intercom',
                 'jira',
                 'linear',
@@ -244,7 +248,7 @@ export const IntegrationsDomainConnectApplyUrlCreateBody = /* @__PURE__ */ zod
                 'vercel',
             ])
             .describe(
-                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `instagram` - Instagram\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
             ),
         config: zod.unknown().optional(),
     })
@@ -275,6 +279,7 @@ export const IntegrationsGithubLinkExistingCreateBody = /* @__PURE__ */ zod
                 'google-pubsub',
                 'google-sheets',
                 'hubspot',
+                'instagram',
                 'intercom',
                 'jira',
                 'linear',
@@ -293,7 +298,7 @@ export const IntegrationsGithubLinkExistingCreateBody = /* @__PURE__ */ zod
                 'vercel',
             ])
             .describe(
-                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `instagram` - Instagram\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
             ),
         config: zod.unknown().optional(),
     })
@@ -324,6 +329,7 @@ export const IntegrationsGithubOauthAuthorizeCreateBody = /* @__PURE__ */ zod
                 'google-pubsub',
                 'google-sheets',
                 'hubspot',
+                'instagram',
                 'intercom',
                 'jira',
                 'linear',
@@ -342,7 +348,7 @@ export const IntegrationsGithubOauthAuthorizeCreateBody = /* @__PURE__ */ zod
                 'vercel',
             ])
             .describe(
-                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
+                '* `apns` - Apple Push\n* `azure-blob` - Azure Blob\n* `bing-ads` - Bing Ads\n* `clickup` - Clickup\n* `customerio-app` - Customerio App\n* `customerio-track` - Customerio Track\n* `customerio-webhook` - Customerio Webhook\n* `databricks` - Databricks\n* `email` - Email\n* `firebase` - Firebase\n* `github` - Github\n* `gitlab` - Gitlab\n* `google-ads` - Google Ads\n* `google-cloud-service-account` - Google Cloud Service Account\n* `google-cloud-storage` - Google Cloud Storage\n* `google-pubsub` - Google Pubsub\n* `google-sheets` - Google Sheets\n* `hubspot` - Hubspot\n* `instagram` - Instagram\n* `intercom` - Intercom\n* `jira` - Jira\n* `linear` - Linear\n* `linkedin-ads` - Linkedin Ads\n* `meta-ads` - Meta Ads\n* `pinterest-ads` - Pinterest Ads\n* `postgresql` - Postgresql\n* `reddit-ads` - Reddit Ads\n* `salesforce` - Salesforce\n* `slack` - Slack\n* `slack-posthog-code` - Slack Posthog Code\n* `snapchat` - Snapchat\n* `stripe` - Stripe\n* `tiktok-ads` - Tiktok Ads\n* `twilio` - Twilio\n* `vercel` - Vercel'
             ),
         config: zod.unknown().optional(),
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20726,6 +20726,7 @@ export namespace Schemas {
     * `google-pubsub` - Google Pubsub
     * `google-sheets` - Google Sheets
     * `hubspot` - Hubspot
+    * `instagram` - Instagram
     * `intercom` - Intercom
     * `jira` - Jira
     * `linear` - Linear
@@ -20765,6 +20766,7 @@ export namespace Schemas {
       GooglePubsub: 'google-pubsub',
       GoogleSheets: 'google-sheets',
       Hubspot: 'hubspot',
+      Instagram: 'instagram',
       Intercom: 'intercom',
       Jira: 'jira',
       Linear: 'linear',


### PR DESCRIPTION
## Problem

The Data warehouse can already pull paid Instagram activity through the existing Meta Ads source (campaigns, adsets, ads, insights for ads targeting Instagram placements). What's been missing is the **organic content** side: published posts, stories, per-media engagement, and account-level insights.

Instagram has been listed as scaffolded in `SOURCES.md` (registered in `__init__.py` with `unreleasedSource=True`, empty `source.py`) for a while. This PR fills it in.

## Changes

Implements the Instagram Graph API as a working `ResumableSource`. Mirrors the existing Meta Ads source closely — same Graph API host, same `paging.next` cursor pagination, same access-token-stripping pattern when persisting resume URLs.

### Endpoints (v1)

| Schema           | Grain                | Incremental? | Partition key     |
| ---------------- | -------------------- | ------------ | ----------------- |
| `users`          | The IG account row   | No (1 row)   | none              |
| `media`          | Each published post  | No           | `timestamp`       |
| `media_insights` | Per-media metrics    | No           | `timestamp`       |
| `stories`        | Each story (24h TTL) | No           | `timestamp`       |
| `story_insights` | Per-story metrics    | No           | `timestamp`       |
| `user_insights`  | Daily account stats  | Yes          | `end_time` (date) |

`user_insights` is the only true incremental endpoint — Instagram lets us pass `since`/`until` UNIX timestamps and returns daily buckets.

### OAuth

Adds a new `instagram` `IntegrationKind` rather than extending the existing `meta-ads` kind. Reuses `META_ADS_APP_CLIENT_ID` / `META_ADS_APP_CLIENT_SECRET` (same Facebook app), but requests `instagram_basic instagram_manage_insights pages_show_list pages_read_engagement business_management` scopes — keeps ad-side and content-side trust grants separate so existing Meta Ads users don't have to re-authorize for content scopes they didn't ask for.

### Release status

- `releaseStatus="alpha"`, `featureFlag="dwh-instagram"` — gated until validated.
- Instagram moved from Scaffolded to Implemented in `SOURCES.md` (HTTP / requests, ✅ tracked transport).

### Files

- New: `posthog/temporal/data_imports/sources/instagram/{instagram.py,schemas.py,test_instagram.py,test_instagram_source.py}`
- New: `posthog/migrations/1141_alter_integration_kind.py` (adds `instagram` choice)
- Modified: `posthog/models/integration.py` (new `INSTAGRAM` kind, OAuth config branch, `InstagramIntegration` token-refresh class)
- Modified: `posthog/temporal/data_imports/sources/instagram/source.py` (full impl replacing the scaffold)
- Modified: `posthog/temporal/data_imports/sources/SOURCES.md`
- Modified: `posthog/temporal/data_imports/sources/generated_configs.py` (hand-edited — see Agent context)

## How did you test this code?

I'm an agent (PostHog Code). Only ran automated tests — no manual / UI testing.

- 33/33 unit tests pass: `pytest posthog/temporal/data_imports/sources/instagram/`
  - 22 transport tests: paginator behavior, resume-from-saved-state, access-token stripping, fan-out fallthrough on per-media 400s, schema-catalog invariants (primary keys, stable partition keys).
  - 11 source-class tests: `source_type`, `get_source_config` field shape, `get_schemas` filtering, incremental-fields wiring, `validate_credentials` paths, `get_resumable_source_manager` data-class binding, `source_for_pipeline` pass-through, non-retryable errors.
- `ruff check` and `ruff format` clean on all touched files.

Manual smoke test (UI flow with a real Instagram Business account behind the `dwh-instagram` flag) has **not** been done — please verify before flipping the flag on for any team.

## Publish to changelog?

no

## 🤖 Agent context

**Tool:** PostHog Code (Claude Code-based agent), Task ID `453c86d2-8e31-4f78-9bb3-cb5e0f2d7a22`.

**Key prompts that shaped this:**

1. _"please implement instagram as a data warehouse source"_ + an attached spec referencing the `implementing-warehouse-sources` skill.
2. After surveying Airbyte/Fivetran/Stitch endpoints, asked whether to ship a separate `instagram` IntegrationKind or extend `meta-ads`. User clarified: "so we could import instagram ad stuff via the meta ads source?" → confirmed Meta Ads handles paid; this source covers organic. Went with a new `instagram` kind.
3. Asked about endpoint scope. User picked: `users`, `media`, `media_insights`, `stories`, `story_insights`, `user_insights`. Explicitly excluded `user_lifetime_insights` (audience demographics) — punted to v2.

**Decisions:**

- **Reference implementation:** Meta Ads. Same API host, same pagination model, same token-handling concerns. Resume config, access-token stripping, and tracked-session usage all mirror Meta Ads.
- **OAuth integration kind:** new `instagram` rather than extending `meta-ads`. Different scope set; mixing them would force existing Meta Ads users to re-grant.
- **Partition keys:** `timestamp` (media publish time) and `end_time` (insight bucket boundary) — both stable per the skill rule. Test asserts no other partition keys slip in.
- **Fan-out endpoints (`media_insights`, `story_insights`):** silently skip per-media 400s rather than failing the whole sync — Graph API rejects metrics that aren't supported for a given media type.
- **`user_insights` incremental:** chunked time-window pagination (Instagram caps a single request at 30 days), resume captures `chunk_since` + `chunk_next_url`.

**Caveats / things to verify:**

- I hand-edited `posthog/temporal/data_imports/sources/generated_configs.py` to add the `InstagramSourceConfig` fields. The generator (`pnpm run generate:source-configs`) needs Postgres for Django app init, which wasn't available in the sandbox. The hand-edit format matches `MetaAdsSourceConfig` exactly. **Please re-run the generator on a dev box with Postgres to confirm the output is identical** before merging.
- The Facebook app behind `META_ADS_APP_CLIENT_ID` must have the Instagram Graph API product enabled and the listed scopes approved in the Meta dev console — please confirm in the deploy environments.
- No new env vars.
- Migration `1141_alter_integration_kind.py` is a pure `AlterField`-on-`choices` change, identical in shape to the prior `1133` migration. Safe / non-blocking.