### PR TITLE
fix(growth): shorten SDK Doctor team-events cache TTL to reduce out-of-date alerting

### DIFF
--- a/products/growth/backend/constants.py
+++ b/products/growth/backend/constants.py
@@ -1,6 +1,16 @@
 from typing import Literal, TypedDict
 
-SDK_CACHE_EXPIRY = 60 * 60 * 24 * 7  # 7 days
+SDK_CACHE_EXPIRY = 60 * 60 * 24 * 7  # 7 days — used by the GitHub `latestVersion` cache (hourly Dagster job)
+
+# Team-events snapshot TTL — sized to self-heal one missed daily cron run.
+# The Temporal `sdk_outdated` cron starts at 08:00 UTC; per-team writes happen mid-batch, so the
+# previous day's write for any given team can be timestamped meaningfully later. A 26h TTL gives
+# ~2h headroom relative to cron *start*, and less for teams late in the batch queue. That's
+# deliberate: when a team's TTL expires before its next batch slot, the next user request hits
+# the cache-miss fallback in posthog/api/sdk_doctor.py:get_team_data, which runs one fresh
+# single-team HogQL query and repopulates Redis. Steady-state load is unchanged; the trade-off
+# prevents days-long stale snapshots when a team's batch is skipped or times out.
+TEAM_SDK_CACHE_EXPIRY = 60 * 60 * 26  # 26 hours
 
 
 # Canonical list of the SDK identifiers SDK Doctor tracks. Lives here (rather than in

--- a/products/growth/backend/team_sdk_versions.py
+++ b/products/growth/backend/team_sdk_versions.py
@@ -15,7 +15,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 
-from products.growth.backend.constants import SDK_CACHE_EXPIRY, SdkVersionEntry, team_sdk_versions_key
+from products.growth.backend.constants import TEAM_SDK_CACHE_EXPIRY, SdkVersionEntry, team_sdk_versions_key
 from products.growth.dags.github_sdk_versions import SDK_TYPES
 
 default_logger: BoundLogger = structlog.get_logger(__name__)
@@ -103,7 +103,7 @@ def get_and_cache_team_sdk_versions(
         if sdk_versions is not None:
             payload = json.dumps(sdk_versions)
             cache_key = team_sdk_versions_key(team_id)
-            redis_client.setex(cache_key, SDK_CACHE_EXPIRY, payload)
+            redis_client.setex(cache_key, TEAM_SDK_CACHE_EXPIRY, payload)
             logger.info(f"[SDK Doctor] Team {team_id} SDK versions cached successfully")
 
             return sdk_versions

--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -12,8 +12,8 @@ from posthog.temporal.health_checks.models import HealthCheckResult
 from posthog.temporal.health_checks.query import execute_clickhouse_health_team_query
 
 from products.growth.backend.constants import (
-    SDK_CACHE_EXPIRY,
     SDK_TYPES,
+    TEAM_SDK_CACHE_EXPIRY,
     SdkVersionEntry,
     github_sdk_versions_key,
     team_sdk_versions_key,
@@ -74,7 +74,7 @@ def _cache_team_sdk_data(team_sdk_data: dict[int, dict[str, list[SdkVersionEntry
     pipe = redis_client.pipeline()
     for team_id, sdk_data in team_sdk_data.items():
         cache_key = team_sdk_versions_key(team_id)
-        pipe.setex(cache_key, SDK_CACHE_EXPIRY, json.dumps(sdk_data))
+        pipe.setex(cache_key, TEAM_SDK_CACHE_EXPIRY, json.dumps(sdk_data))
     pipe.execute()
 
 

--- a/products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py
@@ -6,8 +6,8 @@ from django.test import TestCase
 
 from posthog.models.health_issue import HealthIssue
 
-from products.growth.backend.constants import SDK_TYPES
-from products.growth.backend.temporal.health_checks.sdk_outdated import SdkOutdatedCheck
+from products.growth.backend.constants import SDK_TYPES, TEAM_SDK_CACHE_EXPIRY
+from products.growth.backend.temporal.health_checks.sdk_outdated import SdkOutdatedCheck, _cache_team_sdk_data
 
 
 def _make_github_data(latest_version: str, release_dates: dict | None = None) -> dict:
@@ -176,3 +176,16 @@ class TestSdkOutdatedCheck(TestCase):
         results = self.check.detect([1])
 
         assert results == {}
+
+    @patch("products.growth.backend.temporal.health_checks.sdk_outdated.get_client")
+    def test_cache_team_sdk_data_uses_team_sdk_cache_expiry(self, mock_get_client: MagicMock):
+        mock_redis = MagicMock()
+        mock_pipe = MagicMock()
+        mock_redis.pipeline.return_value = mock_pipe
+        mock_get_client.return_value = mock_redis
+
+        _cache_team_sdk_data({1: {"web": [{"lib_version": "1.0.0", "max_timestamp": "x", "count": 1}]}})
+
+        mock_pipe.setex.assert_called_once()
+        _key, ttl, _payload = mock_pipe.setex.call_args[0]
+        assert ttl == TEAM_SDK_CACHE_EXPIRY

--- a/products/growth/backend/tests/test_team_sdk_versions.py
+++ b/products/growth/backend/tests/test_team_sdk_versions.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from products.growth.backend.constants import TEAM_SDK_CACHE_EXPIRY
+from products.growth.backend.team_sdk_versions import get_and_cache_team_sdk_versions
+
+
+class TestGetAndCacheTeamSdkVersions(TestCase):
+    @patch("products.growth.backend.team_sdk_versions.get_sdk_versions_for_team")
+    def test_uses_team_sdk_cache_expiry(self, mock_get_sdk_versions: MagicMock):
+        mock_get_sdk_versions.return_value = {"web": [{"lib_version": "1.0.0", "max_timestamp": "x", "count": 1}]}
+        mock_redis = MagicMock()
+
+        get_and_cache_team_sdk_versions(team_id=1, redis_client=mock_redis)
+
+        mock_redis.setex.assert_called_once()
+        _key, ttl, _payload = mock_redis.setex.call_args[0]
+        assert ttl == TEAM_SDK_CACHE_EXPIRY

--- a/products/growth/backend/tests/test_team_sdk_versions.py
+++ b/products/growth/backend/tests/test_team_sdk_versions.py
@@ -1,12 +1,12 @@
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from products.growth.backend.constants import TEAM_SDK_CACHE_EXPIRY
 from products.growth.backend.team_sdk_versions import get_and_cache_team_sdk_versions
 
 
-class TestGetAndCacheTeamSdkVersions(TestCase):
+class TestGetAndCacheTeamSdkVersions(SimpleTestCase):
     @patch("products.growth.backend.team_sdk_versions.get_sdk_versions_for_team")
     def test_uses_team_sdk_cache_expiry(self, mock_get_sdk_versions: MagicMock):
         mock_get_sdk_versions.return_value = {"web": [{"lib_version": "1.0.0", "max_timestamp": "x", "count": 1}]}


### PR DESCRIPTION
## Problem

As reported by a customer in ticket [57380](https://posthoghelp.zendesk.com/agent/tickets/57380), SDK Doctor users sometimes see a red warning badge on the Health menu even though their actual SDK traffic is healthy. Clicking "Scan events" on the SDK Doctor page flips it back to green. After reviewing the code, it looks like the heuristic is doing its job, but the underlying cache gets too stale.

The team-events Redis snapshot is written by the Temporal `sdk_outdated` cron daily at 08:00 UTC, but the snapshot's TTL is **7 days**. When the cron's per-team batch fails, or skips a team (a real concern given the recent timeout-tuning history in #54949 / #54997 / #55090 lowered batch size to 10 and concurrency to 3), the stale snapshot keeps driving the badge for up to a week, even though SDK Doctor's API recomputes health on every request against fresh GitHub `latestVersion` data. The 7-day TTL is far longer than the cron's cadence needs.

## Changes

- New `TEAM_SDK_CACHE_EXPIRY = 60 * 60 * 26` constant for the team-events Redis snapshot, sized to evict one missed cron run.
- Both team-events writers now use the new constant:
  - `products/growth/backend/temporal/health_checks/sdk_outdated.py` (`_cache_team_sdk_data`, the cron writer)
  - `products/growth/backend/team_sdk_versions.py` (`get_and_cache_team_sdk_versions`, the API cache-miss fallback)
- `SDK_CACHE_EXPIRY` (7 days) is preserved for the GitHub `latestVersion` cache only (its hourly Dagster job is unrelated and unaffected.)

This fix relies on the _existing_ cache-miss fallback in `posthog/api/sdk_doctor.py:get_team_data`: when Redis has no entry, the API already runs a single-team HogQL query and repopulates the cache. Shortening the TTL just lets that fallback fire after one missed cron run, instead of after seven missed runs. No new code paths.

In the steady state (cron runs successfully each day) the TTL never matters — the cron's `setex` resets it well before expiry, so load is unchanged.

## How did you test this code?

Claude ran:

**Automated** — added two regression tests pinning the new constant on
each writer:
- `test_cache_team_sdk_data_uses_team_sdk_cache_expiry` (cron writer)
- `test_uses_team_sdk_cache_expiry` (API cache-miss writer)

Both pass locally:

```
collected 2 items
products/growth/backend/temporal/health_checks/tests/test_sdk_outdated.py .
products/growth/backend/tests/test_team_sdk_versions.py .
======== 2 passed in 385.71s ========
```

I ran manually on my local:
1. Clicked "Scan events" on the SDK Doctor page → verified `r.ttl("sdk_versions:team:3")` returned ~93600 (26h) instead of ~604800 (7d).
2. Deleted the Redis key → reloaded SDK Doctor page (no force-refresh) → verified the cache-miss fallback, re-populated with the new TTL, and the page rendered correctly.
3. Planted a fake stale-but-different snapshot with a 60s TTL to compress the eviction window → confirmed the UI shows the planted stale verdict, then confirmed it auto-corrected on the next page load after eviction.

## Publish to changelog?

No

## Docs update

No user-facing surface changed; no docs update needed.

## 🤖 Agent context

- **Tool**: PostHog Code (Claude Opus 4.7), pair-programming with @slshults.
- **Investigation path**:
  1. Started from a user report of a red SDK Doctor badge that "Refresh events" reliably fixed.
  2. Walked through `sdkDoctorLogic.tsx`, `sdk_health.py`, and `team_sdk_versions.py` to confirm the heuristic itself is correct.
  3. Modeled the 13-version snapshot the user shared and computed the outdated-traffic share at 0.09% — well below the 20% web threshold. With current data the badge should be green, so the bug had to be in the cached snapshot, not the heuristic.
  4. Considered and rejected: increasing cron frequency (Rafa & Jordan have been tuning the cron *down* for ClickHouse-load reasons), adding `refreshed_at` instrumentation, changing the GitHub `latestVersion` cache (stale GitHub data can only push verdicts toward green, not red).
  5. Landed on shortening the team-events TTL because it leverages an existing cache-miss code path with no new background work.
- **Code review**: Sent through the `code-reviewer` agent pre-commit; approved with two non-blocking suggestions, both incorporated (sharper comment about mid-batch write timing, regression tests pinning the constant).
- **Not done**: did not run the cron's `_cache_team_sdk_data` setex end-to-end against a local Temporal worker — exercised it via unit test instead, since the swap is mechanically identical to the API writer which was tested manually.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*