### PR TITLE
chore: Remove MSK producer

### DIFF
--- a/nodejs/src/cdp/outputs/producer-registry.ts
+++ b/nodejs/src/cdp/outputs/producer-registry.ts
@@ -1,7 +1,5 @@
 import { KafkaProducerRegistryBuilder } from '../../ingestion/outputs/kafka-producer-registry-builder'
 import {
-    MSK_PRODUCER,
-    MSK_PRODUCER_CONFIG_MAP,
     WAREHOUSE_PRODUCER,
     WAREHOUSE_PRODUCER_CONFIG_MAP,
     WARPSTREAM_CALCULATED_EVENTS_PRODUCER,
@@ -24,8 +22,6 @@ import {
  *   batch hogflow request enqueue. Distinct env-var prefix from the legacy
  *   `KAFKA_CDP_PRODUCER_*` so output routing is decoupled from the cyclotron
  *   job queue's own producer.
- * - `MSK_PRODUCER` — legacy MSK cluster. Retained for outputs that historically
- *   used the default `KafkaProducerWrapper` and still need MSK destinations.
  * - `WAREHOUSE_PRODUCER` — dedicated cluster for warehouse source webhooks.
  */
 export function createCdpProducerRegistry(kafkaClientRack: string | undefined) {
@@ -33,6 +29,5 @@ export function createCdpProducerRegistry(kafkaClientRack: string | undefined) {
         .register(WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_INGESTION_PRODUCER_CONFIG_MAP)
         .register(WARPSTREAM_CALCULATED_EVENTS_PRODUCER, WARPSTREAM_CALCULATED_EVENTS_PRODUCER_CONFIG_MAP)
         .register(WARPSTREAM_CYCLOTRON_PRODUCER, WARPSTREAM_CYCLOTRON_PRODUCER_CONFIG_MAP)
-        .register(MSK_PRODUCER, MSK_PRODUCER_CONFIG_MAP)
         .register(WAREHOUSE_PRODUCER, WAREHOUSE_PRODUCER_CONFIG_MAP)
 }

--- a/nodejs/src/cdp/outputs/producers.ts
+++ b/nodejs/src/cdp/outputs/producers.ts
@@ -7,10 +7,6 @@
  */
 import { AllowedConfigKey } from '../../ingestion/outputs/kafka-producer-config'
 
-/** Targets the legacy MSK cluster. Default CDP cluster for every output that isn't monitoring/warehouse. */
-export const MSK_PRODUCER = 'MSK_PRODUCER' as const
-export type MskProducer = typeof MSK_PRODUCER
-
 /** Targets the shared Warpstream cluster used by ingestion. Current default for CDP. */
 export const WARPSTREAM_INGESTION_PRODUCER = 'WARPSTREAM_INGESTION_PRODUCER' as const
 export type WarpstreamIngestionProducer = typeof WARPSTREAM_INGESTION_PRODUCER
@@ -37,35 +33,10 @@ export type WarpstreamCyclotronProducer = typeof WARPSTREAM_CYCLOTRON_PRODUCER
 
 /** Producer names registered by the CDP deployments. */
 export type CdpProducerName =
-    | MskProducer
     | WarpstreamIngestionProducer
     | WarehouseProducer
     | WarpstreamCalculatedEventsProducer
     | WarpstreamCyclotronProducer
-
-/** Cluster-named env var prefix mirroring the producer it configures. */
-export const MSK_PRODUCER_CONFIG_MAP = {
-    'client.id': 'KAFKA_MSK_PRODUCER_CLIENT_ID',
-    'metadata.broker.list': 'KAFKA_MSK_PRODUCER_METADATA_BROKER_LIST',
-    'security.protocol': 'KAFKA_MSK_PRODUCER_SECURITY_PROTOCOL',
-    'sasl.mechanisms': 'KAFKA_MSK_PRODUCER_SASL_MECHANISMS',
-    'sasl.username': 'KAFKA_MSK_PRODUCER_SASL_USERNAME',
-    'sasl.password': 'KAFKA_MSK_PRODUCER_SASL_PASSWORD',
-    'compression.codec': 'KAFKA_MSK_PRODUCER_COMPRESSION_CODEC',
-    'linger.ms': 'KAFKA_MSK_PRODUCER_LINGER_MS',
-    'batch.size': 'KAFKA_MSK_PRODUCER_BATCH_SIZE',
-    'queue.buffering.max.messages': 'KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES',
-    'queue.buffering.max.kbytes': 'KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_KBYTES',
-    'enable.ssl.certificate.verification': 'KAFKA_MSK_PRODUCER_ENABLE_SSL_CERTIFICATE_VERIFICATION',
-    'enable.idempotence': 'KAFKA_MSK_PRODUCER_ENABLE_IDEMPOTENCE',
-    'message.max.bytes': 'KAFKA_MSK_PRODUCER_MESSAGE_MAX_BYTES',
-    'batch.num.messages': 'KAFKA_MSK_PRODUCER_BATCH_NUM_MESSAGES',
-    'sticky.partitioning.linger.ms': 'KAFKA_MSK_PRODUCER_STICKY_PARTITIONING_LINGER_MS',
-    'topic.metadata.refresh.interval.ms': 'KAFKA_MSK_PRODUCER_TOPIC_METADATA_REFRESH_INTERVAL_MS',
-    'metadata.max.age.ms': 'KAFKA_MSK_PRODUCER_METADATA_MAX_AGE_MS',
-    'message.send.max.retries': 'KAFKA_MSK_PRODUCER_RETRIES',
-    'max.in.flight.requests.per.connection': 'KAFKA_MSK_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION',
-} as const satisfies Partial<Record<AllowedConfigKey, string>>
 
 /** Cluster-named env var prefix mirroring the producer it configures. */
 export const WARPSTREAM_INGESTION_PRODUCER_CONFIG_MAP = {
@@ -91,55 +62,6 @@ export const WARPSTREAM_INGESTION_PRODUCER_CONFIG_MAP = {
     'max.in.flight.requests.per.connection':
         'KAFKA_WARPSTREAM_INGESTION_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION',
 } as const satisfies Partial<Record<AllowedConfigKey, string>>
-
-/** Typed env vars referenced by `MSK_PRODUCER_CONFIG_MAP`. */
-export type KafkaMskProducerEnvConfig = {
-    KAFKA_MSK_PRODUCER_CLIENT_ID: string
-    KAFKA_MSK_PRODUCER_METADATA_BROKER_LIST: string
-    KAFKA_MSK_PRODUCER_SECURITY_PROTOCOL: string
-    KAFKA_MSK_PRODUCER_SASL_MECHANISMS: string
-    KAFKA_MSK_PRODUCER_SASL_USERNAME: string
-    KAFKA_MSK_PRODUCER_SASL_PASSWORD: string
-    KAFKA_MSK_PRODUCER_COMPRESSION_CODEC: string
-    KAFKA_MSK_PRODUCER_LINGER_MS: string
-    KAFKA_MSK_PRODUCER_BATCH_SIZE: string
-    KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: string
-    KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_KBYTES: string
-    KAFKA_MSK_PRODUCER_ENABLE_SSL_CERTIFICATE_VERIFICATION: string
-    KAFKA_MSK_PRODUCER_ENABLE_IDEMPOTENCE: string
-    KAFKA_MSK_PRODUCER_MESSAGE_MAX_BYTES: string
-    KAFKA_MSK_PRODUCER_BATCH_NUM_MESSAGES: string
-    KAFKA_MSK_PRODUCER_STICKY_PARTITIONING_LINGER_MS: string
-    KAFKA_MSK_PRODUCER_TOPIC_METADATA_REFRESH_INTERVAL_MS: string
-    KAFKA_MSK_PRODUCER_METADATA_MAX_AGE_MS: string
-    KAFKA_MSK_PRODUCER_RETRIES: string
-    KAFKA_MSK_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION: string
-}
-
-export function getDefaultKafkaMskProducerEnvConfig(): KafkaMskProducerEnvConfig {
-    return {
-        KAFKA_MSK_PRODUCER_CLIENT_ID: '',
-        KAFKA_MSK_PRODUCER_METADATA_BROKER_LIST: '',
-        KAFKA_MSK_PRODUCER_SECURITY_PROTOCOL: '',
-        KAFKA_MSK_PRODUCER_SASL_MECHANISMS: '',
-        KAFKA_MSK_PRODUCER_SASL_USERNAME: '',
-        KAFKA_MSK_PRODUCER_SASL_PASSWORD: '',
-        KAFKA_MSK_PRODUCER_COMPRESSION_CODEC: '',
-        KAFKA_MSK_PRODUCER_LINGER_MS: '',
-        KAFKA_MSK_PRODUCER_BATCH_SIZE: '',
-        KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: '',
-        KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_KBYTES: '',
-        KAFKA_MSK_PRODUCER_ENABLE_SSL_CERTIFICATE_VERIFICATION: '',
-        KAFKA_MSK_PRODUCER_ENABLE_IDEMPOTENCE: '',
-        KAFKA_MSK_PRODUCER_MESSAGE_MAX_BYTES: '',
-        KAFKA_MSK_PRODUCER_BATCH_NUM_MESSAGES: '',
-        KAFKA_MSK_PRODUCER_STICKY_PARTITIONING_LINGER_MS: '',
-        KAFKA_MSK_PRODUCER_TOPIC_METADATA_REFRESH_INTERVAL_MS: '',
-        KAFKA_MSK_PRODUCER_METADATA_MAX_AGE_MS: '',
-        KAFKA_MSK_PRODUCER_RETRIES: '',
-        KAFKA_MSK_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION: '',
-    }
-}
 
 /** Typed env vars referenced by `WARPSTREAM_INGESTION_PRODUCER_CONFIG_MAP`. */
 export type KafkaWarpstreamIngestionProducerEnvConfig = {

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -1,6 +1,5 @@
 import { getDefaultCdpConfig } from '../cdp/config'
 import {
-    getDefaultKafkaMskProducerEnvConfig,
     getDefaultKafkaWarehouseProducerEnvConfig,
     getDefaultKafkaWarpstreamCalculatedEventsProducerEnvConfig,
     getDefaultKafkaWarpstreamCyclotronProducerEnvConfig,
@@ -34,7 +33,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         ...getDefaultErrorTrackingConsumerConfig(),
         ...getDefaultSessionRecordingConfig(),
         ...getDefaultSessionRecordingApiConfig(),
-        ...getDefaultKafkaMskProducerEnvConfig(),
         ...getDefaultKafkaWarpstreamIngestionProducerEnvConfig(),
         ...getDefaultKafkaWarpstreamCalculatedEventsProducerEnvConfig(),
         ...getDefaultKafkaWarpstreamCyclotronProducerEnvConfig(),

--- a/nodejs/src/logs-ingestion/outputs/producer-registry.ts
+++ b/nodejs/src/logs-ingestion/outputs/producer-registry.ts
@@ -1,7 +1,5 @@
 import { KafkaProducerRegistryBuilder } from '../../ingestion/outputs/kafka-producer-registry-builder'
 import {
-    MSK_PRODUCER,
-    MSK_PRODUCER_CONFIG_MAP,
     WARPSTREAM_INGESTION_PRODUCER,
     WARPSTREAM_INGESTION_PRODUCER_CONFIG_MAP,
     WARPSTREAM_LOGS_PRODUCER,
@@ -12,14 +10,11 @@ import {
  * Producers used by the logs/traces ingestion deployments.
  *
  * - `WARPSTREAM_LOGS_PRODUCER` — main log/trace data path (Warpstream logs cluster).
- * - `MSK_PRODUCER` — current default destination for app_metrics rows.
- * - `WARPSTREAM_INGESTION_PRODUCER` — alternate destination for app_metrics,
- *    enabled by setting `LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER` to flip
- *    the route off MSK and onto the shared ingestion Warpstream cluster.
+ * - `WARPSTREAM_INGESTION_PRODUCER` — destination for app_metrics rows on the
+ *    shared ingestion Warpstream cluster.
  */
 export function createProducerRegistry(kafkaClientRack: string | undefined) {
     return new KafkaProducerRegistryBuilder(kafkaClientRack)
         .register(WARPSTREAM_LOGS_PRODUCER, WARPSTREAM_LOGS_PRODUCER_CONFIG_MAP)
-        .register(MSK_PRODUCER, MSK_PRODUCER_CONFIG_MAP)
         .register(WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_INGESTION_PRODUCER_CONFIG_MAP)
 }

--- a/nodejs/src/logs-ingestion/outputs/producers.ts
+++ b/nodejs/src/logs-ingestion/outputs/producers.ts
@@ -8,101 +8,18 @@
 import { AllowedConfigKey } from '../../ingestion/outputs/kafka-producer-config'
 
 /**
- * Targets the legacy MSK cluster — used to write usage metrics back to
- * `clickhouse_app_metrics2` even though the main data path runs on Warpstream.
- */
-export const MSK_PRODUCER = 'MSK_PRODUCER' as const
-export type MskProducer = typeof MSK_PRODUCER
-
-/**
  * Targets the Warpstream cluster dedicated to logs/traces. The main log/trace
  * data path produces here.
  */
 export const WARPSTREAM_LOGS_PRODUCER = 'WARPSTREAM_LOGS_PRODUCER' as const
 export type WarpstreamLogsProducer = typeof WARPSTREAM_LOGS_PRODUCER
 
-/**
- * Targets the Warpstream cluster shared with the rest of ingestion. App
- * metrics will migrate from `MSK_PRODUCER` to here once routed via env var.
- */
+/** Targets the Warpstream cluster shared with the rest of ingestion. App metrics produce here. */
 export const WARPSTREAM_INGESTION_PRODUCER = 'WARPSTREAM_INGESTION_PRODUCER' as const
 export type WarpstreamIngestionProducer = typeof WARPSTREAM_INGESTION_PRODUCER
 
 /** Producer names registered by the logs/traces deployments. */
-export type LogsProducerName = MskProducer | WarpstreamLogsProducer | WarpstreamIngestionProducer
-
-/** Cluster-named env var prefix mirroring the producer it configures. */
-export const MSK_PRODUCER_CONFIG_MAP = {
-    'client.id': 'KAFKA_MSK_PRODUCER_CLIENT_ID',
-    'metadata.broker.list': 'KAFKA_MSK_PRODUCER_METADATA_BROKER_LIST',
-    'security.protocol': 'KAFKA_MSK_PRODUCER_SECURITY_PROTOCOL',
-    'sasl.mechanisms': 'KAFKA_MSK_PRODUCER_SASL_MECHANISMS',
-    'sasl.username': 'KAFKA_MSK_PRODUCER_SASL_USERNAME',
-    'sasl.password': 'KAFKA_MSK_PRODUCER_SASL_PASSWORD',
-    'compression.codec': 'KAFKA_MSK_PRODUCER_COMPRESSION_CODEC',
-    'linger.ms': 'KAFKA_MSK_PRODUCER_LINGER_MS',
-    'batch.size': 'KAFKA_MSK_PRODUCER_BATCH_SIZE',
-    'queue.buffering.max.messages': 'KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES',
-    'queue.buffering.max.kbytes': 'KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_KBYTES',
-    'enable.ssl.certificate.verification': 'KAFKA_MSK_PRODUCER_ENABLE_SSL_CERTIFICATE_VERIFICATION',
-    'enable.idempotence': 'KAFKA_MSK_PRODUCER_ENABLE_IDEMPOTENCE',
-    'message.max.bytes': 'KAFKA_MSK_PRODUCER_MESSAGE_MAX_BYTES',
-    'batch.num.messages': 'KAFKA_MSK_PRODUCER_BATCH_NUM_MESSAGES',
-    'sticky.partitioning.linger.ms': 'KAFKA_MSK_PRODUCER_STICKY_PARTITIONING_LINGER_MS',
-    'topic.metadata.refresh.interval.ms': 'KAFKA_MSK_PRODUCER_TOPIC_METADATA_REFRESH_INTERVAL_MS',
-    'metadata.max.age.ms': 'KAFKA_MSK_PRODUCER_METADATA_MAX_AGE_MS',
-    'message.send.max.retries': 'KAFKA_MSK_PRODUCER_RETRIES',
-    'max.in.flight.requests.per.connection': 'KAFKA_MSK_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION',
-} as const satisfies Partial<Record<AllowedConfigKey, string>>
-
-/** Typed env vars referenced by `MSK_PRODUCER_CONFIG_MAP`. */
-export type KafkaMskProducerEnvConfig = {
-    KAFKA_MSK_PRODUCER_CLIENT_ID: string
-    KAFKA_MSK_PRODUCER_METADATA_BROKER_LIST: string
-    KAFKA_MSK_PRODUCER_SECURITY_PROTOCOL: string
-    KAFKA_MSK_PRODUCER_SASL_MECHANISMS: string
-    KAFKA_MSK_PRODUCER_SASL_USERNAME: string
-    KAFKA_MSK_PRODUCER_SASL_PASSWORD: string
-    KAFKA_MSK_PRODUCER_COMPRESSION_CODEC: string
-    KAFKA_MSK_PRODUCER_LINGER_MS: string
-    KAFKA_MSK_PRODUCER_BATCH_SIZE: string
-    KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: string
-    KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_KBYTES: string
-    KAFKA_MSK_PRODUCER_ENABLE_SSL_CERTIFICATE_VERIFICATION: string
-    KAFKA_MSK_PRODUCER_ENABLE_IDEMPOTENCE: string
-    KAFKA_MSK_PRODUCER_MESSAGE_MAX_BYTES: string
-    KAFKA_MSK_PRODUCER_BATCH_NUM_MESSAGES: string
-    KAFKA_MSK_PRODUCER_STICKY_PARTITIONING_LINGER_MS: string
-    KAFKA_MSK_PRODUCER_TOPIC_METADATA_REFRESH_INTERVAL_MS: string
-    KAFKA_MSK_PRODUCER_METADATA_MAX_AGE_MS: string
-    KAFKA_MSK_PRODUCER_RETRIES: string
-    KAFKA_MSK_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION: string
-}
-
-export function getDefaultKafkaMskProducerEnvConfig(): KafkaMskProducerEnvConfig {
-    return {
-        KAFKA_MSK_PRODUCER_CLIENT_ID: '',
-        KAFKA_MSK_PRODUCER_METADATA_BROKER_LIST: '',
-        KAFKA_MSK_PRODUCER_SECURITY_PROTOCOL: '',
-        KAFKA_MSK_PRODUCER_SASL_MECHANISMS: '',
-        KAFKA_MSK_PRODUCER_SASL_USERNAME: '',
-        KAFKA_MSK_PRODUCER_SASL_PASSWORD: '',
-        KAFKA_MSK_PRODUCER_COMPRESSION_CODEC: '',
-        KAFKA_MSK_PRODUCER_LINGER_MS: '',
-        KAFKA_MSK_PRODUCER_BATCH_SIZE: '',
-        KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: '',
-        KAFKA_MSK_PRODUCER_QUEUE_BUFFERING_MAX_KBYTES: '',
-        KAFKA_MSK_PRODUCER_ENABLE_SSL_CERTIFICATE_VERIFICATION: '',
-        KAFKA_MSK_PRODUCER_ENABLE_IDEMPOTENCE: '',
-        KAFKA_MSK_PRODUCER_MESSAGE_MAX_BYTES: '',
-        KAFKA_MSK_PRODUCER_BATCH_NUM_MESSAGES: '',
-        KAFKA_MSK_PRODUCER_STICKY_PARTITIONING_LINGER_MS: '',
-        KAFKA_MSK_PRODUCER_TOPIC_METADATA_REFRESH_INTERVAL_MS: '',
-        KAFKA_MSK_PRODUCER_METADATA_MAX_AGE_MS: '',
-        KAFKA_MSK_PRODUCER_RETRIES: '',
-        KAFKA_MSK_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION: '',
-    }
-}
+export type LogsProducerName = WarpstreamLogsProducer | WarpstreamIngestionProducer
 
 /** Cluster-named env var prefix mirroring the producer it configures. */
 export const WARPSTREAM_LOGS_PRODUCER_CONFIG_MAP = {

--- a/nodejs/src/servers/ingestion-logs-server.ts
+++ b/nodejs/src/servers/ingestion-logs-server.ts
@@ -13,11 +13,9 @@ import {
 import { LogsIngestionConsumer } from '../logs-ingestion/logs-ingestion-consumer'
 import { createProducerRegistry } from '../logs-ingestion/outputs/producer-registry'
 import {
-    KafkaMskProducerEnvConfig,
     KafkaWarpstreamIngestionProducerEnvConfig,
     KafkaWarpstreamLogsProducerEnvConfig,
     LogsProducerName,
-    getDefaultKafkaMskProducerEnvConfig,
     getDefaultKafkaWarpstreamIngestionProducerEnvConfig,
     getDefaultKafkaWarpstreamLogsProducerEnvConfig,
 } from '../logs-ingestion/outputs/producers'
@@ -37,7 +35,7 @@ import { BaseServerConfig, CleanupResources, NodeServer, ServerLifecycle } from 
  * - BaseServerConfig: HTTP server, profiling, pod termination lifecycle
  * - LogsIngestionConsumerConfig: Kafka topics, Redis, rate limiter settings
  * - LogsIngestionOutputsConfig: per-output topic + producer routing
- * - Producer env configs: typed env vars for the DEFAULT + MSK producers
+ * - Producer env configs: typed env vars for the Warpstream logs + ingestion producers
  * - Infrastructure configs: Kafka broker, Postgres, Redis
  * - Remaining CommonConfig picks: server mode, observability
  */
@@ -45,7 +43,6 @@ export type IngestionLogsServerConfig = BaseServerConfig &
     LogsIngestionConsumerConfig &
     LogsIngestionOutputsConfig &
     KafkaWarpstreamLogsProducerEnvConfig &
-    KafkaMskProducerEnvConfig &
     KafkaWarpstreamIngestionProducerEnvConfig &
     KafkaBrokerConfig &
     DatabaseConnectionConfig &
@@ -64,7 +61,6 @@ export class IngestionLogsServer implements NodeServer {
         this.config = {
             ...defaultConfig,
             ...overrideConfigWithEnv(getDefaultKafkaWarpstreamLogsProducerEnvConfig()),
-            ...overrideConfigWithEnv(getDefaultKafkaMskProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaWarpstreamIngestionProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultLogsIngestionOutputsConfig()),
             ...config,

--- a/nodejs/src/servers/ingestion-traces-server.ts
+++ b/nodejs/src/servers/ingestion-traces-server.ts
@@ -13,11 +13,9 @@ import {
 } from '../logs-ingestion/config'
 import { createProducerRegistry } from '../logs-ingestion/outputs/producer-registry'
 import {
-    KafkaMskProducerEnvConfig,
     KafkaWarpstreamIngestionProducerEnvConfig,
     KafkaWarpstreamLogsProducerEnvConfig,
     LogsProducerName,
-    getDefaultKafkaMskProducerEnvConfig,
     getDefaultKafkaWarpstreamIngestionProducerEnvConfig,
     getDefaultKafkaWarpstreamLogsProducerEnvConfig,
 } from '../logs-ingestion/outputs/producers'
@@ -38,7 +36,7 @@ import { BaseServerConfig, CleanupResources, NodeServer, ServerLifecycle } from 
  * - LogsIngestionConsumerConfig: base consumer config (traces reuses the logs consumer)
  * - TracesIngestionConsumerConfig: traces-specific Kafka topics, Redis, rate limiter settings
  * - LogsIngestionOutputsConfig: per-output topic + producer routing
- * - Producer env configs: typed env vars for the DEFAULT + MSK producers
+ * - Producer env configs: typed env vars for the Warpstream logs + ingestion producers
  * - Infrastructure configs: Kafka broker, Postgres, Redis
  * - Remaining CommonConfig picks: server mode, observability
  */
@@ -47,7 +45,6 @@ export type IngestionTracesServerConfig = BaseServerConfig &
     TracesIngestionConsumerConfig &
     LogsIngestionOutputsConfig &
     KafkaWarpstreamLogsProducerEnvConfig &
-    KafkaMskProducerEnvConfig &
     KafkaWarpstreamIngestionProducerEnvConfig &
     KafkaBrokerConfig &
     DatabaseConnectionConfig &
@@ -66,7 +63,6 @@ export class IngestionTracesServer implements NodeServer {
         this.config = {
             ...defaultConfig,
             ...overrideConfigWithEnv(getDefaultKafkaWarpstreamLogsProducerEnvConfig()),
-            ...overrideConfigWithEnv(getDefaultKafkaMskProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaWarpstreamIngestionProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultLogsIngestionOutputsConfig()),
             ...config,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -8,7 +8,6 @@ import { Element, PluginEvent, Properties } from '~/plugin-scaffold'
 
 import type { CdpConfig } from './cdp/config'
 import type {
-    KafkaMskProducerEnvConfig,
     KafkaWarehouseProducerEnvConfig,
     KafkaWarpstreamCalculatedEventsProducerEnvConfig,
     KafkaWarpstreamCyclotronProducerEnvConfig,
@@ -121,7 +120,6 @@ export interface PluginsServerConfig
         SessionRecordingConfig,
         SessionRecordingApiConfig,
         // Producer envs needed by the CDP producer registry the legacy big server builds.
-        KafkaMskProducerEnvConfig,
         KafkaWarpstreamIngestionProducerEnvConfig,
         KafkaWarpstreamCalculatedEventsProducerEnvConfig,
         KafkaWarpstreamCyclotronProducerEnvConfig,

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -4,7 +4,6 @@ import { CdpConsumerBaseDeps } from '../../src/cdp/consumers/cdp-base.consumer'
 import { CdpLegacyEventsConsumerDeps } from '../../src/cdp/consumers/cdp-legacy-event.consumer'
 import {
     CdpProducerName,
-    MSK_PRODUCER,
     WAREHOUSE_PRODUCER,
     WARPSTREAM_CALCULATED_EVENTS_PRODUCER,
     WARPSTREAM_CYCLOTRON_PRODUCER,
@@ -28,7 +27,6 @@ function buildTestCdpProducerRegistry(
         [WARPSTREAM_INGESTION_PRODUCER]: kafkaProducer,
         [WARPSTREAM_CALCULATED_EVENTS_PRODUCER]: kafkaProducer,
         [WARPSTREAM_CYCLOTRON_PRODUCER]: kafkaProducer,
-        [MSK_PRODUCER]: kafkaProducer,
         [WAREHOUSE_PRODUCER]: kafkaProducer,
     })
 }


### PR DESCRIPTION
## Problem

The MSKProducer is no longer used by cdp and ingestion-logs, but its presence in the code forces the env vars to exist. Removing it so that we can remove associated MSK env variables

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
