### PR TITLE
fix(ws): fix datetime comparison crash in partitioned postgres sync

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/partitioned_tables.py
+++ b/posthog/temporal/data_imports/sources/postgres/partitioned_tables.py
@@ -550,6 +550,8 @@ def iterate_partitions(
     # If range-partitioned on the incremental field, skip children whose upper
     # bound is at or below cursor to avoid reading already-synced data.
     skippable_upper: Any = db_incremental_field_last_value
+    if incremental_field_type is not None and skippable_upper is not None:
+        skippable_upper = _ensure_aware(skippable_upper, incremental_field_type)
     partition_bounds: dict[str, tuple[Any, Any] | None] = {}
     if incremental_field_type is not None and skippable_upper is not None:
         for child in child_partitions:


### PR DESCRIPTION
## Problem

Partition bounds from the PG catalog are always parsed as UTC-aware datetimes. But the incremental cursor (last synced value) can be a naive datetime if the source column has no timezone. When `iterate_partitions()` compares them to skip already-synced partitions, Python raises a TypeError.

## Changes

* Fixed naive-vs-aware datetime crash in `iterate_partitions()` partition-skip logic

## How did you test this code?

Test pass

## Publish to changelog?

NO