### PR TITLE
feat(error-tracking): add per-issue rate limit settings section

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5231,9 +5231,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-error-tracking--light:
         hash: v1.k794b7964.b4bf729d080caa78b6bb98d10580d77e217236e0fc6f00c43e72b1be7678b2f2.1_6VuVmWbHmWYusiDjuMTRx3rWlIDWehPi9H_BJD7qc
     scenes-app-settings-environment--settings-environment-error-tracking-configuration--dark:
-        hash: v1.k794b7964.beea6d68de5516c6c7e482ce88f065fd0a1b2fdffc50638df199acc38d73a77c.V8mH4gzfvHK9nMszJJUv4CsxPJsUSOeTYOWPr-P_xAQ
+        hash: v1.k794b7964.f476b5aa495c5e23811314b06443b6f320d764a6bc290091c4bf7225c4237627.iT2dyMcVSF68wqyB2r9F1QBHyW-iIagZ6SCf639GN_8
     scenes-app-settings-environment--settings-environment-error-tracking-configuration--light:
-        hash: v1.k794b7964.31cfe7a159eceba2b5b77a509be4bdb5aecfcd563f5ac026308a7821036cdfa5.G9Mf095SgmmZVmSzplDhCbnoqh5o7h5F7Cr1J__5XAs
+        hash: v1.k794b7964.d79e3a0193b1ef39590f90820a06dac571351266b6ff8c184dfb99b8eed2a9ec.Rwqw_BRK0TOc_11jA-Pdmni5_khXgJU5WAlZW2IH6Ak
     scenes-app-settings-environment--settings-environment-feature-flags--dark:
         hash: v1.k794b7964.8e1edff6d728b3343686536c5514b0eb48f25f16a76ea274ee257c5a5844922c.9yA1OXDgg_49YTBECuJG06dwayX_2b-asQIwVUCXGUQ
     scenes-app-settings-environment--settings-environment-feature-flags--light:

--- a/frontend/src/lib/components/Errors/types.ts
+++ b/frontend/src/lib/components/Errors/types.ts
@@ -158,6 +158,8 @@ export interface ErrorTrackingSpikeDetectionConfig {
 export interface ErrorTrackingSettings {
     project_rate_limit_value: number | null
     project_rate_limit_bucket_size_minutes: number | null
+    per_issue_rate_limit_value: number | null
+    per_issue_rate_limit_bucket_size_minutes: number | null
 }
 
 export interface ErrorTrackingSpikeEventIssue {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -287,6 +287,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_QUERY_V2: 'error-tracking-query-v2', // owner: #team-error-tracking
     ERROR_TRACKING_QUERY_V3: 'error-tracking-query-v3', // owner: #team-error-tracking
     ERROR_TRACKING_RATE_LIMITING: 'error-tracking-rate-limiting', // owner: @ablaszkiewicz #team-error-tracking
+    ERROR_TRACKING_RATE_LIMITING_PER_ISSUE: 'error-tracking-rate-limiting-per-issue', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RECOMMENDATIONS: 'error-tracking-recommendations', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RELATED_ISSUES: 'error-tracking-related-issues', // owner: #team-error-tracking
     ERROR_TRACKING_REVENUE_SORTING: 'error-tracking-revenue-sorting', // owner: @david #team-error-tracking

--- a/products/error_tracking/backend/api/settings.py
+++ b/products/error_tracking/backend/api/settings.py
@@ -23,10 +23,27 @@ class ErrorTrackingSettingsSerializer(serializers.ModelSerializer):
         required=False,
         help_text="Bucket window over which the project-wide rate limit applies, in minutes.",
     )
+    per_issue_rate_limit_value = serializers.IntegerField(
+        min_value=1,
+        allow_null=True,
+        required=False,
+        help_text="Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.",
+    )
+    per_issue_rate_limit_bucket_size_minutes = serializers.IntegerField(
+        min_value=1,
+        allow_null=True,
+        required=False,
+        help_text="Bucket window over which the per-issue rate limit applies, in minutes.",
+    )
 
     class Meta:
         model = ErrorTrackingSettings
-        fields = ["project_rate_limit_value", "project_rate_limit_bucket_size_minutes"]
+        fields = [
+            "project_rate_limit_value",
+            "project_rate_limit_bucket_size_minutes",
+            "per_issue_rate_limit_value",
+            "per_issue_rate_limit_bucket_size_minutes",
+        ]
 
 
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -840,6 +840,18 @@ export interface ErrorTrackingSettingsApi {
      * @nullable
      */
     project_rate_limit_bucket_size_minutes?: number | null
+    /**
+     * Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.
+     * @minimum 1
+     * @nullable
+     */
+    per_issue_rate_limit_value?: number | null
+    /**
+     * Bucket window over which the per-issue rate limit applies, in minutes.
+     * @minimum 1
+     * @nullable
+     */
+    per_issue_rate_limit_bucket_size_minutes?: number | null
 }
 
 export interface PatchedErrorTrackingSettingsApi {
@@ -855,6 +867,18 @@ export interface PatchedErrorTrackingSettingsApi {
      * @nullable
      */
     project_rate_limit_bucket_size_minutes?: number | null
+    /**
+     * Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.
+     * @minimum 1
+     * @nullable
+     */
+    per_issue_rate_limit_value?: number | null
+    /**
+     * Bucket window over which the per-issue rate limit applies, in minutes.
+     * @minimum 1
+     * @nullable
+     */
+    per_issue_rate_limit_bucket_size_minutes?: number | null
 }
 
 export interface ErrorTrackingSpikeDetectionConfigApi {

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -309,6 +309,18 @@ export const ErrorTrackingSettingsUpdateSettingsPartialUpdateBody = /* @__PURE__
         .min(1)
         .nullish()
         .describe('Bucket window over which the project-wide rate limit applies, in minutes.'),
+    per_issue_rate_limit_value: zod
+        .number()
+        .min(1)
+        .nullish()
+        .describe(
+            'Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.'
+        ),
+    per_issue_rate_limit_bucket_size_minutes: zod
+        .number()
+        .min(1)
+        .nullish()
+        .describe('Bucket window over which the per-issue rate limit applies, in minutes.'),
 })
 
 export const ErrorTrackingSpikeDetectionConfigUpdateConfigPartialUpdateBody = /* @__PURE__ */ zod.object({

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/IssueRateLimitSettings.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/IssueRateLimitSettings.tsx
@@ -1,0 +1,223 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonSelect, Link } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { humanFriendlyLargeNumber } from 'lib/utils'
+import { urls } from 'scenes/urls'
+
+import { issueRateLimitConfigLogic } from './issueRateLimitConfigLogic'
+import { BUCKET_OPTIONS } from './rateLimitConfigLogic'
+import { formatTotalDuration, RateLimitSimulationChart } from './RateLimitSimulationChart'
+
+export function IssueRateLimitSettings(): JSX.Element {
+    const { configLoading } = useValues(issueRateLimitConfigLogic)
+
+    if (configLoading) {
+        return (
+            <div className="space-y-4">
+                <LemonSkeleton className="w-full h-10" />
+                <LemonSkeleton className="w-full h-64" />
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <h3 className="font-semibold text-base mb-1">Per-issue rate limit</h3>
+                <p className="text-muted-foreground">
+                    This limit applies to each issue individually. Once an issue exceeds the configured rate, further
+                    exceptions for it are dropped at ingestion.
+                </p>
+            </div>
+
+            <Form logic={issueRateLimitConfigLogic} formKey="configForm" enableFormOnSubmit>
+                <div className="grid grid-cols-1 md:grid-cols-10 gap-6">
+                    <div className="md:col-span-3">
+                        <ConfigColumn />
+                    </div>
+                    <div className="md:col-span-3">
+                        <IssuesListColumn />
+                    </div>
+                    <div className="md:col-span-4">
+                        <PreviewColumn />
+                    </div>
+                </div>
+            </Form>
+        </div>
+    )
+}
+
+function ConfigColumn(): JSX.Element {
+    const { configFormChanged, isConfigFormSubmitting } = useValues(issueRateLimitConfigLogic)
+
+    return (
+        <div className="space-y-3">
+            <LemonField name="per_issue_rate_limit_value" label="Maximum exceptions">
+                {({ value, onChange }) => (
+                    <LemonInput
+                        type="number"
+                        min={1}
+                        value={value ?? undefined}
+                        onChange={(v) => onChange(v ?? null)}
+                        placeholder="Unlimited"
+                        fullWidth
+                        data-attr="issue-rate-limit-value"
+                    />
+                )}
+            </LemonField>
+
+            <LemonField name="per_issue_rate_limit_bucket_size_minutes" label="Per">
+                {({ value, onChange }) => (
+                    <LemonSelect
+                        value={value}
+                        onChange={onChange}
+                        options={BUCKET_OPTIONS.map((o) => ({ label: o.label, value: o.minutes }))}
+                        fullWidth
+                        data-attr="issue-rate-limit-bucket-size"
+                    />
+                )}
+            </LemonField>
+
+            <p className="text-muted-foreground text-xs">
+                Applies to every issue independently. Leave the value empty for no limit.
+            </p>
+
+            <div className="flex justify-start pt-2">
+                <LemonButton
+                    type="primary"
+                    htmlType="submit"
+                    disabledReason={!configFormChanged ? 'No changes to save' : undefined}
+                    loading={isConfigFormSubmitting}
+                >
+                    Save
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+function IssuesListColumn(): JSX.Element {
+    const { topIssues, topIssuesLoading, selectedIssueId } = useValues(issueRateLimitConfigLogic)
+    const { selectIssue } = useActions(issueRateLimitConfigLogic)
+
+    const heading = <div className="text-sm font-medium mb-1">Most active issues — past 7 days</div>
+
+    if (topIssuesLoading) {
+        return (
+            <div className="space-y-1">
+                {heading}
+                <LemonSkeleton className="w-full h-80" />
+            </div>
+        )
+    }
+
+    if (topIssues.length === 0) {
+        return (
+            <div className="space-y-1">
+                {heading}
+                <div className="border rounded p-4 text-sm text-muted-foreground h-80 flex items-center justify-center text-center">
+                    No exceptions captured in the past 7 days yet.
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-1">
+            {heading}
+            <div className="border rounded divide-y h-80 overflow-y-auto bg-surface-secondary">
+                {topIssues.map((issue) => {
+                    const isSelected = issue.issue_id === selectedIssueId
+                    return (
+                        <div
+                            key={issue.issue_id}
+                            role="button"
+                            tabIndex={0}
+                            className={`w-full flex items-center gap-3 pl-3 pr-3 py-2 cursor-pointer border-l-2 ${
+                                isSelected
+                                    ? 'border-l-primary bg-fill-highlight-100'
+                                    : 'border-l-transparent hover:bg-fill-highlight-50'
+                            }`}
+                            onClick={() => selectIssue(issue.issue_id)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    selectIssue(issue.issue_id)
+                                }
+                            }}
+                            data-attr="issue-rate-limit-row"
+                        >
+                            <div className="flex-1 min-w-0">
+                                <div className="text-sm font-medium truncate">
+                                    <Link
+                                        subtle
+                                        to={urls.errorTrackingIssue(issue.issue_id)}
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        {issue.name || 'Untitled issue'}
+                                    </Link>
+                                </div>
+                                {issue.description ? (
+                                    <div className="text-xs text-secondary truncate">{issue.description}</div>
+                                ) : null}
+                            </div>
+                            <div className="text-right shrink-0">
+                                <div className="text-sm font-medium">{humanFriendlyLargeNumber(issue.occurrences)}</div>
+                                <div className="text-xs text-muted-foreground">events</div>
+                            </div>
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+function PreviewColumn(): JSX.Element {
+    const { selectedIssue, selectedIssueVolume, selectedIssueVolumeLoading, configForm, topIssues } =
+        useValues(issueRateLimitConfigLogic)
+
+    const limit = configForm.per_issue_rate_limit_value
+    const bucketMinutes = configForm.per_issue_rate_limit_bucket_size_minutes
+
+    const heading = (
+        <div className="text-sm font-medium mb-1 truncate">
+            {selectedIssue
+                ? `Exception volume for "${selectedIssue.name || 'Untitled issue'}" — past ${formatTotalDuration(bucketMinutes)}`
+                : 'Volume'}
+        </div>
+    )
+
+    if (topIssues.length === 0) {
+        return (
+            <div className="space-y-1">
+                {heading}
+                <div className="border rounded p-4 text-sm text-muted-foreground h-80 flex items-center justify-center text-center">
+                    Pick an issue from the list to preview its volume.
+                </div>
+            </div>
+        )
+    }
+
+    if (selectedIssueVolumeLoading) {
+        return (
+            <div className="space-y-1">
+                {heading}
+                <LemonSkeleton className="w-full h-80" />
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-1">
+            {heading}
+            <RateLimitSimulationChart volume={selectedIssueVolume} rateLimit={limit} bucketMinutes={bucketMinutes} />
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSettings.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSettings.tsx
@@ -1,22 +1,30 @@
 import { useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { useMemo } from 'react'
 
 import { LemonSelect } from '@posthog/lemon-ui'
 
-import { dayjs } from 'lib/dayjs'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { pluralize } from 'lib/utils'
 
-import { LineGraph } from '~/queries/nodes/DataVisualization/Components/Charts/LineGraph'
-import { ChartDisplayType } from '~/types'
-
-import { BUCKET_OPTIONS, ExceptionVolumeBucket, getBucketOption, rateLimitConfigLogic } from './rateLimitConfigLogic'
+import { IssueRateLimitSettings } from './IssueRateLimitSettings'
+import { BUCKET_OPTIONS, rateLimitConfigLogic } from './rateLimitConfigLogic'
+import { formatTotalDuration, RateLimitSimulationChart } from './RateLimitSimulationChart'
 
 export function RateLimitSettings(): JSX.Element {
+    const hasPerIssueRateLimit = useFeatureFlag('ERROR_TRACKING_RATE_LIMITING_PER_ISSUE')
+
+    return (
+        <div className="space-y-8">
+            <ProjectRateLimitSection />
+            {hasPerIssueRateLimit ? <IssueRateLimitSettings /> : null}
+        </div>
+    )
+}
+
+function ProjectRateLimitSection(): JSX.Element {
     const {
         configLoading,
         configFormChanged,
@@ -108,113 +116,6 @@ export function RateLimitSettings(): JSX.Element {
                     </div>
                 </div>
             </Form>
-        </div>
-    )
-}
-
-function formatTotalDuration(bucketMinutes: number): string {
-    const option = getBucketOption(bucketMinutes)
-    const totalMinutes = option.minutes * option.bucketCount
-    if (totalMinutes >= 10080) {
-        return pluralize(Math.round(totalMinutes / 10080), 'week')
-    }
-    if (totalMinutes >= 1440) {
-        return pluralize(Math.round(totalMinutes / 1440), 'day')
-    }
-    return pluralize(Math.round(totalMinutes / 60), 'hour')
-}
-
-function fillBuckets(volume: ExceptionVolumeBucket[], bucketMinutes: number): ExceptionVolumeBucket[] {
-    const option = getBucketOption(bucketMinutes)
-    const bucketMs = option.minutes * 60_000
-    const counts = new Map<number, number>()
-    volume.forEach((b) => {
-        const aligned = Math.floor(dayjs(b.bucket).valueOf() / bucketMs) * bucketMs
-        counts.set(aligned, b.count)
-    })
-    const endMs = Math.floor(Date.now() / bucketMs) * bucketMs
-    const buckets: ExceptionVolumeBucket[] = []
-    for (let i = option.bucketCount - 1; i >= 0; i--) {
-        const ms = endMs - i * bucketMs
-        buckets.push({ bucket: dayjs(ms).toISOString(), count: counts.get(ms) ?? 0 })
-    }
-    return buckets
-}
-
-function formatBucketLabel(iso: string, bucketMinutes: number): string {
-    const ts = dayjs(iso)
-    if (bucketMinutes >= 1440) {
-        return ts.format('MMM D')
-    }
-    return ts.format('MMM D, HH:mm')
-}
-
-function RateLimitSimulationChart({
-    volume,
-    rateLimit,
-    bucketMinutes,
-}: {
-    volume: ExceptionVolumeBucket[]
-    rateLimit: number | null
-    bucketMinutes: number
-}): JSX.Element {
-    const { xData, yData } = useMemo(() => {
-        const filled = fillBuckets(volume, bucketMinutes)
-        const labels = filled.map((b) => formatBucketLabel(b.bucket, bucketMinutes))
-        const counts = filled.map((b) => b.count)
-        return {
-            xData: {
-                column: {
-                    name: 'bucket',
-                    type: { name: 'STRING' as const, isNumerical: false },
-                    label: 'Bucket',
-                    dataIndex: 0,
-                },
-                data: labels,
-            },
-            yData: [
-                {
-                    column: {
-                        name: 'count',
-                        type: { name: 'INTEGER' as const, isNumerical: true },
-                        label: 'Exceptions',
-                        dataIndex: 0,
-                    },
-                    data: counts,
-                    settings: {
-                        display: {
-                            displayType: 'bar' as const,
-                        },
-                    },
-                },
-            ],
-        }
-    }, [volume, bucketMinutes])
-
-    const goalLines = useMemo(() => {
-        if (!rateLimit || rateLimit <= 0) {
-            return []
-        }
-        const option = getBucketOption(bucketMinutes)
-        return [
-            {
-                label: `Limit: ${rateLimit} per ${option.label}`,
-                value: rateLimit,
-                displayLabel: true,
-            },
-        ]
-    }, [rateLimit, bucketMinutes])
-
-    return (
-        <div className="h-80 border rounded">
-            <LineGraph
-                className="h-full p-4"
-                xData={xData}
-                yData={yData}
-                visualizationType={ChartDisplayType.ActionsBar}
-                chartSettings={{ showXAxisTicks: false, showXAxisBorder: false }}
-                goalLines={goalLines}
-            />
         </div>
     )
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.tsx
@@ -1,0 +1,147 @@
+import { useMemo } from 'react'
+
+import { getColorVar } from 'lib/colors'
+import { dayjs } from 'lib/dayjs'
+import { pluralize } from 'lib/utils'
+
+import { LineGraph } from '~/queries/nodes/DataVisualization/Components/Charts/LineGraph'
+import { ChartDisplayType } from '~/types'
+
+import { ExceptionVolumeBucket, getBucketOption } from './rateLimitConfigLogic'
+
+export function formatTotalDuration(bucketMinutes: number): string {
+    const option = getBucketOption(bucketMinutes)
+    const totalMinutes = option.minutes * option.bucketCount
+    if (totalMinutes >= 10080) {
+        return pluralize(Math.round(totalMinutes / 10080), 'week')
+    }
+    if (totalMinutes >= 1440) {
+        return pluralize(Math.round(totalMinutes / 1440), 'day')
+    }
+    return pluralize(Math.round(totalMinutes / 60), 'hour')
+}
+
+function fillBuckets(volume: ExceptionVolumeBucket[], bucketMinutes: number): ExceptionVolumeBucket[] {
+    const option = getBucketOption(bucketMinutes)
+    const bucketMs = option.minutes * 60_000
+    const counts = new Map<number, number>()
+    volume.forEach((b) => {
+        const aligned = Math.floor(dayjs(b.bucket).valueOf() / bucketMs) * bucketMs
+        counts.set(aligned, b.count)
+    })
+    const endMs = Math.floor(Date.now() / bucketMs) * bucketMs
+    const buckets: ExceptionVolumeBucket[] = []
+    for (let i = option.bucketCount - 1; i >= 0; i--) {
+        const ms = endMs - i * bucketMs
+        buckets.push({ bucket: dayjs(ms).toISOString(), count: counts.get(ms) ?? 0 })
+    }
+    return buckets
+}
+
+function formatBucketLabel(iso: string, bucketMinutes: number): string {
+    const ts = dayjs(iso)
+    if (bucketMinutes >= 1440) {
+        return ts.format('MMM D')
+    }
+    return ts.format('MMM D, HH:mm')
+}
+
+export function RateLimitSimulationChart({
+    volume,
+    rateLimit,
+    bucketMinutes,
+}: {
+    volume: ExceptionVolumeBucket[]
+    rateLimit: number | null
+    bucketMinutes: number
+}): JSX.Element {
+    const hasLimit = !!rateLimit && rateLimit > 0
+
+    const { xData, yData } = useMemo(() => {
+        const filled = fillBuckets(volume, bucketMinutes)
+        const labels = filled.map((b) => formatBucketLabel(b.bucket, bucketMinutes))
+        const counts = filled.map((b) => b.count)
+        const xAxis = {
+            column: {
+                name: 'bucket',
+                type: { name: 'STRING' as const, isNumerical: false },
+                label: 'Bucket',
+                dataIndex: 0,
+            },
+            data: labels,
+        }
+
+        if (!hasLimit || rateLimit === null) {
+            return {
+                xData: xAxis,
+                yData: [
+                    {
+                        column: {
+                            name: 'count',
+                            type: { name: 'INTEGER' as const, isNumerical: true },
+                            label: 'Exceptions',
+                            dataIndex: 0,
+                        },
+                        data: counts,
+                        settings: { display: { displayType: 'bar' as const } },
+                    },
+                ],
+            }
+        }
+
+        const within = counts.map((c) => Math.min(c, rateLimit))
+        const above = counts.map((c) => Math.max(c - rateLimit, 0))
+        return {
+            xData: xAxis,
+            yData: [
+                {
+                    column: {
+                        name: 'within',
+                        type: { name: 'INTEGER' as const, isNumerical: true },
+                        label: 'Within limit',
+                        dataIndex: 0,
+                    },
+                    data: within,
+                    settings: { display: { displayType: 'bar' as const } },
+                },
+                {
+                    column: {
+                        name: 'above',
+                        type: { name: 'INTEGER' as const, isNumerical: true },
+                        label: 'Would be dropped',
+                        dataIndex: 0,
+                    },
+                    data: above,
+                    settings: { display: { displayType: 'bar' as const, color: getColorVar('danger') } },
+                },
+            ],
+        }
+    }, [volume, bucketMinutes, hasLimit, rateLimit])
+
+    const goalLines = useMemo(() => {
+        if (!hasLimit || rateLimit === null) {
+            return []
+        }
+        const option = getBucketOption(bucketMinutes)
+        return [
+            {
+                label: `Limit: ${rateLimit} per ${option.label}`,
+                value: rateLimit,
+                displayLabel: true,
+            },
+        ]
+    }, [hasLimit, rateLimit, bucketMinutes])
+
+    return (
+        <div className="h-80 border rounded">
+            <LineGraph
+                className="h-full p-4"
+                xData={xData}
+                yData={yData}
+                visualizationType={hasLimit ? ChartDisplayType.ActionsStackedBar : ChartDisplayType.ActionsBar}
+                chartSettings={{ showXAxisTicks: false, showXAxisBorder: false }}
+                goalLines={goalLines}
+            />
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/issueRateLimitConfigLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/issueRateLimitConfigLogic.ts
@@ -1,0 +1,216 @@
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
+import { forms } from 'kea-forms'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import { ErrorTrackingSettings } from 'lib/components/Errors/types'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import { HogQLQueryResponse, NodeKind, ProductKey } from '~/queries/schema/schema-general'
+
+import type { issueRateLimitConfigLogicType } from './issueRateLimitConfigLogicType'
+import { DEFAULT_BUCKET_MINUTES, ExceptionVolumeBucket, getBucketOption } from './rateLimitConfigLogic'
+
+export interface IssueRateLimitConfigForm {
+    per_issue_rate_limit_value: number | null
+    per_issue_rate_limit_bucket_size_minutes: number
+}
+
+export interface TopIssue {
+    issue_id: string
+    name: string | null
+    description: string | null
+    occurrences: number
+}
+
+const TOP_ISSUES_WINDOW_DAYS = 7
+
+const DEFAULT_CONFIG: IssueRateLimitConfigForm = {
+    per_issue_rate_limit_value: null,
+    per_issue_rate_limit_bucket_size_minutes: DEFAULT_BUCKET_MINUTES,
+}
+
+export const issueRateLimitConfigLogic = kea<issueRateLimitConfigLogicType>([
+    path([
+        'products',
+        'error_tracking',
+        'scenes',
+        'ErrorTrackingConfigurationScene',
+        'rate_limit',
+        'issueRateLimitConfigLogic',
+    ]),
+
+    actions({
+        selectIssue: (issueId: string | null) => ({ issueId }),
+    }),
+
+    reducers({
+        hasLoadedConfig: [
+            false,
+            {
+                loadConfigSuccess: () => true,
+            },
+        ],
+        selectedIssueId: [
+            null as string | null,
+            {
+                selectIssue: (_, { issueId }) => issueId,
+            },
+        ],
+    }),
+
+    loaders(() => ({
+        config: [
+            null as ErrorTrackingSettings | null,
+            {
+                loadConfig: async () => {
+                    return await api.errorTracking.getSettings()
+                },
+            },
+        ],
+        topIssues: [
+            [] as TopIssue[],
+            {
+                loadTopIssues: async () => {
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
+                            SELECT
+                                toString(issue_id_v2) AS issue_id,
+                                any(issue_name) AS name,
+                                any(issue_description) AS description,
+                                count() AS occurrences
+                            FROM events
+                            WHERE event = '$exception'
+                              AND timestamp >= now() - INTERVAL ${TOP_ISSUES_WINDOW_DAYS} DAY
+                              AND issue_id_v2 IS NOT NULL
+                            GROUP BY issue_id_v2
+                            ORDER BY occurrences DESC
+                            LIMIT 100
+                        `,
+                        tags: { productKey: ProductKey.ERROR_TRACKING },
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []).map(([issue_id, name, description, occurrences]) => ({
+                        issue_id: String(issue_id),
+                        name: name == null ? null : String(name),
+                        description: description == null ? null : String(description),
+                        occurrences: Number(occurrences),
+                    }))
+                },
+            },
+        ],
+        selectedIssueVolume: [
+            [] as ExceptionVolumeBucket[],
+            {
+                loadSelectedIssueVolume: async ({
+                    issueId,
+                    bucketMinutes,
+                }: {
+                    issueId: string
+                    bucketMinutes: number
+                }) => {
+                    const option = getBucketOption(bucketMinutes)
+                    const totalMinutes = option.minutes * option.bucketCount
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
+                            SELECT
+                                toStartOfInterval(timestamp, INTERVAL ${option.minutes} MINUTE) AS bucket,
+                                count() AS count
+                            FROM events
+                            WHERE event = '$exception'
+                              AND timestamp >= now() - INTERVAL ${totalMinutes} MINUTE
+                              AND toString(issue_id_v2) = '${issueId}'
+                            GROUP BY bucket
+                            ORDER BY bucket
+                        `,
+                        tags: { productKey: ProductKey.ERROR_TRACKING },
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []).map(([bucket, count]) => ({
+                        bucket: String(bucket),
+                        count: Number(count),
+                    }))
+                },
+            },
+        ],
+    })),
+
+    forms(({ actions }) => ({
+        configForm: {
+            defaults: DEFAULT_CONFIG,
+            errors: ({ per_issue_rate_limit_value }) => ({
+                per_issue_rate_limit_value:
+                    per_issue_rate_limit_value !== null && per_issue_rate_limit_value < 1
+                        ? 'Rate limit must be at least 1'
+                        : undefined,
+            }),
+            submit: async ({ per_issue_rate_limit_value, per_issue_rate_limit_bucket_size_minutes }) => {
+                try {
+                    const payload = { per_issue_rate_limit_value, per_issue_rate_limit_bucket_size_minutes }
+                    await api.errorTracking.updateSettings(payload)
+                    actions.resetConfigForm(payload)
+                    posthog.capture('error_tracking_per_issue_rate_limit_updated', payload)
+                    lemonToast.success('Settings saved')
+                } catch (e) {
+                    lemonToast.error('Failed to save settings')
+                    throw e
+                }
+            },
+        },
+    })),
+
+    selectors({
+        selectedIssue: [
+            (s) => [s.topIssues, s.selectedIssueId],
+            (issues, selectedId) => issues.find((i) => i.issue_id === selectedId) ?? null,
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        loadConfigSuccess: ({ config }) => {
+            const bucket = config?.per_issue_rate_limit_bucket_size_minutes ?? DEFAULT_BUCKET_MINUTES
+            const limit = config?.per_issue_rate_limit_value ?? null
+            if (config) {
+                actions.resetConfigForm({
+                    per_issue_rate_limit_value: limit,
+                    per_issue_rate_limit_bucket_size_minutes: bucket,
+                })
+            }
+            actions.loadTopIssues()
+        },
+        setConfigFormValue: ({ name, value }) => {
+            const fieldName = Array.isArray(name) ? name[name.length - 1] : name
+            if (
+                fieldName === 'per_issue_rate_limit_bucket_size_minutes' &&
+                typeof value === 'number' &&
+                values.selectedIssueId
+            ) {
+                actions.loadSelectedIssueVolume({
+                    issueId: values.selectedIssueId,
+                    bucketMinutes: value,
+                })
+            }
+        },
+        selectIssue: ({ issueId }) => {
+            if (issueId) {
+                actions.loadSelectedIssueVolume({
+                    issueId,
+                    bucketMinutes: values.configForm.per_issue_rate_limit_bucket_size_minutes,
+                })
+            }
+        },
+        loadTopIssuesSuccess: ({ topIssues }) => {
+            const first = topIssues[0]
+            if (first) {
+                actions.selectIssue(first.issue_id)
+            }
+        },
+    })),
+
+    afterMount(({ actions, values }) => {
+        if (!values.hasLoadedConfig) {
+            actions.loadConfig()
+        }
+    }),
+])

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/rateLimitConfigLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/rateLimitConfigLogic.ts
@@ -123,8 +123,8 @@ export const rateLimitConfigLogic = kea<rateLimitConfigLogicType>([
             submit: async ({ project_rate_limit_value, project_rate_limit_bucket_size_minutes }) => {
                 try {
                     const payload = { project_rate_limit_value, project_rate_limit_bucket_size_minutes }
-                    const updated = await api.errorTracking.updateSettings(payload)
-                    actions.loadConfigSuccess(updated)
+                    await api.errorTracking.updateSettings(payload)
+                    actions.resetConfigForm(payload)
                     posthog.capture('error_tracking_settings_updated', payload)
                     lemonToast.success('Settings saved')
                 } catch (e) {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15566,6 +15566,18 @@ export namespace Schemas {
        * @nullable
        */
       project_rate_limit_bucket_size_minutes?: number | null;
+      /**
+       * Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.
+       * @minimum 1
+       * @nullable
+       */
+      per_issue_rate_limit_value?: number | null;
+      /**
+       * Bucket window over which the per-issue rate limit applies, in minutes.
+       * @minimum 1
+       * @nullable
+       */
+      per_issue_rate_limit_bucket_size_minutes?: number | null;
     }
 
     export type ErrorTrackingSimilarIssuesQueryKind = typeof ErrorTrackingSimilarIssuesQueryKind[keyof typeof ErrorTrackingSimilarIssuesQueryKind];
@@ -27356,6 +27368,18 @@ export namespace Schemas {
        * @nullable
        */
       project_rate_limit_bucket_size_minutes?: number | null;
+      /**
+       * Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.
+       * @minimum 1
+       * @nullable
+       */
+      per_issue_rate_limit_value?: number | null;
+      /**
+       * Bucket window over which the per-issue rate limit applies, in minutes.
+       * @minimum 1
+       * @nullable
+       */
+      per_issue_rate_limit_bucket_size_minutes?: number | null;
     }
 
     export interface PatchedErrorTrackingSpikeDetectionConfig {


### PR DESCRIPTION
- new "Per-issue rate limit" section under Error tracking → Rate limits, gated behind `error-tracking-rate-limiting-per-issue`. The parent "Rate limits" entry still gates on `error-tracking-rate-limiting`, and the new flag is purely additive (no OR logic).

<img width="4717" height="2084" alt="image" src="https://github.com/user-attachments/assets/7499eff2-d29c-45ca-8838-ba7022e91186" />



## How did you test this code?

Manually

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Human prompts that shaped this:
  - Add a per-issue rate limit section, hidden behind a new flag (no OR with the parent flag — anyone with the new flag is expected to also have the parent on).
  - Make the new layout three columns: form + Save, issue list, chart. Match the form column width to the project-wide section.
  - Drop the "issues over the limit" framing — just show top issues by occurrence count over the last 7 days.
  - Make the selected row obvious (left accent border) and give the list its own background so it doesn't blend into the page.
  - Branch was migrated off Graphite mid-stream and rebased onto master after the parent PR landed; one squashed commit on top of `origin/master`.
- Decisions:
  - Initially the list was filtered to issues that would have been rate-limited at the configured threshold. Removed per request — list is now decoupled from the limit value, only the chart's goal line uses it.
  - Auto-selects the first issue on list load so the preview column is populated without an extra click.
  - Kept all rate-limit calls scoped to the existing `ErrorTrackingSettings` model and serializer instead of introducing a separate per-issue endpoint.