### PR TITLE
feat(surveys): add regex URL targeting to guided surveys

### DIFF
--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -17,7 +17,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { SurveyQuestionBranchingType } from '~/types'
+import { SurveyMatchType, SurveyQuestionBranchingType } from '~/types'
 
 import { SdkVersionWarnings } from '../components/SdkVersionWarnings'
 import { NewSurvey } from '../constants'
@@ -168,7 +168,14 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         const summary: string[] = []
 
         if (conditions?.url) {
-            summary.push(`URL ${conditions.urlMatchType === 'exact' ? 'is exactly' : 'contains'} "${conditions.url}"`)
+            const urlMatchLabel =
+                conditions.urlMatchType === SurveyMatchType.Exact
+                    ? 'is exactly'
+                    : conditions.urlMatchType === SurveyMatchType.Regex
+                      ? 'matches regex'
+                      : 'contains'
+
+            summary.push(`URL ${urlMatchLabel} "${conditions.url}"`)
         }
 
         if (conditions?.selector) {

--- a/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
@@ -16,7 +16,13 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import type { HogQLQueryString } from '~/queries/utils'
-import { PropertyDefinitionType, PropertyFilterType, SurveyDisplayConditions, SurveyMatchType } from '~/types'
+import {
+    PropertyDefinitionType,
+    PropertyFilterType,
+    PropertyOperator,
+    SurveyDisplayConditions,
+    SurveyMatchType,
+} from '~/types'
 
 import { surveyLogic } from '../../surveyLogic'
 import { SurveyAudienceFilters } from '../SurveyAudienceFilters'
@@ -36,6 +42,12 @@ type UrlAudienceEstimate =
     | { status: 'loading' }
     | { status: 'loaded'; count: number }
     | { status: 'error' }
+
+const URL_MATCH_MODE_PROPERTY_OPERATORS: Record<UrlMatchMode, PropertyOperator> = {
+    [SurveyMatchType.Contains]: PropertyOperator.IContains,
+    [SurveyMatchType.Exact]: PropertyOperator.Exact,
+    [SurveyMatchType.Regex]: PropertyOperator.Regex,
+}
 
 function getRegexValidationError(pattern: string, matchType: UrlMatchMode): string | null {
     if (matchType !== SurveyMatchType.Regex || !pattern) {
@@ -168,7 +180,7 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                             properties: [
                                 {
                                     key: '$current_url',
-                                    operator: urlMatchMode,
+                                    operator: URL_MATCH_MODE_PROPERTY_OPERATORS[urlMatchMode],
                                     type: PropertyFilterType.Event,
                                     value: trimmedPattern,
                                 },

--- a/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
@@ -1,14 +1,16 @@
 import { useActions, useValues } from 'kea'
+import { RE2JS } from 're2js'
 import { useEffect, useState } from 'react'
 
 import { IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInputSelect, LemonSegmentedButton, Spinner } from '@posthog/lemon-ui'
 
-import { api } from 'lib/api'
+import api from 'lib/api'
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { ANY_VARIANT, variantOptions } from 'lib/components/IngestionControls/triggers/FlagTrigger/VariantSelector'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { humanFriendlyNumber } from 'lib/utils'
+import { formatRE2Error } from 'lib/utils/regexp'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -41,9 +43,9 @@ function getRegexValidationError(pattern: string, matchType: UrlMatchMode): stri
     }
 
     try {
-        new RegExp(pattern)
+        RE2JS.compile(pattern)
     } catch (error) {
-        return error instanceof Error ? error.message : 'Invalid regex'
+        return error instanceof Error ? formatRE2Error(error, pattern) : 'Invalid RE2 regex'
     }
 
     return null
@@ -282,7 +284,7 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                             placeholder={urlInputPlaceholder}
                             allowCustomValues
                             status={isPathInputInExactMode || regexValidationError ? 'danger' : undefined}
-                            loading={urlOptions?.status === 'loading'}
+                            loading={urlMatchMode !== SurveyMatchType.Regex && urlOptions?.status === 'loading'}
                             options={urlSuggestions}
                         />
                         {regexValidationError ? (

--- a/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
@@ -1,45 +1,87 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInputSelect, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonInputSelect, LemonSegmentedButton, Spinner } from '@posthog/lemon-ui'
 
+import { api } from 'lib/api'
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { ANY_VARIANT, variantOptions } from 'lib/components/IngestionControls/triggers/FlagTrigger/VariantSelector'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { humanFriendlyNumber } from 'lib/utils'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { PropertyDefinitionType, SurveyDisplayConditions, SurveyMatchType } from '~/types'
+import type { HogQLQueryString } from '~/queries/utils'
+import { PropertyDefinitionType, PropertyFilterType, SurveyDisplayConditions, SurveyMatchType } from '~/types'
 
 import { surveyLogic } from '../../surveyLogic'
 import { SurveyAudienceFilters } from '../SurveyAudienceFilters'
 import { WizardSection, WizardStepLayout } from '../WizardLayout'
 
 const DEVICE_OPTIONS = ['Desktop', 'Mobile', 'Tablet']
+const URL_AUDIENCE_ESTIMATE_DAYS = 30
+const URL_AUDIENCE_ESTIMATE_TAGS = {
+    scene: 'Survey' as const,
+    productKey: 'surveys' as const,
+    name: 'survey_url_audience_estimate' as const,
+}
+
+type UrlMatchMode = SurveyMatchType.Contains | SurveyMatchType.Exact | SurveyMatchType.Regex
+type UrlAudienceEstimate =
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'loaded'; count: number }
+    | { status: 'error' }
+
+function getRegexValidationError(pattern: string, matchType: UrlMatchMode): string | null {
+    if (matchType !== SurveyMatchType.Regex || !pattern) {
+        return null
+    }
+
+    try {
+        new RegExp(pattern)
+    } catch (error) {
+        return error instanceof Error ? error.message : 'Invalid regex'
+    }
+
+    return null
+}
 
 export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void }): JSX.Element {
     const { survey } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
     const { featureFlag } = useValues(featureFlagLogic({ id: survey.linked_flag_id || 'link' }))
+    const { currentTeamId } = useValues(teamLogic)
 
     const { options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
     const urlOptions = options['$current_url']
+    const [urlAudienceEstimate, setUrlAudienceEstimate] = useState<UrlAudienceEstimate>({ status: 'idle' })
 
     const conditions: Partial<SurveyDisplayConditions> = survey.conditions || {}
     const targetingMode = conditions.urlMatchType ? 'specific' : 'all'
     const urlPattern = conditions.url || ''
-    const urlMatchMode =
-        conditions.urlMatchType === SurveyMatchType.Exact ? SurveyMatchType.Exact : SurveyMatchType.Contains
+    const urlMatchMode: UrlMatchMode =
+        conditions.urlMatchType === SurveyMatchType.Exact || conditions.urlMatchType === SurveyMatchType.Regex
+            ? conditions.urlMatchType
+            : SurveyMatchType.Contains
     const isPathInputInExactMode = urlMatchMode === SurveyMatchType.Exact && urlPattern.trim().startsWith('/')
+    const regexValidationError = getRegexValidationError(urlPattern, urlMatchMode)
     const selectedDevices = conditions.deviceTypes || []
     const resolvedLinkedFlag = survey.linked_flag || (survey.linked_flag_id ? featureFlag : null)
     const urlInputPlaceholder =
         urlMatchMode === SurveyMatchType.Exact
             ? 'Select a page or type the full URL'
-            : 'Select a page or type a path like /pricing'
+            : urlMatchMode === SurveyMatchType.Regex
+              ? 'Type a regex like ^https://example.com/docs/.*'
+              : 'Select a page or type a path like /pricing'
     const urlSuggestions = (() => {
+        if (urlMatchMode === SurveyMatchType.Regex) {
+            return []
+        }
+
         const seen = new Set<string>()
 
         return (urlOptions?.values || [])
@@ -72,7 +114,12 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
     })()
 
     useEffect(() => {
-        if (targetingMode === 'specific' && urlOptions?.status !== 'loading' && urlOptions?.status !== 'loaded') {
+        if (
+            targetingMode === 'specific' &&
+            urlMatchMode !== SurveyMatchType.Regex &&
+            urlOptions?.status !== 'loading' &&
+            urlOptions?.status !== 'loaded'
+        ) {
             loadPropertyValues({
                 endpoint: undefined,
                 type: PropertyDefinitionType.Event,
@@ -82,7 +129,65 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                 properties: [],
             })
         }
-    }, [targetingMode, urlOptions?.status, loadPropertyValues])
+    }, [targetingMode, urlMatchMode, urlOptions?.status, loadPropertyValues])
+
+    useEffect(() => {
+        const trimmedPattern = urlPattern.trim()
+
+        if (
+            targetingMode !== 'specific' ||
+            !currentTeamId ||
+            !trimmedPattern ||
+            isPathInputInExactMode ||
+            regexValidationError
+        ) {
+            setUrlAudienceEstimate({ status: 'idle' })
+            return
+        }
+
+        const abortController = new AbortController()
+        const timeout = window.setTimeout(async () => {
+            setUrlAudienceEstimate({ status: 'loading' })
+
+            try {
+                const query = `
+                    SELECT uniq(person_id)
+                    FROM events
+                    WHERE team_id = ${currentTeamId}
+                        AND event = '$pageview'
+                        AND timestamp >= now() - INTERVAL ${URL_AUDIENCE_ESTIMATE_DAYS} DAY
+                        AND {filters}
+                ` as HogQLQueryString
+
+                const response = await api.queryHogQL<[[number]]>(query, URL_AUDIENCE_ESTIMATE_TAGS, {
+                    requestOptions: { signal: abortController.signal },
+                    queryParams: {
+                        filters: {
+                            properties: [
+                                {
+                                    key: '$current_url',
+                                    operator: urlMatchMode,
+                                    type: PropertyFilterType.Event,
+                                    value: trimmedPattern,
+                                },
+                            ],
+                        },
+                    },
+                })
+
+                setUrlAudienceEstimate({ status: 'loaded', count: response.results?.[0]?.[0] ?? 0 })
+            } catch (error) {
+                if ((error as { name?: string }).name !== 'AbortError') {
+                    setUrlAudienceEstimate({ status: 'error' })
+                }
+            }
+        }, 500)
+
+        return () => {
+            window.clearTimeout(timeout)
+            abortController.abort()
+        }
+    }, [currentTeamId, isPathInputInExactMode, regexValidationError, targetingMode, urlMatchMode, urlPattern])
 
     const setTargetingMode = (mode: 'all' | 'specific'): void => {
         if (mode === 'all') {
@@ -96,7 +201,7 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
         setSurveyValue('conditions', { ...conditions, url: pattern, urlMatchType: urlMatchMode })
     }
 
-    const setUrlMatchMode = (matchType: SurveyMatchType.Exact | SurveyMatchType.Contains): void => {
+    const setUrlMatchMode = (matchType: UrlMatchMode): void => {
         setSurveyValue('conditions', {
             ...conditions,
             urlMatchType: matchType,
@@ -147,12 +252,11 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                         <div className="mb-2">
                             <LemonSegmentedButton
                                 value={urlMatchMode}
-                                onChange={(value) =>
-                                    setUrlMatchMode(value as SurveyMatchType.Exact | SurveyMatchType.Contains)
-                                }
+                                onChange={(value) => setUrlMatchMode(value as UrlMatchMode)}
                                 options={[
                                     { value: SurveyMatchType.Contains, label: 'Contains path' },
                                     { value: SurveyMatchType.Exact, label: 'Exact URL' },
+                                    { value: SurveyMatchType.Regex, label: 'Regex' },
                                 ]}
                                 size="small"
                             />
@@ -162,6 +266,10 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                             value={urlPattern ? [urlPattern] : []}
                             onChange={(val) => setUrlPattern(val[0] || '')}
                             onInputChange={(newInput) => {
+                                if (urlMatchMode === SurveyMatchType.Regex) {
+                                    return
+                                }
+
                                 loadPropertyValues({
                                     type: PropertyDefinitionType.Event,
                                     endpoint: undefined,
@@ -173,11 +281,13 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                             }}
                             placeholder={urlInputPlaceholder}
                             allowCustomValues
-                            status={isPathInputInExactMode ? 'danger' : undefined}
+                            status={isPathInputInExactMode || regexValidationError ? 'danger' : undefined}
                             loading={urlOptions?.status === 'loading'}
                             options={urlSuggestions}
                         />
-                        {isPathInputInExactMode ? (
+                        {regexValidationError ? (
+                            <p className="text-xs text-danger mt-1.5">{regexValidationError}</p>
+                        ) : isPathInputInExactMode ? (
                             <p className="text-xs text-danger mt-1.5">
                                 Exact URL requires the full URL, including protocol and host. Use Contains path for
                                 entries like /pricing.
@@ -186,7 +296,26 @@ export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void 
                             <p className="text-xs text-muted mt-1.5">
                                 {urlMatchMode === SurveyMatchType.Exact
                                     ? 'Select from your most visited pages or type the full URL, including protocol and host.'
-                                    : 'Select from your most visited pages or type a path like /pricing.'}
+                                    : urlMatchMode === SurveyMatchType.Regex
+                                      ? 'Match against the full current URL using a regular expression.'
+                                      : 'Select from your most visited pages or type a path like /pricing.'}
+                            </p>
+                        )}
+                        {urlAudienceEstimate.status === 'loading' && (
+                            <p className="text-xs text-muted mt-1.5 flex items-center gap-1">
+                                <Spinner className="text-xs" /> Estimating matching users...
+                            </p>
+                        )}
+                        {urlAudienceEstimate.status === 'loaded' && (
+                            <p className="text-xs text-muted mt-1.5">
+                                About {humanFriendlyNumber(urlAudienceEstimate.count)} unique{' '}
+                                {urlAudienceEstimate.count === 1 ? 'user' : 'users'} viewed matching URLs in the last{' '}
+                                {URL_AUDIENCE_ESTIMATE_DAYS} days.
+                            </p>
+                        )}
+                        {urlAudienceEstimate.status === 'error' && (
+                            <p className="text-xs text-muted mt-1.5">
+                                Unable to estimate matching users for this URL condition.
                             </p>
                         )}
                     </div>


### PR DESCRIPTION
## Problem

Guided survey creation only exposed contains and exact URL targeting, even though survey conditions already support regex in the full editor. This made URL-pattern targeting harder to configure from the guided flow, and creators had no quick sense of how many recent users a URL rule might reach.

## Changes

- Adds a Regex option to guided survey URL display conditions.
- Validates regex input inline and keeps URL suggestions focused on exact/contains modes.
- Shows a debounced estimate of unique users who viewed matching URLs in the last 30 days, based on `$pageview` and `$current_url`.
- Updates the guided launch confirmation summary so regex URL rules are described accurately.

## How did you test this code?

As an agent, I ran:

- `pnpm exec oxlint --quiet frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx frontend/src/scenes/surveys/wizard/SurveyWizard.tsx`
- `hogli test frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx`

I also attempted `pnpm --filter=@posthog/frontend typescript:check`; it failed on unrelated repo-wide TypeScript issues such as missing generated logic/type modules and `@protomaps/basemaps`, with no errors reported for the changed survey files.

## Publish to changelog?

no

## Docs update

No docs update. Regex URL targeting already exists in the survey model/full editor; this surfaces it in the guided UI.

## 🤖 Agent context

Authored by Codex. Key decisions: reused `SurveyMatchType.Regex`, kept ad hoc HogQL querying consistent with existing survey stats code because there is no generated client for arbitrary HogQL queries, and made the reach estimate approximate with `uniq(person_id)` over recent `$pageview` events for performance. Human review required before merge.