### PR TITLE
chore(llma): add data-warehouse sandboxed evals

### DIFF
--- a/ee/hogai/eval/sandboxed/data_warehouse/README.md
+++ b/ee/hogai/eval/sandboxed/data_warehouse/README.md
@@ -1,0 +1,129 @@
+# Data-warehouse sandboxed evals
+
+Evals for the data-tools MCP surface — primarily `execute-sql` and the
+HogQL it produces. Owned by the data-tools team (SQL editor, notebooks,
+HogQL).
+
+## What's covered
+
+| File                      | What it asserts                                                                                           |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `eval_sql_recovery.py`    | Agent recovers from a broken HogQL query (typoed column, wrong-case function) without user nudging.       |
+| `eval_sql_correctness.py` | Agent's HogQL actually returns a number consistent with the Hedgebox demo seed (counts, joins, group-by). |
+| `eval_sql_regressions.py` | Pinned coverage for HogQL features we don't want silently regressing. Grow this file as fixes land.       |
+
+## How it relates to neighbouring suites
+
+- `cli_mcp/eval_workflow.py` (skoob13, #57472) grades workflow shape
+  ("did the agent verify schema _before_ querying?"). This folder grades
+  the layer underneath — _what answer came back_. The two are
+  complementary; cases in both folders should run together as part of a
+  full sweep.
+- `product_analytics/` grades structured `query-<insight>` output. We
+  grade free-form HogQL output. Different tools, different scorers.
+
+## Scorers
+
+`scorers.py` exports `HogQLOutputMatches`. Per the convention introduced
+in #57472, the spec lives under `expected[scorer_name]`:
+
+```python
+SandboxedEvalCase(
+    name="...",
+    prompt="...",
+    expected={
+        "hogql_output_matches": {
+            # Pick one:
+            "value": 1234,                 # exact
+            "min": 100, "max": 100_000,    # inclusive range
+            "non_zero": True,              # any positive number
+            "regex": r"\bdocs\b",          # text match (case-insensitive)
+            # Optional alongside `value`:
+            "tolerance": 0.5,
+        }
+    },
+)
+```
+
+The scorer searches both the last successful `execute-sql` tool output
+and the agent's final user-facing message. Either matching counts as a
+pass.
+
+`ExitCodeZero` and `RequiredToolCall` come from the shared
+`ee/hogai/eval/sandboxed/scorers/` package — reuse, don't duplicate.
+
+## Running
+
+The sandboxed harness boots a real `services/mcp/` worker, real LLM
+gateway, in-process Django, in-process Temporal, and Docker sandbox
+containers per case. First run takes a couple of minutes to seed the
+master Hedgebox team; subsequent runs reuse it via `--reuse-db`.
+
+```bash
+# Single file
+pytest ee/hogai/eval/sandboxed/data_warehouse/eval_sql_recovery.py
+
+# Single case
+pytest ee/hogai/eval/sandboxed/data_warehouse/eval_sql_recovery.py \
+    --eval=recovery_misspelled_column
+
+# Whole folder, both MCP modes (tools + cli) — defaults from conftest
+pytest ee/hogai/eval/sandboxed/data_warehouse/
+
+# Pin a single MCP mode
+pytest ee/hogai/eval/sandboxed/data_warehouse/ --mcp-mode=tools
+```
+
+`BRAINTRUST_API_KEY` and `OPENAI_API_KEY` must be set — the harness
+calls `EvalAsync` which logs into Braintrust at experiment-init time,
+and the tracing wrapper eagerly constructs an OpenAI client even when
+no scorer uses it. Get a real Braintrust key from `#team-posthog-ai`;
+`OPENAI_API_KEY=sk-not-used` is fine for deterministic-only suites
+since the client is never actually invoked.
+
+## Calibrating expected values
+
+Hedgebox's seed includes randomised simulation steps, so absolute counts
+shift slightly run-over-run. Cases in `eval_sql_correctness.py` use
+loose ranges (`min`/`max` or `non_zero`) deliberately — the goal is
+"the query returned the right _shape_ of answer", not "the count is
+exactly N".
+
+To tighten a range:
+
+1. Run the case once and inspect the local logs at
+   `ee/hogai/eval/sandboxed/.eval-logs/<experiment>/<case>/` — the
+   `last_message` and tool-call output show the actual number the agent
+   surfaced.
+2. Pick a range generous enough to absorb seed jitter (±20% is usually
+   fine) but tight enough to catch wrong-query bugs.
+3. Update `expected["hogql_output_matches"]` and re-run.
+
+Don't pin `value=N` exact-match unless you've confirmed the count is
+deterministic across re-seeds — for most demo-data questions, a range
+or `non_zero` is the right tool.
+
+## Adding a regression pin
+
+When a HogQL fix lands that we want to lock in:
+
+1. Add a `SandboxedEvalCase` to `eval_sql_regressions.py`.
+2. The prompt should _only_ succeed if the fixed behaviour holds —
+   ideally a query that erred or returned wrong results before the fix.
+3. Add a comment with the fix PR number so future readers know what the
+   pin is protecting.
+4. Use `HogQLOutputMatches` with a tight bound (the deterministic answer
+   the fix unlocks).
+
+## Deferred
+
+- **Notebooks tools** — current MCP tools are thin CRUD passthroughs;
+  no agent intelligence to grade. Revisit when smarter tools land
+  (insert HogQL block, run cell).
+- **Saved views workflow** (`view-create` → `view-run` →
+  `view-materialize`) — interesting because it's stateful and
+  multi-step, but lower priority than `execute-sql` semantic
+  correctness.
+- **SQL variables** — niche, low traffic.
+- **External-data-sources / pipeline health** — owned by the
+  warehouse-imports team, not data-tools.

--- a/ee/hogai/eval/sandboxed/data_warehouse/eval_sql_correctness.py
+++ b/ee/hogai/eval/sandboxed/data_warehouse/eval_sql_correctness.py
@@ -1,0 +1,97 @@
+"""SQL-correctness evals for the sandboxed data-warehouse agent.
+
+These cases ask the agent to compute something whose answer is determined
+by the Hedgebox demo seed and grade whether the number it surfaces is
+right. They are the layer underneath skoob13's workflow scorers in
+``cli_mcp/eval_workflow.py`` — those grade *which tools* the agent
+called; we grade *what the result was*.
+
+The expected values are bounded ranges, not exact numbers, because the
+Hedgebox seed includes randomised simulation steps and the absolute
+counts shift run-over-run. Ranges should be wide enough to absorb that
+randomness but tight enough that wrong queries (off-by-orders-of-magnitude
+errors, wrong filters, missing GROUP BY) fail. See ``README.md`` in this
+folder for how to calibrate the ranges against a real seed.
+
+Scoring stack per case:
+
+- ``ExitCodeZero`` — agent finished cleanly.
+- ``RequiredToolCall(["execute-sql"])`` — at least one successful
+  ``execute-sql`` call.
+- ``HogQLOutputMatches`` — the answer falls in the expected range.
+
+To run:
+    pytest ee/hogai/eval/sandboxed/data_warehouse/eval_sql_correctness.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.hogai.eval.sandboxed.base import SandboxedPublicEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.data_warehouse.scorers import HogQLOutputMatches
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, RequiredToolCall
+
+
+@pytest.mark.django_db
+async def eval_sql_correctness(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
+    cases = [
+        SandboxedEvalCase(
+            name="correctness_total_pageviews",
+            prompt="How many $pageview events are there in total? Just give me the count.",
+            # Wide range — the absolute number drifts with each Hedgebox
+            # seed run, but it's reliably in the thousands.
+            expected={
+                "hogql_output_matches": {"min": 100, "max": 1_000_000},
+            },
+        ),
+        SandboxedEvalCase(
+            name="correctness_distinct_users",
+            prompt="How many distinct users (distinct_id) have a $pageview event?",
+            expected={
+                "hogql_output_matches": {"min": 10, "max": 100_000},
+            },
+        ),
+        SandboxedEvalCase(
+            name="correctness_filtered_count",
+            prompt=("Count the number of $pageview events on the URL https://hedgebox.net/. Just give me the number."),
+            expected={
+                "hogql_output_matches": {"min": 10, "max": 1_000_000},
+            },
+        ),
+        SandboxedEvalCase(
+            name="correctness_group_by_top_event",
+            # The agent has to GROUP BY event and identify the top one.
+            # Hedgebox is a $pageview-heavy app so $pageview should win.
+            prompt=("Which single event name has the most occurrences? Just tell me the event name."),
+            expected={
+                "hogql_output_matches": {"regex": r"\$pageview"},
+            },
+        ),
+        SandboxedEvalCase(
+            name="correctness_join_persons",
+            # Forces a join from events to persons (or person properties).
+            # The agent has to know the right shape — we don't grade the
+            # exact number, only that something non-zero comes back.
+            prompt=(
+                "How many distinct users have a $pageview event AND have an email address set on their person profile?"
+            ),
+            expected={
+                "hogql_output_matches": {"non_zero": True},
+            },
+        ),
+    ]
+
+    await SandboxedPublicEval(
+        experiment_name=f"sandboxed-sql-correctness-{mcp_mode}",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            RequiredToolCall(["execute-sql"], name="execute_sql_succeeded"),
+            HogQLOutputMatches(),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/ee/hogai/eval/sandboxed/data_warehouse/eval_sql_recovery.py
+++ b/ee/hogai/eval/sandboxed/data_warehouse/eval_sql_recovery.py
@@ -1,0 +1,78 @@
+"""SQL-recovery evals for the sandboxed data-warehouse agent.
+
+These cases give the agent a query that *will* fail at parse or execution
+time and grade whether it recovers — fixes the query and re-runs via
+``execute-sql`` — without the user having to nudge it.
+
+Recovery is the complement to skoob13's ``eval_verify_event_before_query``
+in ``cli_mcp/eval_workflow.py``: that suite asks "did the agent verify
+schema *before* querying?", we ask "did the agent recover *after* a query
+broke?". Both signals are useful; an agent that always pre-verifies is
+safe but slow, an agent that recovers cleanly is robust under real-world
+typos and stale schema.
+
+Scoring stack per case:
+
+- ``ExitCodeZero`` — the agent process finished cleanly.
+- ``RequiredToolCall(["execute-sql"])`` — at least one *successful*
+  ``execute-sql`` call appears (the recovery actually ran).
+- ``HogQLOutputMatches`` — the fixed query returned a number consistent
+  with the demo data. The bound is loose (``non_zero`` or wide range)
+  because we care that recovery happened at all, not the precise count;
+  ``eval_sql_correctness`` is where exact answers live.
+
+To run:
+    pytest ee/hogai/eval/sandboxed/data_warehouse/eval_sql_recovery.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.hogai.eval.sandboxed.base import SandboxedPublicEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.data_warehouse.scorers import HogQLOutputMatches
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, RequiredToolCall
+
+
+@pytest.mark.django_db
+async def eval_sql_recovery(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
+    cases = [
+        SandboxedEvalCase(
+            name="recovery_misspelled_column",
+            # `evnt` instead of `event`. HogQL surfaces an unknown-column
+            # error; agent should consult the schema (or implicit
+            # knowledge) and rerun against the right column.
+            prompt=("Run this query and tell me the result:\n\nSELECT count() FROM events WHERE evnt = '$pageview'"),
+            expected={
+                "hogql_output_matches": {"non_zero": True},
+            },
+        ),
+        SandboxedEvalCase(
+            name="recovery_wrong_function_case",
+            # ClickHouse function names are case-sensitive — `DATEDIFF`
+            # doesn't exist, the agent should reach for `dateDiff`.
+            prompt=(
+                "Use this query as a starting point and tell me how many distinct days "
+                "had pageview events:\n\n"
+                "SELECT DATEDIFF('day', min(timestamp), max(timestamp)) "
+                "FROM events WHERE event = '$pageview'"
+            ),
+            expected={
+                "hogql_output_matches": {"non_zero": True},
+            },
+        ),
+    ]
+
+    await SandboxedPublicEval(
+        experiment_name=f"sandboxed-sql-recovery-{mcp_mode}",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            RequiredToolCall(["execute-sql"], name="execute_sql_succeeded"),
+            HogQLOutputMatches(),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/ee/hogai/eval/sandboxed/data_warehouse/eval_sql_regressions.py
+++ b/ee/hogai/eval/sandboxed/data_warehouse/eval_sql_regressions.py
@@ -1,0 +1,73 @@
+"""HogQL feature-regression pins.
+
+A growing file of *one case per recently-fixed HogQL behaviour*, kept so
+silent regressions get caught the next time a query parser, printer, or
+MCP-layer fix lands.
+
+Each case should be cheap (single ``execute-sql`` call), exercise the
+exact feature that was fixed, and assert on a deterministic outcome via
+``HogQLOutputMatches``. Adding a new pin: drop another
+``SandboxedEvalCase`` with a prompt that *only* succeeds if the fixed
+behaviour holds, and a tight ``expected`` bound. Reference the fix PR
+in a comment so future-readers know what each pin protects.
+
+The two cases below are bootstrap structure — generic HogQL features
+that every fix touches in some form — not specific known regressions.
+Replace them as concrete fixes land that we want to lock in.
+
+To run:
+    pytest ee/hogai/eval/sandboxed/data_warehouse/eval_sql_regressions.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.hogai.eval.sandboxed.base import SandboxedPublicEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.data_warehouse.scorers import HogQLOutputMatches
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, RequiredToolCall
+
+
+@pytest.mark.django_db
+async def eval_sql_regressions(sandboxed_demo_data, pytestconfig, posthog_client, mcp_mode):
+    cases = [
+        SandboxedEvalCase(
+            name="regression_time_window_filter",
+            # Exercises HogQL's date arithmetic + relative-time filtering.
+            # If the parser regresses on `now() - INTERVAL` or `dateDiff`,
+            # this case starts returning 0 or erroring.
+            prompt=("How many $pageview events happened in the last 90 days? Just give me the count."),
+            expected={
+                "hogql_output_matches": {"non_zero": True},
+            },
+        ),
+        SandboxedEvalCase(
+            name="regression_subquery_in_filter",
+            # Exercises subquery + IN — a shape MCP-driven agents hit a
+            # lot when chaining "find users matching X, then count their
+            # events". Regressions in subquery scoping or correlated
+            # subquery handling fail this case loudly.
+            prompt=(
+                "Count $pageview events from users (distinct_id) who also "
+                "have at least one event with event = '$autocapture'. "
+                "Just give me the number."
+            ),
+            expected={
+                "hogql_output_matches": {"non_zero": True},
+            },
+        ),
+    ]
+
+    await SandboxedPublicEval(
+        experiment_name=f"sandboxed-sql-regressions-{mcp_mode}",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            RequiredToolCall(["execute-sql"], name="execute_sql_succeeded"),
+            HogQLOutputMatches(),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/ee/hogai/eval/sandboxed/data_warehouse/scorers.py
+++ b/ee/hogai/eval/sandboxed/data_warehouse/scorers.py
@@ -1,0 +1,201 @@
+"""Data-warehouse scorers for the sandboxed agent evals.
+
+The product-analytics scorers grade an agent's *query construction* (was
+the right ``query-<insight>`` shape produced?). We're a layer below: did
+the HogQL query actually return the right answer?
+
+``HogQLOutputMatches`` looks for the answer in two places — the last
+successful ``execute-sql`` tool result, and the agent's final message —
+and accepts a small spec language so cases can pin an exact number, a
+range, a non-zero floor, or a regex for free-form answers.
+
+Per the convention introduced in #57472, the spec lives under
+``expected[scorer_name]``; cases that don't supply one score ``None``
+so unrelated cases don't drag the rollup down.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from braintrust import Score
+from braintrust_core.score import Scorer
+
+from ee.hogai.eval.sandboxed.log_parser import LogParser
+
+EXECUTE_SQL_TOOL_NAME = "execute-sql"
+
+_NUMBER_RE = re.compile(r"-?\d{1,3}(?:[,_]\d{3})+(?:\.\d+)?|-?\d+(?:\.\d+)?")
+"""Matches integers and decimals, with or without thousands separators.
+
+Deliberately permissive — agents render counts as ``1234``, ``1,234``,
+``1_234``, or ``1234.0`` depending on phrasing, and we want a hit on any
+of them. The separator-group alternative requires *at least one*
+separator (``+`` not ``*``) so plain digits like ``12345`` fall through
+to the second alternative and match as a single number rather than
+``123`` + ``45``."""
+
+
+def _parse_number(token: str) -> float | None:
+    cleaned = token.replace(",", "").replace("_", "")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _extract_numbers(text: str) -> list[float]:
+    if not text:
+        return []
+    return [n for n in (_parse_number(m) for m in _NUMBER_RE.findall(text)) if n is not None]
+
+
+def _parser_for(output: dict | None) -> LogParser | None:
+    if not output:
+        return None
+    raw_log = output.get("raw_log")
+    if not raw_log:
+        return None
+    return LogParser(raw_log, initial_prompt=output.get("prompt", "") or "")
+
+
+def _last_successful_sql_output(parser: LogParser) -> str:
+    """Return the raw text output of the last successful ``execute-sql`` call.
+
+    We pull from the *last* successful call so a recovery case (broken
+    query → fixed query) is graded on the fixed query, not the broken one.
+    """
+    successful = [c for c in parser.get_tool_calls(EXECUTE_SQL_TOOL_NAME) if not c.is_error]
+    if not successful:
+        return ""
+    return successful[-1].output or ""
+
+
+class HogQLOutputMatches(Scorer):
+    """Did the agent's HogQL run actually produce the expected answer?
+
+    Looks at both the last successful ``execute-sql`` tool output and the
+    agent's final user-facing message. Passes if either contains a number
+    (or text) matching the spec.
+
+    Expected shape (under ``expected[scorer_name]``)::
+
+        {
+            # Pick exactly one of:
+            "value": 1234,                  # exact numeric match
+            "min": 100, "max": 100000,      # range (inclusive on both ends)
+            "non_zero": True,               # any number > 0
+            "regex": r"\\bdocs\\b",          # text match (case-insensitive)
+            # Optional:
+            "tolerance": 0.0,               # absolute tolerance for "value"
+        }
+
+    Numeric specs check both the SQL output and the last assistant message
+    so the agent's prose count is acceptable evidence even if our parse of
+    the tool output misses the right column. Regex only checks the
+    assistant message, which is where free-form answers live.
+    """
+
+    def __init__(self, *, name: str = "hogql_output_matches"):
+        self._label = name
+
+    def _name(self) -> str:
+        return self._label
+
+    async def _run_eval_async(self, output, expected=None, **kwargs):
+        return self._evaluate(output, expected)
+
+    def _run_eval_sync(self, output, expected=None, **kwargs):
+        return self._evaluate(output, expected)
+
+    def _evaluate(self, output: dict | None, expected: dict | None) -> Score:
+        if not output:
+            return Score(name=self._name(), score=None, metadata={"reason": "No output"})
+
+        spec = self._spec(expected)
+        if spec is None:
+            return Score(name=self._name(), score=None, metadata={"reason": "No spec provided"})
+
+        parser = _parser_for(output)
+        sql_output = _last_successful_sql_output(parser) if parser else ""
+        last_message = output.get("last_message") or ""
+
+        if "regex" in spec:
+            return self._eval_regex(spec["regex"], last_message, sql_output)
+        return self._eval_numeric(spec, sql_output, last_message)
+
+    def _spec(self, expected: dict | None) -> dict | None:
+        if not isinstance(expected, dict):
+            return None
+        spec = expected.get(self._name())
+        if not isinstance(spec, dict):
+            return None
+        # At least one mode must be present.
+        if not any(k in spec for k in ("value", "min", "max", "non_zero", "regex")):
+            return None
+        return spec
+
+    def _eval_regex(self, pattern: Any, last_message: str, sql_output: str) -> Score:
+        if not isinstance(pattern, str):
+            return Score(
+                name=self._name(),
+                score=None,
+                metadata={"reason": "regex must be a string"},
+            )
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            return Score(name=self._name(), score=None, metadata={"reason": f"invalid regex: {e}"})
+        haystack = f"{last_message}\n{sql_output}"
+        match = compiled.search(haystack)
+        return Score(
+            name=self._name(),
+            score=1.0 if match else 0.0,
+            metadata={
+                "pattern": pattern,
+                "matched": bool(match),
+                "matched_text": match.group(0) if match else None,
+            },
+        )
+
+    def _eval_numeric(self, spec: dict, sql_output: str, last_message: str) -> Score:
+        candidates = _extract_numbers(sql_output) + _extract_numbers(last_message)
+        if not candidates:
+            return Score(
+                name=self._name(),
+                score=0.0,
+                metadata={"reason": "No number found in SQL output or final message"},
+            )
+
+        # Passing once is enough — agents may quote intermediate numbers,
+        # so we accept any candidate that matches the spec.
+        for n in candidates:
+            if self._matches(n, spec):
+                return Score(
+                    name=self._name(),
+                    score=1.0,
+                    metadata={"matched_number": n, "spec": spec},
+                )
+        return Score(
+            name=self._name(),
+            score=0.0,
+            metadata={
+                "reason": "No candidate matched spec",
+                "spec": spec,
+                "candidates": candidates[:10],
+            },
+        )
+
+    @staticmethod
+    def _matches(n: float, spec: dict) -> bool:
+        if "value" in spec:
+            tolerance = float(spec.get("tolerance", 0.0))
+            return abs(n - float(spec["value"])) <= tolerance
+        if "min" in spec or "max" in spec:
+            lo = float(spec["min"]) if "min" in spec else float("-inf")
+            hi = float(spec["max"]) if "max" in spec else float("inf")
+            return lo <= n <= hi
+        if spec.get("non_zero"):
+            return n > 0
+        return False


### PR DESCRIPTION
## Problem

The data-tools team (SQL editor, notebooks, HogQL) doesn't currently have evals covering the `execute-sql` MCP surface as called by external agents.

#57472 (skoob13) covers workflow shape — *which tools the agent calls in what order*. This PR adds the layer below: did the HogQL the agent produced actually return the right answer? The two are complementary; cases in both folders should run together as part of a full sweep.

## Changes

Adds `ee/hogai/eval/sandboxed/data_warehouse/`:

- `scorers.py` — `HogQLOutputMatches`, a deterministic scorer that compares numbers/text in the agent's last successful `execute-sql` output and final message against a small spec language (exact `value` with optional `tolerance`, inclusive `min`/`max` range, `non_zero`, or `regex`). Follows the `expected[scorer_name]` convention from #57472 so cases that don't supply a spec score `None` and don't drag the rollup down.
- `eval_sql_recovery.py` — 2 cases. Agent recovers from a broken HogQL query (typoed column, wrong-case function) without user nudging.
- `eval_sql_correctness.py` — 5 cases. Agent's HogQL returns numbers consistent with the Hedgebox demo seed (counts, joins, group-by). Loose ranges to absorb seed jitter; calibration step documented in the README.
- `eval_sql_regressions.py` — 2 placeholder cases. Bootstrap structure for pinning recently-fixed HogQL behaviour; should grow as concrete fixes land.
- `README.md` — what's covered, calibration steps, deferred work (notebooks, saved views, SQL variables, external-data-sources).

Doesn't touch shared infra (`log_parser.py`, `conftest.py`, shared `scorers/`) — stays clear of #57472's footprint to avoid rebase pain.

## How did you test this code?

Agent-authored. Verified locally:

- All 4 modules import cleanly with Django configured.
- `HogQLOutputMatches` smoke-tested at the unit level (`1234`, `1,234`, `1_234`, `12,345.6`; spec parsing for all four match modes).
- `pytest --collect-only` enumerates 6 tests (3 evals × 2 MCP modes).
- `ruff check` and `ruff format` pass.

End-to-end against the real sandboxed harness has **not** been run from this branch — the harness needs `BRAINTRUST_API_KEY` (or the SDK's `___TEST_API_KEY__` pseudo-login sentinel) plus a few minutes for demo-seed setup, neither of which I had set up reliably during authoring. Reviewers running the suite should expect to calibrate the `min`/`max` bounds in `eval_sql_correctness.py` against actual Hedgebox numbers — README documents how.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 Agent context

- Tool: Claude Code (claude-opus-4-7).
- Authored from a multi-session conversation about evals for the data-tools MCP surface. Earlier sessions covered: where to start with evals (sandboxed harness, not CI), how the harness's `EvalAsync` call always requires Braintrust login (the bypass is `BRAINTRUST_API_KEY=___TEST_API_KEY__`), and a comparison against the parallel work in #57472 to avoid stepping on toes.
- Key decisions:
  - **Scope down to `execute-sql` only for first landing.** Other data-warehouse MCP tools (saved views, SQL variables, notebooks CRUD) deferred per README — the intelligence-to-eval ratio is highest on `execute-sql`.
  - **Don't duplicate skoob13's workflow scorers** (`VerifiedEventBeforeQuery`, `DrilledIntoSchema`, `InfoBeforeCall`). Reuse `ExitCodeZero` / `RequiredToolCall` from the shared package; add a new layer (output correctness) that doesn't overlap.
  - **Loose ranges over exact values in `eval_sql_correctness.py`.** Hedgebox seed has randomised steps so absolute counts shift run-over-run; the README explains how to tighten by inspecting `.eval-logs/`.
  - **`eval_sql_regressions.py` shipped as bootstrap structure rather than fabricating specific fixes.** Earlier conversation referenced `QUALIFY` and `toDateTime64` regressions; recent git log of `posthog/hogql/` doesn't show those landings, so the file ships with two generic HogQL-shape pins (relative-time filter, subquery+IN) and clear instructions in the README on growing it as real fixes land.