### PR TITLE
chore(phai): set explicit bypass permission mode for slack task runs

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -773,6 +773,7 @@ def create_posthog_code_task_for_repo_activity(
             slack_thread_url=slack_thread_url,
             start_workflow=False,
             posthog_mcp_scopes="full",
+            initial_permission_mode="bypassPermissions",
         )
     except Exception as e:
         log.exception(
@@ -1069,6 +1070,10 @@ def _resume_task_with_new_run(
 
     extra_state: dict[str, Any] = {
         "interaction_origin": "slack",  # Makes the agent auto-push and open a draft PR
+        # No desktop is attached to Slack runs; bypass the destructive
+        # PostHog sub-tool gate so it doesn't make a permission roundtrip
+        # only to auto-allow at the cloud client.
+        "initial_permission_mode": "bypassPermissions",
     }
 
     previous_state = previous_run.state or {}

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -283,6 +283,7 @@ class Task(DeletedMetaFields, models.Model):
         output_schema: type[BaseModel] | dict | None = None,
         interaction_origin: str | None = None,
         model: str | None = None,
+        initial_permission_mode: str | None = None,
     ) -> "Task":
         from products.tasks.backend.temporal.client import execute_task_processing_workflow
 
@@ -369,6 +370,9 @@ class Task(DeletedMetaFields, models.Model):
 
         if model:
             extra_state["model"] = model
+
+        if initial_permission_mode:
+            extra_state["initial_permission_mode"] = initial_permission_mode
 
         task_run = task.create_run(mode=mode, extra_state=extra_state or None, branch=branch)
 

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -82,6 +82,44 @@ class TestTask(TestCase):
         self.assertEqual(task_run.status, TaskRun.Status.QUEUED)
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_threads_initial_permission_mode_into_state(self, mock_execute_workflow):
+        user = User.objects.create(email="test@test.com")
+        Integration.objects.create(team=self.team, kind="github", config={})
+
+        task = Task.create_and_run(
+            team=self.team,
+            title="Slack Task",
+            description="Slack Description",
+            origin_product=Task.OriginProduct.SLACK,
+            user_id=user.id,
+            repository="posthog/posthog",
+            initial_permission_mode="bypassPermissions",
+        )
+
+        run_id = mock_execute_workflow.call_args.kwargs["run_id"]
+        task_run = TaskRun.objects.get(id=run_id)
+        self.assertEqual(task_run.state["initial_permission_mode"], "bypassPermissions")
+        self.assertEqual(task.origin_product, Task.OriginProduct.SLACK)
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_omits_permission_mode_when_not_provided(self, mock_execute_workflow):
+        user = User.objects.create(email="test@test.com")
+        Integration.objects.create(team=self.team, kind="github", config={})
+
+        Task.create_and_run(
+            team=self.team,
+            title="Plain Task",
+            description="Plain Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            user_id=user.id,
+            repository="posthog/posthog",
+        )
+
+        run_id = mock_execute_workflow.call_args.kwargs["run_id"]
+        task_run = TaskRun.objects.get(id=run_id)
+        self.assertNotIn("initial_permission_mode", task_run.state)
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_create_and_run_with_repository(self, mock_execute_workflow):
         user = User.objects.create(email="test@test.com")
         Integration.objects.create(team=self.team, kind="github", config={})
@@ -416,6 +454,11 @@ class TestTaskRun(TestCase):
         self.assertEqual(call_args.args[1]["type"], "task_run_state")
         self.assertEqual(call_args.args[1]["status"], TaskRun.Status.QUEUED)
         self.assertEqual(call_args.args[1]["branch"], "main")
+
+    def test_create_run_does_not_inject_permission_mode_by_default(self):
+        run = self.task.create_run(mode="interactive")
+
+        self.assertNotIn("initial_permission_mode", run.state)
 
     def test_s3_prefixes_keep_existing_logs_and_artifact_paths(self):
         run = TaskRun.objects.create(


### PR DESCRIPTION
## Problem

Slack-originated cloud runs have no desktop attached, so tool permission prompts auto-resolve in the cloud client anyway. The destructive PostHog MCP sub-tool gate (`mcp__posthog__exec` for `*-update` / `*-delete` family) was still making a `requestPermission` roundtrip from the agent to the cloud client only to auto-allow on the other side. Slack runs also relied implicitly on the agent-server's Claude default of `bypassPermissions` rather than setting it explicitly.

## Changes

- Threaded `initial_permission_mode` through `Task.create_and_run` (mirroring the existing `model` kwarg).
- Slack mention + Slack resume call sites pass `initial_permission_mode="bypassPermissions"` so the destructive sub-tool gate at `permission-handlers.ts` short-circuits at the agent without a roundtrip.

## How did you test this code?

- Added unit tests in `products/tasks/backend/tests/test_models.py`:
  - `Task.create_and_run` writes `initial_permission_mode` into the run state when provided.
  - `Task.create_and_run` omits the key when not provided.
  - `Task.create_run` does not auto-inject anything.

## Publish to changelog?

no