### PR TITLE
fix(tasks): include tasks task queue in liveness interceptor

### DIFF
--- a/posthog/temporal/common/liveness_tracker.py
+++ b/posthog/temporal/common/liveness_tracker.py
@@ -121,7 +121,7 @@ class _LivenessWorkflowInterceptor(WorkflowInboundInterceptor):
 class LivenessInterceptor(Interceptor):
     """Interceptor that tracks worker liveness for health checks."""
 
-    task_queue = (settings.DATA_WAREHOUSE_TASK_QUEUE, settings.MAX_AI_TASK_QUEUE)
+    task_queue = (settings.DATA_WAREHOUSE_TASK_QUEUE, settings.MAX_AI_TASK_QUEUE, settings.TASKS_TASK_QUEUE)
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _LivenessActivityInboundInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/common/liveness_tracker.py
+++ b/posthog/temporal/common/liveness_tracker.py
@@ -2,6 +2,8 @@ import time
 import threading
 from typing import Any
 
+from django.conf import settings
+
 from temporalio.worker import (
     ActivityInboundInterceptor,
     ExecuteActivityInput,
@@ -10,8 +12,6 @@ from temporalio.worker import (
     WorkflowInboundInterceptor,
     WorkflowInterceptorClassInput,
 )
-
-from posthog.temporal.common.interceptor import ALL_TASK_QUEUES
 
 
 class LivenessTracker:
@@ -121,7 +121,7 @@ class _LivenessWorkflowInterceptor(WorkflowInboundInterceptor):
 class LivenessInterceptor(Interceptor):
     """Interceptor that tracks worker liveness for health checks."""
 
-    task_queue = ALL_TASK_QUEUES
+    task_queue = (settings.DATA_WAREHOUSE_TASK_QUEUE, settings.MAX_AI_TASK_QUEUE, settings.TASKS_TASK_QUEUE)
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _LivenessActivityInboundInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/common/liveness_tracker.py
+++ b/posthog/temporal/common/liveness_tracker.py
@@ -2,8 +2,6 @@ import time
 import threading
 from typing import Any
 
-from django.conf import settings
-
 from temporalio.worker import (
     ActivityInboundInterceptor,
     ExecuteActivityInput,
@@ -12,6 +10,8 @@ from temporalio.worker import (
     WorkflowInboundInterceptor,
     WorkflowInterceptorClassInput,
 )
+
+from posthog.temporal.common.interceptor import ALL_TASK_QUEUES
 
 
 class LivenessTracker:
@@ -121,7 +121,7 @@ class _LivenessWorkflowInterceptor(WorkflowInboundInterceptor):
 class LivenessInterceptor(Interceptor):
     """Interceptor that tracks worker liveness for health checks."""
 
-    task_queue = (settings.DATA_WAREHOUSE_TASK_QUEUE, settings.MAX_AI_TASK_QUEUE, settings.TASKS_TASK_QUEUE)
+    task_queue = ALL_TASK_QUEUES
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _LivenessActivityInboundInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/tests/common/test_liveness_tracker.py
+++ b/posthog/temporal/tests/common/test_liveness_tracker.py
@@ -3,9 +3,13 @@ import time
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from django.conf import settings
+
 from temporalio.worker import ExecuteActivityInput, ExecuteWorkflowInput
 
+from posthog.temporal.common.interceptor import is_task_queue_supported
 from posthog.temporal.common.liveness_tracker import (
+    LivenessInterceptor,
     LivenessTracker,
     _LivenessActivityInboundInterceptor,
     _LivenessWorkflowInterceptor,
@@ -146,6 +150,19 @@ class TestLivenessTracker:
         tracker2 = get_liveness_tracker()
 
         assert tracker1 is tracker2
+
+
+@pytest.mark.parametrize(
+    "task_queue,supported",
+    (
+        (settings.DATA_WAREHOUSE_TASK_QUEUE, True),
+        (settings.MAX_AI_TASK_QUEUE, True),
+        (settings.TASKS_TASK_QUEUE, True),
+        ("some-other-queue", False),
+    ),
+)
+def test_liveness_interceptor_supports_expected_task_queues(task_queue, supported):
+    assert is_task_queue_supported(task_queue, LivenessInterceptor) is supported
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The tasks Temporal worker is being killed every ~30 minutes by its kubelet liveness probe, causing downstream activity timeouts, "workflow not found" heartbeats, and Modal "Container finished" errors.

Root cause chain:

1. The tasks worker's Helm values set `livenessProbe.enabled: true`, which deep-merges with the shared probe config (`/healthz` on port `8011`, `periodSeconds: 30`, `failureThreshold: 3`).
2. `TEMPORAL_HEALTH_PORT=8011` and `TEMPORAL_HEALTH_MAX_IDLE_SECONDS=1800` are wired into the worker, so `HealthCheckServer` starts on `:8011` with a 30-minute idle threshold.
3. `HealthCheckServer._handle_liveness` returns 503 when `liveness_tracker.is_healthy(1800)` is `False`.
4. `LivenessTracker._last_activity_time` / `_last_workflow_time` are only updated via `LivenessInterceptor`.
5. `LivenessInterceptor.task_queue` was `(DATA_WAREHOUSE_TASK_QUEUE, MAX_AI_TASK_QUEUE)` — `TASKS_TASK_QUEUE` was missing.
6. The worker startup path filters interceptors by `is_task_queue_supported(task_queue, interceptor)`, so on the tasks worker `LivenessInterceptor` was filtered out and never installed.
7. Tracker timestamps stayed at process-start time forever. After 30 minutes, `is_healthy(1800)` flipped to `False`, the kubelet probe failed 3x (~90s), and the container was restarted — repeatedly.

The k8s event confirmed this directly: `Liveness probe failed: HTTP probe failed with statuscode: 503` -> `Container ... failed liveness probe, will be restarted`.

## Changes

Add `settings.TASKS_TASK_QUEUE` to `LivenessInterceptor.task_queue` so the interceptor is installed on the tasks worker and updates `LivenessTracker` on every workflow / activity execution and heartbeat.

```python
task_queue = (settings.DATA_WAREHOUSE_TASK_QUEUE, settings.MAX_AI_TASK_QUEUE, settings.TASKS_TASK_QUEUE)
```

## How did you test this code?

I am an agent. I have not performed manual testing. The change is a one-line addition to a tuple of supported task queues; verifying behavior end-to-end requires deploying the tasks worker and observing that `/healthz` on port 8011 stays 200 while the worker is processing tasks. Reviewer should validate this by either running the tasks worker locally (or in a staging environment) and watching the liveness tracker timestamps update, or by inspecting the existing liveness tracker tests under `posthog/temporal/common/` for coverage gaps.

## Publish to changelog?

no

## Agent context

- Tool: PostHog Code (Claude Code, Opus 4.7)
- Human prompt: a detailed diagnosis from Josh Snyder identifying that `TASKS_TASK_QUEUE` was missing from `LivenessInterceptor.task_queue` and proposing the exact one-line fix.
- Decisions: applied the fix verbatim; did not introduce additional refactoring, tests, or telemetry alongside the fix per the user's "one-line fix" framing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*