### PR TITLE
fix(trends): move annotation to correct bar for compare against

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -68,6 +68,7 @@ export interface AnnotationsOverlayProps {
     chart: Chart
     chartWidth: number
     chartHeight: number
+    datasetIndex?: number
 }
 
 interface AnnotationsOverlayCSSProperties extends React.CSSProperties {
@@ -82,9 +83,15 @@ export const AnnotationsOverlay = React.memo(function AnnotationsOverlay({
     chartHeight,
     dates,
     insightNumericId,
+    datasetIndex = 0,
 }: AnnotationsOverlayProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { tickIntervalPx, firstTickLeftPx, getDataPointX } = useAnnotationsPositioning(chart, chartWidth, chartHeight)
+    const { tickIntervalPx, firstTickLeftPx, getDataPointX } = useAnnotationsPositioning(
+        chart,
+        chartWidth,
+        chartHeight,
+        datasetIndex
+    )
 
     // Memoize ticks by value to prevent unnecessary kea selector cascades.
     // chart.scales.x.ticks is a Chart.js internal array that is the same object between renders

--- a/frontend/src/lib/components/AnnotationsOverlay/useAnnotationsPositioning.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/useAnnotationsPositioning.ts
@@ -12,19 +12,21 @@ export interface AnnotationsPositioning {
 export function useAnnotationsPositioning(
     chart: Chart | undefined,
     chartWidth: number,
-    chartHeight: number
+    chartHeight: number,
+    datasetIndex = 0
 ): AnnotationsPositioning {
     // Calculate chart content coordinates for annotations overlay positioning
     return useMemo<AnnotationsPositioning>(() => {
         // @ts-expect-error - _metasets is not officially exposed
-        if (chart && chart.scales.x.ticks.length > 1 && chart._metasets?.[0]?.data?.length > 0) {
+        const metasets = chart?._metasets as PointMetaset[] | undefined
+        const points = metasets?.[datasetIndex]?.data ?? metasets?.[0]?.data ?? null
+
+        if (chart && chart.scales.x.ticks.length > 1 && points && points.length > 0) {
             const tickCount = chart.scales.x.ticks.length
             // NOTE: If there are lots of points on the X axis, Chart.js only renders a tick once n data points
             // so that the axis is readable. We use that mechanism to aggregate annotations for readability too.
             // We use the internal _metasets instead just taking graph area width, because it's NOT guaranteed that the
             // last tick is positioned at the right edge of the graph area. We need to find out where it is.
-            // @ts-expect-error - _metasets is not officially exposed
-            const points = chart._metasets[0].data as Point[]
             const firstTickPointIndex = chart.scales.x.ticks[0].value
             const lastTickPointIndex = chart.scales.x.ticks[tickCount - 1].value
             // Fall back to zero for resiliency against temporary chart inconsistencies during loading
@@ -44,5 +46,5 @@ export function useAnnotationsPositioning(
             firstTickLeftPx: 0,
             getDataPointX: () => null,
         }
-    }, [chart, chartWidth, chartHeight])
+    }, [chart, chartWidth, chartHeight, datasetIndex])
 }

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -365,6 +365,13 @@ export function LineGraph_({
     const isHighlightBarMode = isBar && isStacked && isShiftPressed
     const hasMultipleSeries = new Set(_datasets.map((d) => d.action?.order).filter((o) => o !== undefined)).size > 1
     const effectiveZoomCallback = !isBar && !isHorizontal ? onDateRangeZoom : undefined
+    const visibleAnnotationDatasets = !isHorizontal
+        ? datasets.filter((data) => !getTrendsHidden(data as IndexedTrendResult))
+        : datasets
+    const currentPeriodDatasetIndex = visibleAnnotationDatasets.findIndex(
+        (dataset) => dataset.compare && dataset.compare_label === 'current'
+    )
+    const annotationDatasetIndex = isBar && currentPeriodDatasetIndex >= 0 ? currentPeriodDatasetIndex : 0
     const zoomPluginOptions = useChartZoom({
         datasets,
         onDateRangeZoom: effectiveZoomCallback,
@@ -1308,6 +1315,7 @@ export function LineGraph_({
                     chartWidth={chartWidth}
                     chartHeight={chartHeight}
                     insightNumericId={insight.id || 'new'}
+                    datasetIndex={annotationDatasetIndex}
                 />
             ) : null}
         </div>

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -8,7 +8,7 @@ import chartTrendline from 'chartjs-plugin-trendline'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import {
     ActiveElement,
@@ -65,6 +65,9 @@ function truncateString(str: string, num: number): string {
 }
 
 const INCOMPLETE_SEGMENT_BORDER_DASH = [10, 10]
+// Chart.js locks up the main thread when rendering too many series, effectively
+// freezing the browser. Cap the dataset count to keep the UI responsive.
+const MAX_CHART_DATASETS = 150
 
 export function onTooltipClick(
     datasetIndex: number,
@@ -365,10 +368,18 @@ export function LineGraph_({
     const isHighlightBarMode = isBar && isStacked && isShiftPressed
     const hasMultipleSeries = new Set(_datasets.map((d) => d.action?.order).filter((o) => o !== undefined)).size > 1
     const effectiveZoomCallback = !isBar && !isHorizontal ? onDateRangeZoom : undefined
-    const visibleAnnotationDatasets = !isHorizontal
-        ? datasets.filter((data) => !getTrendsHidden(data as IndexedTrendResult))
-        : datasets
-    const currentPeriodDatasetIndex = visibleAnnotationDatasets.findIndex(
+    const visibleDatasets = useMemo(
+        () => (!isHorizontal ? datasets.filter((data) => !getTrendsHidden(data as IndexedTrendResult)) : datasets),
+        [datasets, getTrendsHidden, isHorizontal]
+    )
+    const chartDatasets = useMemo(
+        () =>
+            visibleDatasets.length > MAX_CHART_DATASETS
+                ? visibleDatasets.slice(0, MAX_CHART_DATASETS)
+                : visibleDatasets,
+        [visibleDatasets]
+    )
+    const currentPeriodDatasetIndex = chartDatasets.findIndex(
         (dataset) => dataset.compare && dataset.compare_label === 'current'
     )
     const annotationDatasetIndex = isBar && currentPeriodDatasetIndex >= 0 ? currentPeriodDatasetIndex : 0
@@ -623,22 +634,9 @@ export function LineGraph_({
     Chart.register(annotationPlugin)
     Chart.register(chartTrendline)
 
-    // Chart.js locks up the main thread when rendering too many series, effectively
-    // freezing the browser. Cap the dataset count to keep the UI responsive.
-    const MAX_CHART_DATASETS = 150
-
     const { canvasRef, chartRef } = useChart({
         getConfig: () => {
-            let filteredDatasets = datasets
-            if (!isHorizontal) {
-                filteredDatasets = filteredDatasets.filter((data) => !getTrendsHidden(data as IndexedTrendResult))
-            }
-
-            if (filteredDatasets.length > MAX_CHART_DATASETS) {
-                filteredDatasets = filteredDatasets.slice(0, MAX_CHART_DATASETS)
-            }
-
-            const processedDatasets = filteredDatasets.map(processDataset)
+            const processedDatasets = chartDatasets.map(processDataset)
             let seriesNonZeroMax = Number.NEGATIVE_INFINITY
             let seriesNonZeroMin = Number.POSITIVE_INFINITY
             for (const dataset of processedDatasets) {
@@ -1271,7 +1269,7 @@ export function LineGraph_({
             }
         },
         deps: [
-            datasets,
+            chartDatasets,
             isDarkModeOn,
             trendsFilter,
             formula,


### PR DESCRIPTION
## Problem

For trends insights with the "compare against previous" option enabled, the annotation for the current period was display at the bar for the previous period.

![Bildschirmfoto 2026-05-06 um 14.37.43.png](https://app.graphite.com/user-attachments/assets/b290f2be-b1fc-4b92-b76a-2778959f8b90.png)

## Changes

Fixes this.

![Bildschirmfoto 2026-05-06 um 14.36.01.png](https://app.graphite.com/user-attachments/assets/d5535872-bdfa-4fae-8a58-fda1279baa3c.png)

## How did you test this code?

Manual testing