### PR TITLE
feat(posthog-code): warn about in-progress runs on github disconnect

### DIFF
--- a/frontend/src/scenes/settings/user/PersonalIntegrations.tsx
+++ b/frontend/src/scenes/settings/user/PersonalIntegrations.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconGithub, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDialog, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { GitHubRepoSummary } from 'lib/integrations/GitHubRepoSummary'
@@ -24,6 +24,12 @@ function GitHubInstallationRow({ integration }: { integration: PersonalGitHubInt
             title: `Disconnect ${accountName || 'GitHub installation'}?`,
             description:
                 'PostHog will no longer be able to access repos from this installation or act on your behalf there.',
+            content: (
+                <LemonBanner type="warning" className="mt-2">
+                    Any PostHog Code agent runs currently in progress will be unable to push commits or open pull
+                    requests on GitHub. Wait for in-progress runs to finish before disconnecting.
+                </LemonBanner>
+            ),
             primaryButton: {
                 children: 'Disconnect',
                 status: 'danger',


### PR DESCRIPTION
## Problem

When a user disconnects their personal GitHub integration, any in-progress PostHog Code agent runs lose the ability to push commits or open pull requests on GitHub. The current confirmation modal only mentions losing repo access in general terms, so it's easy to disconnect mid-run and silently lose work that's still in the agent's sandbox.

## Changes

- Added a `LemonBanner` warning inside the disconnect confirmation modal on the Personal integrations settings page, explicitly calling out that any in-progress PostHog Code agent runs will be unable to push commits or open PRs, and recommending waiting for them to finish.

## How did you test this code?

I'm an agent. I did not perform manual UI testing. Automated checks I ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no new type errors introduced by this change (pre-existing errors in unrelated files only)
- `pnpm --filter=@posthog/frontend format` — formatting is clean

A reviewer should manually verify the modal renders the warning correctly.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

- Authored by PostHog Code (cloud agent run, task `d9dc5579-d4d7-433e-907d-057b1388960d`).
- Human prompt: a user lost in-progress agent work after disconnecting their GitHub integration mid-run; they asked for a clear warning in the disconnect modal so this is harder to do by accident.
- Decision: kept the existing `description` (general-purpose copy) and added a `LemonBanner` via the `content` slot — this matches the pattern already supported by `LemonDialog` (`content` accepts `ReactNode`) and gives the warning visual weight without restructuring the modal.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*