### PR TITLE
feat(observability): tag /sessions/values queries by scene

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -7,6 +7,7 @@ import { captureTimeToSeeData } from 'lib/internalMetrics'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { colonDelimitedDuration, toString, isKeyOf } from 'lib/utils'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import {
@@ -155,7 +156,8 @@ const constructValuesEndpoint = (
     eventNames: string[] | undefined,
     newInput: string | undefined,
     properties?: { key: string; values: string | string[] }[],
-    refresh?: string
+    refresh?: string,
+    scene?: string | null
 ): string => {
     let basePath: string
 
@@ -187,6 +189,7 @@ const constructValuesEndpoint = (
         path +
         (newInput ? '&value=' + encodeURIComponent(newInput) : '') +
         (refresh ? '&refresh=' + refresh : '') +
+        (scene ? '&scene=' + encodeURIComponent(scene) : '') +
         eventParams
     )
 }
@@ -443,6 +446,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             actions.setOptionsSearchInput(propertyKey, newInput || '')
 
             try {
+                const activeScene = sceneLogic.findMounted()?.values.activeSceneId ?? null
                 const responseData: { results: PropValue[]; refreshing: boolean } = await api.get(
                     constructValuesEndpoint(
                         endpoint,
@@ -452,7 +456,8 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                         eventNames,
                         newInput,
                         properties,
-                        refresh
+                        refresh,
+                        activeScene
                     ),
                     methodOptions
                 )

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -189,7 +189,7 @@ const constructValuesEndpoint = (
         path +
         (newInput ? '&value=' + encodeURIComponent(newInput) : '') +
         (refresh ? '&refresh=' + refresh : '') +
-        (scene ? '&scene=' + encodeURIComponent(scene) : '') +
+        (scene && type === PropertyDefinitionType.Session ? '&scene=' + encodeURIComponent(scene) : '') +
         eventParams
     )
 }

--- a/posthog/api/session.py
+++ b/posthog/api/session.py
@@ -4,7 +4,7 @@ from opentelemetry import trace
 from rest_framework import request, response, viewsets
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import SessionTableVersion
+from posthog.schema import ProductKey, SessionTableVersion
 
 from posthog.hogql.database.schema.sessions_v1 import (
     get_lazy_session_table_properties_v1,
@@ -23,10 +23,18 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.api.property_value_metrics import PROPERTY_VALUES_DURATION
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
+from posthog.clickhouse.query_tagging import SCENE_TO_TAGS, Feature, Product, tag_queries
 from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
 from posthog.utils import convert_property_value, flatten
 
 tracer = trace.get_tracer(__name__)
+
+# Container scenes (`Insight`, `Dashboard`, `Notebook`) intentionally map to `None` in
+# `SCENE_TO_TAGS` because they host arbitrary query kinds — for query endpoints the
+# NodeKind drives product attribution. `/sessions/values` has no NodeKind to fall back
+# to, so when one of these scenes calls the endpoint we attribute it to product analytics
+# directly. Any other unmapped scene falls through to a generic API tag below.
+_PRODUCT_ANALYTICS_CONTAINER_SCENES = frozenset({"Insight", "Dashboard", "Notebook"})
 
 
 class SessionViewSet(
@@ -36,6 +44,16 @@ class SessionViewSet(
     scope_object = "query"
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]
     scope_object_read_actions = ["property_definitions", "values"]
+
+    def _tag_query(self, scene: str | None) -> None:
+        product: Product | ProductKey = Product.API
+        if scene in _PRODUCT_ANALYTICS_CONTAINER_SCENES:
+            product = ProductKey.PRODUCT_ANALYTICS
+        elif scene and (scene_tags := SCENE_TO_TAGS.get(scene)) is not None:
+            mapped_product = scene_tags.get("product")
+            if mapped_product is not None:
+                product = mapped_product
+        tag_queries(product=product, feature=Feature.SESSIONS_VALUES_API, scene=scene)
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:
@@ -47,6 +65,13 @@ class SessionViewSet(
 
             key = request.GET.get("key")
             search_term = request.GET.get("value")
+            scene = request.GET.get("scene")
+
+            # `/sessions/values` is hit from many surfaces (insight editor, surveys,
+            # product tours, etc.). Attribute load to product analytics only when the
+            # frontend reports a product-analytics scene; everything else gets a generic
+            # API tag so we don't artificially inflate product-analytics attribution.
+            self._tag_query(scene)
 
             if not key:
                 raise ValidationError(detail=f"Key not provided")

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -89,6 +89,7 @@ class Feature(StrEnum):
     # is hit from every taxonomic property-value picker across the app, so attribution by scene
     # would be misleading; tagging by endpoint name keeps the signal honest.
     EVENTS_VALUES_API = "events_values_api"
+    SESSIONS_VALUES_API = "sessions_values_api"
     USAGE_REPORT = "usage_report"
     BILLING_ETL = "billing_etl"
     QUOTA_LIMITING = "quota_limiting"


### PR DESCRIPTION
## Problem

ClickHouse query attribution for `/sessions/values` was opaque — every call landed in the same bucket regardless of which surface (insight editor, surveys, web analytics, etc.) triggered it. Without scene context we can't tell whether a spike in session-property-value lookups is product analytics, a survey filter UI, or somewhere else, which makes capacity planning and regression hunting harder.

## Changes

- `frontend/src/models/propertyDefinitionsModel.ts`: when calling `/sessions/values`, read the currently active scene from `sceneLogic` and pass it as a `scene` query parameter.
- `posthog/api/session.py`: read the `scene` parameter and tag the ClickHouse query with `product`, `feature=sessions_values_api`, and `scene`. Container scenes (`Insight`, `Dashboard`, `Notebook`) — which `SCENE_TO_TAGS` deliberately maps to `None` because they host arbitrary node kinds — are attributed to product analytics here, since this endpoint has no `NodeKind` to fall back on. Other unmapped scenes fall through to a generic `Product.API` tag so we don't artificially inflate product-analytics attribution.
- `posthog/clickhouse/query_tagging.py`: add `Feature.SESSIONS_VALUES_API`, mirroring the existing `EVENTS_VALUES_API` pattern.

## How did you test this code?

I'm an agent — I did not run manual UI testing. No automated tests were added or run for this change; the touched code paths are thin wrappers over existing tagging primitives that are already covered by their own tests.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude).
- Mirrors the prior `EVENTS_VALUES_API` tagging work for the analogous events endpoint, applied to `/sessions/values`.
- Container-scene carve-out (`Insight`/`Dashboard`/`Notebook` → product analytics) is intentional and documented inline; without it those scenes would fall through to the generic API bucket because `SCENE_TO_TAGS` returns `None` for them.

Generated-By: PostHog Code
Task-Id: ce1802e2-4a89-461a-959a-4f8288da3459