### PR TITLE
feat(tasks): emit p90 age gauge for queued TaskRun rows

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -541,6 +541,8 @@ def capture_task_run_state_metrics() -> None:
     """Emit gauges describing the current state of the Tasks product's TaskRun table"""
     from django.db.models import Count, Min
 
+    from posthog.models.utils import Percentile
+
     from products.tasks.backend.models import TaskRun
 
     try:
@@ -557,6 +559,12 @@ def capture_task_run_state_metrics() -> None:
             oldest_age_gauge = Gauge(
                 "posthog_tasks_oldest_open_run_age_seconds",
                 "Age (seconds) of the oldest TaskRun still in a given non-terminal status, by origin_product and run_environment.",
+                registry=registry,
+                labelnames=["status", "origin_product", "run_environment"],
+            )
+            p90_age_gauge = Gauge(
+                "posthog_tasks_open_run_age_seconds_p90",
+                "p90 age (seconds) of TaskRun rows still in a given non-terminal status, by origin_product and run_environment.",
                 registry=registry,
                 labelnames=["status", "origin_product", "run_environment"],
             )
@@ -585,19 +593,27 @@ def capture_task_run_state_metrics() -> None:
                     run_environment=row["environment"],
                 ).set(row["count"])
 
-            oldest = (
+            # `percentile_disc(0.1) WITHIN GROUP (ORDER BY created_at)` returns the timestamp at the 10th percentile
+            # of created_at (oldest 10% boundary). The corresponding age (now - that timestamp) is the p90 age — the
+            # value such that 90% of open rows are younger and 10% are older.
+            age_rows = (
                 TaskRun.objects.filter(status__in=_TASKS_RUN_AGE_STATUSES)
                 .values("status", "environment", "task__origin_product")
-                .annotate(oldest_created_at=Min("created_at"))
+                .annotate(
+                    oldest_created_at=Min("created_at"),
+                    p90_oldest_created_at=Percentile(0.1, "created_at"),
+                )
             )
             now = timezone.now()
-            for row in oldest:
-                age_seconds = (now - row["oldest_created_at"]).total_seconds()
-                oldest_age_gauge.labels(
-                    status=row["status"],
-                    origin_product=row["task__origin_product"] or "unknown",
-                    run_environment=row["environment"],
-                ).set(age_seconds)
+            for row in age_rows:
+                labels = {
+                    "status": row["status"],
+                    "origin_product": row["task__origin_product"] or "unknown",
+                    "run_environment": row["environment"],
+                }
+                oldest_age_gauge.labels(**labels).set((now - row["oldest_created_at"]).total_seconds())
+                if row["p90_oldest_created_at"] is not None:
+                    p90_age_gauge.labels(**labels).set((now - row["p90_oldest_created_at"]).total_seconds())
 
             created_1h = (
                 TaskRun.objects.filter(created_at__gte=now - datetime.timedelta(hours=1))

--- a/posthog/tasks/test/test_task_run_state_metrics.py
+++ b/posthog/tasks/test/test_task_run_state_metrics.py
@@ -131,6 +131,46 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         # Oldest run was ~30 minutes ago; allow generous slack for test timing.
         assert 1500 < age < 2400
 
+    def test_emits_p90_open_run_age(self) -> None:
+        # 9 fresh runs and 1 ~30-minute-old run — only the oldest 10% is stale, so p90 age should be ~30 min.
+        long_ago = timezone.now() - timedelta(minutes=30)
+        self._make_task_run(
+            origin=Task.OriginProduct.SLACK,
+            status=TaskRun.Status.QUEUED,
+            created_at=long_ago,
+        )
+        for _ in range(9):
+            self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
+
+        registry = self._run_with_registry()
+
+        p90 = registry.get_sample_value(
+            "posthog_tasks_open_run_age_seconds_p90",
+            {"status": "queued", "origin_product": "slack", "run_environment": "cloud"},
+        )
+        assert p90 is not None
+        assert 1500 < p90 < 2400
+
+    def test_p90_age_ignores_lone_straggler(self) -> None:
+        # 1 ~30-minute-old run and 99 fresh runs — only 1% is stale, so p90 should be ~0, not the straggler's age.
+        long_ago = timezone.now() - timedelta(minutes=30)
+        self._make_task_run(
+            origin=Task.OriginProduct.SLACK,
+            status=TaskRun.Status.QUEUED,
+            created_at=long_ago,
+        )
+        for _ in range(99):
+            self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
+
+        registry = self._run_with_registry()
+
+        p90 = registry.get_sample_value(
+            "posthog_tasks_open_run_age_seconds_p90",
+            {"status": "queued", "origin_product": "slack", "run_environment": "cloud"},
+        )
+        assert p90 is not None
+        assert p90 < 60
+
     def test_emits_runs_created_1h_by_origin_and_environment(self) -> None:
         # Two Slack runs created just now, one old run (outside the 1h window), one PostHog-code run.
         self._make_task_run(origin=Task.OriginProduct.SLACK, status=TaskRun.Status.QUEUED)
@@ -196,6 +236,13 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert (
             registry.get_sample_value(
                 "posthog_tasks_oldest_open_run_age_seconds",
+                {"status": "not_started", "origin_product": "slack", "run_environment": "cloud"},
+            )
+            is None
+        )
+        assert (
+            registry.get_sample_value(
+                "posthog_tasks_open_run_age_seconds_p90",
                 {"status": "not_started", "origin_product": "slack", "run_environment": "cloud"},
             )
             is None


### PR DESCRIPTION
## Problem

The TasksAgentStaleQueuedRuns alert is driven by `posthog_tasks_oldest_open_run_age_seconds`, which is `MIN(created_at)` per group — a single abandoned queued TaskRun is enough to page the rotation, even when the rest of the queue is healthy. Josh asked to switch the alert to a p90-based metric so single stragglers don't fire the alert. This PR adds the metric; the alert change lives in posthog/charts.

## Changes

- New gauge `posthog_tasks_open_run_age_seconds_p90` with the same `(status, origin_product, run_environment)` labels as the existing oldest gauge. Computed via `percentile_disc(0.1) WITHIN GROUP (ORDER BY created_at)` on the same filter (`status IN ('queued', 'in_progress')`), reusing `posthog.models.utils.Percentile`. Result is converted from a timestamp to seconds-since-now in Python so the math is unambiguous (10th percentile of `created_at` <-> 90th percentile of age).
- Existing `posthog_tasks_oldest_open_run_age_seconds` gauge kept — it still backs dashboards.
- Two new tests in `posthog/tasks/test/test_task_run_state_metrics.py`: one verifies p90 surfaces the stale row when 10% of rows are stale, the other verifies it ignores a single straggler in a population of 100.
- Both gauges are now emitted from a single annotated query so we do one DB scan instead of two.

## How did you test this code?

Agent-authored. Automated only:

- Added `test_emits_p90_open_run_age` and `test_p90_age_ignores_lone_straggler` to `posthog/tasks/test/test_task_run_state_metrics.py`. Verified the test file collects (`pytest --collect-only`).
- Smoke-tested the underlying `percentile_disc(0.1) WITHIN GROUP (ORDER BY created_at)` SQL against a local Postgres 16 with the same row distributions used in the new tests:
  - 1 stale + 9 fresh -> p90 age ~ 1800s (matches stale row's age)
  - 1 stale + 99 fresh -> p90 age ~ 0s (single straggler excluded)
- Did not run the full test suite — environment lacks ClickHouse/Kafka/Redis. Relying on CI for full validation.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Code, claude-opus-4-7).
- Triggered by Josh asking, on the back of a `TasksAgentStaleQueuedRuns` cancellation, "can we change these alerts to be based on p90 age of cloud tasks, rather than oldest". Then "clone posthog/charts and use that instead" to direct the alert change into the charts repo.
- Decisions:
  - Kept the oldest gauge instead of replacing it — dashboards likely reference it; emitting both is cheap (single annotated query).
  - Used the existing `Percentile` aggregate from `posthog.models.utils` (`percentile_disc`) rather than introducing a new `percentile_cont` aggregate — the existing class works for ordered timestamps and stays consistent with the codebase.
  - Computed p90 by ordering on `created_at` and taking the 0.1 percentile, then converting to age in Python, instead of doing `EXTRACT(EPOCH FROM NOW() - created_at)` inside the SQL. Equivalent result, simpler Django expression.
  - Flagged the obvious tradeoff to the user before implementing: p90 hides 1-2 stuck rows by design. They confirmed by direction.
- Companion PR: posthog/charts changes the alert query to point at the new metric.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*