### PR TITLE
fix(experiments): Confirm before disabling query precomputation

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconDatabase } from '@posthog/icons'
-import { LemonButton, LemonTabs } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonTabs } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -100,7 +100,27 @@ export function QueryPerformance(): JSX.Element {
                 return (
                     <LemonSwitch
                         checked={team.experiment_precomputation_enabled}
-                        onChange={(enabled) => setPrecomputation(team.team_id, enabled)}
+                        onChange={(enabled) => {
+                            if (!enabled) {
+                                LemonDialog.open({
+                                    title: 'Disable precomputation?',
+                                    maxWidth: '30rem',
+                                    description: `Are you sure you want to disable precomputation for ${
+                                        team.team_name || `team ${team.team_id}`
+                                    }? Experiment queries will fall back to on-demand execution and may become significantly slower.`,
+                                    primaryButton: {
+                                        status: 'danger',
+                                        children: 'Disable precomputation',
+                                        onClick: () => setPrecomputation(team.team_id, false),
+                                    },
+                                    secondaryButton: {
+                                        children: 'Cancel',
+                                    },
+                                })
+                                return
+                            }
+                            setPrecomputation(team.team_id, true)
+                        }}
                     />
                 )
             },


### PR DESCRIPTION
## Problem

The Precomputation toggle in the Query performance scene disables a team's experiment query precomputation immediately on click — a single misclick switches a team back to on-demand execution.

## Changes

Toggling off now opens a `LemonDialog` confirmation. Enabling still applies immediately.

## How did you test this code?

I'm an agent. Ran `tsc --noEmit` on the frontend project — no type errors. No automated tests added; manual UI verification not performed.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code (Opus 4.7).
- Human prompt: "in the Query performance scene (for experiments), we have a section 'Precomputation' to manage precomputation. There's a toggle to do that. Pls add a dialog - we don't want to inadvertently disable this feature for a team - a confirmation dialog should always pop up".
- Decision: only confirm on disable. Enabling carries no operational risk and adding a dialog there would be friction without benefit. The user's stated concern was specifically inadvertent disabling.
- Pattern matched existing `LemonDialog.open` usage in `MaterializationStatusPanel.tsx` (danger primary, Cancel secondary).