### PR TITLE
chore: align CLAUDE.md with Claude Code memory docs

### DIFF
--- a/.claude/rules/celery-event-capture.md
+++ b/.claude/rules/celery-event-capture.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - '**/tasks.py'
+  - '**/tasks/**/*.py'
+  - 'posthog/celery.py'
+  - 'posthog/ph_client.py'
+---
+
+# PostHog event capture in Celery tasks
+
+Do not use `posthoganalytics.capture()` in Celery tasks — events are silently lost.
+
+Use `ph_scoped_capture` from `posthog.ph_client` instead (see its docstring for why and usage).

--- a/.claude/rules/django-admin-foreign-keys.md
+++ b/.claude/rules/django-admin-foreign-keys.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - '**/admin.py'
+  - 'posthog/admin/**/*.py'
+  - 'ee/admin/**/*.py'
+---
+
+# Django admin `ForeignKey` fields need explicit widget config
+
+When adding a `ForeignKey`/`OneToOneField` to a model that's exposed in Django admin (including via
+inlines attached to a _related_ admin), list the new field in `autocomplete_fields`,
+`raw_id_fields`, or `readonly_fields` on **every** admin class that renders the model — otherwise
+the default `<select>` widget loads the entire target table per row on each change-page render.
+
+Prefer declaring the config on a shared base inline so per-parent variants (e.g., subclasses
+differentiated by `fk_name`) inherit it automatically.

--- a/.claude/rules/personhog-data-access.md
+++ b/.claude/rules/personhog-data-access.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - 'posthog/models/person/**'
+  - 'posthog/models/cohort/**'
+  - 'posthog/models/group_type_mapping.py'
+  - 'posthog/personhog_client/**'
+  - 'posthog/api/person*.py'
+  - 'posthog/api/cohort*.py'
+  - 'posthog/queries/**'
+  - 'posthog/management/commands/**'
+  - 'products/*/backend/**/*.py'
+  - 'ee/**/*.py'
+---
+
+# Person/group data access — use personhog client
+
+Use the personhog client for all person/group data access — do not query persons DB tables via the
+Django ORM or raw SQL. The `posthog/personhog_client/` gRPC client is the required interface for
+reading and writing person-related data.
+
+This applies to the following tables:
+`posthog_person`, `posthog_persondistinctid`, `posthog_cohortpeople`, `posthog_group`,
+`posthog_grouptypemapping`, and related override tables (`posthog_personoverride`,
+`posthog_pendingpersonoverride`, `posthog_flatpersonoverride`, `posthog_featureflaghashkeyoverride`,
+`posthog_personlessdistinctid`, `posthog_personoverridemapping`).
+
+Use the helpers in `posthog/models/person/util.py` (e.g. `get_person_by_uuid`,
+`get_persons_by_distinct_ids`, `get_person_by_distinct_id`) and `posthog/models/group_type_mapping.py`
+(`get_group_types_for_project`) — these already route through personhog with ORM fallback via
+`_personhog_routed()`.
+
+When adding new person/group data access, follow the same `_personhog_routed()` pattern: provide a
+`personhog_fn` using `get_personhog_client()` and an `orm_fn` fallback. Never add new direct ORM
+queries like `Person.objects.filter(...)` or `PersonDistinctId.objects.filter(...)` — use the
+existing routed helpers or create new ones following the established pattern.
+
+See `posthog/personhog_client/README.md` for client details and `posthog/personhog_client/client.py`
+for the full RPC interface.

--- a/.claude/rules/temporal-activities.md
+++ b/.claude/rules/temporal-activities.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - 'posthog/temporal/**'
+  - 'products/*/backend/temporal/**'
+---
+
+# Temporal activity payload size
+
+Temporal activity payloads have a ~2 MiB hard limit — pass large data by reference, not by value.
+Activity inputs and outputs are serialized across a gRPC boundary that Temporal caps at ~2 MiB per
+payload (the server rejects larger payloads via `blobSizeLimitError`).
+
+As a conservative field-level rule, if a field could exceed ~256 KB once serialized (serialized
+query results, exported file contents, LLM context, rendered HTML, image bytes, unbounded
+`list[dict[str, Any]]`), write it to Postgres / S3 / object storage from _inside_ the activity and
+return only the reference (row ID, S3 key). The workflow already has access to any row ID created
+earlier in the same run; it does not need the content to flow back through.
+
+Shuttling large data through the workflow on the way to persistence is a foreseeable failure mode
+that produces `PayloadSizeError` (`TMPRL1103`) the moment the underlying data crosses the limit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,10 +105,13 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - New features should live in `products/` — read [products/README.md](products/README.md) for layout and setup. When _creating a new_ product, follow [products/architecture.md](products/architecture.md) (DTOs, facades, isolation)
 - Always filter querysets by `team_id` — in serializers, access the team via `self.context["get_team"]()`
 - **Do not add domain-specific fields to the `Team` model.** Use a Team Extension model instead — see `posthog/models/team/README.md` for the pattern and helpers
-- **PostHog event capture in Celery tasks:** Do not use `posthoganalytics.capture()` in Celery tasks — events are silently lost. Use `ph_scoped_capture` from `posthog.ph_client` instead (see its docstring for why and usage).
-- **Django admin `ForeignKey` fields need explicit widget config.** When adding a `ForeignKey`/`OneToOneField` to a model that's exposed in Django admin (including via inlines attached to a _related_ admin), list the new field in `autocomplete_fields`, `raw_id_fields`, or `readonly_fields` on **every** admin class that renders the model — otherwise the default `<select>` widget loads the entire target table per row on each change-page render. Prefer declaring the config on a shared base inline so per-parent variants (e.g., subclasses differentiated by `fk_name`) inherit it automatically.
-- **Use personhog client for all person/group data access — do not query persons DB tables via the Django ORM or raw SQL.** The `posthog/personhog_client/` gRPC client is the required interface for reading and writing person-related data. This applies to the following tables: `posthog_person`, `posthog_persondistinctid`, `posthog_cohortpeople`, `posthog_group`, `posthog_grouptypemapping`, and related override tables (`posthog_personoverride`, `posthog_pendingpersonoverride`, `posthog_flatpersonoverride`, `posthog_featureflaghashkeyoverride`, `posthog_personlessdistinctid`, `posthog_personoverridemapping`). Use the helpers in `posthog/models/person/util.py` (e.g. `get_person_by_uuid`, `get_persons_by_distinct_ids`, `get_person_by_distinct_id`) and `posthog/models/group_type_mapping.py` (`get_group_types_for_project`) — these already route through personhog with ORM fallback via `_personhog_routed()`. When adding new person/group data access, follow the same `_personhog_routed()` pattern: provide a `personhog_fn` using `get_personhog_client()` and an `orm_fn` fallback. Never add new direct ORM queries like `Person.objects.filter(...)` or `PersonDistinctId.objects.filter(...)` — use the existing routed helpers or create new ones following the established pattern. See `posthog/personhog_client/README.md` for client details and `posthog/personhog_client/client.py` for the full RPC interface.
-- **Temporal activity payloads have a ~2 MiB hard limit — pass large data by reference, not by value.** Activity inputs and outputs are serialized across a gRPC boundary that Temporal caps at ~2 MiB per payload (the server rejects larger payloads via `blobSizeLimitError`). As a conservative field-level rule, if a field could exceed ~256 KB once serialized (serialized query results, exported file contents, LLM context, rendered HTML, image bytes, unbounded `list[dict[str, Any]]`), write it to Postgres / S3 / object storage from _inside_ the activity and return only the reference (row ID, S3 key). The workflow already has access to any row ID created earlier in the same run; it does not need the content to flow back through. Shuttling large data through the workflow on the way to persistence is a foreseeable failure mode that produces `PayloadSizeError` (`TMPRL1103`) the moment the underlying data crosses the limit.
+
+Topic-specific guidance loads on demand via path-scoped rules in `.claude/rules/`:
+
+- Celery event capture (`ph_scoped_capture` vs `posthoganalytics.capture()`) — `.claude/rules/celery-event-capture.md`
+- Django admin `ForeignKey`/`OneToOneField` widget config — `.claude/rules/django-admin-foreign-keys.md`
+- Personhog client for person/group data access — `.claude/rules/personhog-data-access.md`
+- Temporal activity payload size limit — `.claude/rules/temporal-activities.md`
 
 ## Code Style
 
@@ -146,14 +149,9 @@ Claude Code hooks are reserved for environment bootstrapping (`SessionStart` onl
 
 ALWAYS invoke the matching skill **before** writing or reviewing code in these areas — do not skip, do not attempt the work without loading the skill first.
 
-**Always invoke:**
+Path-triggered (auto-loaded via `.claude/rules/` when you read matching files): DRF viewsets/serializers, Django migrations, ClickHouse migrations, generated API types, product isolation, proto changes, tach boundaries.
 
-- `/improving-drf-endpoints` — any DRF viewset or serializer change
-- `/django-migrations` — any Django migration
-- `/clickhouse-migrations` — any ClickHouse migration
-- `/adopting-generated-api-types` — any frontend file using `lib/api`, `api.get<`, `api.create<`, or handwritten API types
-
-**Invoke when in the area:**
+**Invoke when in the area** (no path trigger — invoke explicitly):
 
 - `/implementing-mcp-tools` — adding/modifying endpoints or `tools.yaml`
 - `/modifying-taxonomic-filter` — any TaxonomicFilter change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/quill/CLAUDE.md
+++ b/packages/quill/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/quill/packages/blocks/CLAUDE.md
+++ b/packages/quill/packages/blocks/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/quill/packages/primitives/CLAUDE.md
+++ b/packages/quill/packages/primitives/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/quill/packages/tokens/CLAUDE.md
+++ b/packages/quill/packages/tokens/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/posthog/clickhouse/migrations/CLAUDE.md
+++ b/posthog/clickhouse/migrations/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/posthog/temporal/data_imports/signals/CLAUDE.md
+++ b/posthog/temporal/data_imports/signals/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/products/llm_analytics/CLAUDE.md
+++ b/products/llm_analytics/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/products/signals/backend/management/CLAUDE.md
+++ b/products/signals/backend/management/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/products/signals/backend/report_generation/CLAUDE.md
+++ b/products/signals/backend/report_generation/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/products/signals/eval/CLAUDE.md
+++ b/products/signals/eval/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/proto/CLAUDE.md
+++ b/proto/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/rust/personhog-replica/CLAUDE.md
+++ b/rust/personhog-replica/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/rust/personhog-router/CLAUDE.md
+++ b/rust/personhog-router/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
**tl;dr: I pointed Claude Code at https://code.claude.com/docs/en/memory and asked it to fixup any missing best practices**

Followup to [feat(devex): add Claude rules and AGENTS.md references for code governance (#57478)](https://github.com/PostHog/posthog/pull/57478)

## Problem

Two gaps vs the [Claude Code memory docs](https://code.claude.com/docs/en/memory):

1. Every `CLAUDE.md` is a symlink to its sibling `AGENTS.md`. The docs recommend an `@AGENTS.md` import instead — same sharing, but leaves room for Claude-only notes without polluting `AGENTS.md` (read by Codex/Cursor too).
2. Root `AGENTS.md` carried narrow rules (Temporal payload, personhog, Celery capture, admin FK widgets) loaded into every session despite each applying to <5% of edits, plus an "Always invoke" sublist duplicating path-scoped rules already in `.claude/rules/`.

## Changes

- 14 `CLAUDE.md` symlinks → one-line `@AGENTS.md` files.
- 4 narrow rules moved into path-scoped `.claude/rules/`: `temporal-activities.md`, `personhog-data-access.md`, `celery-event-capture.md`, `django-admin-foreign-keys.md`.
- AGENTS.md "Always invoke" sublist → one-line pointer at `.claude/rules/`.

Net: ~85 lines no longer cost session context unless you edit matching paths.

## How did you test this code?

Agent-authored. Static checks only: every new `CLAUDE.md` is `@AGENTS.md`, all rule frontmatter parses, pre-commit hooks pass. No runtime behavior changed.

## Publish to changelog?

no

## 🤖 Agent context

Claude Code (Opus 4.7). User asked me to read the memory docs and apply the recommendations in a worktree. Notable call: scoped `personhog-data-access.md` to likely person-ORM directories rather than `**/*.py` — broaden later if regressions slip through.