### PR TITLE
fix: execute queries sync when viewed shared notebook

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -206,6 +206,10 @@ _SHARED_MODE_WHITELIST = {
     # when the throttle clock is younger than `SHARED_FORCE_BLOCKING_MIN_AGE`.
     ExecutionMode.CALCULATE_BLOCKING_ALWAYS: ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
     ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE: ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+    # Used by the shared-notebook inline query payload builder. Without this entry the
+    # request silently falls through to EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE, which causes
+    # the frontend to incorrectly render a "unsupported node" placeholder until the async calc finishes and a later reload picks up the warm cache.
+    ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE: ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
 }
 
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1084,10 +1084,14 @@ class TestSharedInsightsExecutionMode(BaseTest):
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
             ),
             (
-                "unlisted_blocking_if_stale_falls_back_to_extended_async",
+                "blocking_if_stale_passes_through",
+                # Used by the shared-notebook inline query payload builder. Must pass through so
+                # cold-cache loads block and return real results — falling back to async would
+                # ship a CacheMissResponse to the frontend, which renders the "unsupported node"
+                # placeholder until a later reload picks up the warmed cache.
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 None,
-                ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
+                ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
             ),
         ]
     )

--- a/products/notebooks/backend/test/test_sharing.py
+++ b/products/notebooks/backend/test/test_sharing.py
@@ -403,10 +403,16 @@ class TestNotebookSharingGrantsInsightAccess(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         body = response.json()
         self.assertIn("inline_query_results", body)
-        # Even on an empty events table the runner returns a response shape; key presence is
-        # the contract we're locking in here.
         self.assertIn("inline-node-1", body["inline_query_results"])
-        self.assertIsInstance(body["inline_query_results"]["inline-node-1"], dict)
+        inline_result = body["inline_query_results"]["inline-node-1"]
+        self.assertIsInstance(inline_result, dict)
+        # Must be a real query response, not a CacheMissResponse — otherwise the frontend
+        # renders an empty `<Query cachedResults={...} inSharedMode />`, throws, and the
+        # SharedNodeErrorBoundary swaps in the "unsupported node" placeholder. This is the
+        # bug that made inline insights appear broken on the first shared-notebook view and
+        # "fix themselves" after a few reloads (once the async cache finished warming).
+        self.assertIn("results", inline_result)
+        self.assertNotIn("error", {k: v for k, v in inline_result.items() if v})
 
     def test_shared_notebook_payload_inlines_referenced_insights(self) -> None:
         """The shared notebook payload pre-serializes every referenced saved insight so the

--- a/products/notebooks/backend/test/test_sharing.py
+++ b/products/notebooks/backend/test/test_sharing.py
@@ -412,7 +412,7 @@ class TestNotebookSharingGrantsInsightAccess(APIBaseTest):
         # bug that made inline insights appear broken on the first shared-notebook view and
         # "fix themselves" after a few reloads (once the async cache finished warming).
         self.assertIn("results", inline_result)
-        self.assertNotIn("error", {k: v for k, v in inline_result.items() if v})
+        self.assertFalse(inline_result.get("error"))
 
     def test_shared_notebook_payload_inlines_referenced_insights(self) -> None:
         """The shared notebook payload pre-serializes every referenced saved insight so the


### PR DESCRIPTION
## Problem

Shared notebooks are sometimes showing "unsupported node" when viewing the page for the first time. This is because the cache has not yet been populated, but the backend returns a cache miss instead of blocking and running the query.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Allow shared notebook queries to run using the block if cache miss mode.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually + tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
