### PR TITLE
chore(sandbox): Add TTL to sandbox image digest cache

### DIFF
--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -6,6 +6,7 @@ import shlex
 import shutil
 import logging
 import tempfile
+import threading
 from collections.abc import Iterable
 from functools import lru_cache
 from io import StringIO
@@ -13,6 +14,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from django.conf import settings
+
+from cachetools import TTLCache, cached
 
 if TYPE_CHECKING:
     from products.tasks.backend.temporal.process_task.utils import McpServerConfig
@@ -90,10 +93,14 @@ LOCAL_MODAL_DOCKERFILES = {
 LOCAL_MODAL_INSTALL_SKILLS_SCRIPT = Path("products/tasks/backend/sandbox/images/install-skills.sh")
 
 
-@lru_cache(maxsize=2)
+_image_ref_cache: TTLCache = TTLCache(maxsize=2, ttl=300)
+_image_ref_lock = threading.Lock()
+
+
+@cached(cache=_image_ref_cache, lock=_image_ref_lock)
 def _get_sandbox_image_reference(image: str = SANDBOX_IMAGE) -> str:
     """Modal caches sandbox images indefinitely. This function resolves the digest of the master tag
-    so Modal fetches the correct version. Queries GHCR once per deployment.
+    so Modal fetches the correct version. Re-resolves from GHCR every ~5 minutes.
     """
     image_repo = image.replace("ghcr.io/", "")
     try:
@@ -152,7 +159,11 @@ def _attach_local_package_mounts(image: modal.Image, template: SandboxTemplate) 
     return image
 
 
-@lru_cache(maxsize=2)
+_template_image_cache: TTLCache = TTLCache(maxsize=2, ttl=300)
+_template_image_lock = threading.Lock()
+
+
+@cached(cache=_template_image_cache, lock=_template_image_lock)
 def _get_template_image(template: SandboxTemplate) -> modal.Image:
     registry_image = {
         SandboxTemplate.DEFAULT_BASE: SANDBOX_BASE_IMAGE,

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -16,6 +16,7 @@ from products.tasks.backend.services.modal_sandbox import (
     ModalSandbox,
     _get_modal_region,
     _get_sandbox_image_reference,
+    _image_ref_cache,
 )
 from products.tasks.backend.services.sandbox import AgentServerResult, ExecutionResult, SandboxConfig
 from products.tasks.backend.temporal.exceptions import SandboxExecutionError
@@ -37,7 +38,7 @@ def _mock_manifest_response(status_code: int = 200, digest: str | None = "sha256
 
 class TestGetSandboxImageReference:
     def setup_method(self):
-        _get_sandbox_image_reference.cache_clear()
+        _image_ref_cache.clear()
 
     def test_returns_digest_reference_on_success(self):
         with patch(
@@ -115,10 +116,31 @@ class TestGetSandboxImageReference:
         assert result1 == result2 == result3 == f"{SANDBOX_IMAGE}@sha256:cached123"
         assert mock_get.call_count == 2  # token + manifest, called only once due to cache
 
+    def test_re_resolves_after_cache_expiry(self):
+        """After TTL expiry (simulated via clear), a fresh GHCR query picks up the new digest."""
+        with patch(
+            "products.tasks.backend.services.modal_sandbox.requests.get",
+            side_effect=[
+                _mock_token_response(),
+                _mock_manifest_response(digest="sha256:old"),
+                _mock_token_response(),
+                _mock_manifest_response(digest="sha256:new"),
+            ],
+        ) as mock_get:
+            result1 = _get_sandbox_image_reference()
+            assert result1 == f"{SANDBOX_IMAGE}@sha256:old"
+            assert mock_get.call_count == 2
+
+            _image_ref_cache.clear()
+
+            result2 = _get_sandbox_image_reference()
+            assert result2 == f"{SANDBOX_IMAGE}@sha256:new"
+            assert mock_get.call_count == 4
+
 
 class TestGetSandboxImageReferenceIntegration:
     def setup_method(self):
-        _get_sandbox_image_reference.cache_clear()
+        _image_ref_cache.clear()
 
     @pytest.mark.xfail(
         reason="Flaky: depends on GHCR availability. Remove this mark when we've figured out a less flaky approach"


### PR DESCRIPTION
## Problem

The GHCR digest lookup for sandbox images (`_get_sandbox_image_reference`) uses `@lru_cache`, which caches for the entire process lifetime. When a new sandbox base image is pushed to GHCR, running Temporal workers keep spawning sandboxes with the old image until they're manually redeployed. This means agent updates require coordinated redeploys to take effect.

## Changes

- Replace `@lru_cache` with `cachetools.TTLCache` (already a direct dependency) on `_get_sandbox_image_reference` and `_get_template_image`, using a 5-minute TTL.
- New images are picked up automatically without requiring a worker redeploy.

## How did you test this code?

- All existing `TestGetSandboxImageReference` tests pass (20/20).
- Added `test_re_resolves_after_cache_expiry` verifying a fresh GHCR query happens after cache expiry and picks up the new digest.

## Publish to changelog?

No

## 🤖 Agent context

- Co-authored with Claude Code (Opus 4.6)
- Prompted by investigating why cloud runs were stuck on an old agent version after a sandbox image rebuild — traced to the `@lru_cache` never expiring