### PR TITLE
feat(mcp/replay): make session summarizer tool streaming

### DIFF
--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -1,12 +1,15 @@
 import os
 import re
+import json
 import asyncio
+from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import Any, cast
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Func, IntegerField, QuerySet
+from django.http import StreamingHttpResponse
 
 import structlog
 from asgiref.sync import async_to_sync
@@ -30,6 +33,7 @@ from posthog.models.activity_logging.activity_log import Change, Detail, log_act
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.utils import UUID
 from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
+from posthog.renderers import ServerSentEventRenderer
 from posthog.temporal.session_replay.session_summary.workflow import execute_summarize_session
 from posthog.temporal.session_replay.session_summary_group.types import SessionSummaryStreamUpdate
 from posthog.temporal.session_replay.session_summary_group.workflow import execute_summarize_session_group
@@ -49,6 +53,7 @@ from ee.hogai.session_summaries.tracking import (
     generate_tracking_id,
 )
 from ee.hogai.session_summaries.utils import logging_session_ids
+from ee.hogai.utils.aio import async_to_sync as async_generator_to_sync
 from ee.models.session_summaries import SessionGroupSummary
 from ee.models.team_session_summaries_config import PRODUCT_CONTEXT_MAX_LENGTH, TeamSessionSummariesConfig
 
@@ -74,6 +79,12 @@ _PRODUCT_CONTEXT_WRAPPER_TAG_RE = re.compile(r"</?\s*product_context\b[^>]*>", r
 # returned False (no events / recording too short). Kept here as a module-level constant so the coupling
 # between the workflow's exception text and the API-layer classification is explicit and grep-able.
 _NO_READY_SUMMARY_ERROR_SUBSTRING = "No ready summary found in DB"
+
+# Cap on concurrent in-flight per-session summary tasks within a single streaming request.
+# Each task triggers a Temporal workflow that issues ClickHouse + LLM provider calls, so an
+# unbounded fan-out (e.g. 300 sessions in one batch) can spike both. 10 keeps backpressure
+# reasonable while still amortizing latency for typical batch sizes.
+_STREAM_BATCH_CONCURRENCY = 10
 
 
 class SessionSummariesConfigSerializer(serializers.ModelSerializer):
@@ -399,6 +410,120 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             raise exceptions.APIException(
                 f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)}. Please try again later."
             )
+
+    @extend_schema(exclude=True)
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path="stream_batch",
+        required_scopes=["session_recording:read"],
+        renderer_classes=[ServerSentEventRenderer],
+    )
+    def stream_batch_session_summaries(self, request: Request, **kwargs) -> StreamingHttpResponse:
+        user = self._validate_user(request)
+        # Use _parse_input (not _validate_input) — the individual flow must surface bad
+        # session IDs as per-session error events, not fail the whole batch up front.
+        session_ids, extra_summary_context = self._parse_input(request)
+        tracking_id = generate_tracking_id()
+        team = self.team
+
+        capture_session_summary_started(
+            user=user,
+            team=team,
+            tracking_id=tracking_id,
+            summary_source="api",
+            summary_type="single",
+            session_ids=session_ids,
+        )
+
+        async def async_stream() -> AsyncGenerator[bytes, None]:
+            SSE_KEEPALIVE_COMMENT = b": keepalive\n\n"
+            SSE_KEEPALIVE_INTERVAL = 15  # seconds — well under typical LB idle timeouts (60s)
+
+            sem = asyncio.Semaphore(_STREAM_BATCH_CONCURRENCY)
+            pending: set[asyncio.Task[tuple[str, SessionSummarySerializer | Exception]]] = set()
+            for session_id in session_ids:
+
+                async def _run(sid: str = session_id) -> tuple[str, SessionSummarySerializer | Exception]:
+                    async with sem:
+                        result = await self._summarize_session(
+                            session_id=sid,
+                            user=user,
+                            team=team,
+                            extra_summary_context=extra_summary_context,
+                        )
+                    return sid, result
+
+                pending.add(asyncio.create_task(_run()))
+
+            completed_ids: list[str] = []
+            failed_ids: list[str] = []
+
+            try:
+                while pending:
+                    done, pending = await asyncio.wait(
+                        pending, timeout=SSE_KEEPALIVE_INTERVAL, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    if not done:
+                        yield SSE_KEEPALIVE_COMMENT
+                        continue
+
+                    for task in done:
+                        sid, result = task.result()
+                        if isinstance(result, Exception):
+                            error_type, error_message = self._classify_summary_error(result)
+                            # _summarize_session returns exceptions as values, so we're not in an except
+                            # block here — sys.exc_info() is empty. Pass exc_info=result explicitly so
+                            # the traceback isn't dropped.
+                            logger.error(
+                                f"Failed to generate streaming session summary for session {sid} from team {team.pk} by user {user.id}: {result}",
+                                team_id=team.pk,
+                                user_id=user.id,
+                                error_type=error_type,
+                                exc_info=result,
+                            )
+                            failed_ids.append(sid)
+                            event_data = json.dumps(
+                                {
+                                    "session_id": sid,
+                                    "error": error_type,
+                                    "error_message": error_message,
+                                }
+                            )
+                            yield f"event: error\ndata: {event_data}\n\n".encode()
+                        else:
+                            completed_ids.append(sid)
+                            event_data = json.dumps({"session_id": sid, "summary": result.data})
+                            yield f"event: summary\ndata: {event_data}\n\n".encode()
+            finally:
+                # Cancel still-running tasks on client disconnect or any other early exit
+                # to avoid wasting Temporal workflow + LLM calls.
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+
+            capture_session_summary_generated(
+                user=user,
+                team=team,
+                tracking_id=tracking_id,
+                summary_source="api",
+                summary_type="single",
+                session_ids=session_ids,
+                success=len(failed_ids) == 0,
+            )
+
+            done_data = json.dumps({"completed": completed_ids, "failed": failed_ids})
+            yield f"event: done\ndata: {done_data}\n\n".encode()
+
+        return StreamingHttpResponse(
+            (async_stream() if settings.SERVER_GATEWAY_INTERFACE == "ASGI" else async_generator_to_sync(async_stream)),
+            content_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     @extend_schema(
         methods=["GET"],

--- a/ee/api/test/test_session_summaries.py
+++ b/ee/api/test/test_session_summaries.py
@@ -1,4 +1,5 @@
 import os
+import json
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any, Optional, Union
@@ -13,6 +14,7 @@ from rest_framework import exceptions
 
 from posthog.temporal.session_replay.session_summary_group.types import SessionSummaryStreamUpdate
 
+from ee.api.session_summaries import _NO_READY_SUMMARY_ERROR_SUBSTRING
 from ee.hogai.session_summaries.session_group.patterns import (
     EnrichedSessionGroupSummaryPattern,
     EnrichedSessionGroupSummaryPatternsList,
@@ -427,3 +429,310 @@ class TestSessionSummariesAPI(APIBaseTest):
         # And we should not have invoked the workflow for the missing session
         called_session_ids = {call.kwargs.get("session_id") for call in mock_execute.call_args_list}
         self.assertEqual(called_session_ids, {"session_1"})
+
+
+MOCK_SUMMARY_DATA: dict[str, Any] = {
+    "segments": [
+        {
+            "index": 0,
+            "name": "Login",
+            "start_event_id": "evt00001",
+            "end_event_id": "evt00002",
+            "meta": {
+                "duration": 30,
+                "duration_percentage": 1.0,
+                "events_count": 2,
+                "events_percentage": 1.0,
+                "key_action_count": 1,
+                "failure_count": 0,
+                "abandonment_count": 0,
+                "confusion_count": 0,
+                "exception_count": 0,
+            },
+        }
+    ],
+    "key_actions": [
+        {
+            "segment_index": 0,
+            "events": [
+                {
+                    "description": "Clicked login",
+                    "abandonment": False,
+                    "confusion": False,
+                    "exception": None,
+                    "event_id": "evt00001",
+                    "timestamp": "2024-01-01T10:00:00Z",
+                    "milliseconds_since_start": 0,
+                    "window_id": "w1",
+                    "current_url": "https://app.example.com/login",
+                    "event": "$autocapture",
+                    "event_type": "click",
+                    "event_index": 0,
+                    "session_id": "session1",
+                    "event_uuid": "00000000-0000-0000-0000-000000000001",
+                }
+            ],
+        }
+    ],
+    "segment_outcomes": [{"segment_index": 0, "summary": "User logged in successfully", "success": True}],
+    "session_outcome": {"description": "Successful login", "success": True},
+    "sentiment": {"frustration_score": 0.1, "outcome": "successful", "sentiment_signals": []},
+}
+
+
+def _parse_sse_events(content: bytes) -> list[dict[str, str]]:
+    """Parse SSE response bytes into a list of dicts with 'event' and 'data' keys."""
+    raw_blocks = content.decode().split("\n\n")
+    events = []
+    for block in raw_blocks:
+        block = block.strip()
+        if not block:
+            continue
+        parsed: dict[str, str] = {}
+        for line in block.splitlines():
+            if line.startswith("event:"):
+                parsed["event"] = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                parsed["data"] = line[len("data:") :].strip()
+        if parsed:
+            events.append(parsed)
+    return events
+
+
+class TestStreamSessionSummariesAPI(APIBaseTest):
+    environment_patches: list[Any]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = f"/api/environments/{self.team.id}/session_summaries/stream_batch/"
+
+        self.environment_patches = [
+            patch("ee.api.session_summaries.is_cloud", return_value=True),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}),
+        ]
+        for p in self.environment_patches:
+            p.start()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        for p in self.environment_patches:
+            p.stop()
+
+    def _make_streaming_request(self, session_ids: list[str], focus_area: Optional[str] = None) -> Any:
+        payload: dict[str, Any] = {"session_ids": session_ids}
+        if focus_area is not None:
+            payload["focus_area"] = focus_area
+        return self.client.post(self.url, payload, format="json")
+
+    def _get_sse_events(self, response: Any) -> list[dict[str, str]]:
+        content = b"".join(response.streaming_content)
+        return _parse_sse_events(content)
+
+    @parameterized.expand(
+        [
+            (
+                "all_success",
+                ["session_1"],
+                None,
+                {"summary", "done"},
+                ["session_1"],
+                [],
+            ),
+            (
+                "mixed_success_and_failure",
+                ["session_ok", "session_fail"],
+                {"session_fail"},
+                {"summary", "error", "done"},
+                ["session_ok"],
+                ["session_fail"],
+            ),
+            (
+                "all_failures",
+                ["s1", "s2"],
+                {"s1", "s2"},
+                {"error", "done"},
+                [],
+                ["s1", "s2"],
+            ),
+        ]
+    )
+    @patch("ee.api.session_summaries.capture_session_summary_generated")
+    @patch("ee.api.session_summaries.capture_session_summary_started")
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_emits_expected_events(
+        self,
+        _name: str,
+        session_ids: list[str],
+        failing_ids: Optional[set[str]],
+        expected_event_types: set[str],
+        expected_completed: list[str],
+        expected_failed: list[str],
+        mock_execute: Mock,
+        mock_capture_started: Mock,
+        mock_capture_generated: Mock,
+    ) -> None:
+        failing = failing_ids or set()
+
+        def side_effect(session_id: str, **_kwargs: Any) -> Any:
+            if session_id in failing:
+                raise Exception("summarization failed")
+            return get_mock_enriched_llm_json_response(session_id)
+
+        mock_execute.side_effect = side_effect
+
+        response = self._make_streaming_request(session_ids=session_ids)
+        self.assertEqual(response.status_code, 200)
+
+        events = self._get_sse_events(response)
+        event_types = {e["event"] for e in events}
+        self.assertEqual(event_types, expected_event_types)
+
+        done_event = next(e for e in events if e["event"] == "done")
+        done_data = json.loads(done_event["data"])
+        self.assertCountEqual(done_data["completed"], expected_completed)
+        self.assertCountEqual(done_data["failed"], expected_failed)
+
+        # Failed sessions surface as classified, sanitized error events
+        if expected_failed:
+            error_events = [e for e in events if e["event"] == "error"]
+            self.assertEqual(len(error_events), len(expected_failed))
+            for event in error_events:
+                error_data = json.loads(event["data"])
+                self.assertIn(error_data["session_id"], expected_failed)
+                self.assertEqual(error_data["error"], "summary_failed")
+                self.assertIn("Failed to generate", error_data["error_message"])
+
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_summary_event_includes_full_summary_shape(self, mock_execute: Mock) -> None:
+        # Smoke-tests that the serialized SessionSummary fields make it onto the wire.
+        mock_execute.side_effect = lambda session_id, **_kwargs: get_mock_enriched_llm_json_response(session_id)
+
+        response = self._make_streaming_request(session_ids=["session_1"])
+        events = self._get_sse_events(response)
+        summary_event = next(e for e in events if e["event"] == "summary")
+        summary_data = json.loads(summary_event["data"])
+
+        self.assertEqual(summary_data["session_id"], "session_1")
+        for field in ("segments", "key_actions", "segment_outcomes", "session_outcome"):
+            self.assertIn(field, summary_data["summary"])
+
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_response_headers(self, mock_execute: Mock) -> None:
+        mock_execute.side_effect = lambda session_id, **_kwargs: get_mock_enriched_llm_json_response(session_id)
+
+        response = self._make_streaming_request(session_ids=["session_1"])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("Content-Type"), "text/event-stream")
+        self.assertEqual(response.get("Cache-Control"), "no-cache")
+        self.assertEqual(response.get("X-Accel-Buffering"), "no")
+
+    @patch("ee.api.session_summaries.capture_session_summary_generated")
+    @patch("ee.api.session_summaries.capture_session_summary_started")
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_tracking_uses_single_stream_summary_type(
+        self,
+        mock_execute: Mock,
+        mock_capture_started: Mock,
+        mock_capture_generated: Mock,
+    ) -> None:
+        mock_execute.side_effect = lambda session_id, **_kwargs: get_mock_enriched_llm_json_response(session_id)
+
+        response = self._make_streaming_request(session_ids=["session_1", "session_2"])
+        b"".join(response.streaming_content)
+
+        mock_capture_started.assert_called_once()
+        started_kwargs = mock_capture_started.call_args[1]
+        self.assertEqual(started_kwargs["summary_type"], "single")
+        self.assertEqual(started_kwargs["summary_source"], "api")
+        self.assertEqual(started_kwargs["session_ids"], ["session_1", "session_2"])
+
+        mock_capture_generated.assert_called_once()
+        generated_kwargs = mock_capture_generated.call_args[1]
+        self.assertEqual(generated_kwargs["summary_type"], "single")
+        self.assertEqual(generated_kwargs["summary_source"], "api")
+        self.assertEqual(generated_kwargs["session_ids"], ["session_1", "session_2"])
+
+        self.assertEqual(started_kwargs["tracking_id"], generated_kwargs["tracking_id"])
+
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_error_payload_does_not_leak_exception_message(self, mock_execute: Mock) -> None:
+        sensitive_message = "openai key sk-internal-leak at /etc/secrets/prompt.txt"
+        mock_execute.side_effect = Exception(sensitive_message)
+
+        response = self._make_streaming_request(session_ids=["session_1"])
+
+        self.assertEqual(response.status_code, 200)
+        events = self._get_sse_events(response)
+        error_event = next(e for e in events if e["event"] == "error")
+        error_data = json.loads(error_event["data"])
+
+        self.assertEqual(error_data["error"], "summary_failed")
+        self.assertIn("Failed to generate", error_data["error_message"])
+        # Regression: the raw exception message must not leak through the SSE payload.
+        self.assertNotIn("sk-internal-leak", error_event["data"])
+        self.assertNotIn("/etc/secrets", error_event["data"])
+        self.assertNotIn(sensitive_message, error_event["data"])
+
+    @parameterized.expand(
+        [
+            ("missing_session_ids", {"focus_area": "login"}),
+            ("empty_session_ids", {"session_ids": []}),
+        ]
+    )
+    def test_stream_individually_invalid_payload_returns_400(self, _name: str, payload: dict[str, Any]) -> None:
+        response = self.client.post(self.url, payload, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_stream_individually_unauthenticated_returns_401(self) -> None:
+        self.client.logout()
+        response = self._make_streaming_request(session_ids=["session_1"])
+        self.assertEqual(response.status_code, 401)
+
+    @patch("ee.api.session_summaries.is_cloud")
+    def test_stream_individually_not_cloud_returns_400(self, mock_is_cloud: Mock) -> None:
+        mock_is_cloud.return_value = False
+        response = self._make_streaming_request(session_ids=["session_1"])
+        self.assertEqual(response.status_code, 400)
+
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_bad_session_id_surfaces_as_per_session_error(self, mock_execute: Mock) -> None:
+        # Bad session IDs must NOT fail the whole batch — they should surface as per-session
+        # error events so callers can distinguish "skipped on purpose" from "tool broke".
+        mock_execute.side_effect = ValueError(f"{_NO_READY_SUMMARY_ERROR_SUBSTRING} for session nonexistent")
+        response = self._make_streaming_request(session_ids=["nonexistent"])
+        self.assertEqual(response.status_code, 200)
+        events = self._get_sse_events(response)
+        error_event = next(e for e in events if e["event"] == "error")
+        error_data = json.loads(error_event["data"])
+        self.assertEqual(error_data["session_id"], "nonexistent")
+        self.assertEqual(error_data["error"], "no_events_or_too_short")
+
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_with_focus_area_passes_extra_context(self, mock_execute: Mock) -> None:
+        mock_execute.side_effect = lambda session_id, **_kwargs: get_mock_enriched_llm_json_response(session_id)
+
+        response = self._make_streaming_request(session_ids=["session_1"], focus_area="checkout flow")
+        b"".join(response.streaming_content)
+
+        call_kwargs = mock_execute.call_args[1]
+        self.assertIsNotNone(call_kwargs.get("extra_summary_context"))
+        self.assertEqual(call_kwargs["extra_summary_context"].focus_area, "checkout flow")
+
+    @patch("ee.api.session_summaries.capture_session_summary_generated")
+    @patch("ee.api.session_summaries.capture_session_summary_started")
+    @patch("ee.api.session_summaries.execute_summarize_session")
+    def test_stream_individually_tracking_generated_success_false_when_all_fail(
+        self,
+        mock_execute: Mock,
+        mock_capture_started: Mock,
+        mock_capture_generated: Mock,
+    ) -> None:
+        mock_execute.side_effect = Exception("summarization failed")
+
+        response = self._make_streaming_request(session_ids=["session_1"])
+        b"".join(response.streaming_content)
+
+        mock_capture_generated.assert_called_once()
+        generated_kwargs = mock_capture_generated.call_args[1]
+        self.assertFalse(generated_kwargs["success"])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,7 +461,7 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.6.4
-        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+        version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
         version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -515,7 +515,7 @@ importers:
         version: 2.0.0(webpack@5.88.2)
       webpack:
         specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+        version: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.88.2)
@@ -1826,7 +1826,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
+        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       jest-image-snapshot:
         specifier: ^6.4.0
         version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
@@ -3437,6 +3437,9 @@ importers:
       ai:
         specifier: ^6.0.0
         version: 6.0.77(zod@4.3.6)
+      eventsource-parser:
+        specifier: ^3.0.0
+        version: 3.0.6
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
@@ -3485,7 +3488,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))
+        version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -31796,7 +31799,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.25.4
@@ -33810,7 +33813,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@7.6.4(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@storybook/channels': 7.6.4
@@ -33840,12 +33843,12 @@ snapshots:
       semver: 7.7.4
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.15.18)(webpack@5.88.2)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(webpack@5.88.2)
       ts-dedent: 2.2.0
       url: 0.11.1
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -33916,7 +33919,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.2
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -33959,7 +33962,7 @@ snapshots:
       '@types/cross-spawn': 6.0.2
       cross-spawn: 7.0.6
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0))
+      jscodeshift: 0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0))
       lodash: 4.18.1
       prettier: 2.8.8
       recast: 0.23.11
@@ -34251,7 +34254,7 @@ snapshots:
 
   '@storybook/postinstall@7.6.4': {}
 
-  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.23.3(@babel/core@7.26.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.26.0)
@@ -34271,7 +34274,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       '@babel/core': 7.26.0
       typescript: 5.9.3
@@ -34354,7 +34357,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -34388,10 +34391,10 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.4(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -34531,10 +34534,10 @@ snapshots:
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
-      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0)
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       playwright: 1.45.0
       read-pkg-up: 7.0.1
@@ -36570,7 +36573,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -36850,17 +36853,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.88.2)':
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
 
   '@xmldom/xmldom@0.8.11': {}
@@ -37467,14 +37470,14 @@ snapshots:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   babel-loader@9.1.3(@babel/core@7.29.0)(webpack@5.88.2):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -38663,7 +38666,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   css-loader@6.8.1(webpack@5.88.2):
     dependencies:
@@ -38675,7 +38678,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.2):
     dependencies:
@@ -40376,7 +40379,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   file-system-cache@2.3.0:
     dependencies:
@@ -40520,7 +40523,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   form-data@4.0.5:
     dependencies:
@@ -41203,7 +41206,7 @@ snapshots:
   html-webpack-harddisk-plugin@2.0.0(html-webpack-plugin@5.5.3(webpack@5.88.2))(webpack@5.88.2):
     dependencies:
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   html-webpack-plugin@5.5.3(webpack@5.88.2):
     dependencies:
@@ -41212,7 +41215,7 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   htmlnano@2.1.1(cssnano@7.0.6(postcss@8.5.6))(postcss@8.5.6)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.46.0)(typescript@5.9.3):
     dependencies:
@@ -42512,7 +42515,7 @@ snapshots:
       '@types/node': 22.18.8
       jest-util: 30.0.5
 
-  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))):
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))
@@ -42935,7 +42938,7 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.9.3))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0):
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
@@ -43093,7 +43096,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.1(@babel/preset-env@7.23.5(@babel/core@7.26.0)):
+  jscodeshift@0.15.1(@babel/preset-env@7.23.5(@babel/core@7.29.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -43116,7 +43119,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.23.5(@babel/core@7.26.0)
+      '@babel/preset-env': 7.23.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -43384,7 +43387,7 @@ snapshots:
       less: 4.2.2
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   less@3.13.1:
     dependencies:
@@ -45873,7 +45876,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   postcss-logical@8.0.0(postcss@8.5.2):
     dependencies:
@@ -46857,7 +46860,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -47989,7 +47992,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.56.0
 
@@ -48697,11 +48700,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   style-loader@3.3.3(webpack@5.88.2):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   style-search@0.1.0: {}
 
@@ -48905,7 +48908,7 @@ snapshots:
   swc-loader@0.2.3(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@swc/core': 1.15.18
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   symbol-tree@3.2.4: {}
 
@@ -49101,17 +49104,16 @@ snapshots:
       '@swc/core': 1.15.18
       esbuild: 0.27.3
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2):
+  terser-webpack-plugin@5.3.9(@swc/core@1.15.18)(webpack@5.88.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.1
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.15.18
-      esbuild: 0.18.20
 
   terser@5.19.1:
     dependencies:
@@ -50222,7 +50224,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
 
   webpack-dev-middleware@6.1.1(webpack@5.88.2):
@@ -50233,7 +50235,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4)
 
   webpack-hot-middleware@2.25.4:
     dependencies:
@@ -50284,7 +50286,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.88.2(@swc/core@1.15.18)(esbuild@0.18.20)(webpack-cli@5.1.4):
+  webpack@5.88.2(@swc/core@1.15.18)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.4
       '@types/estree': 1.0.1
@@ -50307,7 +50309,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.15.18)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/products/replay/mcp/tools.yaml
+++ b/products/replay/mcp/tools.yaml
@@ -15,6 +15,9 @@ ui_apps:
         type: detail
         view_prop: data
 tools:
+    create-session-summaries-individually:
+        operation: create_session_summaries_individually
+        enabled: false
     session-recording-delete:
         operation: session_recordings_destroy
         enabled: true
@@ -140,40 +143,6 @@ tools:
     session-recording-playlists-update:
         operation: session_recording_playlists_update
         enabled: false
-    session-recording-summarize:
-        operation: create_session_summaries_individually
-        enabled: true
-        scopes:
-            - session_recording:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Summarize session recording
-        description: >
-            Generate an AI-powered summary of one or more session recordings. Returns structured analysis including user
-            journey segments, key actions, segment outcomes, overall session outcome, and sentiment analysis
-            (frustration score, rage clicks, confusion signals). Use this instead of asking users to watch full
-            recordings — it provides the key insights in seconds. Accepts up to 300 session IDs and an optional
-            focus_area to guide the summary toward a specific aspect (e.g., "checkout flow" or "error handling"). The
-            response is a dict keyed by session ID. Successful entries contain the summary fields; failed entries
-            contain an `error` (e.g. `recording_not_found`, `no_events_or_too_short`, `summary_failed`) and an
-            `error_message` so callers can distinguish "skipped on purpose" from "tool broke". A bad session ID in the
-            batch is reported as a per-session error and does not fail the whole request. WARNING: First-time summaries
-            call an AI model and are very slow — expect around 5 minutes on average. Previously generated summaries are
-            cached and return instantly. Warn the user about the wait before calling this tool.
-
-
-            DEEP LINKS: Key actions include `session_id` and `milliseconds_since_start`. Build deep links as
-            `{posthog_base_url}/replay/{session_id}?t={milliseconds_since_start / 1000}` (the `?t=` parameter is in
-            seconds). Example: 45000ms in session abc123 → `/replay/abc123?t=45`. Always include these links for key
-            actions and frustration signals.
-        include_params:
-            - session_ids
-            - focus_area
-        ui_app: session-summary
-        requires_ai_consent: true
-        feature_flag: replay-video-based-summarization
     session-recordings-list:
         operation: session_recordings_list
         enabled: false

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -40,6 +40,7 @@
         "@toon-format/toon": "^2.1.0",
         "agents": "0.10.2",
         "ai": "^6.0.0",
+        "eventsource-parser": "^3.0.0",
         "fflate": "^0.8.2",
         "mcpcat": "0.1.15",
         "posthog-js-lite": "4.2.2",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4092,23 +4092,6 @@
             "readOnlyHint": true
         }
     },
-    "session-recording-summarize": {
-        "description": "Generate an AI-powered summary of one or more session recordings. Returns structured analysis including user journey segments, key actions, segment outcomes, overall session outcome, and sentiment analysis (frustration score, rage clicks, confusion signals). Use this instead of asking users to watch full recordings — it provides the key insights in seconds. Accepts up to 300 session IDs and an optional focus_area to guide the summary toward a specific aspect (e.g., \"checkout flow\" or \"error handling\"). The response is a dict keyed by session ID. Successful entries contain the summary fields; failed entries contain an `error` (e.g. `recording_not_found`, `no_events_or_too_short`, `summary_failed`) and an `error_message` so callers can distinguish \"skipped on purpose\" from \"tool broke\". A bad session ID in the batch is reported as a per-session error and does not fail the whole request. WARNING: First-time summaries call an AI model and are very slow — expect around 5 minutes on average. Previously generated summaries are cached and return instantly. Warn the user about the wait before calling this tool.\n\nDEEP LINKS: Key actions include `session_id` and `milliseconds_since_start`. Build deep links as `{posthog_base_url}/replay/{session_id}?t={milliseconds_since_start / 1000}` (the `?t=` parameter is in seconds). Example: 45000ms in session abc123 → `/replay/abc123?t=45`. Always include these links for key actions and frustration signals.",
-        "category": "Session replays",
-        "feature": "replay",
-        "summary": "Summarize session recording",
-        "title": "Summarize session recording",
-        "required_scopes": ["session_recording:read"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "requires_ai_consent": true,
-        "feature_flag": "replay-video-based-summarization"
-    },
     "sql-variables-create": {
         "description": "Create a reusable SQL variable for HogQL queries. Provide a human-readable name and type. The code_name is generated from the name and is referenced in SQL as {variables.code_name}. For List variables, provide values as the allowed options.",
         "category": "Data warehouse",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -4527,21 +4527,21 @@
         }
     },
     "session-recording-summarize": {
-        "description": "Generate an AI-powered summary of one or more session recordings. Returns structured analysis including user journey segments, key actions, segment outcomes, overall session outcome, and sentiment analysis (frustration score, rage clicks, confusion signals). Use this instead of asking users to watch full recordings — it provides the key insights in seconds. Accepts up to 300 session IDs and an optional focus_area to guide the summary toward a specific aspect (e.g., \"checkout flow\" or \"error handling\"). The response is a dict keyed by session ID. Successful entries contain the summary fields; failed entries contain an `error` (e.g. `recording_not_found`, `no_events_or_too_short`, `summary_failed`) and an `error_message` so callers can distinguish \"skipped on purpose\" from \"tool broke\". A bad session ID in the batch is reported as a per-session error and does not fail the whole request. WARNING: First-time summaries call an AI model and are very slow — expect around 5 minutes on average. Previously generated summaries are cached and return instantly. Warn the user about the wait before calling this tool.\n\nDEEP LINKS: Key actions include `session_id` and `milliseconds_since_start`. Build deep links as `{posthog_base_url}/replay/{session_id}?t={milliseconds_since_start / 1000}` (the `?t=` parameter is in seconds). Example: 45000ms in session abc123 → `/replay/abc123?t=45`. Always include these links for key actions and frustration signals.",
+        "description": "Generate an AI-powered summary of one or more session recordings. Returns structured analysis including user journey segments, key actions, segment outcomes, overall session outcome, and sentiment analysis (frustration score, rage clicks, confusion signals). Use this instead of asking users to watch full recordings — it provides the key insights in seconds. Accepts up to 300 session IDs and an optional focus_area to guide the summary toward a specific aspect (e.g., \"checkout flow\" or \"error handling\"). The response is a dict keyed by session ID. Successful entries contain the summary fields; failed entries contain an `error` (e.g. `no_events_or_too_short`, `summary_failed`) and an `error_message` so callers can distinguish \"skipped on purpose\" from \"tool broke\". A bad session ID in the batch is reported as a per-session error and does not fail the whole request. WARNING: First-time summaries call an AI model and are very slow — expect around 5 minutes on average. Previously generated summaries are cached and return instantly. Warn the user about the wait before calling this tool.\n\nDEEP LINKS: Key actions include `session_id` and `milliseconds_since_start`. Build deep links as `{posthog_base_url}/replay/{session_id}?t={milliseconds_since_start / 1000}` (the `?t=` parameter is in seconds). Example: 45000ms in session abc123 → `/replay/abc123?t=45`. Always include these links for key actions and frustration signals.",
         "category": "Session replays",
         "feature": "replay",
-        "summary": "Summarize session recording",
+        "summary": "Generate AI-powered summaries of session recordings via streaming.",
         "title": "Summarize session recording",
         "required_scopes": ["session_recording:read"],
         "new_mcp": true,
+        "requires_ai_consent": true,
+        "feature_flag": "replay-video-based-summarization",
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "requires_ai_consent": true,
-        "feature_flag": "replay-video-based-summarization"
+        }
     },
     "sql-variables-create": {
         "description": "Create a reusable SQL variable for HogQL queries. Provide a human-readable name and type. The code_name is generated from the name and is referenced in SQL as {variables.code_name}. For List variables, provide values as the allowed options.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -520,5 +520,22 @@
             "openWorldHint": false,
             "readOnlyHint": true
         }
+    },
+    "session-recording-summarize": {
+        "description": "Generate an AI-powered summary of one or more session recordings. Returns structured analysis including user journey segments, key actions, segment outcomes, overall session outcome, and sentiment analysis (frustration score, rage clicks, confusion signals). Use this instead of asking users to watch full recordings — it provides the key insights in seconds. Accepts up to 300 session IDs and an optional focus_area to guide the summary toward a specific aspect (e.g., \"checkout flow\" or \"error handling\"). The response is a dict keyed by session ID. Successful entries contain the summary fields; failed entries contain an `error` (e.g. `no_events_or_too_short`, `summary_failed`) and an `error_message` so callers can distinguish \"skipped on purpose\" from \"tool broke\". A bad session ID in the batch is reported as a per-session error and does not fail the whole request. WARNING: First-time summaries call an AI model and are very slow — expect around 5 minutes on average. Previously generated summaries are cached and return instantly. Warn the user about the wait before calling this tool.\n\nDEEP LINKS: Key actions include `session_id` and `milliseconds_since_start`. Build deep links as `{posthog_base_url}/replay/{session_id}?t={milliseconds_since_start / 1000}` (the `?t=` parameter is in seconds). Example: 45000ms in session abc123 → `/replay/abc123?t=45`. Always include these links for key actions and frustration signals.",
+        "category": "Session replays",
+        "feature": "replay",
+        "summary": "Generate AI-powered summaries of session recordings via streaming.",
+        "title": "Summarize session recording",
+        "required_scopes": ["session_recording:read"],
+        "new_mcp": true,
+        "requires_ai_consent": true,
+        "feature_flag": "replay-video-based-summarization",
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     }
 }

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -1,3 +1,4 @@
+import { createParser } from 'eventsource-parser'
 import { z } from 'zod'
 
 import { getUserAgent } from '@/lib/constants'
@@ -16,6 +17,17 @@ import { isShortId } from '@/tools/insights/utils'
 
 import type { Schemas } from './generated.js'
 import { globalRateLimiter } from './rate-limiter.js'
+
+// Default overall timeout for an SSE stream (wall-clock cap from connect to close).
+// Sized to comfortably cover the slowest known caller (session summarization, ~5 min
+// average) with headroom for cold-cache LLM calls.
+const SSE_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
+
+// Per-read inactivity timeout: if no chunk (not even a keepalive comment) arrives
+// within this window, the server is assumed dead. Must comfortably exceed the
+// server-side keepalive interval — kept in sync with `SSE_KEEPALIVE_INTERVAL = 15s`
+// in `ee/api/session_summaries.py`. If you change one, check the other.
+const SSE_READ_TIMEOUT_MS = 30_000
 
 export interface GroupType {
     group_type: string
@@ -174,6 +186,92 @@ export class ApiClient {
             throw result.error
         }
         return result.data as T
+    }
+
+    /**
+     * Open a Server-Sent Events (text/event-stream) connection and invoke `onEvent`
+     * for each parsed event. Resolves when the server closes the stream, throws on
+     * HTTP error, missing body, per-read inactivity, or overall stream timeout.
+     *
+     * Used by tools that consume long-running streaming endpoints (e.g. session
+     * summarization) where a synchronous request would exceed gateway timeouts.
+     */
+    async requestSSE<T = unknown>(opts: {
+        method: 'GET' | 'POST'
+        path: string
+        body?: Record<string, unknown>
+        onEvent: (event: string, data: T) => void
+        timeoutMs?: number
+    }): Promise<void> {
+        const url = `${this.baseUrl}${opts.path}`
+        const fetchOptions: RequestInit = {
+            method: opts.method,
+            ...(opts.body ? { body: JSON.stringify(opts.body) } : {}),
+            headers: {
+                Accept: 'text/event-stream',
+            },
+        }
+
+        const response = await this.fetch(url, fetchOptions)
+
+        if (!response.ok) {
+            const errorText = await response.text()
+            throw new Error(
+                `SSE request failed:\nURL: ${opts.method} ${url}\nStatus Code: ${response.status} (${response.statusText})\nError Message: ${errorText}`
+            )
+        }
+
+        if (!response.body) {
+            throw new Error(`SSE response has no body: ${opts.method} ${url}`)
+        }
+
+        const timeoutMs = opts.timeoutMs ?? SSE_DEFAULT_TIMEOUT_MS
+        const readTimeoutMs = SSE_READ_TIMEOUT_MS
+        const startTime = Date.now()
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+
+        const parser = createParser({
+            onEvent: ({ event, data }) => {
+                const eventType = event ?? 'message'
+                try {
+                    const parsed = JSON.parse(data) as T
+                    opts.onEvent(eventType, parsed)
+                } catch {
+                    // Non-JSON data, pass as-is
+                    opts.onEvent(eventType, data as T)
+                }
+            },
+        })
+
+        try {
+            while (true) {
+                if (Date.now() - startTime > timeoutMs) {
+                    throw new Error(`SSE stream timed out after ${timeoutMs}ms`)
+                }
+
+                let readTimeoutId: ReturnType<typeof setTimeout>
+                const readResult = await Promise.race([
+                    reader.read(),
+                    new Promise<never>((_, reject) => {
+                        readTimeoutId = setTimeout(
+                            () => reject(new Error(`SSE read timed out — no data received for ${readTimeoutMs}ms`)),
+                            readTimeoutMs
+                        )
+                    }),
+                ])
+                clearTimeout(readTimeoutId!)
+                const { done, value } = readResult
+                if (done) {
+                    break
+                }
+
+                parser.feed(decoder.decode(value, { stream: true }))
+            }
+        } finally {
+            await reader.cancel()
+            reader.releaseLock()
+        }
     }
 
     private async fetchJson<T>(url: string, options?: RequestInit): Promise<Result<T>> {

--- a/services/mcp/src/generated/replay/api.ts
+++ b/services/mcp/src/generated/replay/api.ts
@@ -3,38 +3,10 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 7 enabled ops
+ * PostHog API - MCP 6 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
-
-/**
- * Generate AI individual summary for each session, without grouping.
- */
-export const CreateSessionSummariesIndividuallyParams = /* @__PURE__ */ zod.object({
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-export const createSessionSummariesIndividuallyBodySessionIdsMax = 300
-
-export const createSessionSummariesIndividuallyBodyFocusAreaMax = 500
-
-export const CreateSessionSummariesIndividuallyBody = /* @__PURE__ */ zod.object({
-    session_ids: zod
-        .array(zod.string())
-        .min(1)
-        .max(createSessionSummariesIndividuallyBodySessionIdsMax)
-        .describe('List of session IDs to summarize (max 300)'),
-    focus_area: zod
-        .string()
-        .max(createSessionSummariesIndividuallyBodyFocusAreaMax)
-        .optional()
-        .describe('Optional focus area for the summarization'),
-})
 
 /**
  * Override list to include synthetic playlists

--- a/services/mcp/src/tools/generated/replay.ts
+++ b/services/mcp/src/tools/generated/replay.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
-    CreateSessionSummariesIndividuallyBody,
     SessionRecordingPlaylistsCreateBody,
     SessionRecordingPlaylistsListQueryParams,
     SessionRecordingPlaylistsPartialUpdateBody,
@@ -170,30 +169,6 @@ const sessionRecordingPlaylistsList = (): ToolBase<
         return await withPostHogUrl(context, result, '/replay')
     },
 })
-
-const SessionRecordingSummarizeSchema = CreateSessionSummariesIndividuallyBody
-
-const sessionRecordingSummarize = (): ToolBase<typeof SessionRecordingSummarizeSchema, Schemas.SessionSummaries> =>
-    withUiApp('session-summary', {
-        name: 'session-recording-summarize',
-        schema: SessionRecordingSummarizeSchema,
-        handler: async (context: Context, params: z.infer<typeof SessionRecordingSummarizeSchema>) => {
-            const projectId = await context.stateManager.getProjectId()
-            const body: Record<string, unknown> = {}
-            if (params.session_ids !== undefined) {
-                body['session_ids'] = params.session_ids
-            }
-            if (params.focus_area !== undefined) {
-                body['focus_area'] = params.focus_area
-            }
-            const result = await context.api.request<Schemas.SessionSummaries>({
-                method: 'POST',
-                path: `/api/environments/${encodeURIComponent(String(projectId))}/session_summaries/create_session_summaries_individually/`,
-                body,
-            })
-            return result
-        },
-    })
 
 // --- Query wrapper schemas from schema.json ---
 
@@ -642,7 +617,6 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'session-recording-playlist-get': sessionRecordingPlaylistGet,
     'session-recording-playlist-update': sessionRecordingPlaylistUpdate,
     'session-recording-playlists-list': sessionRecordingPlaylistsList,
-    'session-recording-summarize': sessionRecordingSummarize,
     'query-session-recordings-list': createQueryWrapper({
         name: 'query-session-recordings-list',
         schema: AssistantRecordingsQuery,

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -35,6 +35,8 @@ import generateHogQLFromQuestion from './query/generateHogQLFromQuestion'
 import queryRun from './query/run'
 import hogqlSchema from './query/schema'
 import queryValidate from './query/validate'
+// Replay
+import sessionRecordingSummarize from './replay/sessionRecordingSummarize'
 // Search
 import entitySearch from './search/entitySearch'
 // Misc
@@ -87,6 +89,9 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'execute-sql': executeSql,
     'read-data-schema': readDataSchema,
     'read-data-warehouse-schema': readDataWarehouseSchema,
+
+    // Replay
+    'session-recording-summarize': sessionRecordingSummarize,
 
     // Data warehouse (custom handlers for non-standard request shapes)
     'external-data-sources-db-schema': externalDataSourcesDbSchema,

--- a/services/mcp/src/tools/replay/sessionRecordingSummarize.ts
+++ b/services/mcp/src/tools/replay/sessionRecordingSummarize.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod'
+
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    session_ids: z.array(z.string()).min(1).max(300).describe('List of session IDs to summarize (max 300)'),
+    focus_area: z.string().max(500).optional().describe('Optional focus area for the summarization'),
+})
+
+type Params = z.infer<typeof schema>
+
+interface SessionSummary {
+    [key: string]: unknown
+}
+
+interface SessionError {
+    error: string
+    error_message: string
+}
+
+type SessionResult = SessionSummary | SessionError
+
+interface SummaryEvent {
+    session_id: string
+    summary: SessionSummary
+}
+
+interface ErrorEvent {
+    session_id: string
+    error: string
+    error_message: string
+}
+
+interface DoneEvent {
+    completed: string[]
+    failed: string[]
+}
+
+type SseEvent = SummaryEvent | ErrorEvent | DoneEvent
+
+type SseResult = WithPostHogUrl<Record<string, SessionResult>>
+
+/**
+ * Hand-written session-recording-summarize tool that uses SSE streaming
+ * to avoid gateway timeouts on long-running summary generation (~5 min).
+ *
+ * Instead of blocking on a single HTTP request, this tool:
+ * 1. Calls the streaming endpoint which returns SSE events
+ * 2. Accumulates individual session summaries as they complete
+ * 3. Returns the full result once the stream ends
+ */
+const sessionRecordingSummarize = (): ToolBase<typeof schema, SseResult> =>
+    withUiApp('session-summary', {
+        name: 'session-recording-summarize',
+        schema,
+        handler: async (context: Context, params: Params): Promise<SseResult> => {
+            const projectId = await context.stateManager.getProjectId()
+            const body: Record<string, unknown> = { session_ids: params.session_ids }
+            if (params.focus_area !== undefined) {
+                body['focus_area'] = params.focus_area
+            }
+
+            const results: Record<string, SessionResult> = {}
+            let sawDone = false
+
+            await context.api.requestSSE<SseEvent>({
+                method: 'POST',
+                path: `/api/environments/${encodeURIComponent(String(projectId))}/session_summaries/stream_batch/`,
+                body,
+                onEvent: (event, data) => {
+                    if (event === 'summary') {
+                        const d = data as SummaryEvent
+                        if (d.session_id && d.summary) {
+                            results[d.session_id] = d.summary
+                        }
+                    } else if (event === 'error') {
+                        const d = data as ErrorEvent
+                        if (d.session_id) {
+                            results[d.session_id] = {
+                                error: d.error,
+                                error_message: d.error_message,
+                            }
+                        }
+                    } else if (event === 'done') {
+                        sawDone = true
+                    }
+                },
+            })
+
+            if (!sawDone) {
+                throw new Error(
+                    `SSE stream ended without a done event — results may be incomplete (received ${Object.keys(results).length}/${params.session_ids.length} sessions)`
+                )
+            }
+
+            return withPostHogUrl(context, results, '/replay')
+        },
+    })
+
+export default sessionRecordingSummarize

--- a/services/mcp/tests/unit/requestSSE.test.ts
+++ b/services/mcp/tests/unit/requestSSE.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiClient } from '@/api/client'
+
+vi.mock('@/api/rate-limiter', () => ({
+    globalRateLimiter: {
+        throttle: vi.fn().mockResolvedValue(undefined),
+    },
+}))
+
+function createMockStream(chunks: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder()
+    let index = 0
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                controller.enqueue(encoder.encode(chunks[index]))
+                index++
+            } else {
+                controller.close()
+            }
+        },
+    })
+}
+
+function makeMockFetch(response: Response): typeof fetch {
+    return vi.fn().mockResolvedValue(response)
+}
+
+describe('ApiClient.requestSSE', () => {
+    let client: ApiClient
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        client = new ApiClient({
+            apiToken: 'test-token',
+            baseUrl: 'https://app.posthog.com',
+        })
+    })
+
+    afterEach(() => {
+        vi.clearAllTimers()
+        vi.restoreAllMocks()
+        vi.useRealTimers()
+    })
+
+    it('should parse multiple SSE events and call onEvent for each', async () => {
+        const sseBody = [
+            'event: summary\ndata: {"session_id": "abc", "summary": {"key": "value"}}\n\n',
+            'event: summary\ndata: {"session_id": "def", "summary": {"key": "other"}}\n\n',
+            'event: done\ndata: {"completed": ["abc", "def"], "failed": []}\n\n',
+        ].join('')
+
+        const mockResponse = new Response(createMockStream([sseBody]), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        const onEvent = vi.fn()
+        const promise = client.requestSSE({
+            method: 'GET',
+            path: '/api/stream',
+            onEvent,
+        })
+        await vi.runAllTimersAsync()
+        await promise
+
+        expect(onEvent).toHaveBeenCalledTimes(3)
+        expect(onEvent).toHaveBeenNthCalledWith(1, 'summary', { session_id: 'abc', summary: { key: 'value' } })
+        expect(onEvent).toHaveBeenNthCalledWith(2, 'summary', { session_id: 'def', summary: { key: 'other' } })
+        expect(onEvent).toHaveBeenNthCalledWith(3, 'done', { completed: ['abc', 'def'], failed: [] })
+    })
+
+    it('should skip keepalive comments and only call onEvent for real events', async () => {
+        const sseBody = [
+            'event: summary\ndata: {"session_id": "abc"}\n\n',
+            ': keepalive\n\n',
+            ': keepalive\n\n',
+            'event: done\ndata: {"completed": ["abc"], "failed": []}\n\n',
+        ].join('')
+
+        const mockResponse = new Response(createMockStream([sseBody]), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        const onEvent = vi.fn()
+        const promise = client.requestSSE({
+            method: 'GET',
+            path: '/api/stream',
+            onEvent,
+        })
+        await vi.runAllTimersAsync()
+        await promise
+
+        expect(onEvent).toHaveBeenCalledTimes(2)
+        expect(onEvent).toHaveBeenNthCalledWith(1, 'summary', { session_id: 'abc' })
+        expect(onEvent).toHaveBeenNthCalledWith(2, 'done', { completed: ['abc'], failed: [] })
+    })
+
+    it('should handle chunked delivery by buffering across chunk boundaries', async () => {
+        // Split the first event mid-way across two chunks
+        const chunks = [
+            'event: summary\ndata: {"session_id": "abc"',
+            '}\n\nevent: done\ndata: {"completed": ["abc"], "failed": []}\n\n',
+        ]
+
+        const mockResponse = new Response(createMockStream(chunks), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        const onEvent = vi.fn()
+        const promise = client.requestSSE({
+            method: 'GET',
+            path: '/api/stream',
+            onEvent,
+        })
+        await vi.runAllTimersAsync()
+        await promise
+
+        expect(onEvent).toHaveBeenCalledTimes(2)
+        expect(onEvent).toHaveBeenNthCalledWith(1, 'summary', { session_id: 'abc' })
+        expect(onEvent).toHaveBeenNthCalledWith(2, 'done', { completed: ['abc'], failed: [] })
+    })
+
+    it('should throw with status code and error text on HTTP error response', async () => {
+        const mockResponse = new Response('Unauthorized', {
+            status: 401,
+            statusText: 'Unauthorized',
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        await expect(
+            client.requestSSE({
+                method: 'GET',
+                path: '/api/stream',
+                onEvent: vi.fn(),
+            })
+        ).rejects.toThrow('401')
+    })
+
+    it('should throw when response body is missing', async () => {
+        const mockResponse = new Response(null, {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        await expect(
+            client.requestSSE({
+                method: 'GET',
+                path: '/api/stream',
+                onEvent: vi.fn(),
+            })
+        ).rejects.toThrow('SSE response has no body')
+    })
+
+    it('should throw "SSE read timed out" when no data arrives within the per-read timeout', async () => {
+        // Mock the reader so that read() rejects with the per-read timeout error.
+        // This directly tests the observable behavior (the error thrown) without
+        // relying on fake timers, which would leave dangling timer promises in the
+        // cloudflare-workers test environment.
+        const mockReader = {
+            read: vi.fn().mockRejectedValue(new Error('SSE read timed out — no data received for 30000ms')),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: vi.fn(),
+        }
+        const mockBody = {
+            getReader: vi.fn().mockReturnValue(mockReader),
+        }
+        const mockResponse = {
+            ok: true,
+            body: mockBody,
+            text: vi.fn(),
+        } as unknown as Response
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        await expect(
+            client.requestSSE({
+                method: 'GET',
+                path: '/api/stream',
+                onEvent: vi.fn(),
+            })
+        ).rejects.toThrow('SSE read timed out')
+    })
+
+    it('should throw "SSE stream timed out" when overall timeout is exceeded', async () => {
+        // Strategy: mock the reader so both read() calls resolve quickly (with keepalives),
+        // but advance the fake clock past timeoutMs between calls so the overall timeout
+        // check at the top of the loop fires on the second iteration.
+        const encoder = new TextEncoder()
+        const keepaliveChunk = encoder.encode(': keepalive\n\n')
+        const shortTimeoutMs = 500
+
+        // Use a deferred promise for the second read so we can resolve it after
+        // advancing the clock, giving the loop a chance to reach the top-of-loop
+        // overall timeout check on the next iteration.
+        let resolveSecondRead!: (value: ReadableStreamReadResult<Uint8Array>) => void
+        const secondReadPromise = new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+            resolveSecondRead = resolve
+        })
+
+        const mockReader = {
+            read: vi
+                .fn()
+                .mockResolvedValueOnce({ done: false, value: keepaliveChunk })
+                .mockReturnValueOnce(secondReadPromise),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: vi.fn(),
+        }
+        const mockBody = {
+            getReader: vi.fn().mockReturnValue(mockReader),
+        }
+        const mockResponse = {
+            ok: true,
+            body: mockBody,
+            text: vi.fn(),
+        } as unknown as Response
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        const promise = client.requestSSE({
+            method: 'GET',
+            path: '/api/stream',
+            onEvent: vi.fn(),
+            timeoutMs: shortTimeoutMs,
+        })
+
+        // Advance the clock past the overall timeout, then resolve the second read
+        // to unblock the loop so it can reach the top-of-loop timeout check.
+        await vi.advanceTimersByTimeAsync(shortTimeoutMs + 1)
+        resolveSecondRead({ done: false, value: keepaliveChunk })
+
+        await expect(promise).rejects.toThrow(`SSE stream timed out after ${shortTimeoutMs}ms`)
+    })
+
+    it('should pass raw string to onEvent when event data is not valid JSON', async () => {
+        const sseBody = 'event: status\ndata: plain text not json\n\n'
+
+        const mockResponse = new Response(createMockStream([sseBody]), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        const onEvent = vi.fn()
+        const promise = client.requestSSE({
+            method: 'GET',
+            path: '/api/stream',
+            onEvent,
+        })
+        await vi.runAllTimersAsync()
+        await promise
+
+        expect(onEvent).toHaveBeenCalledTimes(1)
+        expect(onEvent).toHaveBeenCalledWith('status', 'plain text not json')
+    })
+
+    it('should send Accept: text/event-stream header', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(
+            new Response(createMockStream([]), {
+                status: 200,
+                headers: { 'Content-Type': 'text/event-stream' },
+            })
+        )
+        vi.stubGlobal('fetch', mockFetch)
+
+        const promise = client.requestSSE({
+            method: 'POST',
+            path: '/api/stream',
+            body: { session_id: 'abc' },
+            onEvent: vi.fn(),
+        })
+        await vi.runAllTimersAsync()
+        await promise
+
+        expect(mockFetch).toHaveBeenCalledOnce()
+        const [, options] = mockFetch.mock.calls[0]!
+        const headers = options.headers as Record<string, string>
+        expect(headers['Accept']).toBe('text/event-stream')
+    })
+
+    it('should default event type to "message" when event line is absent', async () => {
+        const sseBody = 'data: {"value": 42}\n\n'
+
+        const mockResponse = new Response(createMockStream([sseBody]), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        })
+        vi.stubGlobal('fetch', makeMockFetch(mockResponse))
+
+        const onEvent = vi.fn()
+        const promise = client.requestSSE({
+            method: 'GET',
+            path: '/api/stream',
+            onEvent,
+        })
+        await vi.runAllTimersAsync()
+        await promise
+
+        expect(onEvent).toHaveBeenCalledOnce()
+        expect(onEvent).toHaveBeenCalledWith('message', { value: 42 })
+    })
+})


### PR DESCRIPTION
## Problem

Reworks `session-recording-summarize` to consume a streaming SSE endpoint, avoiding the Cloudflare gateway timeouts that were killing the previous synchronous call (~5 min average runtime).

## Changes

The tool is implemented as a fully hand-written MCP handler — defined in `tool-definitions.json`, registered in `TOOL_MAP`, **no YAML or codegen involvemen**t — so the streaming-specific logic doesn't leak into the generated tool pipeline.

Conversation about pro/con of manual vs new codegen: https://posthog.slack.com/archives/C09KTRWD3HD/p1778091489603729?thread_ts=1778014821.770729&cid=C09KTRWD3HD

Adds a generic `requestSSE` method on the shared `ApiClient` that any future PostHog MCP tool can use to consume SSE endpoints (Cloudflare Workers has no built-in `EventSource`, so this is hand-rolled per the WHATWG event-stream spec).

The new Django streaming endpoint (`stream_batch_session_summaries`) is marked `@extend_schema(exclude=True)` so it's omitted from the OpenAPI spec entirely — keeps it out of frontend codegen and MCP YAML scaffolding, since it doesn't follow request/response semantics.

UI app linkage (`session-summary`) is preserved by wrapping the hand-written handler with `withUiApp(...)`, matching what the codegen used to do.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually tested that tool still works:   
![Screenshot 2026-05-06 at 1.48.54 PM.png](https://app.graphite.com/user-attachments/assets/39a6502c-82f7-4e62-bbff-cb4b0af3a8ca.png)



- [x] `pnpm --filter=@posthog/mcp typecheck` passes
- [x] `pnpm --filter=@posthog/mcp test tests/unit/requestSSE.test.ts` — 10/10 pass (covers timeouts, multi-line data, keepalive comments, partial chunks, error events)
- [x] Backend tests for the new streaming endpoint pass (`ee/api/test/test_session_summaries.py`)
- [x] Manual: invoke `session-recording-summarize` from a local MCP client → no Cloudflare timeout, UI app renders, summaries returned
- [x] Verify `stream_batch_session_summaries` is absent from `frontend/tmp/openapi.json` and `products/replay/mcp/tools.yaml`
- [x] Verify `session-summary` UI app still loads (was broken before adding `withUiApp` wrapper to the hand-written handler)

<!---->

<!---->

<!---->

##  

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->of