### PR TITLE
revert: remove enableGlobalVirtualStore (partial revert of #57452)

### DIFF
--- a/devenv/news.txt
+++ b/devenv/news.txt
@@ -3,4 +3,3 @@ Use 'hogli dev:explain' to see why each service is running
 hogli now collects anonymous usage data - run 'hogli telemetry:status' for details
 Press 't' in phrocs to toggle services on or off — replaces hogli dev:setup
 hogli now supports detached mode: run hogli up -d, then hogli wait / hogli down
-pnpm now uses a global virtual store — worktree installs are nearly instant (avoid concurrent pnpm install)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-enableGlobalVirtualStore: true
-
 packages:
     - '.'
     - common/esbuilder


### PR DESCRIPTION
## Summary

Partial revert of #57452 - removes only:
- `enableGlobalVirtualStore: true` from `pnpm-workspace.yaml`
- The pnpm news line from `devenv/news.txt`

**Keeps** the git blame news display mechanics (showing dates, sorted newest first).

## Why

The `enableGlobalVirtualStore` feature is experimental with known issues:
- Concurrency bug when multiple workers run `pnpm install` simultaneously ([pnpm#10018](https://github.com/pnpm/pnpm/issues/10018))
- `pnpm deploy` may need `--legacy` flag

## Test plan

- Configuration change only

https://claude.ai/code/session_01PJx2wkHQ9JfxDp4HX8qdVJ