### PR TITLE
fix(ws): use strict greater-than for incremental syncs in MySQL, Snowflake, and BigQuery

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -511,7 +511,7 @@ def _get_query(
 
         return f"""
             SELECT * FROM `{bq_table.dataset_id}`.`{bq_table.table_id}`
-            WHERE `{incremental_field}` >= {last_value}
+            WHERE `{incremental_field}` > {last_value}
             ORDER BY `{incremental_field}` ASC
             """
 

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -192,7 +192,7 @@ def _build_query(
 
     query = (
         f"SELECT * FROM {table}{hint}"
-        f" WHERE {_sanitize_identifier(incremental_field)} >= %(incremental_value)s"
+        f" WHERE {_sanitize_identifier(incremental_field)} > %(incremental_value)s"
         f" ORDER BY {_sanitize_identifier(incremental_field)} ASC"
     )
 

--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -161,7 +161,7 @@ def _build_query(
     if db_incremental_field_last_value is None:
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
-    return "SELECT * FROM IDENTIFIER(%s) WHERE IDENTIFIER(%s) >= %s ORDER BY IDENTIFIER(%s) ASC", (
+    return "SELECT * FROM IDENTIFIER(%s) WHERE IDENTIFIER(%s) > %s ORDER BY IDENTIFIER(%s) ASC", (
         f"{database}.{schema}.{table_name}",
         incremental_field,
         db_incremental_field_last_value,


### PR DESCRIPTION
## Problem

warehouse sources' incremental syncs for MySQL, Snowflake, and BigQuery used `>=` (gte) when comparing against the last synced cursor value.

## Changes

  Changed the incremental WHERE clause from `>=` to `>` in:
  - `posthog/temporal/data_imports/sources/mysql/mysql.py`
  - `posthog/temporal/data_imports/sources/snowflake/snowflake.py`
  - `posthog/temporal/data_imports/sources/bigquery/bigquery.py`


## How did you test this code?

Test pass

## Publish to changelog?

NO
