### PR TITLE
fix(sql): restore dashboard SQL table scrolling

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -248,6 +248,7 @@ export const Table = (props: TableProps): JSX.Element => {
             footer={tabularData.length > 0 ? <LoadNext query={props.query} /> : null}
             rowClassName="DataVizRow"
             embedded={props.embedded}
+            allowContentScroll={!!props.embedded}
         />
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+
+import { DataVisualizationNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
+
+import { DataTableVisualization } from './DataVisualization'
+
+const mockLemonTable = jest.fn((): null => null)
+
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    LemonTable: (props: Record<string, unknown>): null => {
+        mockLemonTable(props)
+        return null
+    },
+}))
+
+describe('DataTableVisualization', () => {
+    const query: DataVisualizationNode = {
+        kind: NodeKind.DataVisualizationNode,
+        source: {
+            kind: NodeKind.HogQLQuery,
+            query: 'select number from numbers(2)',
+        },
+        display: ChartDisplayType.ActionsTable,
+    }
+
+    const cachedResults: HogQLQueryResponse<number[][]> = {
+        results: [[1], [2]],
+        columns: ['number'],
+        types: [['number', 'Int64']],
+    }
+
+    beforeEach(() => {
+        initKeaTests()
+        mockLemonTable.mockClear()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    test.each([
+        { embedded: true, expectedAllowContentScroll: true },
+        { embedded: false, expectedAllowContentScroll: false },
+    ])(
+        'sets table scroll mode to $expectedAllowContentScroll when embedded is $embedded',
+        async ({ embedded, expectedAllowContentScroll }) => {
+            render(
+                <DataTableVisualization
+                    uniqueKey={`data-visualization-scroll-${embedded}`}
+                    query={query}
+                    setQuery={jest.fn()}
+                    cachedResults={cachedResults}
+                    readOnly
+                    embedded={embedded}
+                />
+            )
+
+            await waitFor(() => {
+                if (mockLemonTable.mock.calls.length === 0) {
+                    throw new Error('Expected LemonTable to render')
+                }
+            })
+
+            const lemonTableProps = mockLemonTable.mock.calls[mockLemonTable.mock.calls.length - 1][0]
+            expect(lemonTableProps.embedded).toBe(embedded)
+            expect(lemonTableProps.allowContentScroll).toBe(expectedAllowContentScroll)
+        }
+    )
+})

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx
@@ -6,7 +6,16 @@ import { ChartDisplayType } from '~/types'
 
 import { DataTableVisualization } from './DataVisualization'
 
-const mockLemonTable = jest.fn((): null => null)
+type LemonTableMockProps = {
+    embedded?: boolean
+    allowContentScroll?: boolean
+}
+
+let mockLatestLemonTableProps: LemonTableMockProps | null = null
+const mockLemonTable = jest.fn((props: LemonTableMockProps): null => {
+    mockLatestLemonTableProps = props
+    return null
+})
 
 jest.mock('@posthog/lemon-ui', () => ({
     ...jest.requireActual('@posthog/lemon-ui'),
@@ -34,6 +43,7 @@ describe('DataTableVisualization', () => {
 
     beforeEach(() => {
         initKeaTests()
+        mockLatestLemonTableProps = null
         mockLemonTable.mockClear()
     })
 
@@ -59,14 +69,16 @@ describe('DataTableVisualization', () => {
             )
 
             await waitFor(() => {
-                if (mockLemonTable.mock.calls.length === 0) {
+                if (!mockLatestLemonTableProps) {
                     throw new Error('Expected LemonTable to render')
                 }
             })
 
-            const lemonTableProps = mockLemonTable.mock.calls[mockLemonTable.mock.calls.length - 1][0]
-            expect(lemonTableProps.embedded).toBe(embedded)
-            expect(lemonTableProps.allowContentScroll).toBe(expectedAllowContentScroll)
+            if (!mockLatestLemonTableProps) {
+                throw new Error('Expected LemonTable props to be recorded')
+            }
+            expect(mockLatestLemonTableProps.embedded).toBe(embedded)
+            expect(mockLatestLemonTableProps.allowContentScroll).toBe(expectedAllowContentScroll)
         }
     )
 })

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -226,6 +226,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 query={query}
                 context={props.context}
                 cachedResults={props.cachedResults as HogQLQueryResponse | undefined}
+                embedded={props.embedded}
             />
         )
     } else if (


### PR DESCRIPTION
## Problem

SQL insights rendered as tables inside dashboards could no longer scroll when their results exceeded the tile height. This regressed because the embedded SQL visualization path preserved card sizing but did not pass the embedded context through to the table's constrained scroll mode.

## Changes

<img width="1262" height="674" alt="2026-05-06 10 19 35" src="https://github.com/user-attachments/assets/b303f6dd-25f0-44ed-b9a4-5452d1eba338" />


Pass the embedded state from the SQL data visualization renderer into the table component, and enable `allowContentScroll` for embedded SQL tables so dashboard cards can scroll vertically without resizing the tile.

Added a regression test that renders the `DataTableVisualization` table path for embedded and non-embedded modes and verifies the `LemonTable` scroll settings.

No screenshot included; this is a scroll-container behavior fix covered by the regression test.

## How did you test this code?

Agent-authored validation:

- `hogli test frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx`
- `pnpm exec oxfmt --check frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx frontend/src/queries/nodes/DataVisualization/Components/Table.tsx`
- `pnpm exec oxlint frontend/src/queries/nodes/DataVisualization/DataVisualization.test.tsx frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx frontend/src/queries/nodes/DataVisualization/Components/Table.tsx`

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed; this restores dashboard table scroll behavior without changing user-facing documentation.

## 🤖 Agent context

Codex authored this PR from the user report: “you can't scroll SQL insights within dashboards anymore.”

Key decisions:

- Traced SQL dashboard tiles through `DataVisualization` and `LemonTable`.
- Identified the embedded SQL visualization path as the missing propagation point after the notebook sizing change.
- Kept the fix scoped to SQL table visualizations by passing `embedded` into `Table` and enabling `allowContentScroll` only there.
- Added a focused Jest regression test rather than relying on manual dashboard verification.
