### PR TITLE
feat(logs): track sql tab opens, query runs, and saves

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -127,7 +127,12 @@ const LogsSceneTabbedContent = (): JSX.Element => {
             )}
             <LemonTabs<LogsSceneActiveTab>
                 activeKey={activeTab}
-                onChange={(key) => setActiveTab(key)}
+                onChange={(key) => {
+                    if (key === 'sql' && activeTab !== 'sql') {
+                        posthog.capture('logs sql tab opened')
+                    }
+                    setActiveTab(key)
+                }}
                 tabs={tabs}
                 sceneInset
             />

--- a/products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor.tsx
+++ b/products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { SQLEditor } from 'scenes/data-warehouse/editor/SQLEditor'
@@ -8,7 +8,9 @@ import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { ChartDisplayType } from '~/types'
 
-import { logsSceneLogic } from 'products/logs/frontend/logsSceneLogic'
+import { getLogsSqlEditorTabId, logsSceneLogic } from 'products/logs/frontend/logsSceneLogic'
+
+import { logsSqlEditorTrackingLogic } from './logsSqlEditorTrackingLogic'
 
 const DEFAULT_LOGS_QUERY = 'SELECT * FROM logs LIMIT 10'
 
@@ -17,11 +19,12 @@ export interface LogsSqlEditorProps {
 }
 
 export const LogsSqlEditor = ({ id }: LogsSqlEditorProps): JSX.Element => {
-    const sqlEditorTabId = `logs-sql-editor-${id}`
+    const sqlEditorTabId = getLogsSqlEditorTabId(id)
     const { keepSqlEditorMounted } = useActions(logsSceneLogic)
     const logic = sqlEditorLogic({ tabId: sqlEditorTabId, mode: SQLEditorMode.Embedded })
     const { queryInput } = useValues(logic)
     const { setQueryInput, setSourceQuery, runQuery } = useActions(logic)
+    useMountedLogic(logsSqlEditorTrackingLogic({ sqlEditorTabId }))
 
     useEffect(() => {
         keepSqlEditorMounted(sqlEditorTabId)

--- a/products/logs/frontend/components/LogsSqlEditor/logsSqlEditorTrackingLogic.ts
+++ b/products/logs/frontend/components/LogsSqlEditor/logsSqlEditorTrackingLogic.ts
@@ -1,0 +1,48 @@
+import { connect, kea, key, listeners, path, props } from 'kea'
+import posthog from 'posthog-js'
+
+import { SaveAsMenuItem } from 'scenes/data-warehouse/editor/editorSceneLogic'
+import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
+import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
+
+import type { logsSqlEditorTrackingLogicType } from './logsSqlEditorTrackingLogicType'
+
+export interface LogsSqlEditorTrackingLogicProps {
+    sqlEditorTabId: string
+}
+
+const captureSaved = (target: SaveAsMenuItem['action']): void => {
+    posthog.capture('logs sql query saved', { target })
+}
+
+export const logsSqlEditorTrackingLogic = kea<logsSqlEditorTrackingLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsSqlEditor', 'logsSqlEditorTrackingLogic']),
+    props({} as LogsSqlEditorTrackingLogicProps),
+    key((props) => props.sqlEditorTabId),
+    connect((props: LogsSqlEditorTrackingLogicProps) => ({
+        actions: [
+            sqlEditorLogic({ tabId: props.sqlEditorTabId, mode: SQLEditorMode.Embedded }),
+            [
+                'runQuery as sqlEditorRunQuery',
+                'saveAsViewSubmit as sqlEditorSaveAsViewSubmit',
+                'saveAsInsightSubmit as sqlEditorSaveAsInsightSubmit',
+                'saveAsEndpointSubmit as sqlEditorSaveAsEndpointSubmit',
+            ],
+        ],
+    })),
+    listeners(({ cache }) => ({
+        sqlEditorRunQuery: () => {
+            // Skip the auto-init runQuery dispatched by LogsSqlEditor's first mount.
+            // Trade-off: on revisit (queryInput already set, no auto-init), the user's first
+            // manual run is also skipped. Acceptable under-count for an alpha metric.
+            if (!cache.firstRunSeen) {
+                cache.firstRunSeen = true
+                return
+            }
+            posthog.capture('logs sql query run')
+        },
+        sqlEditorSaveAsViewSubmit: () => captureSaved('view'),
+        sqlEditorSaveAsInsightSubmit: () => captureSaved('insight'),
+        sqlEditorSaveAsEndpointSubmit: () => captureSaved('endpoint'),
+    })),
+])

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -35,6 +35,8 @@ import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/lo
 
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
+export const getLogsSqlEditorTabId = (id: string): string => `logs-sql-editor-${id}`
+
 export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'configuration'
 const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'sql', 'configuration']
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'


### PR DESCRIPTION
## Problem

We need to track how users interact with the SQL tab in the Logs scene to understand adoption and usage patterns during the alpha phase.

## Changes

Adds PostHog event capture for the following interactions in the Logs SQL editor:

- **`logs sql tab opened`** — fired when a user navigates to the SQL tab
- **`logs sql query run`** — fired when a user manually runs a query (the initial auto-run on mount is intentionally skipped)
- **`logs sql query saved`** — fired when a user saves a query as a view, insight, or endpoint (with a `target` property indicating which)

A new `logsSqlEditorTrackingLogic` kea logic is introduced to encapsulate all SQL editor tracking, connecting to `sqlEditorLogic` actions and listening for run/save events. The tab ID helper `getLogsSqlEditorTabId` is extracted into a shared export so it can be reused consistently.

## How did you test this code?

Manually navigated to the Logs SQL tab, ran queries, and saved as view/insight/endpoint, verifying events appeared in PostHog.

## Publish to changelog?

No