### PR TITLE
fix(ingestion-consumer): set metadata.broker.list to match Node config

### DIFF
--- a/rust/ingestion-consumer/src/kafka_config.rs
+++ b/rust/ingestion-consumer/src/kafka_config.rs
@@ -22,11 +22,18 @@ impl ConsumerConfigBuilder {
     ///
     /// Sets: auto.offset.store=false, auto.commit=false, socket.timeout.ms,
     /// session.timeout.ms, heartbeat.interval.ms, max.poll.interval.ms.
+    ///
+    /// Uses `metadata.broker.list` (not `bootstrap.servers`) to match the Node.js
+    /// KafkaConsumer in posthog-app. The two are aliases in librdkafka, but
+    /// rdkafka-rs's HashMap-backed ClientConfig has non-deterministic iteration
+    /// order, so setting both via different `KAFKA_*` env vars caused consumers
+    /// to land on the wrong cluster non-deterministically. Sticking with the
+    /// same key Node uses keeps env-var overrides idempotent.
     pub fn for_batch_consumer(bootstrap_servers: &str, group_id: &str) -> Self {
         let mut config = ClientConfig::new();
 
         config
-            .set("bootstrap.servers", bootstrap_servers)
+            .set("metadata.broker.list", bootstrap_servers)
             .set("group.id", group_id);
 
         // Group-consumer defaults


### PR DESCRIPTION
## Problem

The Rust ingestion-consumer was non-deterministically picking which Kafka cluster to consume from. `KAFKA_HOSTS` (events MSK) seeded `bootstrap.servers` while `KAFKA_CONSUMER_METADATA_BROKER_LIST` (msk-ingestion) was applied as an override on `metadata.broker.list`. The two are aliases in librdkafka, but rdkafka-rs stores them in a `HashMap<String, String>` and pushes each entry to librdkafka in iteration order, which is randomised — so on each pod start librdkafka saw the two settings in a different order, and the consumer randomly landed on either cluster. In dev this surfaced as `UnknownTopicOrPartition` because `ingestion-analytics-main-128` only exists on msk-ingestion.

## Changes

`for_batch_consumer` now sets `metadata.broker.list` instead of `bootstrap.servers`, matching the Node KafkaConsumer in nodejs/src/kafka/consumer.ts:214.

The `KAFKA_CONSUMER_METADATA_BROKER_LIST` env override now writes to the same HashMap key as the default, so it overwrites in place and HashMap iteration order stops mattering. librdkafka receives a single, deterministic value.

The change is scoped to ingestion-consumer's local copy of the builder. `for_watermark_consumer` and `for_assigner_consumer` still use `bootstrap.servers` and are unused inside this crate, so they were left alone.