### PR TITLE
fix(trends): display annotations for current period in bar charts

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -1304,7 +1304,7 @@ export function LineGraph_({
             {showAnnotations && chartRef.current && chartWidth && chartHeight ? (
                 <AnnotationsOverlay
                     chart={chartRef.current}
-                    dates={datasets[0]?.days || EMPTY_DATES}
+                    dates={currentPeriodResult?.days || datasets[0]?.days || EMPTY_DATES}
                     chartWidth={chartWidth}
                     chartHeight={chartHeight}
                     insightNumericId={insight.id || 'new'}


### PR DESCRIPTION
## Problem

Trends insights with a bar chart and the "compare against previous period" option enabled, show annotations for the previous period, instead of the current period.

Related ticket: https://posthoghelp.zendesk.com/agent/tickets/57388 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/58694)

## Changes

Try using days from `currentPeriodResult` first.

## How did you test this code?

Manual testing