### PR TITLE
chore: reindex posthog_event_property_unique_proj_event_property (~400-600 GB US / ~800-1000 GB EU reclaim)

### DIFF
--- a/products/event_definitions/backend/migrations/0010_reindex_eventproperty_unique.py
+++ b/products/event_definitions/backend/migrations/0010_reindex_eventproperty_unique.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """REINDEX posthog_event_property_unique_proj_event_property — rebuild 1100 GB / 1629 GB unique constraint.
+
+    The unique constraint is the largest artifact on the table. Audit confirmed the size is bloat plus
+    string-column key bytes, NOT coalesce expression overhead — so REINDEX is the correct lever, not
+    changing the expression to (team_id, event, property). Multi-team-per-project semantics require
+    the coalesce; migration 0532 explicitly deleted child-team rows to enable the project rollup.
+
+    Estimated reclaim: ~400-600 GB US, ~800-1000 GB EU.
+
+    No model state change — purely a physical operation. The unique constraint definition in the
+    model stays identical.
+
+    Aurora-specific risks (same shape as PR 2's REINDEX of (team_id, event), but ~1.4x larger):
+    WAL throughput, AuroraReplicaLag, IOPS, buffer cache eviction. Disk-full is NOT a concern.
+
+    Sequencing: only run AFTER the Tier 2 REINDEX (0009) has stabilized. Reduces concurrent
+    index-update pressure on the table during this longer rebuild.
+
+    Pre-deploy:
+    - Confirm AuroraReplicaLagMaximum p99 < 50 ms baseline.
+    - Schedule the lowest-write window. Sustained INSERT load from property-defs-rs slows the swap.
+    - Don't run prod-us and prod-eu simultaneously.
+    - SET max_parallel_maintenance_workers = 8 is session-scoped — Aurora default is 2,
+      so 8 parallel B-tree builders give a real ~3-4x speedup. maintenance_work_mem is
+      intentionally NOT set here: Aurora cluster defaults (8.12 GB US / 6.09 GB EU) already
+      exceed any safe override we'd pick, so we inherit them. Larger sort buffer = less
+      disk-spill = shorter wall-clock = shorter window of WAL/IOPS/buffer-cache disturbance.
+
+    Abort: pg_cancel_backend on this session, then DROP INDEX CONCURRENTLY IF EXISTS
+    posthog_event_property_unique_proj_event_property_ccnew. Original constraint index untouched.
+    """
+
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0009_reindex_eventproperty_team_event"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                "SET max_parallel_maintenance_workers = 8",
+                "REINDEX INDEX CONCURRENTLY posthog_event_property_unique_proj_event_property",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/max_migration.txt
+++ b/products/event_definitions/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0009_reindex_eventproperty_team_event
+0010_reindex_eventproperty_unique


### PR DESCRIPTION
## Problem

`posthog_event_property_unique_proj_event_property` `(coalesce(project_id, team_id), event, property)` is **1100 GB US / 1629 GB EU** — the single largest index on `posthog_eventproperty`. Natural size at current row count is ~400-600 GB US / ~800-1000 GB EU, so reclaim is roughly **500-700 GB US / 800-1000 GB EU**.

This is the unique constraint that backs property-definition uniqueness; it is the planner's primary index for property-defs lookup queries (verified in prod-us EXPLAIN, May 2026):

```
Index Scan using posthog_event_property_unique_proj_event_property
  Index Cond: (COALESCE(project_id, team_id) = $1
               AND event = ANY ('{$pageview,$autocapture,$pageleave,...}')
               AND property = '$current_url')
```

It cannot be dropped — it backs a uniqueness invariant. The path forward is to **rebuild in place** with `REINDEX CONCURRENTLY`.

pganalyze attributes ~10.5% US / ~5.6% EU of total writer I/O share to the INSERT path that touches this constraint, so trimming bloat here also trims write amplification on every event-property INSERT going forward.

## Changes

`0010_reindex_eventproperty_unique.py` runs:

```sql
SET max_parallel_maintenance_workers = 8;
REINDEX INDEX CONCURRENTLY posthog_event_property_unique_proj_event_property;
```

`atomic = False`. Reverse is a no-op.

Same `maintenance_work_mem` rationale as #57589: intentionally not overridden — Aurora cluster defaults (8.12 GB US / 6.09 GB EU) exceed any safe session-level value, so we inherit them for a faster, less disruptive rebuild.

## Risk

Same shape as #57589 (REINDEX CONCURRENTLY) but on a larger index, so:

- More WAL → more replica replication work
- Longer wall-clock window → longer period of buffer-cache eviction and IOPS pressure
- Briefly doubles the unique-constraint footprint until the swap

Aurora storage auto-grows, so disk-full is **not** a concern.

## Pre-deploy checklist (operator)

Same as #57589, plus:
- [ ] #57589 has shipped and Aurora has stabilized (replica lag, IOPS, buffer cache)
- [ ] **Hard requirement:** deploy only after #57589 has stabilized
- [ ] Don't run prod-us and prod-eu simultaneously

Abort path: `pg_cancel_backend`, then `DROP INDEX CONCURRENTLY IF EXISTS posthog_event_property_unique_proj_event_property_ccnew`. Constraint stays intact via the original.

## Sequencing

Stacked on #57589. Deploy after #57589 is live and replica metrics have settled.

After this PR ships and stabilizes, **#57700** can land — it drops `posthog_eve_proj_id_22de03_idx`, which falls back to this unique constraint as its prefix.

## How did you test this code?

I'm an agent (Claude). I did not run this migration anywhere. Verification was static (EXPLAIN inspection, pganalyze metrics) plus an EXPLAIN run on prod-us by the human author. The human author owns operational verification — please confirm #57589 has stabilized before deploying.
