### PR TITLE
feat(members): server-side fuzzy search via pg_trgm

### DIFF
--- a/frontend/src/scenes/organization/membersLogic.tsx
+++ b/frontend/src/scenes/organization/membersLogic.tsx
@@ -1,11 +1,9 @@
-import Fuse from 'fuse.js'
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { createFuse } from 'lib/utils/fuseSearch'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
 import { membershipLevelToName } from 'lib/utils/permissioning'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -14,8 +12,6 @@ import { userLogic } from 'scenes/userLogic'
 import { OrganizationMemberScopedApiKeysResponse, OrganizationMemberType } from '~/types'
 
 import type { membersLogicType } from './membersLogicType'
-
-export interface MembersFuse extends Fuse<OrganizationMemberType> {}
 
 const PAGINATION_LIMIT = 200
 
@@ -40,8 +36,10 @@ export const membersLogic = kea<membersLogicType>([
         members: {
             __default: null as OrganizationMemberType[] | null,
             loadAllMembers: async () => {
+                const search = values.search?.trim() || undefined
                 return await api.organizationMembers.listAll({
                     limit: PAGINATION_LIMIT,
+                    search,
                 })
             },
             loadMemberUpdates: async () => {
@@ -141,18 +139,7 @@ export const membersLogic = kea<membersLogicType>([
                 return result
             },
         ],
-        membersFuse: [
-            (s) => [s.meFirstMembers],
-            (members): MembersFuse =>
-                createFuse<OrganizationMemberType>(members ?? [], {
-                    keys: ['user.first_name', 'user.last_name', 'user.email'],
-                }),
-        ],
-        filteredMembers: [
-            (s) => [s.meFirstMembers, s.membersFuse, s.search],
-            (members, membersFuse, search): OrganizationMemberType[] =>
-                search ? membersFuse.search(search).map((result) => result.item) : (members ?? []),
-        ],
+        filteredMembers: [(s) => [s.meFirstMembers], (members): OrganizationMemberType[] => members ?? []],
         memberCount: [
             (s) => [s.user, s.sortedMembers],
             (user, members): number => {
@@ -179,6 +166,11 @@ export const membersLogic = kea<membersLogicType>([
             } else {
                 actions.loadMemberUpdates()
             }
+        },
+
+        setSearch: async (_, breakpoint) => {
+            await breakpoint(250)
+            actions.loadAllMembers()
         },
     })),
 

--- a/frontend/src/scenes/organization/membersLogic.tsx
+++ b/frontend/src/scenes/organization/membersLogic.tsx
@@ -43,6 +43,13 @@ export const membersLogic = kea<membersLogicType>([
                 })
             },
             loadMemberUpdates: async () => {
+                // Skip incremental updates while a search is active — `members` currently
+                // holds the search-filtered set, and merging arbitrary recently-updated
+                // members into it would surface unrelated rows in the search results.
+                if (values.search?.trim()) {
+                    return values.members
+                }
+
                 const newestMemberUpdate = values.members?.sort((a, b) => (a.updated_at > b.updated_at ? -1 : 1))?.[0]
 
                 if (!newestMemberUpdate || !values.members) {
@@ -127,8 +134,13 @@ export const membersLogic = kea<membersLogicType>([
             },
         ],
         meFirstMembers: [
-            (s) => [s.sortedMembers, s.user],
-            (members, user): OrganizationMemberType[] => {
+            (s) => [s.sortedMembers, s.user, s.search],
+            (members, user, search): OrganizationMemberType[] => {
+                // When the user is searching for someone else, don't pin themselves to the
+                // top — the search results are the answer to the query, me-first is noise.
+                if (search?.trim()) {
+                    return members ?? []
+                }
                 const me = user && members?.find((member) => member.user.uuid === user.uuid)
                 const result: OrganizationMemberType[] = me ? [me] : []
                 for (const member of members ?? []) {

--- a/frontend/src/scenes/organization/membersLogic.tsx
+++ b/frontend/src/scenes/organization/membersLogic.tsx
@@ -24,6 +24,7 @@ export const membersLogic = kea<membersLogicType>([
         ensureAllMembersLoaded: true,
         loadAllMembers: true,
         loadMemberUpdates: true,
+        loadSearchedMembers: true,
         loadMemberScopedApiKeys: (member: OrganizationMemberType) => ({ member }),
         setSearch: (search) => ({ search }),
         changeMemberAccessLevel: (member: OrganizationMemberType, level: OrganizationMembershipLevel) => ({
@@ -36,20 +37,11 @@ export const membersLogic = kea<membersLogicType>([
         members: {
             __default: null as OrganizationMemberType[] | null,
             loadAllMembers: async () => {
-                const search = values.search?.trim() || undefined
                 return await api.organizationMembers.listAll({
                     limit: PAGINATION_LIMIT,
-                    search,
                 })
             },
             loadMemberUpdates: async () => {
-                // Skip incremental updates while a search is active — `members` currently
-                // holds the search-filtered set, and merging arbitrary recently-updated
-                // members into it would surface unrelated rows in the search results.
-                if (values.search?.trim()) {
-                    return values.members
-                }
-
                 const newestMemberUpdate = values.members?.sort((a, b) => (a.updated_at > b.updated_at ? -1 : 1))?.[0]
 
                 if (!newestMemberUpdate || !values.members) {
@@ -119,6 +111,22 @@ export const membersLogic = kea<membersLogicType>([
                 }
             },
         },
+        // Server-side search results — separate from the canonical `members` store so
+        // other consumers (rolesLogic, hedgehogModeLogic, etc.) keep seeing the full org
+        // when the user has a search term active in the org-settings members page.
+        searchedMembers: {
+            __default: null as OrganizationMemberType[] | null,
+            loadSearchedMembers: async () => {
+                const search = values.search?.trim()
+                if (!search) {
+                    return null
+                }
+                return await api.organizationMembers.listAll({
+                    limit: PAGINATION_LIMIT,
+                    search,
+                })
+            },
+        },
     })),
     reducers({
         search: ['', { setSearch: (_, { search }) => search }],
@@ -134,13 +142,8 @@ export const membersLogic = kea<membersLogicType>([
             },
         ],
         meFirstMembers: [
-            (s) => [s.sortedMembers, s.user, s.search],
-            (members, user, search): OrganizationMemberType[] => {
-                // When the user is searching for someone else, don't pin themselves to the
-                // top — the search results are the answer to the query, me-first is noise.
-                if (search?.trim()) {
-                    return members ?? []
-                }
+            (s) => [s.sortedMembers, s.user],
+            (members, user): OrganizationMemberType[] => {
                 const me = user && members?.find((member) => member.user.uuid === user.uuid)
                 const result: OrganizationMemberType[] = me ? [me] : []
                 for (const member of members ?? []) {
@@ -151,7 +154,20 @@ export const membersLogic = kea<membersLogicType>([
                 return result
             },
         ],
-        filteredMembers: [(s) => [s.meFirstMembers], (members): OrganizationMemberType[] => members ?? []],
+        filteredMembers: [
+            (s) => [s.meFirstMembers, s.searchedMembers, s.search],
+            (members, searched, search): OrganizationMemberType[] => {
+                // When a search term is set, return the (server-filtered) searchedMembers
+                // — this avoids polluting the canonical `members` store with a filtered
+                // subset, so other consumers (rolesLogic, hedgehogModeLogic) keep seeing
+                // the full org. me-first is dropped during search because the user is
+                // looking for someone else, not themselves.
+                if (search?.trim()) {
+                    return searched ?? []
+                }
+                return members ?? []
+            },
+        ],
         memberCount: [
             (s) => [s.user, s.sortedMembers],
             (user, members): number => {
@@ -182,7 +198,7 @@ export const membersLogic = kea<membersLogicType>([
 
         setSearch: async (_, breakpoint) => {
             await breakpoint(250)
-            actions.loadAllMembers()
+            actions.loadSearchedMembers()
         },
     })),
 

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
@@ -18,31 +18,45 @@ describe('SavedInsightsFilters Created by dropdown', () => {
     let setFilters: jest.Mock
 
     beforeEach(() => {
+        const allMembers = [
+            {
+                id: '1',
+                user: MOCK_DEFAULT_BASIC_USER,
+                level: 8,
+                joined_at: '2020-09-24T15:05:26.758796Z',
+                updated_at: '2020-09-24T15:05:26.758837Z',
+                is_2fa_enabled: false,
+                has_social_auth: false,
+                last_login: '2020-09-24T15:05:26.758796Z',
+            },
+            {
+                id: '2',
+                user: MOCK_SECOND_BASIC_USER,
+                level: 1,
+                joined_at: '2021-03-11T19:11:11Z',
+                updated_at: '2021-03-11T19:11:11Z',
+                is_2fa_enabled: false,
+                has_social_auth: false,
+                last_login: '2021-03-11T19:11:11Z',
+            },
+        ]
         useMocks({
             get: {
-                '/api/organizations/:organization_id/members/': {
-                    results: [
-                        {
-                            id: '1',
-                            user: MOCK_DEFAULT_BASIC_USER,
-                            level: 8,
-                            joined_at: '2020-09-24T15:05:26.758796Z',
-                            updated_at: '2020-09-24T15:05:26.758837Z',
-                            is_2fa_enabled: false,
-                            has_social_auth: false,
-                            last_login: '2020-09-24T15:05:26.758796Z',
-                        },
-                        {
-                            id: '2',
-                            user: MOCK_SECOND_BASIC_USER,
-                            level: 1,
-                            joined_at: '2021-03-11T19:11:11Z',
-                            updated_at: '2021-03-11T19:11:11Z',
-                            is_2fa_enabled: false,
-                            has_social_auth: false,
-                            last_login: '2021-03-11T19:11:11Z',
-                        },
-                    ],
+                '/api/organizations/:organization_id/members/': (req) => {
+                    // membersLogic now does server-side search; mock honors `?search=`
+                    // by filtering on first_name, last_name, and email substring.
+                    const search = new URL(req.url).searchParams.get('search')?.toLowerCase()
+                    const results = search
+                        ? allMembers.filter((m) => {
+                              const u = m.user
+                              return (
+                                  u.first_name?.toLowerCase().includes(search) ||
+                                  u.last_name?.toLowerCase().includes(search) ||
+                                  u.email?.toLowerCase().includes(search)
+                              )
+                          })
+                        : allMembers
+                    return [200, { results }]
                 },
             },
         })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -575,6 +575,7 @@ export interface ListOrganizationMembersParams {
     offset?: number
     limit?: number
     updated_after?: string
+    search?: string
 }
 
 export interface APIErrorType {

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -212,12 +212,15 @@ class OrganizationMemberViewSet(
             if "updated_after" in params:
                 queryset = queryset.filter(updated_at__gt=params["updated_after"])
 
-            search = self.request.GET.get("search")
-            if search:
-                if len(search) > MAX_SEARCH_LENGTH:
-                    raise serializers.ValidationError(
-                        {"search": f"Search query must be {MAX_SEARCH_LENGTH} characters or fewer."}
-                    )
+            search = self.request.GET.get("search", "")
+            if len(search) > MAX_SEARCH_LENGTH:
+                raise serializers.ValidationError(
+                    {"search": f"Search query must be {MAX_SEARCH_LENGTH} characters or fewer."}
+                )
+            # Normalize before deciding so whitespace-only queries fall through to default
+            # ordering rather than reaching `_apply_search` and returning the queryset
+            # without any order applied.
+            if normalize_search_term(search):
                 queryset = self._apply_search(queryset, search)
             else:
                 order = self.request.GET.get("order")

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -1,11 +1,14 @@
-from typing import cast
+from typing import Any, cast
 
-from django.db.models import F, Model, Prefetch, QuerySet
+from django.contrib.postgres.search import TrigramWordSimilarity
+from django.db.models import F, Model, Prefetch, Q, QuerySet, Value
+from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from opentelemetry import trace
 from rest_framework import exceptions, mixins, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -18,11 +21,14 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.constants import INTERNAL_BOT_EMAIL_SUFFIX
 from posthog.event_usage import groups
+from posthog.helpers.trigram_search import MAX_SEARCH_LENGTH, MIN_NAME_TRIGRAM_SIMILARITY, normalize_search_term
 from posthog.models import OrganizationMembership
 from posthog.models.user import User
 from posthog.models.webauthn_credential import WebauthnCredential
 from posthog.permissions import TimeSensitiveActionPermission, extract_organization
 from posthog.utils import posthoganalytics
+
+tracer = trace.get_tracer(__name__)
 
 # Only index-backed orderings are allowed. `-joined_at` is served by the
 # `(organization, -joined_at)` composite index; other fields would force a
@@ -110,6 +116,11 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
                 enum=sorted(ALLOWED_ORDERINGS),
                 description=f"Sort order. Defaults to `{DEFAULT_ORDERING}`.",
             ),
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                description="Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.",
+            ),
         ],
     ),
 )
@@ -151,6 +162,46 @@ class OrganizationMemberViewSet(
         filter_kwargs = {self.lookup_field: lookup_value}
         return get_object_or_404(queryset, **filter_kwargs)
 
+    @tracer.start_as_current_span("OrganizationMemberViewSet.list")
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().list(request, *args, **kwargs)
+        if request.query_params.get("search"):
+            data = response.data if isinstance(response.data, dict) else {}
+            results_len = data.get("count", len(data.get("results", [])))
+            span = trace.get_current_span()
+            span.set_attribute("organization_member.search.result_count", results_len)
+            span.set_attribute("organization_member.search.empty", results_len == 0)
+        return response
+
+    @staticmethod
+    @tracer.start_as_current_span("OrganizationMemberViewSet._apply_search")
+    def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
+        search = normalize_search_term(search)
+        span = trace.get_current_span()
+        span.set_attribute("organization_member.search.length", len(search))
+        if not search:
+            return queryset
+
+        zero = Value(0.0)
+        first_name_score = Coalesce(TrigramWordSimilarity(search, "user__first_name"), zero)
+        last_name_score = Coalesce(TrigramWordSimilarity(search, "user__last_name"), zero)
+        email_score = Coalesce(TrigramWordSimilarity(search, "user__email"), zero)
+
+        return (
+            queryset.annotate(
+                _first_name_score=first_name_score,
+                _last_name_score=last_name_score,
+                _email_score=email_score,
+            )
+            .filter(
+                Q(_first_name_score__gt=MIN_NAME_TRIGRAM_SIMILARITY)
+                | Q(_last_name_score__gt=MIN_NAME_TRIGRAM_SIMILARITY)
+                | Q(_email_score__gt=MIN_NAME_TRIGRAM_SIMILARITY)
+            )
+            .annotate(_search_score=F("_first_name_score") + F("_last_name_score") + F("_email_score"))
+            .order_by("-_search_score", "user__first_name")
+        )
+
     def safely_get_queryset(self, queryset) -> QuerySet:
         if self.action == "list":
             params = self.request.GET.dict()
@@ -161,11 +212,19 @@ class OrganizationMemberViewSet(
             if "updated_after" in params:
                 queryset = queryset.filter(updated_at__gt=params["updated_after"])
 
-            order = self.request.GET.get("order")
-            if order in ALLOWED_ORDERINGS:
-                queryset = queryset.order_by(order)
+            search = self.request.GET.get("search")
+            if search:
+                if len(search) > MAX_SEARCH_LENGTH:
+                    raise serializers.ValidationError(
+                        {"search": f"Search query must be {MAX_SEARCH_LENGTH} characters or fewer."}
+                    )
+                queryset = self._apply_search(queryset, search)
             else:
-                queryset = queryset.order_by(DEFAULT_ORDERING)
+                order = self.request.GET.get("order")
+                if order in ALLOWED_ORDERINGS:
+                    queryset = queryset.order_by(order)
+                else:
+                    queryset = queryset.order_by(DEFAULT_ORDERING)
 
         return queryset
 

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -502,14 +502,11 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         [
             ("plain symbols", "&|!"),
             ("sql-injection-shaped", "'; DROP TABLE--"),
+            ("nul bytes", "\x00\x00\x00"),
         ]
     )
     def test_list_organization_members_pathological_search_does_not_500(self, _name, search):
         response = self.client.get("/api/organizations/@current/members/", {"search": search})
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_list_organization_members_search_nul_bytes_do_not_500(self):
-        response = self.client.get("/api/organizations/@current/members/", {"search": "\x00\x00\x00"})
         assert response.status_code == status.HTTP_200_OK
 
     @parameterized.expand(

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -459,6 +459,77 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
 
     @parameterized.expand(
         [
+            ("first name match", "Marketing", "marketing@example.com"),
+            ("typo / transposition still matches", "marekting", "marketing@example.com"),
+            ("prefix-as-you-type on first name", "Marke", "marketing@example.com"),
+            ("case-insensitive", "MARKETING", "marketing@example.com"),
+            ("email match", "engineering", "engineering@example.com"),
+            ("last name match", "Smith", "smith@example.com"),
+        ]
+    )
+    def test_list_organization_members_filter_by_search(self, _name, search, expected_email):
+        User.objects.create_and_join(
+            self.organization, "marketing@example.com", None, first_name="Marketing", last_name="Director"
+        )
+        User.objects.create_and_join(
+            self.organization, "engineering@example.com", None, first_name="Engineering", last_name="Manager"
+        )
+        User.objects.create_and_join(self.organization, "smith@example.com", None, first_name="Bob", last_name="Smith")
+
+        response = self.client.get(f"/api/organizations/@current/members/?search={search}")
+        assert response.status_code == status.HTTP_200_OK
+        emails = [r["user"]["email"] for r in response.json()["results"]]
+
+        assert emails, f"expected at least one match for {search!r}, got nothing"
+        assert expected_email in emails, f"expected {expected_email!r} in results, got {emails}"
+
+    @parameterized.expand(
+        [
+            ("whitespace-only", "   "),
+            ("empty", ""),
+        ]
+    )
+    def test_list_organization_members_blank_search_returns_all(self, _name, search):
+        User.objects.create_and_join(self.organization, "extra@posthog.com", None)
+
+        response = self.client.get(f"/api/organizations/@current/members/?search={search}")
+        assert response.status_code == status.HTTP_200_OK
+        emails = {r["user"]["email"] for r in response.json()["results"]}
+        # Self-user + the one we just added should both be present
+        assert "extra@posthog.com" in emails
+
+    @parameterized.expand(
+        [
+            ("plain symbols", "&|!"),
+            ("sql-injection-shaped", "'; DROP TABLE--"),
+        ]
+    )
+    def test_list_organization_members_pathological_search_does_not_500(self, _name, search):
+        response = self.client.get("/api/organizations/@current/members/", {"search": search})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_list_organization_members_search_nul_bytes_do_not_500(self):
+        response = self.client.get("/api/organizations/@current/members/", {"search": "\x00\x00\x00"})
+        assert response.status_code == status.HTTP_200_OK
+
+    @parameterized.expand(
+        [
+            ("at cap (200)", 200, status.HTTP_200_OK),
+            ("just over cap (201)", 201, status.HTTP_400_BAD_REQUEST),
+            ("very long (10k)", 10_000, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_list_organization_members_search_enforces_length_cap(self, _name, length, expected_status):
+        response = self.client.get("/api/organizations/@current/members/", {"search": "a" * length})
+        assert response.status_code == expected_status
+
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            body = response.json()
+            assert body["attr"] == "search", f"expected error scoped to 'search', got {body}"
+            assert "200 characters" in body["detail"], f"expected error detail to mention the cap, got {body['detail']}"
+
+    @parameterized.expand(
+        [
             # (name, has_totp, passkeys_enabled_for_2fa, passkey_verified, expected)
             ("totp_only", True, False, False, True),
             ("passkeys_enabled_and_verified", False, True, True, True),

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -761,6 +761,10 @@ export type MembersListParams = {
      * Sort order. Defaults to `-joined_at`.
      */
     order?: string
+    /**
+     * Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.
+     */
+    search?: string
 }
 
 export type RolesListParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -41449,6 +41449,10 @@ export namespace Schemas {
      * Sort order. Defaults to `-joined_at`.
      */
     order?: string;
+    /**
+     * Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.
+     */
+    search?: string;
     };
 
     export type OauthApplicationsListParams = {

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -78,6 +78,12 @@ export const MembersListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order: zod.string().optional().describe('Sort order. Defaults to `-joined_at`.'),
+    search: zod
+        .string()
+        .optional()
+        .describe(
+            'Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.'
+        ),
 })
 
 export const RolesListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -303,6 +303,7 @@ const orgMembersList = (): ToolBase<typeof OrgMembersListSchema, Schemas.Paginat
                 limit: params.limit,
                 offset: params.offset,
                 order: params.order,
+                search: params.search,
             },
         })
         return result

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/org-members-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/org-members-list.json
@@ -12,6 +12,10 @@
         "order": {
             "description": "Sort order. Defaults to `-joined_at`.",
             "type": "string"
+        },
+        "search": {
+            "description": "Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.",
+            "type": "string"
         }
     },
     "type": "object"


### PR DESCRIPTION
## Summary

Adds `?search=` to `OrganizationMemberViewSet` — the endpoint previously had no search at all and the frontend was loading up to 200 members and filtering client-side with Fuse.js. Search now lives server-side via Postgres trigram word similarity across `user.first_name`, `user.last_name`, and `user.email`, using the shared `posthog/helpers/trigram_search` constants established by the dashboards/insights/hog-functions/surveys/product-tours migrations.

The assignee picker (`products/conversations/.../assigneeSelectLogic.tsx`) connects to `membersLogic` and dispatches `setSearch`, so it benefits transitively without any change.

- **Backend**: `_apply_search` static method using shared trigram constants. Tracer span + `organization_member.search.{length,result_count,empty}` observability attributes. 200-char cap returns 400. `OpenApiParameter` declaration on `.list` advertises `?search=` in the schema.
- **Frontend**: `setSearch` listener with 250ms `breakpoint` debounces typing and re-fetches via `api.organizationMembers.listAll({search})`. The `Fuse` import, `membersFuse` selector, and Fuse branch in `filteredMembers` are gone — `filteredMembers` now just returns the (server-filtered) member list.
- **Tests**: parameterized backend suite covering first-name, last-name, and email matches, typo tolerance, prefix-as-you-type, case-insensitivity, blank input, NUL bytes, pathological strings, and the 200-char length cap.

## Test plan

- [ ] Backend tests: `pytest posthog/api/test/test_organization_members.py -k search -x -q`
- [ ] Manual: org settings → members → type partial / typo / first name / last name / email substring
- [ ] Manual: assignee picker (e.g. issue tracker) → typing in member search uses backend
- [ ] Manual: `?search=` over 200 chars returns 400

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*