### PR TITLE
fix(experiments): Use sentence case for stopped early conclusion label

### DIFF
--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -63,7 +63,7 @@ export const CONCLUSION_DISPLAY_CONFIG: Record<
         color: 'bg-warning',
     },
     [ExperimentConclusion.StoppedEarly]: {
-        title: 'Stopped Early',
+        title: 'Stopped early',
         description: 'The experiment was terminated before reaching a conclusive result.',
         color: 'bg-muted-alt',
     },


### PR DESCRIPTION
## Problem

The "Stopped Early" experiment conclusion label is in title case. PostHog's UI copy convention is sentence case, and it's the only conclusion with two words — Won, Lost, Inconclusive, and Invalid are all single-word.

## Changes

Rename the title to "Stopped early" in \`CONCLUSION_DISPLAY_CONFIG\`. This is the single source of truth — it propagates to the experiments grid Result column, the experiment detail view, the conclusion-picker dropdown, the edit modal, and activity descriptions.

## How did you test this code?

I'm an agent. Verified with grep that no other frontend reference to "Stopped Early" remains. No automated UI tests run; manual visual check is up to the reviewer.

## 🤖 Agent context

Authored with Claude Code as a follow-up to the Result column PR. Backend choice label `("stopped_early", "Stopped Early")` is intentionally left untouched — it's the Django choices pair, not user-facing copy.