### PR TITLE
fix(mcp): prevent 500 errors for OAuth bearer tokens

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -628,8 +628,13 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
         return None
 
     def _validate_token(self, token: str):
+        from posthog.models.oauth import find_oauth_access_token
+
         try:
-            access_token = OAuthAccessToken.objects.select_related("user").get(token=token)
+            access_token = find_oauth_access_token(token)
+
+            if access_token is None:
+                return None
 
             if access_token.is_expired():
                 raise AuthenticationFailed(detail="Access token has expired.")
@@ -645,8 +650,6 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
 
             return access_token
 
-        except OAuthAccessToken.DoesNotExist:
-            return None
         except AuthenticationFailed:
             raise
         except Exception:

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -130,11 +130,27 @@ const onCatchErrorHandler = async (
     return new Response('Internal server error', { status: 500 })
 }
 
+const AUTH_ERROR_PATTERNS = [
+    'Access token has expired',
+    'access token is disabled',
+    'access token not found',
+    'Failed to validate access token',
+    'Authentication credentials were not provided',
+]
+
 const generateErrorResponseFromMessage = (message: string): Response | null => {
     if (message.includes(ErrorCode.INACTIVE_OAUTH_TOKEN)) {
         return new Response('OAuth token is inactive', { status: 401 })
     } else if (message.includes(ErrorCode.INVALID_API_KEY)) {
         return new Response('Invalid API key', { status: 401 })
+    }
+
+    if (AUTH_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
+        return new Response('Authentication failed', { status: 401 })
+    }
+
+    if (message.includes('Rate limit exceeded')) {
+        return new Response('Rate limited', { status: 429 })
     }
 
     return null

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -103,46 +103,56 @@ export class StateManager {
         organizationId?: string
         projectId?: number
     }> {
-        const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([this.getApiKey(), this.getUser()])
-        const { organization: activeOrganization, team: activeTeam } = user
-
-        // Team-scoped key: prefer the active team if the scope allows it,
-        // otherwise pick the first scoped team deterministically. The org is
-        // omitted here — `getAnalyticsContext` recovers it from the project.
-        if (scoped_teams.length > 0) {
-            if (scoped_teams.includes(activeTeam.id)) {
-                return { projectId: activeTeam.id }
-            }
-            return { projectId: scoped_teams[0]! }
-        }
-
-        // No team scoping: prefer the user's active org/team when the scope
-        // allows it.
-        if (scoped_organizations.length === 0 || scoped_organizations.includes(activeOrganization.id)) {
-            return { organizationId: activeOrganization.id, projectId: activeTeam.id }
-        }
-
-        // Active org isn't in the scope. Pick the first allowed org and fall
-        // back to its first project. If the project lookup fails or the org has
-        // no projects, return the org alone and let the agent disambiguate.
-        const organizationId = scoped_organizations[0]!
         try {
-            const projectsResult = await this._api.organizations().projects({ orgId: organizationId }).list()
-            if (projectsResult.success && projectsResult.data.length > 0) {
-                return { organizationId, projectId: Number(projectsResult.data[0]!) }
+            const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([this.getApiKey(), this.getUser()])
+            const activeOrganization = user.organization ?? undefined
+            const activeTeam = user.team ?? undefined
+
+            // Team-scoped key: prefer the active team if the scope allows it,
+            // otherwise pick the first scoped team deterministically. The org is
+            // omitted here — `getAnalyticsContext` recovers it from the project.
+            if (scoped_teams.length > 0) {
+                if (activeTeam && scoped_teams.includes(activeTeam.id)) {
+                    return { projectId: activeTeam.id }
+                }
+                return { projectId: scoped_teams[0]! }
             }
-            if (!projectsResult.success) {
-                this._reportException(projectsResult.error, 'default_org_project_projects_list_failed', {
+
+            if (!activeOrganization || !activeTeam) {
+                return {}
+            }
+
+            // No team scoping: prefer the user's active org/team when the scope
+            // allows it.
+            if (scoped_organizations.length === 0 || scoped_organizations.includes(activeOrganization.id)) {
+                return { organizationId: activeOrganization.id, projectId: activeTeam.id }
+            }
+
+            // Active org isn't in the scope. Pick the first allowed org and fall
+            // back to its first project. If the project lookup fails or the org has
+            // no projects, return the org alone and let the agent disambiguate.
+            const organizationId = scoped_organizations[0]!
+            try {
+                const projectsResult = await this._api.organizations().projects({ orgId: organizationId }).list()
+                if (projectsResult.success && projectsResult.data.length > 0) {
+                    return { organizationId, projectId: Number(projectsResult.data[0]!) }
+                }
+                if (!projectsResult.success) {
+                    this._reportException(projectsResult.error, 'default_org_project_projects_list_failed', {
+                        organization_id: organizationId,
+                    })
+                }
+            } catch (error) {
+                this._reportException(error, 'default_org_project_projects_list_threw', {
                     organization_id: organizationId,
                 })
             }
-        } catch (error) {
-            this._reportException(error, 'default_org_project_projects_list_threw', {
-                organization_id: organizationId,
-            })
-        }
 
-        return { organizationId }
+            return { organizationId }
+        } catch (error) {
+            this._reportException(error, 'default_org_project_resolution_failed')
+            return {}
+        }
     }
 
     private _reportException(error: unknown, context: string, extra: Record<string, unknown> = {}): void {


### PR DESCRIPTION
## Problem

OAuth bearer tokens (from Claude Code plugin SSO) cause HTTP 500 on every `POST /mcp` request, while Personal API Key bearer tokens work fine on the same endpoint. This blocks all OAuth-based MCP usage.

The regression was introduced in `673d45bdb5b` (Apr 23, "fix(mcp): initialization of project and org ids"), which rewrote `StateManager._getDefaultOrganizationAndProject` and removed null guards on `user.organization` and `user.team`.

Root cause has two parts:

1. **MCP service (`services/mcp/src/lib/StateManager.ts`):** `getDefaultOrganizationAndProject` destructures `user.organization` and `user.team` without null checks, then accesses `.id` on them. For OAuth-authenticated users, these can be null (unlike Personal API Key users who always have an active project context). This causes a TypeError that propagates unhandled → 500.

2. **MCP service (`services/mcp/src/index.ts`):** Authentication errors from the Django backend were not mapped to proper HTTP status codes — they bubbled up as unhandled 500s instead of 401s.

3. **Backend (`posthog/auth.py`):** `OAuthAccessTokenAuthentication._validate_token` looked up tokens with `.get(token=token)` (unindexed TextField scan) instead of the canonical `find_oauth_access_token()` (indexed `token_checksum` lookup) that every other OAuth consumer in the codebase uses.

## Changes

- **`services/mcp/src/lib/StateManager.ts`**: Defensively handle `null` organization/team on the user object, and wrap the entire resolution in a try/catch so failures degrade gracefully (empty context) rather than crashing the request.
- **`services/mcp/src/index.ts`**: Map known authentication error messages to 401 responses and rate-limit errors to 429, instead of letting them fall through to 500.
- **`posthog/auth.py`**: Use `find_oauth_access_token()` (indexed checksum lookup) instead of a raw ORM `.get(token=token)`. Return `None` on not-found instead of catching `DoesNotExist`.

## How did you test this code?

Verified that `find_oauth_access_token` is the same function used by other OAuth consumers in the codebase (`agentic_provisioning`, `github` integration, `views.py`). The MCP error mapping changes are straightforward string-match → status-code mappings. The StateManager change adds null checks and a top-level catch that reports exceptions and returns an empty object.

## 🤖 Agent context

- Agent: Claude Code (Opus), prompted by Vojta
- Key prompt: investigate and fix the OAuth 500 support ticket for MCP
- Root cause identified by tracing the MCP request flow and correlating with the Apr 23 StateManager refactor that dropped null guards