### PR TITLE
chore(tasks): bump sandbox TTL to 6h and inactivity timeout to 2h

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -51,9 +51,10 @@ TASKS_USE_MODAL_RESUME_SNAPSHOTS: bool = get_from_env(
     type_cast=str_to_bool,
 )
 
-# Override the process_task workflow's inactivity timeout (default 5 min). Set
-# this to e.g. 30 for local testing of the shutdown / resume flow. When set,
-# the CI-follow-up floor is also bypassed so the timer actually fires fast.
+# Override the process_task workflow's inactivity timeout (default 2 hours).
+# Set this to e.g. 30 for local testing of the shutdown / resume flow. When
+# set, the CI-follow-up floor is also bypassed so the timer actually fires
+# fast.
 TASKS_INACTIVITY_TIMEOUT_SECONDS: int = get_from_env("TASKS_INACTIVITY_TIMEOUT_SECONDS", 0, type_cast=int)
 
 TEMPORAL_LOG_LEVEL_PRODUCE: str = os.getenv("TEMPORAL_LOG_LEVEL_PRODUCE", "DEBUG")

--- a/products/tasks/backend/services/agent_command.py
+++ b/products/tasks/backend/services/agent_command.py
@@ -18,6 +18,11 @@ CANCEL_TIMEOUT_SECONDS = 10
 # Refresh triggers a query.interrupt() + resume with a 30s SDK timeout on the
 # agent-server, so we need more headroom than a plain command.
 REFRESH_TIMEOUT_SECONDS = 45
+# Follow-up delivery blocks until the agent has fully ingested the new turn,
+# which can take a while. Must stay below the activity's start_to_close_timeout
+# so a hung socket doesn't keep a worker thread blocked after Temporal has
+# already abandoned the activity.
+FOLLOWUP_TIMEOUT_SECONDS = 30 * 60  # 30 min
 
 REFRESH_SESSION_METHOD = "_posthog/refresh_session"
 

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -60,7 +60,7 @@ class ExecutionStream(Protocol):
     def wait(self) -> ExecutionResult: ...
 
 
-SANDBOX_TTL_SECONDS = 60 * 120  # 2 hours (safety net; workflow inactivity timeout handles cleanup)
+SANDBOX_TTL_SECONDS = 6 * 60 * 60  # 6 hours (safety net; workflow inactivity timeout handles cleanup)
 
 
 class SandboxConfig(BaseModel):

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -60,7 +60,10 @@ class ExecutionStream(Protocol):
     def wait(self) -> ExecutionResult: ...
 
 
-SANDBOX_TTL_SECONDS = 6 * 60 * 60  # 6 hours (safety net; workflow inactivity timeout handles cleanup)
+# Production: 6 hours (safety net; workflow inactivity timeout handles cleanup).
+# Tests: 15 min so any sandbox orphaned by a crashed test auto-destroys quickly
+# instead of burning Modal capacity for hours.
+SANDBOX_TTL_SECONDS = 15 * 60 if settings.TEST else 6 * 60 * 60
 
 
 class SandboxConfig(BaseModel):

--- a/products/tasks/backend/temporal/process_task/README.md
+++ b/products/tasks/backend/temporal/process_task/README.md
@@ -29,7 +29,7 @@ User ─────────────────────────
                               │     _repository            │
                               │  3. start_agent_server     │
                               │  4. wait_condition         │
-                              │     (5 min inactivity      │
+                              │     (2 hr inactivity       │
                               │      timeout, heartbeat-   │
                               │      extended)             │
                               │  5. cleanup_sandbox        │
@@ -61,7 +61,7 @@ User ─────────────────────────
 1. **get_task_processing_context** — Loads the TaskRun, validates GitHub integration and repository, builds a `TaskProcessingContext` with IDs and credentials
 2. **get_sandbox_for_repository** — Creates an OAuth token, provisions a sandbox (with snapshot if available), clones the repo, stores `sandbox_id`/`sandbox_url`/`sandbox_connect_token` in TaskRun.state
 3. **start_agent_server** — Runs `npx agent-server` inside the sandbox, waits for health check
-4. **wait_condition** — Blocks with a 5-minute inactivity timeout. The agent sends `heartbeat` signals to keep the workflow alive; each heartbeat resets the timer. The workflow exits when it receives a `complete_task` signal or when no heartbeat arrives within 5 minutes
+4. **wait_condition** — Blocks with a 2-hour inactivity timeout. The agent sends `heartbeat` signals to keep the workflow alive; each heartbeat resets the timer. The workflow exits when it receives a `complete_task` signal or when no heartbeat arrives within 2 hours
 5. **cleanup_sandbox** — Destroys the sandbox container (always runs via `finally`)
 
 ### Temporal client
@@ -97,7 +97,7 @@ Environment variables consumed inside the sandbox:
 4. **update_task_run_status** — Sets status to IN_PROGRESS
 5. **get_sandbox_for_repository** — Gets GitHub token from integration, creates OAuth access token, provisions sandbox, clones repo (unless snapshot used), stores sandbox credentials in TaskRun.state
 6. **start_agent_server** — Starts `npx agent-server` in sandbox, polls `/health` until ready
-7. **wait_condition** — Workflow blocks with a 5-minute inactivity timeout, extended by `heartbeat` signals from the agent. PostHog Code or the agent server signals completion via the API
+7. **wait_condition** — Workflow blocks with a 2-hour inactivity timeout, extended by `heartbeat` signals from the agent. PostHog Code or the agent server signals completion via the API
 8. Agent server calls `PATCH /api/projects/{team_id}/task_runs/{run_id}/` with terminal status
 9. API handler sends `complete_task(status, error_message)` signal to the Temporal workflow
 10. **cleanup_sandbox** — Sandbox destroyed

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -11,13 +11,13 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.services.agent_command import (
+    FOLLOWUP_TIMEOUT_SECONDS,
     REFRESH_TIMEOUT_SECONDS,
     CommandResult,
     send_refresh_session,
     send_user_message,
 )
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
-from products.tasks.backend.services.sandbox import SANDBOX_TTL_SECONDS
 from products.tasks.backend.services.staged_artifacts import get_task_run_artifacts_by_id
 from products.tasks.backend.stream.redis_stream import get_task_run_stream_key
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
@@ -85,7 +85,7 @@ def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
         input.message,
         artifacts=artifacts,
         auth_token=auth_token,
-        timeout=SANDBOX_TTL_SECONDS,
+        timeout=FOLLOWUP_TIMEOUT_SECONDS,
     )
     logger.info(
         "send_followup_to_sandbox_attempted",

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -119,7 +119,7 @@ class TestFollowupDeliveryFailure:
     async def test_failed_followup_marks_run_as_failed_promptly(self):
         """The workflow must exit its main loop and mark the run as failed
         within seconds when a followup delivery fails — not after the
-        5-minute inactivity timeout."""
+        2-hour inactivity timeout."""
         _status_updates.clear()
 
         async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -338,12 +338,12 @@ class TestCIFollowUpLoop:
                     id=f"test-{uuid.uuid4()}",
                     task_queue=task_queue,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=timedelta(hours=2),
+                    execution_timeout=timedelta(hours=3),
                 )
                 # With CI gated off, the inactivity timer stays at its default
-                # 5m and is not extended to cover CI_FOLLOW_UP_DELAY (15m). The
-                # workflow therefore terminates via inactivity well before the
-                # CI deadline — which itself proves no follow-up could fire.
+                # 2h and is not extended to cover CI_FOLLOW_UP_DELAY (15m). No
+                # CI follow-up scheduler is armed, so the workflow terminates
+                # via inactivity — which itself proves no follow-up could fire.
                 await handle.result()
 
         assert _ci_followup_calls == []
@@ -443,7 +443,7 @@ class TestFollowupGuards:
                     id=f"test-{uuid.uuid4()}",
                     task_queue=task_queue,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=timedelta(hours=2),
+                    execution_timeout=timedelta(hours=3),
                 )
                 # The CI loop stops after finding no PR, then the workflow
                 # exits via inactivity timeout — no signal needed.
@@ -566,7 +566,7 @@ class TestFollowupGuards:
                     id=f"test-{uuid.uuid4()}",
                     task_queue=task_queue,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=timedelta(hours=2),
+                    execution_timeout=timedelta(hours=3),
                 )
                 # No heartbeats sent — agent is idle. The CI loop should stop
                 # after one check and the workflow exits via inactivity timeout.

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -79,11 +79,11 @@ class CIFollowUpDecision(StrEnum):
     NO_PR = "no_pr"
 
 
-# Default 5 min in production. Override via TASKS_INACTIVITY_TIMEOUT_SECONDS
+# Default 2 hours in production. Override via TASKS_INACTIVITY_TIMEOUT_SECONDS
 # for local testing (e.g. `TASKS_INACTIVITY_TIMEOUT_SECONDS=30` to force a fast
 # shutdown for resume-flow testing). When overridden, the CI follow-up floor
 # below is bypassed so the timer actually fires that fast.
-INACTIVITY_TIMEOUT = timedelta(seconds=settings.TASKS_INACTIVITY_TIMEOUT_SECONDS or 300)
+INACTIVITY_TIMEOUT = timedelta(seconds=settings.TASKS_INACTIVITY_TIMEOUT_SECONDS or 2 * 60 * 60)
 CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
 RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT = timedelta(hours=24)
 PENDING_MESSAGE_FORWARD_TIMEOUT_SECONDS = 180


### PR DESCRIPTION
## Problem

We previously dropped the process_task sandbox TTL and the workflow inactivity timeout to keep runs within the lifetime of short-lived tokens. Now that the workflow uses user-to-server tokens (which we refresh as needed), runs are less impacted by token expiries — so we can bump the bounds back up to give long-running agent tasks room to finish.

## Changes

- `SANDBOX_TTL_SECONDS`: 2h → 6h (max sandbox lifetime, boot to close)
- `INACTIVITY_TIMEOUT` default: 5 min → 2 hr (workflow's idle exit)
- Updated supporting comments in `posthog/settings/temporal.py` and `workflow.py`
- Updated `process_task/README.md` references to the inactivity timeout
- Updated test docstring referencing the old 5-min timeout
- Bumped `execution_timeout` on the three time-skipping tests that wait for the inactivity timer to fire (`test_no_ci_follow_up_when_gated_off`, `test_skips_ci_follow_up_when_pr_context_missing`, `test_stops_ci_loop_when_no_pr_and_agent_idle`) from 2h → 3h since virtual workflow time now exceeds 2h once the inactivity timer is the only exit path.

The `TASKS_INACTIVITY_TIMEOUT_SECONDS` env var override is unchanged — local testing with `TASKS_INACTIVITY_TIMEOUT_SECONDS=30` (or similar small value) still works for fast shutdown / resume-flow testing, and still bypasses the CI-follow-up floor as before.

## How did you test this code?

I'm an agent. I did **not** run the test suite locally (no test environment available in the cloud agent runtime). I only verified Python syntax via `ast.parse`. Reviewers should run `hogli test products/tasks/backend/temporal/process_task/tests/test_followup.py` locally.

Reasoning for execution_timeout bumps: with `INACTIVITY_TIMEOUT=2h` and CI gated off (or stopped early via no-PR / idle), the workflow's virtual elapsed time before exit is ~`CI_FOLLOW_UP_DELAY (15m, optional) + INACTIVITY_TIMEOUT (2h)`, which exceeds the previous `execution_timeout=timedelta(hours=2)` boundary. Bumping to 3h leaves comfortable headroom.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude)
- Human prompts:
  - "we can bump the sandbox ttl back again since we're using user to server tokens now, we'll be less impacted by expiries, will put it at 2 hours again"
  - "set the sandbox ttl in process task workflow to be 2 hours"
  - "okay a sandbox should live for a maximum of 6 hours from boot to close, the inactivity timeout should be set to 2 hours instead of 5 mins"
- Decisions:
  - The first request seemed redundant — `SANDBOX_TTL_SECONDS` was already `60 * 120` (= 2h) on master. After clarification, the user wanted the sandbox max-lifetime at 6h and the workflow inactivity timeout at 2h (separate concept). Changed both.
  - Kept the `TASKS_INACTIVITY_TIMEOUT_SECONDS` override mechanism unchanged so local testing semantics are preserved.
  - Did not touch the stale comment on `MAX_POLL_SECONDS` in `custom_prompt_internals.py` (says "matches sandbox TTL") — separate concern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*