### PR TITLE
chore(quill): align all quill package versions to 0.3.0-beta.1

### DIFF
--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.1.0-alpha.0",
+    "version": "0.3.0-beta.1",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.2.0-alpha.0",
+    "version": "0.3.0-beta.1",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.1.2-alpha.0",
+    "version": "0.3.0-beta.1",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

The manual `Publish Quill npm packages` workflow [run on master 5h ago](https://github.com/PostHog/posthog/actions/runs/25371775094/job/74396832111) failed at the `Publish @posthog/quill-tokens` step:

```
npm error 403 You cannot publish over the previously published versions: 0.1.2-alpha.0.
```

PR #57623 bumped `@posthog/quill` and `@posthog/quill-primitives` to `0.3.0-beta.1` but did not bump `@posthog/quill-tokens`, which remained at `0.1.2-alpha.0` — a version already on the registry. The publish step is the first one in the workflow, so it never even got to `@posthog/quill@0.3.0-beta.1`.

## Changes

Bump all quill workspace packages to `0.3.0-beta.1` so versions are coherent across the workspace:

- `@posthog/quill-tokens`: `0.1.2-alpha.0` → `0.3.0-beta.1` (public, was blocking the publish)
- `@posthog/quill-components`: `0.2.0-alpha.0` → `0.3.0-beta.1` (private, alignment only)
- `@posthog/quill-blocks`: `0.1.0-alpha.0` → `0.3.0-beta.1` (private, alignment only)

`@posthog/quill` and `@posthog/quill-primitives` already at `0.3.0-beta.1`.

The workspace dependency entries already use `workspace:^`, so no lockfile churn — `pnpm install` reports "Lockfile is up to date".

## How did you test this code?

I'm an agent. Verified:

- `pnpm install --no-frozen-lockfile` reports `Lockfile is up to date, resolution step is skipped`
- All five `packages/quill/packages/*/package.json` files now show `"version": "0.3.0-beta.1"`
- `npm view` confirms `0.3.0-beta.1` is unpublished for both `@posthog/quill-tokens` and `@posthog/quill`, so a re-trigger of the workflow will publish cleanly
- No other lockfile entries reference the old version strings

## Publish to changelog?

no

## 🤖 Agent context

Triggered by reviewing the failed `Publish Quill npm packages` workflow run. The user explicitly asked for all versions to be matched (rather than only bumping tokens to `0.1.2-alpha.1`) so the public-and-private workspace tells one consistent story going forward.

Co-authored by Claude (Opus 4.7) under @adamleith's direction.