### PR TITLE
refactor(messaging): tighten message category field validation

### DIFF
--- a/products/messaging/backend/api/message_templates.py
+++ b/products/messaging/backend/api/message_templates.py
@@ -5,8 +5,10 @@ from rest_framework.permissions import IsAuthenticated
 
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
 
+from products.messaging.backend.models.message_category import MessageCategory
 from products.messaging.backend.models.message_template import MessageTemplate
 
 
@@ -25,6 +27,9 @@ class MessageTemplateContentSerializer(serializers.Serializer):
 class MessageTemplateSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     content = MessageTemplateContentSerializer(required=False)
+    message_category = TeamScopedPrimaryKeyRelatedField(
+        queryset=MessageCategory.objects.all(), required=False, allow_null=True
+    )
 
     class Meta:
         model = MessageTemplate

--- a/products/messaging/backend/api/test/test_message_templates.py
+++ b/products/messaging/backend/api/test/test_message_templates.py
@@ -4,6 +4,7 @@ from rest_framework import status
 
 from posthog.models import Organization, Team
 
+from products.messaging.backend.models.message_category import MessageCategory
 from products.messaging.backend.models.message_template import MessageTemplate
 
 
@@ -110,3 +111,32 @@ class TestMessageTemplatesAPI(APIBaseTest):
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
+
+    def test_cannot_bind_template_to_other_teams_message_category_via_patch(self):
+        """Regression: PATCH must not accept a MessageCategory pk owned by a different team."""
+        foreign_category = MessageCategory.objects.create(team=self.other_team, key="foreign-key", name="Foreign")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/messaging_templates/{self.message_template.id}/",
+            data={"message_category": str(foreign_category.id)},
+            format="json",
+        )
+
+        # TeamScopedPrimaryKeyRelatedField restricts the queryset to the caller's
+        # team, so the foreign id is unknown — DRF returns 400.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        self.message_template.refresh_from_db()
+        assert self.message_template.message_category_id is None
+
+    def test_can_bind_template_to_own_teams_message_category(self):
+        own_category = MessageCategory.objects.create(team=self.team, key="own-key", name="Own")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/messaging_templates/{self.message_template.id}/",
+            data={"message_category": str(own_category.id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        self.message_template.refresh_from_db()
+        assert self.message_template.message_category_id == own_category.id


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
