### PR TITLE
fix(experiments): Keep metric tooltip alive while hovered

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -534,16 +534,6 @@ export function MetricRowGroup({
         }
     }
 
-    const closeTooltipNow = (): void => {
-        clearTooltipCloseTimer()
-        setTooltipState((prev) => ({
-            ...prev,
-            isVisible: false,
-            variantResult: null,
-            isPositioned: false,
-        }))
-    }
-
     useEffect(() => {
         return () => {
             clearTooltipCloseTimer()
@@ -625,7 +615,15 @@ export function MetricRowGroup({
     // Defer closing so the user can move onto the portaled tooltip without it disappearing.
     const handleTooltipMouseLeave = (): void => {
         clearTooltipCloseTimer()
-        tooltipCloseTimerRef.current = setTimeout(closeTooltipNow, 150)
+        tooltipCloseTimerRef.current = setTimeout(() => {
+            tooltipCloseTimerRef.current = null
+            setTooltipState((prev) => ({
+                ...prev,
+                isVisible: false,
+                variantResult: null,
+                isPositioned: false,
+            }))
+        }, 150)
     }
 
     const handleTooltipMouseMove = (e: React.MouseEvent, variantResult: ExperimentVariantResult): void => {
@@ -757,7 +755,7 @@ export function MetricRowGroup({
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
                         onMouseEnter={clearTooltipCloseTimer}
-                        onMouseLeave={closeTooltipNow}
+                        onMouseLeave={handleTooltipMouseLeave}
                         onClick={
                             timeseriesEnabled && tooltipState.variantResult
                                 ? () => handleTimeseriesClick(tooltipState.variantResult!)

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -1,7 +1,7 @@
 import './MetricRowGroup.scss'
 
 import { useActions } from 'kea'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { IconTrending } from '@posthog/icons'
@@ -524,7 +524,32 @@ export function MetricRowGroup({
         isPositioned: false,
     })
     const tooltipRef = useRef<HTMLDivElement>(null)
+    const tooltipCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
     const colors = useChartColors()
+
+    const clearTooltipCloseTimer = (): void => {
+        if (tooltipCloseTimerRef.current !== null) {
+            clearTimeout(tooltipCloseTimerRef.current)
+            tooltipCloseTimerRef.current = null
+        }
+    }
+
+    const closeTooltipNow = (): void => {
+        clearTooltipCloseTimer()
+        setTooltipState((prev) => ({
+            ...prev,
+            isVisible: false,
+            variantResult: null,
+            isPositioned: false,
+        }))
+    }
+
+    useEffect(() => {
+        return () => {
+            clearTooltipCloseTimer()
+        }
+    }, [])
+
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
     const { reportExperimentTimeseriesViewed, retryPrimaryMetric, retrySecondaryMetric } = useActions(experimentLogic)
@@ -587,6 +612,7 @@ export function MetricRowGroup({
             return
         }
 
+        clearTooltipCloseTimer()
         const position = calculateTooltipPosition(chartCell, variantResult)
         setTooltipState({
             isVisible: true,
@@ -596,13 +622,10 @@ export function MetricRowGroup({
         })
     }
 
+    // Defer closing so the user can move onto the portaled tooltip without it disappearing.
     const handleTooltipMouseLeave = (): void => {
-        setTooltipState((prev) => ({
-            ...prev,
-            isVisible: false,
-            variantResult: null,
-            isPositioned: false,
-        }))
+        clearTooltipCloseTimer()
+        tooltipCloseTimerRef.current = setTimeout(closeTooltipNow, 150)
     }
 
     const handleTooltipMouseMove = (e: React.MouseEvent, variantResult: ExperimentVariantResult): void => {
@@ -733,6 +756,8 @@ export function MetricRowGroup({
                             top: tooltipState.position.y,
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
+                        onMouseEnter={clearTooltipCloseTimer}
+                        onMouseLeave={closeTooltipNow}
                         onClick={
                             timeseriesEnabled && tooltipState.variantResult
                                 ? () => handleTimeseriesClick(tooltipState.variantResult!)


### PR DESCRIPTION
## Problem

In the experiment results table, hovering a variant row shows a portaled tooltip with a \"Click to view timeseries\" affordance (when timeseries scheduling is enabled). The row's `onMouseLeave` unmounted the tooltip immediately, so moving the cursor onto the tooltip dismissed it before the click could land — the affordance was visible but unusable.

## Changes

In `MetricRowGroup.tsx`, defer the close on row `onMouseLeave` by 150 ms and cancel the timer when the tooltip itself is hovered. Re-entering a row also cancels any pending close. Timer is cleared on unmount.

## How did you test this code?
Manually