### PR TITLE
feat(hog-charts): restore auto x-axis formatter and group axis state on layout context

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -100,12 +100,13 @@ function BarChartInner<Meta = unknown>({
         return m
     }, [barLayout, series])
 
-    const chartConfig = useMemo<BarChartConfig | undefined>(() => {
+    const chartConfig = useMemo<BarChartConfig>(() => {
+        const base = { ...config, isPercent: barLayout === 'percent' }
         if (barLayout !== 'percent' || config?.yTickFormatter) {
-            return config
+            return base
         }
         return {
-            ...config,
+            ...base,
             yTickFormatter: (v: number) => `${Math.round(v * 100)}%`,
         }
     }, [config, barLayout])
@@ -262,7 +263,6 @@ function BarChartInner<Meta = unknown>({
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}
-            isPercent={barLayout === 'percent'}
         >
             {children}
         </Chart>

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -80,11 +80,12 @@ function LineChartInner<Meta = unknown>({
     }, [percentStackView, hasAreaFill, series, labels])
 
     const chartConfig = useMemo(() => {
+        const base = { ...config, isPercent: percentStackView }
         if (!percentStackView || config?.yTickFormatter) {
-            return config
+            return base
         }
         return {
-            ...config,
+            ...base,
             yTickFormatter: (v: number) => `${Math.round(v * 100)}%`,
         }
     }, [config, percentStackView])
@@ -239,7 +240,6 @@ function LineChartInner<Meta = unknown>({
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}
-            isPercent={percentStackView}
         >
             {children}
         </Chart>

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { createXAxisTickCallback, TimeSeriesLineChart } from 'lib/hog-charts'
+import { TimeSeriesLineChart } from 'lib/hog-charts'
 import type { Series, TimeInterval, YAxisConfig } from 'lib/hog-charts'
 import { ciRanges } from 'lib/statistics'
 
@@ -88,7 +88,6 @@ interface DateAxisCellProps {
 
 function DateAxisCell({ title, labels, series, interval, timezone }: DateAxisCellProps): JSX.Element {
     const theme = useReactiveTheme()
-    const tickFormatter = createXAxisTickCallback({ timezone, interval, allDays: labels })
     return (
         // eslint-disable-next-line react/forbid-dom-props
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -99,7 +98,7 @@ function DateAxisCell({ title, labels, series, interval, timezone }: DateAxisCel
                     labels={labels}
                     theme={theme}
                     config={{
-                        xAxis: { tickFormatter },
+                        xAxis: { timezone, interval },
                         yAxis: { showGrid: true },
                     }}
                 />

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup } from '@testing-library/react'
 
+import { useChartLayout } from '../../core/chart-context'
 import type { ChartTheme, Series } from '../../core/types'
 import { renderHogChart, setupJsdom, setupSyncRaf } from '../../testing'
 import { TimeSeriesLineChart } from './TimeSeriesLineChart'
@@ -42,6 +43,57 @@ describe('TimeSeriesLineChart', () => {
                 />
             )
             expect(chart.xTicks()).toEqual(['tick-0', 'tick-1', 'tick-2'])
+        })
+
+        it('builds an auto date formatter from xAxis.timezone + xAxis.interval', () => {
+            const labels = ['2024-06-10', '2024-06-11', '2024-06-12']
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                    labels={labels}
+                    theme={THEME}
+                    config={{ xAxis: { timezone: 'UTC', interval: 'day' } }}
+                />
+            )
+            const ticks = chart.xTicks()
+            expect(ticks.length).toBeGreaterThan(0)
+            // The auto formatter renders day-mode labels as "MMM D" (or month name on the 1st).
+            expect(ticks.some((t) => /Jun \d+/.test(t))).toBe(true)
+        })
+
+        it('explicit xAxis.tickFormatter wins over the auto date formatter', () => {
+            const explicit = (_v: string, i: number): string => `tick-${i}`
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                    labels={['2024-06-10', '2024-06-11', '2024-06-12']}
+                    theme={THEME}
+                    config={{
+                        xAxis: { tickFormatter: explicit, timezone: 'UTC', interval: 'day' },
+                    }}
+                />
+            )
+            expect(chart.xTicks()).toEqual(['tick-0', 'tick-1', 'tick-2'])
+        })
+
+        it('exposes the resolved formatter to children via ChartLayoutContext', () => {
+            let observed: ((value: string, index: number) => string | null) | undefined
+            function Probe(): null {
+                observed = useChartLayout().axis.xTickFormatter
+                return null
+            }
+            renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                    labels={['2024-06-10', '2024-06-11', '2024-06-12']}
+                    theme={THEME}
+                    config={{ xAxis: { timezone: 'UTC', interval: 'day' } }}
+                >
+                    <Probe />
+                </TimeSeriesLineChart>
+            )
+            expect(observed).not.toBeUndefined()
+            expect(observed?.('2024-06-10', 0)).toMatch(/Jun \d+|June/)
         })
     })
 

--- a/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -11,7 +11,12 @@ import type {
 import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import { buildGoalLineReferenceLines, type GoalLineConfig } from '../../utils/goal-lines'
-import { useYTickFormatter, type XAxisConfig, type YAxisConfig } from '../../utils/use-axis-formatters'
+import {
+    useXTickFormatter,
+    useYTickFormatter,
+    type XAxisConfig,
+    type YAxisConfig,
+} from '../../utils/use-axis-formatters'
 import { LineChart } from '../LineChart'
 import {
     useDerivedSeries,
@@ -93,6 +98,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
         showCrosshair,
         tooltip: tooltipConfig,
     } = config ?? {}
+    const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
 
     const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
@@ -125,7 +131,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
 
     const lineChartConfig: LineChartConfig = {
         yScaleType: yAxis?.scale,
-        xTickFormatter: xAxis?.tickFormatter,
+        xTickFormatter,
         yTickFormatter,
         hideXAxis: xAxis?.hide,
         hideYAxis: yAxis?.hide,

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -70,9 +70,6 @@ export interface ChartProps<Meta = unknown> {
     tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
     onPointClick?: (data: PointClickData<Meta>) => void
     className?: string
-    /** `data-attr` applied to the chart wrapper. Lets product-level tests
-     *  (`waitForSelector: '[data-attr=…] > canvas'`) target a chart instance
-     *  without having to know its className. */
     dataAttr?: string
     children?: React.ReactNode
     /** Resolves the y-value for a series at a given index. Defaults to series.data[index].
@@ -86,8 +83,6 @@ export interface ChartProps<Meta = unknown> {
      *  axis (y in horizontal mode). Should be referentially stable; non-stable identities
      *  invalidate the interaction memo on every render. */
     labelToCoord?: (label: string) => number | undefined
-    /** Surfaced on layout context so overlays can default to a percent formatter. */
-    isPercent?: boolean
 }
 
 export function Chart<Meta = unknown>({
@@ -105,7 +100,6 @@ export function Chart<Meta = unknown>({
     children,
     resolveValue,
     labelToCoord,
-    isPercent = false,
 }: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
@@ -115,6 +109,7 @@ export function Chart<Meta = unknown>({
         tooltip: tooltipConfig,
         showCrosshair = false,
         axisOrientation = 'vertical',
+        isPercent = false,
     } = config ?? {}
     const interactionAxis: 'x' | 'y' = axisOrientation === 'horizontal' ? 'y' : 'x'
     const {
@@ -208,6 +203,11 @@ export function Chart<Meta = unknown>({
 
     const stableResolveValue = useStableResolveValue(resolveValue)
 
+    const axisValue = useMemo(
+        () => ({ orientation: axisOrientation, xTickFormatter, isPercent }),
+        [axisOrientation, xTickFormatter, isPercent]
+    )
+
     const layoutValue = useMemo<ChartLayoutContextValue | null>(() => {
         if (!scales || !dimensions) {
             return null
@@ -220,10 +220,9 @@ export function Chart<Meta = unknown>({
             theme,
             resolveValue: stableResolveValue,
             canvasBounds,
-            axisOrientation,
-            isPercent,
+            axis: axisValue,
         }
-    }, [scales, dimensions, labels, coloredSeries, theme, stableResolveValue, canvasBounds, axisOrientation, isPercent])
+    }, [scales, dimensions, labels, coloredSeries, theme, stableResolveValue, canvasBounds, axisValue])
 
     const hoverValue = useMemo<ChartHoverContextValue>(() => ({ hoverIndex }), [hoverIndex])
 

--- a/frontend/src/lib/hog-charts/core/chart-context.test.tsx
+++ b/frontend/src/lib/hog-charts/core/chart-context.test.tsx
@@ -15,8 +15,7 @@ const LAYOUT: ChartLayoutContextValue = {
     theme: THEME,
     resolveValue: (s, i) => s.data[i] ?? 0,
     canvasBounds: () => null,
-    axisOrientation: 'vertical',
-    isPercent: false,
+    axis: { orientation: 'vertical', xTickFormatter: undefined, isPercent: false },
 }
 
 describe('chart-context split', () => {

--- a/frontend/src/lib/hog-charts/core/chart-context.ts
+++ b/frontend/src/lib/hog-charts/core/chart-context.ts
@@ -2,6 +2,18 @@ import { createContext, useContext } from 'react'
 
 import type { ChartDimensions, ChartScales, ChartTheme, ResolvedSeries, ResolveValueFn } from './types'
 
+/** Axis-related state exposed to overlays. */
+export interface ChartAxisContextValue {
+    /** `horizontal` swaps which axis carries the value scale (`scales.y` returns x-pixels). */
+    orientation: 'vertical' | 'horizontal'
+    /** Resolved x-axis tick formatter (the same one `<AxisLabels>` uses). Overlays that
+     *  need to align with the visible tick set should read this rather than recompute. */
+    xTickFormatter: ((value: string, index: number) => string | null) | undefined
+    /** True for BarChart `barLayout: 'percent'` / LineChart `percentStackView`. Overlays
+     *  that format values can use this to default to a percent formatter. */
+    isPercent: boolean
+}
+
 /** Layout-stable values exposed to overlays. Identity does NOT change on hover —
  *  consumers reading from {@link useChartLayout} won't re-render on mousemove. */
 export interface ChartLayoutContextValue<Meta = unknown> {
@@ -24,10 +36,8 @@ export interface ChartLayoutContextValue<Meta = unknown> {
      *  This is a getter (not a value) because DOMRect changes on scroll. Useful for
      *  custom overlays that portal positioned content outside the chart wrapper. */
     canvasBounds: () => DOMRect | null
-    /** `horizontal` swaps which axis carries the value scale (`scales.y` returns x-pixels). */
-    axisOrientation: 'vertical' | 'horizontal'
-    /** True for BarChart `barLayout: 'percent'` / LineChart `percentStackView`. */
-    isPercent: boolean
+    /** Axis-related state (orientation, x-axis formatter, value-scale flags). */
+    axis: ChartAxisContextValue
 }
 
 /** Hover state isolated from layout so mousemoves don't invalidate every overlay.

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -155,6 +155,9 @@ export interface ChartConfig {
     showCrosshair?: boolean
     /** `vertical` (default): categories on x, values on y. `horizontal`: swapped. */
     axisOrientation?: 'vertical' | 'horizontal'
+    /** True for BarChart `barLayout: 'percent'` / LineChart `percentStackView`. Surfaced
+     *  on layout context so overlays can default to a percent formatter. */
+    isPercent?: boolean
 }
 
 export interface TooltipConfig {

--- a/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ValueLabels.tsx
@@ -293,8 +293,9 @@ export function ValueLabels({
     minGap = 4,
     mode = 'per-segment',
 }: ValueLabelsProps): React.ReactElement | null {
-    const { series, scales, labels, theme, resolveValue, axisOrientation, isPercent } = useChartLayout()
-    const isHorizontal = axisOrientation === 'horizontal'
+    const { series, scales, labels, theme, resolveValue, axis } = useChartLayout()
+    const isHorizontal = axis.orientation === 'horizontal'
+    const isPercent = axis.isPercent
 
     const formatter = valueFormatter ?? defaultLocaleFormatter
 

--- a/frontend/src/lib/hog-charts/testing/overlay.tsx
+++ b/frontend/src/lib/hog-charts/testing/overlay.tsx
@@ -19,6 +19,7 @@ export interface OverlayContextOverrides {
     axisOrientation?: 'vertical' | 'horizontal'
     isPercent?: boolean
     hoverIndex?: number
+    xTickFormatter?: (value: string, index: number) => string | null
 }
 
 /** Build a fully-populated overlay context with sensible defaults. Required:
@@ -32,8 +33,11 @@ export function makeOverlayContext(scales: ChartScales, overrides: OverlayContex
         theme: overrides.theme ?? DEFAULT_THEME,
         resolveValue: overrides.resolveValue ?? DEFAULT_RESOLVE,
         canvasBounds: overrides.canvasBounds ?? (() => null),
-        axisOrientation: overrides.axisOrientation ?? 'vertical',
-        isPercent: overrides.isPercent ?? false,
+        axis: {
+            orientation: overrides.axisOrientation ?? 'vertical',
+            xTickFormatter: overrides.xTickFormatter,
+            isPercent: overrides.isPercent ?? false,
+        },
         hoverIndex: overrides.hoverIndex ?? -1,
     }
 }

--- a/frontend/src/lib/hog-charts/utils/use-axis-formatters.ts
+++ b/frontend/src/lib/hog-charts/utils/use-axis-formatters.ts
@@ -27,6 +27,10 @@ export function useXTickFormatter(
     xAxis: XAxisConfig | undefined,
     labels: string[]
 ): ((value: string, index: number) => string | null) | undefined {
+    // Resolve outside the memo so `labels` only participates as a dep when it's
+    // actually the source — when `xAxis.allDays` is provided, label-only changes
+    // shouldn't rebuild the formatter (and ripple a new identity through context).
+    const effectiveAllDays = xAxis?.allDays ?? labels
     return useMemo(() => {
         if (xAxis?.tickFormatter) {
             return xAxis.tickFormatter
@@ -35,11 +39,11 @@ export function useXTickFormatter(
             return createXAxisTickCallback({
                 timezone: xAxis.timezone,
                 interval: xAxis.interval,
-                allDays: xAxis.allDays ?? labels,
+                allDays: effectiveAllDays,
             })
         }
         return undefined
-    }, [xAxis?.tickFormatter, xAxis?.timezone, xAxis?.interval, xAxis?.allDays, labels])
+    }, [xAxis?.tickFormatter, xAxis?.timezone, xAxis?.interval, effectiveAllDays])
 }
 
 export function useYTickFormatter(yAxis: YAxisConfig | undefined): ((value: number) => string) | undefined {

--- a/frontend/src/lib/hog-charts/utils/use-axis-formatters.ts
+++ b/frontend/src/lib/hog-charts/utils/use-axis-formatters.ts
@@ -1,10 +1,18 @@
 import { useMemo } from 'react'
 
+import { createXAxisTickCallback, type TimeInterval } from './dates'
 import { buildYTickFormatter, type YFormatterConfig } from './y-formatters'
 
 export interface XAxisConfig {
+    /** Explicit tick formatter. When set, it wins over the auto date formatter. */
     tickFormatter?: (value: string, index: number) => string | null
     hide?: boolean
+    /** Timezone used when interpreting date labels for the auto date formatter. */
+    timezone?: string
+    /** Bucket size for the auto date formatter. */
+    interval?: TimeInterval
+    /** Source dates for the auto date formatter. Falls back to `labels` when omitted. */
+    allDays?: string[]
 }
 
 export interface YAxisConfig extends YFormatterConfig {
@@ -13,6 +21,25 @@ export interface YAxisConfig extends YFormatterConfig {
     tickFormatter?: (value: number) => string
     hide?: boolean
     showGrid?: boolean
+}
+
+export function useXTickFormatter(
+    xAxis: XAxisConfig | undefined,
+    labels: string[]
+): ((value: string, index: number) => string | null) | undefined {
+    return useMemo(() => {
+        if (xAxis?.tickFormatter) {
+            return xAxis.tickFormatter
+        }
+        if (xAxis?.timezone && xAxis?.interval) {
+            return createXAxisTickCallback({
+                timezone: xAxis.timezone,
+                interval: xAxis.interval,
+                allDays: xAxis.allDays ?? labels,
+            })
+        }
+        return undefined
+    }, [xAxis?.tickFormatter, xAxis?.timezone, xAxis?.interval, xAxis?.allDays, labels])
 }
 
 export function useYTickFormatter(yAxis: YAxisConfig | undefined): ((value: number) => string) | undefined {

--- a/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-bar-chart/TrendsBarChart.tsx
@@ -310,13 +310,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
                 />
             )}
             {showValuesOnSeries && <ValueLabels valueFormatter={valueLabelFormatter} />}
-            {showAnnotations && (
-                <AnnotationsLayer
-                    insightNumericId={insight.id || 'new'}
-                    dates={annotationsDates}
-                    xTickFormatter={xTickFormatter}
-                />
-            )}
+            {showAnnotations && <AnnotationsLayer insightNumericId={insight.id || 'new'} dates={annotationsDates} />}
         </BarChart>
     )
 }

--- a/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/AnnotationsLayer.tsx
@@ -9,9 +9,6 @@ interface AnnotationsLayerProps {
     insightNumericId: number | 'new'
     /** Per-data-point date strings; used for grouping annotations. */
     dates: string[]
-    /** Custom x-axis tick formatter — must match the one passed to the chart so the
-     *  computed tick set lines up with what the user sees. */
-    xTickFormatter?: (value: string, index: number) => string | null
 }
 
 const WRAPPER_STYLE: React.CSSProperties = {
@@ -25,12 +22,9 @@ const stopPointerPropagation = (e: React.MouseEvent<HTMLDivElement>): void => {
     e.stopPropagation()
 }
 
-export function AnnotationsLayer({
-    insightNumericId,
-    dates,
-    xTickFormatter,
-}: AnnotationsLayerProps): React.ReactElement | null {
-    const { scales, dimensions, labels } = useChartLayout()
+export function AnnotationsLayer({ insightNumericId, dates }: AnnotationsLayerProps): React.ReactElement | null {
+    const { scales, dimensions, labels, axis } = useChartLayout()
+    const xTickFormatter = axis.xTickFormatter
 
     const chartLike = useMemo(() => {
         const visibleXLabels = computeVisibleXLabels(labels, scales.x, xTickFormatter)

--- a/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
+++ b/frontend/src/scenes/trends/viz/trends-line-chart/TrendsLineChart.tsx
@@ -3,7 +3,7 @@ import posthog from 'posthog-js'
 import { useCallback, useMemo, type ErrorInfo } from 'react'
 
 import { buildTheme } from 'lib/charts/utils/theme'
-import { createXAxisTickCallback, DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from 'lib/hog-charts'
+import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from 'lib/hog-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipConfig, TooltipContext } from 'lib/hog-charts'
 import { formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -123,17 +123,6 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         ]
     )
 
-    // Built here so the same instance can be threaded into <AnnotationsLayer> below.
-    const xTickFormatter = useMemo(
-        () =>
-            createXAxisTickCallback({
-                interval: interval ?? 'day',
-                allDays: currentPeriodResult?.days ?? [],
-                timezone,
-            }),
-        [interval, currentPeriodResult?.days, timezone]
-    )
-
     const yAxisConfig = useMemo(
         () =>
             buildTrendsYAxisConfig(trendsFilter, isPercentStackView, baseCurrency, {
@@ -177,7 +166,11 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
 
     const chartConfig: TimeSeriesLineChartConfig = useMemo(
         () => ({
-            xAxis: { tickFormatter: xTickFormatter },
+            xAxis: {
+                timezone,
+                interval: interval ?? 'day',
+                allDays: currentPeriodResult?.days ?? [],
+            },
             yAxis: yAxisConfig,
             valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
             goalLines: goalLineConfigs,
@@ -187,7 +180,9 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             tooltip: TOOLTIP_CONFIG,
         }),
         [
-            xTickFormatter,
+            timezone,
+            interval,
+            currentPeriodResult?.days,
             yAxisConfig,
             showValuesOnSeries,
             valueLabelFormatter,
@@ -317,13 +312,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                     isHidden={getTrendsHidden}
                 />
             ) : null}
-            {showAnnotations && (
-                <AnnotationsLayer
-                    insightNumericId={insight.id || 'new'}
-                    dates={annotationsDates}
-                    xTickFormatter={xTickFormatter}
-                />
-            )}
+            {showAnnotations && <AnnotationsLayer insightNumericId={insight.id || 'new'} dates={annotationsDates} />}
         </TimeSeriesLineChart>
     )
 }


### PR DESCRIPTION
## Problem

The previous cleanup PR (#57765) deleted the auto x-axis formatter from `TimeSeriesLineChart` as dead code, but it was only unused because the API didn't expose enough for overlay children to share the same formatter. Trends ended up rebuilding the formatter twice — once via `xAxis.tickFormatter` on the chart, and once threaded into `<AnnotationsLayer xTickFormatter={...}>` — which is what the auto-formatter was meant to prevent.

## Changes

- `XAxisConfig` regains `timezone`, `interval`, and `allDays` fields. When provided (and `tickFormatter` isn't), `TimeSeriesLineChart` calls `createXAxisTickCallback` itself — single source of truth.
- New `useXTickFormatter` hook in `use-axis-formatters.ts` mirrors the existing `useYTickFormatter` pattern.
- `ChartLayoutContext` now exposes axis-related state under a single `axis` namespace: `{ orientation, xTickFormatter, isPercent }`. Top-level `axisOrientation` and `isPercent` are gone.
- `isPercent` moves from a standalone `Chart` prop into `ChartConfig`, matching how `axisOrientation` already flows. `LineChart`/`BarChart` set it on the config they pass to `Chart`.
- `AnnotationsLayer` drops its `xTickFormatter` prop and reads `axis.xTickFormatter` from context.
- `TrendsLineChart` swaps its hand-rolled `createXAxisTickCallback` + `xAxis.tickFormatter` for `xAxis: { timezone, interval, allDays }`, and stops threading the formatter into `<AnnotationsLayer>`.

`createXAxisTickCallback` is still exported — `DataVisualization/.../LineGraph.tsx`, `scenes/insights/views/LineGraph/LineGraph.tsx`, and `TrendsBarChart` (which uses `BarChart`, not `TimeSeriesLineChart`) call it directly. Those are out of scope here.

## How did you test this code?

I'm an agent. I ran:

- `hogli test` on `TimeSeriesLineChart.test.tsx` (24 tests), `chart-context.test.tsx` (3 tests), `ValueLabels.test.tsx` (20 tests), `TrendsLineChart.test.tsx` and `TrendsBarChart.test.tsx` (63 tests combined) — all pass.
- Added new tests covering: auto formatter from `xAxis.timezone + xAxis.interval`, explicit `xAxis.tickFormatter` winning over auto, and the resolved formatter being readable from `ChartLayoutContext.axis.xTickFormatter`.
- `oxfmt --check` and `oxlint` clean on touched files (pre-existing warnings unchanged).
- Per-file `tsc` clean on touched files (project-wide check OOMs locally).
- I did **not** manually verify Storybook renders or trends charts in a browser.

## Publish to changelog?

no

## 🤖 Agent context

- Authored with PostHog Code (Claude Opus 4.7).
- Prompt-driven: user asked to revert the over-correction from #57765 by re-adding the auto-formatter and exposing it to children without prop-drilling.
- Original plan called for a sibling `TimeSeriesAxisContext` provider. Mid-implementation, the user pushed back: "do we really need a new context? Can we expose this in existing contexts?" — switched to extending `ChartLayoutContext` since `LineChart`/`BarChart` already provide it.
- User then asked to consolidate axis state under a single `axis` namespace and to extend the same treatment to `isPercent` (which was a Chart prop only used to forward into context). Pulled `isPercent` into `ChartConfig` so it flows the same way `axisOrientation` does.
- Other `ChartProps` (series, labels, theme, callbacks, render functions, `resolveValue`, `labelToCoord`) were considered for the same move and kept as props — they're real chart inputs, not context-pipes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*