### PR TITLE
fix(insights): forward query tags onto actors drill-down queries

### DIFF
--- a/frontend/src/scenes/retention/queries.ts
+++ b/frontend/src/scenes/retention/queries.ts
@@ -1,4 +1,5 @@
 import { RetentionTableAppearanceType, RetentionTablePeoplePayload } from 'scenes/retention/types'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 import { performQuery } from '~/queries/query'
 import { ActorsQuery, NodeKind, RetentionQuery } from '~/queries/schema/schema-general'
@@ -19,6 +20,11 @@ export function retentionToActorsQuery(
     const customBrackets = query.retentionFilter.retentionCustomBrackets
     const columnCount = customBrackets && customBrackets.length > 0 ? customBrackets.length + 1 : totalIntervals
     const selects = Array.from({ length: columnCount }, (_, intervalNumber) => `${periodName}_${intervalNumber}`)
+    const activeScene = sceneLogic.findMounted()?.values.activeSceneId
+    const tags = {
+        ...query.tags,
+        ...(activeScene && !query.tags?.scene ? { scene: activeScene } : {}),
+    }
     return setLatestVersionsOnQuery(
         {
             kind: NodeKind.ActorsQuery,
@@ -41,6 +47,7 @@ export function retentionToActorsQuery(
             ),
             offset,
             limit: offset ? offset * 2 : undefined,
+            ...(Object.keys(tags).length > 0 ? { tags } : {}),
         },
         { recursion: false }
     )

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -459,11 +459,11 @@ export const personsModalLogic = kea<personsModalLogicType>([
                 if (!query) {
                     return null
                 }
-                const sourceTags = query.tags ?? query.source?.tags
+                const sourceTags = { ...query.source?.tags, ...query.tags }
                 const activeScene = sceneLogic.findMounted()?.values.activeSceneId
                 const tags = {
                     ...sourceTags,
-                    ...(activeScene && !sourceTags?.scene ? { scene: activeScene } : {}),
+                    ...(activeScene && !sourceTags.scene ? { scene: activeScene } : {}),
                 }
                 return setLatestVersionsOnQuery(
                     {

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -8,6 +8,7 @@ import api from 'lib/api'
 import { assignField, isGroupType, isSessionType } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -458,6 +459,12 @@ export const personsModalLogic = kea<personsModalLogicType>([
                 if (!query) {
                     return null
                 }
+                const sourceTags = query.tags ?? query.source?.tags
+                const activeScene = sceneLogic.findMounted()?.values.activeSceneId
+                const tags = {
+                    ...sourceTags,
+                    ...(activeScene && !sourceTags?.scene ? { scene: activeScene } : {}),
+                }
                 return setLatestVersionsOnQuery(
                     {
                         kind: NodeKind.ActorsQuery,
@@ -465,6 +472,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         select: selectFields,
                         orderBy: orderBy || [],
                         search: searchTerm,
+                        ...(Object.keys(tags).length > 0 ? { tags } : {}),
                     },
                     { recursion: false }
                 )


### PR DESCRIPTION
## Problem

Drilling into a Lifecycle / Trends / Stickiness / Retention chart via the persons modal builds an outer `ActorsQuery` that wraps the original insight query. The query runner extracts query-log tags off the **top-level** query, but the wrapper construction sites never forwarded `tags` from the inner insight. With the recently added `UntaggedQueryError` guard requiring a `product` tag, every actors drill-down failed with:

> `sync_execute called with missing query tags: product`

In addition, the standalone insight payload picks up `scene: "Insight"` via `addTags()` in `dataNodeLogic`, but the persons modal calls `performQuery` directly and bypasses that, so even after forwarding `productKey` the modal request still lacked `scene`.

## Changes

Isolated, minimal fix at the two actors-wrapper construction sites:

- `frontend/src/scenes/trends/persons-modal/personsModalLogic.ts` — when building the modal's `ActorsQuery`, copy `tags` from the wrapper or its inner insight (`query.tags ?? query.source?.tags`) and stamp the active scene from `sceneLogic.findMounted()` if the source didn't already carry one.
- `frontend/src/scenes/retention/queries.ts` — same forwarding in `retentionToActorsQuery`.

No changes to the shared `addTags` / `performQuery` plumbing — keeping the blast radius local to actors queries.

## How did you test this code?

Agent-assisted. Verified via:
- `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- Manual reproduction by the human author against the failing payloads (Lifecycle drill-down, Stickiness drill-down, Retention drill-down)

No automated tests added — the change is a small, targeted forwarding fix in two existing files.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7, 1M context)
- Key prompts shaped the scope: started by exploring a backend source-walking fallback in `query_runner.py`, but the human steered toward a frontend fix at the wrapper construction sites for clarity. A broader refactor (moving `addTags` into `performQuery`) was tried and reverted after it broke `InsightActorsQueryOptions` (whose pydantic schema forbids `tags`). Final fix is intentionally local to the actors-query construction sites.