### PR TITLE
fix(replay): dedupe replay summary event

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -33,7 +33,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
         summaryDisabledReason,
     } = useValues(playerMetaLogic(logicProps))
     const { summarizeSession } = useActions(playerMetaLogic(logicProps))
-    const { openBySessionId } = useValues(sessionSummaryProgressLogic)
+    const { openBySessionId, summaryIdBySessionId } = useValues(sessionSummaryProgressLogic)
     const { setSummaryOpen, cancelSummarization } = useActions(sessionSummaryProgressLogic)
     const { reportAISessionSummaryViewed } = useActions(sessionRecordingEventUsageLogic)
 
@@ -48,17 +48,28 @@ export function PlayerSummaryDock(): JSX.Element | null {
     const isEnabled = featureFlags[FEATURE_FLAGS.REPLAY_VIDEO_BASED_SUMMARIZATION]
     const hasSummary = !!sessionSummary
     const isOpen = !!openBySessionId[sessionRecordingId]
+    const summaryId = summaryIdBySessionId[sessionRecordingId] ?? null
+    const hasRenderedSummary = hasSummary && !sessionSummaryError
     const setIsOpen = (open: boolean): void => setSummaryOpen(sessionRecordingId, open)
     const expandedHeight = Math.max(
         MIN_EXPANDED_HEIGHT,
         Math.min(MAX_EXPANDED_HEIGHT, desiredSize ?? DEFAULT_EXPANDED_HEIGHT)
     )
 
+    // `isOpen` flips multiple times per summary, so dedupe to one capture per render.
+    const capturedKeyRef = useRef<string | null>(null)
+
     useEffect(() => {
-        if (sessionRecordingId && isOpen) {
-            reportAISessionSummaryViewed(sessionRecordingId, 'dock')
+        if (!sessionRecordingId || !isOpen || !hasRenderedSummary) {
+            return
         }
-    }, [sessionRecordingId, isOpen, reportAISessionSummaryViewed])
+        const key = `${sessionRecordingId}|${summaryId ?? 'unknown'}`
+        if (capturedKeyRef.current === key) {
+            return
+        }
+        capturedKeyRef.current = key
+        reportAISessionSummaryViewed(sessionRecordingId, 'dock', summaryId)
+    }, [sessionRecordingId, isOpen, hasRenderedSummary, summaryId, reportAISessionSummaryViewed])
 
     if (!isEnabled) {
         return null

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
@@ -72,7 +72,11 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
         reportRecordingPinnedToList: (pinned: boolean) => ({ pinned }),
         reportRecordingPlaylistCreated: (source: 'filters' | 'new' | 'pin' | 'duplicate') => ({ source }),
         reportRecordingOpenedFromRecentRecordingList: true,
-        reportAISessionSummaryViewed: (recording_id: string, source: 'dock') => ({ recording_id, source }),
+        reportAISessionSummaryViewed: (recording_id: string, source: 'dock', summary_id: string | null) => ({
+            recording_id,
+            source,
+            summary_id,
+        }),
     }),
     listeners(() => ({
         reportRecordingLoaded: ({ playerData, metadata }) => {
@@ -156,8 +160,8 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
         reportRecordingPlaylistCreated: (properties) => {
             posthog.capture('recording playlist created', properties)
         },
-        reportAISessionSummaryViewed: ({ recording_id, source }) => {
-            posthog.capture('ai session summary viewed', { recording_id, source })
+        reportAISessionSummaryViewed: ({ recording_id, source, summary_id }) => {
+            posthog.capture('ai session summary viewed', { recording_id, source, summary_id })
         },
     })),
 ])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
`ai session summary viewed` fires on dock-open, not on render. The `useEffect` gates only on `isOpen`, and three reducer paths flip `isOpen` `true` (manual expand, startSummarization, setSummary), so one summary fires 1–3 captures and errored summaries also fire. No `summary_id` on the event means it can't be joined to server-side session summary generated to compute view-rate.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Gate the capture on `hasSummary && !sessionSummaryError` so errored/loading states don't fire.
- Dedupe via ref keyed on `summary_id` so the three flip paths collapse to one capture per rendered summary. Retries (new `summary_id`) re-fire correctly.
- Add `summary_id` to the event payload (from `summaryIdBySessionId`, already populated by the SSE stream). Enables a clean funnel --> distinct `summary_id` viewed ÷ distinct `summary_id` generated(success=true).

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
