### PR TITLE
feat(admin): event restriction shows team id

### DIFF
--- a/posthog/admin/admins/event_ingestion_restriction_config.py
+++ b/posthog/admin/admins/event_ingestion_restriction_config.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+from django.db.models import OuterRef, Subquery
 
 from posthog.models.event_ingestion_restriction_config import (
     INGESTION_PIPELINES,
@@ -105,12 +106,17 @@ class EventIngestionRestrictionConfigAdmin(admin.ModelAdmin):
     readonly_fields = ("display_team_id",)
     search_fields = ("token", "distinct_ids", "session_ids", "event_names", "event_uuids")
 
-    @admin.display(description="Team ID")
-    def display_team_id(self, obj):
+    def get_queryset(self, request):
         from posthog.models.team.team import Team
 
-        team = Team.objects.filter(api_token=obj.token).values_list("id", flat=True).first()
-        return team
+        qs = super().get_queryset(request)
+        return qs.annotate(
+            team_id_from_token=Subquery(Team.objects.filter(api_token=OuterRef("token")).values("id")[:1])
+        )
+
+    @admin.display(description="Team ID")
+    def display_team_id(self, obj):
+        return getattr(obj, "team_id_from_token", None)
 
     @admin.display(description="Topic")
     def display_topic(self, obj):

--- a/posthog/admin/admins/event_ingestion_restriction_config.py
+++ b/posthog/admin/admins/event_ingestion_restriction_config.py
@@ -91,6 +91,7 @@ class EventIngestionRestrictionConfigAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "token",
+        "display_team_id",
         "restriction_type",
         "pipelines",
         "display_topic",
@@ -100,7 +101,16 @@ class EventIngestionRestrictionConfigAdmin(admin.ModelAdmin):
         "has_event_uuids",
     )
     list_filter = ("restriction_type",)
+    list_per_page = 20
+    readonly_fields = ("display_team_id",)
     search_fields = ("token", "distinct_ids", "session_ids", "event_names", "event_uuids")
+
+    @admin.display(description="Team ID")
+    def display_team_id(self, obj):
+        from posthog.models.team.team import Team
+
+        team = Team.objects.filter(api_token=obj.token).values_list("id", flat=True).first()
+        return team
 
     @admin.display(description="Topic")
     def display_topic(self, obj):

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -150,21 +150,19 @@ class TestPluginAttachmentInline(BaseTest):
 
 
 class TestEventIngestionRestrictionConfigAdmin(BaseTest):
-    def test_display_team_id_returns_team_id_for_matching_token(self):
-        config = EventIngestionRestrictionConfig.objects.create(
-            token=self.team.api_token,
-            restriction_type=RestrictionType.DROP_EVENT_FROM_INGESTION,
-        )
+    def test_display_team_id_resolves_token_to_team_id(self):
         admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
-        assert admin_instance.display_team_id(config) == self.team.id
-
-    def test_display_team_id_returns_none_for_unknown_token(self):
-        config = EventIngestionRestrictionConfig.objects.create(
-            token="phc_nonexistent_token",
-            restriction_type=RestrictionType.DROP_EVENT_FROM_INGESTION,
-        )
-        admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
-        assert admin_instance.display_team_id(config) is None
+        cases = [
+            ("matching token", self.team.api_token, self.team.id),
+            ("unknown token", "phc_nonexistent_token", None),
+        ]
+        for label, token, expected in cases:
+            with self.subTest(label):
+                config = EventIngestionRestrictionConfig.objects.create(
+                    token=token,
+                    restriction_type=RestrictionType.DROP_EVENT_FROM_INGESTION,
+                )
+                assert admin_instance.display_team_id(config) == expected
 
 
 class TestEventIngestionRestrictionConfigAdminConfig:

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -11,7 +11,7 @@ from posthog.admin.admins.user_admin import UserAdmin
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
 from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
 from posthog.models import User
-from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig, RestrictionType
+from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
 
 
 class TestAdmin(BaseTest):
@@ -149,20 +149,17 @@ class TestPluginAttachmentInline(BaseTest):
         assert "cannot preview:" in result
 
 
-class TestEventIngestionRestrictionConfigAdmin(BaseTest):
-    def test_display_team_id_resolves_token_to_team_id(self):
+class TestEventIngestionRestrictionConfigAdmin:
+    def test_display_team_id_reads_annotation(self):
         admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
         cases = [
-            ("matching token", self.team.api_token, self.team.id),
-            ("unknown token", "phc_nonexistent_token", None),
+            ("present", 42, 42),
+            ("missing", None, None),
         ]
-        for label, token, expected in cases:
-            with self.subTest(label):
-                config = EventIngestionRestrictionConfig.objects.create(
-                    token=token,
-                    restriction_type=RestrictionType.DROP_EVENT_FROM_INGESTION,
-                )
-                assert admin_instance.display_team_id(config) == expected
+        for label, annotation_value, expected in cases:
+            obj = MagicMock()
+            obj.team_id_from_token = annotation_value
+            assert admin_instance.display_team_id(obj) == expected, label
 
 
 class TestEventIngestionRestrictionConfigAdminConfig:

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -6,10 +6,12 @@ from django.contrib.admin import AdminSite
 from django.test import RequestFactory
 
 from posthog.admin import _OAUTH_ADMIN_MODEL_NAMES, install_admin_app_list_overrides, register_all_admin
+from posthog.admin.admins.event_ingestion_restriction_config import EventIngestionRestrictionConfigAdmin
 from posthog.admin.admins.user_admin import UserAdmin
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
 from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
 from posthog.models import User
+from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig, RestrictionType
 
 
 class TestAdmin(BaseTest):
@@ -145,6 +147,31 @@ class TestPluginAttachmentInline(BaseTest):
         result = str(inline.raw_contents(attachment))
 
         assert "cannot preview:" in result
+
+
+class TestEventIngestionRestrictionConfigAdmin(BaseTest):
+    def test_display_team_id_returns_team_id_for_matching_token(self):
+        config = EventIngestionRestrictionConfig.objects.create(
+            token=self.team.api_token,
+            restriction_type=RestrictionType.DROP_EVENT_FROM_INGESTION,
+        )
+        admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
+        assert admin_instance.display_team_id(config) == self.team.id
+
+    def test_display_team_id_returns_none_for_unknown_token(self):
+        config = EventIngestionRestrictionConfig.objects.create(
+            token="phc_nonexistent_token",
+            restriction_type=RestrictionType.DROP_EVENT_FROM_INGESTION,
+        )
+        admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
+        assert admin_instance.display_team_id(config) is None
+
+
+class TestEventIngestionRestrictionConfigAdminConfig:
+    def test_display_team_id_in_list_display_and_readonly_fields(self):
+        admin_instance = EventIngestionRestrictionConfigAdmin(EventIngestionRestrictionConfig, AdminSite())
+        assert "display_team_id" in admin_instance.list_display
+        assert "display_team_id" in admin_instance.readonly_fields
 
 
 class TestOrganizationMemberInlineConfig(BaseTest):


### PR DESCRIPTION
## Problem

The event restriction configuration list in admin panel doesn't show the team id.

## Changes

Change the admin list to look up the team id based on the token a restriction is applied to and show it when listing.

Paginate the event restriction config list by 20 so it doesn't overload with too many team id -> token lookups one day when we have a million event restrictions.

## How did you test this code?

some added unit tests
