### PR TITLE
fix(tasks): fall back from stale user github token

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -346,8 +346,8 @@ class TestGetSandboxGitHubToken(TestCase):
             ("cached_token_wins", "ghu_cached", True, "ghu_user", None, "ghu_cached"),
             ("identity_token", None, True, "ghu_user", None, "ghu_user"),
             ("missing_identity_falls_back_to_team_token", None, False, None, "missing", "ghs_team"),
-            ("identity_requires_reauthorization", None, True, None, "reauthorization", None),
-            ("identity_without_token_requires_reauthorization", None, True, None, "empty_token", None),
+            ("identity_reauthorization_falls_back_to_team_token", None, True, None, "reauthorization", "ghs_team"),
+            ("identity_without_token_falls_back_to_team_token", None, True, None, "empty_token", "ghs_team"),
         ]
     )
     @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
@@ -376,23 +376,14 @@ class TestGetSandboxGitHubToken(TestCase):
             identity.get_usable_user_access_token.return_value = identity_token
         mock_get_identity.return_value = identity if has_identity else None
 
-        if error_case in ("reauthorization", "empty_token"):
-            with self.assertRaises(ReauthorizationRequired):
-                get_sandbox_github_token(
-                    123,
-                    run_id="run-1",
-                    state={"pr_authorship_mode": "user"},
-                    created_by=creator,
-                )
-        else:
-            mock_get_github_token.return_value = expected_token
-            result = get_sandbox_github_token(
-                123,
-                run_id="run-1",
-                state={"pr_authorship_mode": "user"},
-                created_by=creator,
-            )
-            assert result == expected_token
+        mock_get_github_token.return_value = expected_token
+        result = get_sandbox_github_token(
+            123,
+            run_id="run-1",
+            state={"pr_authorship_mode": "user"},
+            created_by=creator,
+        )
+        assert result == expected_token
 
         mock_cached.assert_called_once_with("run-1")
         if cached_token:
@@ -407,10 +398,42 @@ class TestGetSandboxGitHubToken(TestCase):
             )
             if has_identity:
                 identity.get_usable_user_access_token.assert_called_once()
-        if error_case == "missing":
+        if error_case in ("missing", "reauthorization", "empty_token"):
             mock_get_github_token.assert_called_once_with(123)
         else:
             mock_get_github_token.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("reauthorization",),
+            ("empty_token",),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
+    def test_user_authorship_requires_reauthorization_without_team_fallback(
+        self,
+        error_case: str,
+        mock_get_identity: MagicMock,
+        mock_cached: MagicMock,
+    ) -> None:
+        from posthog.models.user_integration import ReauthorizationRequired
+
+        mock_cached.return_value = None
+        identity = MagicMock()
+        if error_case == "reauthorization":
+            identity.get_usable_user_access_token.side_effect = ReauthorizationRequired("reauthorize GitHub")
+        else:
+            identity.get_usable_user_access_token.return_value = None
+        mock_get_identity.return_value = identity
+
+        with self.assertRaises(ReauthorizationRequired):
+            get_sandbox_github_token(
+                None,
+                run_id="run-1",
+                state={"pr_authorship_mode": "user"},
+                created_by=MagicMock(name="creator"),
+            )
 
     @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
     def test_bot_authorship_uses_installation_token(self, mock_get_github_token) -> None:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -527,13 +527,20 @@ def get_sandbox_github_token(
                 raise ReauthorizationRequired(
                     f"User-authored run {run_id} requires a linked GitHub account with repo access."
                 )
-        else:
+        elif github_integration_id is None:
             token = user_github_integration.get_usable_user_access_token()
             if token is None:
                 raise ReauthorizationRequired(
                     f"User-authored run {run_id} requires a linked GitHub account with repo access."
                 )
             return token
+        else:
+            try:
+                token = user_github_integration.get_usable_user_access_token()
+            except ReauthorizationRequired:
+                token = None
+            if token is not None:
+                return token
 
     if github_integration_id is None:
         return None


### PR DESCRIPTION
## Problem

User-authored cloud runs can have both a personal GitHub integration and a team GitHub integration available. If the personal GitHub token is stale or requires reauthorization, the run currently fails before using the team integration fallback.
