### PR TITLE
fix(ci): Optimize CI backend workflow git operations with shallow clones

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1728,7 +1728,8 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1000
+                  filter: blob:none
 
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
@@ -1756,7 +1757,7 @@ jobs:
                   # base.sha is captured at webhook time and goes stale if the branch
                   # later merges a newer master, which makes `base.sha...HEAD` balloon
                   # to include every merged-in master change.
-                  git fetch --no-tags origin "$BASE_REF"
+                  git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
                   uv run tools/snob_backend_test_selection_shadow.py \
                       --base-ref "origin/$BASE_REF" \


### PR DESCRIPTION
## Problem

The CI backend workflow performs full git clones and fetches that can be slow and resource-intensive, especially when dealing with large repositories or frequent CI runs. This impacts CI performance and resource usage.

## Changes

Optimized git operations in the CI backend workflow:

1. Changed `checkout@v6` to use `fetch-depth: 1000` instead of `fetch-depth: 0` (full clone) to perform a shallow clone with recent history
2. Added `filter: blob:none` to the checkout action to exclude blob objects, reducing clone size
3. Updated the `git fetch` command for the base reference to include `--depth=1000` and `--filter=blob:none` flags for consistency
4. Fixed the git fetch refspec to properly track the remote branch with `refs/remotes/origin/$BASE_REF`

These changes reduce the amount of data fetched while maintaining sufficient history for the test selection logic that compares against the base branch.

## How did you test this code?

CI will validate these changes automatically. The workflow uses these git operations for test selection, and the shallow clone with 1000 commits of history should be sufficient for typical branch comparisons while reducing resource usage.

## Publish to changelog?

No

https://claude.ai/code/session_01KiN1LiT7woPVoQBpKtRWa8