### PR TITLE
chore(observability): histogram for template.context render duration

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -936,13 +936,14 @@ class TestTemplateContextHistogram(TestCase):
     def _count_for_labels(template_name: str, authenticated: str) -> int:
         from posthog.utils import TEMPLATE_CONTEXT_DURATION_HISTOGRAM
 
-        for sample in TEMPLATE_CONTEXT_DURATION_HISTOGRAM.collect()[0].samples:
-            if (
-                sample.name.endswith("_count")
-                and sample.labels.get("template_name") == template_name
-                and sample.labels.get("authenticated") == authenticated
-            ):
-                return int(sample.value)
+        for metric in TEMPLATE_CONTEXT_DURATION_HISTOGRAM.collect():
+            for sample in metric.samples:
+                if (
+                    sample.name.endswith("_count")
+                    and sample.labels.get("template_name") == template_name
+                    and sample.labels.get("authenticated") == authenticated
+                ):
+                    return int(sample.value)
         return 0
 
     @parameterized.expand(

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -929,3 +929,43 @@ class TestSharingOverrideProtection(TestCase):
         result = tile_filters_override_requested_by_client(request, tile)
 
         assert result == {"breakdown": "region"}
+
+
+class TestTemplateContextHistogram(TestCase):
+    @staticmethod
+    def _count_for_labels(template_name: str, authenticated: str) -> int:
+        from posthog.utils import TEMPLATE_CONTEXT_DURATION_HISTOGRAM
+
+        for sample in TEMPLATE_CONTEXT_DURATION_HISTOGRAM.collect()[0].samples:
+            if (
+                sample.name.endswith("_count")
+                and sample.labels.get("template_name") == template_name
+                and sample.labels.get("authenticated") == authenticated
+            ):
+                return int(sample.value)
+        return 0
+
+    @parameterized.expand(
+        [
+            ("authenticated", True, "true"),
+            ("anonymous", False, "false"),
+        ]
+    )
+    def test_template_context_duration_histogram_uses_correct_authenticated_label(
+        self, _name: str, authenticated: bool, expected_label: str
+    ):
+        request = RequestFactory().get("/")
+        # Stash the is_authenticated value via a simple attribute on the request
+        # itself; the wrapper reads it via getattr() so it tolerates any user shape.
+        request.user = cast(Any, type("FakeUser", (), {"is_authenticated": authenticated})())
+
+        before = self._count_for_labels("index.html", expected_label)
+
+        # Drive only the label-selection wrapper; bypass the heavy inner body so this
+        # stays a fast, hermetic unit test of the metric plumbing itself.
+        with patch("posthog.utils._get_context_for_template_inner", return_value={}):
+            from posthog.utils import get_context_for_template
+
+            get_context_for_template("index.html", request)
+
+        assert self._count_for_labels("index.html", expected_label) == before + 1

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -963,7 +963,7 @@ class TestTemplateContextHistogram(TestCase):
 
         # Drive only the label-selection wrapper; bypass the heavy inner body so this
         # stays a fast, hermetic unit test of the metric plumbing itself.
-        with patch("posthog.utils._get_context_for_template_inner", return_value={}):
+        with patch("posthog.utils._build_template_context", return_value={}):
             from posthog.utils import get_context_for_template
 
             get_context_for_template("index.html", request)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -46,6 +46,7 @@ from celery.schedules import crontab
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from opentelemetry import trace
+from prometheus_client import Histogram
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.utils.encoders import JSONEncoder
@@ -60,6 +61,13 @@ from posthog.metrics import KLUDGES_COUNTER
 from posthog.redis import get_client
 
 tracer = trace.get_tracer(__name__)
+
+TEMPLATE_CONTEXT_DURATION_HISTOGRAM = Histogram(
+    "posthog_template_context_duration_seconds",
+    "Time spent building the SPA template context (get_context_for_template).",
+    labelnames=["template_name", "authenticated"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
@@ -387,6 +395,17 @@ def get_context_for_template(
     request: HttpRequest,
     context: Optional[dict] = None,
     team_for_public_context: Optional["Team"] = None,
+) -> dict:
+    authenticated = "true" if getattr(request.user, "is_authenticated", False) else "false"
+    with TEMPLATE_CONTEXT_DURATION_HISTOGRAM.labels(template_name=template_name, authenticated=authenticated).time():
+        return _get_context_for_template_inner(template_name, request, context, team_for_public_context)
+
+
+def _get_context_for_template_inner(
+    template_name: str,
+    request: HttpRequest,
+    context: Optional[dict],
+    team_for_public_context: Optional["Team"],
 ) -> dict:
     if context is None:
         context = {}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -62,6 +62,9 @@ from posthog.redis import get_client
 
 tracer = trace.get_tracer(__name__)
 
+# Cardinality is bounded: render_template is only called with the literal template
+# names "index.html", "demo.html", and "render_query.html" — 3 templates × 2 auth
+# states = 6 series total.
 TEMPLATE_CONTEXT_DURATION_HISTOGRAM = Histogram(
     "posthog_template_context_duration_seconds",
     "Time spent building the SPA template context (get_context_for_template).",
@@ -396,12 +399,12 @@ def get_context_for_template(
     context: Optional[dict] = None,
     team_for_public_context: Optional["Team"] = None,
 ) -> dict:
-    authenticated = "true" if getattr(request.user, "is_authenticated", False) else "false"
+    authenticated = "true" if request.user.is_authenticated else "false"
     with TEMPLATE_CONTEXT_DURATION_HISTOGRAM.labels(template_name=template_name, authenticated=authenticated).time():
-        return _get_context_for_template_inner(template_name, request, context, team_for_public_context)
+        return _build_template_context(template_name, request, context, team_for_public_context)
 
 
-def _get_context_for_template_inner(
+def _build_template_context(
     template_name: str,
     request: HttpRequest,
     context: Optional[dict],


### PR DESCRIPTION
## Problem

We have OTel spans on the home-view render path (\`get_context_for_template\` and its sub-blocks), which is great for inspecting individual slow traces. But they make it awkward to track *variance* of the render path over time — a 500ms outlier in Jaeger doesn't tell you whether p50 has moved.

## Changes

- Adds \`posthog_template_context_duration_seconds\` Prometheus histogram, labelled by \`template_name\` (\`index.html\`, \`exporter.html\`, \`render_query.html\`, …) and \`authenticated\` (\`true\` / \`false\`). Cardinality is small (~8 combinations).
- Buckets match the project convention: \`(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0)\`.
- Implementation is a thin wrapper around the existing \`_get_context_for_template_inner\` body; the OTel \`template.context\` span continues to wrap the whole thing, so trace-level observability is unchanged.

## Tests

Two parameterised cases verify the histogram observes once per call with the correct \`authenticated\` label, isolated from the heavy inner body via \`patch\`.

## 🤖 Agent context

Driven by trace investigation of the home-view path. Recent caching work (\#57608, \#57610) addressed dominant DB hot spots; this lets us confirm the impact in aggregate (p50/p95/p99 over time) rather than relying on cherry-picked traces. Cheap, additive, no behaviour change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*