### PR TITLE
fix(ws): correct Meta Ads token refresh to prevent auth errors

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2959,11 +2959,11 @@ class MetaAdsIntegration:
     def refresh_access_token(self):
         oauth_config = OauthIntegration.oauth_config_for_kind(self.integration.kind)
 
-        # check if refresh is necessary (less than 7 days)
+        # skip refresh if more than 7 days until expiry
         if self.integration.config.get("expires_in") and self.integration.config.get("refreshed_at"):
             if (
                 time.time()
-                > self.integration.config.get("refreshed_at") + self.integration.config.get("expires_in") - 604800
+                < self.integration.config.get("refreshed_at") + self.integration.config.get("expires_in") - 604800
             ):
                 return
 

--- a/posthog/tasks/integrations.py
+++ b/posthog/tasks/integrations.py
@@ -14,7 +14,7 @@ def refresh_integrations() -> int:
     from posthog.models.integration import Integration, OauthIntegration
 
     oauth_integrations = defer_repository_cache_fields(
-        Integration.objects.filter(kind__in=OauthIntegration.supported_kinds).all()
+        Integration.objects.filter(kind__in=OauthIntegration.supported_kinds).exclude(kind="meta-ads").all()
     )
 
     for integration in oauth_integrations:


### PR DESCRIPTION
## Problem

Users with Meta Ads sources connected for 30+ days see persistent "Authentication token could not be refreshed" errors on the configuration tab, even though their data syncs are completing successfully

## Changes

  * Fixed Meta Ads token refresh using wrong OAuth grant type from periodic task
  * Fixed inverted expiry check in `MetaAdsIntegration.refresh_access_token()` — now only refreshes within 7 days of expiry instead of on every sync

## How did you test this code?

Test pass

## Publish to changelog?

NO