### PR TITLE
fix(ci): scope dagster merge-base fetch to base ref

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -66,9 +66,14 @@ jobs:
             schema_cache_key: ${{ steps.schema-key.outputs.key }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
-            # also want this to run on master so we need to checkout
+            # also want this to run on master so we need to checkout.
+            # fetch-depth=1000 + blob:none mirrors ci-backend's turbo-discover so
+            # HEAD^2 (PR branch tip) is reachable for the merge-base step below
+            # without the cost of fetching blobs.
             - uses: actions/checkout@v6
               with:
+                  fetch-depth: 1000
+                  filter: blob:none
                   clean: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -185,12 +190,10 @@ jobs:
               if: github.event_name == 'pull_request'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
-              run: |
-                  # Deepen the shallow checkout so HEAD^2 (PR branch tip) becomes
-                  # reachable, then fetch enough of the base branch to find where
-                  # the PR diverged from it.
-                  git fetch --deepen=200
-                  git fetch --no-tags --depth=200 origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+              # Scoped, blob-less, no-tags — matches ci-backend's pattern.
+              # Without an explicit refspec, `git fetch --deepen` would fall back
+              # to remote.origin.fetch and pull every branch.
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
             - name: Compute schema cache key from merge-base
               id: schema-key


### PR DESCRIPTION
## Problem

The dagster CI \`changes\` job started timing out at 5m on every PR after #57544 merged. The new "Fetch base branch for merge-base computation" step called \`git fetch --deepen=200\` with no refspec, which falls back to \`remote.origin.fetch\` (\`+refs/heads/*:refs/remotes/origin/*\`) and pulls every branch in the repo. Run [25362642161](https://github.com/PostHog/posthog/actions/runs/25362642161/job/74365671555?pr=57206) is one example.

## Changes

Match the existing ci-backend \`turbo-discover\` pattern:

- Bump the \`changes\` job checkout to \`fetch-depth: 1000\` + \`filter: blob:none\` so HEAD^2 is reachable cheaply
- Replace the broken \`git fetch --deepen\` call with a scoped, blob-filtered, no-tags fetch of just the base ref

## How did you test this code?

Agent-authored. No automated tests run — this is a CI workflow change. Will verify on the PR's own CI run that the dagster \`changes\` job completes well under 5m and \`schema_cache_key\` is computed correctly.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Root cause: \`git fetch --deepen=200\` without a refspec uses the default wildcard \`refs/heads/*\` refspec, fetching every branch. \`actions/checkout@v6\` itself uses an explicit refspec (\`refs/pull/N/merge\`), so bumping its \`fetch-depth\` does not have the same problem.
- The schema cache restore is gated on \`schema_cache_key != ''\`, so this is safe — worst case is a full migrate, which is the existing baseline.