### PR TITLE
chore(batch-exports): mock databricks connect in test

### DIFF
--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest.mock
 
 from products.batch_exports.backend.temporal.destinations.databricks_batch_export import (
     DatabricksClient,
@@ -185,9 +186,13 @@ async def test_connect_when_invalid_host():
         catalog="test",
         schema="test",
     )
-    with pytest.raises(
-        DatabricksConnectionError,
-        match="Failed to connect to Databricks. Please check that your connection details are valid.",
+    with unittest.mock.patch(
+        "products.batch_exports.backend.temporal.destinations.databricks_batch_export.sql.connect",
+        side_effect=ValueError("invalid host"),
     ):
-        async with client.connect():
-            pass
+        with pytest.raises(
+            DatabricksConnectionError,
+            match="Failed to connect to Databricks. Please check that your connection details are valid.",
+        ):
+            async with client.connect():
+                pass


### PR DESCRIPTION
## Problem

`test_connect_when_invalid_host` consumed about 300 seconds every backend CI run on the temporal-7 shard — about 40 percent of that shard's wall time. The test made a real network call against an unresolvable host and waited for the production `_socket_timeout=300` budget to elapse, but its only assertion is the error-translation contract — there's no value in actually waiting on the timer.

### Evidence — three master runs

Each link goes to the specific "Django tests – Temporal (7/7)" shard job that ran the test.

| SHA | Shard job | Test time |
|---|---|---:|
| `7d1aa75` | [run 25391280523, job 74466367718](https://github.com/PostHog/posthog/actions/runs/25391280523/job/74466367718) | 300.13 seconds |
| `e91bba3` | [run 25389206413, job 74460700929](https://github.com/PostHog/posthog/actions/runs/25389206413/job/74460700929) | 300.98 seconds |
| `e575366` | [run 25387579889, job 74456157819](https://github.com/PostHog/posthog/actions/runs/25387579889/job/74456157819) | 301.37 seconds |

Mean across 3 runs: 300.83 seconds. Standard deviation: 0.64 seconds. This isn't a flake — the test deterministically hits the production 300-second connect timeout every run.

### After fix — this PR

| SHA | Shard job | Test time |
|---|---|---:|
| `fdd0e44` | [run 25396301615, job 74484160869](https://github.com/PostHog/posthog/actions/runs/25396301615/job/74484160869) | under 1 second (excluded from pytest's `--durations=100 --durations-min=1.0` list) |

## Changes

Patch `databricks.sql.connect` in the test to raise `ValueError` synchronously. The existing `except (ValueError, urllib3.exceptions.HTTPError, urllib3.exceptions.MaxRetryError)` branch in `_connect` translates it to `DatabricksConnectionError` with the same user-facing message. Assertion preserved verbatim. Pattern mirrors `bigquery/test_client.py::test_execute_query_pending_timeout`.

### Impact

| Metric | Before | After |
|---|---|---|
| Test runtime | 300 seconds | under a millisecond |
| Share of temporal-7 shard wall time | about 40 percent | negligible |
| temporal-7 shard wall time | about 23 minutes | about 18 minutes |
| Backend CI wall time today | 24-25 minutes | unchanged |
| Runner minutes per run | — | 5 fewer minutes on the temporal-7 runner |

The backend CI wall time does **not** drop with this PR alone. The actual critical path across all three sampled runs is a `Django tests – Core (persons-on-events off)` shard finishing in 24-25 minutes; temporal-7 was the second-longest at 21.8-23.4 minutes. Once temporal-7 drops to about 18 minutes, the Core shards remain the gate. The savings here are runner minutes (we still pay for the 5 minutes the temporal-7 runner used to burn) and headroom — temporal-7 was 0.8 minutes behind the bottleneck on `7d1aa75`, so we're widening that margin instead of shortening total wall time.

This is the first of three obvious wins on temporal-7. The next two are the 90-second `Retry-After` test and the cluster of 13-15 second retry-exhaustion tests; once those land, the temporal shard stops being a credible bottleneck and attention shifts to whichever Core shard owns the actual critical path.

## How did you test this code?

I'm an agent. Ran the automated test suite for the file locally:

\`\`\`
hogli test products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py --reuse-db
\`\`\`

All 5 tests pass in 3.92 seconds. The fixed test body itself runs in about 314 microseconds, down from about 300 seconds.

## Publish to changelog?

no

## 🤖 Agent context

Surfaced as the top optimization target after #57216 unblinded per-test traces beyond the old 60-second \`.test_durations\` cap. Initial draft of this PR claimed about 5 minutes of wall-clock CI savings; that was wrong — the actual critical path is a Core shard, not temporal-7. Corrected before merge.
