### PR TITLE
chore(tasks): clarify GitHub App env vars in sandbox setup guide

### DIFF
--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -30,13 +30,24 @@ Steps:
 1. GitHub → Settings → Developer Settings → GitHub Apps → New GitHub App
 2. Set the **Setup URL** (NOT the Callback or Homepage URL) to
    `http://localhost:8010/integrations/github/callback`
-3. Set the permissions above
-4. Generate and download a private key
-5. Install the app on your test repositories by going to `http://localhost:8010/project/1/settings/project-integrations` and installing the GitHub Integration
-6. Add to your `.env`:
+3. Set a **Callback URL** — `http://localhost:8010/complete/github-link/`
+   works for the personal user-link flow used by Code. Any URL under your
+   localhost is fine; the value just has to be a valid URL since it's
+   required when creating the App.
+4. Set the permissions above
+5. Generate a **client secret** under "Client secrets" on the App page —
+   this is required (added a couple of releases back). If your local setup
+   stopped working recently, this is most likely what's missing.
+6. Generate a private key
+7. Install the app on your test repositories by going to `http://localhost:8010/project/1/settings/project-integrations` and installing the GitHub Integration
+8. Add to your `.env`:
 
 ```bash
-GITHUB_APP_CLIENT_ID=your_app_id
+# The OAuth Client ID (starts with Iv1 or Iv23) — NOT the numeric App ID.
+# Both fields are visible on the GitHub App settings page; the App ID is the
+# small grey number at the top, the Client ID is the labelled field below.
+GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
+GITHUB_APP_CLIENT_SECRET=your_client_secret
 GITHUB_APP_SLUG=your-app-slug
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 ```

--- a/products/tasks/backend/management/commands/setup_background_agents.py
+++ b/products/tasks/backend/management/commands/setup_background_agents.py
@@ -186,11 +186,16 @@ class Command(BaseCommand):
         self.stdout.write("  Each engineer needs their own dev GitHub App. Steps:")
         self.stdout.write(f"    1. Open: {GITHUB_APP_NEW_URL}")
         self.stdout.write(f"    2. Set the Setup URL (NOT Callback or Homepage) to: {GITHUB_APP_SETUP_URL}")
-        self.stdout.write("    3. Permissions: Contents R/W, Pull requests R/W, Metadata R")
-        self.stdout.write("    4. Generate a private key, install the app on your test repos")
-        self.stdout.write("    5. Add to your .env (the slug is the URL-friendly name from the App URL):")
+        self.stdout.write(
+            "    3. Set a Callback URL (any localhost URL is fine; "
+            "http://localhost:8010/complete/github-link/ is what Code's user-link flow uses)"
+        )
+        self.stdout.write("    4. Permissions: Contents R/W, Pull requests R/W, Metadata R")
+        self.stdout.write("    5. Generate a client secret and a private key, install the app on your test repos")
+        self.stdout.write("    6. Add to your .env (the slug is the URL-friendly name from the App URL):")
         self.stdout.write("")
-        self.stdout.write('       GITHUB_APP_CLIENT_ID="your_app_id"')
+        self.stdout.write("       # OAuth Client ID (starts with Iv1/Iv23) — NOT the numeric App ID")
+        self.stdout.write('       GITHUB_APP_CLIENT_ID="Iv1xxxxxxxxxxxxxxxx"')
         self.stdout.write('       GITHUB_APP_CLIENT_SECRET="your_client_secret"')
         self.stdout.write('       GITHUB_APP_SLUG="your-app-slug"')
         self.stdout.write(


### PR DESCRIPTION
## Problem

The cloud-runs sandbox setup guide and the printed instructions from `setup_background_agents` were ambiguous about `GITHUB_APP_CLIENT_ID` ("your_app_id" placeholder), didn't mention the required `GITHUB_APP_CLIENT_SECRET` at all, and weren't clear that the GitHub App Callback URL is just a required-field-at-creation, not something that has to match a specific path.

I hit this trying to connect a personal GitHub from PostHog Code: the authorize URL 404'd because my `GITHUB_APP_CLIENT_ID` was the numeric App ID rather than the OAuth Client ID (`Iv1.…`/`Iv23.…`). Per discussion with @apoglia in #team-tasks, `GITHUB_APP_CLIENT_SECRET` became required a couple of releases back and is the most likely thing missing from older local setups.

## Changes

- `docs/internal/sandboxes-setup-guide.md` — clarify Client ID format, add `GITHUB_APP_CLIENT_SECRET` to the `.env` block (with a note that this is the usual culprit for setups that broke recently), reword the Callback URL step.
- `products/tasks/backend/management/commands/setup_background_agents.py` — same three corrections in the printed instructions.

## How did you test this code?

Agent-authored. No automated tests touched. Manual verification: re-read both files end-to-end and confirmed the `.env` 

## Publish to changelog?

no
