### PR TITLE
chore(flags): add redis-cli and awscli to rust-jumphost image

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -40,6 +40,8 @@
   dockerfile: ./rust/Dockerfile
   project: vglf58qgzw
   features: warm-flags-cache
+  # Adds redis-cli + awscli for operator use (see bin/rust-jumphost).
+  target: runtime-jumphost
 
 - image: batch-import-worker
   dockerfile: ./rust/Dockerfile

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -145,6 +145,7 @@ jobs:
                   project: ${{ matrix.project }}
                   context: ./rust/
                   file: ${{ matrix.dockerfile }}
+                  target: ${{ matrix.target || '' }}
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -70,3 +70,13 @@ USER nobody
 
 COPY --from=builder /app/target/release/$BIN /usr/local/bin
 ENTRYPOINT ["/bin/sh", "-c", "/usr/local/bin/$BIN"]
+
+# Opt-in stage for jumphost images (see bin/rust-jumphost) — not used by
+# request-path services, which keep building the smaller `runtime` stage.
+FROM runtime AS runtime-jumphost
+
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends redis-tools awscli && \
+    rm -rf /var/lib/apt/lists/*
+USER nobody

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -80,3 +80,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends redis-tools awscli && \
     rm -rf /var/lib/apt/lists/*
 USER nobody
+
+# Keep the file's final stage equivalent to `runtime` so builds without an
+# explicit `--target` (e.g. canary-flags-enable.yml, ad-hoc `docker build`)
+# keep producing the minimal image instead of silently inheriting the larger
+# jumphost layer.
+FROM runtime AS default


### PR DESCRIPTION
## Problem

When operators claim a rust-jumphost pod (`bin/rust-jumphost`) to inspect feature-flag cache state, the only tools inside the pod are libssl, ca-certs, curl, and brotli. There is no way to reach Redis (e.g. `redis-cli GET posthog:1:cache/teams/<id>/feature_flags/flags.json`) or S3 (the bucket the warmer writes to) from inside the pod.

We can't add redis-tools to the shared `runtime` stage in `rust/Dockerfile`, because that stage is the final base for every Rust service image (capture, feature-flags, property-defs-rs, etc.) and would inflate all of them for tooling only the jumphost needs.

## Changes

A new opt-in `runtime-jumphost` build stage layers `redis-tools` and `awscli` on top of the shared `runtime` stage in `rust/Dockerfile`. The binary copy, `USER nobody`, and entrypoint are inherited unchanged.

The `flags-cache-warmer` image opts in by setting `target: runtime-jumphost` in `.github/rust-images.yml`. The shared workflow `.github/workflows/_rust-build-images.yml` threads `target: ${{ matrix.target || '' }}` into `depot/build-push-action`, so every other Rust service keeps building the smaller `runtime` stage by default.

No charts PR is needed: image SHAs are auto-bumped via the `repository_dispatch` step in `rust-docker-build.yml`.

## How did you test this code?

Verified locally that `apt-get install -y --no-install-recommends redis-tools awscli` succeeds on `debian:bookworm-slim`, with `redis-cli 7.0.15` and `aws-cli/2.9.19` on the resulting image. The full Rust image build runs through CI on this PR; I haven't built the full image locally.

Post-merge: claim a jumphost with `KUBE_CONTEXT=posthog-dev bin/rust-jumphost`, then run `redis-cli --version` and `aws --version` inside the pod.

## Publish to changelog?

no