### PR TITLE
fix(cohorts): add missing query tags to _get_existing_ch_member_uuids

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -844,6 +844,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         """Return the subset of person_uuids that already exist in the CH static cohort table."""
         if not person_uuids:
             return set()
+        tag_queries(product=ProductKey.COHORTS, feature=Feature.COHORT)
         # nosemgrep: clickhouse-fstring-param-audit - table name from constant, values parameterized
         rows = sync_execute(
             f"SELECT person_id FROM {table} WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND person_id IN %(person_uuids)s GROUP BY person_id",


### PR DESCRIPTION
## Problem

`_get_existing_ch_member_uuids`, introduced in https://github.com/PostHog/posthog/commit/5357ae3b6958877264f5f5c203cd69975dbae468, calls `sync_execute` without `product`/`feature` query tags. This triggers `UntaggedQueryError` in local dev (`DEBUG=True`) when adding persons to a static cohort via the personhog path.

The error does not affect production since the enforcement is `DEBUG`-only.

Closes https://github.com/PostHog/posthog/issues/57744

## Changes

Added `tag_queries(product=ProductKey.COHORTS, feature=Feature.COHORT)` in `_get_existing_ch_member_uuids` before the `sync_execute` call, following the same pattern used by `_get_uuids_for_emails_batch_ch` and `insert_static_cohort`.

## How did you test this code?

Reproduced the error locally by adding persons to a static cohort with personhog enabled, confirmed the `UntaggedQueryError` was raised, applied the fix, and confirmed the operation succeeded.

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 Agent context

Authored with Claude Code (claude-sonnet-4-6).

Key prompts: diagnose internal server error when adding persons to a static cohort → traced to missing query tags in `_get_existing_ch_member_uuids` introduced by https://github.com/PostHog/posthog/commit/5357ae3b6958877264f5f5c203cd69975dbae468.

Decision: tag at the method level (same pattern as `_get_uuids_for_emails_batch_ch`) rather than at the API layer, so the method is self-contained regardless of caller.
