### PR TITLE
fix(devex): revert hogli db command rename breaking PR CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -452,7 +452,7 @@ jobs:
                   fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-schema-fresh
+                  ./bin/hogli db:restore-test-db
 
             - name: Register Temporal search attributes
               run: |
@@ -1322,7 +1322,7 @@ jobs:
                   fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-schema-fresh
+                  ./bin/hogli db:restore-test-db
 
             - name: Determine if --snapshot-update should be on
               # UPDATE mode: human commits - update snapshots

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -530,13 +530,13 @@ db:
     db:prime-test-db:
         steps:
             - db:download-schema
-            - db:restore-schema-fresh
+            - db:restore-test-db
         description: Download pre-migrated schema and prime the test_posthog database for
             pytest --reuse-db
         services:
             - postgresql
             - docker
-    db:restore-schema-fresh:
+    db:restore-test-db:
         cmd: |
             set -e
             TARGET_DB="${TARGET_DB:-test_posthog}"
@@ -570,6 +570,12 @@ db:
         services:
             - postgresql
             - docker
+    db:restore-schema-fresh:
+        steps:
+            - db:restore-test-db
+        description: Alias for db:restore-test-db. Kept so PR branches that pulled in the
+            short-lived rename (#57657) still resolve a valid command after the revert.
+            Safe to remove once those branches are merged or rebased.
     db:download-schema:
         cmd: "set -e\nmkdir -p .postgres-backups\necho \"Finding latest CI run with migrated-schema\
             \ artifact...\"\nRUN_ID=$(gh api 'repos/PostHog/posthog/actions/artifacts?name=migrated-schema&per_page=10'\


### PR DESCRIPTION
## Problem

#57657 renamed the hogli command `db:restore-test-db` to `db:restore-schema-fresh` in both `hogli.yaml` and `.github/workflows/ci-backend.yml`. For `pull_request` runs, GitHub executes the workflow YAML from the merge ref (PR + base) but `actions/checkout@v6` (no explicit `ref:`) ends up checking out the PR branch HEAD into the workspace. That asymmetry means PRs that hadn't pulled in the rename ran the new workflow command against an old `hogli.yaml`, blowing up the "Prime test_posthog from cached schema" step:

```
Error: No such command 'db:restore-schema-fresh'.
```

Looks intermittent across PRs because the step is gated on a schema-cache hit — cache miss exits 0, cache hit explodes.

## Changes

- Revert the rename in `ci-backend.yml` and `hogli.yaml` so the original `db:restore-test-db` name is back.
- Keep the `TARGET_DB` env-var support added in #57657 — only the command key changes.
- Add a `db:restore-schema-fresh` alias (steps → `db:restore-test-db`) so any PR that *did* pull in the rename, in the case where checkout grabs the merge ref, still resolves a valid command. Safe to remove once those branches have rebased.

## How did you test this code?

Agent-authored. Verified locally:
- `./bin/hogli --help` lists both `db:restore-test-db` and `db:restore-schema-fresh`
- `./bin/hogli db:restore-schema-fresh --help` shows the alias resolving to the same command

Real validation will be PRs going green again on master once this lands.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by Claude Code at the user's direction after a Slack report from #dev about every backend PR red on the schema-prime step.
- User asked to investigate first; root-caused to PR #57657 (mine) renaming the hogli command in lockstep across both files. Worked through the GitHub Actions ref asymmetry to understand why the failure was intermittent (cache hit only) and why it affects branches that haven't pulled in the rename.
- Initial draft was a plain revert; user pushed back asking whether reverting only on master would actually help older PR branches. Walked through the GH Actions workflow-file ref vs. checkout ref split to confirm the merged workflow YAML *does* propagate to all PR runs automatically — so a master-side fix is enough for stale branches, while branches that already pulled in #57657 will need a rebase. Added the alias as a belt-and-braces shim for the path where checkout pulls the merge ref.