### PR TITLE
feat(ci): Skip Storybook CI when bot updates only snapshots.yml

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -27,12 +27,20 @@ jobs:
             # every file NOT at that path — effectively matching ALL changes
             # including backend files. Instead we use two positive filters and
             # compare counts to exclude generated-only PRs.
+            #
+            # Additionally skip when a bot commits only frontend/snapshots.yml on
+            # a PR — that file is updated automatically after human review and CI
+            # approval, so re-running the full storybook suite is pure waste.
             frontend: >-
                 ${{
                     github.event_name == 'push'
                     || (steps.filter.outputs.frontend == 'true'
                         && fromJSON(steps.filter.outputs.frontend_count || '0')
-                           > fromJSON(steps.filter.outputs.frontend_generated_count || '0'))
+                           > fromJSON(steps.filter.outputs.frontend_generated_count || '0')
+                        && !(github.event_name == 'pull_request'
+                             && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
+                             && fromJSON(steps.filter.outputs.snapshots_count || '0')
+                                == fromJSON(steps.filter.outputs.frontend_count || '0')))
                 }}
             matrix: ${{ steps.matrix.outputs.matrix }}
         steps:
@@ -61,6 +69,8 @@ jobs:
                       frontend_generated:
                         - 'frontend/src/generated/**'
                         - 'products/**/frontend/generated/**'
+                      snapshots:
+                        - 'frontend/snapshots.yml'
 
             # Build the visual-regression matrix.
             # On PRs, only run chromium shards — no story currently opts into webkit snapshots


### PR DESCRIPTION
## Problem

The Storybook CI workflow runs unnecessarily when a bot (like PostHog Bot) commits changes that only update `frontend/snapshots.yml`. This file is automatically updated after human review and CI approval, so re-running the full Storybook suite in these cases is wasteful.

## Changes

Updated the `ci-storybook.yml` workflow to:

1. Added a new filter for `snapshots` that matches `frontend/snapshots.yml`
2. Enhanced the `frontend` job condition to skip execution when:
   - The event is a pull request
   - The actor is a bot (contains `[bot]` or is `posthog-bot`)
   - The only changed frontend file is `snapshots.yml`

This prevents unnecessary Storybook builds while still running the full suite for actual code changes.

## How did you test this code?

The changes are to GitHub Actions workflow configuration. The logic will be validated by the CI system itself when:
- A bot commits only `frontend/snapshots.yml` changes (job should skip)
- A bot commits other frontend changes (job should run)
- A human commits changes (job should run regardless)

## Publish to changelog?

No

https://claude.ai/code/session_01NRAL5ZwjdkFrQkA4r1GafT