### PR TITLE
chore(experiments): Remove rolled-out feature flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -222,7 +222,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_API: 'web-analytics-api', // owner: #team-web-analytics
     WEB_ANALYTICS_FOR_MOBILE: 'web-analytics-for-mobile', // owner: #team-web-analytics
     WEB_ANALYTICS_REFERRER_URL_DRILLDOWN: 'web-analytics-referrer-url-drilldown', // owner: @jabahamondes #team-web-analytics
-    WEB_EXPERIMENTS: 'web-experiments', // owner: #team-experiments
 
     // Temporary feature flags, still WIP, should be removed eventually
     AA_TEST_BAYESIAN_LEGACY: 'aa-test-bayesian-legacy', // owner: #team-experiments
@@ -294,10 +293,8 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_SPIKE_ALERTING: 'error-tracking-spike-alerting', // owner: #team-error-tracking
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
-    EXPERIMENT_AI_ANALYSIS_TAB: 'experiment-ai-analysis-tab', // owner: @rodrigoi #team-experiments
     EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
     EXPERIMENT_FUNNEL_DWH_SUPPORT: 'experiment-funnel-dwh-support', // owner: @rodrigoi #team-experiments
-    EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -5,9 +5,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { LemonTagType, PaginationManual } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual, toParams } from 'lib/utils'
 import { FLAGS_PER_PAGE, type FeatureFlagsResult, featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 import { projectLogic } from 'scenes/projectLogic'
@@ -180,8 +178,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
             ['currentProjectId'],
             userLogic,
             ['user', 'hasAvailableFeature'],
-            featureFlagLogic,
-            ['featureFlags'],
             featureFlagsLogic,
             ['featureFlags'],
             router,
@@ -480,10 +476,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
                     entryCount: count,
                 }
             },
-        ],
-        webExperimentsAvailable: [
-            () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags: FeatureFlagsSet) => featureFlags[FEATURE_FLAGS.WEB_EXPERIMENTS],
         ],
         // TRICKY: we do not load all feature flags here, just the latest ones.
         unavailableFeatureFlagKeys: [

--- a/frontend/src/scenes/toolbar-launch/ToolbarLaunch.stories.tsx
+++ b/frontend/src/scenes/toolbar-launch/ToolbarLaunch.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -20,7 +19,6 @@ const meta: Meta = {
         testOptions: {
             includeNavigationInSnapshot: true,
         },
-        featureFlags: [FEATURE_FLAGS.WEB_EXPERIMENTS],
         viewMode: 'story',
         mockDate: '2024-01-01',
     },

--- a/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
+++ b/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
@@ -5,7 +5,6 @@ import { LemonBanner } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconGroupedEvents, IconHeatmap } from 'lib/lemon-ui/icons'
 import { Link } from 'lib/lemon-ui/Link'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -22,8 +21,6 @@ export const scene: SceneExport = {
 }
 
 export function ToolbarLaunch(): JSX.Element {
-    const isExperimentsEnabled = useFeatureFlag('WEB_EXPERIMENTS')
-
     const features: FeatureHighlightProps[] = [
         {
             title: 'Heatmaps',
@@ -50,15 +47,11 @@ export function ToolbarLaunch(): JSX.Element {
             caption: "Measure your website's performance.",
             icon: <IconPieChart />,
         },
-        ...(isExperimentsEnabled
-            ? [
-                  {
-                      title: 'Experiments',
-                      caption: 'Run experiments and A/B test your website.',
-                      icon: <IconFlask />,
-                  },
-              ]
-            : []),
+        {
+            title: 'Experiments',
+            caption: 'Run experiments and A/B test your website.',
+            icon: <IconFlask />,
+        },
     ]
 
     return (

--- a/frontend/src/toolbar/Toolbar.stories.tsx
+++ b/frontend/src/toolbar/Toolbar.stories.tsx
@@ -71,7 +71,6 @@ const meta: Meta<StoryArgs> = {
                     isAuthenticated: props.unauthenticated ?? true,
                     supportedCompression: ['gzip', 'gzip-js', 'lz64'],
                     featureFlags: {
-                        'web-experiments': true,
                         'web-vitals': true,
                         'web-vitals-toolbar': true,
                     },

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -319,9 +319,6 @@ export function ToolbarInfoMenu(): JSX.Element | null {
 
     const { isAuthenticated } = useValues(toolbarConfigLogic)
 
-    const showExperimentsFlag = useToolbarFeatureFlag('web-experiments')
-    const showExperiments = inStorybook() || inStorybookTestRunner() || showExperimentsFlag
-
     const productToursFlag = useToolbarFeatureFlag('product-tours-2025')
     const showProductTours = inStorybook() || inStorybookTestRunner() || productToursFlag
 
@@ -338,7 +335,7 @@ export function ToolbarInfoMenu(): JSX.Element | null {
         <EventDebugMenu />
     ) : visibleMenu === 'web-vitals' ? (
         <WebVitalsToolbarMenu />
-    ) : visibleMenu === 'experiments' && showExperiments ? (
+    ) : visibleMenu === 'experiments' ? (
         <ExperimentsToolbarMenu />
     ) : visibleMenu === 'product-tours' && showProductTours ? (
         <ProductToursToolbarMenu />
@@ -396,9 +393,6 @@ export function Toolbar(): JSX.Element | null {
     const { selectedTourId, isPreviewing } = useValues(productToursLogic)
     const { isCreating: isSurveyCreating } = useValues(surveysToolbarLogic)
 
-    const showExperimentsFlag = useToolbarFeatureFlag('web-experiments')
-    const showExperiments = inStorybook() || inStorybookTestRunner() || showExperimentsFlag
-
     const productToursFlag = useToolbarFeatureFlag('product-tours-2025')
     const showProductTours = inStorybook() || inStorybookTestRunner() || productToursFlag
 
@@ -452,12 +446,9 @@ export function Toolbar(): JSX.Element | null {
                     'Toolbar--minimized': minimized,
                     'Toolbar--hedgehog-mode': hedgehogMode,
                     'Toolbar--dragging': isDragging,
-                    'Toolbar--extra-buttons-1':
-                        (showExperiments ? 1 : 0) + (showProductTours ? 1 : 0) + (showSurveys ? 1 : 0) === 1,
-                    'Toolbar--extra-buttons-2':
-                        (showExperiments ? 1 : 0) + (showProductTours ? 1 : 0) + (showSurveys ? 1 : 0) === 2,
-                    'Toolbar--extra-buttons-3':
-                        (showExperiments ? 1 : 0) + (showProductTours ? 1 : 0) + (showSurveys ? 1 : 0) === 3,
+                    'Toolbar--extra-buttons-1': 1 + (showProductTours ? 1 : 0) + (showSurveys ? 1 : 0) === 1,
+                    'Toolbar--extra-buttons-2': 1 + (showProductTours ? 1 : 0) + (showSurveys ? 1 : 0) === 2,
+                    'Toolbar--extra-buttons-3': 1 + (showProductTours ? 1 : 0) + (showSurveys ? 1 : 0) === 3,
                 })}
                 onMouseDown={(e) => onMouseOrTouchDown(e.nativeEvent)}
                 onTouchStart={(e) => onMouseOrTouchDown(e.nativeEvent)}
@@ -501,11 +492,9 @@ export function Toolbar(): JSX.Element | null {
                         <ToolbarButton menuId="web-vitals" title="Web vitals">
                             <IconPieChart />
                         </ToolbarButton>
-                        {showExperiments && (
-                            <ToolbarButton menuId="experiments" title="Experiments">
-                                <IconFlask />
-                            </ToolbarButton>
-                        )}
+                        <ToolbarButton menuId="experiments" title="Experiments">
+                            <IconFlask />
+                        </ToolbarButton>
                         {showProductTours && (
                             <ToolbarButton menuId="product-tours" title="Product tours">
                                 <IconSpotlight />


### PR DESCRIPTION
## Problem

`WEB_EXPERIMENTS`, `EXPERIMENT_AI_ANALYSIS_TAB`, and `EXPERIMENT_QUERY_PREAGGREGATION` are fully rolled out and no longer need flag gating.

## Changes

- Removed flag definitions from `frontend/src/lib/constants.tsx`
- Removed the unused `webExperimentsAvailable` selector and now-unneeded `featureFlagLogic` / `FEATURE_FLAGS` / `FeatureFlagsSet` imports from `experimentsLogic.ts`
- Inlined `WEB_EXPERIMENTS` checks in `ToolbarLaunch.tsx` and `bar/Toolbar.tsx` — Experiments feature card and toolbar button now always show
- Dropped flag mocks from `ToolbarLaunch.stories.tsx` and `Toolbar.stories.tsx`

`EXPERIMENT_AI_ANALYSIS_TAB` and `EXPERIMENT_QUERY_PREAGGREGATION` had no consumers — only the constant entries needed removal.

## How did you test this code?

I'm an agent. Ran `pnpm --filter=@posthog/frontend format` and regenerated kea types via `kea-typegen write`. Full `tsc --noEmit` OOMs locally on this machine (pre-existing); relying on CI for type verification. No manual UI testing performed.

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (claude-opus-4-7) at the user's request to clean up three rolled-out experiment-related feature flags. The agent searched all source files for both `FEATURE_FLAGS.*` constant references and the raw `'web-experiments'` / `'experiment-*'` string literals, then removed the gates while preserving unrelated occurrences (the `AuthorizedUrlListType.WEB_EXPERIMENTS` enum, `no-code-web-experiments` doc URLs, and the `list-web-experiments-response` mock filename are unrelated to the flags).