### PR TITLE
fix(experiments): Defer metric tooltip close only when moving toward it

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -118,7 +118,7 @@ interface CollapsibleBreakdownSectionProps {
     onRetry: () => void
     query?: Record<string, any>
     handleTooltipMouseEnter: (e: React.MouseEvent, variantResult: ExperimentVariantResult) => void
-    handleTooltipMouseLeave: () => void
+    handleTooltipMouseLeave: (e: React.MouseEvent) => void
     handleTooltipMouseMove: (e: React.MouseEvent, variantResult: ExperimentVariantResult) => void
 }
 
@@ -534,6 +534,28 @@ export function MetricRowGroup({
         }
     }
 
+    const hideTooltipState = (): void => {
+        setTooltipState((prev) => ({
+            ...prev,
+            isVisible: false,
+            variantResult: null,
+            isPositioned: false,
+        }))
+    }
+
+    const scheduleTooltipClose = (): void => {
+        clearTooltipCloseTimer()
+        tooltipCloseTimerRef.current = setTimeout(() => {
+            tooltipCloseTimerRef.current = null
+            hideTooltipState()
+        }, 150)
+    }
+
+    const closeTooltipNow = (): void => {
+        clearTooltipCloseTimer()
+        hideTooltipState()
+    }
+
     useEffect(() => {
         return () => {
             clearTooltipCloseTimer()
@@ -612,18 +634,17 @@ export function MetricRowGroup({
         })
     }
 
-    // Defer closing so the user can move onto the portaled tooltip without it disappearing.
-    const handleTooltipMouseLeave = (): void => {
-        clearTooltipCloseTimer()
-        tooltipCloseTimerRef.current = setTimeout(() => {
-            tooltipCloseTimerRef.current = null
-            setTooltipState((prev) => ({
-                ...prev,
-                isVisible: false,
-                variantResult: null,
-                isPositioned: false,
-            }))
-        }, 150)
+    // The portaled tooltip sits above the row. Defer closing only when the cursor
+    // exits upward (toward the tooltip) so the click affordance is reachable.
+    // Sideways or downward exits — i.e. moving to another variant row — close
+    // immediately so row-to-row transitions stay snappy.
+    const handleTooltipMouseLeave = (e: React.MouseEvent): void => {
+        const rect = e.currentTarget.getBoundingClientRect()
+        if (e.clientY <= rect.top + 1) {
+            scheduleTooltipClose()
+        } else {
+            closeTooltipNow()
+        }
     }
 
     const handleTooltipMouseMove = (e: React.MouseEvent, variantResult: ExperimentVariantResult): void => {
@@ -755,7 +776,15 @@ export function MetricRowGroup({
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
                         onMouseEnter={clearTooltipCloseTimer}
-                        onMouseLeave={handleTooltipMouseLeave}
+                        onMouseLeave={(e) => {
+                            // Defer only when leaving downward — toward a row that may pick the tooltip back up.
+                            const rect = e.currentTarget.getBoundingClientRect()
+                            if (e.clientY >= rect.bottom - 1) {
+                                scheduleTooltipClose()
+                            } else {
+                                closeTooltipNow()
+                            }
+                        }}
                         onClick={
                             timeseriesEnabled && tooltipState.variantResult
                                 ? () => handleTimeseriesClick(tooltipState.variantResult!)


### PR DESCRIPTION
## Problem

Following #57598, hovering between variant rows felt sticky and laggy because the tooltip waited 150 ms before closing on every row exit. The deferred close was only ever needed for the narrow case of moving the cursor onto the portaled tooltip itself.

## Changes

In `MetricRowGroup.tsx`, branch on the `mouseLeave` direction:

- On a row, defer the close only if the cursor exits *upward* (toward the tooltip). Sideways or downward exits — variant-to-variant transitions, leaving the table — close immediately.
- On the tooltip, defer only if the cursor exits *downward* (back toward a row). Anywhere else closes immediately.

Extracted `scheduleTooltipClose` / `closeTooltipNow` helpers around the existing close-timer ref.

## How did you test this code?

I'm an agent. Verified the project's TypeScript check reports no new errors in `scenes/experiments/MetricsView`. Did not run manual UI testing — please verify by hovering across variant rows quickly (should be snappy, no lingering tooltip) and by moving the cursor up onto the tooltip and clicking the timeseries hint (should still work).

## Publish to changelog?

no

## 🤖 Agent context

Authored by Claude (Opus 4.7) at the user's direction. Initial fix in #57598 used a blanket 150 ms delay; user noted that made row-to-row transitions feel sluggish. Picked geometric direction over `relatedTarget` because the 8 px gap between the row and the portaled tooltip means `relatedTarget` is often null/document. Tooltip is always rendered above the row (`y = chartCellRect.top - tooltipRect.height - 8`), so the up/down split cleanly maps to user intent.