### PR TITLE
refactor(signals): streamline SignalReportViewSet artefacts and access

### DIFF
--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -62,8 +62,6 @@ from products.signals.backend.models import (
 from products.signals.backend.report_generation.resolve_reviewers import (
     get_org_member_github_login_to_user_map,
     get_org_member_github_logins_by_user_uuid,
-    normalized_github_logins_from_suggested_reviewer_artefacts,
-    resolve_org_github_login_to_users,
 )
 from products.signals.backend.serializers import (
     SignalReportArtefactSerializer,
@@ -524,7 +522,6 @@ class SignalReportViewSet(
         # and checking jsonb containment on the artefact content list. This stays fresh
         # even when a user connects their GitHub account after the report was generated.
         # Never true for ready + not_actionable — there is nothing actionable to review.
-        # Failed reports are excluded too — pipelines that errored should not bubble as "needs your review".
         github_login = self._get_github_login(self.request.user)
         if not github_login:
             return queryset.annotate(is_suggested_reviewer=Value(False))
@@ -543,7 +540,6 @@ class SignalReportViewSet(
         return queryset.annotate(
             is_suggested_reviewer=Case(
                 When(self._Q_READY_NOT_ACTIONABLE, then=Value(False)),
-                When(status=SignalReport.Status.FAILED, then=Value(False)),
                 default=suggested_exists,
                 output_field=BooleanField(),
             ),
@@ -775,19 +771,14 @@ class SignalReportViewSet(
     @action(detail=True, methods=["get"], url_path="artefacts", required_scopes=["task:read"])
     def artefacts(self, request, pk=None, **kwargs):
         report = cast(SignalReport, self.get_object())
-        artefacts = list(report.artefacts.all().order_by("-created_at"))
-        logins_union = normalized_github_logins_from_suggested_reviewer_artefacts(artefacts)
-        login_map = resolve_org_github_login_to_users(self.team.id, logins_union) if logins_union else {}
-        serializer = SignalReportArtefactSerializer(
-            artefacts,
-            many=True,
-            context={
-                **self.get_serializer_context(),
-                "signals_github_login_to_user_map": login_map,
-            },
+        artefacts = report.artefacts.all().order_by("-created_at")
+        serializer = SignalReportArtefactSerializer(artefacts, many=True)
+        return Response(
+            {
+                "results": serializer.data,
+                "count": len(serializer.data),
+            }
         )
-        results = serializer.data
-        return Response({"results": results, "count": len(results)})
 
     @extend_schema(exclude=True)
     @action(detail=True, methods=["get"], url_path="signals", required_scopes=["task:read"])
@@ -838,13 +829,7 @@ class SignalReportViewSet(
     @extend_schema(exclude=True)
     @action(detail=True, methods=["post"], url_path="reingest", required_scopes=["task:write"])
     def reingest(self, request, pk=None, **kwargs):
-        """Re-ingest a report's signals. Staff-only."""
-        if not request.user.is_staff:
-            return Response(
-                {"error": "Only staff users can reingest reports."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
-
+        """Re-ingest a report's signals."""
         report = cast(SignalReport, self.get_object())
         report_id = str(report.id)
         team_id = self.team.id


### PR DESCRIPTION
## Problem

Streamline the signal report viewset: reduce work in the artefacts endpoint, adjust which reports count as suggested reviewers for failed status, and align reingest with scope-based access instead of a staff-only gate.

## Changes

- **`artefacts`**: Stop building `signals_github_login_to_user_map` from suggested-reviewer artefacts; serialize the ordered artefact queryset without that context.
- **`is_suggested_reviewer`**: Remove the branch that forced the annotation to false when report status is failed (and drop the related comment).
- **`reingest`**: Remove the staff-only check; rely on existing `task:write` scope on the action.

## How did you test this code?

I am an agent and did not run manual QA. I did not run automated tests for this PR in this session.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs — internal API / behavior tweak only; no docs change in this PR.

## 🤖 Agent context

- Tooling: Cursor agent; user requested committing working tree changes and opening a PR.
- Branch: created `refactor/signals-report-viewset-streamline` from prior `master` checkout (local branch was behind `origin/master`) and pushed one commit touching `products/signals/backend/views.py`.
- Pre-commit ran Python lint/format and `ty check` successfully.
