### PR TITLE
fix(property-defs-rs): sanitize null bytes in property keys

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -335,11 +335,15 @@ impl Event {
                 continue;
             }
 
+            // Property keys flow into posthog_eventproperty.property and
+            // posthog_propertydefinition.name — both text columns. Postgres rejects null bytes
+            // in text, so any payload with an embedded \u{0000} burns the full 3-retry cycle and
+            // is then dropped. Mirror the existing sanitize on event names (line 222 above).
             updates.push(Update::EventProperty(EventProperty {
                 team_id: self.team_id,
                 project_id: self.project_id,
                 event: sanitize_string(&self.event),
-                property: key.clone(),
+                property: sanitize_string(key),
             }));
 
             let property_type = detect_property_type(key, value);
@@ -348,7 +352,7 @@ impl Event {
             updates.push(Update::Property(PropertyDefinition {
                 team_id: self.team_id,
                 project_id: self.project_id,
-                name: key.clone(),
+                name: sanitize_string(key),
                 is_numerical,
                 property_type,
                 event_type: parent_type,

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
-use property_defs_rs::types::{detect_property_type, get_floored_last_seen, PropertyValueType};
+use property_defs_rs::types::{
+    detect_property_type, get_floored_last_seen, Event, PropertyValueType, Update,
+};
 use serde_json::{Number, Value};
 
 #[test]
@@ -422,4 +424,66 @@ fn test_bare_utm_properties_still_string() {
             "expected String for key={key}, value={value}"
         );
     }
+}
+
+#[test]
+fn test_property_keys_are_sanitized_of_null_bytes() {
+    // Property keys with embedded null bytes must be sanitized before reaching Postgres,
+    // otherwise the INSERT fails with 22021 (invalid_text_representation) and burns the
+    // 3-retry batch. We mirror the existing sanitize on event names.
+    let event = Event {
+        team_id: 1,
+        project_id: 1,
+        event: "$pageview".to_string(),
+        properties: Some(r#"{"clean_key":"v","key\u0000with\u0000nulls":"v"}"#.to_string()),
+    };
+
+    let updates = event.into_updates(1000);
+
+    // Expect: 1 EventDefinition + 2 EventProperty + 2 PropertyDefinition = 5 updates
+    assert_eq!(
+        updates.len(),
+        5,
+        "all keys should produce updates: {updates:?}"
+    );
+
+    let replacement_char = '\u{FFFD}';
+
+    let mut saw_sanitized_event_property = false;
+    let mut saw_sanitized_property_definition = false;
+
+    for update in &updates {
+        match update {
+            Update::EventProperty(ep) => {
+                assert!(
+                    !ep.property.contains('\u{0000}'),
+                    "EventProperty.property must not contain null bytes: {:?}",
+                    ep.property
+                );
+                if ep.property.contains(replacement_char) {
+                    saw_sanitized_event_property = true;
+                }
+            }
+            Update::Property(pd) => {
+                assert!(
+                    !pd.name.contains('\u{0000}'),
+                    "PropertyDefinition.name must not contain null bytes: {:?}",
+                    pd.name
+                );
+                if pd.name.contains(replacement_char) {
+                    saw_sanitized_property_definition = true;
+                }
+            }
+            Update::Event(_) => {}
+        }
+    }
+
+    assert!(
+        saw_sanitized_event_property,
+        "expected at least one EventProperty with the sanitized key: {updates:?}"
+    );
+    assert!(
+        saw_sanitized_property_definition,
+        "expected at least one PropertyDefinition with the sanitized name: {updates:?}"
+    );
 }


### PR DESCRIPTION
## Problem

In `rust/property-defs-rs/src/types.rs`, `Event::into_updates` constructs `EventProperty` and `PropertyDefinition` updates from each property key in the incoming event. The event name is already passed through `sanitize_string(...)` before being written, but **the property key itself is not.**

`sanitize_string` strips `\u{0000}` (null bytes), which Postgres rejects in `text` / `varchar` columns with error `22021 (invalid_text_representation)`. When a payload arrives with a null byte embedded in a property key, the worker fails the INSERT, retries the full batch 3 times, and then silently drops it. We see this pattern in the wild on a small but non-trivial volume of events.

## Fix

Apply `sanitize_string` to the property key when building both `EventProperty.property` and `PropertyDefinition.name`, mirroring the existing pattern used for `event` names a few lines above:

```rust
updates.push(Update::EventProperty(EventProperty {
    team_id: self.team_id,
    project_id: self.project_id,
    event: sanitize_string(&self.event),
    property: sanitize_string(key), // was: key.clone()
}));

updates.push(Update::Property(PropertyDefinition {
    ...
    name: sanitize_string(key), // was: key.clone()
    ...
}));
```

## Test

Added `test_property_keys_are_sanitized_of_null_bytes` in `rust/property-defs-rs/tests/types.rs` that:
1. Builds an event with one clean key and one null-byte key (`"key\u{0000}with\u{0000}nulls"`).
2. Calls `into_updates`.
3. Asserts no resulting `EventProperty.property` or `PropertyDefinition.name` contains a null byte, and that at least one of each carries the sanitized replacement character (`U+FFFD`).

`cargo test`, `cargo fmt --check`, `cargo clippy` all clean on `property-defs-rs`.

## Risk

Drive-by fix, isolated to property-defs-rs ingest. No schema change, no migration, no API surface change. The character substitution (`\u{0000}` → `U+FFFD`) is the same transformation already applied to event names — semantically equivalent for property names.
