### PR TITLE
fix(flags): treat created_at and updated_at as columns for group scope filters

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -9686,6 +9686,69 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_user_blast_radius_with_groups_created_at_filter(self):
+        from datetime import datetime, timezone
+
+        create_group_type_mapping_without_created_at(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type="company",
+            group_type_index=0,
+        )
+
+        old_date = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        new_date = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+        for i in range(5):
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key=f"old-company:{i}",
+                properties={"plan_units": i + 10},
+                created_at=old_date,
+            )
+
+        for i in range(10):
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key=f"new-company:{i}",
+                properties={"plan_units": i + 10},
+                created_at=new_date,
+            )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/user_blast_radius",
+            {
+                "condition": {
+                    "properties": [
+                        {
+                            "key": "plan_units",
+                            "type": "group",
+                            "value": 20,
+                            "operator": "lte",
+                            "group_type_index": 0,
+                        },
+                        {
+                            "key": "created_at",
+                            "type": "group",
+                            "value": "2026-04-01",
+                            "operator": "is_date_after",
+                            "group_type_index": 0,
+                        },
+                    ],
+                    "rollout_percentage": 100,
+                },
+                "group_type_index": 0,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_json = response.json()
+        self.assertEqual(response_json["affected"], 10)
+        self.assertEqual(response_json["total"], 15)
+
         response_json = response.json()
         self.assertLessEqual(
             {

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -878,6 +878,12 @@ def property_to_expr(
         # We pretend elements chain is a property, but it is actually a column on the events table
         if chain == ["properties"] and property.key == "$elements_chain":
             field = ast.Field(chain=["elements_chain"])
+        # Groups table columns (created_at, updated_at, key, index) should be accessed directly, not via properties JSON
+        elif chain == ["properties"] and property.type == "group" and scope == "group" and property.key in (
+            "created_at",
+            "updated_at",
+        ):
+            field = ast.Field(chain=[property.key])
         elif property.key == "":
             field = ast.Field(chain=[*chain])
         else:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -130,6 +130,23 @@ class TestProperty(BaseTest):
             self._parse_expr("properties.arr > 100"),
         )
 
+        # created_at and updated_at should reference the column directly, not properties JSON
+        self.assertEqual(
+            self._property_to_expr(
+                Property(type="group", group_type_index=0, key="created_at", operator="gt", value="2026-04-01"),
+                scope="group",
+            ),
+            self._parse_expr("created_at > '2026-04-01'"),
+        )
+
+        self.assertEqual(
+            self._property_to_expr(
+                Property(type="group", group_type_index=0, key="updated_at", operator="lt", value="2026-05-01"),
+                scope="group",
+            ),
+            self._parse_expr("updated_at < '2026-05-01'"),
+        )
+
     def test_property_to_expr_group_booleans(self):
         PropertyDefinition.objects.create(
             team=self.team,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When filtering groups by `created_at` in feature flags, the system shows an incorrect match count in the UI. For example, a flag configured to match companies where `plan_units <= 20 AND created_at > after 2026-04-01` shows only 11 matching orgs, but running the equivalent ClickHouse query directly returns 233 matches.

The root cause is that `created_at` and `updated_at` are top-level columns on the `groups` table in ClickHouse, but the HogQL property filter logic was treating them as JSON properties within the `properties` column. This caused queries to look for `properties.created_at` (which doesn't exist) instead of the actual `created_at` column.

## Changes

Modified `posthog/hogql/property.py` to add special handling for `created_at` and `updated_at` when filtering groups in group scope:
- When `property.type == "group"`, `scope == "group"`, and `property.key` is `created_at` or `updated_at`, the field now maps directly to the column instead of `properties.created_at`
- This follows the existing pattern for `$elements_chain` which is handled similarly (column vs JSON property)

Added test coverage:
- Unit tests in `posthog/hogql/test/test_property.py` to verify correct HogQL generation
- Integration test in `posthog/api/test/test_feature_flag.py` to verify correct blast radius calculation for groups with `created_at` filters

## How did you test this code?

Added automated tests:
1. Unit tests to verify `created_at` and `updated_at` filters generate correct HogQL (referencing columns, not properties JSON)
2. Integration test that creates 5 old groups and 10 new groups, then verifies blast radius correctly returns only the 10 new groups matching the `created_at` filter

Note: I am an AI agent. I wrote the tests but was unable to run them in the cloud environment due to missing dependencies. The code changes follow established patterns in the codebase and the logic is sound based on schema inspection.

## Publish to changelog?

No

## 🤖 Agent context

Agent: Claude (Cursor Cloud Agent)

Key prompts:
- User reported: "on the flags page a user set up [a group filter with created_at] but it only showed 11 orgs. when I query this manually [...] I get 233. Why is this wrong?"

Approach:
1. Investigated feature flag blast radius calculation code (`posthog/models/feature_flag/user_blast_radius.py`)
2. Traced through HogQL property filter generation (`posthog/hogql/property.py`)
3. Examined groups table schema (`posthog/hogql/database/schema/groups.py`) and confirmed `created_at` is a column, not a JSON property
4. Identified bug: when `property.type == "group"` and `scope == "group"`, all properties default to JSON property lookups via line 876: `chain = ["properties"]`
5. Applied fix by adding special case for `created_at` and `updated_at` before field construction (similar to existing `$elements_chain` handling)
6. Added test coverage at both unit and integration levels
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1778077290054829?thread_ts=1778077290.054829&cid=D0ACMC57HDE)

<div><a href="https://cursor.com/agents/bc-b1518f95-f1bd-5e53-ba97-7d8e96ed4d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1518f95-f1bd-5e53-ba97-7d8e96ed4d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

