### PR TITLE
feat(logs): add metrics for alerting cohort size tracking

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -49,6 +49,8 @@ from posthog.temporal.session_replay.delete_recordings.metrics import (
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 from products.logs.backend.temporal.metrics import (
+    LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS,
+    LOGS_ALERTING_COUNT_HISTOGRAM_METRICS,
     LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS,
     LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS,
     LogsAlertingMetricsInterceptor,
@@ -249,6 +251,7 @@ async def create_worker(
             )
         )
         | dict(zip(LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS, itertools.repeat(LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS)))
+        | dict(zip(LOGS_ALERTING_COUNT_HISTOGRAM_METRICS, itertools.repeat(LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS)))
         | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]}
     )
     if task_queue == settings.DATA_MODELING_TASK_QUEUE:

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -46,6 +46,20 @@ LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS = (
     "logs_alerting_cohort_update_ms",
 )
 
+LOGS_ALERTING_COUNT_HISTOGRAM_METRICS = ("logs_alerting_cohort_size",)
+
+LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS = [
+    1.0,
+    5.0,
+    10.0,
+    20.0,
+    30.0,
+    50.0,
+    100.0,
+    250.0,
+    500.0,
+]
+
 LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS = [
     100.0,
     500.0,
@@ -189,11 +203,14 @@ def record_cohort_update_duration(duration_ms: int) -> None:
 
 
 def record_cohort_size(size: int) -> None:
-    _record_histogram(
-        "logs_alerting_cohort_size",
-        "Number of alerts in a cohort sharing one batched ClickHouse query and one bulk Postgres save",
-        size,
+    """Record a non-timedelta histogram observation — cohort size is a count, not a duration."""
+    meter = get_metric_meter()
+    hist = meter.create_histogram(
+        name="logs_alerting_cohort_size",
+        description="Number of alerts in a cohort sharing one batched ClickHouse query and one bulk Postgres save",
+        unit="alerts",
     )
+    hist.record(size)
 
 
 CohortSaveFallbackReason = typing.Literal["integrity_error"]

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -222,13 +222,6 @@ class TestRecordCohortSaveSubstageDurations:
                 "Postgres bulk_update time for LogsAlertConfiguration rows in a cohort",
                 28,
             ),
-            (
-                "cohort_size",
-                record_cohort_size,
-                "logs_alerting_cohort_size",
-                "Number of alerts in a cohort sharing one batched ClickHouse query and one bulk Postgres save",
-                17,
-            ),
         ]
     )
     @patch("products.logs.backend.temporal.metrics._record_histogram")
@@ -237,6 +230,26 @@ class TestRecordCohortSaveSubstageDurations:
     ):
         fn(sample_value)
         mock_record.assert_called_once_with(metric_name, description, sample_value)
+
+
+class TestRecordCohortSize:
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_records_count_histogram(self, mock_get_meter: MagicMock):
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram.return_value = mock_hist
+        mock_get_meter.return_value = mock_meter
+
+        record_cohort_size(17)
+
+        kwargs = mock_meter.create_histogram.call_args.kwargs
+        assert kwargs["name"] == "logs_alerting_cohort_size"
+        assert kwargs["unit"] == "alerts"
+        assert (
+            kwargs["description"]
+            == "Number of alerts in a cohort sharing one batched ClickHouse query and one bulk Postgres save"
+        )
+        mock_hist.record.assert_called_once_with(17)
 
 
 class TestIncrementCohortSaveFallback:


### PR DESCRIPTION
## Problem

The `logs_alerting_cohort_size` metric was being recorded via `_record_histogram`, which uses millisecond-based latency buckets. Since cohort size is a count (not a duration), it was being bucketed incorrectly, making the histogram data misleading.

## Changes

- Introduced dedicated `LOGS_ALERTING_COUNT_HISTOGRAM_METRICS` and `LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS` constants with count-appropriate bucket boundaries (1, 5, 10, 20, 30, 50, 100, 250, 500).
- Updated `record_cohort_size` to directly use the OpenTelemetry `meter.create_histogram` API with `unit="alerts"` instead of the shared `_record_histogram` helper, which was designed for latency measurements.
- Registered the new count histogram buckets in the worker's histogram bucket configuration so the metric is correctly reported.

## How did you test this code?

No automated tests were added. The change is a metrics instrumentation fix — the histogram is now created with semantically correct buckets and units for a count-based metric rather than a duration-based one.

## Publish to changelog?

No