### PR TITLE
feat(experiments): Ship significance alerts to everyone

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -299,7 +299,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
     EXPERIMENT_FUNNEL_DWH_SUPPORT: 'experiment-funnel-dwh-support', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
-    EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -3,9 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconPencil } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonTag, Link } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { urls } from 'scenes/urls'
 
@@ -21,7 +19,6 @@ export function SettingsTab(): JSX.Element {
     const { experiment, statsMethod } = useValues(experimentLogic)
     const { updateExperiment } = useActions(experimentLogic)
     const { openStatsEngineModal, openCupedModal } = useActions(modalsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const showCupedOption = useFeatureFlag('EXPERIMENT_CUPED')
 
     const isBayesian = statsMethod === ExperimentStatsMethod.Bayesian
@@ -36,8 +33,7 @@ export function SettingsTab(): JSX.Element {
     const returnTo = urls.experiment(experiment.id)
 
     // Only show alerts section for saved experiments, as the alert relies on experiment.id for filtering
-    const shouldShowSignificanceAlerts =
-        featureFlags[FEATURE_FLAGS.EXPERIMENT_SIGNIFICANCE_ALERTS] && typeof experiment.id === 'number'
+    const shouldShowSignificanceAlerts = typeof experiment.id === 'number'
 
     return (
         <div className="flex flex-col gap-8">


### PR DESCRIPTION
## Problem

Experiment significance alerts were gated behind the `experiment-significance-alerts` feature flag. Time to ship to everyone.

## Changes

Removed the flag check from `SettingsTab` and deleted the `EXPERIMENT_SIGNIFICANCE_ALERTS` entry from `FEATURE_FLAGS`. The Notifications section still only renders for saved experiments (where `experiment.id` is numeric), since the alert filter relies on the experiment ID.

## How did you test this code?

I'm an agent. No manual testing performed; relying on CI for typecheck and lint.

## 🤖 Agent context

- Tool: Claude Code
- Prompt: "the `experiment-significance-alerts` feature flag - remove it, i.e. ship the feature to everybody"