### PR TITLE
feat(data-warehouse): defensive pre-write Delta compaction

### DIFF
--- a/posthog/temporal/data_imports/pipelines/common/extract.py
+++ b/posthog/temporal/data_imports/pipelines/common/extract.py
@@ -348,3 +348,29 @@ async def cdp_producer_clear_chunks(cdp_producer: CDPProducer):
 async def write_chunk_for_cdp_producer(cdp_producer: CDPProducer, index: int, pa_table: pa.Table):
     if await cdp_producer.should_produce_table():
         await cdp_producer.write_chunk_for_cdp_producer(chunk=index, table=pa_table)
+
+
+async def run_pre_write_defensive_compact(
+    delta_table_helper: DeltaTableHelper,
+    schema: "ExternalDataSchema",
+    resource: SourceResponse,
+    logger: FilteringBoundLogger,
+) -> None:
+    """Best-effort pre-write compact + vacuum at the start of a sync run.
+
+    Triggers `DeltaTableHelper.compact_if_fragmented` so a sync that arrived
+    at a fragmented Delta target (e.g. because earlier attempts failed
+    before reaching `_post_run_operations`) cleans up before adding more
+    small files. Wrapped in try/except so a compaction failure never blocks
+    the actual sync; the original error is captured but the run continues.
+
+    Used by both `PipelineNonDLT.run` (v2) and `PipelineV3.run` to keep the
+    behaviour identical across pipelines without each having to know how
+    to look up `partition_count` or how to swallow compaction errors.
+    """
+    try:
+        partition_count_for_compact = schema.partition_count or resource.partition_count
+        await delta_table_helper.compact_if_fragmented(partition_count=partition_count_for_compact)
+    except Exception as e:
+        capture_exception(e)
+        await logger.aexception(f"Pre-write compaction failed: {e}", exc_info=e)

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -26,6 +26,13 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
 from products.data_warehouse.backend.s3 import aget_s3_client, ensure_bucket_exists
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 
+# Files-per-partition above this triggers a defensive compact at the start of a
+# sync run. Set above the natural steady-state (a few files per partition per
+# successful run) but well below the level where per-merge file-listing scans
+# blow past PG's idle_in_transaction_session_timeout. Tune from the admin
+# fragmentation view once we have real-world distributions.
+DEFAULT_COMPACT_FILES_PER_PARTITION_THRESHOLD = 200
+
 
 def _write_deltalake(
     table_or_uri: str | deltalake.DeltaTable,
@@ -547,3 +554,41 @@ class DeltaTableHelper:
         await self._logger.adebug(json.dumps(vacuum_stats))
 
         await self._logger.adebug("Compacting and vacuuming complete")
+
+    async def compact_if_fragmented(
+        self,
+        partition_count: int | None,
+        threshold: int = DEFAULT_COMPACT_FILES_PER_PARTITION_THRESHOLD,
+    ) -> bool:
+        """Run compact + vacuum only if files-per-partition exceeds threshold.
+
+        Returns True if compaction ran, False if it was skipped. Cheap when the
+        table is healthy: one S3 LIST via `file_uris`. Intended for pre-write
+        defensive cleanup so a sync that arrived at a fragmented state cleans
+        up before adding to the pile.
+        """
+        table = await self.get_delta_table()
+        if table is None:
+            return False
+
+        file_uris = await self.get_file_uris()
+        total_files = len(file_uris)
+        # Treat unpartitioned tables as one "partition" for the threshold math.
+        effective_partitions = max(partition_count or 1, 1)
+        files_per_partition = total_files / effective_partitions
+
+        if files_per_partition <= threshold:
+            await self._logger.adebug(
+                f"compact_if_fragmented: skipping (total_files={total_files}, "
+                f"partitions={effective_partitions}, files_per_partition={files_per_partition:.1f}, "
+                f"threshold={threshold})"
+            )
+            return False
+
+        await self._logger.ainfo(
+            f"compact_if_fragmented: triggering compact (total_files={total_files}, "
+            f"partitions={effective_partitions}, files_per_partition={files_per_partition:.1f}, "
+            f"threshold={threshold})"
+        )
+        await self.compact_table()
+        return True

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -20,6 +20,7 @@ from posthog.temporal.data_imports.pipelines.common.extract import (
     finalize_desc_sort_incremental_value,
     handle_reset_or_full_refresh,
     reset_rows_synced_if_needed,
+    run_pre_write_defensive_compact,
     setup_row_tracking_with_billing_check,
     should_check_shutdown,
     update_incremental_field_values,
@@ -213,20 +214,15 @@ class PipelineNonDLT(Generic[ResumableData]):
             # If the schema has no DWH table, it's a first ever sync
             is_first_ever_sync: bool = self._table is None
 
-            # Defensive pre-write compaction. If the Delta target has accreted
-            # too many small files since the last successful run (e.g. because
-            # prior attempts failed before reaching `_post_run_operations`),
-            # compact + vacuum here so the upcoming merge cycle isn't dominated
-            # by file-listing scans. Skipped cheaply when the table is healthy.
+            # Defensive pre-write compaction so a sync that arrived at a
+            # fragmented Delta target cleans up before adding more small
+            # files. Skipped cheaply when the table is healthy. Shared
+            # implementation lives in `extract.run_pre_write_defensive_compact`
+            # so the v3 pipeline picks up the same behaviour.
             if not is_first_ever_sync:
-                try:
-                    partition_count_for_compact = self._schema.partition_count or self._resource.partition_count
-                    await self._delta_table_helper.compact_if_fragmented(
-                        partition_count=partition_count_for_compact,
-                    )
-                except Exception as e:
-                    capture_exception(e)
-                    await self._logger.aexception(f"Pre-write compaction failed: {e}", exc_info=e)
+                await run_pre_write_defensive_compact(
+                    self._delta_table_helper, self._schema, self._resource, self._logger
+                )
 
             async for item in async_iterate(self._resource.items()):
                 py_table = None

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -213,6 +213,21 @@ class PipelineNonDLT(Generic[ResumableData]):
             # If the schema has no DWH table, it's a first ever sync
             is_first_ever_sync: bool = self._table is None
 
+            # Defensive pre-write compaction. If the Delta target has accreted
+            # too many small files since the last successful run (e.g. because
+            # prior attempts failed before reaching `_post_run_operations`),
+            # compact + vacuum here so the upcoming merge cycle isn't dominated
+            # by file-listing scans. Skipped cheaply when the table is healthy.
+            if not is_first_ever_sync:
+                try:
+                    partition_count_for_compact = self._schema.partition_count or self._resource.partition_count
+                    await self._delta_table_helper.compact_if_fragmented(
+                        partition_count=partition_count_for_compact,
+                    )
+                except Exception as e:
+                    capture_exception(e)
+                    await self._logger.aexception(f"Pre-write compaction failed: {e}", exc_info=e)
+
             async for item in async_iterate(self._resource.items()):
                 py_table = None
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -136,6 +136,68 @@ class TestHasBatchBeenCommitted:
             m.assert_called_once_with({"run_uuid": run_uuid, "batch_index": str(batch_index)})
 
 
+class TestCompactIfFragmented:
+    """Pre-write defensive compaction gates on files-per-partition threshold."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_delta_table(self, helper: DeltaTableHelper):
+        with patch.object(helper, "get_delta_table", AsyncMock(return_value=None)):
+            ran = await helper.compact_if_fragmented(partition_count=10)
+        assert ran is False
+
+    @pytest.mark.asyncio
+    async def test_skips_below_threshold(self, helper: DeltaTableHelper):
+        # 100 files / 10 partitions = 10 files/partition (< default 200)
+        mock_delta = MagicMock()
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(100)])),
+            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
+        ):
+            ran = await helper.compact_if_fragmented(partition_count=10)
+        assert ran is False
+        mock_compact.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_above_threshold(self, helper: DeltaTableHelper):
+        # 5,000 files / 10 partitions = 500 files/partition (> default 200)
+        mock_delta = MagicMock()
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(5000)])),
+            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
+        ):
+            ran = await helper.compact_if_fragmented(partition_count=10)
+        assert ran is True
+        mock_compact.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_none_partition_count(self, helper: DeltaTableHelper):
+        # Unpartitioned table treated as 1 "partition"; 250 files >> threshold 200.
+        mock_delta = MagicMock()
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(250)])),
+            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
+        ):
+            ran = await helper.compact_if_fragmented(partition_count=None)
+        assert ran is True
+        mock_compact.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_respects_custom_threshold(self, helper: DeltaTableHelper):
+        mock_delta = MagicMock()
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(100)])),
+            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
+        ):
+            # 100 / 10 = 10 files/partition; threshold 5 should fire compact
+            ran = await helper.compact_if_fragmented(partition_count=10, threshold=5)
+        assert ran is True
+        mock_compact.assert_called_once()
+
+
 class TestWriteToDeltalakeCommitMetadataPassThrough:
     """Covers that commit_metadata is forwarded to deltalake.write_deltalake as CommitProperties."""
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -145,57 +145,48 @@ class TestCompactIfFragmented:
             ran = await helper.compact_if_fragmented(partition_count=10)
         assert ran is False
 
-    @pytest.mark.asyncio
-    async def test_skips_below_threshold(self, helper: DeltaTableHelper):
-        # 100 files / 10 partitions = 10 files/partition (< default 200)
-        mock_delta = MagicMock()
-        with (
-            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
-            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(100)])),
-            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
-        ):
-            ran = await helper.compact_if_fragmented(partition_count=10)
-        assert ran is False
-        mock_compact.assert_not_called()
+    # (case_name, file_count, partition_count, threshold_kw, expected_ran)
+    # threshold_kw=None means "use default threshold" — exercises the prod path.
+    _THRESHOLD_CASES: list[tuple[str, int, int | None, int | None, bool]] = [
+        # 100 / 10 = 10 fpp, well below default 200 → skip
+        ("below_default_threshold", 100, 10, None, False),
+        # 5,000 / 10 = 500 fpp, well above default 200 → fire
+        ("above_default_threshold", 5_000, 10, None, True),
+        # partition_count=None treated as 1; 250 fpp >> default 200 → fire
+        ("unpartitioned_above_default", 250, None, None, True),
+        # Custom threshold: 100 / 10 = 10 fpp, threshold=5 → fire
+        ("custom_threshold_fires", 100, 10, 5, True),
+        # Boundary: exactly at threshold — `>` not `>=`, so skip
+        ("exactly_at_default_threshold", 2_000, 10, None, False),
+    ]
 
+    @parameterized.expand([(c[0], c[1], c[2], c[3], c[4]) for c in _THRESHOLD_CASES])
     @pytest.mark.asyncio
-    async def test_runs_above_threshold(self, helper: DeltaTableHelper):
-        # 5,000 files / 10 partitions = 500 files/partition (> default 200)
+    async def test_threshold(
+        self,
+        _name: str,
+        file_count: int,
+        partition_count: int | None,
+        threshold_kw: int | None,
+        expected_ran: bool,
+    ):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
         mock_delta = MagicMock()
         with (
             patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
-            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(5000)])),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(file_count)])),
             patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
         ):
-            ran = await helper.compact_if_fragmented(partition_count=10)
-        assert ran is True
-        mock_compact.assert_called_once()
+            kwargs: dict = {"partition_count": partition_count}
+            if threshold_kw is not None:
+                kwargs["threshold"] = threshold_kw
+            ran = await helper.compact_if_fragmented(**kwargs)
 
-    @pytest.mark.asyncio
-    async def test_handles_none_partition_count(self, helper: DeltaTableHelper):
-        # Unpartitioned table treated as 1 "partition"; 250 files >> threshold 200.
-        mock_delta = MagicMock()
-        with (
-            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
-            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(250)])),
-            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
-        ):
-            ran = await helper.compact_if_fragmented(partition_count=None)
-        assert ran is True
-        mock_compact.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_respects_custom_threshold(self, helper: DeltaTableHelper):
-        mock_delta = MagicMock()
-        with (
-            patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
-            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(100)])),
-            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
-        ):
-            # 100 / 10 = 10 files/partition; threshold 5 should fire compact
-            ran = await helper.compact_if_fragmented(partition_count=10, threshold=5)
-        assert ran is True
-        mock_compact.assert_called_once()
+        assert ran is expected_ran
+        if expected_ran:
+            mock_compact.assert_called_once()
+        else:
+            mock_compact.assert_not_called()
 
 
 class TestWriteToDeltalakeCommitMetadataPassThrough:

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -160,7 +160,7 @@ class TestCompactIfFragmented:
         ("exactly_at_default_threshold", 2_000, 10, None, False),
     ]
 
-    @parameterized.expand([(c[0], c[1], c[2], c[3], c[4]) for c in _THRESHOLD_CASES])
+    @parameterized.expand(_THRESHOLD_CASES)
     @pytest.mark.asyncio
     async def test_threshold(
         self,

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -7,6 +7,7 @@ import posthoganalytics
 from structlog.types import FilteringBoundLogger
 from temporalio import activity
 
+from posthog.exceptions_capture import capture_exception
 from posthog.settings import WAREHOUSE_SOURCES_DATABASE_URL
 from posthog.temporal.common.activity_context import current_workflow_id, current_workflow_run_id
 from posthog.temporal.common.shutdown import ShutdownMonitor
@@ -212,6 +213,21 @@ class PipelineV3(Generic[ResumableData]):
             is_fresh_sync = self._delta_table_helper.is_first_sync or self._schema.table is None
             if is_fresh_sync:
                 self._pg_producer.is_first_ever_sync = True
+
+            # Defensive pre-write compaction. If the Delta target has accreted
+            # too many small files since the last successful run (e.g. because
+            # prior attempts failed before reaching post-load compaction),
+            # compact + vacuum here so the upcoming merge cycle isn't dominated
+            # by file-listing scans. Skipped cheaply when the table is healthy.
+            if not is_fresh_sync:
+                try:
+                    partition_count_for_compact = self._schema.partition_count or self._resource.partition_count
+                    await self._delta_table_helper.compact_if_fragmented(
+                        partition_count=partition_count_for_compact,
+                    )
+                except Exception as e:
+                    capture_exception(e)
+                    await self._logger.aexception(f"Pre-write compaction failed: {e}", exc_info=e)
 
             async for item in async_iterate(self._resource.items()):
                 py_table = None

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -7,7 +7,6 @@ import posthoganalytics
 from structlog.types import FilteringBoundLogger
 from temporalio import activity
 
-from posthog.exceptions_capture import capture_exception
 from posthog.settings import WAREHOUSE_SOURCES_DATABASE_URL
 from posthog.temporal.common.activity_context import current_workflow_id, current_workflow_run_id
 from posthog.temporal.common.shutdown import ShutdownMonitor
@@ -17,6 +16,7 @@ from posthog.temporal.data_imports.pipelines.common.extract import (
     finalize_desc_sort_incremental_value,
     handle_reset_or_full_refresh,
     reset_rows_synced_if_needed,
+    run_pre_write_defensive_compact,
     setup_row_tracking_with_billing_check,
     should_check_shutdown,
     update_incremental_field_values,
@@ -214,20 +214,14 @@ class PipelineV3(Generic[ResumableData]):
             if is_fresh_sync:
                 self._pg_producer.is_first_ever_sync = True
 
-            # Defensive pre-write compaction. If the Delta target has accreted
-            # too many small files since the last successful run (e.g. because
-            # prior attempts failed before reaching post-load compaction),
-            # compact + vacuum here so the upcoming merge cycle isn't dominated
-            # by file-listing scans. Skipped cheaply when the table is healthy.
+            # Defensive pre-write compaction. See
+            # `extract.run_pre_write_defensive_compact` for rationale; shared
+            # with the v2 pipeline so the threshold + error handling stays in
+            # lockstep.
             if not is_fresh_sync:
-                try:
-                    partition_count_for_compact = self._schema.partition_count or self._resource.partition_count
-                    await self._delta_table_helper.compact_if_fragmented(
-                        partition_count=partition_count_for_compact,
-                    )
-                except Exception as e:
-                    capture_exception(e)
-                    await self._logger.aexception(f"Pre-write compaction failed: {e}", exc_info=e)
+                await run_pre_write_defensive_compact(
+                    self._delta_table_helper, self._schema, self._resource, self._logger
+                )
 
             async for item in async_iterate(self._resource.items()):
                 py_table = None


### PR DESCRIPTION
## Problem

Today the Delta target gets compacted only at the end of a successful sync run (`_post_run_operations` calls `compact_table()`). When syncs fail repeatedly, compaction is skipped, small files accrete, merge scan times grow, and we spiral into longer-and-longer cycles that fail more often. The previous PR (#57570) gives operators a manual lever to recover; this PR closes the loop so future drift recovers automatically without admin intervention.

Stacks on #57570 (admin action). Can land independently — no shared code, just a logical follow-up.

## Changes

- New `DeltaTableHelper.compact_if_fragmented(partition_count, threshold=DEFAULT_COMPACT_FILES_PER_PARTITION_THRESHOLD)` method. Lists file URIs (one S3 LIST), divides by `max(partition_count or 1, 1)`, runs the existing `compact_table()` only if files-per-partition exceeds the threshold. Default threshold is 200 — well above the natural steady-state of a few files per partition per successful run, well below the level where merges start tripping `idle_in_transaction_session_timeout`. Tunable from the admin metrics added in #57570 once we have real distributions.
- Both `PipelineNonDLT.run` (v2) and `PipelineV3.run` (v3) call `compact_if_fragmented` near the top of the run, after schema setup and before the source iterator opens. Skipped on first-ever syncs (no Delta target yet). Wrapped in try/except so a compaction failure can't block the sync; the original error path is unaffected.
- Why pre-write and not in `finally`: a `finally`-block compact would amplify cost on retry storms (8 retries × full rewrite), risk activity-heartbeat death on long compacts (Temporal kills the activity → next attempt restarts compact from scratch → livelock), and mask the original failure exception in Sentry. Pre-write fires once per attempt with no PG transaction held and the activity heartbeat alive, and is cheap when the table is already healthy.

## How did you test this code?

I'm an agent. Tests run:

- `hogli test posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py` — 19 tests pass, including 5 new `TestCompactIfFragmented` cases:
  - skips when no Delta table exists
  - skips below threshold (10 files / 10 partitions)
  - runs above threshold (5,000 files / 10 partitions)
  - handles `partition_count=None` (treated as 1 partition)
  - respects custom threshold parameter
- `ruff check` and `ruff format` clean on all modified files; lint-staged hooks ran on commit.

Manual end-to-end test plan for a human reviewer:

- [ ] In staging, force a Delta target into a fragmented state (or use a real one). Trigger a sync. Confirm `compact_if_fragmented: triggering compact` appears in logs at the start of the run, and that subsequent merge cycles are dramatically faster.
- [ ] Trigger a sync against a healthy table. Confirm `compact_if_fragmented: skipping` appears and the run proceeds normally with no extra latency.
- [ ] Force a compaction failure (e.g., revoke S3 perms briefly). Confirm the sync continues and the original failure path still surfaces correctly — the compact exception is captured but does not block the source iteration.

## Publish to changelog?

no

## Docs update

n/a — internal pipeline behavior.

## 🤖 Agent context

Agent-authored (Claude Code) at user direction during the same debugging session as #57570. Investigated recurring Postgres data-import failures for a single customer; root cause was Delta target fragmentation that never got cleaned up because every sync failed before reaching `_post_run_operations`. PR1 (#57570) gives the manual escape hatch; this PR makes the cleanup automatic so future tables don't drift into the same hole.

Threshold value (200 files-per-partition) is a starting guess. Once #57570 ships and we can read real per-customer fragmentation stats from the admin view, expect to tune. Easy follow-up — single constant in `delta_table_helper.py`.

Out of scope (deliberately left for follow-ups): read-side fix in the Postgres source's named-cursor path — even with fast merges, a 2-3 minute write cycle is enough to trip strict read replicas with low `max_standby_streaming_delay`. That's a separate change to the Postgres source's chunking strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)