### PR TITLE
chore(experiments): Tweak product description wording

### DIFF
--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -71,7 +71,7 @@ export const scene: SceneExport = {
 }
 
 export const EXPERIMENTS_PRODUCT_DESCRIPTION =
-    'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or if they are likely just a chance occurrence.'
+    'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or due to chance.'
 
 // Component for the survey button using QuickSurveyModal
 const ExperimentSurveyButton = ({

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -198,7 +198,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Experiments',
         activityScope: ActivityScope.EXPERIMENT,
         description:
-            'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or if they are likely just a chance occurrence.',
+            'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or due to chance.',
         iconType: 'experiment',
     },
     [Scene.Activity]: {


### PR DESCRIPTION
## Problem

\"Chance occurrence\" reads awkwardly in the Experiments product description.

## Changes

Replaced \"if they are likely just a chance occurrence\" with \"due to chance\" in the two places the description appears.

## How did you test this code?

I'm an agent — no manual testing performed. Visual diff only; no functional changes.

## 🤖 Agent context

Agent-authored copy tweak. The user reviewed alternative phrasings (\"down to chance\", \"just noise\") and chose \"due to chance\".