### PR TITLE
chore(devex): block manual api.* calls in product frontends via semgrep

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -141,14 +141,14 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
-            # Custom rules only — the broader JS/security packs (p/javascript, p/owasp-top-ten,
-            # p/trailofbits) would surface a long tail of un-triaged findings on product frontend
-            # code. Keep this job tight: enforce our internal product conventions and grow
-            # incrementally.
+            # Single-rule scan — keeps the failure surface here aligned with the
+            # job name. Other custom TS rules (no-direct-fuse-instantiation,
+            # require-iframe-sandbox, ...) live in semgrep-js. When more
+            # product-specific rules land, extend the --config list explicitly.
             - name: Run Semgrep
               run: |
                   semgrep \
-                    --config ".semgrep/rules/" \
+                    --config ".semgrep/rules/prefer-codegen-api.yaml" \
                     --error \
                     --metrics=off \
                     --verbose \

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -131,6 +131,29 @@ jobs:
                     --verbose \
                     frontend/ nodejs/ services/mcp/ services/oauth-proxy/ services/stripe-app/
 
+    semgrep-products-frontend:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        container:
+            image: semgrep/semgrep
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            # Custom rules only — the broader JS/security packs (p/javascript, p/owasp-top-ten,
+            # p/trailofbits) would surface a long tail of un-triaged findings on product frontend
+            # code. Keep this job tight: enforce our internal product conventions and grow
+            # incrementally.
+            - name: Run Semgrep
+              run: |
+                  semgrep \
+                    --config ".semgrep/rules/" \
+                    --error \
+                    --metrics=off \
+                    --verbose \
+                    products/
+
     # scans GitHub Actions and other repo-wide config
     semgrep-general:
         runs-on: ubuntu-latest
@@ -185,7 +208,14 @@ jobs:
                   semgrep --test .semgrep/
 
     semgrep_checks:
-        needs: [semgrep-python, semgrep-go, semgrep-rust, semgrep-js, semgrep-general, semgrep-test-rules]
+        needs:
+            - semgrep-python
+            - semgrep-go
+            - semgrep-rust
+            - semgrep-js
+            - semgrep-products-frontend
+            - semgrep-general
+            - semgrep-test-rules
         name: Semgrep Checks Pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -207,6 +237,10 @@ jobs:
                   fi
                   if [[ "${{ needs.semgrep-js.result }}" != "success" && "${{ needs.semgrep-js.result }}" != "skipped" ]]; then
                     echo "semgrep-js did not complete successfully."
+                    exit 1
+                  fi
+                  if [[ "${{ needs.semgrep-products-frontend.result }}" != "success" && "${{ needs.semgrep-products-frontend.result }}" != "skipped" ]]; then
+                    echo "semgrep-products-frontend did not complete successfully."
                     exit 1
                   fi
                   if [[ "${{ needs.semgrep-general.result }}" != "success" && "${{ needs.semgrep-general.result }}" != "skipped" ]]; then

--- a/.semgrep/rules/prefer-codegen-api.test.ts
+++ b/.semgrep/rules/prefer-codegen-api.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+// Test fixture for prefer-codegen-api rule.
+
+import api from 'lib/api'
+
+// ruleid: prefer-codegen-api
+const a = await api.get(`api/foo`)
+
+// ruleid: prefer-codegen-api
+const b = await api.post(`api/foo`, {})
+
+// ruleid: prefer-codegen-api
+const c = await api.create(`api/foo`, {})
+
+// ruleid: prefer-codegen-api
+const d = await api.update(`api/foo/${id}`, {})
+
+// ruleid: prefer-codegen-api
+const e = await api.delete(`api/foo/${id}`)
+
+// ruleid: prefer-codegen-api
+const f = await api.patch(`api/foo/${id}`, {})
+
+// ruleid: prefer-codegen-api
+const g = await api.put(`api/foo/${id}`, {})
+
+// ruleid: prefer-codegen-api
+const h = await api.create<Foo>(`api/foo`, {})
+
+// ruleid: prefer-codegen-api
+const i = await api.get<Foo>(`api/foo`)
+
+// ok: prefer-codegen-api
+const j = await api.integrations.authorizeUrl()
+
+// ok: prefer-codegen-api
+const k = await api.dashboards.list()
+
+// ok: prefer-codegen-api
+const l = await legalDocumentsList(orgId)
+
+// nosemgrep: prefer-codegen-api
+const m = await api.get(`api/foo`)

--- a/.semgrep/rules/prefer-codegen-api.test.ts
+++ b/.semgrep/rules/prefer-codegen-api.test.ts
@@ -30,6 +30,12 @@ const h = await api.create<Foo>(`api/foo`, {})
 // ruleid: prefer-codegen-api
 const i = await api.get<Foo>(`api/foo`)
 
+// ruleid: prefer-codegen-api
+const i2 = await api.get<PaginatedResponse<Foo>>(`api/foo`)
+
+// ruleid: prefer-codegen-api
+const i3 = await api.get<CountedPaginatedResponse<ChangeRequest>>(`api/foo`)
+
 // ok: prefer-codegen-api
 const j = await api.integrations.authorizeUrl()
 

--- a/.semgrep/rules/prefer-codegen-api.yaml
+++ b/.semgrep/rules/prefer-codegen-api.yaml
@@ -1,0 +1,33 @@
+rules:
+    - id: prefer-codegen-api
+      message: >-
+          Manual `api.<verb>(...)` call in product frontend code. Prefer the generated
+          client in `products/<product>/frontend/generated/api.ts`.
+
+          Agents: invoke the `adopting-generated-api-types` skill
+          (`.agents/skills/adopting-generated-api-types/SKILL.md`) for the migration
+          workflow. Humans: run `hogli product:maturity --codegen <product>` to see
+          the suggested generated function per call site.
+
+          If no generated equivalent is available yet (endpoint missing OpenAPI tags,
+          dynamic URL, etc.), add `// nosemgrep: prefer-codegen-api` above this line —
+          the maturity tooling continues to track tagged sites.
+      severity: ERROR
+      languages: [typescript, javascript]
+      pattern-either:
+          - pattern: api.get(...)
+          - pattern: api.post(...)
+          - pattern: api.put(...)
+          - pattern: api.patch(...)
+          - pattern: api.delete(...)
+          - pattern: api.create(...)
+          - pattern: api.update(...)
+          # Semgrep's TypeScript parser treats generic-typed calls (api.create<T>())
+          # as a different AST shape that AST-level patterns above don't match,
+          # so fall back to a regex for that case.
+          - pattern-regex: '\bapi\.(get|post|put|patch|delete|create|update)<[^>]*>\s*\('
+      paths:
+          include:
+              - 'products/*/frontend/'
+          exclude:
+              - '**/generated/**'

--- a/.semgrep/rules/prefer-codegen-api.yaml
+++ b/.semgrep/rules/prefer-codegen-api.yaml
@@ -28,6 +28,6 @@ rules:
           - pattern-regex: '\bapi\.(get|post|put|patch|delete|create|update)<[^>]*>\s*\('
       paths:
           include:
-              - 'products/*/frontend/'
+              - '/products/*/frontend/'
           exclude:
               - '**/generated/**'

--- a/.semgrep/rules/prefer-codegen-api.yaml
+++ b/.semgrep/rules/prefer-codegen-api.yaml
@@ -24,8 +24,9 @@ rules:
           - pattern: api.update(...)
           # Semgrep's TypeScript parser treats generic-typed calls (api.create<T>())
           # as a different AST shape that AST-level patterns above don't match,
-          # so fall back to a regex for that case.
-          - pattern-regex: '\bapi\.(get|post|put|patch|delete|create|update)<[^>]*>\s*\('
+          # so fall back to a regex. Bounds the type args by `(` rather than `>` so
+          # nested generics like api.get<PaginatedResponse<Foo>>(...) still match.
+          - pattern-regex: '\bapi\.(get|post|put|patch|delete|create|update)<[^(]*>\s*\('
       paths:
           include:
               - '/products/*/frontend/'

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -211,6 +211,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
                     if (!props.id) {
                         return []
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(`api/projects/@current/actions/${props.id}/references`)
                     return response
                 },

--- a/products/actions/frontend/utils/deleteAction.tsx
+++ b/products/actions/frontend/utils/deleteAction.tsx
@@ -13,6 +13,7 @@ import type { ActionReferenceApi } from '../generated/api.schemas'
 export async function deleteActionWithWarning(action: ActionType, callback: (undo: boolean) => void): Promise<void> {
     let references: ActionReferenceApi[] = []
     try {
+        // nosemgrep: prefer-codegen-api
         references = await api.get(`api/projects/@current/actions/${action.id}/references`)
     } catch {
         // If we can't fetch references, proceed with delete anyway

--- a/products/conversations/frontend/components/SavedViews/ticketViewsLogic.ts
+++ b/products/conversations/frontend/components/SavedViews/ticketViewsLogic.ts
@@ -42,10 +42,12 @@ export const ticketViewsLogic = kea<ticketViewsLogicType>([
             [] as SavedTicketView[],
             {
                 loadViews: async () => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(viewsUrl(values.currentTeamId))
                     return response.results
                 },
                 createView: async ({ name, filters }: { name: string; filters: TicketViewFilters }) => {
+                    // nosemgrep: prefer-codegen-api
                     const created: SavedTicketView = await api.create(viewsUrl(values.currentTeamId), {
                         name,
                         filters,
@@ -100,6 +102,7 @@ export const ticketViewsLogic = kea<ticketViewsLogicType>([
         },
         deleteView: async ({ shortId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.delete(`${viewsUrl(values.currentTeamId)}/${shortId}`)
                 lemonToast.success('View deleted')
             } catch {

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -281,6 +281,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             {
                 loadGithubRepos: async () => {
                     try {
+                        // nosemgrep: prefer-codegen-api
                         const response = await api.create('api/conversations/v1/github/repos', {})
                         return response.repos || []
                     } catch {
@@ -295,6 +296,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             {
                 loadSlackChannelsWithToken: async () => {
                     try {
+                        // nosemgrep: prefer-codegen-api
                         const response = await api.create(`api/conversations/v1/slack/channels`, {})
                         return response.channels || []
                     } catch {
@@ -309,6 +311,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             {
                 loadTeamsTeamsWithToken: async () => {
                     try {
+                        // nosemgrep: prefer-codegen-api
                         const response = await api.create('api/conversations/v1/teams/teams', {})
                         return response.teams || []
                     } catch {
@@ -323,6 +326,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             {
                 loadTeamsChannelsForTeam: async ({ teamId }) => {
                     try {
+                        // nosemgrep: prefer-codegen-api
                         const response = await api.create('api/conversations/v1/teams/channels', {
                             team_id: teamId,
                         })
@@ -407,6 +411,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
     listeners(({ values, actions }) => ({
         connectSlack: async ({ nextPath }) => {
             const query = encodeURIComponent(nextPath)
+            // nosemgrep: prefer-codegen-api
             const response = await api.get(`api/conversations/v1/slack/authorize?next=${query}`)
             window.location.href = response.url
         },
@@ -555,6 +560,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         // Email multi-config listeners
         loadEmailConfigs: async () => {
             try {
+                // nosemgrep: prefer-codegen-api
                 const response = await api.get('api/conversations/v1/email/status')
                 actions.loadEmailConfigsDone(response.configs || [])
             } catch {
@@ -569,6 +575,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 return
             }
             try {
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create('api/conversations/v1/email/connect', {
                     from_email: newEmailFromEmail,
                     from_name: newEmailFromName,
@@ -588,6 +595,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         disconnectEmail: async ({ configId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/email/disconnect', { config_id: configId })
             } catch {
                 lemonToast.error('Failed to disconnect email')
@@ -607,6 +615,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         verifyEmailDomain: async ({ configId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create('api/conversations/v1/email/verify-domain', {
                     config_id: configId,
                 })
@@ -623,6 +632,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         sendTestEmail: async ({ configId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create('api/conversations/v1/email/send-test', {
                     config_id: configId,
                 })
@@ -635,6 +645,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         disconnectSlack: async () => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/slack/disconnect', {})
             } catch {
                 lemonToast.error('Failed to disconnect Slack')
@@ -657,6 +668,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         connectTeams: async ({ nextPath }) => {
             try {
                 const query = encodeURIComponent(nextPath)
+                // nosemgrep: prefer-codegen-api
                 const response = await api.get(`api/conversations/v1/teams/authorize?next=${query}`)
                 window.location.href = response.url
             } catch {
@@ -665,6 +677,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         disconnectTeams: async () => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/teams/disconnect', {})
             } catch {
                 lemonToast.error('Failed to disconnect Microsoft Teams')
@@ -676,6 +689,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         setTeamsTeam: async ({ teamId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/teams/select-channel', {
                     teams_team_id: teamId,
                 })
@@ -692,6 +706,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         installTeamsApp: async ({ teamId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create('api/conversations/v1/teams/install', {
                     team_id: teamId,
                 })
@@ -726,6 +741,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 return
             }
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/teams/select-channel', {
                     teams_team_id: teamsTeamId,
                     teams_channel_id: channelId,
@@ -738,6 +754,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         connectGithub: async ({ integrationId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/github/connect', { integration_id: integrationId })
                 actions.loadCurrentTeam()
                 actions.loadGithubRepos()
@@ -748,6 +765,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         disconnectGithub: async () => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/github/disconnect', {})
                 actions.loadCurrentTeam()
                 lemonToast.success('GitHub disconnected')
@@ -757,6 +775,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         setGithubRepos: async ({ repos }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create('api/conversations/v1/github/select-repos', { repos })
                 actions.loadCurrentTeam()
             } catch {

--- a/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
+++ b/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
@@ -323,6 +323,7 @@ export const supportTicketsSceneLogic = kea<supportTicketsSceneLogicType>([
         const viewShortId = searchParams.view
         if (viewShortId) {
             const teamId = teamLogic.values.currentTeamId
+            // nosemgrep: prefer-codegen-api
             api.get(`api/environments/${teamId}/conversations/views/${viewShortId}`)
                 .then((view: SavedTicketView) => {
                     actions.applyViewFilters(view.filters || {})

--- a/products/legal_documents/frontend/scenes/legalDocumentsLogic.ts
+++ b/products/legal_documents/frontend/scenes/legalDocumentsLogic.ts
@@ -71,6 +71,7 @@ export const legalDocumentsLogic = kea<legalDocumentsLogicType>([
                     if (!values.currentOrganizationId) {
                         return []
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(`api/organizations/${values.currentOrganizationId}/legal_documents`)
                     return (response.results ?? []) as LegalDocument[]
                 },
@@ -103,6 +104,7 @@ export const legalDocumentsLogic = kea<legalDocumentsLogicType>([
                 // single DPA variant, so we never send it on the wire.
                 const { dpa_mode: _dpaMode, ...payload } = formValues
                 try {
+                    // nosemgrep: prefer-codegen-api
                     const legalDocument = await api.create<LegalDocument>(
                         `api/organizations/${values.currentOrganizationId}/legal_documents`,
                         payload

--- a/products/live_debugger/frontend/liveDebuggerLogic.ts
+++ b/products/live_debugger/frontend/liveDebuggerLogic.ts
@@ -70,6 +70,7 @@ export const liveDebuggerLogic = kea<liveDebuggerLogicType>([
 
                     const queryString = params.toString()
                     const url = `api/projects/${values.currentProjectId}/live_debugger_breakpoints/?${queryString}`
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(url)
                     return response.results || []
                 },
@@ -87,6 +88,7 @@ export const liveDebuggerLogic = kea<liveDebuggerLogicType>([
 
                     const queryString = params.toString()
                     const url = `api/projects/${values.currentProjectId}/live_debugger_breakpoints/breakpoint_hits/${queryString ? `?${queryString}` : ''}`
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(url)
                     return response.results || []
                 },
@@ -161,10 +163,12 @@ export const liveDebuggerLogic = kea<liveDebuggerLogicType>([
                 : undefined
 
             if (existingBreakpoint) {
+                // nosemgrep: prefer-codegen-api
                 await api.delete(
                     `api/projects/${values.currentProjectId}/live_debugger_breakpoints/${existingBreakpoint.id}/`
                 )
             } else {
+                // nosemgrep: prefer-codegen-api
                 await api.create(`api/projects/${values.currentProjectId}/live_debugger_breakpoints/`, {
                     repository,
                     filename,
@@ -184,10 +188,12 @@ export const liveDebuggerLogic = kea<liveDebuggerLogicType>([
                 : undefined
 
             if (existingBreakpoint) {
+                // nosemgrep: prefer-codegen-api
                 await api.delete(
                     `api/projects/${values.currentProjectId}/live_debugger_breakpoints/${existingBreakpoint.id}/`
                 )
             } else {
+                // nosemgrep: prefer-codegen-api
                 await api.create(`api/projects/${values.currentProjectId}/live_debugger_breakpoints/`, {
                     repository,
                     filename,
@@ -203,6 +209,7 @@ export const liveDebuggerLogic = kea<liveDebuggerLogicType>([
             if (Array.isArray(values.breakpoints)) {
                 await Promise.all(
                     values.breakpoints.map((bp) =>
+                        // nosemgrep: prefer-codegen-api
                         api.delete(`api/projects/${values.currentProjectId}/live_debugger_breakpoints/${bp.id}/`)
                     )
                 )

--- a/products/llm_analytics/frontend/clusters/clusteringConfigLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusteringConfigLogic.ts
@@ -35,12 +35,14 @@ export const clusteringConfigLogic = kea<clusteringConfigLogicType>([
             { event_filters: [], created_at: '', updated_at: '' } as ClusteringConfig,
             {
                 loadConfig: async () => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_config/`
                     )
                     return response as ClusteringConfig
                 },
                 saveEventFilters: async () => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_config/set_event_filters/`,
                         {

--- a/products/llm_analytics/frontend/clusters/clusteringJobsLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusteringJobsLogic.ts
@@ -25,18 +25,21 @@ export const clusteringJobsLogic = kea<clusteringJobsLogicType>([
             [] as ClusteringJob[],
             {
                 loadJobs: async () => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_jobs/`
                     )
                     return (response.results ?? response) as ClusteringJob[]
                 },
                 createJob: async (payload: Partial<ClusteringJob>) => {
+                    // nosemgrep: prefer-codegen-api
                     await api.create(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_jobs/`,
                         payload
                     )
                     lemonToast.success('Clustering job created')
                     // Reload to get server-assigned fields
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_jobs/`
                     )
@@ -44,11 +47,13 @@ export const clusteringJobsLogic = kea<clusteringJobsLogicType>([
                 },
                 updateJob: async (payload: Partial<ClusteringJob> & { id: number }) => {
                     const { id, ...data } = payload
+                    // nosemgrep: prefer-codegen-api
                     await api.update(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_jobs/${id}/`,
                         data
                     )
                     lemonToast.success('Clustering job updated')
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_jobs/`
                     )
@@ -81,6 +86,7 @@ export const clusteringJobsLogic = kea<clusteringJobsLogicType>([
         },
         deleteJob: async ({ jobId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.delete(
                     `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_jobs/${jobId}/`
                 )

--- a/products/llm_analytics/frontend/clusters/clustersAdminLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersAdminLogic.ts
@@ -92,6 +92,7 @@ export const clustersAdminLogic = kea<clustersAdminLogicType>([
             null as ClusteringRunResponse | null,
             {
                 triggerClusteringRun: async () => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(
                         `api/environments/${values.currentTeamIdStrict}/llm_analytics/clustering_runs`,
                         values.params

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -163,6 +163,7 @@ export async function persistReportDraft(
             lemonToast.warning('Scheduled report not saved — add at least one delivery target.')
             return false
         }
+        // nosemgrep: prefer-codegen-api
         await api.update(
             `api/environments/${teamId}/llm_analytics/evaluation_reports/${activeReport.id}/`,
             buildReportUpdatePayload(draft, activeReport, targets)
@@ -176,6 +177,7 @@ export async function persistReportDraft(
     if (targets.length === 0 && draft.reportPromptGuidance.trim().length === 0) {
         return false
     }
+    // nosemgrep: prefer-codegen-api
     await api.create(
         `api/environments/${teamId}/llm_analytics/evaluation_reports/`,
         buildReportCreatePayload(draft, evaluationId, targets)
@@ -272,6 +274,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     if (props.evaluationId === 'new') {
                         return []
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/?evaluation=${props.evaluationId}`
                     )
@@ -306,6 +309,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     if (params.frequency === 'every_n' && params.cooldown_minutes != null) {
                         body.cooldown_minutes = params.cooldown_minutes
                     }
+                    // nosemgrep: prefer-codegen-api
                     const report = await api.create(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/`,
                         body
@@ -313,6 +317,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     return [...values.reports, report]
                 },
                 updateReport: async ({ reportId, data }: { reportId: string; data: Partial<EvaluationReport> }) => {
+                    // nosemgrep: prefer-codegen-api
                     const updated = await api.update(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/`,
                         data
@@ -320,6 +325,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     return values.reports.map((r) => (r.id === reportId ? updated : r))
                 },
                 deleteReport: async (reportId: string) => {
+                    // nosemgrep: prefer-codegen-api
                     await api.update(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/`,
                         { deleted: true }
@@ -332,6 +338,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
             [] as EvaluationReportRun[],
             {
                 loadReportRuns: async (reportId: string) => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/runs/`
                     )
@@ -345,6 +352,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
             null as null,
             {
                 generateReport: async (reportId: string) => {
+                    // nosemgrep: prefer-codegen-api
                     await api.create(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/generate/`
                     )

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -138,6 +138,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                         const conditions = evaluation.conditions
                             .filter((c) => c.properties && c.properties.length > 0)
                             .map((c) => ({ properties: c.properties }))
+                        // nosemgrep: prefer-codegen-api
                         const response = await api.create(`/api/environments/${teamId}/evaluations/test_hog/`, {
                             source: evaluation.evaluation_config.source,
                             sample_count: 5,
@@ -189,6 +190,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     const requestFilter = values.evaluationSummaryFilter
 
                     // Backend fetches data server-side by ID - we just pass the filter
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(`/api/environments/${teamId}/llm_analytics/evaluation_summary/`, {
                         evaluation_id: props.evaluationId,
                         filter: requestFilter,
@@ -369,6 +371,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                         return
                     }
 
+                    // nosemgrep: prefer-codegen-api
                     const evaluation = await api.get(`/api/environments/${teamId}/evaluations/${props.evaluationId}/`)
                     actions.loadEvaluationSuccess(evaluation)
                 } catch (error) {
@@ -529,8 +532,10 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
 
                 const isNew = props.evaluationId === 'new'
                 const response = isNew
-                    ? await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
-                    : await api.update(
+                    ? // nosemgrep: prefer-codegen-api
+                      await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
+                    : // nosemgrep: prefer-codegen-api
+                      await api.update(
                           `/api/environments/${teamId}/evaluations/${props.evaluationId}/`,
                           values.evaluation!
                       )

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
@@ -124,6 +124,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                     return
                 }
 
+                // nosemgrep: prefer-codegen-api
                 const response = await api.get(`/api/environments/${teamId}/evaluations/`)
                 actions.loadEvaluationsSuccess(response.results)
             } catch (error) {
@@ -139,6 +140,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                     return
                 }
 
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create(`/api/environments/${teamId}/evaluations/`, evaluation)
                 actions.createEvaluationSuccess(response)
 
@@ -160,6 +162,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                     return
                 }
 
+                // nosemgrep: prefer-codegen-api
                 const response = await api.update(`/api/environments/${teamId}/evaluations/${id}/`, evaluation)
                 actions.updateEvaluationSuccess(id, response)
             } catch (error) {
@@ -173,6 +176,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                 if (!teamId) {
                     return
                 }
+                // nosemgrep: prefer-codegen-api
                 await api.update(`/api/environments/${teamId}/evaluations/${id}/`, { deleted: true })
                 actions.deleteEvaluationSuccess(id)
             } catch (error) {
@@ -203,6 +207,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                     return
                 }
 
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create(`/api/environments/${teamId}/evaluations/`, duplicate)
                 actions.duplicateEvaluationSuccess(response)
             } catch (error) {
@@ -222,6 +227,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
             }
 
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.update(`/api/environments/${teamId}/evaluations/${id}/`, {
                     enabled: !evaluation.enabled,
                 })

--- a/products/llm_analytics/frontend/llmAnalyticsSessionDataLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsSessionDataLogic.ts
@@ -203,6 +203,7 @@ export const llmAnalyticsSessionDataLogic = kea<llmAnalyticsSessionDataLogicType
             }
 
             try {
+                // nosemgrep: prefer-codegen-api
                 const data = await api.create(`api/environments/${teamId}/llm_analytics/summarization/batch_check/`, {
                     trace_ids: traceIds,
                     mode: 'minimal',
@@ -278,6 +279,7 @@ export const llmAnalyticsSessionDataLogic = kea<llmAnalyticsSessionDataLogicType
                 // Build the hierarchy tree from full trace events
                 const hierarchy = restoreTree(fullTrace.events || [], traceId)
 
+                // nosemgrep: prefer-codegen-api
                 const data = await api.create(`api/environments/${teamId}/llm_analytics/summarization/`, {
                     summarize_type: 'trace',
                     mode: 'minimal',

--- a/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
@@ -181,6 +181,7 @@ export const llmGenerationSentimentLazyLoaderLogic = kea<llmGenerationSentimentL
 
                     await runWithConcurrency(chunks, MAX_CONCURRENT_BATCHES, async (batch) => {
                         try {
+                            // nosemgrep: prefer-codegen-api
                             const response = await api.create<BatchGenerationSentimentResponse>(
                                 `api/environments/${teamId}/llm_analytics/sentiment/`,
                                 {

--- a/products/llm_analytics/frontend/llmPersonsLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmPersonsLazyLoaderLogic.ts
@@ -138,6 +138,7 @@ export const llmPersonsLazyLoaderLogic = kea<llmPersonsLazyLoaderLogicType>([
                 }
 
                 try {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create<BatchByDistinctIdsResponse>(
                         `api/environments/${teamId}/persons/batch_by_distinct_ids/`,
                         { distinct_ids: batch }

--- a/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
@@ -196,6 +196,7 @@ export const llmSentimentLazyLoaderLogic = kea<llmSentimentLazyLoaderLogicType>(
 
                     await runWithConcurrency(chunks, MAX_CONCURRENT_BATCHES, async (batch) => {
                         try {
+                            // nosemgrep: prefer-codegen-api
                             const response = await api.create<BatchSentimentResponse>(
                                 `api/environments/${teamId}/llm_analytics/sentiment/`,
                                 {

--- a/products/llm_analytics/frontend/modelPickerLogic.ts
+++ b/products/llm_analytics/frontend/modelPickerLogic.ts
@@ -80,6 +80,7 @@ export const modelPickerLogic = kea<modelPickerLogicType>([
                 const results = await Promise.all(
                     validKeys.map(async (key: LLMProviderKey) => {
                         try {
+                            // nosemgrep: prefer-codegen-api
                             const rawModels = (await api.get(
                                 `/api/llm_proxy/models/?provider_key_id=${encodeURIComponent(key.id)}`
                             )) as (Omit<ModelOption, 'providerKeyId' | 'isRecommended'> & {
@@ -113,6 +114,7 @@ export const modelPickerLogic = kea<modelPickerLogicType>([
         trialModels: {
             __default: [] as ModelOption[],
             loadTrialModels: async (): Promise<ModelOption[]> => {
+                // nosemgrep: prefer-codegen-api
                 const rawModels = (await api.get('/api/llm_proxy/models/')) as (Omit<ModelOption, 'isRecommended'> & {
                     is_recommended?: boolean
                 })[]

--- a/products/llm_analytics/frontend/playground/llmPlaygroundModelLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundModelLogic.ts
@@ -137,6 +137,7 @@ export const llmPlaygroundModelLogic = kea<llmPlaygroundModelLogicType>([
                     return null
                 }
                 try {
+                    // nosemgrep: prefer-codegen-api
                     return (await api.get(`/api/environments/${teamId}/llm_analytics/evaluation_config/`)) as {
                         active_provider_key: { id: string } | null
                     }

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -941,6 +941,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                             lemonToast.error('Could not determine team')
                             return
                         }
+                        // nosemgrep: prefer-codegen-api
                         const fetchedEvaluation = await api.get<EvaluationConfig>(
                             `/api/environments/${teamId}/evaluations/${payload.sourceEvaluationId}/`
                         )
@@ -1118,6 +1119,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                 return
             }
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.update(`/api/environments/${teamId}/evaluations/${linkedSource.evaluationId}/`, {
                     evaluation_config: { prompt: prompt.systemPrompt },
                     ...(modelConfig ? { model_configuration: modelConfig } : {}),
@@ -1197,6 +1199,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                 return
             }
             try {
+                // nosemgrep: prefer-codegen-api
                 const created = await api.create<EvaluationConfig>(`/api/environments/${teamId}/evaluations/`, {
                     name,
                     evaluation_type: 'llm_judge',

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -257,6 +257,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return []
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(
                         `/api/environments/${teamId}/llm_analytics/provider_keys/trial_evaluations/?provider=${encodeURIComponent(provider)}`
                     )
@@ -276,6 +277,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return null
                     }
+                    // nosemgrep: prefer-codegen-api
                     return await api.get(
                         `/api/environments/${teamId}/llm_analytics/provider_keys/${keyId}/dependent_configs/`
                     )
@@ -308,6 +310,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                         if (api_version) {
                             body.api_version = api_version
                         }
+                        // nosemgrep: prefer-codegen-api
                         const response = await api.create(
                             `/api/environments/${teamId}/llm_analytics/provider_key_validations/`,
                             body
@@ -336,6 +339,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return null
                     }
+                    // nosemgrep: prefer-codegen-api
                     return await api.get(`/api/environments/${teamId}/llm_analytics/evaluation_config/`)
                 },
             },
@@ -348,6 +352,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return []
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(`/api/environments/${teamId}/llm_analytics/provider_keys/`)
                     return response.results
                 },
@@ -360,6 +365,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return values.providerKeys
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(
                         `/api/environments/${teamId}/llm_analytics/provider_keys/`,
                         payload
@@ -382,6 +388,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return values.providerKeys
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.update(
                         `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/`,
                         payload
@@ -403,6 +410,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     const url = replacementKeyId
                         ? `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/?replacement_key_id=${encodeURIComponent(replacementKeyId)}`
                         : `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/`
+                    // nosemgrep: prefer-codegen-api
                     await api.delete(url)
                     // If deleted key was active, reload config to reflect change
                     if (values.evaluationConfig?.active_provider_key?.id === id) {
@@ -415,6 +423,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     if (!teamId) {
                         return values.providerKeys
                     }
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(
                         `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/validate/`,
                         {}
@@ -493,6 +502,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                 return
             }
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.create(`/api/environments/${teamId}/llm_analytics/provider_keys/${key.id}/assign/`, {
                     evaluation_ids: evaluationIds,
                     enable,

--- a/products/llm_analytics/frontend/summary-view/summaryViewLogic.ts
+++ b/products/llm_analytics/frontend/summary-view/summaryViewLogic.ts
@@ -144,6 +144,7 @@ export const summaryViewLogic = kea<summaryViewLogicType>([
                     throw new Error('Team ID not available')
                 }
 
+                // nosemgrep: prefer-codegen-api
                 const data = await api.create(`api/environments/${teamId}/llm_analytics/summarization/`, payload)
 
                 return {

--- a/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggerLogic.ts
@@ -269,9 +269,11 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
                 }
 
                 if (props.id === 'new') {
+                    // nosemgrep: prefer-codegen-api
                     await api.create('api/environments/@current/taggers/', payload)
                     lemonToast.success('Tagger created')
                 } else {
+                    // nosemgrep: prefer-codegen-api
                     await api.update(`api/environments/@current/taggers/${props.id}/`, payload)
                     lemonToast.success('Tagger updated')
                 }
@@ -291,6 +293,7 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
             }
             try {
                 const teamId = teamLogic.values.currentTeamId
+                // nosemgrep: prefer-codegen-api
                 const response = await api.create(`/api/environments/${teamId}/taggers/test_hog/`, {
                     source,
                     sample_count: 5,
@@ -361,6 +364,7 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
             // Wrap in try/catch so a failed fetch clears taggerLoading — otherwise
             // the UI is stuck on the skeleton indefinitely on any API error.
             try {
+                // nosemgrep: prefer-codegen-api
                 const tagger = await api.get(`api/environments/@current/taggers/${props.id}/`)
                 actions.loadTaggerSuccess(tagger)
                 actions.setTaggerFormValues({
@@ -381,6 +385,7 @@ export const llmTaggerLogic = kea<llmTaggerLogicType>([
             if (props.id === 'new') {
                 return
             }
+            // nosemgrep: prefer-codegen-api
             await api.update(`api/environments/@current/taggers/${props.id}/`, { deleted: true })
             lemonToast.success('Tagger deleted')
             router.actions.push(urls.llmAnalyticsTags())

--- a/products/llm_analytics/frontend/tags/llmTaggersLogic.ts
+++ b/products/llm_analytics/frontend/tags/llmTaggersLogic.ts
@@ -252,9 +252,11 @@ export const llmTaggersLogic = kea<llmTaggersLogicType>([
 
     listeners(({ actions, values }) => ({
         loadTaggers: async () => {
+            // nosemgrep: prefer-codegen-api
             const response = await api.get('api/environments/@current/taggers/')
             if (response.results.length === 0 && !values.hasSeededDefaults) {
                 for (const template of defaultTaggerTemplates) {
+                    // nosemgrep: prefer-codegen-api
                     await api.create('api/environments/@current/taggers/', {
                         name: template.name,
                         description: template.description,
@@ -263,6 +265,7 @@ export const llmTaggersLogic = kea<llmTaggersLogicType>([
                         conditions: [{ id: `cond-${Date.now()}`, rollout_percentage: 100, properties: [] }],
                     })
                 }
+                // nosemgrep: prefer-codegen-api
                 const seeded = await api.get('api/environments/@current/taggers/')
                 actions.loadTaggersSuccess(seeded.results)
             } else {
@@ -278,6 +281,7 @@ export const llmTaggersLogic = kea<llmTaggersLogicType>([
             if (!tagger) {
                 return
             }
+            // nosemgrep: prefer-codegen-api
             await api.update(`api/environments/@current/taggers/${id}/`, { enabled: !tagger.enabled })
             await breakpoint(100)
             actions.loadTaggers()

--- a/products/llm_analytics/frontend/text-view/textViewLogic.ts
+++ b/products/llm_analytics/frontend/text-view/textViewLogic.ts
@@ -135,6 +135,7 @@ export const textViewLogic = kea<textViewLogicType>([
 
                 try {
                     // Call Django API with timeout
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(
                         `api/environments/${props.teamId}/llm_analytics/text_repr/`,
                         requestData,

--- a/products/llm_analytics/frontend/traceReviews/traceReviewsApi.ts
+++ b/products/llm_analytics/frontend/traceReviews/traceReviewsApi.ts
@@ -65,6 +65,7 @@ export const traceReviewsApi = {
         params?: TraceReviewListParams,
         teamId: number = ApiConfig.getCurrentTeamId()
     ): Promise<CountedPaginatedResponse<TraceReview>> {
+        // nosemgrep: prefer-codegen-api
         return api
             .get<CountedPaginatedResponse<TraceReview>>(buildTraceReviewsListUrl(teamId, params))
             .then((response) => ({
@@ -79,6 +80,7 @@ export const traceReviewsApi = {
     },
 
     create(data: TraceReviewUpsertPayload, teamId: number = ApiConfig.getCurrentTeamId()): Promise<TraceReview> {
+        // nosemgrep: prefer-codegen-api
         return api
             .create<TraceReview, TraceReviewUpsertPayload>(getTraceReviewsBaseUrl(teamId), data)
             .then(normalizeTraceReview)
@@ -89,6 +91,7 @@ export const traceReviewsApi = {
         data: Partial<Omit<TraceReviewUpsertPayload, 'trace_id'>>,
         teamId: number = ApiConfig.getCurrentTeamId()
     ): Promise<TraceReview> {
+        // nosemgrep: prefer-codegen-api
         return api
             .update<TraceReview, Partial<Omit<TraceReviewUpsertPayload, 'trace_id'>>>(
                 `${getTraceReviewsBaseUrl(teamId)}${id}/`,
@@ -98,6 +101,7 @@ export const traceReviewsApi = {
     },
 
     delete(id: string, teamId: number = ApiConfig.getCurrentTeamId()): Promise<void> {
+        // nosemgrep: prefer-codegen-api
         return api.delete(`${getTraceReviewsBaseUrl(teamId)}${id}/`)
     },
 

--- a/products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic.ts
@@ -42,6 +42,7 @@ export const serviceFilterLogic = kea<serviceFilterLogicType>([
                         limit: 1000,
                         ...(logicProps.dateRange ? { dateRange: JSON.stringify(logicProps.dateRange) } : {}),
                     }).url
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(url)
                     return ((response.results ?? []) as { name: string }[]).map((r) => r.name)
                 },

--- a/products/logs/frontend/components/LogsViews/logsViewsLogic.ts
+++ b/products/logs/frontend/components/LogsViews/logsViewsLogic.ts
@@ -45,10 +45,12 @@ export const logsViewsLogic = kea<logsViewsLogicType>([
             [] as LogsView[],
             {
                 loadViews: async () => {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(`${logsViewsUrl(values.currentTeamId)}/`)
                     return response.results
                 },
                 createView: async ({ name, filters }: { name: string; filters: LogsViewApiFilters }) => {
+                    // nosemgrep: prefer-codegen-api
                     const created: LogsView = await api.create(`${logsViewsUrl(values.currentTeamId)}/`, {
                         name,
                         filters,
@@ -69,6 +71,7 @@ export const logsViewsLogic = kea<logsViewsLogicType>([
     listeners(({ actions, values }) => ({
         deleteView: async ({ shortId }) => {
             try {
+                // nosemgrep: prefer-codegen-api
                 await api.delete(`${logsViewsUrl(values.currentTeamId)}/${shortId}/`)
                 lemonToast.success('View deleted')
             } catch {

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -72,6 +72,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
             {
                 loadMigrations: async () => {
                     const projectId = ApiConfig.getCurrentProjectId()
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.get(`api/projects/${projectId}/managed_migrations`)
                     return response.results
                 },
@@ -177,6 +178,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                     }
                 }
                 try {
+                    // nosemgrep: prefer-codegen-api
                     const response = await api.create(`api/projects/${projectId}/managed_migrations`, payload)
                     return response
                 } catch (error: any) {
@@ -203,6 +205,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
         pauseMigration: async ({ id }) => {
             try {
                 const projectId = ApiConfig.getCurrentProjectId()
+                // nosemgrep: prefer-codegen-api
                 await api.create(`api/projects/${projectId}/managed_migrations/${id}/pause/`)
                 lemonToast.success('Migration paused successfully')
                 actions.loadMigrations()
@@ -213,6 +216,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
         resumeMigration: async ({ id }) => {
             try {
                 const projectId = ApiConfig.getCurrentProjectId()
+                // nosemgrep: prefer-codegen-api
                 await api.create(`api/projects/${projectId}/managed_migrations/${id}/resume/`)
                 lemonToast.success('Migration resumed successfully')
                 actions.loadMigrations()


### PR DESCRIPTION
## Problem

Product frontends keep reaching for `api.get()` / `api.create()` etc. when the codegen pipeline already produces typed client functions (`legalDocumentsList`, `liveDebuggerBreakpointsCreate`, ...). New code drifts away from the generated client unless we lint for it. Catching this at PR time gives agents and humans an immediate signal pointing at `adopting-generated-api-types` instead of relying on offline maturity audits.

## Changes

**New rule** `.semgrep/rules/prefer-codegen-api.yaml` — flags `api.<verb>(...)` (and the `api.create<T>(...)` generic variant via a regex fallback, since the TS parser doesn't expose generic-typed calls to AST patterns) in `products/*/frontend/`. Sub-namespaced calls like `api.integrations.x()` are deliberately left alone — they're shared platform helpers, not codegen candidates.

**Dedicated CI job** `semgrep-products-frontend` runs only our custom rules on `products/`, instead of expanding the existing `semgrep-js` scan. The broader JS/security packs would otherwise surface a long tail of un-triaged findings on product code, which is out of scope here.

**Bulk suppression** — the 106 existing call sites are tagged with `// nosemgrep: prefer-codegen-api` so the rule lands without breaking CI. The tag is the live worklist (`rg "nosemgrep: prefer-codegen-api"`); cleanup happens incrementally per product. Many are 100% codegen-matched today and quick wins.

**Message** points agents at `.agents/skills/adopting-generated-api-types/SKILL.md` and humans at `hogli product:maturity --codegen <product>` for per-call-site suggestions.

## How did you test this code?

Agent-authored. Verified locally:
- `docker run semgrep/semgrep semgrep --config .semgrep/rules/prefer-codegen-api.yaml products/` — 0 findings after tagging
- `docker run semgrep/semgrep semgrep --test .semgrep/` — 27/27 fixture assertions pass

Did not run the new CI job; it'll execute on this PR.

## Publish to changelog?

no

## 🤖 Agent context

- Authored via Claude Code session (Opus 4.7).
- The rule message intentionally references the existing `adopting-generated-api-types` skill so future agents pick up the migration workflow without extra plumbing.
- Considered a Node-based pre-commit hook with full URL → function-name fuzzy matching (the matcher exists in `tools/hogli-commands/.../ts_helpers.py` from a sibling branch). Rejected: parity between pre-commit and CI is easier when both run the same semgrep rule. The fuzzy suggestions stay in `hogli product:maturity --codegen` for active migrations.
- Considered widening `semgrep-js` to scan `products/`. Rejected: would activate `p/owasp-top-ten` etc. on un-audited code, expanding scope.