### PR TITLE
fix(experiments/mcp): Guide agents around control variant validation

### DIFF
--- a/ee/hogai/eval/sandboxed/experiments/eval_create_control_variant.py
+++ b/ee/hogai/eval/sandboxed/experiments/eval_create_control_variant.py
@@ -1,0 +1,79 @@
+"""Eval: experiment-create must succeed when the user phrases variants
+naturally (A vs B) without explicitly saying "control".
+
+Background — the top experiment-create validation error in production
+($exception telemetry, insight r43SObB1) is "Feature flag variants must
+contain a control variant". 22 hits/week. Caused by the LLM mirroring
+the user's natural language (A/B, old/new, original/redesign) and
+emitting variant keys other than "control".
+
+This eval guards three layers of the fix simultaneously, so a single
+case covers a lot of ground:
+
+1. Field-level schema description (``ExperimentVariant.key``) — the
+   model should read the description and map A → "control" up front.
+2. Server-side case-insensitive normalization — if the model emits
+   "Control"/"CONTROL", the serializer rewrites it silently and the
+   create still succeeds.
+3. Self-correcting validation error — if the model emits "a"/"b",
+   the new error message lists the keys received and tells it to
+   rename the baseline; the model should retry and succeed.
+
+Outcome scorer (``RequiredToolCall(experiment-create)``) is path-agnostic
+on purpose — any of the three success paths above is fine. A regression
+in any layer that prevents the agent from ever producing a successful
+create call will flip this scorer to 0.0.
+
+To run:
+    flox activate -- bash -c "set -a; source .env; set +a; \\
+        pytest -c ee/hogai/eval/pytest.ini \\
+        ee/hogai/eval/sandboxed/experiments/eval_create_control_variant.py \\
+        -v --mcp-mode tools"
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.hogai.eval.sandboxed.base import SandboxedPrivateEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, RequiredToolCall
+
+
+@pytest.mark.django_db
+async def eval_create_control_variant(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
+    cases: list[SandboxedEvalCase] = [
+        # Single high-coverage case. The "A (existing) vs B (new)" framing
+        # is the highest-yield trigger of the production "Feature flag
+        # variants must contain a control variant" error: the user names
+        # the variants and never says "control", so the agent has to map
+        # the baseline (A) to the reserved key on its own.
+        SandboxedEvalCase(
+            name="create_with_natural_language_ab_variants",
+            prompt=(
+                "Create an experiment called 'pricing test' with feature flag key "
+                "'pricing-test', comparing A (the existing pricing page) vs B (the new "
+                "pricing page) with a 50/50 split. Don't ask follow-up questions — just "
+                "create the draft."
+            ),
+        ),
+    ]
+
+    await SandboxedPrivateEval(
+        experiment_name=f"sandboxed-experiments-create-control-{mcp_mode}",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            # The single outcome scorer: did experiment-create return without error?
+            # `RequiredToolCall` matches on `is_error=False`, so any of the three
+            # paths in the docstring (clean call / silent normalization / retry
+            # after better error message) counts as a pass.
+            RequiredToolCall(
+                required={"experiment-create"},
+                name="experiment_created_successfully",
+            ),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17488,7 +17488,7 @@
             "additionalProperties": false,
             "properties": {
                 "feature_flag_variants": {
-                    "description": "Experiment variants. If not specified, defaults to a 50/50 control/test split.",
+                    "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20.",
                     "items": {
                         "$ref": "#/definitions/ExperimentVariant"
                     },
@@ -18066,7 +18066,7 @@
             "additionalProperties": false,
             "properties": {
                 "key": {
-                    "description": "Variant key, e.g. 'control', 'test', 'variant_a'.",
+                    "description": "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'.",
                     "type": "string"
                 },
                 "name": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3387,7 +3387,7 @@ export interface ExperimentApiMetric {
 }
 
 export interface ExperimentVariant {
-    /** Variant key, e.g. 'control', 'test', 'variant_a'. */
+    /** Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'. */
     key: string
     /** Human-readable variant name. */
     name?: string
@@ -3398,7 +3398,7 @@ export interface ExperimentVariant {
 }
 
 export interface ExperimentParameters {
-    /** Experiment variants. If not specified, defaults to a 50/50 control/test split. */
+    /** Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20. */
     feature_flag_variants?: ExperimentVariant[]
     /** Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments. */
     minimum_detectable_effect?: number

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1959,7 +1959,16 @@ class ExperimentVariant(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str = Field(..., description="Variant key, e.g. 'control', 'test', 'variant_a'.")
+    key: str = Field(
+        ...,
+        description=(
+            "Variant key. Exactly one variant in feature_flag_variants must use key"
+            " 'control' (lowercase, exactly) — that is the baseline used for analysis"
+            " and the special key the experiment runtime expects. Other variants use"
+            " keys like 'test', 'variant_a', 'variant_b'. Map natural-language names"
+            " ('original', 'A', 'baseline') to 'control'."
+        ),
+    )
     name: str | None = Field(default=None, description="Human-readable variant name.")
     rollout_percentage: float | None = None
     split_percent: float | None = Field(
@@ -6832,7 +6841,11 @@ class ExperimentParameters(BaseModel):
     )
     feature_flag_variants: list[ExperimentVariant] | None = Field(
         default=None,
-        description=("Experiment variants. If not specified, defaults to a 50/50 control/test split."),
+        description=(
+            "Experiment variants. If specified, must include a variant with key"
+            " 'control' (lowercase). Defaults to a 50/50 control/test split when"
+            " omitted. Minimum 2, maximum 20."
+        ),
     )
     minimum_detectable_effect: float | None = Field(
         default=None,

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -145,8 +145,17 @@ class ExperimentService:
                 raise ValidationError(
                     "Feature flag must have at least 2 variants (control and at least one test variant)"
                 )
-            if "control" not in [variant["key"] for variant in variants]:
-                raise ValidationError("Feature flag variants must contain a control variant")
+            keys = [variant["key"] for variant in variants]
+            if "control" not in keys:
+                # Surface the keys we did receive so LLM callers can self-correct without a
+                # second roundtrip. Capitalized 'Control' is auto-normalized in
+                # ExperimentParametersField.to_internal_value, so anything reaching this
+                # branch genuinely lacks a baseline variant.
+                raise ValidationError(
+                    "Feature flag variants must contain a variant with key 'control' "
+                    f"(lowercase, exactly). Got keys: {keys}. Rename the baseline variant's "
+                    "'key' to 'control'."
+                )
 
     @staticmethod
     def validate_experiment_exposure_criteria(exposure_criteria: dict | None) -> None:

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -62,10 +62,27 @@ class ExperimentParametersField(serializers.JSONField):
         # Deep copy to avoid mutating the caller's dict (e.g. serializer.initial_data / request.data)
         if isinstance(data, dict) and "feature_flag_variants" in data:
             data = deepcopy(data)
-            for variant in data["feature_flag_variants"]:
-                if isinstance(variant, dict) and "split_percent" in variant:
-                    # split_percent wins in case both keys present, as rollout_percentage deprecated
-                    variant["rollout_percentage"] = variant.pop("split_percent")
+            variants = data["feature_flag_variants"]
+            if isinstance(variants, list):
+                # Normalize a case-insensitive 'control' key (e.g. 'Control', 'CONTROL') down
+                # to lowercase 'control'. The downstream validator and runtime treat 'control'
+                # as a special key, so a typo in casing was the leading cause of the
+                # "Feature flag variants must contain a control variant" error in MCP traces —
+                # most often from LLM-generated payloads. Only rewrite when no exact 'control'
+                # match already exists, so we never collapse two distinct keys into a duplicate.
+                existing_keys = {v.get("key") for v in variants if isinstance(v, dict)}
+                if "control" not in existing_keys:
+                    for variant in variants:
+                        if not isinstance(variant, dict):
+                            continue
+                        key = variant.get("key")
+                        if isinstance(key, str) and key != "control" and key.lower() == "control":
+                            variant["key"] = "control"
+                            break
+                for variant in variants:
+                    if isinstance(variant, dict) and "split_percent" in variant:
+                        # split_percent wins in case both keys present, as rollout_percentage deprecated
+                        variant["rollout_percentage"] = variant.pop("split_percent")
         return super().to_internal_value(data)
 
 

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -1910,20 +1910,27 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertIn("'test_1'", detail)
         self.assertIn("'test_2'", detail)
 
-    def test_creating_experiment_normalizes_capitalized_control_key(self):
+    @parameterized.expand(
+        [
+            ("Control",),
+            ("CONTROL",),
+            ("cOnTrOl",),
+        ]
+    )
+    def test_creating_experiment_normalizes_capitalized_control_key(self, control_key: str):
         # LLM callers often emit `Control` or `CONTROL` from natural-language input.
         # The serializer should rewrite it to lowercase `control` instead of rejecting,
         # since intent is unambiguous and the runtime treats `control` as a reserved key.
-        ff_key = "case-insensitive-control"
+        ff_key = f"case-insensitive-{control_key.lower()}-{control_key}"
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
             {
-                "name": "Capitalized control",
+                "name": f"Capitalized control {control_key}",
                 "description": "",
                 "feature_flag_key": ff_key,
                 "parameters": {
                     "feature_flag_variants": [
-                        {"key": "Control", "name": "Control", "split_percent": 50},
+                        {"key": control_key, "name": "Control", "split_percent": 50},
                         {"key": "test", "name": "Test", "split_percent": 50},
                     ]
                 },
@@ -1940,10 +1947,14 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(flag_keys, ["control", "test"])
 
     def test_creating_experiment_does_not_collapse_when_control_already_present(self):
-        # If both `control` and `Control` are passed, leave them alone — normalization
-        # would silently merge two distinct variants into a duplicate key, which
-        # FeatureFlagSerializer would surface as its own error.
-        ff_key = "control-and-Control"
+        # If both `control` and `Control` are passed, normalization must NOT run —
+        # otherwise it would rewrite `Control` → `control` and produce two duplicate
+        # entries. The downstream FeatureFlagSerializer may then accept (variants
+        # preserved) or reject (duplicate-key error) — both prove the normalization
+        # path was skipped. The signal we actively check against: the response must
+        # not be the missing-control error, since that would only fire if our
+        # rewrite logic got confused.
+        ff_key = "control-and-capital-control"
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
             {
@@ -1960,13 +1971,16 @@ class TestExperimentCRUD(APILicensedTest):
             format="json",
         )
 
-        # Either FeatureFlagSerializer rejects the duplicate, or it accepts the second
-        # untouched — either way the normalization path must NOT run when an exact
-        # `control` already exists.
+        # Must land on a deterministic outcome — not silently bypass.
+        self.assertIn(response.status_code, [status.HTTP_201_CREATED, status.HTTP_400_BAD_REQUEST])
         if response.status_code == status.HTTP_201_CREATED:
             variants = response.json()["parameters"]["feature_flag_variants"]
-            keys = [v["key"] for v in variants]
-            self.assertEqual(keys, ["control", "Control"])
+            self.assertEqual([v["key"] for v in variants], ["control", "Control"])
+        else:
+            # 400 path: the error must NOT be the missing-control message,
+            # which would only fire if normalization had wrongly rewritten things.
+            detail = str(response.json())
+            self.assertNotIn("must contain a variant with key 'control'", detail)
 
     def test_creating_updating_experiment_with_group_aggregation(self):
         ff_key = "a-b-tests"

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -1904,10 +1904,69 @@ class TestExperimentCRUD(APILicensedTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.json()["detail"],
-            "Feature flag variants must contain a control variant",
+        detail = response.json()["detail"]
+        self.assertIn("must contain a variant with key 'control'", detail)
+        self.assertIn("'test_0'", detail)
+        self.assertIn("'test_1'", detail)
+        self.assertIn("'test_2'", detail)
+
+    def test_creating_experiment_normalizes_capitalized_control_key(self):
+        # LLM callers often emit `Control` or `CONTROL` from natural-language input.
+        # The serializer should rewrite it to lowercase `control` instead of rejecting,
+        # since intent is unambiguous and the runtime treats `control` as a reserved key.
+        ff_key = "case-insensitive-control"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Capitalized control",
+                "description": "",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "Control", "name": "Control", "split_percent": 50},
+                        {"key": "test", "name": "Test", "split_percent": 50},
+                    ]
+                },
+            },
+            format="json",
         )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        variants = response.json()["parameters"]["feature_flag_variants"]
+        self.assertEqual([v["key"] for v in variants], ["control", "test"])
+        # The persisted flag should also use lowercase `control`.
+        flag = FeatureFlag.objects.get(key=ff_key)
+        flag_keys = [v["key"] for v in flag.filters["multivariate"]["variants"]]
+        self.assertEqual(flag_keys, ["control", "test"])
+
+    def test_creating_experiment_does_not_collapse_when_control_already_present(self):
+        # If both `control` and `Control` are passed, leave them alone — normalization
+        # would silently merge two distinct variants into a duplicate key, which
+        # FeatureFlagSerializer would surface as its own error.
+        ff_key = "control-and-Control"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Both controls",
+                "description": "",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "control", "name": "lowercase", "split_percent": 50},
+                        {"key": "Control", "name": "Capitalized", "split_percent": 50},
+                    ]
+                },
+            },
+            format="json",
+        )
+
+        # Either FeatureFlagSerializer rejects the duplicate, or it accepts the second
+        # untouched — either way the normalization path must NOT run when an exact
+        # `control` already exists.
+        if response.status_code == status.HTTP_201_CREATED:
+            variants = response.json()["parameters"]["feature_flag_variants"]
+            keys = [v["key"] for v in variants]
+            self.assertEqual(keys, ["control", "Control"])
 
     def test_creating_updating_experiment_with_group_aggregation(self):
         ff_key = "a-b-tests"

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -163,7 +163,7 @@ export interface PatchedExperimentSavedMetricApi {
 }
 
 export interface ExperimentVariantApi {
-    /** Variant key, e.g. 'control', 'test', 'variant_a'. */
+    /** Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'. */
     key: string
     /**
      * Human-readable variant name.
@@ -181,7 +181,7 @@ export interface ExperimentVariantApi {
 
 export interface ExperimentParametersApi {
     /**
-     * Experiment variants. If not specified, defaults to a 50/50 control/test split.
+     * Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20.
      * @nullable
      */
     feature_flag_variants?: ExperimentVariantApi[] | null

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -95,6 +95,14 @@ tools:
                     (0-100) to control the overall fraction of users entering the experiment. Set feature_flag_variants
                     with split_percent on each variant to customize the variant split. Default: 50/50 control/test, 100%
                     rollout.
+
+
+                    HARD REQUIREMENT — when you provide feature_flag_variants, exactly one variant's `key` must be
+                    the literal string `control` (lowercase, no variations). It is the baseline used for analysis and
+                    the experiment runtime treats it specially. If the user describes variants as "A/B", "old/new",
+                    "original/redesign", or any other natural-language pair, map the baseline to `key: "control"` — not
+                    "A", "Control", "old", "original", or "baseline". Other variants can use any key (`test`,
+                    `variant_a`, etc.).
         ui_app: experiment
     experiment-delete:
         operation: experiments_destroy

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -97,9 +97,9 @@ tools:
                     rollout.
 
 
-                    HARD REQUIREMENT — when you provide feature_flag_variants, exactly one variant's `key` must be
-                    the literal string `control` (lowercase, no variations). It is the baseline used for analysis and
-                    the experiment runtime treats it specially. If the user describes variants as "A/B", "old/new",
+                    HARD REQUIREMENT — when you provide feature_flag_variants, exactly one variant's `key` must be the
+                    literal string `control` (lowercase, no variations). It is the baseline used for analysis and the
+                    experiment runtime treats it specially. If the user describes variants as "A/B", "old/new",
                     "original/redesign", or any other natural-language pair, map the baseline to `key: "control"` — not
                     "A", "Control", "old", "original", or "baseline". Other variants can use any key (`test`,
                     `variant_a`, etc.).

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16530,7 +16530,7 @@ export namespace Schemas {
     }
 
     export interface ExperimentVariant {
-      /** Variant key, e.g. 'control', 'test', 'variant_a'. */
+      /** Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'. */
       key: string;
       /**
        * Human-readable variant name.
@@ -16548,7 +16548,7 @@ export namespace Schemas {
 
     export interface ExperimentParameters {
       /**
-       * Experiment variants. If not specified, defaults to a 50/50 control/test split.
+       * Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20.
        * @nullable
        */
       feature_flag_variants?: ExperimentVariant[] | null;

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -109,7 +109,11 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                 feature_flag_variants: zod
                     .array(
                         zod.object({
-                            key: zod.string().describe("Variant key, e.g. 'control', 'test', 'variant_a'."),
+                            key: zod
+                                .string()
+                                .describe(
+                                    "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'."
+                                ),
                             name: zod.string().nullish().describe('Human-readable variant name.'),
                             rollout_percentage: zod.number().nullish(),
                             split_percent: zod
@@ -121,7 +125,9 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                         })
                     )
                     .nullish()
-                    .describe('Experiment variants. If not specified, defaults to a 50/50 control/test split.'),
+                    .describe(
+                        "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
+                    ),
                 minimum_detectable_effect: zod
                     .number()
                     .nullish()
@@ -1282,7 +1288,11 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                 feature_flag_variants: zod
                     .array(
                         zod.object({
-                            key: zod.string().describe("Variant key, e.g. 'control', 'test', 'variant_a'."),
+                            key: zod
+                                .string()
+                                .describe(
+                                    "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'."
+                                ),
                             name: zod.string().nullish().describe('Human-readable variant name.'),
                             rollout_percentage: zod.number().nullish(),
                             split_percent: zod
@@ -1294,7 +1304,9 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                         })
                     )
                     .nullish()
-                    .describe('Experiment variants. If not specified, defaults to a 50/50 control/test split.'),
+                    .describe(
+                        "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
+                    ),
                 minimum_detectable_effect: zod
                     .number()
                     .nullish()
@@ -2474,7 +2486,11 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                 feature_flag_variants: zod
                     .array(
                         zod.object({
-                            key: zod.string().describe("Variant key, e.g. 'control', 'test', 'variant_a'."),
+                            key: zod
+                                .string()
+                                .describe(
+                                    "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'."
+                                ),
                             name: zod.string().nullish().describe('Human-readable variant name.'),
                             rollout_percentage: zod.number().nullish(),
                             split_percent: zod
@@ -2486,7 +2502,9 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                         })
                     )
                     .nullish()
-                    .describe('Experiment variants. If not specified, defaults to a 50/50 control/test split.'),
+                    .describe(
+                        "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
+                    ),
                 minimum_detectable_effect: zod
                     .number()
                     .nullish()

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -65,7 +65,7 @@ const ExperimentCreateSchema = ExperimentsCreateBody.omit({
     update_feature_flag_params: true,
 }).extend({
     parameters: ExperimentsCreateBody.shape['parameters'].describe(
-        'Variant split and rollout scope. If the user mentions a specific percentage, load the configuring-experiment-rollout skill and clarify before setting these values. Set rollout_percentage (0-100) to control the overall fraction of users entering the experiment. Set feature_flag_variants with split_percent on each variant to customize the variant split. Default: 50/50 control/test, 100% rollout.'
+        'Variant split and rollout scope. If the user mentions a specific percentage, load the configuring-experiment-rollout skill and clarify before setting these values. Set rollout_percentage (0-100) to control the overall fraction of users entering the experiment. Set feature_flag_variants with split_percent on each variant to customize the variant split. Default: 50/50 control/test, 100% rollout. HARD REQUIREMENT — when you provide feature_flag_variants, exactly one variant\'s `key` must be the literal string `control` (lowercase, no variations). It is the baseline used for analysis and the experiment runtime treats it specially. If the user describes variants as "A/B", "old/new", "original/redesign", or any other natural-language pair, map the baseline to `key: "control"` — not "A", "Control", "old", "original", or "baseline". Other variants can use any key (`test`, `variant_a`, etc.).'
     ),
 })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-create.json
@@ -197,7 +197,7 @@
                                     "items": {
                                         "properties": {
                                             "key": {
-                                                "description": "Variant key, e.g. 'control', 'test', 'variant_a'.",
+                                                "description": "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'.",
                                                 "type": "string"
                                             },
                                             "name": {
@@ -242,7 +242,7 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Experiment variants. If not specified, defaults to a 50/50 control/test split."
+                            "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         },
                         "minimum_detectable_effect": {
                             "anyOf": [
@@ -273,7 +273,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Variant split and rollout scope. If the user mentions a specific percentage, load the configuring-experiment-rollout skill and clarify before setting these values. Set rollout_percentage (0-100) to control the overall fraction of users entering the experiment. Set feature_flag_variants with split_percent on each variant to customize the variant split. Default: 50/50 control/test, 100% rollout."
+            "description": "Variant split and rollout scope. If the user mentions a specific percentage, load the configuring-experiment-rollout skill and clarify before setting these values. Set rollout_percentage (0-100) to control the overall fraction of users entering the experiment. Set feature_flag_variants with split_percent on each variant to customize the variant split. Default: 50/50 control/test, 100% rollout. HARD REQUIREMENT — when you provide feature_flag_variants, exactly one variant's `key` must be the literal string `control` (lowercase, no variations). It is the baseline used for analysis and the experiment runtime treats it specially. If the user describes variants as \"A/B\", \"old/new\", \"original/redesign\", or any other natural-language pair, map the baseline to `key: \"control\"` — not \"A\", \"Control\", \"old\", \"original\", or \"baseline\". Other variants can use any key (`test`, `variant_a`, etc.)."
         },
         "stats_config": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-duplicate.json
@@ -2322,7 +2322,7 @@
                                     "items": {
                                         "properties": {
                                             "key": {
-                                                "description": "Variant key, e.g. 'control', 'test', 'variant_a'.",
+                                                "description": "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'.",
                                                 "type": "string"
                                             },
                                             "name": {
@@ -2367,7 +2367,7 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Experiment variants. If not specified, defaults to a 50/50 control/test split."
+                            "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         },
                         "minimum_detectable_effect": {
                             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/experiment-update.json
@@ -2140,7 +2140,7 @@
                                     "items": {
                                         "properties": {
                                             "key": {
-                                                "description": "Variant key, e.g. 'control', 'test', 'variant_a'.",
+                                                "description": "Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'.",
                                                 "type": "string"
                                             },
                                             "name": {
@@ -2185,7 +2185,7 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Experiment variants. If not specified, defaults to a 50/50 control/test split."
+                            "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         },
                         "minimum_detectable_effect": {
                             "anyOf": [


### PR DESCRIPTION
## Summary

Fixes the top `experiment-create` MCP validation error: "Feature flag variants must contain a control variant".

LLMs map natural-language variant names ("A vs B", "old vs new") to keys other than `control`, so the strict equality check at the API rejects the call.

## Changes

- Case-insensitive matches: `Control` → `control`
- Self-correcting error message: Lists the keys received and tells the caller exactly what to rename
- Tighten field-level descriptions, so the requirement is visible at the parameter level (not only in skills)
- Sandbox eval guards all three layers via one A-vs-B prompt

## How did you test this code?

- New + existing experiment serializer tests pass
- Sandbox eval passes