### PR TITLE
feat(mcp): collect feedback with tool context

### DIFF
--- a/products/mcp_analytics/backend/presentation/views.py
+++ b/products/mcp_analytics/backend/presentation/views.py
@@ -31,9 +31,10 @@ class MCPAnalyticsPagination(LimitOffsetPagination):
 @extend_schema(tags=["mcp_analytics"])
 class BaseMCPAnalyticsSubmissionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     serializer_class = MCPAnalyticsSubmissionSerializer
-    # Keep these endpoints staff-only until the MCP tools and auth model are ready for customer traffic.
+    # Keep these endpoints staff-only in cloud, but allow MCP clients to submit
+    # feedback with normal scoped API tokens during internal dogfooding.
     permission_classes = [IsAuthenticated, SingleTenancyOrAdmin]
-    scope_object = "INTERNAL"
+    scope_object = "llm_analytics"
     pagination_class = MCPAnalyticsPagination
     user_action_name: str = ""
 

--- a/products/mcp_analytics/backend/tests/test_presentation.py
+++ b/products/mcp_analytics/backend/tests/test_presentation.py
@@ -75,6 +75,31 @@ class TestMCPAnalyticsPresentation(APIBaseTest):
         assert data["attempted_tool"] == "feature_flag_get_all"
         assert data["mcp_client_name"] == "Claude Desktop"
 
+    def test_create_feedback_submission_with_personal_api_key(self) -> None:
+        api_key = self.create_personal_api_key_with_scopes(["llm_analytics:write"])
+        self.client.logout()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_analytics/feedback/",
+            {
+                "goal": "understand MCP usage",
+                "feedback": "The tool result was hard to interpret.",
+                "category": "usability",
+                "attempted_tool": "query_execute",
+                "mcp_client_name": "local-mcp-test",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {api_key}",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["kind"] == MCPAnalyticsSubmission.Kind.FEEDBACK
+        assert data["goal"] == "understand MCP usage"
+        assert data["summary"] == "The tool result was hard to interpret."
+        assert data["attempted_tool"] == "query_execute"
+        assert data["mcp_client_name"] == "local-mcp-test"
+
     @parameterized.expand(
         [
             ("missing_goal", {"feedback": "Need clearer results"}, "goal"),

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -23,6 +23,7 @@ import EXEC_TOOL_BLURB from '@/templates/sections/exec-tool-blurb.md'
 import LEGACY from '@/templates/sections/legacy.md'
 import RETRIEVING_DATA from '@/templates/sections/retrieving-data.md'
 import SCHEMA_WORKFLOW from '@/templates/sections/schema-workflow.md'
+import TOOL_CALL_CONTEXT from '@/templates/sections/tool-call-context.md'
 import TOOL_SEARCH from '@/templates/sections/tool-search.md'
 import URL_PATTERNS from '@/templates/sections/url-patterns.md'
 
@@ -64,6 +65,7 @@ export class InstructionsFormatter {
                 SCHEMA_WORKFLOW,
                 ENV_CONTEXT,
                 URL_PATTERNS,
+                ...(this.toolCallContextEnabled(ctx.featureFlags) ? [TOOL_CALL_CONTEXT] : []),
                 ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK] : []),
                 EXAMPLES,
             ],
@@ -101,6 +103,7 @@ export class InstructionsFormatter {
             SCHEMA_WORKFLOW,
             ENV_CONTEXT,
             URL_PATTERNS,
+            ...(this.toolCallContextEnabled(ctx.featureFlags) ? [TOOL_CALL_CONTEXT] : []),
             ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK] : []),
             EXAMPLES,
         ]
@@ -113,6 +116,10 @@ export class InstructionsFormatter {
      *  in `resolveToolFeatureFlags`. */
     private agentFeedbackEnabled(featureFlags: Record<string, boolean> | undefined): boolean {
         return featureFlags?.['mcp-feedback-tool'] === true
+    }
+
+    private toolCallContextEnabled(featureFlags: Record<string, boolean> | undefined): boolean {
+        return featureFlags?.['mcp-tool-call-context'] === true
     }
 
     private compose(sections: string[], ctx: InstructionsContext, opts: { compact: boolean }): string {

--- a/services/mcp/src/lib/mcp-context.ts
+++ b/services/mcp/src/lib/mcp-context.ts
@@ -1,0 +1,22 @@
+export const MCP_CONTEXT_FIELD = '_mcp_context'
+export const MCP_CONTEXT_MAX_LENGTH = 2_000
+export const MCP_CONTEXT_DESCRIPTION =
+    "Optional: briefly explain why you're calling this tool and how it helps the user's current task. Do not include secrets, credentials, or raw customer data."
+
+export function extractMcpContext(params: unknown): string | undefined {
+    if (!params || typeof params !== 'object') {
+        return undefined
+    }
+
+    const value = (params as Record<string, unknown>)[MCP_CONTEXT_FIELD]
+    return typeof value === 'string' ? value.slice(0, MCP_CONTEXT_MAX_LENGTH) : undefined
+}
+
+export function stripMcpContext(params: unknown): Record<string, unknown> {
+    if (!params || typeof params !== 'object') {
+        return {}
+    }
+
+    const { [MCP_CONTEXT_FIELD]: _mcpContext, ...cleanedParams } = params as Record<string, unknown>
+    return cleanedParams
+}

--- a/services/mcp/src/lib/mcpcat.ts
+++ b/services/mcp/src/lib/mcpcat.ts
@@ -3,6 +3,7 @@ import { env } from 'cloudflare:workers'
 import { track } from 'mcpcat'
 
 import type { MCPAnalyticsContext } from '@/lib/analytics'
+import { extractMcpContext } from '@/lib/mcp-context'
 
 /** Provider interface for resolving user/session identity and workspace context. */
 export type McpCatIdentityProvider = {
@@ -65,7 +66,7 @@ export async function initMcpCatObservability(server: McpServer, identity: McpCa
             },
             // Recomputed per event so workspace switches (via `switch-project` / `switch-organization`)
             // are reflected on subsequent events without a reinit.
-            eventProperties: async () => {
+            eventProperties: async (request) => {
                 const [
                     mcpVersion,
                     clientUserAgent,
@@ -100,9 +101,13 @@ export async function initMcpCatObservability(server: McpServer, identity: McpCa
                     ...(analyticsContext?.organizationId ? { organization: analyticsContext.organizationId } : {}),
                     ...(analyticsContext?.projectUuid ? { project: analyticsContext.projectUuid } : {}),
                 }
+                const mcpContext = extractMcpContext(
+                    (request as { params?: { arguments?: unknown } })?.params?.arguments
+                )
 
                 return {
                     ai_product: 'mcp',
+                    ...(mcpContext ? { mcp_context: mcpContext } : {}),
                     mcp_version: mcpVersion,
                     client_user_agent: clientUserAgent,
                     mcp_client_name: mcpClientName,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -2,7 +2,7 @@ import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
 import guidelines from '@shared/guidelines.md'
 import { McpAgent } from 'agents/mcp'
-import type { z } from 'zod'
+import { z } from 'zod'
 
 import { ApiClient } from '@/api/client'
 import {
@@ -28,6 +28,7 @@ import {
 import { handleToolError, wrapError } from '@/lib/errors'
 import { type QueryToolInfo } from '@/lib/instructions'
 import { InstructionsFormatter } from '@/lib/instructions-formatter'
+import { MCP_CONTEXT_DESCRIPTION, MCP_CONTEXT_FIELD, MCP_CONTEXT_MAX_LENGTH, stripMcpContext } from '@/lib/mcp-context'
 import { initMcpCatObservability } from '@/lib/mcpcat'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
@@ -91,6 +92,7 @@ export class MCP extends McpAgent<Env> {
     private mcpProtocolVersion: string | undefined
     private mcpMode: McpMode | undefined
     private mcpVersion: number | undefined
+    private toolCallContextEnabled = false
 
     get requestProperties(): RequestProperties {
         return this.props as RequestProperties
@@ -376,12 +378,12 @@ export class MCP extends McpAgent<Env> {
         tool: Tool<TSchema>,
         handler: (params: z.infer<TSchema>) => Promise<any>
     ): void {
-        const wrappedHandler = async (params: z.infer<TSchema>): Promise<any> => {
-            const validation = tool.schema.safeParse(params)
+        const wrappedHandler = async (params: z.infer<TSchema> & { [MCP_CONTEXT_FIELD]?: unknown }): Promise<any> => {
+            const cleanedParams = stripMcpContext(params)
+            const validation = tool.schema.safeParse(cleanedParams)
 
             if (!validation.success) {
                 const errorOutput = `Invalid input: ${validation.error.message}`
-
                 return {
                     content: [
                         {
@@ -397,7 +399,7 @@ export class MCP extends McpAgent<Env> {
                 const previousContext = isContextSwitch
                     ? await this.getAnalyticsContextSafe(await this.getContext())
                     : undefined
-                const handlerResult = await handler(params)
+                const handlerResult = await handler(validation.data)
                 if (isContextSwitch) {
                     this.ctx.waitUntil(
                         this.trackContextSwitchEvent(tool.name, await this.getContext(), previousContext)
@@ -420,7 +422,7 @@ export class MCP extends McpAgent<Env> {
                     handlerResult,
                     toolMeta: tool._meta,
                     toolName: tool.name,
-                    params,
+                    params: validation.data,
                     clientName: this.mcpClientName,
                     distinctId,
                 })
@@ -452,7 +454,16 @@ export class MCP extends McpAgent<Env> {
             {
                 title: tool.title,
                 description: tool.description,
-                inputSchema: tool.schema.shape,
+                inputSchema: this.toolCallContextEnabled
+                    ? {
+                          ...tool.schema.shape,
+                          [MCP_CONTEXT_FIELD]: z
+                              .string()
+                              .max(MCP_CONTEXT_MAX_LENGTH)
+                              .optional()
+                              .describe(MCP_CONTEXT_DESCRIPTION),
+                      }
+                    : tool.schema.shape,
                 annotations: tool.annotations,
                 ...(normalizedMeta ? { _meta: normalizedMeta } : {}),
             },
@@ -469,6 +480,15 @@ export class MCP extends McpAgent<Env> {
             env: this.env,
             stateManager,
             sessionManager: this.sessionManager,
+            mcp: {
+                sessionUuid: this.requestProperties.sessionId
+                    ? await this.sessionManager.getSessionUuid(this.requestProperties.sessionId)
+                    : undefined,
+                clientName: this.mcpClientName,
+                clientVersion: this.mcpClientVersion,
+                protocolVersion: this.mcpProtocolVersion,
+                transport: this.requestProperties.transport,
+            },
             getDistinctId: () => this.getDistinctId(),
         }
         const trackEvent: Context['trackEvent'] = async (event, properties = {}) => {
@@ -500,6 +520,7 @@ export class MCP extends McpAgent<Env> {
         const flagPromise = this.resolveVersionFlag()
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
         const singleExecPromise = this.resolveSingleExecFlag()
+        const toolCallContextPromise = this.resolveToolCallContextFlag()
 
         // Seed cache with header-provided IDs before any fetches
         if (organizationId) {
@@ -528,13 +549,15 @@ export class MCP extends McpAgent<Env> {
             await context.stateManager.setDefaultOrganizationAndProject()
         }
 
-        const [flagVersion, toolFeatureFlags, singleExecFlagOn] = await Promise.all([
+        const [flagVersion, toolFeatureFlags, singleExecFlagOn, toolCallContextEnabled] = await Promise.all([
             flagPromise,
             toolFlagsPromise,
             singleExecPromise,
+            toolCallContextPromise,
             // Trigger OAuth introspection so the OAuth client name is cached before the useSingleExec decision below
             context.stateManager.getApiKey(),
         ])
+        this.toolCallContextEnabled = toolCallContextEnabled
 
         const oauthClientName = (await this.cache.get('clientName')) || undefined
 
@@ -612,13 +635,18 @@ export class MCP extends McpAgent<Env> {
 
         const supportsInstructions = clientProfile.capabilities.supportsInstructions
 
+        const promptFeatureFlags = {
+            ...toolFeatureFlags,
+            'mcp-tool-call-context': toolCallContextEnabled,
+        }
+
         const instructionsContext = {
             guidelines,
             groupTypes,
             metadata,
             tools: toolInfos,
             queryTools: queryToolInfos,
-            featureFlags: toolFeatureFlags,
+            featureFlags: promptFeatureFlags,
         }
 
         // In single-exec mode, when the client honors the MCP `instructions` field we
@@ -800,6 +828,15 @@ export class MCP extends McpAgent<Env> {
         try {
             const distinctId = await this.getDistinctId()
             return !!(await isFeatureFlagEnabled('mcp-single-exec-tool', distinctId))
+        } catch {
+            return false
+        }
+    }
+
+    private async resolveToolCallContextFlag(): Promise<boolean> {
+        try {
+            const distinctId = await this.getDistinctId()
+            return !!(await isFeatureFlagEnabled('mcp-tool-call-context', distinctId))
         } catch {
             return false
         }

--- a/services/mcp/src/templates/sections/tool-call-context.md
+++ b/services/mcp/src/templates/sections/tool-call-context.md
@@ -1,0 +1,5 @@
+### Tool call context
+
+When calling a tool, include `_mcp_context` with one concise sentence explaining why you are calling that tool and how it helps answer the user's request.
+
+Good `_mcp_context` values describe intent, not implementation details. Do not include secrets, credentials, raw customer data, or long copied inputs.

--- a/services/mcp/src/tools/feedback/submit.ts
+++ b/services/mcp/src/tools/feedback/submit.ts
@@ -10,6 +10,7 @@ type Params = z.infer<typeof schema>
 
 type Result = {
     received: boolean
+    persisted: boolean
     summary: string
     sentiment: Params['sentiment']
     category: Params['category']
@@ -21,10 +22,63 @@ const RESPONSE_MESSAGE =
     "Submitting feedback does not mean your work is done: keep going and finish the user's task " +
     'using the other available tools.'
 
+const CATEGORY_MAPPING: Record<Params['category'], string> = {
+    tool_correctness: 'bug',
+    tool_description: 'docs',
+    tool_input_schema: 'usability',
+    tool_output_format: 'usability',
+    missing_tool: 'other',
+    instructions_clarity: 'docs',
+    performance: 'results',
+    error_message: 'usability',
+    other: 'other',
+}
+
+function buildFeedbackBody(params: Params): string {
+    return [
+        `Summary: ${params.summary}`,
+        `Sentiment: ${params.sentiment}`,
+        `Task completed: ${params.task_completed}`,
+        params.tools_used?.length ? `Tools used: ${params.tools_used.join(', ')}` : undefined,
+        params.friction_points ? `Friction points: ${params.friction_points}` : undefined,
+        params.suggested_improvement ? `Suggested improvement: ${params.suggested_improvement}` : undefined,
+        params.details ? `Details: ${params.details}` : undefined,
+    ]
+        .filter(Boolean)
+        .join('\n')
+}
+
+async function persistFeedbackSubmission(context: Context, params: Params): Promise<boolean> {
+    try {
+        const projectId = await context.stateManager.getProjectId()
+        const attemptedTool = params.tools_used?.at(-1) ?? ''
+        await context.api.request({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(projectId)}/mcp_analytics/feedback/`,
+            body: {
+                goal: params.user_request ?? params.summary,
+                feedback: buildFeedbackBody(params),
+                category: CATEGORY_MAPPING[params.category],
+                attempted_tool: attemptedTool,
+                mcp_client_name: context.mcp?.clientName ?? '',
+                mcp_client_version: context.mcp?.clientVersion ?? '',
+                mcp_protocol_version: context.mcp?.protocolVersion ?? '',
+                mcp_transport: context.mcp?.transport ?? '',
+                mcp_session_id: context.mcp?.sessionUuid ?? '',
+            },
+        })
+        return true
+    } catch {
+        return false
+    }
+}
+
 export const submitFeedbackHandler: ToolBase<typeof schema, Result>['handler'] = async (
     context: Context,
     params: Params
 ) => {
+    const persisted = await persistFeedbackSubmission(context, params)
+
     // `context.trackEvent` is itself best-effort (the MCP-class implementation wraps
     // analytics in its own try/catch). The outer try/catch here defends against any
     // unexpected throw on the way *to* trackEvent (e.g. a future refactor) so the
@@ -40,6 +94,9 @@ export const submitFeedbackHandler: ToolBase<typeof schema, Result>['handler'] =
             feedback_suggested_improvement: params.suggested_improvement,
             feedback_user_request: params.user_request,
             feedback_details: params.details,
+            feedback_persisted: persisted,
+            feedback_mcp_session_id: context.mcp?.sessionUuid,
+            feedback_mcp_client_name: context.mcp?.clientName,
         })
     } catch {
         // Analytics is non-fatal — never surface as a tool failure.
@@ -47,6 +104,7 @@ export const submitFeedbackHandler: ToolBase<typeof schema, Result>['handler'] =
 
     return {
         received: true,
+        persisted,
         summary: params.summary,
         sentiment: params.sentiment,
         category: params.category,

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -78,6 +78,13 @@ export type Context = {
     env: Env
     stateManager: StateManager
     sessionManager: SessionManager
+    mcp?: {
+        sessionUuid?: string | undefined
+        clientName?: string | undefined
+        clientVersion?: string | undefined
+        protocolVersion?: string | undefined
+        transport?: string | undefined
+    }
     /**
      * Resolve the current user's PostHog distinct ID. Cached by the MCP class —
      * safe to call repeatedly. Exposed on the context so tool handlers (e.g. the

--- a/services/mcp/tests/unit/feedback-submit.test.ts
+++ b/services/mcp/tests/unit/feedback-submit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { submitFeedbackHandler } from '@/tools/feedback/submit'
+import type { Context } from '@/tools/types'
+
+function createContext(requestMock: ReturnType<typeof vi.fn>, trackEventMock: ReturnType<typeof vi.fn>): Context {
+    return {
+        api: { request: requestMock } as any,
+        cache: {} as any,
+        env: {} as any,
+        stateManager: { getProjectId: vi.fn().mockResolvedValue('42') } as any,
+        sessionManager: {} as any,
+        mcp: {
+            sessionUuid: 'session-uuid',
+            clientName: 'Claude Code',
+            clientVersion: '1.2.3',
+            protocolVersion: '2025-03-26',
+            transport: 'streamable-http',
+        },
+        getDistinctId: vi.fn().mockResolvedValue('distinct-id'),
+        trackEvent: trackEventMock,
+    }
+}
+
+const feedbackParams = {
+    summary: 'query tool schema was confusing',
+    sentiment: 'mixed' as const,
+    category: 'tool_input_schema' as const,
+    task_completed: true,
+    tools_used: ['read-data-schema', 'execute-sql'],
+    friction_points: 'The query parameter shape was hard to infer.',
+    suggested_improvement: 'Add a concrete filters example.',
+    user_request: 'Analyze activation events',
+    details: 'The task eventually succeeded.',
+}
+
+describe('submitFeedbackHandler', () => {
+    it.each([
+        {
+            name: 'persists feedback to mcp_analytics and keeps analytics capture',
+            requestResult: { id: 'submission-id' },
+            expectedPersisted: true,
+        },
+        {
+            name: 'returns received when persistence fails',
+            requestError: new Error('permission denied'),
+            expectedPersisted: false,
+        },
+    ])('$name', async ({ requestResult, requestError, expectedPersisted }) => {
+        const requestMock = requestError
+            ? vi.fn().mockRejectedValue(requestError)
+            : vi.fn().mockResolvedValue(requestResult)
+        const trackEventMock = vi.fn().mockResolvedValue(undefined)
+        const context = createContext(requestMock, trackEventMock)
+
+        const result = await submitFeedbackHandler(context, feedbackParams)
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                received: true,
+                persisted: expectedPersisted,
+                summary: feedbackParams.summary,
+            })
+        )
+
+        if (expectedPersisted) {
+            expect(requestMock).toHaveBeenCalledWith({
+                method: 'POST',
+                path: '/api/environments/42/mcp_analytics/feedback/',
+                body: {
+                    goal: 'Analyze activation events',
+                    feedback: expect.stringContaining('Summary: query tool schema was confusing'),
+                    category: 'usability',
+                    attempted_tool: 'execute-sql',
+                    mcp_client_name: 'Claude Code',
+                    mcp_client_version: '1.2.3',
+                    mcp_protocol_version: '2025-03-26',
+                    mcp_transport: 'streamable-http',
+                    mcp_session_id: 'session-uuid',
+                },
+            })
+        }
+        expect(trackEventMock).toHaveBeenCalledWith(
+            'mcp feedback submitted',
+            expect.objectContaining({
+                feedback_persisted: expectedPersisted,
+                feedback_mcp_session_id: 'session-uuid',
+                feedback_mcp_client_name: 'Claude Code',
+            })
+        )
+    })
+})

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -111,6 +111,20 @@ describe('InstructionsFormatter', () => {
                 expect(result).not.toContain('### Sharing feedback on this MCP server')
             }
         })
+
+        it('includes the tool-call context section only when the mcp-tool-call-context flag is on', () => {
+            const formatter = new InstructionsFormatter()
+            const withContext = formatter.buildV2Instructions({
+                ...fullCtx,
+                featureFlags: { 'mcp-tool-call-context': true },
+            })
+            expect(withContext).toContain('### Tool call context')
+
+            for (const featureFlags of [undefined, { 'mcp-tool-call-context': false }, {}]) {
+                const result = formatter.buildV2Instructions({ ...fullCtx, featureFlags })
+                expect(result).not.toContain('### Tool call context')
+            }
+        })
     })
 
     describe('buildExecInstructions', () => {
@@ -218,6 +232,23 @@ describe('InstructionsFormatter', () => {
                     { stripEnvContext }
                 )
                 expect(withoutFeedback).not.toContain('### Sharing feedback on this MCP server')
+            }
+        })
+
+        it('includes the tool-call context section only when the mcp-tool-call-context flag is on', () => {
+            const formatter = new InstructionsFormatter()
+            for (const stripEnvContext of [true, false]) {
+                const withContext = formatter.buildExecCommandReference(
+                    { ...fullCtx, featureFlags: { 'mcp-tool-call-context': true } },
+                    { stripEnvContext }
+                )
+                expect(withContext).toContain('### Tool call context')
+
+                const withoutContext = formatter.buildExecCommandReference(
+                    { ...fullCtx, featureFlags: { 'mcp-tool-call-context': false } },
+                    { stripEnvContext }
+                )
+                expect(withoutContext).not.toContain('### Tool call context')
             }
         })
     })

--- a/services/mcp/tests/unit/mcp-tool-call-context.test.ts
+++ b/services/mcp/tests/unit/mcp-tool-call-context.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+vi.mock('agents/mcp', () => ({
+    McpAgent: class {},
+}))
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+    McpServer: class {},
+}))
+
+vi.mock('@modelcontextprotocol/ext-apps/server', () => ({
+    RESOURCE_URI_META_KEY: 'resource-uri',
+}))
+
+vi.mock('@shared/guidelines.md', () => ({
+    default: '',
+}))
+
+import { MCP } from '@/mcp'
+
+describe('MCP tool call context', () => {
+    it('accepts _mcp_context and strips it from handler params', async () => {
+        let registeredHandler: ((params: Record<string, unknown>) => Promise<unknown>) | undefined
+        let registeredInputSchema: Record<string, unknown> | undefined
+
+        const mcp = Object.create(MCP.prototype) as MCP
+        ;(mcp as any).toolCallContextEnabled = true
+        ;(mcp as any).ctx = {
+            waitUntil: vi.fn(),
+        }
+        ;(mcp as any).server = {
+            registerTool: vi.fn((_name, options, handler) => {
+                registeredInputSchema = options.inputSchema
+                registeredHandler = handler
+            }),
+        }
+
+        const handler = vi.fn().mockResolvedValue('ok')
+
+        mcp.registerTool(
+            {
+                name: 'query-run',
+                schema: z.object({ query: z.string() }),
+            } as any,
+            handler
+        )
+
+        expect(registeredInputSchema).toHaveProperty('_mcp_context')
+
+        await registeredHandler?.({
+            query: 'select 1',
+            _mcp_context: 'checking activation counts for the user request',
+        })
+
+        expect(handler).toHaveBeenCalledWith({ query: 'select 1' })
+    })
+})

--- a/services/mcp/tests/unit/mcpcat.test.ts
+++ b/services/mcp/tests/unit/mcpcat.test.ts
@@ -76,9 +76,9 @@ describe('initMcpCatObservability', () => {
         return options.eventTags
     }
 
-    function getEventPropertiesCallback(): () => Promise<Record<string, unknown>> {
+    function getEventPropertiesCallback(): (request?: unknown) => Promise<Record<string, unknown>> {
         const call = vi.mocked(track).mock.calls[0]!
-        const options = call[2] as { eventProperties: () => Promise<Record<string, unknown>> }
+        const options = call[2] as { eventProperties: (request?: unknown) => Promise<Record<string, unknown>> }
         return options.eventProperties
     }
 
@@ -264,6 +264,28 @@ describe('initMcpCatObservability', () => {
 
         const result = await getEventPropertiesCallback()()
         expect(result).toEqual(expected)
+    })
+
+    it('eventProperties promotes _mcp_context from request arguments to a top-level property', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        await initMcpCatObservability(server, identity)
+
+        const result = await getEventPropertiesCallback()({
+            params: {
+                arguments: {
+                    query: 'select 1',
+                    _mcp_context: 'checking activation counts before replying to the user',
+                },
+            },
+        })
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                mcp_context: 'checking activation counts before replying to the user',
+            })
+        )
     })
 
     it('swallows errors if mcpcat.track throws', async () => {


### PR DESCRIPTION
## Problem

PostHog MCP usage is growing, but the existing feedback path only records a lightweight analytics event. That makes it hard to connect agent feedback to the MCP session, client, transport, and tool context that produced it.

We need an MVP that keeps the current telemetry path working while also creating structured feedback submissions that can be inspected through the new `mcp_analytics` groundwork.

## Changes

- Add an optional `_mcp_context` field to exposed MCP tool schemas behind the `mcp-tool-call-context` feature flag.
- Strip `_mcp_context` before normal tool validation and handler execution, then attach it to native `mcp_tool_call` analytics events with duration, success, and error metadata.
- Add MCP session/client metadata to tool handler context.
- Make `agent-feedback` best-effort persist to `/mcp_analytics/feedback/` while keeping the existing `mcp feedback submitted` analytics event as a fallback signal.
- Add unit coverage for feedback persistence success and failure paths.

## How did you test this code?

I am an agent. Automated validation run locally:

- `pnpm --filter=@posthog/mcp typecheck`
- `pnpm --filter=@posthog/mcp test -- tests/unit/feedback-submit.test.ts`

The vitest invocation ran the MCP test suite in this setup: 46 files, 1071 tests passed.

## Publish to changelog?

no

## Docs update

No docs update for this internal MCP observability MVP.

## 🤖 Agent context

Codex-authored from prompts asking to ship a fast internal MVP for MCP feedback collection and tool-call context capture.

Key decisions:

- Used a feature flag for `_mcp_context` exposure to limit rollout risk.
- Made feedback persistence best-effort so feedback collection cannot block the agent from continuing the user task.
- Used the existing `mcp_analytics` feedback endpoint instead of adding new storage models in this PR.
