### PR TITLE
fix(devex): force ESM loading for vite.config to fix start-vite

### DIFF
--- a/frontend/plugins/vite-public-assets-plugin.ts
+++ b/frontend/plugins/vite-public-assets-plugin.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmdirSync, unlinkSync, writeFileSync } from 'fs'
 import { dirname, join, relative, resolve } from 'path'
 import type { Plugin } from 'vite'
 
@@ -37,7 +37,7 @@ function deleteDirectory(dirPath: string): void {
             }
         })
         // Remove the empty directory
-        require('fs').rmdirSync(dirPath)
+        rmdirSync(dirPath)
     } catch (error) {
         console.warn(`⚠️ Could not delete directory ${dirPath}:`, error)
     }

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -1,8 +1,10 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
+import { dirname, resolve } from 'node:path'
 import { URL, fileURLToPath } from 'node:url'
-import { resolve } from 'path'
 import { defineConfig } from 'vite'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // import { toolbarDenylistPlugin } from './vite-toolbar-plugin'
 import { htmlGenerationPlugin } from './plugins/vite-html-plugin'

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
             "bin/hogli lint:feature-flags:fix",
             "bin/hogli format:js"
         ],
-        "{playwright,frontend,products,common,ee,services,docs}/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:js",
-        "nodejs/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:nodejs",
+        "{playwright,frontend,products,common,ee,services,docs}/**/*.{js,jsx,mjs,mts,ts,tsx}": "bin/hogli format:js",
+        "nodejs/**/*.{js,jsx,mjs,mts,ts,tsx}": "bin/hogli format:nodejs",
         "funnel-udf/**/*.rs": "bin/hogli format:rust",
         "!(posthog/hogql/grammar/*|posthog/personhog_client/proto/generated/*|products/*/skills/*/scripts/*)*.{py,pyi}": [
             "bin/hogli lint:python:fix",


### PR DESCRIPTION
## Problem

Running `pnpm --filter=@posthog/frontend start-vite` locally fails with:

```
[plugin: externalize-deps] Failed to resolve "@tailwindcss/vite".
This package is ESM only but it was tried to load by `require`.
```

`@tailwindcss/vite@4.1.11` is ESM-only (no CJS export). With `frontend/vite.config.ts` and no `"type": "module"` in `frontend/package.json`, Vite 7's default `configLoader: 'bundle'` sends the config through esbuild as CJS — which then tries to `require()` the ESM-only plugin and fails.

PR #57075 introduced `@tailwindcss/vite` but didn't switch the config to an ESM-loadable form.

## Changes

- Rename `frontend/vite.config.ts` → `frontend/vite.config.mts`. `.mts` makes Vite skip the CJS bundle path and load the config as native ESM.
- Add `__dirname` shim from `import.meta.url` (CJS globals don't exist in ESM).
- `frontend/plugins/vite-public-assets-plugin.ts`: replace inline `require('fs').rmdirSync(...)` with a named static import — dynamic require also fails under ESM bundling.
- `package.json` lint-staged glob: add `mts` to the JS format globs so the renamed config still runs `bin/hogli format:js` on commit.

Production build (`build:esbuild` via `build.mjs`) does not use Vite, so this change only affects the local dev server (`start-vite`).

## How did you test this code?

I'm an agent. Manual testing the human author ran:

- `pnpm --filter=@posthog/frontend start-vite` — Vite now boots clean, dev server up at `http://localhost:8234/` (previously crashed during config load).

No automated tests exercise `vite.config.*` — the file is only read by the Vite dev-server entry point.

## Publish to changelog?

no

## Docs update

n/a — devex-only fix.

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Human prompt was "trying to start vite locally and getting … Failed to resolve @tailwindcss/vite. This package is ESM only…", then "ok this works, but does this affect anything else?", then "ok PR from here with note on .mts in package file".
- Decisions:
  - Considered adding `"type": "module"` to `frontend/package.json` instead — rejected because that flips module resolution for every loose `.js` file in the package, much wider blast radius than the rename.
  - Considered `--configLoader native` / `runner` — rejected, both still flagged experimental in Vite 7 and would need to thread through the `start-vite` script.
  - `.mts` rename is the narrowest change; only `start-vite` (Vite dev server) reads this file. Production esbuild build is unaffected.