### PR TITLE
perf(product-tours): server-side fuzzy search via pg_trgm

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5056,8 +5056,11 @@ const api = {
     },
 
     productTours: {
-        async list(): Promise<PaginatedResponse<ProductTour>> {
-            return await new ApiRequest().productTours().get()
+        async list({ search }: { search?: string } = {}): Promise<PaginatedResponse<ProductTour>> {
+            return await new ApiRequest()
+                .productTours()
+                .withQueryString(search ? { search } : {})
+                .get()
         },
         async get(tourId: ProductTour['id']): Promise<ProductTour> {
             return await new ApiRequest().productTour(tourId).get()

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -8,7 +8,6 @@ import api, { PaginatedResponse } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { uuid } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { createFuse } from 'lib/utils/fuseSearch'
 import { addProductIntent } from 'lib/utils/product-intents'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -265,7 +264,8 @@ export const productToursLogic = kea<productToursLogicType>([
         productTours: {
             __default: [] as ProductTour[],
             loadProductTours: async () => {
-                const response: PaginatedResponse<ProductTour> = await api.productTours.list()
+                const search = values.searchTerm?.trim() || undefined
+                const response: PaginatedResponse<ProductTour> = await api.productTours.list({ search })
                 return response.results
             },
             deleteProductTour: async (id: string) => {
@@ -341,6 +341,10 @@ export const productToursLogic = kea<productToursLogicType>([
         ],
     }),
     listeners(({ actions }) => ({
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(250)
+            actions.loadProductTours()
+        },
         setTab: ({ tab }) => {
             actions.setFilters({ archived: tab === ProductToursTabs.Archived })
         },
@@ -404,25 +408,12 @@ export const productToursLogic = kea<productToursLogicType>([
     })),
     selectors({
         filteredProductTours: [
-            (s) => [s.productTours, s.searchTerm, s.filters],
-            (productTours: ProductTour[], searchTerm: string, filters: ProductToursFilters) => {
-                let filtered = productTours
-
-                if (searchTerm) {
-                    const fuse = createFuse(filtered, {
-                        keys: ['name', 'description'],
-                        ignoreLocation: true,
-                    })
-                    filtered = fuse.search(searchTerm).map((result) => result.item)
-                }
-
+            (s) => [s.productTours, s.filters],
+            (productTours: ProductTour[], filters: ProductToursFilters) => {
                 if (filters.archived) {
-                    filtered = filtered.filter((tour: ProductTour) => tour.archived)
-                } else {
-                    filtered = filtered.filter((tour: ProductTour) => !tour.archived)
+                    return productTours.filter((tour: ProductTour) => tour.archived)
                 }
-
-                return filtered
+                return productTours.filter((tour: ProductTour) => !tour.archived)
             },
         ],
         breadcrumbs: [

--- a/products/product_tours/backend/api/product_tour.py
+++ b/products/product_tours/backend/api/product_tour.py
@@ -4,15 +4,20 @@ import itertools
 from typing import Any, cast
 
 from django.conf import settings
+from django.contrib.postgres.search import TrigramSimilarity, TrigramWordSimilarity
 from django.db import transaction
+from django.db.models import F, Q, QuerySet, Value
+from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse
 from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
 from loginas.utils import is_impersonated_session
 from nanoid import generate
-from rest_framework import exceptions, filters, serializers, status, viewsets
+from opentelemetry import trace
+from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -25,6 +30,13 @@ from posthog.cloud_utils import is_cloud
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX
 from posthog.event_usage import report_user_action
 from posthog.exceptions import generate_exception_response
+from posthog.helpers.trigram_search import (
+    DESCRIPTION_SCORE_WEIGHT,
+    MAX_SEARCH_LENGTH,
+    MIN_DESCRIPTION_TRIGRAM_SIMILARITY,
+    MIN_NAME_TRIGRAM_SIMILARITY,
+    normalize_search_term,
+)
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.team.team import Team
 from posthog.models.user import User
@@ -37,6 +49,7 @@ from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.models import Survey
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 TOUR_GENERATION_MODEL = "claude-haiku-4-5"
 
@@ -737,6 +750,17 @@ class GenerateResponseSerializer(serializers.Serializer):
     steps = GenerateStepResponseSerializer(many=True)
 
 
+@extend_schema_view(
+    list=extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                description="Fuzzy match against product tour `name` and `description` using Postgres trigram word similarity. Supports typos and prefix-as-you-type.",
+            ),
+        ],
+    ),
+)
 class ProductTourViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
     scope_object = "product_tour"
     scope_object_read_actions = ["list", "retrieve", "draft_status"]
@@ -751,16 +775,66 @@ class ProductTourViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, view
         "generate",
     ]
     queryset = ProductTour.all_objects.select_related("internal_targeting_flag", "linked_flag", "created_by").all()
-    filter_backends = [filters.SearchFilter]
-    search_fields = ["name", "description"]
 
     def get_serializer_class(self) -> type[serializers.Serializer]:
         if self.request.method in ("POST", "PATCH"):
             return ProductTourSerializerCreateUpdateOnly
         return ProductTourSerializer
 
+    @tracer.start_as_current_span("ProductTourViewSet.list")
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().list(request, *args, **kwargs)
+        if request.query_params.get("search"):
+            data = response.data if isinstance(response.data, dict) else {}
+            results_len = data.get("count", len(data.get("results", [])))
+            span = trace.get_current_span()
+            span.set_attribute("product_tour.search.result_count", results_len)
+            span.set_attribute("product_tour.search.empty", results_len == 0)
+        return response
+
+    @staticmethod
+    @tracer.start_as_current_span("ProductTourViewSet._apply_search")
+    def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
+        search = normalize_search_term(search)
+        span = trace.get_current_span()
+        span.set_attribute("product_tour.search.length", len(search))
+        if not search:
+            return queryset
+
+        zero = Value(0.0)
+        name_word_score = Coalesce(TrigramWordSimilarity(search, "name"), zero)
+        name_full_score = Coalesce(TrigramSimilarity("name", search), zero)
+        description_word_score = Coalesce(TrigramWordSimilarity(search, "description"), zero)
+
+        return (
+            queryset.annotate(
+                _name_word=name_word_score,
+                _name_full=name_full_score,
+                _description_word=description_word_score,
+            )
+            .filter(
+                Q(_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY)
+                | Q(_description_word__gt=MIN_DESCRIPTION_TRIGRAM_SIMILARITY)
+            )
+            .annotate(
+                _name_match_score=F("_name_word") + F("_name_full"),
+                _description_match_score=F("_description_word"),
+            )
+            .annotate(_search_score=F("_name_match_score") + F("_description_match_score") * DESCRIPTION_SCORE_WEIGHT)
+            .order_by("-_search_score", "name")
+        )
+
     def safely_get_queryset(self, queryset):
-        return queryset.filter(team_id=self.team_id)
+        queryset = queryset.filter(team_id=self.team_id)
+        if self.action == "list":
+            search = self.request.GET.get("search")
+            if search:
+                if len(search) > MAX_SEARCH_LENGTH:
+                    raise serializers.ValidationError(
+                        {"search": f"Search query must be {MAX_SEARCH_LENGTH} characters or fewer."}
+                    )
+                queryset = self._apply_search(queryset, search)
+        return queryset
 
     def perform_destroy(self, instance: ProductTour) -> None:
         """Hard delete the tour and clean up related resources."""

--- a/products/product_tours/backend/api/test/test_product_tour.py
+++ b/products/product_tours/backend/api/test/test_product_tour.py
@@ -241,6 +241,124 @@ class TestProductTour(APIBaseTest):
         call_args = mock_report.call_args
         assert call_args[0][2]["creation_context"] == "toolbar"
 
+    @parameterized.expand(
+        [
+            (
+                "exact match wins over partial matches",
+                ["Ad Sales", "Email Sales", "Sales", "Sales Funnel", "Weekly Sales", "Unrelated"],
+                "Sales",
+                "Sales",
+                ["Unrelated"],
+            ),
+            (
+                "typo / transposition still matches via trigram",
+                ["Onboarding tour", "Unrelated"],
+                "onbarding",
+                "Onboarding tour",
+                ["Unrelated"],
+            ),
+            (
+                "prefix-as-you-type",
+                ["Marketing tour", "Engineering tour"],
+                "Marke",
+                "Marketing tour",
+                ["Engineering tour"],
+            ),
+            (
+                "case-insensitive: lower",
+                ["NPS Tour", "Engineering tour"],
+                "nps",
+                "NPS Tour",
+                ["Engineering tour"],
+            ),
+            (
+                "case-insensitive: upper",
+                ["NPS Tour", "Engineering tour"],
+                "NPS",
+                "NPS Tour",
+                ["Engineering tour"],
+            ),
+        ]
+    )
+    def test_list_filter_by_search_relevance(self, _name, tour_names, search, expected_first, excluded):
+        for name in tour_names:
+            ProductTour.objects.create(team=self.team, name=name, content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/?search={search}")
+        assert response.status_code == status.HTTP_200_OK
+        result_names = [r["name"] for r in response.json()["results"]]
+
+        assert result_names, f"expected at least one match for {search!r}, got nothing"
+        assert result_names[0] == expected_first, f"expected {expected_first!r} first, got {result_names}"
+        for name in excluded:
+            assert name not in result_names, f"expected {name!r} excluded, got {result_names}"
+
+    def test_list_filter_by_search_matches_description_with_lower_rank_than_name(self):
+        name_match = ProductTour.objects.create(team=self.team, name="revenue", content={"steps": []})
+        description_match = ProductTour.objects.create(
+            team=self.team,
+            name="Q4 review",
+            description="Quarterly revenue tour",
+            content={"steps": []},
+        )
+        ProductTour.objects.create(team=self.team, name="Unrelated", content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/?search=revenue")
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = [r["id"] for r in response.json()["results"]]
+
+        assert result_ids[:2] == [str(name_match.id), str(description_match.id)]
+        assert all(r["name"] != "Unrelated" for r in response.json()["results"])
+
+    @parameterized.expand(
+        [
+            ("whitespace-only", "   "),
+            ("empty", ""),
+        ]
+    )
+    def test_list_filter_by_search_blank_returns_all(self, _name, search):
+        a = ProductTour.objects.create(team=self.team, name="Alpha", content={"steps": []})
+        b = ProductTour.objects.create(team=self.team, name="Beta", content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/?search={search}")
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = {r["id"] for r in response.json()["results"]}
+
+        assert {str(a.id), str(b.id)}.issubset(result_ids)
+
+    @parameterized.expand(
+        [
+            ("plain symbols", "&|!"),
+            ("sql-injection-shaped", "'; DROP TABLE--"),
+        ]
+    )
+    def test_list_filter_by_search_pathological_input_does_not_500(self, _name, search):
+        ProductTour.objects.create(team=self.team, name="Tour overview", content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/", {"search": search})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_list_filter_by_search_nul_bytes_do_not_500(self):
+        ProductTour.objects.create(team=self.team, name="Alpha", content={"steps": []})
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/", {"search": "\x00\x00\x00"})
+        assert response.status_code == status.HTTP_200_OK
+
+    @parameterized.expand(
+        [
+            ("at cap (200)", 200, status.HTTP_200_OK),
+            ("just over cap (201)", 201, status.HTTP_400_BAD_REQUEST),
+            ("very long (10k)", 10_000, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_list_filter_by_search_enforces_length_cap(self, _name, length, expected_status):
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/", {"search": "a" * length})
+        assert response.status_code == expected_status
+
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            body = response.json()
+            assert body["attr"] == "search", f"expected error scoped to 'search', got {body}"
+            assert "200 characters" in body["detail"], f"expected error detail to mention the cap, got {body['detail']}"
+
 
 class TestProductTourAnalyticsMetadata(APIBaseTest):
     @parameterized.expand(

--- a/products/product_tours/frontend/generated/api.schemas.ts
+++ b/products/product_tours/frontend/generated/api.schemas.ts
@@ -274,7 +274,7 @@ export type ProductToursListParams = {
      */
     offset?: number
     /**
-     * A search term.
+     * Fuzzy match against product tour `name` and `description` using Postgres trigram word similarity. Supports typos and prefix-as-you-type.
      */
     search?: string
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44757,7 +44757,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * A search term.
+     * Fuzzy match against product tour `name` and `description` using Postgres trigram word similarity. Supports typos and prefix-as-you-type.
      */
     search?: string;
     };


### PR DESCRIPTION
## Summary

Replaces DRF SearchFilter (icontains) on `ProductTourViewSet` with the trigram word-similarity pattern shared with dashboards (#57106), insights (#57433), hog functions (#57440), and surveys (#57441). Removes the client-side Fuse.js filter from `productToursLogic` — search is now delegated to the API.

This closes the original four-way migration plan (hog functions, surveys, hog templates, product tours), with hog templates intentionally skipped (small curated set, client-side Fuse appropriate).

- **Backend**: `_apply_search` static method using shared `posthog/helpers/trigram_search` constants. Tracer span + `product_tour.search.{length,result_count,empty}` observability attributes. 200-char cap returns 400. `OpenApiParameter` declaration on `.list` keeps `?search=` advertised in the OpenAPI schema after dropping SearchFilter.
- **Frontend**: `setSearchTerm` listener with 250ms `breakpoint` debounces typing and re-fetches via `api.productTours.list({search})`. The `archived` filter stays client-side. Fuse import + search branch in `filteredProductTours` are gone.
- **Tests**: parameterized backend suite covering relevance, typo, prefix, case-insensitive, description-vs-name ranking, blank, NUL bytes, pathological strings, and the length cap.

## Test plan

- [ ] Backend tests: `pytest products/product_tours/backend/api/test/test_product_tour.py -k search -x -q`
- [ ] Manual: list product tours, type partial / typo / uppercase / lowercase queries

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*