### PR TITLE
feat(mcp): add workflow create, update, delete, and run tools

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -80,18 +80,42 @@ class HogFlowConfigFunctionInputsSerializer(serializers.Serializer):
 
 
 class HogFlowActionSerializer(serializers.Serializer):
-    id = serializers.CharField()
-    name = serializers.CharField(max_length=400)
-    description = serializers.CharField(allow_blank=True, default="")
-    on_error = serializers.ChoiceField(
-        choices=["continue", "abort", "complete", "branch"], required=False, allow_null=True
+    id = serializers.CharField(help_text="Unique identifier for this action node within the workflow graph.")
+    name = serializers.CharField(max_length=400, help_text="Human-readable name for the action node.")
+    description = serializers.CharField(
+        allow_blank=True, default="", help_text="Optional description of what this action does."
     )
-    created_at = serializers.IntegerField(required=False)
-    updated_at = serializers.IntegerField(required=False)
-    filters = HogFunctionFiltersSerializer(required=False, default=None, allow_null=True)
-    type = serializers.CharField(max_length=100)
-    config = serializers.JSONField()
-    output_variable = serializers.JSONField(required=False, allow_null=True)
+    on_error = serializers.ChoiceField(
+        choices=["continue", "abort", "complete", "branch"],
+        required=False,
+        allow_null=True,
+        help_text="Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).",
+    )
+    created_at = serializers.IntegerField(
+        required=False, help_text="Unix epoch milliseconds when the action was added. Auto-managed by the frontend."
+    )
+    updated_at = serializers.IntegerField(
+        required=False,
+        help_text="Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.",
+    )
+    filters = HogFunctionFiltersSerializer(
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Property filters that gate execution of this action.",
+    )
+    type = serializers.CharField(
+        max_length=100,
+        help_text="Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.",
+    )
+    config = serializers.JSONField(
+        help_text="Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}.",
+    )
+    output_variable = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text="Variable definition to store this action's output for use by downstream actions.",
+    )
 
     def to_internal_value(self, data):
         # Weirdly nested serializers don't get this set...
@@ -205,6 +229,7 @@ class HogFlowActionSerializer(serializers.Serializer):
 class HogFlowVariableSerializer(serializers.ListSerializer):
     child = serializers.DictField(
         child=serializers.CharField(allow_blank=True),
+        help_text="Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).",
     )
 
     def validate(self, attrs):
@@ -224,10 +249,27 @@ class HogFlowVariableSerializer(serializers.ListSerializer):
 
 
 class HogFlowMaskingSerializer(serializers.Serializer):
-    ttl = serializers.IntegerField(required=False, min_value=60, max_value=60 * 60 * 24 * 365 * 3, allow_null=True)
-    threshold = serializers.IntegerField(required=False, allow_null=True)
-    hash = serializers.CharField(required=True)
-    bytecode = serializers.JSONField(required=False, allow_null=True)
+    ttl = serializers.IntegerField(
+        required=False,
+        min_value=60,
+        max_value=60 * 60 * 24 * 365 * 3,
+        allow_null=True,
+        help_text="Time-to-live in seconds for the masking hash. Min 60s, max 3 years.",
+    )
+    threshold = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Minimum number of matching events before the workflow triggers (k-anonymity threshold).",
+    )
+    hash = serializers.CharField(
+        required=True,
+        help_text="HogQL template expression used as the masking key (e.g. '{person.properties.email}').",
+    )
+    bytecode = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text="Compiled bytecode for the hash template. Auto-generated server-side.",
+    )
 
     def validate(self, attrs):
         attrs["bytecode"] = generate_template_bytecode(attrs["hash"], input_collector=set())
@@ -320,9 +362,50 @@ class HogFlowMinimalSerializer(serializers.ModelSerializer):
 
 
 class HogFlowSerializer(HogFlowMinimalSerializer):
-    actions = serializers.ListField(child=HogFlowActionSerializer(), required=True)
-    trigger_masking = HogFlowMaskingSerializer(required=False, allow_null=True)
-    variables = HogFlowVariableSerializer(required=False)
+    name = serializers.CharField(
+        max_length=400,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="Human-readable name for the workflow.",
+    )
+    description = serializers.CharField(
+        required=False, allow_blank=True, default="", help_text="Optional description of the workflow's purpose."
+    )
+    status = serializers.ChoiceField(
+        choices=HogFlow.State.choices,
+        required=False,
+        help_text="Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).",
+    )
+    trigger_masking = HogFlowMaskingSerializer(
+        required=False,
+        allow_null=True,
+        help_text="Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.",
+    )
+    conversion = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text="Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.",
+    )
+    exit_condition = serializers.ChoiceField(
+        choices=HogFlow.ExitCondition.choices,
+        required=False,
+        allow_null=True,
+        help_text="When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.",
+    )
+    edges = serializers.JSONField(
+        required=False,
+        help_text="Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.",
+    )
+    actions = serializers.ListField(
+        child=HogFlowActionSerializer(),
+        required=True,
+        help_text="Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'.",
+    )
+    variables = HogFlowVariableSerializer(
+        required=False,
+        help_text="Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.",
+    )
 
     def to_internal_value(self, data):
         status = data.get("status")
@@ -358,6 +441,8 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
             "version",
             "created_at",
             "created_by",
+            "updated_at",
+            "trigger",  # Derived from the trigger action in the actions array
             "abort_action",
             "billable_action_types",  # Computed field, not user-editable
         ]
@@ -421,10 +506,26 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
 
 
 class HogFlowInvocationSerializer(serializers.Serializer):
-    configuration = HogFlowSerializer(write_only=True, required=False)
-    globals = serializers.DictField(write_only=True, required=False)
-    mock_async_functions = serializers.BooleanField(default=True, write_only=True)
-    current_action_id = serializers.CharField(write_only=True, required=False)
+    configuration = HogFlowSerializer(
+        write_only=True,
+        required=False,
+        help_text="Optional workflow configuration override for the test run. If omitted, uses the saved workflow definition.",
+    )
+    globals = serializers.DictField(
+        write_only=True,
+        required=False,
+        help_text="Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape.",
+    )
+    mock_async_functions = serializers.BooleanField(
+        default=True,
+        write_only=True,
+        help_text="When true (default), async actions (HTTP requests, emails) are simulated rather than executed for safety.",
+    )
+    current_action_id = serializers.CharField(
+        write_only=True,
+        required=False,
+        help_text="Start execution from a specific action node ID instead of the trigger. Useful for testing mid-workflow actions.",
+    )
 
 
 class CommaSeparatedListFilter(BaseInFilter, CharFilter):
@@ -534,6 +635,7 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
             except Exception as e:
                 logger.warning("Failed to capture hog_flow_activated event", error=str(e))
 
+    @extend_schema(request=HogFlowInvocationSerializer, responses={200: _FallbackSerializer})
     @action(detail=True, methods=["POST"])
     def invocations(self, request: Request, *args, **kwargs):
         try:

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -22,14 +22,20 @@ export const HogFlowTemplateScopeEnumApi = {
 
 export interface HogFlowMaskingApi {
     /**
+     * Time-to-live in seconds for the masking hash. Min 60s, max 3 years.
      * @minimum 60
      * @maximum 94608000
      * @nullable
      */
     ttl?: number | null
-    /** @nullable */
+    /**
+     * Minimum number of matching events before the workflow triggers (k-anonymity threshold).
+     * @nullable
+     */
     threshold?: number | null
+    /** HogQL template expression used as the masking key (e.g. '{person.properties.email}'). */
     hash: string
+    /** Compiled bytecode for the hash template. Auto-generated server-side. */
     bytecode?: unknown | null
 }
 
@@ -125,6 +131,9 @@ export interface HogFlowTemplateActionApi {
  */
 export type HogFlowTemplateApiCreatedBy = { [key: string]: unknown } | null | null
 
+/**
+ * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+ */
 export type HogFlowTemplateApiVariablesItem = { [key: string]: string }
 
 /**
@@ -175,6 +184,9 @@ export interface PaginatedHogFlowTemplateListApi {
  */
 export type PatchedHogFlowTemplateApiCreatedBy = { [key: string]: unknown } | null | null
 
+/**
+ * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+ */
 export type PatchedHogFlowTemplateApiVariablesItem = { [key: string]: string }
 
 /**
@@ -310,73 +322,150 @@ export interface PaginatedHogFlowMinimalListApi {
     results: HogFlowMinimalApi[]
 }
 
+/**
+ * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+ */
 export type HogFlowApiVariablesItem = { [key: string]: string }
 
 export interface HogFlowActionApi {
+    /** Unique identifier for this action node within the workflow graph. */
     id: string
-    /** @maxLength 400 */
+    /**
+     * Human-readable name for the action node.
+     * @maxLength 400
+     */
     name: string
+    /** Optional description of what this action does. */
     description?: string
+    /** Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).
+
+* `continue` - continue
+* `abort` - abort
+* `complete` - complete
+* `branch` - branch */
     on_error?: OnErrorEnumApi | NullEnumApi | null
+    /** Unix epoch milliseconds when the action was added. Auto-managed by the frontend. */
     created_at?: number
+    /** Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend. */
     updated_at?: number
+    /** Property filters that gate execution of this action. */
     filters?: HogFunctionFiltersApi | null
-    /** @maxLength 100 */
+    /**
+     * Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.
+     * @maxLength 100
+     */
     type: string
+    /** Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}. */
     config: unknown
+    /** Variable definition to store this action's output for use by downstream actions. */
     output_variable?: unknown | null
 }
 
 export interface HogFlowApi {
     readonly id: string
     /**
+     * Human-readable name for the workflow.
      * @maxLength 400
      * @nullable
      */
     name?: string | null
+    /** Optional description of the workflow's purpose. */
     description?: string
     readonly version: number
+    /** Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).
+
+* `draft` - Draft
+* `active` - Active
+* `archived` - Archived */
     status?: HogFlowStatusEnumApi
     readonly created_at: string
     readonly created_by: UserBasicApi
     readonly updated_at: string
-    trigger?: unknown
+    readonly trigger: unknown
+    /** Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window. */
     trigger_masking?: HogFlowMaskingApi | null
+    /** Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition. */
     conversion?: unknown | null
-    exit_condition?: ExitConditionEnumApi
+    /** When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.
+
+* `exit_on_conversion` - Conversion
+* `exit_on_trigger_not_matched` - Trigger Not Matched
+* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+* `exit_only_at_end` - Only At End */
+    exit_condition?: ExitConditionEnumApi | NullEnumApi | null
+    /** Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions. */
     edges?: unknown
+    /** Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'. */
     actions: HogFlowActionApi[]
     /** @nullable */
     readonly abort_action: string | null
+    /** Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB. */
     variables?: HogFlowApiVariablesItem[]
     readonly billable_action_types: unknown | null
 }
 
+/**
+ * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+ */
 export type PatchedHogFlowApiVariablesItem = { [key: string]: string }
 
 export interface PatchedHogFlowApi {
     readonly id?: string
     /**
+     * Human-readable name for the workflow.
      * @maxLength 400
      * @nullable
      */
     name?: string | null
+    /** Optional description of the workflow's purpose. */
     description?: string
     readonly version?: number
+    /** Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).
+
+* `draft` - Draft
+* `active` - Active
+* `archived` - Archived */
     status?: HogFlowStatusEnumApi
     readonly created_at?: string
     readonly created_by?: UserBasicApi
     readonly updated_at?: string
-    trigger?: unknown
+    readonly trigger?: unknown
+    /** Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window. */
     trigger_masking?: HogFlowMaskingApi | null
+    /** Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition. */
     conversion?: unknown | null
-    exit_condition?: ExitConditionEnumApi
+    /** When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.
+
+* `exit_on_conversion` - Conversion
+* `exit_on_trigger_not_matched` - Trigger Not Matched
+* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+* `exit_only_at_end` - Only At End */
+    exit_condition?: ExitConditionEnumApi | NullEnumApi | null
+    /** Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions. */
     edges?: unknown
+    /** Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'. */
     actions?: HogFlowActionApi[]
     /** @nullable */
     readonly abort_action?: string | null
+    /** Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB. */
     variables?: PatchedHogFlowApiVariablesItem[]
     readonly billable_action_types?: unknown | null
+}
+
+/**
+ * Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape.
+ */
+export type HogFlowInvocationApiGlobals = { [key: string]: unknown }
+
+export interface HogFlowInvocationApi {
+    /** Optional workflow configuration override for the test run. If omitted, uses the saved workflow definition. */
+    configuration?: HogFlowApi
+    /** Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape. */
+    globals?: HogFlowInvocationApiGlobals
+    /** When true (default), async actions (HTTP requests, emails) are simulated rather than executed for safety. */
+    mock_async_functions?: boolean
+    /** Start execution from a specific action node ID instead of the trigger. Useful for testing mid-workflow actions. */
+    current_action_id?: string
 }
 
 export interface AppMetricSeriesApi {

--- a/products/workflows/frontend/generated/api.ts
+++ b/products/workflows/frontend/generated/api.ts
@@ -14,6 +14,7 @@ import type {
     BlastRadiusApi,
     BlastRadiusRequestApi,
     HogFlowApi,
+    HogFlowInvocationApi,
     HogFlowTemplateApi,
     HogFlowTemplatesListParams,
     HogFlowTemplatesLogsRetrieveParams,
@@ -352,14 +353,14 @@ export const getHogFlowsInvocationsCreateUrl = (projectId: string, id: string) =
 export const hogFlowsInvocationsCreate = async (
     projectId: string,
     id: string,
-    hogFlowApi: NonReadonly<HogFlowApi>,
+    hogFlowInvocationApi: HogFlowInvocationApi,
     options?: RequestInit
-): Promise<HogFlowApi> => {
-    return apiMutator<HogFlowApi>(getHogFlowsInvocationsCreateUrl(projectId, id), {
+): Promise<void> => {
+    return apiMutator<void>(getHogFlowsInvocationsCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(hogFlowApi),
+        body: JSON.stringify(hogFlowInvocationApi),
     })
 }
 

--- a/products/workflows/frontend/generated/api.zod.ts
+++ b/products/workflows/frontend/generated/api.zod.ts
@@ -40,10 +40,21 @@ export const HogFlowTemplatesCreateBody = /* @__PURE__ */ zod
                     .number()
                     .min(hogFlowTemplatesCreateBodyTriggerMaskingOneTtlMin)
                     .max(hogFlowTemplatesCreateBodyTriggerMaskingOneTtlMax)
-                    .nullish(),
-                threshold: zod.number().nullish(),
-                hash: zod.string(),
-                bytecode: zod.unknown().nullish(),
+                    .nullish()
+                    .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+                threshold: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Minimum number of matching events before the workflow triggers (k-anonymity threshold).'
+                    ),
+                hash: zod
+                    .string()
+                    .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+                bytecode: zod
+                    .unknown()
+                    .nullish()
+                    .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
             })
             .nullish(),
         conversion: zod.unknown().nullish(),
@@ -104,7 +115,15 @@ export const HogFlowTemplatesCreateBody = /* @__PURE__ */ zod
                 )
         ),
         abort_action: zod.string().max(hogFlowTemplatesCreateBodyAbortActionMax).nullish(),
-        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+        variables: zod
+            .array(
+                zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                    )
+            )
+            .optional(),
     })
     .describe(
         'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
@@ -141,10 +160,21 @@ export const HogFlowTemplatesUpdateBody = /* @__PURE__ */ zod
                     .number()
                     .min(hogFlowTemplatesUpdateBodyTriggerMaskingOneTtlMin)
                     .max(hogFlowTemplatesUpdateBodyTriggerMaskingOneTtlMax)
-                    .nullish(),
-                threshold: zod.number().nullish(),
-                hash: zod.string(),
-                bytecode: zod.unknown().nullish(),
+                    .nullish()
+                    .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+                threshold: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Minimum number of matching events before the workflow triggers (k-anonymity threshold).'
+                    ),
+                hash: zod
+                    .string()
+                    .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+                bytecode: zod
+                    .unknown()
+                    .nullish()
+                    .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
             })
             .nullish(),
         conversion: zod.unknown().nullish(),
@@ -205,7 +235,15 @@ export const HogFlowTemplatesUpdateBody = /* @__PURE__ */ zod
                 )
         ),
         abort_action: zod.string().max(hogFlowTemplatesUpdateBodyAbortActionMax).nullish(),
-        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+        variables: zod
+            .array(
+                zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                    )
+            )
+            .optional(),
     })
     .describe(
         'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
@@ -243,10 +281,21 @@ export const HogFlowTemplatesPartialUpdateBody = /* @__PURE__ */ zod
                     .number()
                     .min(hogFlowTemplatesPartialUpdateBodyTriggerMaskingOneTtlMin)
                     .max(hogFlowTemplatesPartialUpdateBodyTriggerMaskingOneTtlMax)
-                    .nullish(),
-                threshold: zod.number().nullish(),
-                hash: zod.string(),
-                bytecode: zod.unknown().nullish(),
+                    .nullish()
+                    .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+                threshold: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Minimum number of matching events before the workflow triggers (k-anonymity threshold).'
+                    ),
+                hash: zod
+                    .string()
+                    .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+                bytecode: zod
+                    .unknown()
+                    .nullish()
+                    .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
             })
             .nullish(),
         conversion: zod.unknown().nullish(),
@@ -311,7 +360,15 @@ export const HogFlowTemplatesPartialUpdateBody = /* @__PURE__ */ zod
             )
             .optional(),
         abort_action: zod.string().max(hogFlowTemplatesPartialUpdateBodyAbortActionMax).nullish(),
-        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+        variables: zod
+            .array(
+                zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                    )
+            )
+            .optional(),
     })
     .describe(
         'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
@@ -319,6 +376,7 @@ export const HogFlowTemplatesPartialUpdateBody = /* @__PURE__ */ zod
 
 export const hogFlowsCreateBodyNameMax = 400
 
+export const hogFlowsCreateBodyDescriptionDefault = ``
 export const hogFlowsCreateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsCreateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -329,83 +387,159 @@ export const hogFlowsCreateBodyActionsItemFiltersOneSourceDefault = `events`
 export const hogFlowsCreateBodyActionsItemTypeMax = 100
 
 export const HogFlowsCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod.string().max(hogFlowsCreateBodyNameMax).nullish().describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsCreateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const hogFlowsUpdateBodyNameMax = 400
 
+export const hogFlowsUpdateBodyDescriptionDefault = ``
 export const hogFlowsUpdateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsUpdateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -416,83 +550,159 @@ export const hogFlowsUpdateBodyActionsItemFiltersOneSourceDefault = `events`
 export const hogFlowsUpdateBodyActionsItemTypeMax = 100
 
 export const HogFlowsUpdateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsUpdateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod.string().max(hogFlowsUpdateBodyNameMax).nullish().describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsUpdateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsUpdateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsUpdateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsUpdateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsUpdateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsUpdateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsUpdateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsUpdateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsUpdateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsUpdateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsUpdateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const hogFlowsPartialUpdateBodyNameMax = 400
 
+export const hogFlowsPartialUpdateBodyDescriptionDefault = ``
 export const hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -503,44 +713,86 @@ export const hogFlowsPartialUpdateBodyActionsItemFiltersOneSourceDefault = `even
 export const hogFlowsPartialUpdateBodyActionsItemTypeMax = 100
 
 export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsPartialUpdateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsPartialUpdateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsPartialUpdateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
     actions: zod
         .array(
             zod.object({
-                id: zod.string(),
-                name: zod.string().max(hogFlowsPartialUpdateBodyActionsItemNameMax),
-                description: zod.string().default(hogFlowsPartialUpdateBodyActionsItemDescriptionDefault),
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsPartialUpdateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsPartialUpdateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
                 on_error: zod
                     .union([
                         zod
@@ -550,9 +802,20 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod.object({
                             ),
                         zod.literal(null),
                     ])
-                    .nullish(),
-                created_at: zod.number().optional(),
-                updated_at: zod.number().optional(),
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
                 filters: zod
                     .object({
                         source: zod
@@ -570,18 +833,44 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod.object({
                         filter_test_accounts: zod.boolean().optional(),
                         bytecode_error: zod.string().optional(),
                     })
-                    .nullish(),
-                type: zod.string().max(hogFlowsPartialUpdateBodyActionsItemTypeMax),
-                config: zod.unknown(),
-                output_variable: zod.unknown().nullish(),
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsPartialUpdateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
             })
         )
-        .optional(),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+        .optional()
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const hogFlowsBatchJobsCreateBodyNameMax = 400
 
+export const hogFlowsBatchJobsCreateBodyDescriptionDefault = ``
 export const hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -592,166 +881,420 @@ export const hogFlowsBatchJobsCreateBodyActionsItemFiltersOneSourceDefault = `ev
 export const hogFlowsBatchJobsCreateBodyActionsItemTypeMax = 100
 
 export const HogFlowsBatchJobsCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsBatchJobsCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsBatchJobsCreateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsBatchJobsCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsBatchJobsCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsBatchJobsCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsBatchJobsCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsBatchJobsCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsBatchJobsCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsBatchJobsCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsBatchJobsCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsBatchJobsCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
-export const hogFlowsInvocationsCreateBodyNameMax = 400
+export const hogFlowsInvocationsCreateBodyConfigurationOneNameMax = 400
 
-export const hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMin = 60
-export const hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMax = 94608000
+export const hogFlowsInvocationsCreateBodyConfigurationOneDescriptionDefault = ``
+export const hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneDistinctIdMax = 200
 
-export const hogFlowsInvocationsCreateBodyActionsItemNameMax = 400
+export const hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneFirstNameMax = 150
 
-export const hogFlowsInvocationsCreateBodyActionsItemDescriptionDefault = ``
-export const hogFlowsInvocationsCreateBodyActionsItemFiltersOneSourceDefault = `events`
-export const hogFlowsInvocationsCreateBodyActionsItemTypeMax = 100
+export const hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneLastNameMax = 150
+
+export const hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneEmailMax = 254
+
+export const hogFlowsInvocationsCreateBodyConfigurationOneTriggerMaskingOneTtlMin = 60
+export const hogFlowsInvocationsCreateBodyConfigurationOneTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsInvocationsCreateBodyConfigurationOneActionsItemNameMax = 400
+
+export const hogFlowsInvocationsCreateBodyConfigurationOneActionsItemDescriptionDefault = ``
+export const hogFlowsInvocationsCreateBodyConfigurationOneActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsInvocationsCreateBodyConfigurationOneActionsItemTypeMax = 100
+
+export const hogFlowsInvocationsCreateBodyMockAsyncFunctionsDefault = true
 
 export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsInvocationsCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
-    status: zod
-        .enum(['draft', 'active', 'archived'])
-        .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
-    trigger_masking: zod
+    configuration: zod
         .object({
-            ttl: zod
-                .number()
-                .min(hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMin)
-                .max(hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
-        })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
-    exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
-        ])
-        .optional()
-        .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
-        ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsInvocationsCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsInvocationsCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
+            id: zod.uuid(),
+            name: zod
+                .string()
+                .max(hogFlowsInvocationsCreateBodyConfigurationOneNameMax)
+                .nullish()
+                .describe('Human-readable name for the workflow.'),
+            description: zod
+                .string()
+                .default(hogFlowsInvocationsCreateBodyConfigurationOneDescriptionDefault)
+                .describe("Optional description of the workflow's purpose."),
+            version: zod.number(),
+            status: zod
+                .enum(['draft', 'active', 'archived'])
+                .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
+                .optional()
+                .describe(
+                    'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+                ),
+            created_at: zod.iso.datetime({}),
+            created_by: zod.object({
+                id: zod.number(),
+                uuid: zod.uuid(),
+                distinct_id: zod
+                    .string()
+                    .max(hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneDistinctIdMax)
+                    .nullish(),
+                first_name: zod
+                    .string()
+                    .max(hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneFirstNameMax)
+                    .optional(),
+                last_name: zod
+                    .string()
+                    .max(hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneLastNameMax)
+                    .optional(),
+                email: zod.email().max(hogFlowsInvocationsCreateBodyConfigurationOneCreatedByOneEmailMax),
+                is_email_verified: zod.boolean().nullish(),
+                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+                role_at_organization: zod
+                    .union([
+                        zod
+                            .enum([
+                                'engineering',
+                                'data',
+                                'product',
+                                'founder',
+                                'leadership',
+                                'marketing',
+                                'sales',
+                                'other',
+                            ])
+                            .describe(
+                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                            ),
+                        zod.enum(['']),
+                        zod.literal(null),
+                    ])
+                    .nullish(),
+            }),
+            updated_at: zod.iso.datetime({}),
+            trigger: zod.unknown(),
+            trigger_masking: zod
+                .object({
+                    ttl: zod
+                        .number()
+                        .min(hogFlowsInvocationsCreateBodyConfigurationOneTriggerMaskingOneTtlMin)
+                        .max(hogFlowsInvocationsCreateBodyConfigurationOneTriggerMaskingOneTtlMax)
+                        .nullish()
+                        .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+                    threshold: zod
+                        .number()
+                        .nullish()
+                        .describe(
+                            'Minimum number of matching events before the workflow triggers (k-anonymity threshold).'
+                        ),
+                    hash: zod
+                        .string()
+                        .describe(
+                            "HogQL template expression used as the masking key (e.g. '{person.properties.email}')."
+                        ),
+                    bytecode: zod
+                        .unknown()
+                        .nullish()
+                        .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
+                })
+                .nullish()
+                .describe(
+                    'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+                ),
+            conversion: zod
+                .unknown()
+                .nullish()
+                .describe(
+                    'Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'
+                ),
+            exit_condition: zod
                 .union([
                     zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .enum([
+                            'exit_on_conversion',
+                            'exit_on_trigger_not_matched',
+                            'exit_on_trigger_not_matched_or_conversion',
+                            'exit_only_at_end',
+                        ])
                         .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
                         ),
                     zod.literal(null),
                 ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                .nullish()
+                .describe(
+                    'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            edges: zod
+                .unknown()
+                .optional()
+                .describe(
+                    'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
+                ),
+            actions: zod
+                .array(
+                    zod.object({
+                        id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                        name: zod
+                            .string()
+                            .max(hogFlowsInvocationsCreateBodyConfigurationOneActionsItemNameMax)
+                            .describe('Human-readable name for the action node.'),
+                        description: zod
+                            .string()
+                            .default(hogFlowsInvocationsCreateBodyConfigurationOneActionsItemDescriptionDefault)
+                            .describe('Optional description of what this action does.'),
+                        on_error: zod
+                            .union([
+                                zod
+                                    .enum(['continue', 'abort', 'complete', 'branch'])
+                                    .describe(
+                                        '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                    ),
+                                zod.literal(null),
+                            ])
+                            .nullish()
+                            .describe(
+                                'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        created_at: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'
+                            ),
+                        updated_at: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                            ),
+                        filters: zod
+                            .object({
+                                source: zod
+                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .describe(
+                                        '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                    )
+                                    .default(
+                                        hogFlowsInvocationsCreateBodyConfigurationOneActionsItemFiltersOneSourceDefault
+                                    ),
+                                actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                bytecode: zod.unknown().nullish(),
+                                transpiled: zod.unknown().optional(),
+                                filter_test_accounts: zod.boolean().optional(),
+                                bytecode_error: zod.string().optional(),
+                            })
+                            .nullish()
+                            .describe('Property filters that gate execution of this action.'),
+                        type: zod
+                            .string()
+                            .max(hogFlowsInvocationsCreateBodyConfigurationOneActionsItemTypeMax)
+                            .describe(
+                                'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                            ),
+                        config: zod
+                            .unknown()
+                            .describe(
+                                "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                            ),
+                        output_variable: zod
+                            .unknown()
+                            .nullish()
+                            .describe(
+                                "Variable definition to store this action's output for use by downstream actions."
+                            ),
+                    })
+                )
+                .describe(
+                    "Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."
+                ),
+            abort_action: zod.string().nullable(),
+            variables: zod
+                .array(
+                    zod
+                        .record(zod.string(), zod.string())
                         .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
                         )
-                        .default(hogFlowsInvocationsCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsInvocationsCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
+                )
+                .optional()
+                .describe(
+                    'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+                ),
+            billable_action_types: zod.unknown().nullable(),
         })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+        .optional()
+        .describe(
+            'Optional workflow configuration override for the test run. If omitted, uses the saved workflow definition.'
+        ),
+    globals: zod
+        .record(zod.string(), zod.unknown())
+        .optional()
+        .describe(
+            "Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape."
+        ),
+    mock_async_functions: zod
+        .boolean()
+        .default(hogFlowsInvocationsCreateBodyMockAsyncFunctionsDefault)
+        .describe(
+            'When true (default), async actions (HTTP requests, emails) are simulated rather than executed for safety.'
+        ),
+    current_action_id: zod
+        .string()
+        .optional()
+        .describe(
+            'Start execution from a specific action node ID instead of the trigger. Useful for testing mid-workflow actions.'
+        ),
 })
 
 /**
@@ -759,6 +1302,7 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
  */
 export const hogFlowsReplayAllBlockedRunsCreateBodyNameMax = 400
 
+export const hogFlowsReplayAllBlockedRunsCreateBodyDescriptionDefault = ``
 export const hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -769,79 +1313,158 @@ export const hogFlowsReplayAllBlockedRunsCreateBodyActionsItemFiltersOneSourceDe
 export const hogFlowsReplayAllBlockedRunsCreateBodyActionsItemTypeMax = 100
 
 export const HogFlowsReplayAllBlockedRunsCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsReplayAllBlockedRunsCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsReplayAllBlockedRunsCreateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsReplayAllBlockedRunsCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 /**
@@ -849,6 +1472,7 @@ export const HogFlowsReplayAllBlockedRunsCreateBody = /* @__PURE__ */ zod.object
  */
 export const hogFlowsReplayBlockedRunCreateBodyNameMax = 400
 
+export const hogFlowsReplayBlockedRunCreateBodyDescriptionDefault = ``
 export const hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -859,83 +1483,163 @@ export const hogFlowsReplayBlockedRunCreateBodyActionsItemFiltersOneSourceDefaul
 export const hogFlowsReplayBlockedRunCreateBodyActionsItemTypeMax = 100
 
 export const HogFlowsReplayBlockedRunCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsReplayBlockedRunCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsReplayBlockedRunCreateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsReplayBlockedRunCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsReplayBlockedRunCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsReplayBlockedRunCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsReplayBlockedRunCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsReplayBlockedRunCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsReplayBlockedRunCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsReplayBlockedRunCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsReplayBlockedRunCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsReplayBlockedRunCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const hogFlowsSchedulesCreateBodyNameMax = 400
 
+export const hogFlowsSchedulesCreateBodyDescriptionDefault = ``
 export const hogFlowsSchedulesCreateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsSchedulesCreateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -946,83 +1650,163 @@ export const hogFlowsSchedulesCreateBodyActionsItemFiltersOneSourceDefault = `ev
 export const hogFlowsSchedulesCreateBodyActionsItemTypeMax = 100
 
 export const HogFlowsSchedulesCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsSchedulesCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsSchedulesCreateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsSchedulesCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsSchedulesCreateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsSchedulesCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsSchedulesCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsSchedulesCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsSchedulesCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsSchedulesCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsSchedulesCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsSchedulesCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsSchedulesCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsSchedulesCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const hogFlowsSchedulesPartialUpdateBodyNameMax = 400
 
+export const hogFlowsSchedulesPartialUpdateBodyDescriptionDefault = ``
 export const hogFlowsSchedulesPartialUpdateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsSchedulesPartialUpdateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -1033,44 +1817,86 @@ export const hogFlowsSchedulesPartialUpdateBodyActionsItemFiltersOneSourceDefaul
 export const hogFlowsSchedulesPartialUpdateBodyActionsItemTypeMax = 100
 
 export const HogFlowsSchedulesPartialUpdateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsSchedulesPartialUpdateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsSchedulesPartialUpdateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsSchedulesPartialUpdateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsSchedulesPartialUpdateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsSchedulesPartialUpdateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
     actions: zod
         .array(
             zod.object({
-                id: zod.string(),
-                name: zod.string().max(hogFlowsSchedulesPartialUpdateBodyActionsItemNameMax),
-                description: zod.string().default(hogFlowsSchedulesPartialUpdateBodyActionsItemDescriptionDefault),
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsSchedulesPartialUpdateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsSchedulesPartialUpdateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
                 on_error: zod
                     .union([
                         zod
@@ -1080,9 +1906,20 @@ export const HogFlowsSchedulesPartialUpdateBody = /* @__PURE__ */ zod.object({
                             ),
                         zod.literal(null),
                     ])
-                    .nullish(),
-                created_at: zod.number().optional(),
-                updated_at: zod.number().optional(),
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
                 filters: zod
                     .object({
                         source: zod
@@ -1100,18 +1937,44 @@ export const HogFlowsSchedulesPartialUpdateBody = /* @__PURE__ */ zod.object({
                         filter_test_accounts: zod.boolean().optional(),
                         bytecode_error: zod.string().optional(),
                     })
-                    .nullish(),
-                type: zod.string().max(hogFlowsSchedulesPartialUpdateBodyActionsItemTypeMax),
-                config: zod.unknown(),
-                output_variable: zod.unknown().nullish(),
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsSchedulesPartialUpdateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
             })
         )
-        .optional(),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+        .optional()
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const hogFlowsBulkDeleteCreateBodyNameMax = 400
 
+export const hogFlowsBulkDeleteCreateBodyDescriptionDefault = ``
 export const hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMin = 60
 export const hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMax = 94608000
 
@@ -1122,79 +1985,158 @@ export const hogFlowsBulkDeleteCreateBodyActionsItemFiltersOneSourceDefault = `e
 export const hogFlowsBulkDeleteCreateBodyActionsItemTypeMax = 100
 
 export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(hogFlowsBulkDeleteCreateBodyNameMax).nullish(),
-    description: zod.string().optional(),
+    name: zod
+        .string()
+        .max(hogFlowsBulkDeleteCreateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsBulkDeleteCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
     status: zod
         .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
         .optional()
-        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
-    trigger: zod.unknown().optional(),
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
     trigger_masking: zod
         .object({
             ttl: zod
                 .number()
                 .min(hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMin)
                 .max(hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMax)
-                .nullish(),
-            threshold: zod.number().nullish(),
-            hash: zod.string(),
-            bytecode: zod.unknown().nullish(),
+                .nullish()
+                .describe('Time-to-live in seconds for the masking hash. Min 60s, max 3 years.'),
+            threshold: zod
+                .number()
+                .nullish()
+                .describe('Minimum number of matching events before the workflow triggers (k-anonymity threshold).'),
+            hash: zod
+                .string()
+                .describe("HogQL template expression used as the masking key (e.g. '{person.properties.email}')."),
+            bytecode: zod
+                .unknown()
+                .nullish()
+                .describe('Compiled bytecode for the hash template. Auto-generated server-side.'),
         })
-        .nullish(),
-    conversion: zod.unknown().nullish(),
+        .nullish()
+        .describe(
+            'Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window.'
+        ),
+    conversion: zod
+        .unknown()
+        .nullish()
+        .describe('Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition.'),
     exit_condition: zod
-        .enum([
-            'exit_on_conversion',
-            'exit_on_trigger_not_matched',
-            'exit_on_trigger_not_matched_or_conversion',
-            'exit_only_at_end',
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
         ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
         .optional()
         .describe(
-            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
         ),
-    edges: zod.unknown().optional(),
-    actions: zod.array(
-        zod.object({
-            id: zod.string(),
-            name: zod.string().max(hogFlowsBulkDeleteCreateBodyActionsItemNameMax),
-            description: zod.string().default(hogFlowsBulkDeleteCreateBodyActionsItemDescriptionDefault),
-            on_error: zod
-                .union([
-                    zod
-                        .enum(['continue', 'abort', 'complete', 'branch'])
-                        .describe(
-                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
-                        ),
-                    zod.literal(null),
-                ])
-                .nullish(),
-            created_at: zod.number().optional(),
-            updated_at: zod.number().optional(),
-            filters: zod
-                .object({
-                    source: zod
-                        .enum(['events', 'person-updates', 'data-warehouse-table'])
-                        .describe(
-                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
-                        )
-                        .default(hogFlowsBulkDeleteCreateBodyActionsItemFiltersOneSourceDefault),
-                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    bytecode: zod.unknown().nullish(),
-                    transpiled: zod.unknown().optional(),
-                    filter_test_accounts: zod.boolean().optional(),
-                    bytecode_error: zod.string().optional(),
-                })
-                .nullish(),
-            type: zod.string().max(hogFlowsBulkDeleteCreateBodyActionsItemTypeMax),
-            config: zod.unknown(),
-            output_variable: zod.unknown().nullish(),
-        })
-    ),
-    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsBulkDeleteCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsBulkDeleteCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsBulkDeleteCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsBulkDeleteCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
 })
 
 export const HogFlowsUserBlastRadiusCreateBody = /* @__PURE__ */ zod.object({

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -116,6 +116,43 @@ tools:
     hog-flows-user-blast-radius-create:
         operation: hog_flows_user_blast_radius_create
         enabled: false
+    workflows-create:
+        operation: hog_flows_create
+        enabled: true
+        scopes:
+            - hog_flow:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: hog-{id}
+        title: Create workflow
+        description: >
+            Create a new workflow. Requires an actions array containing exactly one trigger action (type='trigger')
+            with a config specifying the trigger type (event, webhook, manual, batch, schedule, tracking_pixel).
+            Additional actions define the workflow steps: function (call a template), delay (pause execution),
+            conditional_branch (if/else routing), wait_until_condition (pause until a condition is met). Connect
+            actions via the edges array [{source, target}]. New workflows default to 'draft' status — set status
+            to 'active' to enable live execution.
+        exclude_params:
+            - trigger
+            - trigger_masking
+            - conversion
+        ui_app: workflow
+    workflows-delete:
+        operation: hog_flows_destroy
+        enabled: true
+        scopes:
+            - hog_flow:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete workflow
+        description: >
+            Permanently delete a workflow by ID. This removes the workflow definition and all associated data.
+            Consider archiving (set status to 'archived' via update) instead of deleting if you may need to
+            restore it later.
     workflows-get:
         operation: hog_flows_retrieve
         enabled: true
@@ -146,3 +183,41 @@ tools:
             List all workflows in the project. Returns workflows with their name, description, status
             (draft/active/archived), version, trigger configuration, and timestamps.
         ui_app: workflow-list
+    workflows-run:
+        operation: hog_flows_invocations_create
+        enabled: true
+        scopes:
+            - hog_flow:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Test-run workflow
+        description: >
+            Execute a test invocation of a workflow. Sends the workflow to the execution engine for a dry-run
+            with the provided test event data. By default, async functions (HTTP calls, emails, SMS) are mocked
+            for safety. Use globals to provide test event data matching your trigger type. Optionally pass
+            current_action_id to start from a specific node. Returns the execution trace showing which actions
+            ran and their outputs.
+        exclude_params:
+            - configuration
+    workflows-update:
+        operation: hog_flows_partial_update
+        enabled: true
+        scopes:
+            - hog_flow:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: hog-{id}
+        title: Update workflow
+        description: >
+            Update an existing workflow by ID. Supports partial updates — only include fields you want to change.
+            Common operations: change status (draft to active to publish, active to archived to disable), update
+            actions array (must still contain exactly one trigger), modify edges, or update exit_condition.
+        exclude_params:
+            - trigger
+            - trigger_masking
+            - conversion
+        ui_app: workflow

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -128,12 +128,12 @@ tools:
         enrich_url: hog-{id}
         title: Create workflow
         description: >
-            Create a new workflow. Requires an actions array containing exactly one trigger action (type='trigger')
-            with a config specifying the trigger type (event, webhook, manual, batch, schedule, tracking_pixel).
-            Additional actions define the workflow steps: function (call a template), delay (pause execution),
-            conditional_branch (if/else routing), wait_until_condition (pause until a condition is met). Connect
-            actions via the edges array [{source, target}]. New workflows default to 'draft' status — set status
-            to 'active' to enable live execution.
+            Create a new workflow. Requires an actions array containing exactly one trigger action (type='trigger') with
+            a config specifying the trigger type (event, webhook, manual, batch, schedule, tracking_pixel). Additional
+            actions define the workflow steps: function (call a template), delay (pause execution), conditional_branch
+            (if/else routing), wait_until_condition (pause until a condition is met). Connect actions via the edges
+            array [{source, target}]. New workflows default to 'draft' status — set status to 'active' to enable live
+            execution.
         exclude_params:
             - trigger
             - trigger_masking
@@ -150,9 +150,8 @@ tools:
             idempotent: true
         title: Delete workflow
         description: >
-            Permanently delete a workflow by ID. This removes the workflow definition and all associated data.
-            Consider archiving (set status to 'archived' via update) instead of deleting if you may need to
-            restore it later.
+            Permanently delete a workflow by ID. This removes the workflow definition and all associated data. Consider
+            archiving (set status to 'archived' via update) instead of deleting if you may need to restore it later.
     workflows-get:
         operation: hog_flows_retrieve
         enabled: true
@@ -194,11 +193,10 @@ tools:
             idempotent: false
         title: Test-run workflow
         description: >
-            Execute a test invocation of a workflow. Sends the workflow to the execution engine for a dry-run
-            with the provided test event data. By default, async functions (HTTP calls, emails, SMS) are mocked
-            for safety. Use globals to provide test event data matching your trigger type. Optionally pass
-            current_action_id to start from a specific node. Returns the execution trace showing which actions
-            ran and their outputs.
+            Execute a test invocation of a workflow. Sends the workflow to the execution engine for a dry-run with the
+            provided test event data. By default, async functions (HTTP calls, emails, SMS) are mocked for safety. Use
+            globals to provide test event data matching your trigger type. Optionally pass current_action_id to start
+            from a specific node. Returns the execution trace showing which actions ran and their outputs.
         exclude_params:
             - configuration
     workflows-update:
@@ -213,9 +211,9 @@ tools:
         enrich_url: hog-{id}
         title: Update workflow
         description: >
-            Update an existing workflow by ID. Supports partial updates — only include fields you want to change.
-            Common operations: change status (draft to active to publish, active to archived to disable), update
-            actions array (must still contain exactly one trigger), modify edges, or update exit_condition.
+            Update an existing workflow by ID. Supports partial updates — only include fields you want to change. Common
+            operations: change status (draft to active to publish, active to archived to disable), update actions array
+            (must still contain exactly one trigger), modify edges, or update exit_condition.
         exclude_params:
             - trigger
             - trigger_masking

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4638,6 +4638,36 @@
             "readOnlyHint": true
         }
     },
+    "workflows-create": {
+        "description": "Create a new workflow. Requires an actions array containing exactly one trigger action (type='trigger') with a config specifying the trigger type (event, webhook, manual, batch, schedule, tracking_pixel). Additional actions define the workflow steps: function (call a template), delay (pause execution), conditional_branch (if/else routing), wait_until_condition (pause until a condition is met). Connect actions via the edges array [{source, target}]. New workflows default to 'draft' status — set status to 'active' to enable live execution.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Create workflow",
+        "title": "Create workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "workflows-delete": {
+        "description": "Permanently delete a workflow by ID. This removes the workflow definition and all associated data. Consider archiving (set status to 'archived' via update) instead of deleting if you may need to restore it later.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Delete workflow",
+        "title": "Delete workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "workflows-get": {
         "description": "Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
         "category": "Workflows",
@@ -4666,6 +4696,36 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "workflows-run": {
+        "description": "Execute a test invocation of a workflow. Sends the workflow to the execution engine for a dry-run with the provided test event data. By default, async functions (HTTP calls, emails, SMS) are mocked for safety. Use globals to provide test event data matching your trigger type. Optionally pass current_action_id to start from a specific node. Returns the execution trace showing which actions ran and their outputs.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Test-run workflow",
+        "title": "Test-run workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "workflows-update": {
+        "description": "Update an existing workflow by ID. Supports partial updates — only include fields you want to change. Common operations: change status (draft to active to publish, active to archived to disable), update actions array (must still contain exactly one trigger), modify edges, or update exit_condition.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Update workflow",
+        "title": "Update workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     }
 }

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5102,6 +5102,36 @@
             "readOnlyHint": true
         }
     },
+    "workflows-create": {
+        "description": "Create a new workflow. Requires an actions array containing exactly one trigger action (type='trigger') with a config specifying the trigger type (event, webhook, manual, batch, schedule, tracking_pixel). Additional actions define the workflow steps: function (call a template), delay (pause execution), conditional_branch (if/else routing), wait_until_condition (pause until a condition is met). Connect actions via the edges array [{source, target}]. New workflows default to 'draft' status — set status to 'active' to enable live execution.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Create workflow",
+        "title": "Create workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "workflows-delete": {
+        "description": "Permanently delete a workflow by ID. This removes the workflow definition and all associated data. Consider archiving (set status to 'archived' via update) instead of deleting if you may need to restore it later.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Delete workflow",
+        "title": "Delete workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "workflows-get": {
         "description": "Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
         "category": "Workflows",
@@ -5130,6 +5160,36 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "workflows-run": {
+        "description": "Execute a test invocation of a workflow. Sends the workflow to the execution engine for a dry-run with the provided test event data. By default, async functions (HTTP calls, emails, SMS) are mocked for safety. Use globals to provide test event data matching your trigger type. Optionally pass current_action_id to start from a specific node. Returns the execution trace showing which actions ran and their outputs.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Test-run workflow",
+        "title": "Test-run workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "workflows-update": {
+        "description": "Update an existing workflow by ID. Supports partial updates — only include fields you want to change. Common operations: change status (draft to active to publish, active to archived to disable), update actions array (must still contain exactly one trigger), modify edges, or update exit_condition.",
+        "category": "Workflows",
+        "feature": "workflows",
+        "summary": "Update workflow",
+        "title": "Update workflow",
+        "required_scopes": ["hog_flow:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     }
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18454,6 +18454,9 @@ export namespace Schemas {
       results: HeatmapResponseItem[];
     }
 
+    /**
+     * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+     */
     export type HogFlowVariablesItem = {[key: string]: string};
 
     /**
@@ -18472,14 +18475,20 @@ export namespace Schemas {
 
     export interface HogFlowMasking {
       /**
+       * Time-to-live in seconds for the masking hash. Min 60s, max 3 years.
        * @minimum 60
        * @maximum 94608000
        * @nullable
        */
       ttl?: number | null;
-      /** @nullable */
+      /**
+       * Minimum number of matching events before the workflow triggers (k-anonymity threshold).
+       * @nullable
+       */
       threshold?: number | null;
+      /** HogQL template expression used as the masking key (e.g. '{person.properties.email}'). */
       hash: string;
+      /** Compiled bytecode for the hash template. Auto-generated server-side. */
       bytecode?: unknown | null;
     }
 
@@ -18534,43 +18543,96 @@ export namespace Schemas {
     }
 
     export interface HogFlowAction {
+      /** Unique identifier for this action node within the workflow graph. */
       id: string;
-      /** @maxLength 400 */
+      /**
+       * Human-readable name for the action node.
+       * @maxLength 400
+       */
       name: string;
+      /** Optional description of what this action does. */
       description?: string;
+      /** Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).
+
+    * `continue` - continue
+    * `abort` - abort
+    * `complete` - complete
+    * `branch` - branch */
       on_error?: OnErrorEnum | NullEnum | null;
+      /** Unix epoch milliseconds when the action was added. Auto-managed by the frontend. */
       created_at?: number;
+      /** Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend. */
       updated_at?: number;
+      /** Property filters that gate execution of this action. */
       filters?: HogFunctionFilters | null;
-      /** @maxLength 100 */
+      /**
+       * Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.
+       * @maxLength 100
+       */
       type: string;
+      /** Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}. */
       config: unknown;
+      /** Variable definition to store this action's output for use by downstream actions. */
       output_variable?: unknown | null;
     }
 
     export interface HogFlow {
       readonly id: string;
       /**
+       * Human-readable name for the workflow.
        * @maxLength 400
        * @nullable
        */
       name?: string | null;
+      /** Optional description of the workflow's purpose. */
       description?: string;
       readonly version: number;
+      /** Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).
+
+    * `draft` - Draft
+    * `active` - Active
+    * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at: string;
       readonly created_by: UserBasic;
       readonly updated_at: string;
-      trigger?: unknown;
+      readonly trigger: unknown;
+      /** Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window. */
       trigger_masking?: HogFlowMasking | null;
+      /** Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition. */
       conversion?: unknown | null;
-      exit_condition?: ExitConditionEnum;
+      /** When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.
+
+    * `exit_on_conversion` - Conversion
+    * `exit_on_trigger_not_matched` - Trigger Not Matched
+    * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+    * `exit_only_at_end` - Only At End */
+      exit_condition?: ExitConditionEnum | NullEnum | null;
+      /** Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions. */
       edges?: unknown;
+      /** Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'. */
       actions: HogFlowAction[];
       /** @nullable */
       readonly abort_action: string | null;
+      /** Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB. */
       variables?: HogFlowVariablesItem[];
       readonly billable_action_types: unknown | null;
+    }
+
+    /**
+     * Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape.
+     */
+    export type HogFlowInvocationGlobals = { [key: string]: unknown };
+
+    export interface HogFlowInvocation {
+      /** Optional workflow configuration override for the test run. If omitted, uses the saved workflow definition. */
+      configuration?: HogFlow;
+      /** Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape. */
+      globals?: HogFlowInvocationGlobals;
+      /** When true (default), async actions (HTTP requests, emails) are simulated rather than executed for safety. */
+      mock_async_functions?: boolean;
+      /** Start execution from a specific action node ID instead of the trigger. Useful for testing mid-workflow actions. */
+      current_action_id?: string;
     }
 
     export interface HogFlowMinimal {
@@ -18628,6 +18690,9 @@ export namespace Schemas {
      */
     export type HogFlowTemplateCreatedBy = { [key: string]: unknown } | null | null;
 
+    /**
+     * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+     */
     export type HogFlowTemplateVariablesItem = {[key: string]: string};
 
     /**
@@ -28151,29 +28216,50 @@ export namespace Schemas {
       readonly exception?: string | null;
     }
 
+    /**
+     * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+     */
     export type PatchedHogFlowVariablesItem = {[key: string]: string};
 
     export interface PatchedHogFlow {
       readonly id?: string;
       /**
+       * Human-readable name for the workflow.
        * @maxLength 400
        * @nullable
        */
       name?: string | null;
+      /** Optional description of the workflow's purpose. */
       description?: string;
       readonly version?: number;
+      /** Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).
+
+    * `draft` - Draft
+    * `active` - Active
+    * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at?: string;
       readonly created_by?: UserBasic;
       readonly updated_at?: string;
-      trigger?: unknown;
+      readonly trigger?: unknown;
+      /** Optional masking/deduplication configuration. Prevents the same entity from entering the workflow multiple times within a TTL window. */
       trigger_masking?: HogFlowMasking | null;
+      /** Conversion goal definition with filters and bytecode. Used with exit_on_conversion exit condition. */
       conversion?: unknown | null;
-      exit_condition?: ExitConditionEnum;
+      /** When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.
+
+    * `exit_on_conversion` - Conversion
+    * `exit_on_trigger_not_matched` - Trigger Not Matched
+    * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+    * `exit_only_at_end` - Only At End */
+      exit_condition?: ExitConditionEnum | NullEnum | null;
+      /** Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions. */
       edges?: unknown;
+      /** Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'. */
       actions?: HogFlowAction[];
       /** @nullable */
       readonly abort_action?: string | null;
+      /** Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB. */
       variables?: PatchedHogFlowVariablesItem[];
       readonly billable_action_types?: unknown | null;
     }
@@ -28183,6 +28269,9 @@ export namespace Schemas {
      */
     export type PatchedHogFlowTemplateCreatedBy = { [key: string]: unknown } | null | null;
 
+    /**
+     * Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).
+     */
     export type PatchedHogFlowTemplateVariablesItem = {[key: string]: string};
 
     /**

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 4 enabled ops
+ * PostHog API - MCP 8 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -25,12 +25,335 @@ export const HogFlowsListQueryParams = /* @__PURE__ */ zod.object({
     updated_at: zod.iso.datetime({}).optional(),
 })
 
+export const HogFlowsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsCreateBodyNameMax = 400
+
+export const hogFlowsCreateBodyDescriptionDefault = ``
+export const hogFlowsCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(hogFlowsCreateBodyNameMax).nullish().describe('Human-readable name for the workflow.'),
+    description: zod
+        .string()
+        .default(hogFlowsCreateBodyDescriptionDefault)
+        .describe("Optional description of the workflow's purpose."),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
+        .optional()
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
+    exit_condition: zod
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
+        ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
+        ),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsCreateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsCreateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsCreateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsCreateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
+})
+
 export const HogFlowsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this hog flow.'),
     project_id: zod
         .string()
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsPartialUpdateBodyNameMax = 400
+
+export const hogFlowsPartialUpdateBodyActionsItemNameMax = 400
+
+export const hogFlowsPartialUpdateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsPartialUpdateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsPartialUpdateBodyActionsItemTypeMax = 100
+
+export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(hogFlowsPartialUpdateBodyNameMax)
+        .nullish()
+        .describe('Human-readable name for the workflow.'),
+    description: zod.string().optional().describe("Optional description of the workflow's purpose."),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived')
+        .optional()
+        .describe(
+            'Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'
+        ),
+    exit_condition: zod
+        .union([
+            zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            zod.literal(null),
+        ])
+        .nullish()
+        .describe(
+            'When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions.'
+        ),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string().describe('Unique identifier for this action node within the workflow graph.'),
+                name: zod
+                    .string()
+                    .max(hogFlowsPartialUpdateBodyActionsItemNameMax)
+                    .describe('Human-readable name for the action node.'),
+                description: zod
+                    .string()
+                    .default(hogFlowsPartialUpdateBodyActionsItemDescriptionDefault)
+                    .describe('Optional description of what this action does.'),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish()
+                    .describe(
+                        'Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                    ),
+                created_at: zod
+                    .number()
+                    .optional()
+                    .describe('Unix epoch milliseconds when the action was added. Auto-managed by the frontend.'),
+                updated_at: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        'Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.'
+                    ),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsPartialUpdateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish()
+                    .describe('Property filters that gate execution of this action.'),
+                type: zod
+                    .string()
+                    .max(hogFlowsPartialUpdateBodyActionsItemTypeMax)
+                    .describe(
+                        'Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.'
+                    ),
+                config: zod
+                    .unknown()
+                    .describe(
+                        "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    ),
+                output_variable: zod
+                    .unknown()
+                    .nullish()
+                    .describe("Variable definition to store this action's output for use by downstream actions."),
+            })
+        )
+        .optional()
+        .describe("Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'."),
+    variables: zod
+        .array(
+            zod
+                .record(zod.string(), zod.string())
+                .describe(
+                    "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value)."
+                )
+        )
+        .optional()
+        .describe(
+            'Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.'
+        ),
+})
+
+export const HogFlowsDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsInvocationsCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsInvocationsCreateBodyMockAsyncFunctionsDefault = true
+
+export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
+    globals: zod
+        .record(zod.string(), zod.unknown())
+        .optional()
+        .describe(
+            "Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape."
+        ),
+    mock_async_functions: zod
+        .boolean()
+        .default(hogFlowsInvocationsCreateBodyMockAsyncFunctionsDefault)
+        .describe(
+            'When true (default), async actions (HTTP requests, emails) are simulated rather than executed for safety.'
+        ),
+    current_action_id: zod
+        .string()
+        .optional()
+        .describe(
+            'Start execution from a specific action node ID instead of the trigger. Useful for testing mid-workflow actions.'
         ),
 })
 

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -3,11 +3,17 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    HogFlowsCreateBody,
+    HogFlowsDestroyParams,
+    HogFlowsInvocationsCreateBody,
+    HogFlowsInvocationsCreateParams,
     HogFlowsListQueryParams,
     HogFlowsLogsRetrieveParams,
     HogFlowsLogsRetrieveQueryParams,
     HogFlowsMetricsRetrieveParams,
     HogFlowsMetricsRetrieveQueryParams,
+    HogFlowsPartialUpdateBody,
+    HogFlowsPartialUpdateParams,
     HogFlowsRetrieveParams,
 } from '@/generated/workflows/api'
 import { withUiApp } from '@/resources/ui-apps'
@@ -65,6 +71,60 @@ const hogFlowsMetricsRetrieve = (): ToolBase<typeof HogFlowsMetricsRetrieveSchem
     },
 })
 
+const WorkflowsCreateSchema = HogFlowsCreateBody
+
+const workflowsCreate = (): ToolBase<typeof WorkflowsCreateSchema, WithPostHogUrl<Schemas.HogFlow>> =>
+    withUiApp('workflow', {
+        name: 'workflows-create',
+        schema: WorkflowsCreateSchema,
+        handler: async (context: Context, params: z.infer<typeof WorkflowsCreateSchema>) => {
+            const projectId = await context.stateManager.getProjectId()
+            const body: Record<string, unknown> = {}
+            if (params.name !== undefined) {
+                body['name'] = params.name
+            }
+            if (params.description !== undefined) {
+                body['description'] = params.description
+            }
+            if (params.status !== undefined) {
+                body['status'] = params.status
+            }
+            if (params.exit_condition !== undefined) {
+                body['exit_condition'] = params.exit_condition
+            }
+            if (params.edges !== undefined) {
+                body['edges'] = params.edges
+            }
+            if (params.actions !== undefined) {
+                body['actions'] = params.actions
+            }
+            if (params.variables !== undefined) {
+                body['variables'] = params.variables
+            }
+            const result = await context.api.request<Schemas.HogFlow>({
+                method: 'POST',
+                path: `/api/projects/${encodeURIComponent(String(projectId))}/hog_flows/`,
+                body,
+            })
+            return await withPostHogUrl(context, result, `/pipeline/destinations/hog-${result.id}`)
+        },
+    })
+
+const WorkflowsDeleteSchema = HogFlowsDestroyParams.omit({ project_id: true })
+
+const workflowsDelete = (): ToolBase<typeof WorkflowsDeleteSchema, unknown> => ({
+    name: 'workflows-delete',
+    schema: WorkflowsDeleteSchema,
+    handler: async (context: Context, params: z.infer<typeof WorkflowsDeleteSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/hog_flows/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
 const WorkflowsGetSchema = HogFlowsRetrieveParams.omit({ project_id: true })
 
 const workflowsGet = (): ToolBase<typeof WorkflowsGetSchema, WithPostHogUrl<Schemas.HogFlow>> =>
@@ -105,9 +165,82 @@ const workflowsList = (): ToolBase<typeof WorkflowsListSchema, WithPostHogUrl<Sc
         },
     })
 
+const WorkflowsRunSchema = HogFlowsInvocationsCreateParams.omit({ project_id: true }).extend(
+    HogFlowsInvocationsCreateBody.shape
+)
+
+const workflowsRun = (): ToolBase<typeof WorkflowsRunSchema, unknown> => ({
+    name: 'workflows-run',
+    schema: WorkflowsRunSchema,
+    handler: async (context: Context, params: z.infer<typeof WorkflowsRunSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.globals !== undefined) {
+            body['globals'] = params.globals
+        }
+        if (params.mock_async_functions !== undefined) {
+            body['mock_async_functions'] = params.mock_async_functions
+        }
+        if (params.current_action_id !== undefined) {
+            body['current_action_id'] = params.current_action_id
+        }
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/hog_flows/${encodeURIComponent(String(params.id))}/invocations/`,
+            body,
+        })
+        return result
+    },
+})
+
+const WorkflowsUpdateSchema = HogFlowsPartialUpdateParams.omit({ project_id: true }).extend(
+    HogFlowsPartialUpdateBody.shape
+)
+
+const workflowsUpdate = (): ToolBase<typeof WorkflowsUpdateSchema, WithPostHogUrl<Schemas.HogFlow>> =>
+    withUiApp('workflow', {
+        name: 'workflows-update',
+        schema: WorkflowsUpdateSchema,
+        handler: async (context: Context, params: z.infer<typeof WorkflowsUpdateSchema>) => {
+            const projectId = await context.stateManager.getProjectId()
+            const body: Record<string, unknown> = {}
+            if (params.name !== undefined) {
+                body['name'] = params.name
+            }
+            if (params.description !== undefined) {
+                body['description'] = params.description
+            }
+            if (params.status !== undefined) {
+                body['status'] = params.status
+            }
+            if (params.exit_condition !== undefined) {
+                body['exit_condition'] = params.exit_condition
+            }
+            if (params.edges !== undefined) {
+                body['edges'] = params.edges
+            }
+            if (params.actions !== undefined) {
+                body['actions'] = params.actions
+            }
+            if (params.variables !== undefined) {
+                body['variables'] = params.variables
+            }
+            const result = await context.api.request<Schemas.HogFlow>({
+                method: 'PATCH',
+                path: `/api/projects/${encodeURIComponent(String(projectId))}/hog_flows/${encodeURIComponent(String(params.id))}/`,
+                body,
+            })
+            return await withPostHogUrl(context, result, `/pipeline/destinations/hog-${result.id}`)
+        },
+    })
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'hog-flows-logs-retrieve': hogFlowsLogsRetrieve,
     'hog-flows-metrics-retrieve': hogFlowsMetricsRetrieve,
+    'workflows-create': workflowsCreate,
+    'workflows-delete': workflowsDelete,
     'workflows-get': workflowsGet,
     'workflows-list': workflowsList,
+    'workflows-run': workflowsRun,
+    'workflows-update': workflowsUpdate,
 }

--- a/services/mcp/tests/tools/workflows.integration.test.ts
+++ b/services/mcp/tests/tools/workflows.integration.test.ts
@@ -1,10 +1,11 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import {
     TEST_ORG_ID,
     TEST_PROJECT_ID,
     createTestClient,
     createTestContext,
+    generateUniqueKey,
     parseToolResponse,
     setActiveProjectAndOrg,
     validateEnvironmentVariables,
@@ -17,8 +18,14 @@ describe('Workflows', { concurrent: false }, () => {
 
     const listTool = GENERATED_TOOLS['workflows-list']!()
     const getTool = GENERATED_TOOLS['workflows-get']!()
+    const createTool = GENERATED_TOOLS['workflows-create']!()
+    const updateTool = GENERATED_TOOLS['workflows-update']!()
+    const deleteTool = GENERATED_TOOLS['workflows-delete']!()
+    const runTool = GENERATED_TOOLS['workflows-run']!()
     const logsTool = GENERATED_TOOLS['hog-flows-logs-retrieve']!()
     const metricsTool = GENERATED_TOOLS['hog-flows-metrics-retrieve']!()
+
+    const createdWorkflowIds: string[] = []
 
     beforeAll(async () => {
         validateEnvironmentVariables()
@@ -26,6 +33,41 @@ describe('Workflows', { concurrent: false }, () => {
         context = createTestContext(client)
         await setActiveProjectAndOrg(context, TEST_PROJECT_ID!, TEST_ORG_ID!)
     })
+
+    afterEach(async () => {
+        for (const id of createdWorkflowIds) {
+            try {
+                await deleteTool.handler(context, { id })
+            } catch {
+                // Best effort — may already be deleted
+            }
+        }
+        createdWorkflowIds.length = 0
+    })
+
+    function makeWorkflowParams(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+        const ts = Date.now()
+        return {
+            name: `test-workflow-${generateUniqueKey('wf')}`,
+            actions: [
+                {
+                    id: 'trigger_node',
+                    name: 'Trigger',
+                    type: 'trigger',
+                    created_at: ts,
+                    updated_at: ts,
+                    config: {
+                        type: 'event',
+                        filters: {
+                            events: [{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }],
+                        },
+                    },
+                },
+            ],
+            edges: [],
+            ...overrides,
+        }
+    }
 
     describe('workflows-list tool', () => {
         it('should list workflows and return paginated structure', async () => {
@@ -62,7 +104,6 @@ describe('Workflows', { concurrent: false }, () => {
             const { results: workflows } = parseToolResponse(listResult)
 
             if (workflows.length === 0) {
-                // No workflows in this environment — nothing to fetch.
                 return
             }
 
@@ -84,6 +125,127 @@ describe('Workflows', { concurrent: false }, () => {
             const absentId = crypto.randomUUID()
 
             await expect(getTool.handler(context, { id: absentId })).rejects.toThrow()
+        })
+    })
+
+    describe('workflows-create tool', () => {
+        it('should create a minimal draft workflow', async () => {
+            const params = makeWorkflowParams()
+            const result = await createTool.handler(context, params)
+            const workflow = parseToolResponse(result)
+            createdWorkflowIds.push(workflow.id)
+
+            expect(workflow.id).toBeTruthy()
+            expect(workflow.name).toBe(params.name)
+            expect(workflow.status).toBe('draft')
+            expect(Array.isArray(workflow.actions)).toBe(true)
+            expect(workflow.actions.length).toBe(1)
+            expect(workflow.actions[0].type).toBe('trigger')
+        })
+
+        it('should create a workflow with description and exit_condition', async () => {
+            const params = makeWorkflowParams({
+                description: 'A test workflow with exit condition',
+                exit_condition: 'exit_only_at_end',
+            })
+            const result = await createTool.handler(context, params)
+            const workflow = parseToolResponse(result)
+            createdWorkflowIds.push(workflow.id)
+
+            expect(workflow.description).toBe('A test workflow with exit condition')
+            expect(workflow.exit_condition).toBe('exit_only_at_end')
+        })
+    })
+
+    describe('workflows-update tool', () => {
+        it('should update the workflow name', async () => {
+            const created = await createTool.handler(context, makeWorkflowParams())
+            const workflow = parseToolResponse(created)
+            createdWorkflowIds.push(workflow.id)
+
+            const newName = `renamed-${generateUniqueKey('upd')}`
+            const result = await updateTool.handler(context, { id: workflow.id, name: newName })
+            const updated = parseToolResponse(result)
+
+            expect(updated.id).toBe(workflow.id)
+            expect(updated.name).toBe(newName)
+        })
+
+        it('should update status from draft to active', async () => {
+            const created = await createTool.handler(context, makeWorkflowParams())
+            const workflow = parseToolResponse(created)
+            createdWorkflowIds.push(workflow.id)
+
+            const result = await updateTool.handler(context, { id: workflow.id, status: 'active' })
+            const updated = parseToolResponse(result)
+
+            expect(updated.status).toBe('active')
+        })
+    })
+
+    describe('workflows-delete tool', () => {
+        it('should delete a workflow and verify it is gone', async () => {
+            const created = await createTool.handler(context, makeWorkflowParams())
+            const workflow = parseToolResponse(created)
+
+            await deleteTool.handler(context, { id: workflow.id })
+            await expect(getTool.handler(context, { id: workflow.id })).rejects.toThrow()
+        })
+
+        it('should throw for a non-existent UUID', async () => {
+            await expect(deleteTool.handler(context, { id: crypto.randomUUID() })).rejects.toThrow()
+        })
+    })
+
+    describe('workflows-run tool', () => {
+        it('should test-run a workflow with mock globals', async () => {
+            const created = await createTool.handler(context, makeWorkflowParams())
+            const workflow = parseToolResponse(created)
+            createdWorkflowIds.push(workflow.id)
+
+            try {
+                const result = await runTool.handler(context, {
+                    id: workflow.id,
+                    globals: {
+                        event: '$pageview',
+                    },
+                    mock_async_functions: true,
+                })
+                // If the plugin server is running, we get a response
+                expect(result).toBeTruthy()
+            } catch (error: unknown) {
+                // Plugin server may not be running in CI — connection errors are expected
+                const message = error instanceof Error ? error.message : String(error)
+                expect(message).toMatch(/502|503|connection|ECONNREFUSED|fetch failed/i)
+            }
+        })
+    })
+
+    describe('full lifecycle', () => {
+        it('should support create → get → update → delete', async () => {
+            // Create
+            const created = await createTool.handler(context, makeWorkflowParams())
+            const workflow = parseToolResponse(created)
+            expect(workflow.id).toBeTruthy()
+            expect(workflow.status).toBe('draft')
+
+            // Get
+            const retrieved = await getTool.handler(context, { id: workflow.id })
+            expect(parseToolResponse(retrieved).id).toBe(workflow.id)
+
+            // Update
+            const newName = `lifecycle-${generateUniqueKey('lc')}`
+            const updated = await updateTool.handler(context, { id: workflow.id, name: newName })
+            expect(parseToolResponse(updated).name).toBe(newName)
+
+            // Verify appears in list
+            const listResult = await listTool.handler(context, {})
+            const { results } = parseToolResponse(listResult)
+            expect(results.some((w: { id: string }) => w.id === workflow.id)).toBe(true)
+
+            // Delete
+            await deleteTool.handler(context, { id: workflow.id })
+            await expect(getTool.handler(context, { id: workflow.id })).rejects.toThrow()
         })
     })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-create.json
@@ -1,0 +1,216 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "actions": {
+            "description": "Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'.",
+            "items": {
+                "properties": {
+                    "config": {
+                        "description": "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    },
+                    "created_at": {
+                        "description": "Unix epoch milliseconds when the action was added. Auto-managed by the frontend.",
+                        "type": "number"
+                    },
+                    "description": {
+                        "default": "",
+                        "description": "Optional description of what this action does.",
+                        "type": "string"
+                    },
+                    "filters": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "actions": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "bytecode": {
+                                        "anyOf": [
+                                            {},
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "bytecode_error": {
+                                        "type": "string"
+                                    },
+                                    "data_warehouse": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "events": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "filter_test_accounts": {
+                                        "type": "boolean"
+                                    },
+                                    "properties": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "source": {
+                                        "default": "events",
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "type": "string"
+                                    },
+                                    "transpiled": {}
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Property filters that gate execution of this action."
+                    },
+                    "id": {
+                        "description": "Unique identifier for this action node within the workflow graph.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Human-readable name for the action node.",
+                        "maxLength": 400,
+                        "type": "string"
+                    },
+                    "on_error": {
+                        "anyOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "description": "* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch",
+                                        "enum": ["continue", "abort", "complete", "branch"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": null,
+                                        "type": "null"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch"
+                    },
+                    "output_variable": {
+                        "anyOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Variable definition to store this action's output for use by downstream actions."
+                    },
+                    "type": {
+                        "description": "Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.",
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "description": "Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.",
+                        "type": "number"
+                    }
+                },
+                "required": ["id", "name", "type", "config"],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "description": {
+            "default": "",
+            "description": "Optional description of the workflow's purpose.",
+            "type": "string"
+        },
+        "edges": {
+            "description": "Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions."
+        },
+        "exit_condition": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "description": "* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End",
+                            "enum": [
+                                "exit_on_conversion",
+                                "exit_on_trigger_not_matched",
+                                "exit_on_trigger_not_matched_or_conversion",
+                                "exit_only_at_end"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "const": null,
+                            "type": "null"
+                        }
+                    ]
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End"
+        },
+        "name": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable name for the workflow."
+        },
+        "status": {
+            "description": "Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived",
+            "enum": ["draft", "active", "archived"],
+            "type": "string"
+        },
+        "variables": {
+            "description": "Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.",
+            "items": {
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "description": "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).",
+                "propertyNames": {
+                    "type": "string"
+                },
+                "type": "object"
+            },
+            "type": "array"
+        }
+    },
+    "required": ["actions"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-delete.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-delete.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this hog flow.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-run.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "current_action_id": {
+            "description": "Start execution from a specific action node ID instead of the trigger. Useful for testing mid-workflow actions.",
+            "type": "string"
+        },
+        "globals": {
+            "additionalProperties": {},
+            "description": "Test event data to trigger the workflow with. Object with keys like 'event', 'person', 'groups' matching the event shape.",
+            "propertyNames": {
+                "type": "string"
+            },
+            "type": "object"
+        },
+        "id": {
+            "description": "A UUID string identifying this hog flow.",
+            "type": "string"
+        },
+        "mock_async_functions": {
+            "default": true,
+            "description": "When true (default), async actions (HTTP requests, emails) are simulated rather than executed for safety.",
+            "type": "boolean"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/workflows-update.json
@@ -1,0 +1,219 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "actions": {
+            "description": "Ordered list of action nodes in the workflow. Must include exactly one action with type='trigger'.",
+            "items": {
+                "properties": {
+                    "config": {
+                        "description": "Type-specific configuration. For triggers: {type, filters}. For functions: {template_id, inputs}. For delays: {delay_duration, e.g. '30m', '2h', '1d'}. For conditional branches: {conditions}."
+                    },
+                    "created_at": {
+                        "description": "Unix epoch milliseconds when the action was added. Auto-managed by the frontend.",
+                        "type": "number"
+                    },
+                    "description": {
+                        "default": "",
+                        "description": "Optional description of what this action does.",
+                        "type": "string"
+                    },
+                    "filters": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "actions": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "bytecode": {
+                                        "anyOf": [
+                                            {},
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "bytecode_error": {
+                                        "type": "string"
+                                    },
+                                    "data_warehouse": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "events": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "filter_test_accounts": {
+                                        "type": "boolean"
+                                    },
+                                    "properties": {
+                                        "items": {
+                                            "additionalProperties": {},
+                                            "propertyNames": {
+                                                "type": "string"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "source": {
+                                        "default": "events",
+                                        "description": "* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table",
+                                        "enum": ["events", "person-updates", "data-warehouse-table"],
+                                        "type": "string"
+                                    },
+                                    "transpiled": {}
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Property filters that gate execution of this action."
+                    },
+                    "id": {
+                        "description": "Unique identifier for this action node within the workflow graph.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Human-readable name for the action node.",
+                        "maxLength": 400,
+                        "type": "string"
+                    },
+                    "on_error": {
+                        "anyOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "description": "* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch",
+                                        "enum": ["continue", "abort", "complete", "branch"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": null,
+                                        "type": "null"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Behavior when this action fails: continue (skip and proceed), abort (stop workflow), complete (mark as done), or branch (follow error edge).\n\n* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch"
+                    },
+                    "output_variable": {
+                        "anyOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Variable definition to store this action's output for use by downstream actions."
+                    },
+                    "type": {
+                        "description": "Action type: trigger, function, function_email, function_sms, function_push, delay, conditional_branch, wait_until_condition, random_cohort_branch, exit.",
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "description": "Unix epoch milliseconds when the action was last modified. Auto-managed by the frontend.",
+                        "type": "number"
+                    }
+                },
+                "required": ["id", "name", "type", "config"],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "description": {
+            "description": "Optional description of the workflow's purpose.",
+            "type": "string"
+        },
+        "edges": {
+            "description": "Graph edges connecting action nodes. Array of {source, target} objects defining the execution flow between actions."
+        },
+        "exit_condition": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "description": "* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End",
+                            "enum": [
+                                "exit_on_conversion",
+                                "exit_on_trigger_not_matched",
+                                "exit_on_trigger_not_matched_or_conversion",
+                                "exit_only_at_end"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "const": null,
+                            "type": "null"
+                        }
+                    ]
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "When a person exits the workflow: exit_on_conversion, exit_on_trigger_not_matched, exit_on_trigger_not_matched_or_conversion, or exit_only_at_end.\n\n* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End"
+        },
+        "id": {
+            "description": "A UUID string identifying this hog flow.",
+            "type": "string"
+        },
+        "name": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable name for the workflow."
+        },
+        "status": {
+            "description": "Workflow state: draft (editing), active (live and processing events), or archived (soft-deleted).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived",
+            "enum": ["draft", "active", "archived"],
+            "type": "string"
+        },
+        "variables": {
+            "description": "Workflow-level variables that persist across actions. Each variable has a key, type, and default value. Total size must be under 5KB.",
+            "items": {
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "description": "Variable definition with keys: 'key' (unique identifier), 'type' (string/number/boolean), 'default' (initial value).",
+                "propertyNames": {
+                    "type": "string"
+                },
+                "type": "object"
+            },
+            "type": "array"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Agents using the MCP server can list and inspect workflows but cannot create, modify, delete, or test-run them. This limits the usefulness of the workflow MCP integration for automated workflow management.

## Changes

- **Serializer docs** (`posthog/api/hog_flow.py`): Added `help_text` to all fields on `HogFlowActionSerializer`, `HogFlowMaskingSerializer`, `HogFlowVariableSerializer`, `HogFlowSerializer`, and `HogFlowInvocationSerializer`. Marked `trigger` and `updated_at` as read-only (they are derived/auto-managed). Added `@extend_schema` to the `invocations` action so OpenAPI picks up the correct request body schema.
- **MCP tools** (`products/workflows/mcp/tools.yaml`): Enabled four new tools:
  - `workflows-create` — create a workflow with actions/edges
  - `workflows-update` — partial update (name, status, actions, etc.)
  - `workflows-delete` — permanently delete a workflow
  - `workflows-run` — test-run a workflow with mocked async functions
- **Generated types**: Regenerated OpenAPI, Zod, and TypeScript types (8 enabled workflow operations total)
- **Integration tests** (`services/mcp/tests/tools/workflows.integration.test.ts`): Added test suites for create, update, delete, run, and a full lifecycle test

No business logic changes — only field declarations, `help_text`, schema annotations, YAML config, and tests.

## How did you test this code?

This PR was authored by an agent (Claude Code).

- TypeScript compiles cleanly: `pnpm --filter=@posthog/mcp run typecheck`
- mypy passes: `mypy -p posthog.api.hog_flow` — no issues
- All pre-commit hooks pass on every commit
- Integration tests added covering CRUD and lifecycle flows (require a running PostHog instance to execute)

## Publish to changelog?

No

## Docs update

No docs changes needed — MCP tools are auto-discovered.

## 🤖 Agent context

- **Agent**: Claude Code (Opus)
- **Human prompt**: "implement MCP product tools for the workflow, like initial tools for create update and delete, just be able to create workflow and run it as well"
- **Reference**: PR #49852 was used as inspiration for the approach, though most of its scaffolding was already on master
- **Key decisions**:
  - `trigger`, `trigger_masking`, and `conversion` excluded from create/update params — trigger is derived from the actions array, masking/conversion are advanced features that add schema complexity
  - `configuration` excluded from the run tool — it's a full nested `HogFlowSerializer` that would make the schema enormous; agents should save workflows first then test them
  - Run tool named `workflows-run` (not `workflows-test`) because agents think in terms of "running" workflows, but the description clarifies it's a test/dry-run with mocked async functions

---
Supersedes #49852 (used as reference for the approach).