### PR TITLE
fix(replay): country icon not fetching sometimes

### DIFF
--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -463,11 +463,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
     listeners(({ actions, values, props }) => ({
         loadRecordingMetaSuccess: () => {
             // Skip if the list-wide fetch is in flight; calling again cancels it via breakpoint.
-            if (
-                values.sessionPlayerMetaData &&
-                !values.recordingPropertiesLoading &&
-                !values.recordingPropertiesById[values.sessionPlayerMetaData.id]
-            ) {
+            if (values.sessionPlayerMetaData && !values.recordingPropertiesLoading) {
                 actions.maybeLoadPropertiesForSessions([values.sessionPlayerMetaData])
             }
             if (values.sessionPlayerMetaData?.has_summary && !values.sessionSummary && !values.sessionSummaryLoading) {

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -113,7 +113,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             sessionRecordingPlayerLogic(props),
             ['scale', 'currentTimestamp', 'currentPlayerTime', 'currentSegment', 'currentURL', 'resolution'],
             sessionRecordingsListPropertiesLogic,
-            ['recordingPropertiesById'],
+            ['recordingPropertiesById', 'recordingPropertiesLoading'],
             sessionRecordingPinnedPropertiesLogic,
             ['pinnedProperties'],
             sessionSummaryProgressLogic,
@@ -462,7 +462,12 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
     })),
     listeners(({ actions, values, props }) => ({
         loadRecordingMetaSuccess: () => {
-            if (values.sessionPlayerMetaData) {
+            // Skip if the list-wide fetch is in flight; calling again cancels it via breakpoint.
+            if (
+                values.sessionPlayerMetaData &&
+                !values.recordingPropertiesLoading &&
+                !values.recordingPropertiesById[values.sessionPlayerMetaData.id]
+            ) {
                 actions.maybeLoadPropertiesForSessions([values.sessionPlayerMetaData])
             }
             if (values.sessionPlayerMetaData?.has_summary && !values.sessionSummary && !values.sessionSummaryLoading) {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
In the session replay playlist, country and device icons were missing from list rows on initial pageload, they only appear after the user clicked into a recording.
Root cause seems to be a kea-loaders race between two callsites of `loadPropertiesForSessions`:

1. `sessionRecordingsPlaylistLogic` fires it for the whole list once recordings load.
2. `playerMetaLogic` fires it for the auto-played recording once player metadata loads.

The loader uses `breakpoint(100)` and a post-API `breakpoint()` for cancellation. When (2) lands during (1)'s window it cancels the in-flight list-wide query, so only the auto-played row's properties get committed and every other row stays blank until clicked.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Added a guard in `playerMetaLogic`'s `loadRecordingMetaSuccess` listener so the player-side fetch is skipped when (a) a list-wide fetch is already in flight, or (b) this session's properties are already cached. This lets the list-wide loader complete uncancelled and populate every visible row.

The player-side fetch still runs on direct-URL landings where there's no list context (no list fetch in flight, nothing cached), preserving the original callsite.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
