### PR TITLE
chore(ci): key schema cache restore on merge-base sha

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -263,6 +263,7 @@ jobs:
         outputs:
             run_legacy: ${{ steps.discover.outputs.run_legacy }}
             matrix: ${{ steps.discover.outputs.matrix }}
+            schema_cache_key: ${{ steps.schema-key.outputs.key }}
 
         steps:
             - uses: actions/checkout@v6
@@ -275,6 +276,23 @@ jobs:
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+            - name: Compute schema cache key from merge-base
+              id: schema-key
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                  # The fetch-depth:1000 checkout + base-ref fetch above ensure the
+                  # full ancestry needed to find the divergence point is available.
+                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  if [ -n "$MERGE_BASE" ]; then
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                  else
+                      echo "key=" >> $GITHUB_OUTPUT
+                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                  fi
 
             - name: Setup pnpm
               uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -418,12 +436,11 @@ jobs:
               run: bin/ci-wait-for-docker wait
 
             - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' }}
+              if: ${{ github.event_name == 'pull_request' && needs.turbo-discover.outputs.schema_cache_key != '' }}
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                   path: schema.sql.gz
-                  key: posthog-schema-master-${{ github.sha }}
-                  restore-keys: posthog-schema-master-
+                  key: ${{ needs.turbo-discover.outputs.schema_cache_key }}
 
             - name: Prime test_posthog from cached schema
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
@@ -884,11 +901,10 @@ jobs:
                   retention-days: 90
 
             - name: Save schema to Actions cache for PR shards
-              # Seeds a Postgres schema cache that PR test jobs will read in a
-              # follow-up change to skip the full Django migrate. SHA-suffixed
-              # key + restore-keys prefix means the newest master cache always
-              # wins; LRU eviction handles cleanup. No PR-side consumer yet —
-              # this just establishes the cache so the follow-up lands hot.
+              # Seeds a Postgres schema cache consumed by PR test jobs (turbo-tests,
+              # django, dagster). PR jobs restore using the merge-base SHA as the key
+              # so they always get a schema from their exact branch point rather than
+              # the newest master. LRU eviction handles cleanup.
               if: github.event_name == 'push'
               uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
@@ -1290,12 +1306,11 @@ jobs:
               run: bin/ci-wait-for-docker wait
 
             - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' }}
+              if: ${{ github.event_name == 'pull_request' && needs.turbo-discover.outputs.schema_cache_key != '' }}
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                   path: schema.sql.gz
-                  key: posthog-schema-master-${{ github.sha }}
-                  restore-keys: posthog-schema-master-
+                  key: ${{ needs.turbo-discover.outputs.schema_cache_key }}
 
             - name: Prime test_posthog from cached schema
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -63,6 +63,7 @@ jobs:
             dagster: ${{ steps.filter.outputs.dagster || 'true' }}
             oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
             matrix_include: ${{ steps.build-matrix.outputs.include || '[]' }}
+            schema_cache_key: ${{ steps.schema-key.outputs.key }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -180,6 +181,32 @@ jobs:
                   echo "include=$include" >> "$GITHUB_OUTPUT"
                   echo "Dagster matrix: $shards shards"
 
+            - name: Fetch base branch for merge-base computation
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  # Deepen the shallow checkout so HEAD^2 (PR branch tip) becomes
+                  # reachable, then fetch enough of the base branch to find where
+                  # the PR diverged from it.
+                  git fetch --deepen=200
+                  git fetch --no-tags --depth=200 origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+            - name: Compute schema cache key from merge-base
+              id: schema-key
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  if [ -n "$MERGE_BASE" ]; then
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                  else
+                      echo "key=" >> $GITHUB_OUTPUT
+                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                  fi
+
     dagster:
         name: Dagster tests (${{ matrix.group }}/${{ matrix.concurrency }})
         needs: [changes]
@@ -271,13 +298,12 @@ jobs:
                       psql -U posthog -c "CREATE DATABASE test_dagster;"
 
             - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' }}
+              if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.schema_cache_key != '' }}
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               id: schema-cache
               with:
                   path: schema.sql.gz
-                  key: posthog-schema-master-${{ github.sha }}
-                  restore-keys: posthog-schema-master-
+                  key: ${{ needs.changes.outputs.schema_cache_key }}
 
             - name: Prime test_posthog and posthog from cached schema (PR)
               # Primes both test_posthog (used by pytest --reuse-db) and the prod-style


### PR DESCRIPTION
Previously the restore used `restore-keys: posthog-schema-master-` which
always matched the newest master cache regardless of where the PR branch
diverged. A stale branch could get a schema from a master commit ahead of
its branch point, causing migration conflicts when the branch's own
migrations tried to alter tables or columns already changed by master.

Compute `git merge-base HEAD^2 origin/<base>` once in `turbo-discover`
(ci-backend) and `changes` (ci-dagster), output it as `schema_cache_key`,
and use it as the exact restore key in all consumer jobs (turbo-tests,
django, dagster shards). No `restore-keys` fallback — a cache miss falls
through to a full migrate, which is already the safe baseline.

Branches more than ~1000 commits behind master (backend) or ~200 commits
(dagster) also fall through to full migrate gracefully.

https://claude.ai/code/session_017Tj4A8FfHfJLk5F2p3H4or