### PR TITLE
fix: Improve GitHub issues observability

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -288,11 +288,17 @@ class GitHubIntegrationBase:
             data = response.json()
         except ValueError:
             self._on_token_refresh_failed(response)
-            raise Exception(f"Non-JSON response when refreshing installation token: {response.text[:500]}") from None
+            raise GitHubIntegrationError(
+                f"Non-JSON response when refreshing installation token: {response.text[:500]}",
+                status_code=response.status_code,
+            ) from None
 
         if response.status_code != 201 or not data.get("token"):
             self._on_token_refresh_failed(response)
-            raise Exception(f"Failed to refresh installation token: {response.text}")
+            raise GitHubIntegrationError(
+                f"Failed to refresh installation token: {response.text}",
+                status_code=response.status_code,
+            )
 
         if "expires_at" not in data:
             raise Exception("GitHub API response missing expires_at field")
@@ -366,8 +372,12 @@ class GitHubIntegrationBase:
             if response.status_code == 401:
                 try:
                     self.refresh_access_token()
-                except Exception:
-                    logger.warning("GitHubIntegration: token refresh after 401 failed", exc_info=True)
+                except Exception as exc:
+                    logger.exception(
+                        "GitHubIntegration: token refresh after 401 failed",
+                        integration_id=self.integration.id,
+                        status_code=getattr(exc, "status_code", None),
+                    )
                     return None
                 response = fetch()
             return response
@@ -585,8 +595,17 @@ class GitHubIntegrationBase:
             if response.status_code == 401:
                 try:
                     self.refresh_access_token()
-                except Exception:
-                    raise_repository_error("GitHubIntegration: token refresh after 401 failed", exc_info=True)
+                except Exception as exc:
+                    refresh_status = getattr(exc, "status_code", None)
+                    logger.exception(
+                        "GitHubIntegration: token refresh after 401 failed",
+                        integration_id=self.integration.id,
+                        status_code=refresh_status,
+                    )
+                    raise GitHubIntegrationError(
+                        "GitHubIntegration: token refresh after 401 failed",
+                        status_code=refresh_status,
+                    ) from exc
                 try:
                     response = fetch()
                 except requests.RequestException:
@@ -695,8 +714,12 @@ class GitHubIntegrationBase:
         if response.status_code == 401:
             try:
                 self.refresh_access_token()
-            except Exception:
-                logger.warning("GitHubIntegration: token refresh after 401 failed", exc_info=True)
+            except Exception as exc:
+                logger.exception(
+                    "GitHubIntegration: token refresh after 401 failed",
+                    integration_id=self.integration.id,
+                    status_code=getattr(exc, "status_code", None),
+                )
                 return [], False
             try:
                 response = fetch(current_page)

--- a/products/signals/backend/temporal/agentic/select_repository.py
+++ b/products/signals/backend/temporal/agentic/select_repository.py
@@ -6,7 +6,7 @@ import posthoganalytics
 
 from posthog.event_usage import groups
 from posthog.models import Organization
-from posthog.models.integration import Integration
+from posthog.models.integration import GitHubIntegrationError, Integration
 from posthog.models.team.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -165,4 +165,11 @@ async def select_repository_activity(input: SelectRepositoryInput) -> RepoSelect
             result="failed",
             failure_reason=failure_reason,
         )
+        # Permanent GitHub App auth failures (installation gone/suspended) won't recover via retry.
+        if isinstance(e, GitHubIntegrationError) and e.status_code in {401, 403, 404, 410}:
+            raise temporalio.exceptions.ApplicationError(
+                str(e),
+                type="GitHubIntegrationError",
+                non_retryable=True,
+            ) from e
         raise


### PR DESCRIPTION
## Problem
- `select_repository_activity` failed with opaque "GitHubIntegration: token refresh after 401 failed" — the underlying GitHub App API status/cause was swallowed by `raise_repository_error`, and Temporal burned all retry attempts even on permanent installation failures.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes
- `refresh_access_token` now raises typed `GitHubIntegrationError(status_code=...)`.
- Exception instead of warning.
- `select_repository_activity` re-raises permanent statuses (401/403/404/410) as Temporal `ApplicationError(non_retryable=True)`.


<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->