### PR TITLE
chore(web-analytics): Stamp last web analytics vist time on person properties

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -1,6 +1,3 @@
-import posthog from 'posthog-js'
-import { useEffect } from 'react'
-
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { WebAnalyticsDashboard } from 'scenes/web-analytics/WebAnalyticsDashboard'
@@ -12,16 +9,6 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 export function WebAnalyticsScene(): JSX.Element {
-    useEffect(() => {
-        const stampKey = `ph_last_web_analytics_stamp_${posthog.get_distinct_id()}`
-        const oneDayMs = 24 * 60 * 60 * 1000
-        const lastStamp = Number(localStorage.getItem(stampKey) || 0)
-        if (Date.now() - lastStamp > oneDayMs) {
-            posthog.setPersonProperties({ last_used_web_analytics_at: new Date().toISOString() })
-            localStorage.setItem(stampKey, Date.now().toString())
-        }
-    }, [])
-
     return (
         <>
             <SceneContent>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -1,3 +1,6 @@
+import posthog from 'posthog-js'
+import { useEffect } from 'react'
+
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { WebAnalyticsDashboard } from 'scenes/web-analytics/WebAnalyticsDashboard'
@@ -9,6 +12,16 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 export function WebAnalyticsScene(): JSX.Element {
+    useEffect(() => {
+        const stampKey = `ph_last_web_analytics_stamp_${posthog.get_distinct_id()}`
+        const oneDayMs = 24 * 60 * 60 * 1000
+        const lastStamp = Number(localStorage.getItem(stampKey) || 0)
+        if (Date.now() - lastStamp > oneDayMs) {
+            posthog.setPersonProperties({ last_used_web_analytics_at: new Date().toISOString() })
+            localStorage.setItem(stampKey, Date.now().toString())
+        }
+    }, [])
+
     return (
         <>
             <SceneContent>

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2479,6 +2479,15 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 return
             }
 
+            // Stamp the last-used timestamp for feature flag targeting (throttled to once per day per browser).
+            const stampKey = `ph_last_web_analytics_stamp_${posthog.get_distinct_id()}`
+            const oneDayMs = 24 * 60 * 60 * 1000
+            const lastStamp = Number(localStorage.getItem(stampKey) || 0)
+            if (Date.now() - lastStamp > oneDayMs) {
+                posthog.setPersonProperties({ last_used_web_analytics_at: new Date().toISOString() })
+                localStorage.setItem(stampKey, Date.now().toString())
+            }
+
             const parsedFilters = filters ? (isWebAnalyticsPropertyFilters(filters) ? filters : []) : undefined
             if (parsedFilters) {
                 if (productTab === ProductTab.BOT_ANALYTICS) {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2282,7 +2282,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
     // start the loaders after mounting the logic
     afterMount(({ actions }) => {
         actions.loadShouldShowGeoIPQueries()
-        posthog.setPersonProperties({ last_used_web_analytics_at: new Date().toISOString() })
     }),
 
     tabAwareActionToUrl(({ values }) => {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2282,6 +2282,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
     // start the loaders after mounting the logic
     afterMount(({ actions }) => {
         actions.loadShouldShowGeoIPQueries()
+        posthog.setPersonProperties({ last_used_web_analytics_at: new Date().toISOString() })
     }),
 
     tabAwareActionToUrl(({ values }) => {


### PR DESCRIPTION
## Problem
Feature flagging recent web analytics user is difficult since we can't use dynamic cohorts for flags. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Stamp the last visit time on the person.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
