### PR TITLE
chore(devex): make playwright e2e opt-in to cut ci cost

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -452,7 +452,7 @@ jobs:
                   fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-test-db
+                  ./bin/hogli db:restore-schema-fresh
 
             - name: Register Temporal search attributes
               run: |
@@ -1322,7 +1322,7 @@ jobs:
                   fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-test-db
+                  ./bin/hogli db:restore-schema-fresh
 
             - name: Determine if --snapshot-update should be on
               # UPDATE mode: human commits - update snapshots

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -322,7 +322,7 @@ jobs:
                   fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-test-db
+                  ./bin/hogli db:restore-schema-fresh
                   gunzip -c .postgres-backups/schema-latest.sql.gz | \
                     docker compose -f docker-compose.dev.yml exec -T db psql -q -U posthog posthog
 

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -6,6 +6,9 @@
 name: E2E CI Playwright
 on:
     pull_request:
+        # `labeled` lets developers opt in via the `run-playwright` label.
+        # Unrelated label changes are filtered out in the `changes` job.
+        types: [opened, synchronize, reopened, labeled]
     workflow_dispatch:
     push:
         branches:
@@ -63,61 +66,85 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        # Only run on PRs from the same repo (not forks) or on master push
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        # Run on master push, and on internal-repo PRs. Skip the entire workflow when
+        # the only thing that changed is some other label (avoids noisy runs on every
+        # label add/remove unrelated to Playwright).
+        if: |
+            github.event_name == 'push' ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              (github.event.action != 'labeled' || github.event.label.name == 'run-playwright')
+            )
         name: Determine need to run E2E checks
-        # Set job outputs to values from filter step
         outputs:
-            shouldRun: ${{ steps.changes.outputs.shouldRun || 'true' }}
+            shouldRun: ${{ steps.decide.outputs.shouldRun }}
+            shouldSuggest: ${{ steps.changes.outputs.shouldSuggest }}
             oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
+            schema_cache_key: ${{ steps.schema-key.outputs.key }}
         steps:
-            # For pull requests it's not necessary to check out the code
+            # fetch-depth=1000 + blob:none mirrors ci-backend / ci-dagster so HEAD^2
+            # (PR branch tip) is reachable for the merge-base step below without the
+            # cost of fetching blobs.
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1000
+                  filter: blob:none
+                  clean: false
+
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               with:
                   client-id: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
+
             - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
               id: changes
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skip the path filter when the `run-playwright` label is set or on master push —
+              # both already imply we want to run.
+              if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-playwright')
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
-                      shouldRun:
-                        # Avoid running E2E tests for irrelevant changes
-                        # NOTE: we are at risk of missing a dependency here. We could make
-                        # the dependencies more clear if we separated the backend/frontend
-                        # code completely
+                      mustRun:
+                        # Real triggers — only this workflow runs Playwright tests, so changes
+                        # to the tests, page models, utils, snapshots, or this workflow itself
+                        # need to validate before merge.
+                        - playwright/**
+                        - .github/workflows/ci-e2e-playwright.yml
+                      shouldSuggest:
+                        # Wider net — code that *could* affect E2E behavior. We don't auto-run
+                        # Playwright on these (most failures are flakes, real bugs are caught
+                        # elsewhere or fix-forward from master). Instead the `suggest-label` job
+                        # nudges the author to add the `run-playwright` label if they want a
+                        # full sweep before merging.
                         - 'ee/**'
                         - 'posthog/!(temporal/**)/**'
                         - 'bin/*'
                         - frontend/**/*
-                        - playwright/snapshots.yml
-                        - requirements.txt
-                        - requirements-dev.txt
                         - package.json
                         - pnpm-lock.yaml
-                        # Make sure we run if someone is explicitly changes the workflow
-                        - .github/workflows/ci-e2e-playwright.yml
-                        - .github/actions/build-n-cache-image/action.yml
+                        - uv.lock
                         - .github/clickhouse-versions.json
-                        # We use docker compose for tests, make sure we rerun on
-                        # changes to docker-compose.dev.yml e.g. dependency
-                        # version changes
                         - docker-compose.dev.yml
                         - Dockerfile
-                        - playwright/**
 
-            - uses: actions/checkout@v6
-              if: github.event_name == 'push' || steps.changes.outputs.shouldRun == 'true'
-              with:
-                  sparse-checkout: .github/clickhouse-versions.json
-                  sparse-checkout-cone-mode: false
+            - name: Decide whether to run Playwright
+              id: decide
+              env:
+                  IS_PUSH: ${{ github.event_name == 'push' }}
+                  HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-playwright') }}
+                  MUST_RUN: ${{ steps.changes.outputs.mustRun }}
+              run: |
+                  if [[ "$IS_PUSH" == "true" || "$HAS_LABEL" == "true" || "$MUST_RUN" == "true" ]]; then
+                      echo "shouldRun=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "shouldRun=false" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Read ClickHouse versions from JSON
               id: read-versions
-              if: github.event_name == 'push' || steps.changes.outputs.shouldRun == 'true'
+              if: steps.decide.outputs.shouldRun == 'true'
               run: |
                   oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
@@ -126,12 +153,108 @@ jobs:
                   fi
                   echo "oldest_supported=$oldest_supported" >> $GITHUB_OUTPUT
 
+            - name: Fetch base branch for merge-base computation
+              if: steps.decide.outputs.shouldRun == 'true' && github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              # Scoped, blob-less, no-tags — matches ci-backend / ci-dagster.
+              # Without an explicit refspec, `git fetch --deepen` would fall back to
+              # remote.origin.fetch and pull every branch.
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+            - name: Compute schema cache key from merge-base
+              id: schema-key
+              if: steps.decide.outputs.shouldRun == 'true' && github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  if [ -n "$MERGE_BASE" ]; then
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                  else
+                      echo "key=" >> $GITHUB_OUTPUT
+                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                  fi
+
+    # Nudge the author to add the `run-playwright` label when their PR touches code
+    # that *could* affect E2E behavior but doesn't trigger a real run on its own.
+    # Also handles cleanup: if the PR later qualifies for a real run (label added,
+    # narrow paths matched), remove the suggestion comment so it doesn't linger.
+    suggest-label:
+        name: Suggest run-playwright label
+        needs: [changes]
+        if: |
+            github.event_name == 'pull_request' && (
+              needs.changes.outputs.shouldSuggest == 'true' ||
+              needs.changes.outputs.shouldRun == 'true'
+            )
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  SHOULD_RUN: ${{ needs.changes.outputs.shouldRun }}
+                  SHOULD_SUGGEST: ${{ needs.changes.outputs.shouldSuggest }}
+                  HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-playwright') }}
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const marker = '<!-- playwright-suggest-label -->';
+                      const shouldRun = process.env.SHOULD_RUN === 'true';
+                      const shouldSuggest = process.env.SHOULD_SUGGEST === 'true';
+                      const hasLabel = process.env.HAS_LABEL === 'true';
+                      const wantSuggestion = !shouldRun && shouldSuggest && !hasLabel;
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                      });
+                      const existing = comments.find(c => c.body.includes(marker));
+
+                      if (wantSuggestion) {
+                          const body = [
+                              marker,
+                              "🎭 **Playwright didn't run on this PR** — your changes touch code that *could* affect E2E behavior, but Playwright is opt-in via label now to keep CI cost down.",
+                              "",
+                              "Add the **`run-playwright`** label if you want an E2E sweep before merging — CI will pick it up automatically.",
+                              "",
+                              "_Most PRs don't need this. Real regressions still get caught on master and fix-forward._",
+                          ].join('\n');
+                          if (existing) {
+                              await github.rest.issues.updateComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: existing.id,
+                                  body,
+                              });
+                          } else {
+                              await github.rest.issues.createComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  issue_number: context.issue.number,
+                                  body,
+                              });
+                          }
+                      } else if (existing) {
+                          await github.rest.issues.deleteComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                          });
+                      }
+
     playwright:
         name: Playwright E2E tests
         needs: [changes]
         if: needs.changes.outputs.shouldRun == 'true'
-        # WARNING: Runner size is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
-        runs-on: depot-ubuntu-latest-16
+        # 8-core depot: 18% avg / 30% peak memory observed on 16-core runs (#46853 noted
+        # the workload "is not resource constrained" even after sharding was removed).
+        # Talk to #team-devex before changing.
+        runs-on: depot-ubuntu-latest-8
         timeout-minutes: 45
         outputs:
             vr_run_id: ${{ steps.vr-create.outputs.run_id }}
@@ -347,11 +470,40 @@ jobs:
             - name: Install sqlx-cli
               run: cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked
 
+            - name: Restore schema cache from master
+              # Cache key is the merge-base SHA — produced by ci-backend on master push.
+              # Cache miss falls through to a full migrate below.
+              if: github.event_name == 'pull_request' && needs.changes.outputs.schema_cache_key != ''
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              id: schema-cache
+              with:
+                  path: schema.sql.gz
+                  key: ${{ needs.changes.outputs.schema_cache_key }}
+
+            - name: Prime posthog_e2e_test from cached schema
+              # Schema dump is from master's `posthog` db but schemas are db-name agnostic.
+              # Hogli's db:restore-schema-fresh DROPs+CREATEs the target db, restores the
+              # schema, and runs ensure_migration_defaults to seed RunPython data that's
+              # missing from a schema-only dump.
+              id: prime-schema
+              if: steps.schema-cache.outputs.cache-hit == 'true'
+              env:
+                  TARGET_DB: posthog_e2e_test
+              run: |
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  ./bin/hogli db:restore-schema-fresh
+                  echo "primed=true" >> "$GITHUB_OUTPUT"
+
             - name: Apply postgres and clickhouse migrations and setup dev
               run: |
-                  # Postgres migrations must run first — ClickHouse migration 0026
-                  # depends on the posthog_instancesetting table in Postgres
-                  python manage.py migrate --noinput
+                  if [ "${{ steps.prime-schema.outputs.primed }}" = "true" ]; then
+                      echo "Schema restored from cache — skipping python manage.py migrate"
+                  else
+                      # Postgres migrations must run first — ClickHouse migration 0026
+                      # depends on the posthog_instancesetting table in Postgres
+                      python manage.py migrate --noinput
+                  fi
 
                   # Run Rust migrations for persons e2e test database
                   PERSONS_DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons_e2e_test"

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -66,11 +66,12 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        # Run on master push, and on internal-repo PRs. Skip the entire workflow when
-        # the only thing that changed is some other label (avoids noisy runs on every
-        # label add/remove unrelated to Playwright).
+        # Run on master push, manual dispatch, and on internal-repo PRs. Skip the
+        # entire workflow when the only thing that changed is some other label (avoids
+        # noisy runs on every label add/remove unrelated to Playwright).
         if: |
             github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch' ||
             (
               github.event.pull_request.head.repo.full_name == github.repository &&
               (github.event.action != 'labeled' || github.event.label.name == 'run-playwright')
@@ -133,10 +134,11 @@ jobs:
               id: decide
               env:
                   IS_PUSH: ${{ github.event_name == 'push' }}
+                  IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
                   HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-playwright') }}
                   MUST_RUN: ${{ steps.changes.outputs.mustRun }}
               run: |
-                  if [[ "$IS_PUSH" == "true" || "$HAS_LABEL" == "true" || "$MUST_RUN" == "true" ]]; then
+                  if [[ "$IS_PUSH" == "true" || "$IS_DISPATCH" == "true" || "$HAS_LABEL" == "true" || "$MUST_RUN" == "true" ]]; then
                       echo "shouldRun=true" >> "$GITHUB_OUTPUT"
                   else
                       echo "shouldRun=false" >> "$GITHUB_OUTPUT"
@@ -484,8 +486,9 @@ jobs:
               # Schema dump is from master's `posthog` db but schemas are db-name agnostic.
               # Hogli's db:restore-schema-fresh DROPs+CREATEs the target db, restores the
               # schema, and runs ensure_migration_defaults to seed RunPython data that's
-              # missing from a schema-only dump.
-              id: prime-schema
+              # missing from a schema-only dump. The migrate step below still runs and
+              # layers any PR-added migrations on top — the cache just skips the bulk of
+              # the historical migration work.
               if: steps.schema-cache.outputs.cache-hit == 'true'
               env:
                   TARGET_DB: posthog_e2e_test
@@ -493,17 +496,14 @@ jobs:
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
                   ./bin/hogli db:restore-schema-fresh
-                  echo "primed=true" >> "$GITHUB_OUTPUT"
 
             - name: Apply postgres and clickhouse migrations and setup dev
               run: |
-                  if [ "${{ steps.prime-schema.outputs.primed }}" = "true" ]; then
-                      echo "Schema restored from cache — skipping python manage.py migrate"
-                  else
-                      # Postgres migrations must run first — ClickHouse migration 0026
-                      # depends on the posthog_instancesetting table in Postgres
-                      python manage.py migrate --noinput
-                  fi
+                  # Postgres migrations must run first — ClickHouse migration 0026
+                  # depends on the posthog_instancesetting table in Postgres.
+                  # On cache hit this is near no-op; on cache miss it's a full migrate.
+                  # Either way, any PR-added migrations get applied here.
+                  python manage.py migrate --noinput
 
                   # Run Rust migrations for persons e2e test database
                   PERSONS_DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons_e2e_test"

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -540,6 +540,16 @@ db:
         cmd: |
             set -e
             TARGET_DB="${TARGET_DB:-test_posthog}"
+            # Validate before interpolating into psql -c. Postgres unquoted identifiers
+            # must start with a letter or underscore, contain only [A-Za-z0-9_], and
+            # fit in NAMEDATALEN-1 (63 chars). Reject anything else outright rather
+            # than trying to escape — callers always pass static names like
+            # `test_posthog` or `posthog_e2e_test`. POSIX-only (no bash `[[ =~ ]]`)
+            # since hogli runs cmd blocks via /bin/sh.
+            if ! printf '%s' "$TARGET_DB" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]{0,62}$'; then
+                echo "❌ TARGET_DB must be a simple SQL identifier (got: $TARGET_DB)"
+                exit 1
+            fi
             if [ ! -f .postgres-backups/schema-latest.sql.gz ]; then
                 echo "❌ No schema at .postgres-backups/schema-latest.sql.gz — run db:download-schema first"
                 exit 1

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -530,30 +530,33 @@ db:
     db:prime-test-db:
         steps:
             - db:download-schema
-            - db:restore-test-db
+            - db:restore-schema-fresh
         description: Download pre-migrated schema and prime the test_posthog database for
             pytest --reuse-db
         services:
             - postgresql
             - docker
-    db:restore-test-db:
+    db:restore-schema-fresh:
         cmd: |
             set -e
+            TARGET_DB="${TARGET_DB:-test_posthog}"
             if [ ! -f .postgres-backups/schema-latest.sql.gz ]; then
                 echo "❌ No schema at .postgres-backups/schema-latest.sql.gz — run db:download-schema first"
                 exit 1
             fi
             # Validate up front; substitutes for `set -o pipefail` (dash doesn't support it).
             gunzip -t .postgres-backups/schema-latest.sql.gz
-            docker compose -f docker-compose.dev.yml exec -T db psql -U posthog -c "DROP DATABASE IF EXISTS test_posthog;"
-            docker compose -f docker-compose.dev.yml exec -T db psql -U posthog -c "CREATE DATABASE test_posthog;"
-            gunzip -c .postgres-backups/schema-latest.sql.gz | docker compose -f docker-compose.dev.yml exec -T db psql -q -U posthog test_posthog
+            docker compose -f docker-compose.dev.yml exec -T db psql -U posthog -c "DROP DATABASE IF EXISTS $TARGET_DB;"
+            docker compose -f docker-compose.dev.yml exec -T db psql -U posthog -c "CREATE DATABASE $TARGET_DB;"
+            gunzip -c .postgres-backups/schema-latest.sql.gz | docker compose -f docker-compose.dev.yml exec -T db psql -q -U posthog "$TARGET_DB"
             # Schema-only dumps skip RunPython data migrations (e.g. the Default Theme row from 0537).
             # Reseed defaults so tests don't hit empty tables. Idempotent.
-            DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog python manage.py ensure_migration_defaults
-            echo "✅ Restored test_posthog from .postgres-backups/schema-latest.sql.gz"
-        description: Restore test_posthog from a local schema dump (no download). Used by
-            CI after restoring the schema from Actions cache.
+            DATABASE_URL="postgres://posthog:posthog@localhost:5432/$TARGET_DB" python manage.py ensure_migration_defaults
+            echo "✅ Restored $TARGET_DB from .postgres-backups/schema-latest.sql.gz"
+        description: 'Restore a fresh DB from a local schema dump (no download). Drops and
+            recreates the target DB then loads schema-latest.sql.gz into it. Target DB
+            defaults to test_posthog; override via TARGET_DB env var. Used by CI after
+            restoring the schema from Actions cache.'
         services:
             - postgresql
             - docker


### PR DESCRIPTION
## Problem

Playwright e2e is one of the most expensive CI workflows. Empirically, failures are mostly flakes rather than real bugs, and most regression classes are caught earlier (ci-backend, jest, typecheck, storybook VR) or fix forward from master. Currently we pay for a 16-core runner spinning up on most PRs without much to show for it.

## Changes

Three layers of cost cuts on `ci-e2e-playwright.yml`:

**Runner downsize.** `depot-ubuntu-latest-16` → `-8`. Observed ~18% avg / 30% peak memory on 16-core runs. The 16-core was a flake-fix experiment from #40314 ("Playwright flakey. Will more resources help?") that was never revisited; my own #46853 already noted the workload isn't resource constrained.

**Opt-in path filter.** Only `playwright/**` and the workflow file trigger the runner automatically. PRs touching the broader path set (`frontend/**`, `posthog/**`, deps, compose) get a comment from a new `suggest-label` job nudging the author to add the new `run-playwright` label if they want an E2E sweep. Master push always runs. The suggest-label job also cleans up its own comment when the label is later added or narrow paths match.

**Schema cache restore.** Pulls the postgres schema from the same Actions cache `ci-backend` already produces, keyed on merge-base SHA (mirrors the pattern in `ci-dagster`). Skips the ~3 min Django migrate step on cache hit. Cache miss falls back to a full migrate.

Hogli refactor:
- `db:restore-test-db` → `db:restore-schema-fresh`, parameterized via a `TARGET_DB` env var. Defaults to `test_posthog` so existing callers in `ci-backend` / `ci-dagster` keep working without changes.

**Pre-merge:** the `run-playwright` label needs to be created in repo settings.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.7). No manual testing — only YAML lint validation locally. Real validation needs CI runs against this PR. Note that this PR's own playwright job will run because it modifies `.github/workflows/ci-e2e-playwright.yml` (mustRun trigger), so the changes get exercised here.

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7)
- Key human prompts that shaped this:
  - Started with "adjust how often we run playwright" + "offer a label to run it"
  - I investigated runner cost first; we discovered the 16-core was a 2025 flake-fix experiment never revisited, confirmed via CPU graphs showing ~18% avg utilization
  - Mirrored the ci-dagster schema cache restore pattern after I flagged that we have one for non-test DBs too
  - I initially proposed narrowing the path filter aggressively; pushback on doing it without debate, so I reverted, then debated, then landed on narrow + suggest-label nudge as the discoverability safety net
- Decisions:
  - Did NOT implement the "must vs should paths" advisory-mode idea — would re-introduce cost on advisory paths; nudge comment fills the gap better
  - Did NOT implement the "real fail vs technical fail" classifier yet — too risky as a v1, can be a follow-up
  - Renamed `db:restore-test-db` to `db:restore-schema-fresh` rather than keeping the old name as an alias — cleaner, low blast radius