### PR TITLE
perf(organization): cache member_count per-org

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -147,6 +147,28 @@ def _cached_per_user_org(field: CacheField, user_id: int, organization_id: str, 
     return result
 
 
+OrgCacheField = Literal["member_count"]
+
+
+def _fetch_member_count(organization: Organization) -> int:
+    return (
+        OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
+        .filter(user__is_active=True, organization=organization)
+        .count()
+    )
+
+
+def _cached_per_org(field: OrgCacheField, organization_id: str, fetcher: Callable[[], Any]) -> Any:
+    version = _org_serializer_cache_version(organization_id)
+    cache_key = f"org_serializer:{field}:{organization_id}:v{version}"
+    cached = get_safe_cache(cache_key)
+    if cached is not None:
+        return cached
+    result = fetcher()
+    safe_cache_set(cache_key, result, timeout=ORG_SERIALIZER_CACHE_TTL_SECONDS)
+    return result
+
+
 def _resolve_cached_user_id(serializer_context: dict[str, Any]) -> int | None:
     request = serializer_context.get("request")
     if request is None:
@@ -389,15 +411,11 @@ class OrganizationSerializer(
 
     @extend_schema_field(serializers.IntegerField())
     @tracer.start_as_current_span("organization_serializer.member_count")
-    def get_member_count(self, organization: Organization):
-        return (
-            OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
-            .filter(
-                user__is_active=True,
-            )
-            .filter(organization=organization)
-            .count()
-        )
+    def get_member_count(self, organization: Organization) -> int:
+        organization_id = str(organization.id) if organization.id is not None else None
+        if organization_id is None:
+            return _fetch_member_count(organization)
+        return _cached_per_org("member_count", organization_id, lambda: _fetch_member_count(organization))
 
     @tracer.start_as_current_span("organization_serializer.to_representation")
     def to_representation(self, instance):

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -134,11 +134,10 @@ def _bump_org_serializer_cache_version(organization_id: str) -> None:
 
 
 CacheField = Literal["teams", "projects"]
+OrgCacheField = Literal["member_count"]
 
 
-def _cached_per_user_org(field: CacheField, user_id: int, organization_id: str, fetcher: Callable[[], Any]) -> Any:
-    version = _org_serializer_cache_version(organization_id)
-    cache_key = f"org_serializer:{field}:{organization_id}:v{version}:{user_id}"
+def _cached_org_serializer_field(cache_key: str, fetcher: Callable[[], Any]) -> Any:
     cached = get_safe_cache(cache_key)
     if cached is not None:
         return cached
@@ -147,7 +146,10 @@ def _cached_per_user_org(field: CacheField, user_id: int, organization_id: str, 
     return result
 
 
-OrgCacheField = Literal["member_count"]
+def _cached_per_user_org(field: CacheField, user_id: int, organization_id: str, fetcher: Callable[[], Any]) -> Any:
+    version = _org_serializer_cache_version(organization_id)
+    cache_key = f"org_serializer:{field}:{organization_id}:v{version}:{user_id}"
+    return _cached_org_serializer_field(cache_key, fetcher)
 
 
 def _fetch_member_count(organization: Organization) -> int:
@@ -165,12 +167,7 @@ def _fetch_member_count(organization: Organization) -> int:
 def _cached_per_org(field: OrgCacheField, organization_id: str, fetcher: Callable[[], Any]) -> Any:
     version = _org_serializer_cache_version(organization_id)
     cache_key = f"org_serializer:{field}:{organization_id}:v{version}"
-    cached = get_safe_cache(cache_key)
-    if cached is not None:
-        return cached
-    result = fetcher()
-    safe_cache_set(cache_key, result, timeout=ORG_SERIALIZER_CACHE_TTL_SECONDS)
-    return result
+    return _cached_org_serializer_field(cache_key, fetcher)
 
 
 def _resolve_cached_user_id(serializer_context: dict[str, Any]) -> int | None:

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -151,6 +151,10 @@ OrgCacheField = Literal["member_count"]
 
 
 def _fetch_member_count(organization: Organization) -> int:
+    # The cache version is bumped on OrganizationMembership signals (see _INVALIDATION_SOURCES
+    # below), so add/remove of members invalidates immediately. User.is_active flips and email
+    # changes to/from INTERNAL_BOT_EMAIL_SUFFIX do NOT invalidate via signals — they rely on
+    # ORG_SERIALIZER_CACHE_TTL_SECONDS (1h) as the staleness bound.
     return (
         OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
         .filter(user__is_active=True, organization=organization)
@@ -412,10 +416,7 @@ class OrganizationSerializer(
     @extend_schema_field(serializers.IntegerField())
     @tracer.start_as_current_span("organization_serializer.member_count")
     def get_member_count(self, organization: Organization) -> int:
-        organization_id = str(organization.id) if organization.id is not None else None
-        if organization_id is None:
-            return _fetch_member_count(organization)
-        return _cached_per_org("member_count", organization_id, lambda: _fetch_member_count(organization))
+        return _cached_per_org("member_count", str(organization.id), lambda: _fetch_member_count(organization))
 
     @tracer.start_as_current_span("organization_serializer.to_representation")
     def to_representation(self, instance):

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -787,6 +787,31 @@ class TestOrganizationSerializer(APIBaseTest):
             serializer.get_teams(self.organization)
         assert spy.call_count == 2
 
+    def test_get_member_count_caches_per_org(self):
+        from posthog.api.organization import _fetch_member_count
+
+        serializer = OrganizationSerializer(self.organization, context=self.context)
+        with patch("posthog.api.organization._fetch_member_count", wraps=_fetch_member_count) as spy:
+            first = serializer.get_member_count(self.organization)
+            second = serializer.get_member_count(self.organization)
+        assert spy.call_count == 1
+        assert first == second == 1
+
+    def test_get_member_count_invalidates_on_membership_change(self):
+        OrganizationSerializer(self.organization, context=self.context).get_member_count(self.organization)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self._create_user("new-member@posthog.com")
+
+        from posthog.api.organization import _fetch_member_count
+
+        with patch("posthog.api.organization._fetch_member_count", wraps=_fetch_member_count) as spy:
+            after = OrganizationSerializer(
+                self.organization, context=self._fresh_context_for(self.user)
+            ).get_member_count(self.organization)
+        assert spy.call_count == 1
+        assert after == 2
+
 
 class TestOrganizationRbacMigrations(APIBaseTest):
     def setUp(self):

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -15,7 +15,7 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from posthog.api.oauth.test_dcr import generate_rsa_key
-from posthog.api.organization import OrganizationSerializer, _org_serializer_cache_version
+from posthog.api.organization import OrganizationSerializer, _fetch_member_count, _org_serializer_cache_version
 from posthog.models import FeatureFlag, Organization, OrganizationMembership, Team
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.personal_api_key import PersonalAPIKey
@@ -788,8 +788,6 @@ class TestOrganizationSerializer(APIBaseTest):
         assert spy.call_count == 2
 
     def test_get_member_count_caches_per_org(self):
-        from posthog.api.organization import _fetch_member_count
-
         serializer = OrganizationSerializer(self.organization, context=self.context)
         with patch("posthog.api.organization._fetch_member_count", wraps=_fetch_member_count) as spy:
             first = serializer.get_member_count(self.organization)
@@ -797,20 +795,37 @@ class TestOrganizationSerializer(APIBaseTest):
         assert spy.call_count == 1
         assert first == second == 1
 
-    def test_get_member_count_invalidates_on_membership_change(self):
-        OrganizationSerializer(self.organization, context=self.context).get_member_count(self.organization)
+    @parameterized.expand(
+        [
+            (
+                "membership_create",
+                lambda self: self._create_user("invalidates-create@posthog.com"),
+                3,
+            ),
+            (
+                "membership_delete",
+                lambda self: OrganizationMembership.objects.filter(user=self._seeded_user).delete(),
+                1,
+            ),
+        ]
+    )
+    def test_get_member_count_invalidates_on_membership_change(self, _name, mutate, expected_after):
+        # Seed a second member so the delete path has something to remove and the
+        # baseline count is the same for both parameter cases.
+        self._seeded_user = self._create_user("invalidates-seed@posthog.com")
+        cache.clear()
+        baseline = OrganizationSerializer(self.organization, context=self.context).get_member_count(self.organization)
+        assert baseline == 2
 
         with self.captureOnCommitCallbacks(execute=True):
-            self._create_user("new-member@posthog.com")
-
-        from posthog.api.organization import _fetch_member_count
+            mutate(self)
 
         with patch("posthog.api.organization._fetch_member_count", wraps=_fetch_member_count) as spy:
             after = OrganizationSerializer(
                 self.organization, context=self._fresh_context_for(self.user)
             ).get_member_count(self.organization)
         assert spy.call_count == 1
-        assert after == 2
+        assert after == expected_after
 
 
 class TestOrganizationRbacMigrations(APIBaseTest):


### PR DESCRIPTION
## Problem

Production traces show \`organization_serializer.member_count\` taking up to 442 ms on the home view (\`/api/users/@me/\`). The implementation re-runs \`OrganizationMembership.exclude(internal_bot).filter(user__is_active=True, organization=org).count()\` on every render — a value that changes only when membership changes.

## Changes

- New \`_cached_per_org(field, organization_id, fetcher)\` helper sits next to the existing \`_cached_per_user_org\`, sharing the same per-org version key (\`_org_serializer_cache_version\`).
- \`get_member_count\` now reads through the cache; the underlying SQL extracted to \`_fetch_member_count\` so tests can assert hit/miss without monkey-patching ORM internals.
- The existing \`OrganizationMembership\` \`post_save\`/\`post_delete\` signal handler already bumps the version key, so add/remove of members invalidates immediately. No new receivers needed.
- 1 h TTL caps staleness for rare edge cases that don't flow through the membership table (\`User.is_active\` flip, internal-bot email change).

## Tests

- \`test_get_member_count_caches_per_org\` — \`_fetch_member_count\` runs once across two calls.
- \`test_get_member_count_invalidates_on_membership_change\` — creating a user + membership invalidates the cached value within the same transaction (uses \`captureOnCommitCallbacks\`).

## 🤖 Agent context

Stacked on top of the previous \`cache-org-serializer\` work in #57399. Shape mirrors that PR exactly — same version key, same TTL, same signal-handler approach. Member count specifically is per-org (not per-user) so I added a small \`_cached_per_org\` helper rather than wasting Redis entries by reusing \`_cached_per_user_org\`.

Driven by trace IA3XLc which showed \`organization_serializer.member_count\` = 442 ms / 553 ms total \`template.context\`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*