### PR TITLE
chore: reindex posthog_eve_team_id_22de03_idx (~720 GB US / ~1060 GB EU reclaim)

### DIFF
--- a/products/event_definitions/backend/migrations/0009_reindex_eventproperty_team_event.py
+++ b/products/event_definitions/backend/migrations/0009_reindex_eventproperty_team_event.py
@@ -1,0 +1,46 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """REINDEX posthog_eve_team_id_22de03_idx — rebuild bloated 802 GB / 1182 GB index at natural size.
+
+    Production cross-team event_screenshots JOIN uses this index for the Nested Loop inner probe
+    (verified in prod-us EXPLAIN, May 2026 — planner picks this index even with smaller alternatives
+    available). Drop would force costly fallback. REINDEX rebuilds in place at natural ~80 GB / ~120 GB,
+    reclaiming ~720 GB US / ~1060 GB EU with zero plan-choice change.
+
+    No model state change — purely a physical operation. The (team_id, event) Index entry stays
+    in the model; only its on-disk pages are rewritten.
+
+    Aurora-specific risks: WAL throughput, AuroraReplicaLag, IOPS, buffer cache eviction.
+    Disk-full is NOT a concern (Aurora storage auto-grows transparently).
+
+    Pre-deploy:
+    - Confirm AuroraReplicaLagMaximum p99 < 50 ms baseline.
+    - Schedule low-write window (off-peak property-defs-rs INSERT rate).
+    - Don't run prod-us and prod-eu simultaneously.
+    - SET max_parallel_maintenance_workers = 8 is session-scoped — Aurora default is 2,
+      so 8 parallel B-tree builders give a real ~3-4x speedup. maintenance_work_mem is
+      intentionally NOT set here: Aurora cluster defaults (8.12 GB US / 6.09 GB EU) already
+      exceed any safe override we'd pick, so we inherit them. Larger sort buffer = less
+      disk-spill = shorter wall-clock = shorter window of WAL/IOPS/buffer-cache disturbance.
+
+    Abort: pg_cancel_backend on this session, then DROP INDEX CONCURRENTLY IF EXISTS
+    posthog_eve_team_id_22de03_idx_ccnew. Original index untouched.
+    """
+
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0007_drop_eventproperty_team_id_fk_idx"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                "SET max_parallel_maintenance_workers = 8",
+                "REINDEX INDEX CONCURRENTLY posthog_eve_team_id_22de03_idx",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/max_migration.txt
+++ b/products/event_definitions/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0007_drop_eventproperty_team_id_fk_idx
+0009_reindex_eventproperty_team_event


### PR DESCRIPTION
## Problem

`posthog_eve_team_id_22de03_idx` `(team_id, event)` is **802 GB US / 1182 GB EU** — by far the most bloated single index on `posthog_eventproperty`. The natural size at the current row count is ~80 GB / ~120 GB, so this one index has ~10x bloat.

Unlike the indexes dropped in #57588, this one **is in active use**. The cross-team `event_screenshots` Temporal workflow JOINs `posthog_eventproperty.(team_id, event)` against `posthog_eventdefinition` and the planner picks this index for the Nested Loop inner probe — verified in prod-us EXPLAIN (May 2026):

```
Nested Loop
  -> posthog_eventdefinition (last_seen_at > now() - 3h, name NOT LIKE '$%')
  -> Index Scan using posthog_eve_team_id_22de03_idx
       Index Cond: ep.team_id = ed.team_id AND ep.event = ed.name
```

Replica `lastUsedAt = today` corroborates active use. Dropping it would force a fallback to the unique constraint at much higher cost.

The path forward is to **rebuild it in place** — `REINDEX INDEX CONCURRENTLY` produces a new B-tree at natural size, swaps it in, drops the old one, all without taking a write lock or changing the planner's choice.

## Changes

`0009_reindex_eventproperty_team_event.py` runs:

```sql
SET max_parallel_maintenance_workers = 8;
REINDEX INDEX CONCURRENTLY posthog_eve_team_id_22de03_idx;
```

`atomic = False`. Reverse is a no-op (REINDEX is its own rollback path; aborting just leaves the original).

`maintenance_work_mem` is **intentionally not set** in the migration. Aurora cluster defaults are 8.12 GB US / 6.09 GB EU — both higher than any value safe to override at session level. We inherit them, which means a larger sort buffer, less disk-spill, and a shorter window of WAL/IOPS/buffer-cache disturbance. `max_parallel_maintenance_workers = 8` is safe to override (Aurora default is 2; overriding to 8 gives a real ~3-4x wall-clock speedup on a B-tree of this size).

## Risk

`REINDEX CONCURRENTLY` holds `ShareUpdateExclusiveLock` and proceeds without blocking reads/writes, but it does:

- Generate WAL at the rate of the rebuild — Aurora replicates this, so watch `AuroraReplicaLagMaximum`
- Burn IOPS — watch `WriteIOPS`, `ReadIOPS`, `BufferCacheHitRatio`
- Evict warm pages from `shared_buffers` as the new index is built
- Briefly double the index footprint until the swap completes

Aurora storage auto-grows, so disk-full is **not** a concern.

## Pre-deploy checklist (operator)

Before running:
- [ ] `AuroraReplicaLagMaximum` p99 < 50 ms baseline
- [ ] `WriteIOPS` headroom ≥ 2x baseline
- [ ] `BufferCacheHitRatio` ≥ 99% on writer
- [ ] Off-peak window (low property-defs-rs INSERT rate)
- [ ] Confirm `pg_settings` `maintenance_work_mem` ≥ 6 GB on the cluster (it is, but check)
- [ ] Don't run prod-us and prod-eu simultaneously

If the operation needs to be aborted: `pg_cancel_backend` on the migrate session, then `DROP INDEX CONCURRENTLY IF EXISTS posthog_eve_team_id_22de03_idx_ccnew`. Original index is untouched.

## Sequencing

Stacked on #57588. Deploy after that PR has been live and scans are observed against `r32khd9s` (not the dropped duplicate).

## How did you test this code?

I'm an agent (Claude). I did not run this migration anywhere. Verification was static (EXPLAIN inspection, pganalyze metrics) plus an EXPLAIN run on prod-us by the human author. The human author owns operational verification — please confirm pre-deploy checklist before deploying.
