### PR TITLE
chore(alerts): bump investigation agent to sonnet 4.6

### DIFF
--- a/posthog/temporal/ai/anomaly_investigation/runner.py
+++ b/posthog/temporal/ai/anomaly_investigation/runner.py
@@ -36,7 +36,7 @@ from posthog.temporal.ai.anomaly_investigation.tools import (
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_CALLS = 10
-AGENT_MODEL = "claude-sonnet-4-5"
+AGENT_MODEL = "claude-sonnet-4-6"
 MAX_TOOL_RESULT_CHARS = 12_000  # ~3K tokens per call — keeps 10 calls well under the context limit.
 # Per-request cap. The surrounding Temporal activity has its own (longer) deadline;
 # this guards against a single stuck HTTP call hanging for the whole activity budget.


### PR DESCRIPTION
## Problem

The anomaly investigation agent (`posthog/temporal/ai/anomaly_investigation/runner.py`) is on `claude-sonnet-4-5`. The rest of `ee/hogai` (chat agent, conversation summarizer, research mode) moved to `claude-sonnet-4-6` well before this agent was authored — looks like a copy-paste oversight on the original PR. Anthropic now lists 4.5 in the legacy table; 4.6 is the current GA Sonnet.

## Changes

- Bump `AGENT_MODEL` from `claude-sonnet-4-5` to `claude-sonnet-4-6` in `posthog/temporal/ai/anomaly_investigation/runner.py`.

Same price ($3 / $15 per MTok), better tool use, and adaptive thinking — useful for the agent's "is this a one-off spike or a recurring pattern?" reasoning step. Drop-in via `MaxChatAnthropic`.

## How did you test this code?

I'm an agent. No manual testing performed. The change is a single string constant; existing tests in `posthog/temporal/tests/ai/test_anomaly_investigation_verdict.py` mock the LLM so the model ID is not asserted.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Human prompt: "lets look at the more recent models here and see what could be a fit ... why are we using sonnet 4.5?" → "yep lets make a pr to bump to sonnet 4.6"
- Decision: stayed within Sonnet rather than jumping to Haiku 4.5 (verdict gates user notifications, so cheaper-but-less-capable was deemed too risky to flip without an offline eval) or Opus 4.7 (its agentic-coding gains don't apply to a 10-call HogQL investigation, and it's 1.7× the cost).