### PR TITLE
revert: "fix(shared-views): skip API calls that always 401 in shared/exported views"

### DIFF
--- a/frontend/src/exporter/exporterViewLogic.ts
+++ b/frontend/src/exporter/exporterViewLogic.ts
@@ -103,7 +103,3 @@ export const exporterViewLogic = kea<exporterViewLogicType>([
 export const getCurrentExporterData = (): ExportedData | undefined => {
     return exporterViewLogic.findMounted()?.values.exportedData
 }
-
-export const isSharedView = (): boolean => {
-    return !!getCurrentExporterData()
-}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,7 +18,7 @@ import { RecordingComment } from 'scenes/session-recordings/player/inspector/pla
 import { SessionSummaryContent } from 'scenes/session-recordings/player/player-meta/types'
 import { LINK_PAGE_SIZE, SURVEY_PAGE_SIZE } from 'scenes/surveys/constants'
 
-import { getCurrentExporterData, isSharedView } from '~/exporter/exporterViewLogic'
+import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 import { OrganizationOAuthApplicationApi } from '~/generated/core/api.schemas'
 import { Variable } from '~/queries/nodes/DataVisualization/types'
 import {
@@ -6919,8 +6919,6 @@ const api = {
     },
 } as const
 
-const warnedSharedViewLeaks = new Set<string>()
-
 async function handleFetch(url: string, method: string, fetcher: () => Promise<Response>): Promise<Response> {
     const startTime = new Date().getTime()
 
@@ -6944,7 +6942,6 @@ async function handleFetch(url: string, method: string, fetcher: () => Promise<R
     if (!response.ok) {
         const duration = new Date().getTime() - startTime
         const pathname = new URL(url, location.origin).pathname
-        const inSharedView = isSharedView()
         // when used inside the posthog toolbar, `posthog.capture` isn't loaded
         // check if the function is available before calling it.
         if (posthog.capture) {
@@ -6953,15 +6950,7 @@ async function handleFetch(url: string, method: string, fetcher: () => Promise<R
                 method,
                 duration,
                 status: response.status,
-                is_shared_view: inSharedView,
             })
-        }
-        if (inSharedView && (response.status === 401 || response.status === 403)) {
-            const leakKey = `${method} ${pathname}`
-            if (!warnedSharedViewLeaks.has(leakKey)) {
-                warnedSharedViewLeaks.add(leakKey)
-                console.warn(`[shared-view] unexpected ${response.status} on ${leakKey}`)
-            }
         }
 
         const data = await getJSONOrNull(response)

--- a/frontend/src/lib/components/QuickFilters/quickFiltersLogic.ts
+++ b/frontend/src/lib/components/QuickFilters/quickFiltersLogic.ts
@@ -5,7 +5,6 @@ import posthog from 'posthog-js'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
-import { isSharedView } from '~/exporter/exporterViewLogic'
 import { QuickFilterContext } from '~/queries/schema/schema-general'
 import { QuickFilter } from '~/types'
 
@@ -38,9 +37,6 @@ export const quickFiltersLogic = kea<quickFiltersLogicType>([
             [] as QuickFilter[],
             {
                 loadQuickFilters: async () => {
-                    if (isSharedView()) {
-                        return []
-                    }
                     const response = await api.quickFilters.list(props.context)
                     return response.results
                 },

--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -2,7 +2,6 @@ import { useEffect } from 'react'
 
 import api, { ApiConfig } from 'lib/api'
 
-import { isSharedView } from '~/exporter/exporterViewLogic'
 import { recentItemsModel } from '~/models/recentItemsModel'
 
 type FileSystemLogViewType =
@@ -27,14 +26,7 @@ interface TrackFileSystemLogViewOptions {
 }
 
 export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
-    if (
-        !enabled ||
-        window.IMPERSONATED_SESSION ||
-        isSharedView() ||
-        ref === null ||
-        ref === undefined ||
-        !ApiConfig.hasCurrentTeamId()
-    ) {
+    if (!enabled || window.IMPERSONATED_SESSION || ref === null || ref === undefined || !ApiConfig.hasCurrentTeamId()) {
         return
     }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
@@ -5,8 +5,6 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
-import { isSharedView } from '~/exporter/exporterViewLogic'
-
 import { Variable } from '../../types'
 import type { variableDataLogicType } from './variableDataLogicType'
 
@@ -17,9 +15,6 @@ export const variableDataLogic = kea<variableDataLogicType>([
             [] as Variable[],
             {
                 loadVariables: async () => {
-                    if (isSharedView()) {
-                        return []
-                    }
                     const insights = await api.insightVariables.list()
                     return insights.results
                 },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -40,7 +40,6 @@ import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { isSharedView } from '~/exporter/exporterViewLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
@@ -1762,9 +1761,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             })
         },
         updateTileColor: async ({ tileId, color }) => {
-            if (isSharedView()) {
-                return
-            }
             const previousColor = values.tiles.find((tile) => tile.id === tileId)?.color
             actions.setTileProperty(tileId, { color })
             try {
@@ -1777,9 +1773,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
         },
         toggleTileDescription: async ({ tileId }) => {
-            if (isSharedView()) {
-                return
-            }
             const matchingTile = values.tiles.find((tile) => tile.id === tileId)
             const previousValue = matchingTile?.show_description
             const newValue = previousValue === false
@@ -2373,7 +2366,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 .map((insight: QueryBasedInsightModel) => insight?.id)
                 .filter((id): id is number => !!id)
 
-            if (insightIds.length > 0 && values.currentTeamId && !isSharedView()) {
+            if (insightIds.length > 0 && values.currentTeamId) {
                 void api.create(`api/environments/${values.currentTeamId}/insights/viewed`, {
                     insight_ids: insightIds,
                 })

--- a/frontend/src/scenes/insights/insightUsageLogic.ts
+++ b/frontend/src/scenes/insights/insightUsageLogic.ts
@@ -7,7 +7,6 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { projectLogic } from 'scenes/projectLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 
-import { isSharedView } from '~/exporter/exporterViewLogic'
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { Node } from '~/queries/schema/schema-general'
@@ -64,7 +63,7 @@ export const insightUsageLogic = kea<insightUsageLogicType>([
 
             // Report the insight being viewed to our '/viewed' endpoint.
             // Used for "recently viewed insights", and in insights dashboard.
-            if (values.insight.id && !isSharedView()) {
+            if (values.insight.id) {
                 void api.create(`api/environments/${values.currentProjectId}/insights/viewed`, {
                     insight_ids: [values.insight.id],
                 })

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -36,7 +36,6 @@ import {
 } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { isSharedView } from '~/exporter/exporterViewLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { FileSystemIconType, ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel } from '~/types'
@@ -972,9 +971,6 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
         loadPinnedTabsFromBackend: async () => {
-            if (isSharedView()) {
-                return
-            }
             try {
                 const response = await api.get<{
                     tabs?: SceneTab[]
@@ -1576,9 +1572,6 @@ export const sceneLogic = kea<sceneLogicType>([
 
     subscriptions(({ actions, values, cache }) => {
         const schedulePinnedStateSync = (): void => {
-            if (isSharedView()) {
-                return
-            }
             const pinnedTabsForPersistence = getPinnedTabsForPersistence(values.tabs)
             const homepageForPersistence = getHomepageForPersistence(values.homepage)
             const serializedPinnedState = JSON.stringify({


### PR DESCRIPTION
Reverts PostHog/posthog#57670

errors but we don't know why