### PR TITLE
feat(experiments): Always compute timeseries for running experiments

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -339,12 +339,6 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             actions.saveExperimentStarted()
 
             try {
-                // Make experiment eligible for timeseries
-                const schedulingConfig = {
-                    ...values.experiment?.scheduling_config,
-                    timeseries: true,
-                }
-
                 const savedMetrics = [
                     ...values.sharedMetrics.primary.map((metric) => ({
                         id: metric.sharedMetricId!,
@@ -362,7 +356,6 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
 
                 const experimentPayload: Experiment = {
                     ...values.experiment,
-                    scheduling_config: schedulingConfig,
                     saved_metrics_ids: savedMetrics,
                 }
 

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -584,8 +584,6 @@ export function MetricRowGroup({
           }
         : undefined
 
-    const timeseriesEnabled = experiment.scheduling_config?.timeseries
-
     // Helper function to calculate tooltip position
     const calculateTooltipPosition = (
         chartCell: HTMLElement,
@@ -769,7 +767,7 @@ export function MetricRowGroup({
                 createPortal(
                     <div
                         ref={tooltipRef}
-                        className={`fixed bg-bg-light border border-border px-3 py-2 rounded-md text-[13px] shadow-md z-[100] min-w-[280px] ${timeseriesEnabled ? 'cursor-pointer hover:border-primary' : ''}`}
+                        className="fixed bg-bg-light border border-border px-3 py-2 rounded-md text-[13px] shadow-md z-[100] min-w-[280px] cursor-pointer hover:border-primary"
                         style={{
                             left: tooltipState.position.x,
                             top: tooltipState.position.y,
@@ -786,12 +784,12 @@ export function MetricRowGroup({
                             }
                         }}
                         onClick={
-                            timeseriesEnabled && tooltipState.variantResult
+                            tooltipState.variantResult
                                 ? () => handleTimeseriesClick(tooltipState.variantResult!)
                                 : undefined
                         }
                     >
-                        {renderTooltipContent(tooltipState.variantResult, metric, timeseriesEnabled)}
+                        {renderTooltipContent(tooltipState.variantResult, metric)}
                     </div>,
                     document.body
                 )}
@@ -1012,7 +1010,7 @@ export function MetricRowGroup({
                             isAlternatingRow={isAlternatingRow}
                             isLastRow={isLastRow}
                             isSecondary={isSecondary}
-                            onTimeseriesClick={timeseriesEnabled ? () => handleTimeseriesClick(variant) : undefined}
+                            onTimeseriesClick={() => handleTimeseriesClick(variant)}
                         />
                     </tr>
                 )

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -18,11 +18,7 @@ import {
     isWinning,
 } from '../shared/utils'
 
-export const renderTooltipContent = (
-    variantResult: ExperimentVariantResult,
-    metric: ExperimentMetric,
-    timeseriesEnabled?: boolean
-): JSX.Element => {
+export const renderTooltipContent = (variantResult: ExperimentVariantResult, metric: ExperimentMetric): JSX.Element => {
     const intervalPercent = formatIntervalPercent(variantResult)
     const intervalLabel = getIntervalLabel(variantResult)
     const significant = isSignificant(variantResult)
@@ -82,12 +78,10 @@ export const renderTooltipContent = (
                 <span className="font-semibold">{intervalPercent}</span>
             </div>
 
-            {timeseriesEnabled && (
-                <div className="text-muted-alt text-xs mt-1 text-center flex items-center justify-center gap-1">
-                    <IconCursorClick className="text-sm" />
-                    Click to view timeseries
-                </div>
-            )}
+            <div className="text-muted-alt text-xs mt-1 text-center flex items-center justify-center gap-1">
+                <IconCursorClick className="text-sm" />
+                Click to view timeseries
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1503,12 +1503,6 @@ export const experimentLogic = kea<experimentLogicType>([
                         return
                     }
                 } else {
-                    // Make experiment eligible for timeseries
-                    const schedulingConfig = {
-                        ...values.experiment?.scheduling_config,
-                        timeseries: true,
-                    }
-
                     response = await api.create(`api/projects/${values.currentProjectId}/experiments`, {
                         ...values.experiment,
                         parameters:
@@ -1527,7 +1521,6 @@ export const experimentLogic = kea<experimentLogicType>([
                                 : values.experiment?.parameters,
                         ...(!draft && { start_date: dayjs() }),
                         ...(typeof folder === 'string' ? { _create_in_folder: folder } : {}),
-                        scheduling_config: schedulingConfig,
                     })
 
                     if (response) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4597,9 +4597,6 @@ export interface Experiment {
             lookback_days?: number
         }
     }
-    scheduling_config?: {
-        timeseries?: boolean
-    }
     only_count_matured_users?: boolean
     _create_in_folder?: string | null
     conclusion?: ExperimentConclusion | null

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -58,7 +58,6 @@ def _get_experiment_regular_metrics_for_hour_sync(hour: int) -> list[ExperimentR
     experiments = Experiment.objects.filter(
         time_filter,
         deleted=False,
-        scheduling_config__timeseries=True,
         status=Experiment.Status.RUNNING,
         start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=30),
     ).exclude(
@@ -310,7 +309,6 @@ def _get_experiment_saved_metrics_for_hour_sync(hour: int) -> list[ExperimentSav
     experiments = Experiment.objects.filter(
         time_filter,
         deleted=False,
-        scheduling_config__timeseries=True,
         status=Experiment.Status.RUNNING,
         start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=30),
     ).prefetch_related("experimenttosavedmetric_set__saved_metric")

--- a/posthog/temporal/experiments/test_recalculation_time_filter.py
+++ b/posthog/temporal/experiments/test_recalculation_time_filter.py
@@ -22,7 +22,6 @@ def _create_running_experiment(team, user, flag_key, metrics=None):
         feature_flag=flag,
         start_date=datetime.datetime.now(ZoneInfo("UTC")) - datetime.timedelta(days=1),
         status=Experiment.Status.RUNNING,
-        scheduling_config={"timeseries": True},
         metrics=metrics
         or [{"metric_type": "mean", "uuid": f"uuid-{flag_key}", "source": {"kind": "EventsNode", "event": "test"}}],
     )


### PR DESCRIPTION
## Problem

Timeseries computation is silently skipped on running experiments created through any path that doesn't set `scheduling_config.timeseries=true`.

The timeseries chart on metric confidence intervals is gated on `experiment.scheduling_config.timeseries === true`. The feature has been GA for months, but only two of the many experiment-creation paths actually set the flag — the classic form and the wizard. The Feature Flag → Experiments tab "Create draft" card, the Max AI tool, MCP, the REST API, and `web_experiments` all skip it. Result: a steady stream of running experiments where the timeseries chart never appears and the temporal recalculation workflow ignores them.

## Changes

- Drop `scheduling_config__timeseries=True` from both temporal activity filters that discover experiments needing recalculation (regular metrics + saved metrics).
- Drop the frontend UI gate in `MetricRowGroup` / `MetricRowGroupTooltip` — the "Click to view timeseries" hint and the click handler always render now.
- Drop the two frontend create-paths that injected `scheduling_config: { timeseries: true }` and the now-unused property on the `Experiment` type.
- Update the recalculation-time-filter test to no longer set the field on its helper experiments.

The `scheduling_config` JSONField on the model and serializer stays in place — harmless, and external callers still sending it won't break.

## How did you test this code?

Agent-authored; no manual testing. Automated checks:

- `posthog/temporal/experiments/test_recalculation_time_filter.py` — 3/3 pass with the gate removed and the field stripped from the test helper.
- `products/experiments/backend/test/test_experiment_service.py -k "scheduling_config or all_fields or default"` — 7/7 pass.
- `pnpm typescript:check` — no errors in any touched file (full-repo run surfaces only pre-existing errors in `llm_analytics`, `logs`, `tasks`, `visual_review`, `CupedModal`).
- `ruff check` on the touched Python files — clean.

## Publish to changelog?

no

## 🤖 Agent context

Driven by a question about a specific running production experiment (id 369732, team 2) that wasn't getting timeseries computed. Investigation surfaced the inconsistency: 6+ creation paths bypass the flag entirely, transitively poisoning duplicate/copy paths too.

Considered alternatives:
- **Backfill the flag on existing experiments + fix every creation path** — rejected; doesn't address the root cause (the gate is vestigial), more code, more migration risk.
- **Default `scheduling_config={"timeseries": True}` in `ExperimentService.create_experiment`** — preserves opt-out capability, but no opt-out UI exists and nothing uses the field. Not worth keeping.
- **Phased rollout (backend first, frontend later)** — discussed. Single PR is fine here because the frontend UI gate going away is purely an unblocking change; if backend recalc takes 24h to populate, the chart shows "no data" briefly but doesn't break.