### PR TITLE
chore: raise dashboards/team to 5000, lower insights/dashboard to 100

### DIFF
--- a/posthog/resource_limits/registry.py
+++ b/posthog/resource_limits/registry.py
@@ -45,12 +45,12 @@ REGISTRY: dict[str, LimitDefinition] = {
     LimitKey.MAX_DASHBOARDS_PER_TEAM: LimitDefinition(
         key=LimitKey.MAX_DASHBOARDS_PER_TEAM,
         description="Saved dashboards in a project",
-        default=500,
+        default=5000,
     ),
     LimitKey.MAX_INSIGHTS_PER_DASHBOARD: LimitDefinition(
         key=LimitKey.MAX_INSIGHTS_PER_DASHBOARD,
         description="Insight tiles attached to a single dashboard",
-        default=5000,
+        default=100,
     ),
     LimitKey.MAX_ALERTS_PER_TEAM: LimitDefinition(
         key=LimitKey.MAX_ALERTS_PER_TEAM,

--- a/posthog/resource_limits/test/test_evaluator.py
+++ b/posthog/resource_limits/test/test_evaluator.py
@@ -10,15 +10,15 @@ from posthog.resource_limits.registry import REGISTRY, LimitDefinition
 
 class TestGetLimit(BaseTest):
     def test_returns_catalog_default(self) -> None:
-        assert get_limit(team=self.team, key=LimitKey.MAX_DASHBOARDS_PER_TEAM) == 500
+        assert get_limit(team=self.team, key=LimitKey.MAX_DASHBOARDS_PER_TEAM) == 5000
 
 
 class TestCheckCountLimit(BaseTest):
     @parameterized.expand(
         [
             ("below_threshold", 10, False, None),
-            ("one_below_threshold", 499, True, True),
-            ("at_threshold", 500, True, False),
+            ("one_below_threshold", 4999, True, True),
+            ("at_threshold", 5000, True, False),
             ("far_above_threshold", 10_000, True, False),
         ]
     )
@@ -45,7 +45,7 @@ class TestCheckCountLimit(BaseTest):
         assert args[1] == "resource limit hit"
         properties = args[2]
         assert properties["limit_key"] == LimitKey.MAX_DASHBOARDS_PER_TEAM
-        assert properties["limit"] == 500
+        assert properties["limit"] == 5000
         assert properties["current_count"] == current_count
         assert properties["crossing_threshold"] is expect_crossing
         assert properties["team_id"] == self.team.id
@@ -95,7 +95,7 @@ class TestGetOrganizationLimit(BaseTest):
                 organization=self.organization,
                 key=LimitKey.MAX_DASHBOARDS_PER_TEAM,
             )
-            == 500
+            == 5000
         )
 
 


### PR DESCRIPTION
## Problem

Two analytics resource limits need adjustment:
- `analytics.max_dashboards_per_team`: raise from 500 to 5000 
- `analytics.max_insights_per_dashboard`: lower from 5000 to 100 (I made a mistake last pr)