### PR TITLE
feat(tasks): emit open-run age as a histogram for p90 alerts

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 import requests
 from celery import shared_task
-from prometheus_client import Counter, Gauge
+from prometheus_client import Counter, Gauge, Histogram
 from redis import Redis
 from structlog import get_logger
 
@@ -536,10 +536,26 @@ _TASKS_RUN_AGE_STATUSES = ("queued", "in_progress")
 _TASKS_RUN_TERMINAL_STATUSES = ("completed", "failed", "cancelled")
 
 
+_TASKS_RUN_AGE_BUCKETS = (
+    30.0,
+    60.0,
+    2 * 60.0,
+    5 * 60.0,
+    10 * 60.0,
+    15 * 60.0,
+    30 * 60.0,
+    60 * 60.0,
+    2 * 60 * 60.0,
+    4 * 60 * 60.0,
+    8 * 60 * 60.0,
+    24 * 60 * 60.0,
+)
+
+
 @shared_task(ignore_result=True, queue=CeleryQueue.STATS.value)
 def capture_task_run_state_metrics() -> None:
     """Emit gauges describing the current state of the Tasks product's TaskRun table"""
-    from django.db.models import Count, Min
+    from django.db.models import Count
 
     from products.tasks.backend.models import TaskRun
 
@@ -554,11 +570,17 @@ def capture_task_run_state_metrics() -> None:
                 registry=registry,
                 labelnames=["status", "origin_product", "run_environment"],
             )
-            oldest_age_gauge = Gauge(
-                "posthog_tasks_oldest_open_run_age_seconds",
-                "Age (seconds) of the oldest TaskRun still in a given non-terminal status, by origin_product and run_environment.",
+            # Snapshot histogram of open-run ages — one observation per currently-open TaskRun on each
+            # capture cycle. Pushgateway replaces the metric on every push, so the bucket counts reflect
+            # the latest snapshot. Compute quantiles directly without rate(), e.g.:
+            #   histogram_quantile(0.90, sum by (le, origin_product, run_environment)
+            #                          (posthog_tasks_open_run_age_seconds_bucket))
+            open_run_age_histogram = Histogram(
+                "posthog_tasks_open_run_age_seconds",
+                "Distribution of ages (seconds) of open TaskRun rows in queued/in_progress, by status, origin_product, and run_environment. Use histogram_quantile() for p50/p90/p99 alerts.",
                 registry=registry,
                 labelnames=["status", "origin_product", "run_environment"],
+                buckets=_TASKS_RUN_AGE_BUCKETS,
             )
             runs_created_1h_gauge = Gauge(
                 "posthog_tasks_runs_created_1h",
@@ -585,19 +607,17 @@ def capture_task_run_state_metrics() -> None:
                     run_environment=row["environment"],
                 ).set(row["count"])
 
-            oldest = (
-                TaskRun.objects.filter(status__in=_TASKS_RUN_AGE_STATUSES)
-                .values("status", "environment", "task__origin_product")
-                .annotate(oldest_created_at=Min("created_at"))
-            )
             now = timezone.now()
-            for row in oldest:
-                age_seconds = (now - row["oldest_created_at"]).total_seconds()
-                oldest_age_gauge.labels(
+            open_runs = TaskRun.objects.filter(status__in=_TASKS_RUN_AGE_STATUSES).values(
+                "status", "environment", "task__origin_product", "created_at"
+            )
+            for row in open_runs:
+                age_seconds = (now - row["created_at"]).total_seconds()
+                open_run_age_histogram.labels(
                     status=row["status"],
                     origin_product=row["task__origin_product"] or "unknown",
                     run_environment=row["environment"],
-                ).set(age_seconds)
+                ).observe(age_seconds)
 
             created_1h = (
                 TaskRun.objects.filter(created_at__gte=now - datetime.timedelta(hours=1))

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -611,12 +611,12 @@ def capture_task_run_state_metrics() -> None:
             open_runs = TaskRun.objects.filter(status__in=_TASKS_RUN_AGE_STATUSES).values(
                 "status", "environment", "task__origin_product", "created_at"
             )
-            for row in open_runs:
-                age_seconds = (now - row["created_at"]).total_seconds()
+            for open_run in open_runs:
+                age_seconds = (now - open_run["created_at"]).total_seconds()
                 open_run_age_histogram.labels(
-                    status=row["status"],
-                    origin_product=row["task__origin_product"] or "unknown",
-                    run_environment=row["environment"],
+                    status=open_run["status"],
+                    origin_product=open_run["task__origin_product"] or "unknown",
+                    run_environment=open_run["environment"],
                 ).observe(age_seconds)
 
             created_1h = (

--- a/posthog/tasks/test/test_task_run_state_metrics.py
+++ b/posthog/tasks/test/test_task_run_state_metrics.py
@@ -135,13 +135,9 @@ class TestCaptureTaskRunStateMetrics(TestCase):
         assert 1500 < total < 2400
 
         # The fresh run lands in the smallest bucket (≤30s); both runs land in +Inf.
-        bucket_30s = registry.get_sample_value(
-            "posthog_tasks_open_run_age_seconds_bucket", {**labels, "le": "30.0"}
-        )
+        bucket_30s = registry.get_sample_value("posthog_tasks_open_run_age_seconds_bucket", {**labels, "le": "30.0"})
         assert bucket_30s == 1
-        bucket_inf = registry.get_sample_value(
-            "posthog_tasks_open_run_age_seconds_bucket", {**labels, "le": "+Inf"}
-        )
+        bucket_inf = registry.get_sample_value("posthog_tasks_open_run_age_seconds_bucket", {**labels, "le": "+Inf"})
         assert bucket_inf == 2
 
     def test_emits_runs_created_1h_by_origin_and_environment(self) -> None:

--- a/posthog/tasks/test/test_task_run_state_metrics.py
+++ b/posthog/tasks/test/test_task_run_state_metrics.py
@@ -112,7 +112,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
             is None
         )
 
-    def test_emits_oldest_open_run_age(self) -> None:
+    def test_emits_open_run_age_histogram(self) -> None:
         long_ago = timezone.now() - timedelta(minutes=30)
         self._make_task_run(
             origin=Task.OriginProduct.SLACK,
@@ -123,13 +123,26 @@ class TestCaptureTaskRunStateMetrics(TestCase):
 
         registry = self._run_with_registry()
 
-        age = registry.get_sample_value(
-            "posthog_tasks_oldest_open_run_age_seconds",
-            {"status": "queued", "origin_product": "slack", "run_environment": "cloud"},
+        labels = {"status": "queued", "origin_product": "slack", "run_environment": "cloud"}
+
+        # Two open runs observed under the same label combo.
+        count = registry.get_sample_value("posthog_tasks_open_run_age_seconds_count", labels)
+        assert count == 2
+
+        total = registry.get_sample_value("posthog_tasks_open_run_age_seconds_sum", labels)
+        assert total is not None
+        # ~30 minutes (1800s) for the old run + ~0s for the fresh run; allow slack for test timing.
+        assert 1500 < total < 2400
+
+        # The fresh run lands in the smallest bucket (≤30s); both runs land in +Inf.
+        bucket_30s = registry.get_sample_value(
+            "posthog_tasks_open_run_age_seconds_bucket", {**labels, "le": "30.0"}
         )
-        assert age is not None
-        # Oldest run was ~30 minutes ago; allow generous slack for test timing.
-        assert 1500 < age < 2400
+        assert bucket_30s == 1
+        bucket_inf = registry.get_sample_value(
+            "posthog_tasks_open_run_age_seconds_bucket", {**labels, "le": "+Inf"}
+        )
+        assert bucket_inf == 2
 
     def test_emits_runs_created_1h_by_origin_and_environment(self) -> None:
         # Two Slack runs created just now, one old run (outside the 1h window), one PostHog-code run.
@@ -184,7 +197,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
             == 1
         )
 
-    def test_age_gauge_only_covers_queued_and_in_progress(self) -> None:
+    def test_age_histogram_only_covers_queued_and_in_progress(self) -> None:
         self._make_task_run(
             origin=Task.OriginProduct.SLACK,
             status=TaskRun.Status.NOT_STARTED,
@@ -195,7 +208,7 @@ class TestCaptureTaskRunStateMetrics(TestCase):
 
         assert (
             registry.get_sample_value(
-                "posthog_tasks_oldest_open_run_age_seconds",
+                "posthog_tasks_open_run_age_seconds_count",
                 {"status": "not_started", "origin_product": "slack", "run_environment": "cloud"},
             )
             is None


### PR DESCRIPTION
## Problem

The `posthog_tasks_oldest_open_run_age_seconds` gauge stored a single `min(created_at)` value per label combo — i.e. only the single oldest open `TaskRun`. That makes it impossible to express a percentile alert like p90 over open-run ages: there's only one value per label, so `histogram_quantile` and the usual percentile machinery have nothing to chew on.

## Changes

Replace the oldest-only gauge with `posthog_tasks_open_run_age_seconds`, a Prometheus `Histogram` that observes the age of every currently-open `TaskRun` (statuses `queued` and `in_progress`) on each capture cycle. Labels are unchanged: `status`, `origin_product`, `run_environment`. Buckets cover seconds-to-day range (30s, 1m, 2m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 8h, 24h).

Because metrics flow through the pushgateway and are replaced on each push, the histogram is a snapshot — quantiles should be computed directly on the bucket counts without `rate()`:

```promql
histogram_quantile(0.90, sum by (le, origin_product, run_environment)
                       (posthog_tasks_open_run_age_seconds_bucket))
```

## How did you test this code?

I'm an agent. Tests I updated/added:

- `test_emits_open_run_age_histogram` — asserts `_count`, `_sum`, and `_bucket{le="30.0"|"+Inf"}` reflect the two open runs (one ~30 minutes old, one fresh).
- `test_age_histogram_only_covers_queued_and_in_progress` — verifies `not_started` runs do not contribute observations to the histogram.

I did not run the test suite locally (no Python environment in this workspace); CI will exercise the changes.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) at Josh Snyder's request to make the oldest-task metric p90-alertable.
- Decision: chose `Histogram` over `Summary` because Summaries don't aggregate across labels in Prometheus, which would block alerting on a global p90 across origin products / environments.
- Bucket choice tuned for task-run latency expectations (sub-minute to multi-hour stuck runs); easy to revisit if real-world distribution makes them too coarse/fine.
- Renamed the metric (`posthog_tasks_oldest_open_run_age_seconds` → `posthog_tasks_open_run_age_seconds`) instead of reusing the name, since the type and shape are different — any existing dashboard/alert wired to the old gauge will need to be updated to the histogram form.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*