### PR TITLE
feat(mcp): add optional 'custom' flag to yaml for non-gen tools

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -123,6 +123,7 @@ tools:
   your-tool-name: # kebab-case
     operation: operationId_from_openapi
     enabled: true
+    # custom: true # set when codegen should skip this tool because the handler is hand-written in TOOL_MAP. Requires enabled: true.
     scopes:
       - your_product:read
     annotations:
@@ -159,6 +160,23 @@ Add `feature_flag` to any tool (standard or query wrapper) to gate its exposure 
 Reusing the same flag key with both behaviors performs an atomic swap: flag on → new tool visible, old tool hidden; flag off → old tool visible, new tool hidden. Useful for A/B testing tool variations.
 
 Flags are evaluated in parallel at init via `evaluateFeatureFlags`. If a flag can't be evaluated (service error, missing flag), `enable`-gated tools are excluded and `disable`-gated tools are included — fail-closed for new tools, fail-open for existing ones.
+
+### Hand-written overrides (`custom: true`)
+
+When the generated REST handler can't satisfy the tool's needs (SSE streaming, custom request/response shapes, multi-step orchestration), keep the YAML entry as the contract and write the handler by hand:
+
+1. Add `custom: true` to the YAML entry (alongside `enabled: true`). Codegen will skip emitting a generated handler.
+2. Register the hand-written factory in `TOOL_MAP` at `services/mcp/src/tools/index.ts` under the appropriate section comment.
+
+States:
+
+| `enabled` | `custom`             | Meaning                                                                   |
+| --------- | -------------------- | ------------------------------------------------------------------------- |
+| `true`    | `false` (or omitted) | Generated and exposed (default).                                          |
+| `true`    | `true`               | Hand-written; YAML defines the contract, `TOOL_MAP` provides the handler. |
+| `false`   | any                  | Not exposed.                                                              |
+
+`enabled: false` + `custom: true` is rejected at YAML validation. Do **not** use `enabled: false` to "hide" a generated tool while exposing a hand-written replacement — use `custom: true` instead.
 
 ### Syncing after endpoint changes
 

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -218,6 +218,7 @@ Product teams own their definitions and control which operations are exposed as 
      domain-action: # e.g. feature-flags-list, experiments-create
        operation: your_product_endpoint_list # must match an OpenAPI operationId
        enabled: true # false excludes from generation
+       custom: false # set to true to skip codegen and register a hand-written handler in TOOL_MAP. Requires enabled: true.
        # --- required when enabled: ---
        scopes: # API scopes
          - your_product:read
@@ -269,6 +270,28 @@ Product teams own their definitions and control which operations are exposed as 
    ```sh
    hogli build:openapi
    ```
+
+### Hand-written overrides (`custom: true`)
+
+Most tools should be fully generated. When the generated REST handler isn't a fit
+(e.g. SSE streaming, custom request/response shapes, multi-step orchestration),
+write the handler by hand and register it in `TOOL_MAP` (`services/mcp/src/tools/index.ts`).
+
+Mark the YAML entry with `custom: true` so codegen skips it but the YAML still
+defines the contract (operation id, scopes, annotations, description).
+
+The three valid states are:
+
+| `enabled` | `custom`             | Meaning                                                           |
+| --------- | -------------------- | ----------------------------------------------------------------- |
+| `true`    | `false` (or omitted) | Tool is generated and exposed (default).                          |
+| `true`    | `true`               | YAML defines the contract; handler is hand-written in `TOOL_MAP`. |
+| `false`   | `false` (or omitted) | Tool is not exposed (not built yet, or intentionally hidden).     |
+
+`enabled: false` + `custom: true` is rejected at build time — a hand-written override must be exposed.
+
+`TOOL_MAP` wins over `GENERATED_TOOL_MAP` on key collisions, so a hand-written entry
+is never silently shadowed by a generated one.
 
 ### Keeping definitions in sync
 

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -1015,7 +1015,8 @@ function generateCategoryFile(
     const enabledTools: [string, EnabledToolConfig, ResolvedOperation][] = []
 
     for (const [name, config] of Object.entries(category.tools)) {
-        if (!config.enabled) {
+        // `custom: true` means the handler is hand-written in TOOL_MAP, so codegen skips it.
+        if (!config.enabled || config.custom) {
             continue
         }
         if (!config.scopes?.length) {
@@ -1041,7 +1042,7 @@ function generateCategoryFile(
     if (category.wrappers) {
         const querySchema = getQuerySchema()
         for (const [name, wrapperConfig] of Object.entries(category.wrappers)) {
-            if (!wrapperConfig.enabled) {
+            if (!wrapperConfig.enabled || wrapperConfig.custom) {
                 continue
             }
             if (!wrapperConfig.scopes?.length) {

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -11,6 +11,8 @@ export const ToolConfigSchema = z
     .object({
         operation: z.string(),
         enabled: z.boolean(),
+        /** When true, codegen skips this tool — handler is hand-written in `TOOL_MAP`. Requires `enabled: true`. */
+        custom: z.boolean().optional(),
         scopes: z.array(z.string()).optional(),
         annotations: z
             .object({
@@ -152,13 +154,18 @@ export const ToolConfigSchema = z
     .refine((data) => !(data.description && data.description_file), {
         message: 'description and description_file are mutually exclusive',
     })
+    .refine((data) => !(data.enabled === false && data.custom === true), {
+        message:
+            'custom: true requires enabled: true — a hand-written override must be exposed. To hide a tool, omit custom or set custom: false.',
+    })
 
 export type ToolConfig = z.infer<typeof ToolConfigSchema>
 
 /** Narrowed type for enabled tools — scopes and annotations are guaranteed present. */
-export type EnabledToolConfig = Omit<ToolConfig, 'scopes' | 'annotations'> & {
+export type EnabledToolConfig = Omit<ToolConfig, 'scopes' | 'annotations' | 'custom'> & {
     scopes: string[]
     annotations: { readOnly: boolean; destructive: boolean; idempotent: boolean }
+    custom?: boolean
 }
 
 // --- UI App schemas ---
@@ -316,6 +323,8 @@ export const QueryWrapperToolConfigSchema = z
         /** Name of the definition in schema.json (e.g. "AssistantTrendsQuery") */
         schema_ref: z.string(),
         enabled: z.boolean(),
+        /** When true, codegen skips this wrapper — handler is hand-written in `TOOL_MAP`. Requires `enabled: true`. */
+        custom: z.boolean().optional(),
         scopes: z.array(z.string()).optional(),
         annotations: z
             .object({
@@ -376,12 +385,17 @@ export const QueryWrapperToolConfigSchema = z
     .refine((data) => !(data.description && data.description_file), {
         message: 'description and description_file are mutually exclusive',
     })
+    .refine((data) => !(data.enabled === false && data.custom === true), {
+        message:
+            'custom: true requires enabled: true — a hand-written override must be exposed. To hide a wrapper, omit custom or set custom: false.',
+    })
 
 export type QueryWrapperToolConfig = z.infer<typeof QueryWrapperToolConfigSchema>
 
-export type EnabledQueryWrapperToolConfig = Omit<QueryWrapperToolConfig, 'scopes' | 'annotations'> & {
+export type EnabledQueryWrapperToolConfig = Omit<QueryWrapperToolConfig, 'scopes' | 'annotations' | 'custom'> & {
     scopes: string[]
     annotations: { readOnly: boolean; destructive: boolean; idempotent: boolean }
+    custom?: boolean
 }
 
 export const QueryWrappersConfigSchema = z

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -101,7 +101,9 @@ export const getToolsFromContext = async (
     // Check org AI consent to gate tools that use LLMs internally (cached in StateManager)
     const aiConsentGiven = await context.stateManager.getAiConsentGiven()
     const effectiveOptions = aiConsentGiven !== undefined ? { ...options, aiConsentGiven } : options
-    const effectiveMap = { ...TOOL_MAP, ...GENERATED_TOOL_MAP }
+    // TOOL_MAP wins on key collisions: hand-written overrides (YAML `custom: true`)
+    // must shadow any generated entry that slips through, not the other way around.
+    const effectiveMap = { ...GENERATED_TOOL_MAP, ...TOOL_MAP }
     const excludeTools = options?.excludeTools ?? []
     const allowedToolNames = getFilteredToolNames(effectiveOptions).filter((name) => !excludeTools.includes(name))
     const toolBases: ToolBase<ZodObjectAny>[] = []


### PR DESCRIPTION
## Problem

Previously, exposing a hand-written tool that shadowed a generated one required setting `enabled: false` and adding a same-named factory to `TOOL_MAP` — which made `enabled: false` mean three different things (not built, intentionally hidden, or actually exposed via override) and risked silent shadowing if someone re-enabled the YAML entry.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

Adds an explicit `custom: true` flag to MCP tool YAML definitions for hand-written tool overrides, replacing the overloaded `enabled: false` workaround. 

Now:

| `enabled` | `custom` | Meaning |
| --- | --- | --- |
| `true` | omitted/`false` | Generated and exposed (default) |
| `true` | `true` | YAML defines the contract; handler is hand-written in `TOOL_MAP` |
| `false` | any | Not exposed |
| `false` | `true` | **Rejected at build time** (ambiguous) |

Also flipped the spread order in `getToolsFromContext` so `TOOL_MAP` wins over `GENERATED_TOOL_MAP` on key collisions — defense so a forgotten `custom: true` can't silently shadow a hand-written override.

## How did you test this code?

- [x] Schema accepts `enabled: true, custom: true`
- [x] Schema accepts `enabled: false` (with or without `custom`)
- [x] Schema accepts `enabled: true` with `custom` omitted (default)
- [x] Schema rejects `enabled: false, custom: true` with a clear error message
- [x] Same validation applies to `QueryWrapperToolConfigSchema`
- [x] Codegen skips tools with `custom: true` — verified by temporarily flagging `session-recording-summarize`: tool count dropped 292 → 291, no generated handler emitted, key absent from `GENERATED_TOOL_MAP` barrel and `generated-tool-definitions.json`
- [x] `pnpm --filter=@posthog/mcp typecheck` passes
- [x] `pnpm --filter=@posthog/mcp test` — 1068/1069 pass (one unrelated network failure fetching from GitHub)
- [x] Verified no current key collisions between `TOOL_MAP` (23 entries) and `GENERATED_TOOL_MAP` (304 entries) — flipped spread is safe to land
- [x] Existing 525+ `enabled: false` YAML entries still parse and skip codegen identically

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->