### PR TITLE
fix: Fix health page docs urls

### DIFF
--- a/frontend/src/scenes/health/components/WebAnalyticsHealthTable.tsx
+++ b/frontend/src/scenes/health/components/WebAnalyticsHealthTable.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@posthog/lemon-ui'
 
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { urls } from 'scenes/urls'
 
 import type { HealthIssue } from '../types'
 import { dismissActionColumn, severityColumn } from './healthTableColumns'
@@ -9,6 +10,7 @@ interface CheckMeta {
     title: string
     description: string
     docsUrl?: string
+    linkLabel?: string
 }
 
 const CHECK_META: Record<string, CheckMeta> = {
@@ -25,12 +27,13 @@ const CHECK_META: Record<string, CheckMeta> = {
     scroll_depth: {
         title: 'Scroll depth',
         description: 'Enable scroll depth to see how far users read your content before leaving.',
-        docsUrl: 'https://posthog.com/docs/web-analytics/scroll-depth',
+        docsUrl: 'https://posthog.com/tutorials/scroll-depth',
     },
     authorized_urls: {
         title: 'Authorized URLs',
         description: "No authorized URLs configured. Some filters won't work correctly until you set your domains.",
-        docsUrl: 'https://posthog.com/docs/web-analytics/authorized-urls',
+        docsUrl: urls.settings('environment-web-analytics', 'web-analytics-authorized-urls'),
+        linkLabel: 'Settings',
     },
     reverse_proxy: {
         title: 'Reverse proxy',
@@ -74,7 +77,7 @@ export function WebAnalyticsHealthTable({
                             )}
                             {meta?.docsUrl && (
                                 <Link to={meta.docsUrl} className="text-xs text-muted">
-                                    Docs
+                                    {meta.linkLabel ?? 'Docs'}
                                 </Link>
                             )}
                         </div>


### PR DESCRIPTION
## Problem
The scroll depth docs page linked to the wrong resource
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Use the correct docs url for scroll depth
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
