### PR TITLE
feat(logs): add 'Next check' column to LogsAlertList for alert evaluation timing

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -89,6 +89,20 @@ export function LogsAlertList(): JSX.Element {
         },
         {
             title: (
+                <Tooltip title="When this alert is next scheduled to be evaluated. Alerts of the same cadence are spread across the cadence period to smooth load on the database.">
+                    <span className="cursor-help">Next check</span>
+                </Tooltip>
+            ),
+            dataIndex: 'next_check_at',
+            render: (_, alert) =>
+                alert.next_check_at ? (
+                    <TZLabel time={alert.next_check_at} />
+                ) : (
+                    <span className="text-muted text-xs">Pending</span>
+                ),
+        },
+        {
+            title: (
                 <Tooltip title="Alert state over the last 24 hours. Green = OK, red = firing, orange = resolving/errored, grey = snoozed or disabled. Hover to see the state at a point in time.">
                     <span className="cursor-help">Last 24h</span>
                 </Tooltip>


### PR DESCRIPTION
## Problem

Users viewing the Logs Alert List have no visibility into when an alert will next be evaluated. This makes it difficult to understand alert scheduling behavior, especially since alerts of the same cadence are intentionally spread across the cadence period to smooth database load.

## Changes

Adds a **Next check** column to the Logs Alert List table, displaying the next scheduled evaluation time for each alert using the `next_check_at` field. The column header includes a tooltip explaining the scheduling behavior. If no next check time is available, a "Pending" placeholder is shown.

## How did you test this code?

Manually verified the column appears in the alert list, that the tooltip renders correctly on hover, and that the "Pending" fallback displays when `next_check_at` is null.

## Publish to changelog?

No