### PR TITLE
chore: drop posthog_eve_proj_id_22de03_idx (~67 GB reclaim)

### DIFF
--- a/products/event_definitions/backend/migrations/0009_drop_eventproperty_proj_event_coalesce_idx.py
+++ b/products/event_definitions/backend/migrations/0009_drop_eventproperty_proj_event_coalesce_idx.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("event_definitions", "0005_eventdefinition_rename_promoted_to_primary"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name="eventproperty",
+                    name="posthog_eve_proj_id_22de03_idx",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS posthog_eve_proj_id_22de03_idx",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/event_definitions/backend/migrations/max_migration.txt
+++ b/products/event_definitions/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0005_eventdefinition_rename_promoted_to_primary
+0009_drop_eventproperty_proj_event_coalesce_idx

--- a/products/event_definitions/backend/models/event_property.py
+++ b/products/event_definitions/backend/models/event_property.py
@@ -25,7 +25,6 @@ class EventProperty(models.Model):
             # Index on project_id foreign key
             models.Index(fields=["project"], name="posthog_eve_proj_id_dd2337d2"),
             models.Index(fields=["team", "event"]),
-            models.Index(Coalesce(F("project_id"), F("team_id")), F("event"), name="posthog_eve_proj_id_22de03_idx"),
             models.Index(fields=["team", "property"]),
             models.Index(Coalesce(F("project_id"), F("team_id")), F("property"), name="posthog_eve_proj_id_26dbfb_idx"),
         ]


### PR DESCRIPTION
## Problem

`posthog_eve_proj_id_22de03_idx` is a ~67 GB B-tree on `(coalesce(project_id, team_id), event)` — strict leading prefix of the unique constraint, which was reindexed to natural size in May 2026.

## Changes

- Migration `0009_drop_eventproperty_proj_event_coalesce_idx` — `DROP INDEX CONCURRENTLY IF EXISTS` in `SeparateDatabaseAndState`
- Remove the `models.Index(Coalesce(...), F("event"), ...)` entry from `EventProperty.Meta.indexes`
- No `reverse_sql`

**No-op in prod:** this index was already dropped live on prod-us and prod-eu (May 2026). The migration only executes in dev.

## How did you test this code?

Index was dropped live on both production clusters. Migration is idempotent via `IF EXISTS`. Pre-commit hooks pass.

**Note:** This PR and #57588 are independent (both based on `master`). Whichever merges second will need a trivial rebase to renumber its migration.