### PR TITLE
perf(team): cache product_intents on team serializer per team

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -46,6 +46,7 @@ from posthog.models.group_type_mapping import cached_group_types_for_team
 from posthog.models.organization import OrganizationMembership
 from posthog.models.product_intent.product_intent import (
     ProductIntentSerializer,
+    cached_product_intents_for_team,
     enqueue_product_activation_calc_debounced,
 )
 from posthog.models.project import Project
@@ -560,9 +561,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         # we've already enqueued for this team in the last 24h. 99% of renders
         # become a cache hit; the remaining ones still enqueue exactly as before.
         enqueue_product_activation_calc_debounced(obj.id)
-        return ProductIntent.objects.filter(team=obj).values(
-            "product_type", "created_at", "onboarding_completed_at", "updated_at"
-        )
+        return cached_product_intents_for_team(obj.id)
 
     @extend_schema_field(serializers.DictField(child=serializers.BooleanField()))
     @tracer.start_as_current_span("team_serializer.managed_viewsets")

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from django.core.cache import cache
 from django.db import models, transaction
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
 import structlog
@@ -416,9 +416,27 @@ def _invalidate_product_intents_cache(team_id: int) -> None:
     transaction.on_commit(lambda: safe_cache_delete(_team_product_intents_cache_key(team_id)))
 
 
+@receiver(pre_save, sender=ProductIntent)
+def _capture_original_team_id(sender: type[ProductIntent], instance: ProductIntent, **kwargs: Any) -> None:
+    # Stash the persisted team_id before save so post_save can invalidate the previous
+    # team's cache when an intent is reassigned (instance.team_id != original).
+    if instance.pk is None:
+        instance._original_team_id = None  # type: ignore[attr-defined]
+        return
+    try:
+        instance._original_team_id = (  # type: ignore[attr-defined]
+            ProductIntent.objects.filter(pk=instance.pk).values_list("team_id", flat=True).first()
+        )
+    except Exception:
+        instance._original_team_id = None  # type: ignore[attr-defined]
+
+
 @receiver(post_save, sender=ProductIntent)
 def _invalidate_product_intents_on_save(sender: type[ProductIntent], instance: ProductIntent, **kwargs: Any) -> None:
     _invalidate_product_intents_cache(instance.team_id)
+    original_team_id = getattr(instance, "_original_team_id", None)
+    if original_team_id is not None and original_team_id != instance.team_id:
+        _invalidate_product_intents_cache(original_team_id)
 
 
 @receiver(post_delete, sender=ProductIntent)

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -420,9 +420,7 @@ def _invalidate_product_intents_cache(team_id: int) -> None:
 def _capture_original_team_id(sender: type[ProductIntent], instance: ProductIntent, **kwargs: Any) -> None:
     # Stash the persisted team_id before save so post_save can invalidate the previous
     # team's cache when an intent is reassigned (instance.team_id != original).
-    if instance.pk is None:
-        instance._original_team_id = None  # type: ignore[attr-defined]
-        return
+    # For new rows the filter returns None (no row yet), which is the right value to stash.
     try:
         instance._original_team_id = (  # type: ignore[attr-defined]
             ProductIntent.objects.filter(pk=instance.pk).values_list("team_id", flat=True).first()

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -1,8 +1,10 @@
 from datetime import UTC, datetime
-from typing import Optional
+from typing import Any, Optional
 
 from django.core.cache import cache
-from django.db import models
+from django.db import models, transaction
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
 
 import structlog
 from celery import shared_task
@@ -18,7 +20,7 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.utils import RootTeamMixin, UUIDTModel
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
-from posthog.utils import get_instance_realm
+from posthog.utils import get_instance_realm, get_safe_cache, safe_cache_delete, safe_cache_set
 
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.error_tracking.backend.models import ErrorTrackingIssue
@@ -375,3 +377,50 @@ def enqueue_product_activation_calc_debounced(team_id: int) -> bool:
         calculate_product_activation.delay(team_id, only_calc_if_days_since_last_checked=1)
         return True
     return False
+
+
+PRODUCT_INTENTS_CACHE_TTL_SECONDS = 60 * 60
+
+
+def _team_product_intents_cache_key(team_id: int) -> str:
+    return f"team_serializer:product_intents:{team_id}"
+
+
+def _fetch_product_intents(team_id: int) -> list[dict[str, Any]]:
+    return list(
+        ProductIntent.objects.filter(team_id=team_id).values(
+            "product_type", "created_at", "onboarding_completed_at", "updated_at"
+        )
+    )
+
+
+def cached_product_intents_for_team(team_id: int) -> list[dict[str, Any]]:
+    """Per-team cache for the product_intents response on the team serializer.
+
+    Production traces showed `team_serializer.product_intents` taking up to 532ms
+    on the home view. The query result changes only when a ProductIntent row writes
+    or deletes; the post_save / post_delete receivers below invalidate immediately.
+    A 1h TTL caps staleness for any path that bypasses the ORM signals.
+    """
+    cache_key = _team_product_intents_cache_key(team_id)
+    cached = get_safe_cache(cache_key)
+    if cached is not None:
+        return cached
+    result = _fetch_product_intents(team_id)
+    safe_cache_set(cache_key, result, timeout=PRODUCT_INTENTS_CACHE_TTL_SECONDS)
+    return result
+
+
+def _invalidate_product_intents_cache(team_id: int) -> None:
+    safe_cache_delete(_team_product_intents_cache_key(team_id))
+    transaction.on_commit(lambda: safe_cache_delete(_team_product_intents_cache_key(team_id)))
+
+
+@receiver(post_save, sender=ProductIntent)
+def _invalidate_product_intents_on_save(sender: type[ProductIntent], instance: ProductIntent, **kwargs: Any) -> None:
+    _invalidate_product_intents_cache(instance.team_id)
+
+
+@receiver(post_delete, sender=ProductIntent)
+def _invalidate_product_intents_on_delete(sender: type[ProductIntent], instance: ProductIntent, **kwargs: Any) -> None:
+    _invalidate_product_intents_cache(instance.team_id)

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -17,11 +17,13 @@ from posthog.models.hog_flow.hog_flow import HogFlow
 from posthog.models.insight import Insight
 from posthog.models.product_intent.product_intent import (
     ProductIntent,
+    _fetch_product_intents,
     _team_product_intents_cache_key,
     cached_product_intents_for_team,
     calculate_product_activation,
     enqueue_product_activation_calc_debounced,
 )
+from posthog.models.team.team import Team
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.utils import get_instance_realm
 
@@ -820,56 +822,6 @@ class TestEnqueueProductActivationCalcDebounced(BaseTest):
         assert results == expected_returns
         assert mock_delay.call_count == expected_delay_calls
 
-    def test_cached_product_intents_caches_results(self):
-        ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
-
-        with patch(
-            "posthog.models.product_intent.product_intent._fetch_product_intents",
-            wraps=lambda team_id: list(
-                ProductIntent.objects.filter(team_id=team_id).values(
-                    "product_type", "created_at", "onboarding_completed_at", "updated_at"
-                )
-            ),
-        ) as spy:
-            first = cached_product_intents_for_team(self.team.id)
-            second = cached_product_intents_for_team(self.team.id)
-        assert spy.call_count == 1
-        assert first == second
-        assert {row["product_type"] for row in first} == {"surveys"}
-
-    def test_cached_product_intents_invalidates_on_create(self):
-        cached_product_intents_for_team(self.team.id)
-        assert cache.get(_team_product_intents_cache_key(self.team.id)) is not None
-
-        with self.captureOnCommitCallbacks(execute=True):
-            ProductIntent.objects.create(team=self.team, product_type=ProductKey.FEATURE_FLAGS)
-
-        assert cache.get(_team_product_intents_cache_key(self.team.id)) is None
-        refreshed = cached_product_intents_for_team(self.team.id)
-        assert {row["product_type"] for row in refreshed} == {"feature_flags"}
-
-    def test_cached_product_intents_invalidates_on_delete(self):
-        intent = ProductIntent.objects.create(team=self.team, product_type=ProductKey.EXPERIMENTS)
-        cached_product_intents_for_team(self.team.id)
-        assert cache.get(_team_product_intents_cache_key(self.team.id)) is not None
-
-        with self.captureOnCommitCallbacks(execute=True):
-            intent.delete()
-
-        assert cache.get(_team_product_intents_cache_key(self.team.id)) is None
-
-    def test_cached_product_intents_isolates_per_team(self):
-        from posthog.models import Team
-
-        other_team = Team.objects.create(organization=self.organization, name="Other")
-        ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
-        ProductIntent.objects.create(team=other_team, product_type=ProductKey.EXPERIMENTS)
-
-        team_a = cached_product_intents_for_team(self.team.id)
-        team_b = cached_product_intents_for_team(other_team.id)
-        assert {row["product_type"] for row in team_a} == {"surveys"}
-        assert {row["product_type"] for row in team_b} == {"experiments"}
-
     def test_cache_failure_falls_open_logs_and_still_enqueues(self):
         # Redis blip must not 500 the team list endpoint. The helper falls open:
         # treat a cache exception as "we haven't enqueued recently" and proceed.
@@ -888,3 +840,72 @@ class TestEnqueueProductActivationCalcDebounced(BaseTest):
         assert mock_log.call_args.args == ("product_activation_debounce_cache_failure",)
         assert mock_log.call_args.kwargs == {"team_id": self.team.id, "exc_info": True}
         mock_capture.assert_called_once()
+
+
+class TestCachedProductIntentsForTeam(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_caches_results(self):
+        ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
+
+        with patch(
+            "posthog.models.product_intent.product_intent._fetch_product_intents",
+            wraps=_fetch_product_intents,
+        ) as spy:
+            first = cached_product_intents_for_team(self.team.id)
+            second = cached_product_intents_for_team(self.team.id)
+        assert spy.call_count == 1
+        assert first == second
+        assert {row["product_type"] for row in first} == {"surveys"}
+
+    @parameterized.expand(
+        [
+            (
+                "create",
+                lambda self: ProductIntent.objects.create(team=self.team, product_type=ProductKey.FEATURE_FLAGS),
+            ),
+            (
+                "delete",
+                lambda self: ProductIntent.objects.get(team=self.team, product_type=ProductKey.EXPERIMENTS).delete(),
+            ),
+        ]
+    )
+    def test_invalidates_on_signal(self, _name, mutate):
+        # Seed an existing intent so the delete path has something to remove and both
+        # cases share the same starting point.
+        ProductIntent.objects.create(team=self.team, product_type=ProductKey.EXPERIMENTS)
+        cached_product_intents_for_team(self.team.id)
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is not None
+
+        with self.captureOnCommitCallbacks(execute=True):
+            mutate(self)
+
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is None
+
+    def test_invalidates_both_teams_on_reassignment(self):
+        # Codex P2: when an intent's team_id changes, the previous team's cache must
+        # also be evicted, otherwise its /api/users/@me/ payload returns the moved
+        # intent for up to PRODUCT_INTENTS_CACHE_TTL_SECONDS.
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        intent = ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
+        cached_product_intents_for_team(self.team.id)
+        cached_product_intents_for_team(other_team.id)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            intent.team = other_team
+            intent.save()
+
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is None
+        assert cache.get(_team_product_intents_cache_key(other_team.id)) is None
+
+    def test_isolates_per_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
+        ProductIntent.objects.create(team=other_team, product_type=ProductKey.EXPERIMENTS)
+
+        team_a = cached_product_intents_for_team(self.team.id)
+        team_b = cached_product_intents_for_team(other_team.id)
+        assert {row["product_type"] for row in team_a} == {"surveys"}
+        assert {row["product_type"] for row in team_b} == {"experiments"}

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -17,6 +17,8 @@ from posthog.models.hog_flow.hog_flow import HogFlow
 from posthog.models.insight import Insight
 from posthog.models.product_intent.product_intent import (
     ProductIntent,
+    _team_product_intents_cache_key,
+    cached_product_intents_for_team,
     calculate_product_activation,
     enqueue_product_activation_calc_debounced,
 )
@@ -817,6 +819,56 @@ class TestEnqueueProductActivationCalcDebounced(BaseTest):
             results = [enqueue_product_activation_calc_debounced(self.team.id + offset) for offset in team_id_offsets]
         assert results == expected_returns
         assert mock_delay.call_count == expected_delay_calls
+
+    def test_cached_product_intents_caches_results(self):
+        ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
+
+        with patch(
+            "posthog.models.product_intent.product_intent._fetch_product_intents",
+            wraps=lambda team_id: list(
+                ProductIntent.objects.filter(team_id=team_id).values(
+                    "product_type", "created_at", "onboarding_completed_at", "updated_at"
+                )
+            ),
+        ) as spy:
+            first = cached_product_intents_for_team(self.team.id)
+            second = cached_product_intents_for_team(self.team.id)
+        assert spy.call_count == 1
+        assert first == second
+        assert {row["product_type"] for row in first} == {"surveys"}
+
+    def test_cached_product_intents_invalidates_on_create(self):
+        cached_product_intents_for_team(self.team.id)
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is not None
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ProductIntent.objects.create(team=self.team, product_type=ProductKey.FEATURE_FLAGS)
+
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is None
+        refreshed = cached_product_intents_for_team(self.team.id)
+        assert {row["product_type"] for row in refreshed} == {"feature_flags"}
+
+    def test_cached_product_intents_invalidates_on_delete(self):
+        intent = ProductIntent.objects.create(team=self.team, product_type=ProductKey.EXPERIMENTS)
+        cached_product_intents_for_team(self.team.id)
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is not None
+
+        with self.captureOnCommitCallbacks(execute=True):
+            intent.delete()
+
+        assert cache.get(_team_product_intents_cache_key(self.team.id)) is None
+
+    def test_cached_product_intents_isolates_per_team(self):
+        from posthog.models import Team
+
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        ProductIntent.objects.create(team=self.team, product_type=ProductKey.SURVEYS)
+        ProductIntent.objects.create(team=other_team, product_type=ProductKey.EXPERIMENTS)
+
+        team_a = cached_product_intents_for_team(self.team.id)
+        team_b = cached_product_intents_for_team(other_team.id)
+        assert {row["product_type"] for row in team_a} == {"surveys"}
+        assert {row["product_type"] for row in team_b} == {"experiments"}
 
     def test_cache_failure_falls_open_logs_and_still_enqueues(self):
         # Redis blip must not 500 the team list endpoint. The helper falls open:


### PR DESCRIPTION
## Problem

Production home-view traces show \`team_serializer.product_intents\` taking up to **532 ms** on the \`/api/users/@me/\` request path. The implementation re-runs \`ProductIntent.objects.filter(team=obj).values(...)\` on every render — a value that changes only when a ProductIntent row writes or deletes.

## Changes

- New \`cached_product_intents_for_team(team_id)\` lives next to the existing \`enqueue_product_activation_calc_debounced\` in \`posthog/models/product_intent/product_intent.py\`.
- \`post_save\` and \`post_delete\` receivers on \`ProductIntent\` invalidate the cache immediately (with both an immediate delete and an \`on_commit\` delete to handle test isolation, matching the pattern in #57399).
- 1 h TTL caps staleness for any signal-bypassing write paths. Audit found no \`bulk_create\` / \`bulk_update\` / \`.update()\` callers in production code today, so the TTL is more belt-and-braces than load-bearing.
- The \`enqueue_product_activation_calc_debounced\` call stays where it was (independent of the result cache, already 24h-debounced via its own Redis key).

## Tests

- \`test_cached_product_intents_caches_results\` — \`_fetch_product_intents\` runs once across two calls.
- \`test_cached_product_intents_invalidates_on_create\` — creating a ProductIntent invalidates immediately within the same transaction.
- \`test_cached_product_intents_invalidates_on_delete\` — deleting a ProductIntent invalidates immediately.
- \`test_cached_product_intents_isolates_per_team\` — two teams keep independent cache entries.

Existing parameterised debounce tests still pass (10/10 in the file's class), broader \`test_product_intent.py\` clean (64/64).

## 🤖 Agent context

Driven by trace AhxiMk in the home-view investigation: \`team_serializer.product_intents\` was 532 ms / 654 ms total \`template.context\`. Same shape as the org-level \`member_count\` cache in #57608 — small, signal-driven invalidation, conservative TTL.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*