### PR TITLE
fix(llma): guard undefined condition.properties in evaluations table

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -199,13 +199,16 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
             key: 'conditions',
             render: (_, evaluation) => (
                 <div className="flex flex-wrap gap-1">
-                    {evaluation.conditions.map((condition) => (
-                        <LemonTag key={condition.id} type="option">
-                            {parseFloat((condition.rollout_percentage ?? 0).toFixed(2))}%
-                            {condition.properties.length > 0 &&
-                                ` when ${condition.properties.length} condition${condition.properties.length !== 1 ? 's' : ''}`}
-                        </LemonTag>
-                    ))}
+                    {evaluation.conditions.map((condition) => {
+                        const propertyCount = condition.properties?.length ?? 0
+                        return (
+                            <LemonTag key={condition.id} type="option">
+                                {parseFloat((condition.rollout_percentage ?? 0).toFixed(2))}%
+                                {propertyCount > 0 &&
+                                    ` when ${propertyCount} condition${propertyCount !== 1 ? 's' : ''}`}
+                            </LemonTag>
+                        )
+                    })}
                     {evaluation.conditions.length === 0 && <span className="text-muted text-sm">No triggers</span>}
                 </div>
             ),

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -62,7 +62,9 @@ export interface EvaluationConditionSet {
     // Optional because the backend serializer has `default=100` (not `required=True`), so legacy
     // condition rows stored in the JSONField before the field existed read back without the key.
     rollout_percentage?: number
-    properties: AnyPropertyFilter[]
+    // Optional for the same reason: conditions live in a free-form JSONField and the inner shape
+    // isn't validated, so legacy rows can come back without a `properties` key.
+    properties?: AnyPropertyFilter[]
 }
 
 export interface EvaluationRun {


### PR DESCRIPTION
## Problem

A high-priority support ticket (Zendesk #57603) reported that the Evaluations scene crashed on load with:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

The Triggers column in `LLMAnalyticsEvaluationsScene.tsx` read `condition.properties.length` directly. `Evaluation.conditions` is a Postgres `JSONField` with no inner-shape validation — legacy condition rows can come back without a `properties` key, which threw and crashed the entire `/llm-analytics/evaluations` route.

This is the same root cause as the prior `rollout_percentage` fix (#57342), just one more field that was missed. The existing call site at `llmEvaluationLogic.ts:139` already guards `c.properties && c.properties.length > 0`, confirming the data shape is known to be optional.

## Changes

- `LLMAnalyticsEvaluationsScene.tsx`: compute `propertyCount = condition.properties?.length ?? 0` once and reuse it.
- `types.ts`: mark `properties` optional with the same comment style as `rollout_percentage`.

`PropertyFilters` (used in the editor at `EvaluationTriggers.tsx:148`) already accepts `AnyPropertyFilter[] | null | undefined`, so no other call sites needed updates.

## How did you test this code?

I'm an agent (Claude). Manual reproduction in a browser was not done. Verified automated tests:

- `pnpm --filter=@posthog/frontend exec jest products/llm_analytics/frontend/evaluations` — 70/70 pass.
- TypeScript: no new errors introduced (preexisting kea-generated stub errors are unrelated).

## Publish to changelog?

no

## Docs update

n/a — internal bug fix.

## 🤖 Agent context

- Authored by Claude (Opus 4.7) via Claude Code, prompted by Andy with the Zendesk ticket.
- Investigation: traced the stack to the `Triggers` column render, confirmed the `JSONField` shape lets legacy rows omit `properties`, mirrored the prior `rollout_percentage` fix pattern (#57342).
- Considered tightening the backend serializer to normalize the inner condition shape, but deferred — the defensive frontend guard restores the page immediately and matches the existing `?? 0` pattern.