### PR TITLE
feat(hog-charts): expose timeseries config additions for trends migration

### DIFF
--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -1,6 +1,13 @@
 import React, { useMemo } from 'react'
 
-import type { ChartTheme, LineChartConfig, PointClickData, Series, TooltipContext } from '../../core/types'
+import type {
+    ChartTheme,
+    LineChartConfig,
+    PointClickData,
+    Series,
+    TooltipConfig,
+    TooltipContext,
+} from '../../core/types'
 import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import { LineChart } from '../LineChart'
@@ -32,10 +39,18 @@ export interface TimeSeriesLineChartConfig {
     movingAverage?: MovingAverageConfig[]
     trendLines?: TrendLineConfig[]
     /** Map of comparison series key → its primary series key. Comparison series render
-     *  at reduced opacity so they read as subordinate to their primary. */
+     *  at reduced opacity so they read as subordinate to their primary. The mapped
+     *  primary key is reserved for future tooltip-linking ("compared against …") and is
+     *  currently unread by the dimming pass — only the presence of the key matters today. */
     comparisonOf?: Record<string, string>
     /** Anomaly markers rendered as filled circles on top of the chart. */
     anomalies?: AnomalyMarker[]
+    /** Render area-fill series as a 100% stacked view; y-axis becomes 0–100%. */
+    percentStackView?: boolean
+    /** Show a vertical crosshair line that follows the cursor. */
+    showCrosshair?: boolean
+    /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
+    tooltip?: TooltipConfig
 }
 
 export interface TimeSeriesLineChartProps<Meta = unknown> {
@@ -48,6 +63,7 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     dataAttr?: string
     className?: string
     children?: React.ReactNode
+    onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
 function resolveValueLabelsConfig(valueLabels: TimeSeriesLineChartConfig['valueLabels']): ValueLabelsConfig | null {
@@ -70,6 +86,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
     dataAttr,
     className,
     children,
+    onError,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
     const {
         xAxis,
@@ -82,6 +99,9 @@ export function TimeSeriesLineChart<Meta = unknown>({
         trendLines,
         comparisonOf,
         anomalies,
+        percentStackView,
+        showCrosshair,
+        tooltip: tooltipConfig,
     } = config ?? {}
     const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
@@ -129,6 +149,9 @@ export function TimeSeriesLineChart<Meta = unknown>({
         hideXAxis: xAxis?.hide,
         hideYAxis: yAxis?.hide,
         showGrid: yAxis?.showGrid,
+        percentStackView,
+        showCrosshair,
+        tooltip: tooltipConfig,
     }
 
     return (
@@ -141,6 +164,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
             onPointClick={onPointClick}
             className={className}
             dataAttr={dataAttr}
+            onError={onError}
         >
             {referenceLines.length > 0 && <ReferenceLines lines={referenceLines} />}
             {valueLabelsConfig && <ValueLabels valueFormatter={valueLabelFormatter} />}

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -38,10 +38,7 @@ export interface TimeSeriesLineChartConfig {
     confidenceIntervals?: ConfidenceIntervalConfig[]
     movingAverage?: MovingAverageConfig[]
     trendLines?: TrendLineConfig[]
-    /** Map of comparison series key → its primary series key. Comparison series render
-     *  at reduced opacity so they read as subordinate to their primary. The mapped
-     *  primary key is reserved for future tooltip-linking ("compared against …") and is
-     *  currently unread by the dimming pass — only the presence of the key matters today. */
+    /** Comparison series keys mapped to their primary. Comparison series render dimmed. */
     comparisonOf?: Record<string, string>
     /** Anomaly markers rendered as filled circles on top of the chart. */
     anomalies?: AnomalyMarker[]

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/derived-series.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/derived-series.ts
@@ -41,10 +41,14 @@ export interface BuildMovingAverageSeriesInput<Meta = unknown> {
     label?: string
 }
 
+export function movingAverageKey(sourceKey: string): string {
+    return `${sourceKey}-ma`
+}
+
 export function buildMovingAverageSeries<Meta = unknown>(input: BuildMovingAverageSeriesInput<Meta>): Series<Meta> {
     const { sourceSeries, window: windowSize } = input
     return {
-        key: `${sourceSeries.key}-ma`,
+        key: movingAverageKey(sourceSeries.key),
         label: input.label ?? `${sourceSeries.label} (Moving avg)`,
         data: movingAverage(sourceSeries.data, windowSize),
         color: sourceSeries.color,

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/derived-series.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/derived-series.ts
@@ -41,17 +41,10 @@ export interface BuildMovingAverageSeriesInput<Meta = unknown> {
     label?: string
 }
 
-/** Series-key convention for the moving-average derivation. Trends and any other adapter
- *  that wants to reference the MA series by key (e.g. for `trendLines.seriesKey`,
- *  `comparisonOf`) must use this helper rather than re-string-templating the suffix. */
-export function movingAverageKey(sourceKey: string): string {
-    return `${sourceKey}-ma`
-}
-
 export function buildMovingAverageSeries<Meta = unknown>(input: BuildMovingAverageSeriesInput<Meta>): Series<Meta> {
     const { sourceSeries, window: windowSize } = input
     return {
-        key: movingAverageKey(sourceSeries.key),
+        key: `${sourceSeries.key}-ma`,
         label: input.label ?? `${sourceSeries.label} (Moving avg)`,
         data: movingAverage(sourceSeries.data, windowSize),
         color: sourceSeries.color,

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/derived-series.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/derived-series.ts
@@ -41,10 +41,17 @@ export interface BuildMovingAverageSeriesInput<Meta = unknown> {
     label?: string
 }
 
+/** Series-key convention for the moving-average derivation. Trends and any other adapter
+ *  that wants to reference the MA series by key (e.g. for `trendLines.seriesKey`,
+ *  `comparisonOf`) must use this helper rather than re-string-templating the suffix. */
+export function movingAverageKey(sourceKey: string): string {
+    return `${sourceKey}-ma`
+}
+
 export function buildMovingAverageSeries<Meta = unknown>(input: BuildMovingAverageSeriesInput<Meta>): Series<Meta> {
     const { sourceSeries, window: windowSize } = input
     return {
-        key: `${sourceSeries.key}-ma`,
+        key: movingAverageKey(sourceSeries.key),
         label: input.label ?? `${sourceSeries.label} (Moving avg)`,
         data: movingAverage(sourceSeries.data, windowSize),
         color: sourceSeries.color,

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/use-derived-series.test.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/use-derived-series.test.ts
@@ -41,4 +41,50 @@ describe('useDerivedSeries', () => {
         expect(result.current[0].color).toBe('#112233')
         expect(result.current[1].color).toMatch(/^rgba\([^)]*,\s*0\.5\)$/)
     })
+
+    it('resolves a trendline whose seriesKey targets a moving-average series', () => {
+        const { result } = renderHook(() =>
+            useDerivedSeries(SOURCE, {
+                movingAverage: [{ seriesKey: 'a', window: 2 }],
+                trendLines: [{ seriesKey: 'a-ma', kind: 'linear' }],
+            })
+        )
+        // Order: source (a, b) → MA (a-ma) → trendline of MA (a-ma__trendline)
+        expect(result.current.map((s) => s.key)).toEqual(['a', 'b', 'a-ma', 'a-ma__trendline'])
+    })
+
+    it('threads fitUpTo from the trendLines config into the regression fit', () => {
+        // Linear regression over [10, 10, 10, 10, 100, 100] would slope upward; restricting
+        // the fit to the first 4 indices (all 10s) produces a flat ~10 trendline across the
+        // full range. The two configs must therefore yield different first values.
+        const data = [10, 10, 10, 10, 100, 100]
+        const labels = ['mo', 'tu', 'we', 'th', 'fr', 'sa']
+        const source: Series[] = [{ key: 'a', label: 'A', data, color: '#112233' }]
+        const { result: fitted } = renderHook(() =>
+            useDerivedSeries(source, { trendLines: [{ seriesKey: 'a', kind: 'linear', fitUpTo: 4 }] })
+        )
+        const { result: full } = renderHook(() =>
+            useDerivedSeries(source, { trendLines: [{ seriesKey: 'a', kind: 'linear' }] })
+        )
+        const fittedTrend = fitted.current.find((s) => s.key === 'a__trendline')!.data
+        const fullTrend = full.current.find((s) => s.key === 'a__trendline')!.data
+        expect(labels.length).toBe(data.length) // sanity
+        // Constrained fit stays flat near 10; unconstrained fit slopes up.
+        expect(fittedTrend.every((v) => Math.abs(v - 10) < 1e-6)).toBe(true)
+        expect(fullTrend[fullTrend.length - 1]).toBeGreaterThan(fittedTrend[fittedTrend.length - 1])
+    })
+
+    it('busts the memo cache when fitUpTo changes between renders', () => {
+        const data = [10, 10, 10, 10, 100, 100]
+        const source: Series[] = [{ key: 'a', label: 'A', data, color: '#112233' }]
+        const { result, rerender } = renderHook(
+            ({ fitUpTo }: { fitUpTo: number | undefined }) =>
+                useDerivedSeries(source, { trendLines: [{ seriesKey: 'a', kind: 'linear', fitUpTo }] }),
+            { initialProps: { fitUpTo: 4 as number | undefined } }
+        )
+        const constrained = result.current.find((s) => s.key === 'a__trendline')!.data.slice()
+        rerender({ fitUpTo: undefined })
+        const unconstrained = result.current.find((s) => s.key === 'a__trendline')!.data
+        expect(unconstrained[unconstrained.length - 1]).toBeGreaterThan(constrained[constrained.length - 1])
+    })
 })

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/use-derived-series.test.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/use-derived-series.test.ts
@@ -54,11 +54,8 @@ describe('useDerivedSeries', () => {
     })
 
     it('threads fitUpTo from the trendLines config into the regression fit', () => {
-        // Linear regression over [10, 10, 10, 10, 100, 100] would slope upward; restricting
-        // the fit to the first 4 indices (all 10s) produces a flat ~10 trendline across the
-        // full range. The two configs must therefore yield different first values.
+        // Constrained fit over [0, 4) stays flat near 10; unconstrained fit slopes up.
         const data = [10, 10, 10, 10, 100, 100]
-        const labels = ['mo', 'tu', 'we', 'th', 'fr', 'sa']
         const source: Series[] = [{ key: 'a', label: 'A', data, color: '#112233' }]
         const { result: fitted } = renderHook(() =>
             useDerivedSeries(source, { trendLines: [{ seriesKey: 'a', kind: 'linear', fitUpTo: 4 }] })
@@ -68,10 +65,11 @@ describe('useDerivedSeries', () => {
         )
         const fittedTrend = fitted.current.find((s) => s.key === 'a__trendline')!.data
         const fullTrend = full.current.find((s) => s.key === 'a__trendline')!.data
-        expect(labels.length).toBe(data.length) // sanity
-        // Constrained fit stays flat near 10; unconstrained fit slopes up.
-        expect(fittedTrend.every((v) => Math.abs(v - 10) < 1e-6)).toBe(true)
-        expect(fullTrend[fullTrend.length - 1]).toBeGreaterThan(fittedTrend[fittedTrend.length - 1])
+        const fittedDeviationFromTen = fittedTrend.map((v) => Math.abs(v - 10))
+        const fittedLast = fittedTrend[fittedTrend.length - 1]
+        const fullLast = fullTrend[fullTrend.length - 1]
+        expect(Math.max(...fittedDeviationFromTen)).toBeLessThan(1e-6)
+        expect(fullLast).toBeGreaterThan(fittedLast)
     })
 
     it('busts the memo cache when fitUpTo changes between renders', () => {

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/use-derived-series.ts
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/utils/use-derived-series.ts
@@ -24,6 +24,10 @@ export interface TrendLineConfig {
     seriesKey: string
     kind: 'linear' | 'exponential'
     label?: string
+    /** Restrict the regression fit to indices `[0, fitUpTo)`; trend is still extrapolated
+     *  across the full range. Use to exclude an in-progress tail so the partial bucket
+     *  doesn't drag the slope. */
+    fitUpTo?: number
 }
 
 export interface DerivedSeriesOptions {
@@ -91,13 +95,30 @@ export function useDerivedSeries<Meta>(source: Series<Meta>[], options: DerivedS
             maSeries.push(buildMovingAverageSeries<Meta>({ sourceSeries: found, window: ma.window, label: ma.label }))
         }
 
+        // Trend lines may reference moving-average series too (e.g. trends renders both a
+        // raw trendline and a trendline of the MA), so fold MA keys into the lookup —
+        // but only clone the source map when there are MA entries to add.
+        let trendLineSourceByKey = sourceByKey
+        if (maSeries.length > 0) {
+            trendLineSourceByKey = new Map(sourceByKey)
+            for (const ma of maSeries) {
+                trendLineSourceByKey.set(ma.key, ma)
+            }
+        }
         const tlSeries: Series<Meta>[] = []
         for (const tl of trendLines ?? []) {
-            const found = sourceByKey.get(tl.seriesKey)
+            const found = trendLineSourceByKey.get(tl.seriesKey)
             if (!found) {
                 continue
             }
-            tlSeries.push(buildTrendLineSeries<Meta>({ sourceSeries: found, kind: tl.kind, label: tl.label }))
+            tlSeries.push(
+                buildTrendLineSeries<Meta>({
+                    sourceSeries: found,
+                    kind: tl.kind,
+                    label: tl.label,
+                    fitUpTo: tl.fitUpTo,
+                })
+            )
         }
 
         return applyComparisonDimming([...ciSeries, ...source, ...maSeries, ...tlSeries], comparisonOf)
@@ -128,7 +149,7 @@ function tlSig(tl: TrendLineConfig[] | undefined): string {
     if (!tl?.length) {
         return ''
     }
-    return tl.map((t) => `${t.seriesKey}|${t.kind}|${t.label ?? ''}`).join(';')
+    return tl.map((t) => `${t.seriesKey}|${t.kind}|${t.label ?? ''}|${t.fitUpTo ?? ''}`).join(';')
 }
 
 function cmpSig(cmp: Record<string, string> | undefined): string {

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -68,9 +68,6 @@ export { computeVisibleXLabels } from './overlays/AxisLabels'
 export { AnomalyPointsLayer } from './charts/TimeSeriesLineChart/overlays/AnomalyPointsLayer'
 export type { AnomalyMarker } from './charts/TimeSeriesLineChart/overlays/AnomalyPointsLayer'
 
-// Helpers for building derived-series configs that reference MA / CI / trendline keys.
-export { movingAverageKey } from './charts/TimeSeriesLineChart/utils/derived-series'
-
 // Timeseries utils
 export { createXAxisTickCallback, parseDateForAxis } from './charts/TimeSeriesLineChart/utils/dates'
 export type { TimeInterval } from './charts/TimeSeriesLineChart/utils/dates'

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -67,6 +67,7 @@ export { computeVisibleXLabels } from './overlays/AxisLabels'
 // Timeseries overlays
 export { AnomalyPointsLayer } from './charts/TimeSeriesLineChart/overlays/AnomalyPointsLayer'
 export type { AnomalyMarker } from './charts/TimeSeriesLineChart/overlays/AnomalyPointsLayer'
+export { movingAverageKey } from './charts/TimeSeriesLineChart/utils/derived-series'
 
 // Timeseries utils
 export { createXAxisTickCallback, parseDateForAxis } from './charts/TimeSeriesLineChart/utils/dates'

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -38,6 +38,7 @@ export type {
     ResolvedSeries,
     ResolveValueFn,
     Series,
+    TooltipConfig,
     TooltipContext,
     YAxisScale,
 } from './core/types'
@@ -66,6 +67,9 @@ export { computeVisibleXLabels } from './overlays/AxisLabels'
 // Timeseries overlays
 export { AnomalyPointsLayer } from './charts/TimeSeriesLineChart/overlays/AnomalyPointsLayer'
 export type { AnomalyMarker } from './charts/TimeSeriesLineChart/overlays/AnomalyPointsLayer'
+
+// Helpers for building derived-series configs that reference MA / CI / trendline keys.
+export { movingAverageKey } from './charts/TimeSeriesLineChart/utils/derived-series'
 
 // Timeseries utils
 export { createXAxisTickCallback, parseDateForAxis } from './charts/TimeSeriesLineChart/utils/dates'


### PR DESCRIPTION
## Problem

`<TimeSeriesLineChart>` is the matured replacement for `<LineChart>`, and the trends `TrendsLineChart` migration onto it (PR2 in this stack) needs a few additive config knobs to express full feature parity declaratively. Today those knobs only exist on the lower-level `<LineChart>`, so the wrapper component drops them.

## Changes

- `TimeSeriesLineChartConfig` gains three pass-through fields: `percentStackView`, `showCrosshair`, and `tooltip` (`TooltipConfig`). All forwarded into the underlying `LineChartConfig`.
- `TimeSeriesLineChartProps` gains an `onError` prop, forwarded to `<LineChart>`'s `ChartErrorBoundary`.
- `TrendLineConfig` gains `fitUpTo`, threaded through `buildTrendLineSeries` so a config-level trendline can exclude an in-progress tail from its regression fit (matches the existing leaf-builder behaviour). Also folded into `tlSig` so the cache invalidates when the value changes.
- `useDerivedSeries`'s trend-line lookup now folds in the moving-average series it just built, so a `TrendLineConfig.seriesKey` can target an MA series (e.g. `${id}-ma`). The lookup map is only cloned when MA series exist.
- New exported `movingAverageKey(sourceKey)` helper in `derived-series.ts` — single source of truth for the `${sourceKey}-ma` suffix convention so adapters don't re-string-template it.
- Public barrel exports `TooltipConfig` (previously referenced by `TimeSeriesLineChartConfig.tooltip` but not in `index.ts`) and `movingAverageKey`.

No production consumer in this PR — the trends adapter that uses every one of these lands in the stacked PR on top.

## How did you test this code?

I'm an agent. Ran:

- `hogli test src/lib/hog-charts/` — 724 tests pass on this branch alone.
- 3 new test cases in `use-derived-series.test.ts` cover: trendline whose `seriesKey` resolves to an MA-derived series; `fitUpTo` threading from config to `buildTrendLineSeries`; cache invalidation via `tlSig` when `fitUpTo` changes.
- LSP diagnostics empty on every changed file.

## Publish to changelog?

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Driven by feedback on the original combined PR (#57642): "TooltipConfig referenced from TimeSeriesLineChartConfig.tooltip but not exported"; "movingAverageKey lives in two places — extract"; "library-level test coverage for MA→trendline lookup and fitUpTo threading was deleted but not re-added at the library layer." Each of those is addressed here.
- Carved out from the combined PR so library reviewers can look at the additive surface in isolation.