### PR TITLE
feat(experiments): make metric reloading an explicit action.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -145,6 +145,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
         updateExperimentMetrics,
         addSharedMetricsToExperiment,
         removeSharedMetricFromExperiment,
+        removeMetric,
     } = useActions(experimentLogic)
 
     if (!tabId) {
@@ -265,11 +266,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                                 return
                             }
 
-                            setExperiment({
-                                [context.field]: experiment[context.field].filter((m) => m.uuid !== metric.uuid),
-                            })
-
-                            updateExperimentMetrics()
+                            removeMetric(metric.uuid, context.type)
                             closeExperimentMetricModal()
                         }}
                     />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1843,10 +1843,12 @@ export const experimentLogic = kea<experimentLogicType>([
                 lemonToast.error(error.detail || 'Failed to reset experiment')
             }
         },
-        updateExperimentSuccess: async ({ experiment, payload }) => {
-            actions.updateExperiments(experiment)
-            if (payload?.update_feature_flag_params && experiment.feature_flag) {
-                actions.updateFlagFromPartial(experiment.feature_flag)
+        updateExperimentSuccess: async ({ experimentUpdate, payload }) => {
+            if (experimentUpdate) {
+                actions.updateExperiments(experimentUpdate)
+                if (payload?.update_feature_flag_params && experimentUpdate.feature_flag) {
+                    actions.updateFlagFromPartial(experimentUpdate.feature_flag)
+                }
             }
             // NOTE: No implicit metric reload here. Each action that calls updateExperiment
             // is responsible for triggering its own reload if needed. This prevents:
@@ -2476,17 +2478,25 @@ export const experimentLogic = kea<experimentLogicType>([
                 }
                 return NEW_EXPERIMENT
             },
-            updateExperiment: async (update: Partial<Experiment> & { update_feature_flag_params?: boolean }) => {
-                const response: Experiment = await api.update(
-                    `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
-                    update
-                )
-                const responseWithMetricsOrdering = initializeMetricOrdering(response)
-                refreshTreeItem('experiment', String(values.experimentId))
-                actions.setUnmodifiedExperiment(structuredClone(responseWithMetricsOrdering))
-                return responseWithMetricsOrdering
-            },
         },
+        // Separate loader for updates to avoid triggering experimentLoading
+        experimentUpdate: [
+            null as Experiment | null,
+            {
+                updateExperiment: async (update: Partial<Experiment> & { update_feature_flag_params?: boolean }) => {
+                    const response: Experiment = await api.update(
+                        `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
+                        update
+                    )
+                    const responseWithMetricsOrdering = initializeMetricOrdering(response)
+                    refreshTreeItem('experiment', String(values.experimentId))
+                    actions.setUnmodifiedExperiment(structuredClone(responseWithMetricsOrdering))
+                    // Also update the main experiment state
+                    actions.setExperiment(responseWithMetricsOrdering)
+                    return responseWithMetricsOrdering
+                },
+            },
+        ],
         exposureCohort: [
             null as CohortType | null,
             {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -849,6 +849,8 @@ export const experimentLogic = kea<experimentLogicType>([
             isSecondary,
             newUuid,
         }),
+        // Semantic metric actions - each controls its own reload behavior
+        removeMetric: (uuid: string, context: 'primary' | 'secondary') => ({ uuid, context }),
         updateMetricBreakdown: (uuid: string, breakdown: Breakdown) => ({ uuid, breakdown }),
         removeMetricBreakdown: (uuid: string, index: number, breakdown: Breakdown) => ({ uuid, index, breakdown }),
         // METRICS RESULTS
@@ -1604,10 +1606,12 @@ export const experimentLogic = kea<experimentLogicType>([
         changeExperimentStartDate: async ({ startDate }) => {
             actions.updateExperiment({ start_date: startDate, update_feature_flag_params: false })
             values.experiment && eventUsageLogic.actions.reportExperimentStartDateChange(values.experiment, startDate)
+            actions.refreshExperimentResults(true, 'config_change')
         },
         changeExperimentEndDate: async ({ endDate }) => {
             actions.updateExperiment({ end_date: endDate, update_feature_flag_params: false })
             values.experiment && eventUsageLogic.actions.reportExperimentEndDateChange(values.experiment, endDate)
+            actions.refreshExperimentResults(true, 'config_change')
         },
         endExperiment: async () => {
             try {
@@ -1801,6 +1805,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 metrics_secondary: values.experiment.metrics_secondary,
                 update_feature_flag_params: false,
             })
+            // Reload results for added/edited metrics
+            actions.refreshExperimentResults(true, 'config_change')
         },
         updateExperimentCollectionGoal: async () => {
             const { recommendedRunningTime, recommendedSampleSize, minimumDetectableEffect } = values
@@ -1842,17 +1848,11 @@ export const experimentLogic = kea<experimentLogicType>([
             if (payload?.update_feature_flag_params && experiment.feature_flag) {
                 actions.updateFlagFromPartial(experiment.feature_flag)
             }
-            if (isLaunched(experiment)) {
-                // For launched experiments, refresh results if any of these fields are updated
-                const forceRefresh =
-                    payload?.start_date !== undefined ||
-                    payload?.end_date !== undefined ||
-                    payload?.metrics !== undefined ||
-                    payload?.metrics_secondary !== undefined ||
-                    payload?.stats_config !== undefined ||
-                    payload?.only_count_matured_users !== undefined
-                actions.refreshExperimentResults(forceRefresh, 'config_change')
-            }
+            // NOTE: No implicit metric reload here. Each action that calls updateExperiment
+            // is responsible for triggering its own reload if needed. This prevents:
+            // 1. Unnecessary reloads (e.g., removing a metric doesn't need to re-query)
+            // 2. Double reloads (callers that explicitly reload were also getting implicit reload)
+            // See the semantic actions (removeMetric, etc.) for explicit reload patterns.
         },
         createExposureCohortSuccess: ({ exposureCohort }) => {
             if (exposureCohort && exposureCohort.id !== 'new') {
@@ -2316,6 +2316,18 @@ export const experimentLogic = kea<experimentLogicType>([
                     logic.actions.loadFeatureFlag() // Access the loader through actions
                 }
             }
+        },
+        removeMetric: ({ uuid, context }) => {
+            const isPrimary = context === 'primary'
+            const field = isPrimary ? 'metrics' : 'metrics_secondary'
+            const currentMetrics: (ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery)[] =
+                values.experiment[field] || []
+            const filtered = currentMetrics.filter((m) => m.uuid !== uuid)
+
+            actions.updateExperiment({
+                [field]: filtered,
+                update_feature_flag_params: false,
+            })
         },
         updateMetricBreakdown: async ({ uuid, breakdown }) => {
             const isPrimary = values.experiment.metrics.some((m) => m.uuid === uuid)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1604,12 +1604,12 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         changeExperimentStartDate: async ({ startDate }) => {
-            actions.updateExperiment({ start_date: startDate, update_feature_flag_params: false })
+            await asyncActions.updateExperiment({ start_date: startDate, update_feature_flag_params: false })
             values.experiment && eventUsageLogic.actions.reportExperimentStartDateChange(values.experiment, startDate)
             actions.refreshExperimentResults(true, 'config_change')
         },
         changeExperimentEndDate: async ({ endDate }) => {
-            actions.updateExperiment({ end_date: endDate, update_feature_flag_params: false })
+            await asyncActions.updateExperiment({ end_date: endDate, update_feature_flag_params: false })
             values.experiment && eventUsageLogic.actions.reportExperimentEndDateChange(values.experiment, endDate)
             actions.refreshExperimentResults(true, 'config_change')
         },
@@ -1800,7 +1800,7 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         updateExperimentMetrics: async () => {
-            actions.updateExperiment({
+            await asyncActions.updateExperiment({
                 metrics: values.experiment.metrics,
                 metrics_secondary: values.experiment.metrics_secondary,
                 update_feature_flag_params: false,


### PR DESCRIPTION
## Problem

The `updateExperimentSuccess` listener implicitly decided whether to reload metrics by inspecting payload fields. This caused double loading (explicit + implicit reloads), unnecessary loading when removing metrics, and unpredictable side effects.

Additionally:
- Race condition where `refreshExperimentResults` fired before the `updateExperiment` API call completed.
- UI flicker when removing metrics because `updateExperiment` triggered `experimentLoading`.

## Changes

**experimentLogic.tsx - Explicit reload control**
- Removed payload inspection from `updateExperimentSuccess` that auto-triggered `refreshExperimentResults`
- Added explicit `refreshExperimentResults` to `changeExperimentStartDate`, `changeExperimentEndDate`, `updateExperimentMetrics`
- Added semantic `removeMetric(uuid, context)` action that deletes without reload

**experimentLogic.tsx - Race condition fix**
- Changed `actions.updateExperiment` to `await asyncActions.updateExperiment` in `changeExperimentStartDate`, `changeExperimentEndDate`, and `updateExperimentMetrics`.

**experimentLogic.tsx - Flicker fix**
- Separated 1updateExperiment1 into its own 1experimentUpdate1 loader so update operations do not trigger `experimentLoading`.
- Updated `updateExperimentSuccess` listener to use `experimentUpdate` instead of experiment.

**ExperimentView.tsx**
- Updated `onDelete` callback to use `removeMetric` instead of `setExperiment` + `updateExperimentMetrics`

## Kea vs. sagas

Redux-saga makes async flows explicit and readable:

```typescript
function* removeMetricSaga(action) {
    const experiment = yield select(getExperiment)
    const filtered = experiment.metrics.filter(m => m.uuid !== action.uuid)
    yield call(api.update, { metrics: filtered })
    yield put(updateExperimentState(response))
    // NO reload - explicit choice, visible here
}
```

Kea's listeners are **reactive** ("when X happens, also do Y"), not **orchestrative** ("do X, then Y, then Z"). When you need orchestration, you get `asyncActions` (an escape hatch), chained actions, or payload inspection, all of which obscure the flow.

Since we can't use sagas, the pragmatic solution:
1. Remove implicit side effects from success listeners.
2. Make each semantic action responsible for its own reload.
3. Document the rules.

## How did you test this code?

**Automated tests**
```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/experimentLogic.test.ts
```
```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/experimentSceneLogic.test.ts
```

![cat-type-small](https://github.com/user-attachments/assets/fb038596-5003-4a70-9c64-fe69a6520777)

## 🤖 Agent context

**Tool**: Claude Code (Opus 4.5)

**Key prompts**:
- "find common patterns in the codebase for API side effects on kea logics"

**Decisions**:
- Rejected optimistic updates (race conditions, Kea doesn't manage a queue)
- Rejected saga-like abstraction (no existing pattern in codebase)
<!-- The most robust patterns are in insightDashboardModalLogic.ts and globalSetupLogic.ts—they have dedicated actions like
  setOptimisticDashboardState/clearOptimisticDashboardState with proper rollback on failure. -->