### PR TITLE
chore(ci): cache typescript incremental build info

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -306,7 +306,6 @@ jobs:
                   NODE_OPTIONS: --max-old-space-size=16384
 
             - name: Save TypeScript incremental build info
-              if: github.ref == 'refs/heads/master'
               uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                   path: frontend/tsconfig.tsbuildinfo

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -273,6 +273,14 @@ jobs:
                   key: ${{ runner.os }}-typegen-${{ hashFiles('pnpm-lock.yaml') }}
                   restore-keys: ${{ runner.os }}-typegen-
 
+            # If tsc starts skipping checks it should run, bump the suffix (e.g. -v2) to invalidate.
+            - name: Restore TypeScript incremental build info
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: frontend/tsconfig.tsbuildinfo
+                  key: ${{ runner.os }}-tsbuildinfo-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'frontend/tsconfig.json') }}
+                  restore-keys: ${{ runner.os }}-tsbuildinfo-
+
             - name: Build products
               run: pnpm --filter=@posthog/frontend build:products
 
@@ -296,6 +304,13 @@ jobs:
               run: pnpm --filter=@posthog/frontend typescript:check
               env:
                   NODE_OPTIONS: --max-old-space-size=16384
+
+            - name: Save TypeScript incremental build info
+              if: github.ref == 'refs/heads/master'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: frontend/tsconfig.tsbuildinfo
+                  key: ${{ runner.os }}-tsbuildinfo-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'frontend/tsconfig.json') }}
 
             - name: Check if schema.json and validators.js are up to date
               run: pnpm --filter=@posthog/frontend schema:build:json && git diff --exit-code


### PR DESCRIPTION
## Problem

`Run typescript with strict` cold-starts `tsc` on every CI run (~2m on master). `tsc` already writes `frontend/tsconfig.tsbuildinfo` thanks to `incremental: true` in the root tsconfig, but nothing preserves it across runs.

## Changes

Cache `frontend/tsconfig.tsbuildinfo` between CI runs using the same `actions/cache@v5` Pattern A shape as the existing `.typegen`, mypy, and storybook webpack caches in this repo. Restore before tsc, save after (master only). Key invalidates on `pnpm-lock.yaml` + both relevant tsconfigs; `restore-keys` fallback lets a slightly stale cache still seed work — tsc fingerprints files itself, so a bad cache means cold tsc, never wrong diagnostics. Manual escape hatch documented inline (bump key suffix).

**This is an experiment.** TS docs don't endorse CI caching of tsbuildinfo. Our setup sidesteps the absolute-paths caveat (GitHub-hosted runners use a stable checkout path) and modern TS uses content hashes for invalidation, but the only honest measure is post-merge numbers. Revert if a handful of post-cache PR runs don't show a clear drop on this step.

## How did you test this code?

Agent-authored. YAML parses; structure mirrors `.typegen` cache one-to-one. No automated test added — workflow YAML. Real validation is the post-merge measurement below.

### Baseline (cold tsc on recent master runs)

| Commit | Run | "Run typescript with strict" |
|---|---|---|
| `a68ada2` | [25391382535](https://github.com/PostHog/posthog/actions/runs/25391382535) | 2m04s |
| `7d1aa75` | [25391280512](https://github.com/PostHog/posthog/actions/runs/25391280512) | 2m16s |
| `e91bba3` | [25389206365](https://github.com/PostHog/posthog/actions/runs/25389206365) | 2m16s |

## Publish to changelog?

no

## 🤖 Agent context

Claude Code (Opus 4.7). Pattern mirrors the existing `.typegen` cache in the same job.