### PR TITLE
chore(propdefs): drop 4 unused posthog_eventproperty indexes (dev only)

### DIFF
--- a/products/event_definitions/backend/migrations/0006_drop_eventproperty_team_property_bloated_idx.py
+++ b/products/event_definitions/backend/migrations/0006_drop_eventproperty_team_property_bloated_idx.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0005_eventdefinition_rename_promoted_to_primary"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name="eventproperty",
+                    name="posthog_eve_team_id_26dbfb_idx",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS posthog_eve_team_id_26dbfb_idx",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/0007_drop_eventproperty_team_id_fk_idx.py
+++ b/products/event_definitions/backend/migrations/0007_drop_eventproperty_team_id_fk_idx.py
@@ -1,0 +1,32 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0006_drop_eventproperty_team_property_bloated_idx"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="eventproperty",
+                    name="team",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS posthog_eventproperty_team_id_be898eaa",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/0008_drop_eventproperty_proj_property_coalesce_idx.py
+++ b/products/event_definitions/backend/migrations/0008_drop_eventproperty_proj_property_coalesce_idx.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0007_drop_eventproperty_team_id_fk_idx"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name="eventproperty",
+                    name="posthog_eve_proj_id_26dbfb_idx",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS posthog_eve_proj_id_26dbfb_idx",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/0009_drop_eventproperty_proj_event_coalesce_idx.py
+++ b/products/event_definitions/backend/migrations/0009_drop_eventproperty_proj_event_coalesce_idx.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0008_drop_eventproperty_proj_property_coalesce_idx"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name="eventproperty",
+                    name="posthog_eve_proj_id_22de03_idx",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS posthog_eve_proj_id_22de03_idx",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/max_migration.txt
+++ b/products/event_definitions/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0005_eventdefinition_rename_promoted_to_primary
+0009_drop_eventproperty_proj_event_coalesce_idx

--- a/products/event_definitions/backend/models/event_property.py
+++ b/products/event_definitions/backend/models/event_property.py
@@ -1,13 +1,11 @@
 from django.db import models
-from django.db.models.expressions import F
-from django.db.models.functions import Coalesce
 
 from posthog.models.utils import UniqueConstraintByExpression, sane_repr
 
 
 class EventProperty(models.Model):
     id = models.BigAutoField(primary_key=True)
-    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, db_index=False)
     project = models.ForeignKey("posthog.Project", on_delete=models.CASCADE, null=True)
     event = models.CharField(max_length=400, null=False)
     property = models.CharField(max_length=400, null=False)
@@ -22,12 +20,8 @@ class EventProperty(models.Model):
             ),
         ]
         indexes = [
-            # Index on project_id foreign key
             models.Index(fields=["project"], name="posthog_eve_proj_id_dd2337d2"),
             models.Index(fields=["team", "event"]),
-            models.Index(Coalesce(F("project_id"), F("team_id")), F("event"), name="posthog_eve_proj_id_22de03_idx"),
-            models.Index(fields=["team", "property"]),
-            models.Index(Coalesce(F("project_id"), F("team_id")), F("property"), name="posthog_eve_proj_id_26dbfb_idx"),
         ]
 
     __repr__ = sane_repr("event", "property", "team_id")


### PR DESCRIPTION
## Problem

`posthog_eventproperty` carried four unused indexes totaling ~567 GB across prod-us and prod-eu:

| Index | Definition | Size US | Size EU |
|-------|-----------|---------|---------|
| posthog_eve_team_id_26dbfb_idx | (team_id, property) | 293 GB | 236 GB |
| posthog_eventproperty_team_id_be898eaa | (team_id) | 154 GB | 135 GB |
| posthog_eve_proj_id_26dbfb_idx | (coalesce(project_id, team_id), property) | 54 GB | 41 GB |
| posthog_eve_proj_id_22de03_idx | (coalesce(project_id, team_id), event) | ~34 GB | ~33 GB |

All four were already **dropped live** on prod-us and prod-eu (May 2026). These migrations are **no-ops in production** via `DROP INDEX CONCURRENTLY IF EXISTS` and only actually execute in dev.

Closes #57700

## Changes

* 4 new migrations (0006–0009) — one `DROP INDEX CONCURRENTLY IF EXISTS` each, wrapped in `SeparateDatabaseAndState`
* `db_index=False` on the `team` ForeignKey to prevent Django from regenerating the bare FK index
* Removed dropped indexes from `Meta.indexes`
* Removed unused `Coalesce`/`F` imports from model
* No `reverse_sql` — rollback would be handled differently if ever needed

## How did you test this code?

These indexes were dropped live on both production clusters. The migrations here are idempotent no-ops in prod, only executing in dev. Pre-commit hooks (ruff, ty, lint-staged) pass.

## Publish to changelog?

no

## 🤖 Agent context

Combined PR #57588 and PR #57700 into a single PR. Agent rebased onto master, chained the migration dependencies (0005→0006→…→0009), resolved model conflicts, and verified all migrations meet safety criteria (drop-only, idempotent IF EXISTS guards, no reverse ops, no reindexes).