### PR TITLE
chore(admin): split oauth models into their own sidebar section

### DIFF
--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -175,3 +175,77 @@ def register_all_admin():
     admin.site.register(UserProductList, UserProductListAdmin)
 
     admin.site.register(MCPServerTemplate, MCPServerTemplateAdmin)
+
+
+# OAuth models live in the `posthog` app, so by default they appear under
+# "PostHog" in the admin sidebar alongside dozens of unrelated models. Move
+# them into their own "OAuth" section by overriding `get_app_list` — this
+# avoids changing model `app_label` (which would force a db_table migration).
+_OAUTH_ADMIN_MODEL_NAMES = frozenset(
+    {
+        "OAuthApplication",
+        "OAuthAccessToken",
+        "OAuthGrant",
+        "OAuthIDToken",
+        "OAuthRefreshToken",
+    }
+)
+
+
+def install_admin_app_list_overrides():
+    """Override admin sidebar grouping. Must run before any admin request so the
+    first call goes through the patched function — otherwise the lazy admin
+    registry would only install this mid-call after `get_app_list` has already
+    started executing on the original method."""
+    from django.contrib import admin
+    from django.urls import NoReverseMatch, reverse
+
+    original_get_app_list = admin.site.get_app_list
+
+    def _build_oauth_app_dict(oauth_models):
+        try:
+            app_url = reverse("admin:app_list", kwargs={"app_label": "oauth"})
+        except NoReverseMatch:
+            app_url = ""
+        return {
+            "name": "OAuth",
+            "app_label": "oauth",
+            "app_url": app_url,
+            "has_module_perms": True,
+            "models": oauth_models,
+        }
+
+    def _extract_oauth_models(app_list):
+        oauth_models = []
+        for app in app_list:
+            kept = []
+            for model in app["models"]:
+                if model.get("object_name") in _OAUTH_ADMIN_MODEL_NAMES:
+                    oauth_models.append(model)
+                else:
+                    kept.append(model)
+            app["models"] = kept
+        return oauth_models
+
+    def get_app_list(request, app_label=None):
+        # The synthetic "oauth" app_label has no real models registered against it,
+        # so we have to source its models from the `posthog` app and rebuild the
+        # group ourselves — otherwise visiting /admin/oauth/ would 404.
+        if app_label == "oauth":
+            posthog_app_list = original_get_app_list(request, app_label="posthog")
+            oauth_models = _extract_oauth_models(posthog_app_list)
+            oauth_models.sort(key=lambda model: model["name"].lower())
+            return [_build_oauth_app_dict(oauth_models)] if oauth_models else []
+
+        app_list = original_get_app_list(request, app_label=app_label)
+        oauth_models = _extract_oauth_models(app_list)
+        if not oauth_models:
+            return app_list
+
+        oauth_models.sort(key=lambda model: model["name"].lower())
+        app_list = [app for app in app_list if app["models"]]
+        app_list.append(_build_oauth_app_dict(oauth_models))
+        app_list.sort(key=lambda app: app["name"].lower())
+        return app_list
+
+    admin.site.get_app_list = get_app_list  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]

--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -177,10 +177,15 @@ def register_all_admin():
     admin.site.register(MCPServerTemplate, MCPServerTemplateAdmin)
 
 
-# OAuth models live in the `posthog` app, so by default they appear under
-# "PostHog" in the admin sidebar alongside dozens of unrelated models. Move
-# them into their own "OAuth" section by overriding `get_app_list` — this
-# avoids changing model `app_label` (which would force a db_table migration).
+# :KRUDGE: OAuth models live in the `posthog` app, so by default they appear
+# under "PostHog" in the admin sidebar alongside dozens of unrelated models.
+# The "real" fix would be to move these to `products/oauth/` so Django groups
+# them automatically — but every model here is `swappable` (referenced as
+# `OAUTH2_PROVIDER_APPLICATION_MODEL` etc.). Changing the app_label means
+# rewriting every existing migration that points at the swappable target,
+# both in oauth2_provider and in any FK that's been added on top — a known
+# Django landmine. Until there's a separate reason to isolate OAuth as its
+# own product, override `get_app_list` instead.
 _OAUTH_ADMIN_MODEL_NAMES = frozenset(
     {
         "OAuthApplication",

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.test import RequestFactory
 
-from posthog.admin import register_all_admin
+from posthog.admin import install_admin_app_list_overrides, register_all_admin
 from posthog.admin.admins.user_admin import UserAdmin
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
 from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
@@ -16,6 +16,67 @@ class TestAdmin(BaseTest):
     def test_register_admin_models_succeeds(self):
         with patch.object(admin, "site", AdminSite()):
             register_all_admin()
+
+
+class TestOAuthSidebarRegrouping(BaseTest):
+    def _patched_get_app_list(self):
+        site = AdminSite()
+        site.get_app_list = lambda request, app_label=None: [  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+            {
+                "name": "PostHog",
+                "app_label": "posthog",
+                "app_url": "/admin/posthog/",
+                "has_module_perms": True,
+                "models": [
+                    {"name": "OAuth applications", "object_name": "OAuthApplication"},
+                    {"name": "OAuth access tokens", "object_name": "OAuthAccessToken"},
+                    {"name": "OAuth grants", "object_name": "OAuthGrant"},
+                    {"name": "OAuth ID tokens", "object_name": "OAuthIDToken"},
+                    {"name": "OAuth refresh tokens", "object_name": "OAuthRefreshToken"},
+                    {"name": "Users", "object_name": "User"},
+                ]
+                if app_label in (None, "posthog")
+                else [],
+            }
+        ]
+        with patch.object(admin, "site", site):
+            install_admin_app_list_overrides()
+            return site.get_app_list
+
+    def test_oauth_models_moved_to_oauth_section(self):
+        get_app_list = self._patched_get_app_list()
+        result = get_app_list(request=None)
+
+        oauth_apps = [app for app in result if app["app_label"] == "oauth"]
+        assert len(oauth_apps) == 1
+        oauth_object_names = {model["object_name"] for model in oauth_apps[0]["models"]}
+        assert oauth_object_names == {
+            "OAuthApplication",
+            "OAuthAccessToken",
+            "OAuthGrant",
+            "OAuthIDToken",
+            "OAuthRefreshToken",
+        }
+
+        posthog_apps = [app for app in result if app["app_label"] == "posthog"]
+        assert len(posthog_apps) == 1
+        posthog_object_names = {model["object_name"] for model in posthog_apps[0]["models"]}
+        assert posthog_object_names == {"User"}
+
+    def test_oauth_app_label_returns_only_oauth_models(self):
+        get_app_list = self._patched_get_app_list()
+        result = get_app_list(request=None, app_label="oauth")
+
+        assert len(result) == 1
+        assert result[0]["app_label"] == "oauth"
+        assert result[0]["name"] == "OAuth"
+        assert {model["object_name"] for model in result[0]["models"]} == {
+            "OAuthApplication",
+            "OAuthAccessToken",
+            "OAuthGrant",
+            "OAuthIDToken",
+            "OAuthRefreshToken",
+        }
 
 
 class TestUserAdmin(BaseTest):

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.test import RequestFactory
 
-from posthog.admin import install_admin_app_list_overrides, register_all_admin
+from posthog.admin import _OAUTH_ADMIN_MODEL_NAMES, install_admin_app_list_overrides, register_all_admin
 from posthog.admin.admins.user_admin import UserAdmin
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
 from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
@@ -50,13 +50,7 @@ class TestOAuthSidebarRegrouping(BaseTest):
         oauth_apps = [app for app in result if app["app_label"] == "oauth"]
         assert len(oauth_apps) == 1
         oauth_object_names = {model["object_name"] for model in oauth_apps[0]["models"]}
-        assert oauth_object_names == {
-            "OAuthApplication",
-            "OAuthAccessToken",
-            "OAuthGrant",
-            "OAuthIDToken",
-            "OAuthRefreshToken",
-        }
+        assert oauth_object_names == _OAUTH_ADMIN_MODEL_NAMES
 
         posthog_apps = [app for app in result if app["app_label"] == "posthog"]
         assert len(posthog_apps) == 1
@@ -70,13 +64,7 @@ class TestOAuthSidebarRegrouping(BaseTest):
         assert len(result) == 1
         assert result[0]["app_label"] == "oauth"
         assert result[0]["name"] == "OAuth"
-        assert {model["object_name"] for model in result[0]["models"]} == {
-            "OAuthApplication",
-            "OAuthAccessToken",
-            "OAuthGrant",
-            "OAuthIDToken",
-            "OAuthRefreshToken",
-        }
+        assert {model["object_name"] for model in result[0]["models"]} == _OAUTH_ADMIN_MODEL_NAMES
 
 
 class TestUserAdmin(BaseTest):

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -166,3 +166,11 @@ class PostHogConfig(AppConfig):
         # Don't use lazy loading in tests and migrations
         if not settings.TEST and "migrate" not in sys.argv and "test" not in sys.argv:
             admin.site._registry = LazyAdminRegistry()
+
+        # Install the OAuth sidebar regrouping override eagerly. It must wrap
+        # `get_app_list` before the first admin request — if it were installed
+        # from inside `register_all_admin()` it would only land mid-call, after
+        # the original method had already started executing.
+        from posthog.admin import install_admin_app_list_overrides
+
+        install_admin_app_list_overrides()

--- a/products/mcp_store/backend/apps.py
+++ b/products/mcp_store/backend/apps.py
@@ -5,3 +5,4 @@ class McpStoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "products.mcp_store.backend"
     label = "mcp_store"
+    verbose_name = "MCP STORE"


### PR DESCRIPTION
## Problem

The Django admin sidebar groups models by `app_label`. All OAuth models (`OAuthApplication`, `OAuthAccessToken`, `OAuthGrant`, `OAuthIDToken`, `OAuthRefreshToken`) live in `posthog/models/oauth.py`, which means they end up under `app_label="posthog"` and are buried in the already-massive "PostHog" group alongside dozens of unrelated models. They're hard to find when you need them.

Separately, the `mcp_store` group renders its `AppConfig.label` as the heading, so it displays with the underscore (`mcp_store`/`MCP_STORE`) instead of a readable name.

## Changes

- `posthog/admin/__init__.py`: added `install_admin_app_list_overrides()` that wraps `admin.site.get_app_list` to pull OAuth-named models out of every app group and insert them into a synthetic `{name: "OAuth", app_label: "oauth"}` group. Also handles the `app_label="oauth"` case so navigating directly to `/admin/oauth/` lists the OAuth models instead of 404'ing.
- `posthog/apps.py`: install the override eagerly during `_setup_lazy_admin()` rather than at the end of `register_all_admin()`. If it were installed lazily, the very first admin request would already be executing on the original (un-patched) `get_app_list` by the time the lazy load fires.
- `products/mcp_store/backend/apps.py`: set `verbose_name = "MCP STORE"` on `McpStoreConfig`.

Considered changing `Meta.app_label = "oauth"` on the OAuth models, but that would force a `db_table` migration on existing tables, so the sidebar-only override is much safer.

## How did you test this code?

Added unit tests in `posthog/admin/test_admin.py::TestOAuthSidebarRegrouping` covering:
- The default app-list call: OAuth models are extracted from the `posthog` group and placed in their own `oauth` group.
- The direct `app_label="oauth"` lookup: returns only the OAuth models, so `/admin/oauth/` works.

Existing `posthog/admin/test_admin.py` and `posthog/admin/test_oauth_admin.py` suites still pass.

I'm an agent — I have not manually verified the rendered admin sidebar. Worth a quick sanity check in dev before merging.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7, 1M context).
- Human prompt: "In the Django admin we have some categorization in the sidebar and then most stuff is under 'posthog'. Can you split all of the OAuth-related models to a new OAuth section? Also, can the 'mcp_store' one be titled 'MCP STORE' and not include the underscore like it does right now?"
- Decisions:
    - Rejected changing model `Meta.app_label` — would require a `db_table` migration on existing OAuth tables.
    - Rejected installing the override at the end of `register_all_admin()` — the lazy admin registry triggers `register_all_admin()` from inside the original `get_app_list` call, so the patch would only take effect on the *second* request. Moved the install to `_setup_lazy_admin()` instead.
    - Used `# type: ignore[method-assign]  # ty: ignore[invalid-assignment]` for the `admin.site.get_app_list` rebind because the patched function isn't a bound method.