### PR TITLE
refactor(data-warehouse): handle missing saved query in draft creation

### DIFF
--- a/products/data_warehouse/backend/api/saved_query_draft.py
+++ b/products/data_warehouse/backend/api/saved_query_draft.py
@@ -29,13 +29,15 @@ class DataWarehouseSavedQueryDraftSerializer(serializers.ModelSerializer):
 
         name = "Untitled"
         if saved_query_id:
+            try:
+                saved_query = DataWarehouseSavedQuery.objects.get(id=saved_query_id, team_id=validated_data["team_id"])
+            except DataWarehouseSavedQuery.DoesNotExist:
+                raise serializers.ValidationError({"saved_query_id": "Saved query not found."})
             count = DataWarehouseSavedQueryDraft.objects.filter(
                 saved_query_id=saved_query_id,
                 team_id=validated_data["team_id"],
                 created_by=validated_data["created_by"],
             ).count()
-            # nosemgrep: idor-lookup-without-team (internal endpoint; only reads name for draft naming)
-            saved_query = DataWarehouseSavedQuery.objects.get(id=saved_query_id)
             name = f"({count + 1}) {saved_query.name}"
 
         validated_data["name"] = name

--- a/products/data_warehouse/backend/api/test/test_saved_query_draft.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query_draft.py
@@ -1,6 +1,6 @@
 from posthog.test.base import APIBaseTest
 
-from posthog.models import Team
+from posthog.models import Organization, Team
 
 from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_warehouse.backend.models.datawarehouse_saved_query_draft import DataWarehouseSavedQueryDraft
@@ -159,3 +159,27 @@ class TestDataWarehouseSavedQueryDraft(APIBaseTest):
         self.assertIsNotNone(draft_obj.saved_query)
         assert draft_obj.saved_query is not None
         self.assertEqual(draft_obj.saved_query.id, saved_query.id)
+
+    def test_cannot_create_draft_pointing_at_other_teams_saved_query(self):
+        """Regression: POST must not accept a saved_query_id from a different team."""
+        other_org = Organization.objects.create(name="Other Org (IDOR test)")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        foreign_saved_query = DataWarehouseSavedQuery.objects.create(
+            name="confidential_query",
+            team=other_team,
+            query={"kind": "HogQLQuery", "query": "select 1"},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/warehouse_saved_query_drafts/",
+            {
+                "query": {"kind": "HogQLQuery", "query": "select 2"},
+                "saved_query_id": str(foreign_saved_query.id),
+            },
+        )
+
+        # The serializer scopes the saved_query lookup by team_id, so the foreign
+        # id is unknown — DRF returns 400.
+        self.assertEqual(response.status_code, 400, response.content)
+        # And no draft should have been created bound to the foreign saved_query.
+        assert not DataWarehouseSavedQueryDraft.objects.filter(saved_query_id=foreign_saved_query.id).exists()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
