### PR TITLE
fix(flags): tolerate stale keys in cached flag entries during verification

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -618,8 +618,8 @@ def verify_team_flags(
         if flag_id in cached_flags_by_id:
             db_flag = db_flags_by_id[flag_id]
             cached_flag = cached_flags_by_id[flag_id]
-            if db_flag != cached_flag:
-                field_diffs = _compare_flag_fields(db_flag, cached_flag)
+            field_diffs = _compare_flag_fields(db_flag, cached_flag)
+            if field_diffs:
                 diff = {
                     "type": "FIELD_MISMATCH",
                     "flag_id": flag_id,
@@ -674,12 +674,18 @@ def verify_team_flags(
 
 
 def _compare_flag_fields(db_flag: dict, cached_flag: dict) -> list[dict]:
-    """Compare field values between DB and cached versions of a flag."""
-    field_diffs = []
-    all_keys = set(db_flag.keys()) | set(cached_flag.keys())
+    """Compare field values between DB and cached versions of a flag.
 
-    for key in all_keys:
-        db_val = db_flag.get(key)
+    The DB serialization is treated as the source of truth: only keys present in
+    ``db_flag`` are compared. Extra keys in ``cached_flag`` (e.g. fields that
+    were removed from the serializer but still linger in pre-existing cache
+    entries) are ignored so that benign serializer field removals do not flag
+    every team's cache as mismatched.
+    """
+    field_diffs = []
+
+    for key in db_flag.keys():
+        db_val = db_flag[key]
         cached_val = cached_flag.get(key)
 
         if db_val != cached_val:

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -791,8 +791,8 @@ def verify_team_flag_definitions(
         if flag_key in cached_flags_by_key:
             db_flag = db_flags_by_key[flag_key]
             cached_flag = cached_flags_by_key[flag_key]
-            if db_flag != cached_flag:
-                field_diffs = _compare_flag_fields(db_flag, cached_flag)
+            field_diffs = _compare_flag_fields(db_flag, cached_flag)
+            if field_diffs:
                 diff: dict = {
                     "type": "FIELD_MISMATCH",
                     "flag_key": flag_key,

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1903,10 +1903,29 @@ class TestManagementCommands(BaseTest):
         self.assertIn("db_data", result)
         self.assertIsInstance(result["db_data"], dict)
 
-    def test_verify_ignores_extra_keys_in_cached_flag(self):
-        """A serializer field removal leaves stale extra keys in pre-existing cache
-        entries. Those extras must not trigger FIELD_MISMATCH; otherwise every
-        team's cache would be needlessly rewritten on every benign field removal."""
+    @parameterized.expand(
+        [
+            (
+                "extra_key_in_cache_is_tolerated",
+                lambda flag: flag.__setitem__("legacy_field_that_no_longer_exists", True),
+                "match",
+                None,
+            ),
+            (
+                "missing_key_in_cache_still_flagged",
+                lambda flag: flag.pop("filters"),
+                "mismatch",
+                "filters",
+            ),
+        ]
+    )
+    def test_verify_handles_key_drift_between_cache_and_db(
+        self, _name, mutate_cached_flag, expected_status, expected_diff_field
+    ):
+        """The DB serialization is the source of truth: stale extras in the
+        cache must be ignored (otherwise a benign serializer field removal
+        rewrites every team's cache), but a key the DB has and the cache
+        doesn't is a real divergence and must still be flagged."""
         from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
 
         FeatureFlag.objects.create(
@@ -1920,40 +1939,16 @@ class TestManagementCommands(BaseTest):
         cached_data, _source = flags_hypercache.get_from_cache_with_source(self.team)
         assert cached_data is not None
         assert len(cached_data["flags"]) == 1
-        cached_data["flags"][0]["legacy_field_that_no_longer_exists"] = True
+        mutate_cached_flag(cached_data["flags"][0])
         flags_hypercache.set_cache_value(self.team, cached_data)
 
         result = verify_team_flags(self.team, verbose=True)
 
-        self.assertEqual(result["status"], "match")
-
-    def test_verify_flags_field_missing_from_cached_flag(self):
-        """If a key is present in db_flag but missing from cached_flag, that's a
-        real divergence (e.g. cache entry pre-dates a newly added field) and
-        must still be reported as FIELD_MISMATCH so the cache gets refreshed."""
-        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
-
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="test-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-        update_flags_cache(self.team)
-
-        cached_data, _source = flags_hypercache.get_from_cache_with_source(self.team)
-        assert cached_data is not None
-        assert len(cached_data["flags"]) == 1
-        assert "filters" in cached_data["flags"][0]
-        del cached_data["flags"][0]["filters"]
-        flags_hypercache.set_cache_value(self.team, cached_data)
-
-        result = verify_team_flags(self.team, verbose=True)
-
-        self.assertEqual(result["status"], "mismatch")
-        field_mismatches = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
-        self.assertEqual(len(field_mismatches), 1)
-        self.assertIn("filters", field_mismatches[0]["diff_fields"])
+        self.assertEqual(result["status"], expected_status)
+        if expected_diff_field is not None:
+            field_mismatches = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
+            self.assertEqual(len(field_mismatches), 1)
+            self.assertIn(expected_diff_field, field_mismatches[0]["diff_fields"])
 
     def test_verify_miss_includes_db_data(self):
         """Test that cache miss result includes db_data for direct cache write."""

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1903,6 +1903,58 @@ class TestManagementCommands(BaseTest):
         self.assertIn("db_data", result)
         self.assertIsInstance(result["db_data"], dict)
 
+    def test_verify_ignores_extra_keys_in_cached_flag(self):
+        """A serializer field removal leaves stale extra keys in pre-existing cache
+        entries. Those extras must not trigger FIELD_MISMATCH; otherwise every
+        team's cache would be needlessly rewritten on every benign field removal."""
+        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+
+        cached_data, _source = flags_hypercache.get_from_cache_with_source(self.team)
+        assert cached_data is not None
+        assert len(cached_data["flags"]) == 1
+        cached_data["flags"][0]["legacy_field_that_no_longer_exists"] = True
+        flags_hypercache.set_cache_value(self.team, cached_data)
+
+        result = verify_team_flags(self.team, verbose=True)
+
+        self.assertEqual(result["status"], "match")
+
+    def test_verify_flags_field_missing_from_cached_flag(self):
+        """If a key is present in db_flag but missing from cached_flag, that's a
+        real divergence (e.g. cache entry pre-dates a newly added field) and
+        must still be reported as FIELD_MISMATCH so the cache gets refreshed."""
+        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+
+        cached_data, _source = flags_hypercache.get_from_cache_with_source(self.team)
+        assert cached_data is not None
+        assert len(cached_data["flags"]) == 1
+        assert "filters" in cached_data["flags"][0]
+        del cached_data["flags"][0]["filters"]
+        flags_hypercache.set_cache_value(self.team, cached_data)
+
+        result = verify_team_flags(self.team, verbose=True)
+
+        self.assertEqual(result["status"], "mismatch")
+        field_mismatches = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
+        self.assertEqual(len(field_mismatches), 1)
+        self.assertIn("filters", field_mismatches[0]["diff_fields"])
+
     def test_verify_miss_includes_db_data(self):
         """Test that cache miss result includes db_data for direct cache write."""
         from posthog.models.feature_flag.flags_cache import clear_flags_cache, verify_team_flags

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1247,11 +1247,29 @@ class TestVerifyFlagDefinitions(BaseTest):
         assert len(field_mismatch_diffs) == 1
         assert field_mismatch_diffs[0]["flag_key"] == "test-flag"
 
-    def test_verify_ignores_extra_keys_in_cached_flag(self):
-        """Stale extra keys in pre-existing cache entries (e.g. fields removed
-        from the serializer) must not be reported as FIELD_MISMATCH — otherwise
-        a benign serializer field removal triggers a cache rewrite for every
-        team."""
+    @parameterized.expand(
+        [
+            (
+                "extra_key_in_cache_is_tolerated",
+                lambda flag: flag.__setitem__("legacy_field_that_no_longer_exists", True),
+                "match",
+                None,
+            ),
+            (
+                "missing_key_in_cache_still_flagged",
+                lambda flag: flag.pop("filters"),
+                "mismatch",
+                "filters",
+            ),
+        ]
+    )
+    def test_verify_handles_key_drift_between_cache_and_db(
+        self, _name, mutate_cached_flag, expected_status, expected_diff_field
+    ):
+        """The DB serialization is the source of truth: stale extras in the
+        cache must be ignored (otherwise a benign serializer field removal
+        rewrites every team's cache), but a key the DB has and the cache
+        doesn't is a real divergence and must still be flagged."""
         FeatureFlag.objects.create(
             team=self.team,
             key="test-flag",
@@ -1263,38 +1281,17 @@ class TestVerifyFlagDefinitions(BaseTest):
         cached_data, _source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert cached_data is not None
         assert len(cached_data["flags"]) == 1
-        cached_data["flags"][0]["legacy_field_that_no_longer_exists"] = True
+        mutate_cached_flag(cached_data["flags"][0])
         flag_definitions_hypercache.set_cache_value(self.team, cached_data)
 
         result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
 
-        assert result["status"] == "match"
-
-    def test_verify_field_missing_from_cached_flag(self):
-        """A field present in the DB serialization but absent from the cached
-        flag is still a real divergence and must surface as FIELD_MISMATCH."""
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="test-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-        update_flag_definitions_cache(self.team)
-
-        cached_data, _source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
-        assert cached_data is not None
-        assert len(cached_data["flags"]) == 1
-        assert "filters" in cached_data["flags"][0]
-        del cached_data["flags"][0]["filters"]
-        flag_definitions_hypercache.set_cache_value(self.team, cached_data)
-
-        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
-
-        assert result["status"] == "mismatch"
-        field_mismatch_diffs = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
-        assert len(field_mismatch_diffs) == 1
-        assert field_mismatch_diffs[0]["flag_key"] == "test-flag"
-        assert "filters" in field_mismatch_diffs[0]["diff_fields"]
+        assert result["status"] == expected_status
+        if expected_diff_field is not None:
+            field_mismatch_diffs = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
+            assert len(field_mismatch_diffs) == 1
+            assert field_mismatch_diffs[0]["flag_key"] == "test-flag"
+            assert expected_diff_field in field_mismatch_diffs[0]["diff_fields"]
 
     def test_verify_both_variants_independently(self):
         FeatureFlag.objects.create(

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1247,6 +1247,55 @@ class TestVerifyFlagDefinitions(BaseTest):
         assert len(field_mismatch_diffs) == 1
         assert field_mismatch_diffs[0]["flag_key"] == "test-flag"
 
+    def test_verify_ignores_extra_keys_in_cached_flag(self):
+        """Stale extra keys in pre-existing cache entries (e.g. fields removed
+        from the serializer) must not be reported as FIELD_MISMATCH — otherwise
+        a benign serializer field removal triggers a cache rewrite for every
+        team."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flag_definitions_cache(self.team)
+
+        cached_data, _source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        assert cached_data is not None
+        assert len(cached_data["flags"]) == 1
+        cached_data["flags"][0]["legacy_field_that_no_longer_exists"] = True
+        flag_definitions_hypercache.set_cache_value(self.team, cached_data)
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
+
+        assert result["status"] == "match"
+
+    def test_verify_field_missing_from_cached_flag(self):
+        """A field present in the DB serialization but absent from the cached
+        flag is still a real divergence and must surface as FIELD_MISMATCH."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flag_definitions_cache(self.team)
+
+        cached_data, _source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        assert cached_data is not None
+        assert len(cached_data["flags"]) == 1
+        assert "filters" in cached_data["flags"][0]
+        del cached_data["flags"][0]["filters"]
+        flag_definitions_hypercache.set_cache_value(self.team, cached_data)
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
+
+        assert result["status"] == "mismatch"
+        field_mismatch_diffs = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
+        assert len(field_mismatch_diffs) == 1
+        assert field_mismatch_diffs[0]["flag_key"] == "test-flag"
+        assert "filters" in field_mismatch_diffs[0]["diff_fields"]
+
     def test_verify_both_variants_independently(self):
         FeatureFlag.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

When a field is removed from `MinimalFeatureFlagSerializer.Meta.fields`, freshly-serialized flag dicts no longer carry that key, but every team's existing Redis cache entry still does. The verifier compares dicts by full equality and reports `FIELD_MISMATCH` for every team, so the auto-fix path then re-writes every cache entry. That's a lot of unnecessary churn for a benign serializer change.

## Changes

`_compare_flag_fields` now iterates only `db_flag.keys()` instead of the union of both keysets, treating the DB serialization as the source of truth. Extra keys in `cached_flag` are ignored.

Both verifier callers (`verify_team_flags` in `flags_cache.py`, `verify_team_flag_definitions` in `local_evaluation.py`) drop the `if db_flag != cached_flag:` shortcut and emit `FIELD_MISMATCH` only when the per-key walk produces a non-empty diff. Without this, a flag whose only divergence is a stale extra cached key would `!=` but should be considered a match.

Behavior:

| Scenario | Old | New |
| --- | --- | --- |
| Field removed from serializer (stale extra in cache) | FIELD_MISMATCH | match |
| Field added to serializer (cache missing the key) | FIELD_MISMATCH | FIELD_MISMATCH |
| Value drift on a shared key | FIELD_MISMATCH | FIELD_MISMATCH |
| Identical dicts | match | match |

## How did you test this code?

Automated:

- Added two unit tests in `posthog/models/feature_flag/test/test_flags_cache.py`: one for the tolerated case (extra key in cache), one for the still-flagged case (key missing from cache).
- Added matching tests in `posthog/models/feature_flag/test/test_local_evaluation.py`.
- All 247 tests in those two files pass.

Manual:

- Warmed `flags_hypercache` against a local dev team while `has_encrypted_payloads` was still present in `MinimalFeatureFlagSerializer.Meta.fields`, then removed the field, then ran `python manage.py verify_flags_cache --verbose` and `python manage.py verify_flag_definitions_cache --verbose`. Both reported 100% match across 9 teams. Confirmed via Django shell that the cache still contained `has_encrypted_payloads`, so the run exercised the new tolerance behavior rather than trivially matching.

## Publish to changelog?

no