### PR TITLE
chore: use consistent UI for notifications sidebar menu

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -1,6 +1,7 @@
 import { cva } from 'cva'
 import { useActions, useMountedLogic, useValues } from 'kea'
 
+import { NotificationsPanel } from 'lib/components/NotificationsMenu/NotificationsPanel'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 
@@ -135,6 +136,7 @@ export function PanelLayout({ className }: { className?: string }): JSX.Element 
                         {activePanelIdentifier === 'People' && (
                             <ProjectTree root="persons://" searchPlaceholder="Search people tools" />
                         )}
+                        {activePanelIdentifier === 'Notifications' && <NotificationsPanel />}
                     </PanelLayoutNavBar>
                 )}
             </div>

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -11,6 +11,7 @@ import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
+import { NotificationsPanel } from 'lib/components/NotificationsMenu/NotificationsPanel'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Collapsible } from 'lib/ui/Collapsible/Collapsible'
@@ -318,6 +319,7 @@ export function Nav(): JSX.Element {
             {activePanelIdentifier === 'Shortcuts' && (
                 <ProjectTree root="shortcuts://" searchPlaceholder="Search starred items" />
             )}
+            {activePanelIdentifier === 'Notifications' && <NotificationsPanel />}
             {activePanelIdentifier === 'Chat' && (
                 <div className="flex flex-col h-full min-h-screen max-h-screen bg-surface-tertiary border-r overflow-hidden w-[var(--project-panel-width)]">
                     <Suspense

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -16,6 +16,7 @@ export type PanelLayoutNavIdentifier =
     | 'DataManagement'
     | 'DataAndPeople'
     | 'Chat'
+    | 'Notifications'
 export type NavExperimentTab = 'home' | 'chat'
 export type PanelLayoutTreeRef = React.RefObject<LemonTreeRef> | null
 export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsMenu.tsx
@@ -1,27 +1,20 @@
-import { Menu } from '@base-ui/react/menu'
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef, useState } from 'react'
 
 import { IconNotification } from '@posthog/icons'
-import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 
-import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { IconWithCount } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { cn } from 'lib/utils/css-classes'
 
 import { sidePanelNotificationsLogic } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
-import { InAppNotification } from '~/types'
-
-import { NotificationRow } from './NotificationRow'
-import { notificationsMenuLogic } from './notificationsMenuLogic'
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
 export const NotificationsMenu = ({ iconOnly = false }: { iconOnly?: boolean }): JSX.Element => {
-    const { isNotificationsMenuOpen, activeTab } = useValues(notificationsMenuLogic)
-    const { setNotificationsMenuOpen, setActiveTab } = useActions(notificationsMenuLogic)
-    const { inAppNotifications, inAppUnreadCount, importantChangesLoading, hasMoreNotifications, isLoadingMore } =
-        useValues(sidePanelNotificationsLogic)
-    const { markAllAsRead, loadMoreNotifications } = useActions(sidePanelNotificationsLogic)
+    const { activePanelIdentifier, isLayoutPanelVisible } = useValues(panelLayoutLogic)
+    const { setActivePanelIdentifier, clearActivePanelIdentifier, showLayoutPanel } = useActions(panelLayoutLogic)
+    const { inAppUnreadCount } = useValues(sidePanelNotificationsLogic)
     const [badgePulse, setBadgePulse] = useState(false)
     const prevCountRef = useRef(inAppUnreadCount)
 
@@ -34,136 +27,46 @@ export const NotificationsMenu = ({ iconOnly = false }: { iconOnly?: boolean }):
         }
     }, [inAppUnreadCount])
 
-    const filteredNotifications =
-        activeTab === 'unread' ? inAppNotifications.filter((n: InAppNotification) => !n.read) : inAppNotifications
+    const isActive = isLayoutPanelVisible && activePanelIdentifier === 'Notifications'
 
-    const handleCloseForNavigation = (): void => {
-        setNotificationsMenuOpen(false)
+    const handleClick = (): void => {
+        if (isActive) {
+            clearActivePanelIdentifier()
+            showLayoutPanel(false)
+        } else {
+            setActivePanelIdentifier('Notifications')
+            showLayoutPanel(true)
+        }
     }
 
     return (
-        <Menu.Root open={isNotificationsMenuOpen} onOpenChange={setNotificationsMenuOpen}>
-            <Menu.Trigger
-                render={
-                    <ButtonPrimitive
-                        tooltip={iconOnly ? 'Notifications' : undefined}
-                        tooltipPlacement="right"
-                        tooltipCloseDelayMs={0}
-                        iconOnly={iconOnly}
-                        className="group"
-                        menuItem={!iconOnly}
-                        data-attr="notifications-menu-button"
-                    >
-                        <span
-                            className={`flex text-secondary group-hover:text-primary transition-transform duration-300 ${
-                                badgePulse ? 'scale-125' : 'scale-100'
-                            }`}
-                        >
-                            <IconWithCount count={inAppUnreadCount} size="xsmall">
-                                <IconNotification className="size-4.5" />
-                            </IconWithCount>
-                        </span>
-                        {!iconOnly && (
-                            <>
-                                <span className="-ml-[2px]">Notifications</span>
-                                <MenuOpenIndicator direction="right" />
-                            </>
-                        )}
-                    </ButtonPrimitive>
-                }
-            />
-            <Menu.Portal>
-                <Menu.Backdrop className="fixed inset-0 z-[var(--z-modal)]" />
-                <Menu.Positioner
-                    className="z-[var(--z-popover)]"
-                    side="right"
-                    align="end"
-                    sideOffset={8}
-                    collisionPadding={{ top: 50, bottom: 50, right: 16 }}
-                >
-                    <Menu.Popup className="primitive-menu-content max-h-[calc(var(--available-height)-4px)] min-w-[380px] flex flex-col">
-                        <div className="flex items-center justify-between px-3 py-2 border-b border-primary shrink-0">
-                            <div className="flex gap-1">
-                                <button
-                                    className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
-                                        activeTab === 'all'
-                                            ? 'bg-fill-highlight-100 text-primary'
-                                            : 'text-secondary hover:text-primary'
-                                    }`}
-                                    onClick={() => setActiveTab('all')}
-                                >
-                                    All
-                                </button>
-                                <button
-                                    className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
-                                        activeTab === 'unread'
-                                            ? 'bg-fill-highlight-100 text-primary'
-                                            : 'text-secondary hover:text-primary'
-                                    }`}
-                                    onClick={() => setActiveTab('unread')}
-                                >
-                                    Unread
-                                    {inAppUnreadCount > 0 && (
-                                        <span className="ml-1 text-[10px] text-danger font-bold">
-                                            {inAppUnreadCount}
-                                        </span>
-                                    )}
-                                </button>
-                            </div>
-                            {inAppUnreadCount > 0 && (
-                                <LemonButton size="xsmall" type="secondary" onClick={() => markAllAsRead()}>
-                                    Mark all as read
-                                </LemonButton>
-                            )}
-                        </div>
-                        <ScrollableShadows
-                            direction="vertical"
-                            styledScrollbars
-                            className="flex-1 overflow-hidden"
-                            innerClassName="p-1"
-                        >
-                            {importantChangesLoading && inAppNotifications.length === 0 ? (
-                                <div className="p-2">
-                                    <LemonSkeleton className="h-10 my-1" repeat={5} fade />
-                                </div>
-                            ) : filteredNotifications.length > 0 ? (
-                                <>
-                                    <div className="flex flex-col gap-px">
-                                        {filteredNotifications.map((notification: InAppNotification) => (
-                                            <NotificationRow
-                                                key={notification.id}
-                                                notification={notification}
-                                                onNavigate={handleCloseForNavigation}
-                                            />
-                                        ))}
-                                    </div>
-                                    {hasMoreNotifications && activeTab === 'all' && (
-                                        <div className="p-2">
-                                            <LemonButton
-                                                type="secondary"
-                                                fullWidth
-                                                center
-                                                size="small"
-                                                loading={isLoadingMore}
-                                                onClick={() => loadMoreNotifications()}
-                                            >
-                                                Load more
-                                            </LemonButton>
-                                        </div>
-                                    )}
-                                </>
-                            ) : (
-                                <div className="flex flex-col items-center justify-center p-6 text-center">
-                                    <IconNotification className="size-8 text-muted mb-2" />
-                                    <span className="text-sm text-secondary">
-                                        {activeTab === 'unread' ? "You're all caught up!" : 'No notifications yet'}
-                                    </span>
-                                </div>
-                            )}
-                        </ScrollableShadows>
-                    </Menu.Popup>
-                </Menu.Positioner>
-            </Menu.Portal>
-        </Menu.Root>
+        <ButtonPrimitive
+            tooltip={iconOnly ? 'Notifications' : undefined}
+            tooltipPlacement="right"
+            tooltipCloseDelayMs={0}
+            iconOnly={iconOnly}
+            menuItem={!iconOnly}
+            active={isActive}
+            onClick={handleClick}
+            className="group"
+            data-attr="notifications-menu-button"
+        >
+            <span
+                className={cn(
+                    'flex text-secondary group-hover:text-primary transition-transform duration-300',
+                    badgePulse ? 'scale-125' : 'scale-100'
+                )}
+            >
+                <IconWithCount count={inAppUnreadCount} size="xsmall">
+                    <IconNotification className="size-4.5" />
+                </IconWithCount>
+            </span>
+            {!iconOnly && (
+                <>
+                    <span className="-ml-[2px]">Notifications</span>
+                    <MenuOpenIndicator direction="right" />
+                </>
+            )}
+        </ButtonPrimitive>
     )
 }

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsMenu.tsx
@@ -13,7 +13,7 @@ import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
 export const NotificationsMenu = ({ iconOnly = false }: { iconOnly?: boolean }): JSX.Element => {
     const { activePanelIdentifier, isLayoutPanelVisible } = useValues(panelLayoutLogic)
-    const { setActivePanelIdentifier, clearActivePanelIdentifier, showLayoutPanel } = useActions(panelLayoutLogic)
+    const { setActivePanelIdentifier, showLayoutPanel, closePanel } = useActions(panelLayoutLogic)
     const { inAppUnreadCount } = useValues(sidePanelNotificationsLogic)
     const [badgePulse, setBadgePulse] = useState(false)
     const prevCountRef = useRef(inAppUnreadCount)
@@ -31,8 +31,7 @@ export const NotificationsMenu = ({ iconOnly = false }: { iconOnly?: boolean }):
 
     const handleClick = (): void => {
         if (isActive) {
-            clearActivePanelIdentifier()
-            showLayoutPanel(false)
+            closePanel()
         } else {
             setActivePanelIdentifier('Notifications')
             showLayoutPanel(true)

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
@@ -26,7 +26,8 @@ export function NotificationsPanel(): JSX.Element {
 
     const header = (
         <div className="flex items-center gap-2 flex-1 min-w-0">
-            <div className="flex gap-1">
+            <div className="flex gap-1 pl-1">
+                {/* TODO: make tab primitives */}
                 <button
                     className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
                         activeTab === 'all' ? 'bg-fill-highlight-100 text-primary' : 'text-secondary hover:text-primary'

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
@@ -1,0 +1,109 @@
+import { useActions, useValues } from 'kea'
+
+import { IconNotification } from '@posthog/icons'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+
+import { sidePanelNotificationsLogic } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import { PanelLayoutPanel } from '~/layout/panel-layout/PanelLayoutPanel'
+import { InAppNotification } from '~/types'
+
+import { NotificationRow } from './NotificationRow'
+import { notificationsMenuLogic } from './notificationsMenuLogic'
+
+export function NotificationsPanel(): JSX.Element {
+    const { activeTab } = useValues(notificationsMenuLogic)
+    const { setActiveTab } = useActions(notificationsMenuLogic)
+    const { inAppNotifications, inAppUnreadCount, importantChangesLoading, hasMoreNotifications, isLoadingMore } =
+        useValues(sidePanelNotificationsLogic)
+    const { markAllAsRead, loadMoreNotifications } = useActions(sidePanelNotificationsLogic)
+    const { closePanel } = useActions(panelLayoutLogic)
+
+    const filteredNotifications =
+        activeTab === 'unread' ? inAppNotifications.filter((n: InAppNotification) => !n.read) : inAppNotifications
+
+    const header = (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+            <div className="flex gap-1">
+                <button
+                    className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
+                        activeTab === 'all' ? 'bg-fill-highlight-100 text-primary' : 'text-secondary hover:text-primary'
+                    }`}
+                    onClick={() => setActiveTab('all')}
+                >
+                    All
+                </button>
+                <button
+                    className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
+                        activeTab === 'unread'
+                            ? 'bg-fill-highlight-100 text-primary'
+                            : 'text-secondary hover:text-primary'
+                    }`}
+                    onClick={() => setActiveTab('unread')}
+                >
+                    Unread
+                    {inAppUnreadCount > 0 && (
+                        <span className="ml-1 text-[10px] text-danger font-bold">{inAppUnreadCount}</span>
+                    )}
+                </button>
+            </div>
+            {inAppUnreadCount > 0 && (
+                <LemonButton size="xsmall" type="secondary" onClick={() => markAllAsRead()} className="ml-auto">
+                    Mark all as read
+                </LemonButton>
+            )}
+        </div>
+    )
+
+    return (
+        <PanelLayoutPanel searchField={header}>
+            <ScrollableShadows
+                direction="vertical"
+                styledScrollbars
+                className="flex-1 overflow-hidden"
+                innerClassName="p-1"
+            >
+                {importantChangesLoading && inAppNotifications.length === 0 ? (
+                    <div className="p-2">
+                        <LemonSkeleton className="h-10 my-1" repeat={5} fade />
+                    </div>
+                ) : filteredNotifications.length > 0 ? (
+                    <>
+                        <div className="flex flex-col gap-px">
+                            {filteredNotifications.map((notification: InAppNotification) => (
+                                <NotificationRow
+                                    key={notification.id}
+                                    notification={notification}
+                                    onNavigate={() => closePanel()}
+                                />
+                            ))}
+                        </div>
+                        {hasMoreNotifications && activeTab === 'all' && (
+                            <div className="p-2">
+                                <LemonButton
+                                    type="secondary"
+                                    fullWidth
+                                    center
+                                    size="small"
+                                    loading={isLoadingMore}
+                                    onClick={() => loadMoreNotifications()}
+                                >
+                                    Load more
+                                </LemonButton>
+                            </div>
+                        )}
+                    </>
+                ) : (
+                    <div className="flex flex-col items-center justify-center p-6 text-center">
+                        <IconNotification className="size-8 text-muted mb-2" />
+                        <span className="text-sm text-secondary">
+                            {activeTab === 'unread' ? "You're all caught up!" : 'No notifications yet'}
+                        </span>
+                    </div>
+                )}
+            </ScrollableShadows>
+        </PanelLayoutPanel>
+    )
+}


### PR DESCRIPTION
## Problem

The notificiations menu in the sidebar shows a different result than the other menu options in the sidebar. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use the same sidepanel UI as "Apps", "Data", etc. in the sidebar to provide a more consistent experiene. This includes refactoring the notifications side panel content into a re-usable component.
<img width="1025" height="979" alt="Screenshot 2026-05-05 at 9 20 35 AM" src="https://github.com/user-attachments/assets/dcd4344c-c895-4e81-afc1-93b5ea611e20" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
