### PR TITLE
chore(codeowners): exclude generated schema snapshot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@ posthog/clickhouse/migrations/** @PostHog/clickhouse
 posthog/hogql/** @PostHog/hogql
 # ...except per-table schema definitions, which product teams add and maintain for their own features
 posthog/hogql/database/schema/**
+# ...and the generated schema snapshot, which changes when those definitions are regenerated
+posthog/hogql/database/test/__snapshots__/test_database.ambr
 
 # Being open source brings us unwanted problems because Github Actions are untrusted and inherently unsafe
 # so we have to be extra careful with changes here. Let's have the security team own these checks.


### PR DESCRIPTION
## Problem

The generated HogQL database schema snapshot changes when schema definitions are regenerated, but it currently inherits the broader HogQL CODEOWNERS rule.

## Changes

Add an ownerless CODEOWNERS exception for `posthog/hogql/database/test/__snapshots__/test_database.ambr`, placed next to the existing schema exception so regenerated schema snapshots do not require HogQL code owner approval.

## How did you test this code?

Agent-authored. Ran `git diff --check -- .github/CODEOWNERS`.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

- Agent: Codex CLI in a local checkout.
- Human prompts: requested a new branch and CODEOWNERS exception for `test_database.ambr`; then requested push and PR creation.
- Decision: used an ownerless CODEOWNERS entry after the broader HogQL rule so this generated snapshot is excluded while preserving ownership for other HogQL files.
