### PR TITLE
feat(taxonomy): add property_values deny-list for autocomplete

### DIFF
--- a/posthog/taxonomy/property_values_deny.py
+++ b/posthog/taxonomy/property_values_deny.py
@@ -1,0 +1,42 @@
+"""Deny-list of property keys that should not be ingested into the
+property_values autocomplete table.
+
+Two sources, combined into a single frozenset:
+
+1. Taxonomy flags from CORE_FILTER_DEFINITIONS_BY_GROUP. Anything already marked
+   `system`, `ignored_in_assistant`, or `used_for_debug` is by definition not
+   shown to users in the filter UI, so storing its values for autocomplete is
+   wasted work.
+2. Empirically high-cardinality keys observed during the property_values
+   rollout that are not yet flagged in the taxonomy. Promote these into the
+   taxonomy with the appropriate flag and remove from the supplementary set
+   when convenient.
+
+Used by the WarpStream Bento pipeline to drop fan-out for these keys at the
+source, and by the autocomplete API to avoid serving stored values for them.
+"""
+
+from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
+
+_DENY_FROM_TAXONOMY: frozenset[str] = frozenset(
+    key
+    for group in CORE_FILTER_DEFINITIONS_BY_GROUP.values()
+    for key, meta in group.items()
+    if meta.get("system") or meta.get("ignored_in_assistant") or meta.get("used_for_debug")
+)
+
+# Keys not yet flagged in the taxonomy but observed to have unbounded cardinality
+# (UUIDs, free-text blobs) or no autocomplete utility (numeric coordinates,
+# high-resolution timestamps stored as date-typed strings).
+_DENY_SUPPLEMENTARY: frozenset[str] = frozenset(
+    {
+        "$creator_event_uuid",
+        "$initial_geoip_longitude",
+        "$initial_geoip_latitude",
+        "$geoip_longitude",
+        "$geoip_latitude",
+        "$survey_last_seen_date",
+    }
+)
+
+PROPERTY_VALUES_DENY: frozenset[str] = _DENY_FROM_TAXONOMY | _DENY_SUPPLEMENTARY

--- a/posthog/taxonomy/test/test_property_values_deny.py
+++ b/posthog/taxonomy/test/test_property_values_deny.py
@@ -1,0 +1,35 @@
+from posthog.taxonomy.property_values_deny import PROPERTY_VALUES_DENY
+
+
+def test_includes_known_high_cardinality_offenders() -> None:
+    expected = {
+        "$insert_id",
+        "$set",
+        "$set_once",
+        "$cymbal_errors",
+        "$creator_event_uuid",
+        "$initial_geoip_longitude",
+        "$initial_geoip_latitude",
+        "$survey_last_seen_date",
+    }
+    missing = expected - PROPERTY_VALUES_DENY
+    assert not missing, f"deny-list missing expected keys: {sorted(missing)}"
+
+
+def test_does_not_block_useful_autocomplete_keys() -> None:
+    must_keep = {
+        "$browser",
+        "$os",
+        "$current_url",
+        "$pathname",
+        "$initial_geoip_country_name",
+        "$initial_geoip_city_name",
+        "utm_source",
+        "utm_campaign",
+    }
+    leaked = must_keep & PROPERTY_VALUES_DENY
+    assert not leaked, f"deny-list should not contain user-facing keys: {sorted(leaked)}"
+
+
+def test_is_a_frozenset() -> None:
+    assert isinstance(PROPERTY_VALUES_DENY, frozenset)


### PR DESCRIPTION
## Problem

The `property_values` autocomplete table fans out one row per `(team_id, property_type, property_key, property_value)` tuple from the event stream. Some properties have unbounded cardinality (UUIDs, free-text blobs) or no autocomplete utility (system internals, numeric coordinates, high-resolution date strings). Storing values for these keys is wasted work and amplifies the two main rollout risks for the property_values pipeline:

1. **Throughput**: every message costs a Kafka poll, JSON parse, MV filter, row append, and text-index update on the AUX cluster. High-cardinality keys also pay a higher per-insert index cost since each unique value adds new ngram postings.
2. **Storage / index growth**: only duplicate rows collapse during `AggregatingMergeTree` merges. Unbounded keys never collapse, so the storage table and its 3.5x-data-size text index grow linearly with their cardinality.

Filtering high-cardinality / non-autocomplete keys at the source addresses both risks in one move.

## Changes

`posthog/taxonomy/property_values_deny.py`
- New module exporting `PROPERTY_VALUES_DENY: frozenset[str]`.
- Combines two sources:
  - Taxonomy flags from `CORE_FILTER_DEFINITIONS_BY_GROUP`: any property already marked `system`, `ignored_in_assistant`, or `used_for_debug` (147 keys).
  - A small supplementary set of empirically high-cardinality keys not yet flagged in the taxonomy: `$creator_event_uuid`, `$initial_geoip_longitude`, `$initial_geoip_latitude`, `$geoip_longitude`, `$geoip_latitude`, `$survey_last_seen_date` (6 keys).
- Total: 153 keys.

`posthog/taxonomy/test/test_property_values_deny.py`
- Asserts known high-cardinality keys are caught.
- Asserts useful autocomplete keys are not blocked.
- Sanity check that the export is a frozenset.

## How did you test this code?

I am an agent and have not run the deny-list against the live pipeline. Verification done:

- Loaded `PROPERTY_VALUES_DENY` locally and confirmed the size (153 keys) and contents.
- Confirmed all expected high-cardinality offenders observed during the dev rollout are present.
- Confirmed user-facing keys are not denied.
- Tests in `test_property_values_deny.py` codify both checks.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored with Claude Code (Opus 4.7) during the property_values pipeline rollout discussion. The deny-list is derived from an analysis of which keys dominated cardinality on the dev consumer once the property_values pipeline was un-paused at full sample rate.

The two-source design is intentional. The taxonomy flag set is authoritative and self-maintaining: properties added to the taxonomy with `system` or `ignored_in_assistant` are picked up automatically. The supplementary set captures keys that should be flagged in the taxonomy but currently are not, with the intent to migrate them into the taxonomy with the appropriate flag over time.

Next steps in separate PRs: cloud-infra change to apply `PROPERTY_VALUES_DENY` in the Bento `events_json_to_property_values_ws` mapping, and optionally query-time filtering in the autocomplete API for defense in depth.