### PR TITLE
feat(web-analytics): link live tab tiles to product analytics insights

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
@@ -5,6 +5,8 @@ import { Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { getSeriesColorPalette } from 'lib/colors'
 
+import { LiveOpenInsightButton } from './LiveOpenInsightButton'
+
 interface BreakdownItem {
     count: number
     percentage: number
@@ -20,6 +22,7 @@ interface BreakdownLiveCardProps<T extends BreakdownItem> {
     statLabel: string
     totalCount?: number
     isLoading?: boolean
+    openInsightUrl?: string
 }
 
 const BreakdownLiveCardInner = <T extends BreakdownItem>({
@@ -32,6 +35,7 @@ const BreakdownLiveCardInner = <T extends BreakdownItem>({
     statLabel,
     totalCount,
     isLoading,
+    openInsightUrl,
 }: BreakdownLiveCardProps<T>): JSX.Element => {
     const colors = useMemo(() => getSeriesColorPalette(), [])
 
@@ -67,8 +71,9 @@ const BreakdownLiveCardInner = <T extends BreakdownItem>({
 
     return (
         <div className="bg-bg-light rounded-lg border border-border p-4 h-full min-h-[340px] flex flex-col">
-            <div className="mb-4">
+            <div className="mb-4 flex items-start justify-between gap-2">
                 {typeof title === 'string' ? <h3 className="text-sm font-semibold text-default">{title}</h3> : title}
+                {openInsightUrl && <LiveOpenInsightButton to={openInsightUrl} />}
             </div>
 
             {isLoading ? (

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveAnimatedTable.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveAnimatedTable.tsx
@@ -3,6 +3,8 @@ import { ReactNode, useLayoutEffect, useRef } from 'react'
 
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
+import { LiveOpenInsightButton } from './LiveOpenInsightButton'
+
 const ROW_HEIGHT = 36
 
 interface AnimatedRowProps {
@@ -78,6 +80,7 @@ interface LiveAnimatedTableProps<T> {
     isLoading: boolean
     totalPageviews: number
     className?: string
+    openInsightUrl?: string
 }
 
 export function LiveAnimatedTable<T>({
@@ -91,6 +94,7 @@ export function LiveAnimatedTable<T>({
     isLoading,
     totalPageviews,
     className,
+    openInsightUrl,
 }: LiveAnimatedTableProps<T>): JSX.Element {
     const prevPositionsRef = useRef<Map<string, number>>(new Map())
     const deltaVersionRef = useRef(0)
@@ -114,7 +118,10 @@ export function LiveAnimatedTable<T>({
 
     return (
         <div className={clsx('bg-bg-light rounded-lg border p-4 h-full min-h-[340px] flex flex-col', className)}>
-            <h3 className="text-sm font-semibold mb-4">{title}</h3>
+            <div className="flex items-start justify-between gap-2 mb-4">
+                <h3 className="text-sm font-semibold">{title}</h3>
+                {openInsightUrl && <LiveOpenInsightButton to={openInsightUrl} />}
+            </div>
             {isLoading ? (
                 <div className="flex-1 flex flex-col justify-center space-y-2">
                     {Array.from({ length: 5 }).map((_, i) => (

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveBotTrafficCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveBotTrafficCard.tsx
@@ -1,11 +1,15 @@
 import clsx from 'clsx'
 import React, { useMemo } from 'react'
 
-import { LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { getSeriesColorPalette } from 'lib/colors'
 import { IconRobot } from 'lib/lemon-ui/icons'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+
+import { LiveOpenInsightButton } from './LiveOpenInsightButton'
 import { BotBreakdownItem } from './LiveWebAnalyticsMetricsTypes'
 
 interface LiveBotTrafficCardProps {
@@ -13,6 +17,8 @@ interface LiveBotTrafficCardProps {
     totalBotEvents: number
     totalEvents: number
     isLoading?: boolean
+    openInsightUrl?: string
+    getRowInsightUrl?: (item: BotBreakdownItem) => string | undefined
 }
 
 const LiveBotTrafficCardInner = ({
@@ -20,6 +26,8 @@ const LiveBotTrafficCardInner = ({
     totalBotEvents,
     totalEvents,
     isLoading,
+    openInsightUrl,
+    getRowInsightUrl,
 }: LiveBotTrafficCardProps): JSX.Element => {
     const colors = useMemo(() => getSeriesColorPalette(), [])
 
@@ -45,14 +53,23 @@ const LiveBotTrafficCardInner = ({
 
     return (
         <div className="bg-bg-light rounded-lg border border-border p-4 h-full min-h-[340px] flex flex-col">
-            <div className="mb-4 flex items-center justify-between">
+            <div className="mb-4 flex items-center justify-between gap-2">
                 <h3 className="text-sm font-semibold text-default flex items-center gap-2">
                     <IconRobot className="text-base text-muted" />
                     Bot traffic
                 </h3>
-                <Tooltip title="Based on PostHog's experimental user agent bot detection, matching search engines, AI crawlers, monitoring tools and more.">
-                    <span className="text-xs text-muted">Preview</span>
-                </Tooltip>
+                <div className="flex items-center gap-2">
+                    <Tooltip title="Based on PostHog's experimental user agent bot detection, matching search engines, AI crawlers, monitoring tools and more.">
+                        <span className="text-xs text-muted">Preview</span>
+                    </Tooltip>
+                    {openInsightUrl && (
+                        <LiveOpenInsightButton
+                            to={openInsightUrl}
+                            label="Breakdown"
+                            title="Open the bot traffic breakdown as a Trends insight"
+                        />
+                    )}
+                </div>
             </div>
 
             {isLoading ? (
@@ -76,45 +93,68 @@ const LiveBotTrafficCardInner = ({
                     <div className="space-y-2">
                         {processedData.map(({ item, color }, index) => {
                             const isTop = index === 0
-                            return (
-                                <Tooltip
-                                    key={item.bot}
-                                    title={`${item.count.toLocaleString()} events · ${item.bot}${
-                                        item.category ? ` (${item.category})` : ''
-                                    }`}
+                            const rowUrl = getRowInsightUrl?.(item)
+                            const tooltip = `${item.count.toLocaleString()} events · ${item.bot}${
+                                item.category ? ` (${item.category})` : ''
+                            }${rowUrl ? ' · click to open as insight' : ''}`
+                            const rowContent = (
+                                <div
+                                    className={clsx(
+                                        'flex items-center gap-2 px-1 py-0.5 rounded',
+                                        rowUrl ? 'cursor-pointer hover:bg-bg-3000 transition-colors' : 'cursor-default'
+                                    )}
                                 >
-                                    <div className="flex items-center gap-2 cursor-default">
-                                        <div
-                                            className={clsx(
-                                                'text-xs truncate w-20',
-                                                isTop ? 'text-default font-medium' : 'text-muted'
-                                            )}
-                                        >
-                                            {item.bot}
-                                        </div>
-                                        {item.category ? (
-                                            <LemonTag type="muted" size="small" className="shrink-0 text-[10px]">
-                                                {item.category}
-                                            </LemonTag>
-                                        ) : null}
-                                        <div className="flex-1 h-2 bg-border-light rounded-full overflow-hidden">
-                                            <div
-                                                className="h-full rounded-full transition-all duration-300 ease-out"
-                                                style={{
-                                                    width: `${item.percentage}%`,
-                                                    backgroundColor: color,
-                                                }}
-                                            />
-                                        </div>
-                                        <div
-                                            className={clsx(
-                                                'w-10 text-xs text-right tabular-nums',
-                                                isTop ? 'text-default font-medium' : 'text-muted'
-                                            )}
-                                        >
-                                            {item.percentage.toFixed(0)}%
-                                        </div>
+                                    <div
+                                        className={clsx(
+                                            'text-xs truncate w-20',
+                                            isTop ? 'text-default font-medium' : 'text-muted'
+                                        )}
+                                    >
+                                        {item.bot}
                                     </div>
+                                    {item.category ? (
+                                        <LemonTag type="muted" size="small" className="shrink-0 text-[10px]">
+                                            {item.category}
+                                        </LemonTag>
+                                    ) : null}
+                                    <div className="flex-1 h-2 bg-border-light rounded-full overflow-hidden">
+                                        <div
+                                            className="h-full rounded-full transition-all duration-300 ease-out"
+                                            style={{
+                                                width: `${item.percentage}%`,
+                                                backgroundColor: color,
+                                            }}
+                                        />
+                                    </div>
+                                    <div
+                                        className={clsx(
+                                            'w-10 text-xs text-right tabular-nums',
+                                            isTop ? 'text-default font-medium' : 'text-muted'
+                                        )}
+                                    >
+                                        {item.percentage.toFixed(0)}%
+                                    </div>
+                                </div>
+                            )
+                            return (
+                                <Tooltip key={item.bot} title={tooltip}>
+                                    {rowUrl ? (
+                                        <Link
+                                            to={rowUrl}
+                                            className="block no-underline text-default hover:text-default"
+                                            onClick={() => {
+                                                void addProductIntentForCrossSell({
+                                                    from: ProductKey.WEB_ANALYTICS,
+                                                    to: ProductKey.PRODUCT_ANALYTICS,
+                                                    intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+                                                })
+                                            }}
+                                        >
+                                            {rowContent}
+                                        </Link>
+                                    ) : (
+                                        rowContent
+                                    )}
                                 </Tooltip>
                             )
                         })}

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveChartCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveChartCard.tsx
@@ -3,6 +3,8 @@ import { type ReactNode } from 'react'
 
 import { Spinner, Tooltip } from '@posthog/lemon-ui'
 
+import { LiveOpenInsightButton } from './LiveOpenInsightButton'
+
 interface LiveChartCardProps {
     title: string
     subtitle?: string
@@ -11,6 +13,8 @@ interface LiveChartCardProps {
     children: ReactNode
     className?: string
     contentClassName?: string
+    openInsightUrl?: string
+    openInsightLabel?: string
 }
 
 export const LiveChartCard = ({
@@ -21,19 +25,24 @@ export const LiveChartCard = ({
     children,
     className = '',
     contentClassName = '',
+    openInsightUrl,
+    openInsightLabel,
 }: LiveChartCardProps): JSX.Element => {
     return (
         <div className={clsx('bg-bg-light rounded-lg border p-4 h-full min-h-[340px] flex flex-col', className)}>
-            <div className="flex items-baseline justify-between mb-4">
+            <div className="flex items-baseline justify-between gap-2 mb-4">
                 <h3 className="text-sm font-semibold">{title}</h3>
-                {subtitle &&
-                    (subtitleTooltip ? (
-                        <Tooltip title={subtitleTooltip}>
-                            <span className="text-xs text-muted cursor-help">{subtitle}</span>
-                        </Tooltip>
-                    ) : (
-                        <span className="text-xs text-muted">{subtitle}</span>
-                    ))}
+                <div className="flex items-center gap-2">
+                    {subtitle &&
+                        (subtitleTooltip ? (
+                            <Tooltip title={subtitleTooltip}>
+                                <span className="text-xs text-muted cursor-help">{subtitle}</span>
+                            </Tooltip>
+                        ) : (
+                            <span className="text-xs text-muted">{subtitle}</span>
+                        ))}
+                    {openInsightUrl && <LiveOpenInsightButton to={openInsightUrl} label={openInsightLabel} />}
+                </div>
             </div>
             {isLoading ? (
                 <div className="flex-1 flex items-center justify-center">

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveLocationsCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveLocationsCard.tsx
@@ -14,6 +14,7 @@ interface LiveLocationsCardProps {
     countryData: CountryBreakdownItem[]
     cityData: CityBreakdownItem[]
     isLoading?: boolean
+    openInsightUrl?: string
 }
 
 const renderFlagOrGlobe = (countryCode: string): JSX.Element => {
@@ -45,7 +46,12 @@ const getCityLabel = (d: CityBreakdownItem): string => {
 const renderCityIcon = (d: CityBreakdownItem): JSX.Element =>
     renderFlagOrGlobe(d.cityName === 'Other' ? 'Other' : d.countryCode)
 
-export const LiveLocationsCard = ({ countryData, cityData, isLoading }: LiveLocationsCardProps): JSX.Element => {
+export const LiveLocationsCard = ({
+    countryData,
+    cityData,
+    isLoading,
+    openInsightUrl,
+}: LiveLocationsCardProps): JSX.Element => {
     const [activeTab, setActiveTab] = useState<LocationTab>('country')
 
     const tabs = (
@@ -71,6 +77,7 @@ export const LiveLocationsCard = ({ countryData, cityData, isLoading }: LiveLoca
                 emptyMessage="No city data"
                 statLabel="unique visitors"
                 isLoading={isLoading}
+                openInsightUrl={openInsightUrl}
             />
         )
     }
@@ -85,6 +92,7 @@ export const LiveLocationsCard = ({ countryData, cityData, isLoading }: LiveLoca
             emptyMessage="No country data"
             statLabel="unique visitors"
             isLoading={isLoading}
+            openInsightUrl={openInsightUrl}
         />
     )
 }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveOpenInsightButton.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveOpenInsightButton.tsx
@@ -1,0 +1,35 @@
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
+
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+
+interface LiveOpenInsightButtonProps {
+    to: string
+    label?: string
+    title?: string
+}
+
+export const LiveOpenInsightButton = ({
+    to,
+    label = 'Open as new insight',
+    title,
+}: LiveOpenInsightButtonProps): JSX.Element => (
+    <LemonButton
+        to={to}
+        icon={<IconOpenInNew />}
+        size="xsmall"
+        type="secondary"
+        tooltip={title ?? label}
+        onClick={() => {
+            void addProductIntentForCrossSell({
+                from: ProductKey.WEB_ANALYTICS,
+                to: ProductKey.PRODUCT_ANALYTICS,
+                intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+            })
+        }}
+    >
+        {label}
+    </LemonButton>
+)

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveTopPathsTable.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveTopPathsTable.tsx
@@ -6,6 +6,7 @@ interface LiveTopPathsTableProps {
     isLoading: boolean
     className?: string
     totalPageviews: number
+    openInsightUrl?: string
 }
 
 const renderPathLabel = (item: PathItem): { node: React.ReactNode; tooltipTitle: string } => ({
@@ -18,6 +19,7 @@ export const LiveTopPathsTable = ({
     isLoading,
     className,
     totalPageviews,
+    openInsightUrl,
 }: LiveTopPathsTableProps): JSX.Element => (
     <LiveAnimatedTable
         items={paths}
@@ -30,5 +32,6 @@ export const LiveTopPathsTable = ({
         isLoading={isLoading}
         totalPageviews={totalPageviews}
         className={className}
+        openInsightUrl={openInsightUrl}
     />
 )

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveTopReferrersTable.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveTopReferrersTable.tsx
@@ -39,6 +39,7 @@ interface LiveTopReferrersTableProps {
     isLoading: boolean
     className?: string
     totalPageviews: number
+    openInsightUrl?: string
 }
 
 export const LiveTopReferrersTable = ({
@@ -46,6 +47,7 @@ export const LiveTopReferrersTable = ({
     isLoading,
     className,
     totalPageviews,
+    openInsightUrl,
 }: LiveTopReferrersTableProps): JSX.Element => (
     <LiveAnimatedTable
         items={referrers}
@@ -58,5 +60,6 @@ export const LiveTopReferrersTable = ({
         isLoading={isLoading}
         totalPageviews={totalPageviews}
         className={className}
+        openInsightUrl={openInsightUrl}
     />
 )

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -30,12 +30,28 @@ import { CONTENT_CARD_SPAN, LiveContentCardId, LiveStatCardId } from './liveCard
 import { LiveChartCard } from './LiveChartCard'
 import { LiveLocationsCard } from './LiveLocationsCard'
 import { LiveStatCard, LiveStatDivider } from './LiveStatCard'
+import {
+    activeUsersChartInsightUrl,
+    botEventsChartInsightUrl,
+    botRowInsightUrl,
+    botTrafficBreakdownInsightUrl,
+    browsersInsightUrl,
+    countriesInsightUrl,
+    devicesInsightUrl,
+    topPathsInsightUrl,
+    topReferrersInsightUrl,
+} from './liveTileInsightUrls'
 import { LiveTopPathsTable } from './LiveTopPathsTable'
 import { LiveTopReferrersTable } from './LiveTopReferrersTable'
 import { liveWebAnalyticsLayoutLogic } from './liveWebAnalyticsLayoutLogic'
 import { BotEventsPerMinuteChart, UsersPerMinuteChart } from './liveWebAnalyticsMetricsCharts'
 import { liveWebAnalyticsMetricsLogic } from './liveWebAnalyticsMetricsLogic'
-import { BrowserBreakdownItem, CountryBreakdownItem, DeviceBreakdownItem } from './LiveWebAnalyticsMetricsTypes'
+import {
+    BotBreakdownItem,
+    BrowserBreakdownItem,
+    CountryBreakdownItem,
+    DeviceBreakdownItem,
+} from './LiveWebAnalyticsMetricsTypes'
 import { LiveWorldMap } from './LiveWorldMap'
 
 const LIVE_FEED_COLUMNS: LiveEventsFeedColumn[] = ['event', 'person', 'url', 'timestamp']
@@ -183,6 +199,12 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
         }
     }
 
+    const insightCtx = { host: selectedHost ?? null }
+    const getBotRowInsightUrl = (item: BotBreakdownItem): string | undefined =>
+        item.bot && item.bot !== 'Other'
+            ? botRowInsightUrl({ ...insightCtx, botName: item.bot, category: item.category })
+            : undefined
+
     const renderContentCard = (id: LiveContentCardId): JSX.Element | null => {
         switch (id) {
             case 'active_users_chart':
@@ -192,18 +214,27 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         subtitle={timezone}
                         subtitleTooltip="Metrics are shown in your local timezone"
                         isLoading={isLoading}
+                        openInsightUrl={activeUsersChartInsightUrl(insightCtx)}
                     >
                         <UsersPerMinuteChart data={chartData} />
                     </LiveChartCard>
                 )
             case 'top_paths':
-                return <LiveTopPathsTable paths={topPaths} isLoading={isLoading} totalPageviews={totalPageviews} />
+                return (
+                    <LiveTopPathsTable
+                        paths={topPaths}
+                        isLoading={isLoading}
+                        totalPageviews={totalPageviews}
+                        openInsightUrl={topPathsInsightUrl(insightCtx)}
+                    />
+                )
             case 'top_referrers':
                 return (
                     <LiveTopReferrersTable
                         referrers={topReferrers}
                         isLoading={isLoading}
                         totalPageviews={totalPageviews}
+                        openInsightUrl={topReferrersInsightUrl(insightCtx)}
                     />
                 )
             case 'devices':
@@ -216,6 +247,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         emptyMessage="No device data"
                         statLabel="unique devices"
                         isLoading={isLoading}
+                        openInsightUrl={devicesInsightUrl(insightCtx)}
                     />
                 )
             case 'browsers':
@@ -230,6 +262,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         statLabel="unique browsers"
                         totalCount={totalBrowsers}
                         isLoading={isLoading}
+                        openInsightUrl={browsersInsightUrl(insightCtx)}
                     />
                 )
             case 'top_countries':
@@ -244,6 +277,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                             emptyMessage="No country data"
                             statLabel="unique visitors"
                             isLoading={isLoading}
+                            openInsightUrl={countriesInsightUrl(insightCtx)}
                         />
                     )
                 }
@@ -252,6 +286,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         countryData={topCountryBreakdown}
                         cityData={topCityBreakdown}
                         isLoading={isLoading}
+                        openInsightUrl={countriesInsightUrl(insightCtx)}
                     />
                 )
             case 'bot_events_chart':
@@ -265,6 +300,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         subtitleTooltip="Metrics are shown in your local timezone"
                         isLoading={isLoading}
                         contentClassName="h-64 md:h-80"
+                        openInsightUrl={botEventsChartInsightUrl(insightCtx)}
                     >
                         <BotEventsPerMinuteChart data={chartData} />
                     </LiveChartCard>
@@ -279,6 +315,8 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         totalBotEvents={totalBotEvents}
                         totalEvents={totalBotEligibleEvents}
                         isLoading={isLoading}
+                        openInsightUrl={botTrafficBreakdownInsightUrl(insightCtx)}
+                        getRowInsightUrl={getBotRowInsightUrl}
                     />
                 )
             case 'countries':

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveTileInsightUrls.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveTileInsightUrls.ts
@@ -1,0 +1,222 @@
+import { urls } from 'scenes/urls'
+
+import { EventsNode, GroupNode, InsightVizNode, NodeKind, TrendsFilter } from '~/queries/schema/schema-general'
+import {
+    BaseMathType,
+    BreakdownType,
+    ChartDisplayType,
+    EventPropertyFilter,
+    FilterLogicalOperator,
+    InsightSceneSource,
+    IntervalType,
+    PropertyFilterType,
+    PropertyOperator,
+} from '~/types'
+
+import { BOT_ELIGIBLE_EVENTS } from './LiveWebAnalyticsMetricsTypes'
+
+// The live tab has no global date picker; opened insights default to the same window the
+// pre-built bot trends tabs use ("last 7 days") so users land on a populated chart instead
+// of an empty one.
+const DEFAULT_DATE_FROM = '-7d'
+const DEFAULT_DATE_TO: string | null = null
+const DEFAULT_INTERVAL: IntervalType = 'hour'
+
+const PRODUCT_INTENT_HOST_PROPERTY = '$host'
+
+type AnyEventsSeries = EventsNode | GroupNode
+
+const buildHostFilter = (host: string | null): EventPropertyFilter[] =>
+    host
+        ? [
+              {
+                  key: PRODUCT_INTENT_HOST_PROPERTY,
+                  value: [host],
+                  operator: PropertyOperator.Exact,
+                  type: PropertyFilterType.Event,
+              },
+          ]
+        : []
+
+const pageviewSeries = (custom_name?: string): EventsNode => ({
+    kind: NodeKind.EventsNode,
+    event: '$pageview',
+    name: '$pageview',
+    math: BaseMathType.UniqueUsers,
+    custom_name,
+})
+
+const pageviewCountSeries = (custom_name?: string): EventsNode => ({
+    kind: NodeKind.EventsNode,
+    event: '$pageview',
+    name: '$pageview',
+    math: BaseMathType.TotalCount,
+    custom_name,
+})
+
+// Combine bot-eligible events into one "Requests" series so opened insights have parity with
+// the live tile (which counts $pageview, $pageleave, $screen, $http_log, $autocapture together).
+const botRequestsSeries = (): GroupNode[] => {
+    const nodes: EventsNode[] = BOT_ELIGIBLE_EVENTS.map((event) => ({
+        kind: NodeKind.EventsNode,
+        event,
+        name: event,
+        math: BaseMathType.TotalCount,
+    }))
+    return [
+        {
+            kind: NodeKind.GroupNode,
+            name: BOT_ELIGIBLE_EVENTS.join(', '),
+            custom_name: 'Requests',
+            operator: FilterLogicalOperator.Or,
+            nodes,
+            math: BaseMathType.TotalCount,
+        },
+    ]
+}
+
+interface TrendsInsightArgs {
+    series: AnyEventsSeries[]
+    breakdown?: { breakdown: string; breakdown_type: BreakdownType; breakdown_limit?: number }
+    properties?: EventPropertyFilter[]
+    display?: ChartDisplayType
+    interval?: IntervalType
+    dateFrom?: string
+    dateTo?: string | null
+}
+
+const buildTrendsInsightUrl = ({
+    series,
+    breakdown,
+    properties,
+    display = ChartDisplayType.ActionsLineGraph,
+    interval = DEFAULT_INTERVAL,
+    dateFrom = DEFAULT_DATE_FROM,
+    dateTo = DEFAULT_DATE_TO,
+}: TrendsInsightArgs): string => {
+    const query: InsightVizNode = {
+        kind: NodeKind.InsightVizNode,
+        source: {
+            kind: NodeKind.TrendsQuery,
+            interval,
+            series,
+            dateRange: { date_from: dateFrom, date_to: dateTo },
+            trendsFilter: { display } as TrendsFilter,
+            ...(breakdown ? { breakdownFilter: breakdown } : {}),
+            ...(properties && properties.length > 0 ? { properties } : {}),
+        },
+    }
+    return urls.insightNew({ query, sceneSource: 'web-analytics' as InsightSceneSource })
+}
+
+export interface LiveInsightUrlContext {
+    host: string | null
+}
+
+// Each helper returns a URL for an "Open as new insight" button on the matching live tile.
+// All helpers default to last 7d / hourly interval and inherit the host filter when set.
+
+export const activeUsersChartInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: [pageviewSeries('Unique visitors')],
+        properties: buildHostFilter(host),
+        display: ChartDisplayType.ActionsBar,
+    })
+
+export const topPathsInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: [pageviewCountSeries('Pageviews')],
+        breakdown: { breakdown: '$pathname', breakdown_type: 'event', breakdown_limit: 10 },
+        properties: buildHostFilter(host),
+        display: ChartDisplayType.ActionsBarValue,
+    })
+
+export const topReferrersInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: [pageviewCountSeries('Pageviews')],
+        breakdown: { breakdown: '$referring_domain', breakdown_type: 'event', breakdown_limit: 10 },
+        properties: buildHostFilter(host),
+        display: ChartDisplayType.ActionsBarValue,
+    })
+
+export const devicesInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: [pageviewSeries('Unique visitors')],
+        breakdown: { breakdown: '$device_type', breakdown_type: 'event' },
+        properties: buildHostFilter(host),
+        display: ChartDisplayType.ActionsPie,
+    })
+
+export const browsersInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: [pageviewSeries('Unique visitors')],
+        breakdown: { breakdown: '$browser', breakdown_type: 'event' },
+        properties: buildHostFilter(host),
+        display: ChartDisplayType.ActionsPie,
+    })
+
+export const countriesInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: [pageviewSeries('Unique visitors')],
+        breakdown: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+        properties: buildHostFilter(host),
+        display: ChartDisplayType.WorldMap,
+    })
+
+const isBotFilter: EventPropertyFilter = {
+    key: '$virt_is_bot',
+    value: ['true'],
+    operator: PropertyOperator.Exact,
+    type: PropertyFilterType.Event,
+}
+
+// Matches the clipboard reference: $http_log over time, filtered to bot traffic, broken down
+// by bot name. Used as the bot-tile header CTA so users land on an explorable version of the
+// "named bots" panel.
+export const botTrafficBreakdownInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: botRequestsSeries(),
+        breakdown: { breakdown: '$virt_bot_name', breakdown_type: 'event', breakdown_limit: 25 },
+        properties: [isBotFilter, ...buildHostFilter(host)],
+        display: ChartDisplayType.ActionsBarValue,
+    })
+
+export const botEventsChartInsightUrl = ({ host }: LiveInsightUrlContext): string =>
+    buildTrendsInsightUrl({
+        series: botRequestsSeries(),
+        breakdown: { breakdown: '$virt_traffic_category', breakdown_type: 'event' },
+        properties: [isBotFilter, ...buildHostFilter(host)],
+        display: ChartDisplayType.ActionsBar,
+    })
+
+// Per-row click on the bot traffic tile — drills into a single bot's request volume over time,
+// broken down by category so the user can see the same "bot · category" labels as on the tile.
+export const botRowInsightUrl = ({
+    host,
+    botName,
+    category,
+}: LiveInsightUrlContext & { botName: string; category: string }): string => {
+    const properties: EventPropertyFilter[] = [
+        isBotFilter,
+        {
+            key: '$virt_bot_name',
+            value: [botName],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        },
+        ...buildHostFilter(host),
+    ]
+    if (category) {
+        properties.push({
+            key: '$virt_traffic_category',
+            value: [category],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        })
+    }
+    return buildTrendsInsightUrl({
+        series: botRequestsSeries(),
+        properties,
+        display: ChartDisplayType.ActionsLineGraph,
+    })
+}


### PR DESCRIPTION
## Problem

The Web analytics Live tab (`/web/live`) shows real-time tiles backed by an SSE stream + HogQL backfill, but every tile is a dead-end view — no way to expand into product analytics for a longer window, save as a dashboard tile, or drill into a specific bot. Users who spot something interesting on the live view have to manually rebuild the equivalent insight from scratch.

## Changes

- New `liveTileInsightUrls.ts` helper that builds `TrendsQuery` `InsightVizNode` URLs for each live tile type. Defaults to last 7 days / hourly interval and inherits the host filter when set.
- New shared `LiveOpenInsightButton` component with cross-sell intent tracking (mirrors the existing `WEB_ANALYTICS_INSIGHT` cross-sell pattern from the standard tabs).
- Threaded an optional `openInsightUrl` prop through `LiveChartCard`, `BreakdownLiveCard`, `LiveAnimatedTable` (top paths / referrers), `LiveLocationsCard`, and `LiveBotTrafficCard`.
- Bot traffic tile gets two new affordances:
  - **Header "Breakdown" CTA** → opens a 7-day Trends chart of bot-eligible events (`$pageview`, `$pageleave`, `$screen`, `$http_log`, `$autocapture`) filtered to `$virt_is_bot = true` and broken down by `$virt_bot_name`. This is the canonical "who's crawling me?" view.
  - **Per-row click** → opens a single-bot drill-down filtered by `$virt_bot_name` + optional `$virt_traffic_category`.
- Wired the URLs into `LiveWebAnalyticsMetrics.tsx` for: active users chart, top paths, top referrers, devices, browsers, top countries, bot events chart, and bot traffic.
- Tiles without a clean insight equivalent (live event feed, world map) intentionally have no button.

## How did you test this code?

I'm an agent. Automated checks I ran locally:

- `pnpm exec tsc --noEmit` — clean for all new and modified files (only pre-existing kea Logic-type errors elsewhere)
- `hogli test frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts` — 65/65 passing
- `hogli test frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsLayoutLogic.test.ts` — 12/12 passing
- `pnpm --filter=@posthog/frontend format` — clean

I did not start the dev server or click through the new buttons in a browser — needs human verification before merge.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

- Agent: PostHog Code (Claude Opus 4.7)
- Initial human prompt: "Let's revamp the UI on the web analytics live tab a bit. I think we can link much of the tiles there with a product analytics insight like for the bot tiles we could link each breakdown to a filtered trend for that specific bot category and the general one could show something like the clipboard image attached.".
- Decisions made along the way:
  - Chose `last 7 days` / hourly as opened-insight defaults (matches the existing `botAnalyticsLogic` pre-built tabs and the user's reference clipboard) instead of mirroring the live tab's 30-min window — the user is almost always asking about a longer window when they request an insight version.
  - Kept the per-bot-row click as the primary CTA on the bot tile and put the all-bots breakdown on a small header button, after explicit user agreement.
  - Used `BOT_ELIGIBLE_EVENTS` as the source for the bot insights (combined into a `GroupNode` "Requests" series) for parity with the live tile, which counts the same five events.
  - Live event feed and world map skipped — no clean Trends equivalent.
- Originally the skill ("teach PostHog AI about the live tab") was bundled into this work; on the user's request the skill moved to a separate PR for cleaner review scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*