### PR TITLE
docs: track .nvmrc and packageManager in manual setup

### DIFF
--- a/docs/published/handbook/engineering/manual-dev-setup.md
+++ b/docs/published/handbook/engineering/manual-dev-setup.md
@@ -124,9 +124,9 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
     <code>$PATH</code>. Otherwise the command line will use your system Node.js version instead.
 </blockquote>
 
-2. Install the latest Node.js 22 (the version used by PostHog in production) with `nvm install 22`. You can start using it in the current shell with `nvm use 22`.
+2. Install the Node.js version pinned in `.nvmrc` (the version used by PostHog in production) with `nvm install` (run from the repo root — nvm reads `.nvmrc`). Activate it in the current shell with `nvm use`.
 
-3. Install pnpm by running `corepack enable` and then running `corepack prepare pnpm@10 --activate`. Validate the installation with `pnpm --version`.
+3. Install pnpm by running `corepack enable`. Corepack will activate the version pinned in the root `package.json`'s `packageManager` field on the next `pnpm` invocation. Validate with `pnpm --version`.
 
 4. Install Node packages by running `pnpm i`.
 


### PR DESCRIPTION
## Problem

`docs/published/handbook/engineering/manual-dev-setup.md` tells contributors to `nvm install 22` and calls it "the version used by PostHog in production" — but `.nvmrc` pins `v24.13.0` and every `package.json` engines field requires `>=24 <25`. The same step's `corepack prepare pnpm@10 --activate` also drifts from the `packageManager: "pnpm@10.29.3"` pin.

## Changes

- `nvm install 22` → `nvm install` (reads `.nvmrc`)
- `corepack prepare pnpm@10 --activate` → `corepack enable` (Corepack activates the `packageManager` version on first `pnpm` invocation)

## How did you test this code?

I'm an agent. Verified `.nvmrc`, all `package.json` engines fields, and the `packageManager` pin are consistent with the new wording.

## Publish to changelog?

no

## 🤖 Agent context

Agent-authored.