### PR TITLE
fix(tasks): ignore transport keepalive events

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -283,9 +283,11 @@ async def _relay_loop(
                                 )
                                 continue
 
+                            if _is_keepalive_event(event_data):
+                                continue
+
                             await redis_stream.write_event(event_data)
-                            if not _is_keepalive_event(event_data):
-                                reconnect_count = 0
+                            reconnect_count = 0
                             last_event_time[0] = time.monotonic()
 
                             if _is_end_of_turn(event_data):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -1,3 +1,4 @@
+import json
 import asyncio
 import importlib
 from types import SimpleNamespace
@@ -314,6 +315,52 @@ class TestRelaySandboxEventsErrorHandling:
         assert connect_attempts == 2
         sleep_mock.assert_awaited_once_with(2)
         redis_stream.write_event.assert_awaited_once()
+        redis_stream.mark_complete.assert_awaited_once()
+        redis_stream.mark_error.assert_not_awaited()
+
+    async def test_keepalive_events_are_transport_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis_stream = SimpleNamespace(
+            write_event=AsyncMock(),
+            mark_complete=AsyncMock(),
+            mark_error=AsyncMock(),
+        )
+        terminal_event = {
+            "type": "notification",
+            "notification": {"method": "_posthog/task_complete"},
+        }
+
+        class SuccessfulEventSource:
+            response = SimpleNamespace(raise_for_status=lambda: None)
+
+            async def __aenter__(self) -> "SuccessfulEventSource":
+                return self
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+            async def aiter_sse(self):
+                yield SimpleNamespace(data='{"type":"keepalive"}')
+                yield SimpleNamespace(data=json.dumps(terminal_event))
+
+        def fake_connect_sse(*_args: object, **_kwargs: object) -> SuccessfulEventSource:
+            return SuccessfulEventSource()
+
+        async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
+        monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
+
+        await _relay_loop(
+            events_url="https://sandbox.example/events",
+            headers={"Authorization": "Bearer token"},
+            params={},
+            redis_stream=cast(TaskRunRedisStream, redis_stream),
+            run_id="run-id",
+            task_id="task-id",
+        )
+
+        redis_stream.write_event.assert_awaited_once_with(terminal_event)
         redis_stream.mark_complete.assert_awaited_once()
         redis_stream.mark_error.assert_not_awaited()
 


### PR DESCRIPTION
## Problem

cloud task event streams can include transport keepalives to keep idle sockets open, relay should not persist those keepalives or treat them as task activity, otherwise a transport-only signal could extend task liveness (which we want to avoid if not needed)

## Changes

* skip ka-events before writing to the task Redis stream, resetting reconnect state, or updating the relay liveness timestamp