### PR TITLE
fix(activities): include alert IDs in exception tracking for cohort queries

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -628,6 +628,7 @@ def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
     except Exception as e:
         team_id = cohort.team_id
         cohort_size = len(cohort.alerts)
+        alert_ids = [str(a.id) for a in cohort.alerts]
 
         if cohort_size == 1:
             return _CohortQueryResult(per_alert={str(cohort.alerts[0].id): _PrefetchedQuery(error=e)})
@@ -638,6 +639,7 @@ def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
                 "Batched cohort query failed (transient); skipping per-alert fallback",
                 team_id=team_id,
                 cohort_size=cohort_size,
+                alert_ids=alert_ids,
                 error=str(e),
                 classification=classified.code,
             )
@@ -648,10 +650,11 @@ def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
             "Batched cohort query failed; falling back to per-alert queries",
             team_id=team_id,
             cohort_size=cohort_size,
+            alert_ids=alert_ids,
             error=str(e),
             classification=classified.code,
         )
-        capture_exception(e, {"team_id": team_id, "cohort_size": cohort_size})
+        capture_exception(e, {"team_id": team_id, "cohort_size": cohort_size, "alert_ids": alert_ids})
         _safe_record("cohort_query_fallback counter", increment_cohort_query_fallback, "batched_failure")
         return _run_per_alert_queries(cohort)
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -628,10 +628,11 @@ def _run_cohort_query(cohort: _AlertCohort) -> _CohortQueryResult:
     except Exception as e:
         team_id = cohort.team_id
         cohort_size = len(cohort.alerts)
-        alert_ids = [str(a.id) for a in cohort.alerts]
 
         if cohort_size == 1:
             return _CohortQueryResult(per_alert={str(cohort.alerts[0].id): _PrefetchedQuery(error=e)})
+
+        alert_ids = [str(a.id) for a in cohort.alerts]
 
         classified = classify_alert_error(e)
         if classified.is_transient:


### PR DESCRIPTION
## Problem

When a batched cohort query fails, the logs and error tracking don't include the specific alert IDs involved. This makes it difficult to identify which alerts were affected when investigating failures.

## Changes

Added `alert_ids` to the structured log output and `capture_exception` call in `_run_cohort_query` when a batched cohort query fails — both for the transient (skip fallback) and non-transient (fallback to per-alert) paths.

## How did you test this code?

Changes are additive logging/observability improvements with no behavioral impact. Verified by code review that `alert_ids` is correctly constructed from `cohort.alerts` and passed to all relevant log and exception capture call sites.

## Publish to changelog?

No