### PR TITLE
Fix sandbox MCP readonly header mismatch

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -24,7 +24,7 @@ class TestGetSandboxMcpConfigs(TestCase):
             {"name": "Authorization", "value": f"Bearer {self.TOKEN}"},
             {"name": "x-posthog-project-id", "value": str(self.PROJECT_ID)},
             {"name": "x-posthog-mcp-version", "value": "2"},
-            {"name": "x-posthog-read-only", "value": str(read_only).lower()},
+            {"name": "x-posthog-readonly", "value": str(read_only).lower()},
             {"name": "x-posthog-mcp-consumer", "value": consumer},
         ]
 
@@ -143,6 +143,17 @@ class TestGetSandboxMcpConfigs(TestCase):
             mock_settings.SANDBOX_MCP_URL = None
             mock_settings.SITE_URL = ""
             assert get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID) == []
+
+    def test_uses_canonical_readonly_header_name(self) -> None:
+        with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:
+            mock_settings.SANDBOX_MCP_URL = None
+            mock_settings.SITE_URL = "https://app.posthog.com"
+
+            [config] = get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID)
+            header_names = {header["name"] for header in config.headers}
+
+            assert "x-posthog-readonly" in header_names
+            assert "x-posthog-read-only" not in header_names
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -299,7 +299,7 @@ def get_sandbox_ph_mcp_configs(
         {"name": "Authorization", "value": f"Bearer {token}"},
         {"name": "x-posthog-project-id", "value": str(project_id)},
         {"name": "x-posthog-mcp-version", "value": "2"},
-        {"name": "x-posthog-read-only", "value": str(read_only).lower()},
+        {"name": "x-posthog-readonly", "value": str(read_only).lower()},
         {"name": "x-posthog-mcp-consumer", "value": _resolve_mcp_consumer(interaction_origin)},
     ]
     return [McpServerConfig(type="http", name="posthog", url=url, headers=headers)]


### PR DESCRIPTION
## Problem
Sandbox-spawned MCP sessions were sending `x-posthog-read-only`, but the MCP server only checks `x-posthog-readonly`.

That meant the sandbox read-only hint never actually made it across the wire, so read-only sessions could end up with the full tool set if their scopes allowed it.

Closes #57268

## Changes
- switched the sandbox MCP config builder to send the canonical `x-posthog-readonly` header
- updated the existing config tests to assert the canonical header name
- added a small regression test to make sure we do not drift back to the legacy hyphenated form

## How did you test this code?
- `python3 -m py_compile products/tasks/backend/temporal/process_task/utils.py products/tasks/backend/temporal/process_task/tests/test_utils.py`
- `git diff --check`
- attempted `uv run pytest -q products/tasks/backend/temporal/process_task/tests/test_utils.py`, but this checkout does not currently have the repo's pinned Python 3.12.12 test environment available, so I could not complete the pytest run locally

## Publish to changelog?
no

## Docs update
No docs update needed.
