### PR TITLE
fix(shared-views): skip API calls that always 401 in shared/exported views

### DIFF
--- a/frontend/src/exporter/exporterViewLogic.ts
+++ b/frontend/src/exporter/exporterViewLogic.ts
@@ -103,3 +103,7 @@ export const exporterViewLogic = kea<exporterViewLogicType>([
 export const getCurrentExporterData = (): ExportedData | undefined => {
     return exporterViewLogic.findMounted()?.values.exportedData
 }
+
+export const isSharedView = (): boolean => {
+    return !!getCurrentExporterData()
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6870,6 +6870,8 @@ const api = {
     },
 } as const
 
+const warnedSharedViewLeaks = new Set<string>()
+
 async function handleFetch(url: string, method: string, fetcher: () => Promise<Response>): Promise<Response> {
     const startTime = new Date().getTime()
 
@@ -6906,9 +6908,11 @@ async function handleFetch(url: string, method: string, fetcher: () => Promise<R
             })
         }
         if (inSharedView && (response.status === 401 || response.status === 403)) {
-            console.warn(
-                `[shared-view] ${method} ${pathname} returned ${response.status} — call site should be gated with isSharedView()`
-            )
+            const leakKey = `${method} ${pathname}`
+            if (!warnedSharedViewLeaks.has(leakKey)) {
+                warnedSharedViewLeaks.add(leakKey)
+                console.warn(`[shared-view] unexpected ${response.status} on ${leakKey}`)
+            }
         }
 
         const data = await getJSONOrNull(response)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,7 +18,7 @@ import { RecordingComment } from 'scenes/session-recordings/player/inspector/pla
 import { SessionSummaryContent } from 'scenes/session-recordings/player/player-meta/types'
 import { LINK_PAGE_SIZE, SURVEY_PAGE_SIZE } from 'scenes/surveys/constants'
 
-import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
+import { getCurrentExporterData, isSharedView } from '~/exporter/exporterViewLogic'
 import { OrganizationOAuthApplicationApi } from '~/generated/core/api.schemas'
 import { Variable } from '~/queries/nodes/DataVisualization/types'
 import {
@@ -6893,6 +6893,7 @@ async function handleFetch(url: string, method: string, fetcher: () => Promise<R
     if (!response.ok) {
         const duration = new Date().getTime() - startTime
         const pathname = new URL(url, location.origin).pathname
+        const inSharedView = isSharedView()
         // when used inside the posthog toolbar, `posthog.capture` isn't loaded
         // check if the function is available before calling it.
         if (posthog.capture) {
@@ -6901,7 +6902,13 @@ async function handleFetch(url: string, method: string, fetcher: () => Promise<R
                 method,
                 duration,
                 status: response.status,
+                is_shared_view: inSharedView,
             })
+        }
+        if (inSharedView && (response.status === 401 || response.status === 403)) {
+            console.warn(
+                `[shared-view] ${method} ${pathname} returned ${response.status} — call site should be gated with isSharedView()`
+            )
         }
 
         const data = await getJSONOrNull(response)

--- a/frontend/src/lib/components/QuickFilters/quickFiltersLogic.ts
+++ b/frontend/src/lib/components/QuickFilters/quickFiltersLogic.ts
@@ -5,6 +5,7 @@ import posthog from 'posthog-js'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
 import { QuickFilterContext } from '~/queries/schema/schema-general'
 import { QuickFilter } from '~/types'
 
@@ -37,6 +38,9 @@ export const quickFiltersLogic = kea<quickFiltersLogicType>([
             [] as QuickFilter[],
             {
                 loadQuickFilters: async () => {
+                    if (isSharedView()) {
+                        return []
+                    }
                     const response = await api.quickFilters.list(props.context)
                     return response.results
                 },

--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import api, { ApiConfig } from 'lib/api'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
 import { recentItemsModel } from '~/models/recentItemsModel'
 
 type FileSystemLogViewType =
@@ -26,7 +27,14 @@ interface TrackFileSystemLogViewOptions {
 }
 
 export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
-    if (!enabled || window.IMPERSONATED_SESSION || ref === null || ref === undefined || !ApiConfig.hasCurrentTeamId()) {
+    if (
+        !enabled ||
+        window.IMPERSONATED_SESSION ||
+        isSharedView() ||
+        ref === null ||
+        ref === undefined ||
+        !ApiConfig.hasCurrentTeamId()
+    ) {
         return
     }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
@@ -5,6 +5,8 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
+
 import { Variable } from '../../types'
 import type { variableDataLogicType } from './variableDataLogicType'
 
@@ -15,6 +17,9 @@ export const variableDataLogic = kea<variableDataLogicType>([
             [] as Variable[],
             {
                 loadVariables: async () => {
+                    if (isSharedView()) {
+                        return []
+                    }
                     const insights = await api.insightVariables.list()
                     return insights.results
                 },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -40,6 +40,7 @@ import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
@@ -1763,6 +1764,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
         updateTileColor: async ({ tileId, color }) => {
             const previousColor = values.tiles.find((tile) => tile.id === tileId)?.color
             actions.setTileProperty(tileId, { color })
+            if (isSharedView()) {
+                return
+            }
             try {
                 await api.update(`api/environments/${values.currentTeamId}/dashboards/${props.id}`, {
                     tiles: [{ id: tileId, color }],
@@ -1777,6 +1781,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const previousValue = matchingTile?.show_description
             const newValue = previousValue === false
             actions.setTileProperty(tileId, { show_description: newValue })
+            if (isSharedView()) {
+                return
+            }
             try {
                 await api.update(`api/environments/${values.currentTeamId}/dashboards/${props.id}`, {
                     tiles: [{ id: tileId, show_description: newValue }],
@@ -2366,7 +2373,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 .map((insight: QueryBasedInsightModel) => insight?.id)
                 .filter((id): id is number => !!id)
 
-            if (insightIds.length > 0 && values.currentTeamId) {
+            if (insightIds.length > 0 && values.currentTeamId && !isSharedView()) {
                 void api.create(`api/environments/${values.currentTeamId}/insights/viewed`, {
                     insight_ids: insightIds,
                 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1762,11 +1762,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
             })
         },
         updateTileColor: async ({ tileId, color }) => {
-            const previousColor = values.tiles.find((tile) => tile.id === tileId)?.color
-            actions.setTileProperty(tileId, { color })
             if (isSharedView()) {
                 return
             }
+            const previousColor = values.tiles.find((tile) => tile.id === tileId)?.color
+            actions.setTileProperty(tileId, { color })
             try {
                 await api.update(`api/environments/${values.currentTeamId}/dashboards/${props.id}`, {
                     tiles: [{ id: tileId, color }],
@@ -1777,13 +1777,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
         },
         toggleTileDescription: async ({ tileId }) => {
+            if (isSharedView()) {
+                return
+            }
             const matchingTile = values.tiles.find((tile) => tile.id === tileId)
             const previousValue = matchingTile?.show_description
             const newValue = previousValue === false
             actions.setTileProperty(tileId, { show_description: newValue })
-            if (isSharedView()) {
-                return
-            }
             try {
                 await api.update(`api/environments/${values.currentTeamId}/dashboards/${props.id}`, {
                     tiles: [{ id: tileId, show_description: newValue }],

--- a/frontend/src/scenes/insights/insightUsageLogic.ts
+++ b/frontend/src/scenes/insights/insightUsageLogic.ts
@@ -7,6 +7,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { projectLogic } from 'scenes/projectLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { Node } from '~/queries/schema/schema-general'
@@ -63,7 +64,7 @@ export const insightUsageLogic = kea<insightUsageLogicType>([
 
             // Report the insight being viewed to our '/viewed' endpoint.
             // Used for "recently viewed insights", and in insights dashboard.
-            if (values.insight.id) {
+            if (values.insight.id && !isSharedView()) {
                 void api.create(`api/environments/${values.currentProjectId}/insights/viewed`, {
                     insight_ids: [values.insight.id],
                 })

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -36,6 +36,7 @@ import {
 } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { FileSystemIconType, ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel } from '~/types'
@@ -957,6 +958,9 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
         loadPinnedTabsFromBackend: async () => {
+            if (isSharedView()) {
+                return
+            }
             try {
                 const response = await api.get<{
                     tabs?: SceneTab[]
@@ -1558,6 +1562,9 @@ export const sceneLogic = kea<sceneLogicType>([
 
     subscriptions(({ actions, values, cache }) => {
         const schedulePinnedStateSync = (): void => {
+            if (isSharedView()) {
+                return
+            }
             const pinnedTabsForPersistence = getPinnedTabsForPersistence(values.tabs)
             const homepageForPersistence = getHomepageForPersistence(values.homepage)
             const serializedPinnedState = JSON.stringify({


### PR DESCRIPTION
## Problem

Rendering a dashboard or insight in a shared/exported view (`/shared/<token>` or `/embedded/<token>`) is unauthenticated, but the frontend still kicks off a stream of API requests that can never succeed. They show up as 401/403 noise in the network tab and waste round-trips:

- `GET /api/user_home_settings/@me/` -> 401
- `POST /api/environments/{id}/file_system/log_view/` -> 401
- `GET /api/environments/{id}/insight_variables/` -> 401 (token sent, not accepted)
- `GET /api/environments/{id}/quick_filters` -> 401
- `POST /api/environments/{id}/insights/viewed/` -> 403
- `PATCH /api/environments/{id}/dashboards/{id}/` -> 401 (an actual write attempt from a read-only view)
- `PATCH /api/user_home_settings/@me/` -> 401

## Changes

### Per-callsite guards

Added a tiny `isSharedView()` helper next to the existing `getCurrentExporterData()` in `frontend/src/exporter/exporterViewLogic.ts`, and gated each call site that we know can't succeed unauthenticated:

- `sceneLogic.tsx` - skip both `loadPinnedTabsFromBackend` (GET) and the debounced `schedulePinnedStateSync` (PATCH) for `user_home_settings/@me/`.
- `useFileSystemLogView.ts` - extend the existing `IMPERSONATED_SESSION` guard to also short-circuit in shared mode.
- `variableDataLogic.ts` - return `[]` from `loadVariables` instead of hitting `insight_variables`.
- `quickFiltersLogic.ts` - return `[]` from `loadQuickFilters` instead of hitting `quick_filters`.
- `insightUsageLogic.ts` and `dashboardLogic.tsx` - skip the `insights/viewed` POST.
- `dashboardLogic.tsx` - skip the dashboard PATCH from `updateTileColor` and `toggleTileDescription`. The guards sit *above* the optimistic `setTileProperty` so a shared viewer doesn't see a phantom local change that reverts on reload.

### Centralised measurement (no behaviour change)

Considered moving the gate itself into `api.ts` per reviewer feedback, but the loaders genuinely need typed empty values (`[]`) that the API layer can't provide without forcing every caller into a `try/catch SharedViewBlockedError` shape. So the **gates** stay per-callsite, and the **measurement** is centralised:

- `frontend/src/lib/api.ts` `handleFetch` now tags the existing `client_request_failure` capture with `is_shared_view: boolean` (the event already has 10M events / 270k users instrumented, so we get an immediate graph). Pathname-by-pathname view of leaked 401/403s while in shared mode catches new leaks added by future call sites without per-callsite changes.
- A `console.warn` for 401/403 responses while `isSharedView()` is true, so leaks also surface in dev logs.

The user-edit-only PATCH paths (`saveEditModeChanges`, `removeTile`, `duplicateTile`, `moveToDashboard`, `copyToDashboard`, `setTileOverride` dialog submit) are left untouched - they aren't auto-fired and the UI shouldn't expose them in shared mode. The new telemetry will surface them if that assumption ever breaks.

## How did you test this code?

I'm an agent. I have not done manual browser testing. I ran:

- `pnpm --filter=@posthog/frontend exec oxlint` on each touched file - 0 warnings, 0 errors.
- `pnpm --filter=@posthog/frontend typescript:check` - the only failures are pre-existing (missing kea-generated `*LogicType` modules and unrelated `products/workflows` errors); none of my edits introduced new TS errors.

No automated tests added - the new behaviour is "don't make a request when this global is set", which is awkward to assert without re-mocking the exporter logic in each call-site test. The new `is_shared_view` capture property gives a production-side check.

## Publish to changelog?

no

## Docs update

Not needed.

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Trigger: user reported the list of failing requests above and asked to skip them when we know we're shared/exported.
- Decisions:
  - Reused the existing `getCurrentExporterData()` truthy-check pattern (already used by `internalMetrics.ts`, `cohortsModel.ts`, etc.) rather than threading a new prop or context through.
  - Added a one-line `isSharedView()` wrapper for readability at call sites.
  - Hoisted the guards above the optimistic `setTileProperty` calls in `updateTileColor` / `toggleTileDescription` after qa-swarm flagged it (convergent across all three reviewers) — a phantom local change that reverts on reload is worse than no change at all.
  - After reviewer pushback on Shotgun Surgery, evaluated centralising the gate in `api.ts`. Concluded it's the wrong layer (loaders need typed empty values the network layer can't provide). Centralised the *measurement* instead — single property on the existing `client_request_failure` capture covers all current and future leaks without restructuring callers.
  - Left user-edit-only loaders (`removeTile` etc.) ungated since they're only reachable via UI that shared mode shouldn't expose. The new telemetry catches it if that ever breaks.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
