### PR TITLE
fix: correct kafka named collection and add dev tables

### DIFF
--- a/posthog/clickhouse/migrations/0249_property_values_kafka_named_collection.py
+++ b/posthog/clickhouse/migrations/0249_property_values_kafka_named_collection.py
@@ -1,0 +1,35 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_values import (
+    DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL,
+    DROP_PROPERTY_VALUES_MV_SQL,
+    KAFKA_PROPERTY_VALUES_TABLE_SQL_FN,
+    PROPERTY_VALUES_MV_SQL,
+    PROPERTY_VALUES_TABLE_SQL,
+)
+
+# Two fixes to 0244:
+# - US/EU: kafka_property_values used the default msk_cluster named collection,
+#   but the topic is produced to warpstream_ingestion. Drop the MV first, then
+#   the Kafka table, then recreate both with the right named collection.
+#   Storage table is untouched.
+# - DEV: 0244's AUX ops no-op'd because dev has no hostClusterRole=aux nodes.
+#   Create storage, Kafka, and MV on DATA. Dev's `aux` cluster aliases to those
+#   same hosts so the existing Distributed proxy resolves correctly.
+
+if settings.CLOUD_DEPLOYMENT in ("US", "EU"):
+    operations = [
+        run_sql_with_exceptions(DROP_PROPERTY_VALUES_MV_SQL(), node_roles=[NodeRole.AUX]),
+        run_sql_with_exceptions(DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL(), node_roles=[NodeRole.AUX]),
+        run_sql_with_exceptions(KAFKA_PROPERTY_VALUES_TABLE_SQL_FN(), node_roles=[NodeRole.AUX]),
+        run_sql_with_exceptions(PROPERTY_VALUES_MV_SQL(), node_roles=[NodeRole.AUX]),
+    ]
+elif settings.CLOUD_DEPLOYMENT == "DEV":
+    operations = [
+        run_sql_with_exceptions(PROPERTY_VALUES_TABLE_SQL(), node_roles=[NodeRole.DATA]),
+        run_sql_with_exceptions(KAFKA_PROPERTY_VALUES_TABLE_SQL_FN(), node_roles=[NodeRole.DATA]),
+        run_sql_with_exceptions(PROPERTY_VALUES_MV_SQL(), node_roles=[NodeRole.DATA]),
+    ]
+else:
+    operations = []

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0248_drop_msk_kafka_engines_with_ws_equivalents
+0249_property_values_kafka_named_collection

--- a/posthog/clickhouse/property_values.py
+++ b/posthog/clickhouse/property_values.py
@@ -57,8 +57,20 @@ SETTINGS
 def KAFKA_PROPERTY_VALUES_TABLE_SQL_FN() -> str:
     return KAFKA_PROPERTY_VALUES_TABLE_SQL.format(
         table_name=KAFKA_TABLE_NAME,
-        engine=kafka_engine(topic=KAFKA_CLICKHOUSE_PROPERTY_VALUES, group=CONSUMER_GROUP_PROPERTY_VALUES),
+        engine=kafka_engine(
+            topic=KAFKA_CLICKHOUSE_PROPERTY_VALUES,
+            group=CONSUMER_GROUP_PROPERTY_VALUES,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+        ),
     )
+
+
+def DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL() -> str:
+    return f"DROP TABLE IF EXISTS {KAFKA_TABLE_NAME}"
+
+
+def DROP_PROPERTY_VALUES_MV_SQL() -> str:
+    return f"DROP TABLE IF EXISTS {MV_NAME}"
 
 
 def PROPERTY_VALUES_MV_SQL() -> str:

--- a/posthog/clickhouse/property_values.py
+++ b/posthog/clickhouse/property_values.py
@@ -17,8 +17,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     `team_id` Int64,
     `property_type` LowCardinality(String),
     `property_key` String,
-    `property_value` String,
-    `_timestamp` DateTime
+    `property_value` String
 ) ENGINE = {engine}
 """
 
@@ -83,7 +82,7 @@ AS SELECT
     property_key,
     property_value,
     toUInt64(1) as property_count,
-    _timestamp as last_seen
+    coalesce(_timestamp, now()) as last_seen
 FROM {database}.{kafka_table}
 WHERE lengthUTF8(property_key) > 0
   AND lengthUTF8(property_key) <= 400  -- matches Django PropertyDefinition.name max_length

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -602,8 +602,7 @@
       `team_id` Int64,
       `property_type` LowCardinality(String),
       `property_key` String,
-      `property_value` String,
-      `_timestamp` DateTime
+      `property_value` String
   ) ENGINE = Kafka(warpstream_ingestion, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
   
   '''
@@ -2330,8 +2329,7 @@
       `team_id` Int64,
       `property_type` LowCardinality(String),
       `property_key` String,
-      `property_value` String,
-      `_timestamp` DateTime
+      `property_value` String
   ) ENGINE = Kafka(warpstream_ingestion, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
   
   '''
@@ -3421,7 +3419,7 @@
       property_key,
       property_value,
       toUInt64(1) as property_count,
-      _timestamp as last_seen
+      coalesce(_timestamp, now()) as last_seen
   FROM posthog_test.kafka_property_values
   WHERE lengthUTF8(property_key) > 0
     AND lengthUTF8(property_key) <= 400  -- matches Django PropertyDefinition.name max_length

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -604,7 +604,7 @@
       `property_key` String,
       `property_value` String,
       `_timestamp` DateTime
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(warpstream_ingestion, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -2332,7 +2332,7 @@
       `property_key` String,
       `property_value` String,
       `_timestamp` DateTime
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(warpstream_ingestion, kafka_topic_list = 'clickhouse_property_values_test', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
   
   '''
 # ---


### PR DESCRIPTION
## Problem

Two problems with migration 0244's property_values setup (https://github.com/PostHog/posthog/pull/55351): 

1. The Kafka engine table on prod was created with the default `msk_cluster` named collection, but the WarpStream pipeline (created in https://github.com/PostHog/posthog-cloud-infra/pull/7600) `events_json_to_property_values_ws` produces `clickhouse_property_values` to the warpstream-ingestion VC.

Issue verified via: 
```sql
SELECT name, engine_full
FROM clusterAllReplicas(aux, system, tables)
WHERE database = 'posthog' AND name = 'kafka_property_values'
LIMIT 1


name
kafka_property_values

engine_full
Kafka(msk_cluster, kafka_topic_list = 'clickhouse_property_values', kafka_group_name = 'clickhouse_property_values', kafka_format = 'JSONEachRow')
```

2. On dev, 0244's AUX-targeted operations are no-op because dev has no nodes with `hostClusterRole = aux`. 

```sql

SELECT hostName() AS host,
	getMacro('hostClusterType') AS cluster_type,
	getMacro('hostClusterRole') AS cluster_role
FROM clusterAllReplicas(posthog, system, one)
ORDER BY host

host                  cluster_type  cluster_role
dev-us-iad-ch-1a      online        data
dev-us-iad-ch-1b      online        data
dev-us-iad-ch-2a      online        data
dev-us-iad-ch-2b      online        data
```

## Changes

`posthog/clickhouse/property_values.py`
- `KAFKA_PROPERTY_VALUES_TABLE_SQL_FN` now passes `named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION` to `kafka_engine`. Resulting engine SQL: `Kafka(warpstream_ingestion, ...)`.
- Added `DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL` and `DROP_PROPERTY_VALUES_MV_SQL` helpers for the migration.
- Dropped `_timestamp DateTime` from `KAFKA_PROPERTY_VALUES_TABLE_SQL`. Kafka engine tables exposes `_timestamp` as a virtual `Nullable(DateTime)` column from message metadata, declaring it explicitly creates a name collision. Matches the convention used by other Kafka engine tables

`posthog/clickhouse/migrations/0248_property_values_kafka_named_collection.py`
- Prod: drop `property_values_mv`, drop `kafka_property_values`, recreate Kafka table with corrected named collection, recreate MV (all on AUX).
- Dev: create storage, Kafka, and MV on DATA. Dev's `aux` cluster aliases to those same hosts, so the existing Distributed proxy from 0244 resolves correctly.

## How did you test this code?

- verified snapshot contains `ENGINE = Kafka(warpstream_ingestion ...`
- verified locally that the consumer and MV chain are working 
```sh
docker exec -i posthog-kafka-1 rpk topic produce clickhouse_property_values --format='%v\n' <<'EOF'
{"team_id":1,"property_type":"event","property_key":"foo","property_value":"bar"}
EOF
sleep 3
curl -s "http://localhost:8123/" --data-binary "SELECT * FROM default.property_values WHERE property_key='foo' FORMAT TSV"
```

## Publish to changelog?

no

## Docs update

n/a