### PR TITLE
refactor(data-modeling): tighten DAG field validation in node serializer

### DIFF
--- a/products/data_modeling/backend/api/node.py
+++ b/products/data_modeling/backend/api/node.py
@@ -15,6 +15,7 @@ from rest_framework.pagination import PageNumberPagination
 from temporalio.common import RetryPolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.models import Team, User
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.data_modeling.run_workflow import RunWorkflowInputs, Selector
@@ -33,6 +34,7 @@ class NodeSerializer(serializers.ModelSerializer):
     user_tag = serializers.SerializerMethodField(read_only=True)
     sync_interval = serializers.SerializerMethodField(read_only=True)
     dag_name = serializers.SerializerMethodField(read_only=True)
+    dag = TeamScopedPrimaryKeyRelatedField(queryset=DAG.objects.all())
 
     class Meta:
         model = Node

--- a/products/data_modeling/backend/api/node.py
+++ b/products/data_modeling/backend/api/node.py
@@ -63,6 +63,7 @@ class NodeSerializer(serializers.ModelSerializer):
             "user_tag",
             "sync_interval",
             "dag_name",
+            "saved_query_id",
         ]
 
     def get_upstream_count(self, node: Node) -> int:

--- a/products/data_modeling/backend/api/test/test_node_api.py
+++ b/products/data_modeling/backend/api/test/test_node_api.py
@@ -1,6 +1,7 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import AsyncMock, patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Team
@@ -357,22 +358,64 @@ class TestNodeViewSet(APIBaseTest):
         self.assertNotIn(str(other_table.id), node_ids)
         self.assertNotIn(str(other_view.id), node_ids)
 
-    def test_cannot_bind_node_to_other_teams_dag_via_patch(self):
-        """Regression: PATCH must not accept a DAG pk owned by a different team."""
+    @parameterized.expand(["post", "put", "patch"])
+    def test_dag_field_rejects_other_teams_dag(self, method):
         other_team = Team.objects.create(organization=self.organization)
         foreign_dag = DAG.objects.create(team=other_team, name=f"posthog_{other_team.id}")
 
-        original_dag_id = self.view_node.dag_id
+        if method == "post":
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/data_modeling_nodes/",
+                data={"name": "new_table", "type": NodeType.TABLE, "dag": str(foreign_dag.id)},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertFalse(Node.objects.filter(name="new_table", dag=foreign_dag).exists())
+            return
 
-        response = self.client.patch(
-            f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/",
-            data={"dag": str(foreign_dag.id)},
-            format="json",
-        )
+        original_dag_id = self.view_node.dag_id
+        url = f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/"
+        if method == "patch":
+            response = self.client.patch(url, data={"dag": str(foreign_dag.id)}, format="json")
+        else:
+            response = self.client.put(
+                url,
+                data={"name": "test_view", "type": NodeType.VIEW, "dag": str(foreign_dag.id)},
+                format="json",
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.view_node.refresh_from_db()
         self.assertEqual(self.view_node.dag_id, original_dag_id)
+
+    @parameterized.expand(["put", "patch"])
+    def test_saved_query_id_cannot_be_bound_to_other_teams_query(self, method):
+        other_team = Team.objects.create(organization=self.organization)
+        foreign_sq = DataWarehouseSavedQuery.objects.create(
+            name="leaked_name",
+            team=other_team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        )
+
+        original_saved_query_id = self.view_node.saved_query_id
+        url = f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/"
+        if method == "patch":
+            self.client.patch(url, data={"saved_query_id": str(foreign_sq.id)}, format="json")
+        else:
+            self.client.put(
+                url,
+                data={
+                    "name": "test_view",
+                    "type": NodeType.VIEW,
+                    "dag": str(self.dag.id),
+                    "saved_query_id": str(foreign_sq.id),
+                },
+                format="json",
+            )
+
+        self.view_node.refresh_from_db()
+        self.assertEqual(self.view_node.saved_query_id, original_saved_query_id)
+        self.assertNotEqual(self.view_node.name, foreign_sq.name)
 
 
 class TestEdgeViewSet(APIBaseTest):

--- a/products/data_modeling/backend/api/test/test_node_api.py
+++ b/products/data_modeling/backend/api/test/test_node_api.py
@@ -357,6 +357,23 @@ class TestNodeViewSet(APIBaseTest):
         self.assertNotIn(str(other_table.id), node_ids)
         self.assertNotIn(str(other_view.id), node_ids)
 
+    def test_cannot_bind_node_to_other_teams_dag_via_patch(self):
+        """Regression: PATCH must not accept a DAG pk owned by a different team."""
+        other_team = Team.objects.create(organization=self.organization)
+        foreign_dag = DAG.objects.create(team=other_team, name=f"posthog_{other_team.id}")
+
+        original_dag_id = self.view_node.dag_id
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/",
+            data={"dag": str(foreign_dag.id)},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.view_node.refresh_from_db()
+        self.assertEqual(self.view_node.dag_id, original_dag_id)
+
 
 class TestEdgeViewSet(APIBaseTest):
     def setUp(self):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
