### PR TITLE
feat(propdefs): drop unused index on posthog_eventproperty

### DIFF
--- a/products/event_definitions/backend/migrations/0006_drop_eventproperty_proj_property_coalesce_idx.py
+++ b/products/event_definitions/backend/migrations/0006_drop_eventproperty_proj_property_coalesce_idx.py
@@ -1,0 +1,42 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Drop posthog_eve_proj_id_26dbfb_idx — (coalesce(project_id, team_id), property), ~50 GB US / ~41 GB EU.
+
+    Tier 1 follow-up to #57588. Provably unused:
+    - 0 idx_scan on prod-us and prod-eu writers (pg_stat_user_indexes).
+    - lastUsedAt also stale on read replicas (pganalyze).
+    - No code path queries (coalesce, property) without an event filter — codebase audit clean.
+
+    Coverage post-drop:
+    - (coalesce, property) lookups with event filter → unique constraint
+      posthog_event_property_unique_proj_event_property (coalesce, event, property).
+    - (team, property) lookups → posthog_eventproperty_team_id_and_property_r32khd9s.
+    """
+
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0005_eventdefinition_rename_promoted_to_primary"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name="eventproperty",
+                    name="posthog_eve_proj_id_26dbfb_idx",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS posthog_eve_proj_id_26dbfb_idx",
+                    reverse_sql="""
+                        CREATE INDEX CONCURRENTLY IF NOT EXISTS posthog_eve_proj_id_26dbfb_idx
+                        ON posthog_eventproperty (COALESCE(project_id, (team_id)::bigint), property)
+                    """,
+                ),
+            ],
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/max_migration.txt
+++ b/products/event_definitions/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0005_eventdefinition_rename_promoted_to_primary
+0006_drop_eventproperty_proj_property_coalesce_idx

--- a/products/event_definitions/backend/models/event_property.py
+++ b/products/event_definitions/backend/models/event_property.py
@@ -27,7 +27,6 @@ class EventProperty(models.Model):
             models.Index(fields=["team", "event"]),
             models.Index(Coalesce(F("project_id"), F("team_id")), F("event"), name="posthog_eve_proj_id_22de03_idx"),
             models.Index(fields=["team", "property"]),
-            models.Index(Coalesce(F("project_id"), F("team_id")), F("property"), name="posthog_eve_proj_id_26dbfb_idx"),
         ]
 
     __repr__ = sane_repr("event", "property", "team_id")


### PR DESCRIPTION
## Problem

The `posthog_eve_proj_id_26dbfb_idx` expression index on
`(coalesce(project_id, team_id), property)` is ~50 GB on prod-us and ~41 GB on
prod-eu. Tier 1 follow-up to #57588 — kept it out of that PR pending stronger
read-replica evidence; pganalyze now confirms it's unused on replicas too.

## Changes

- Drop `posthog_eve_proj_id_26dbfb_idx` via `DROP INDEX CONCURRENTLY` in a
  `SeparateDatabaseAndState` migration (`atomic = False`).
- Remove the matching `models.Index(...)` from `EventProperty.Meta.indexes`.

### Why this is safe

- **Writer scans:** `idx_scan = 0` on both prod-us and prod-eu writers
  (`pg_stat_user_indexes`).
- **Replica scans:** pganalyze `lastUsedAt` stale on read replicas — distinct
  from the PR #57589 target, where replicas show recent use.
- **No callers:** codebase audit (Django ORM, raw SQL, Temporal/Dagster,
  HogQL) finds zero queries that would prefer this index. Any
  `(coalesce, property)` access either also filters on `event` (served by the
  unique constraint `posthog_event_property_unique_proj_event_property` on
  `(coalesce, event, property)`) or uses `(team_id, property)` directly
  (served by `posthog_eventproperty_team_id_and_property_r32khd9s`).
- **Reversible:** `reverse_sql` recreates the index concurrently if needed.

## How did you test this code?

- Static checks (ruff/lints) clean on touched files.
- Migration shape mirrors #57588's drops, validated locally with
  `manage.py makemigrations --dry-run --check` and `sqlmigrate`.
- Operationally identical to a `DROP INDEX CONCURRENTLY` — no AccessExclusive
  lock; brief ShareUpdateExclusive while the catalog entry is removed.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs
