### PR TITLE
fix(docs): make onboarding doc links absolute

### DIFF
--- a/docs/onboarding/error-tracking/android.tsx
+++ b/docs/onboarding/error-tracking/android.tsx
@@ -55,7 +55,7 @@ export const getAndroidSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                 <CalloutBox type="fyi" title="Planned features">
                     <Markdown>
                         {dedent`
-                            We currently don't support [source code context](/docs/error-tracking/stack-traces.md) associated with an exception.
+                            We currently don't support [source code context](https://posthog.com/docs/error-tracking/stack-traces) associated with an exception.
 
                             These features will be added in a future release.
                         `}

--- a/docs/onboarding/error-tracking/api.tsx
+++ b/docs/onboarding/error-tracking/api.tsx
@@ -19,7 +19,7 @@ export const getAPISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                     
                             If a platform you use is not supported by error tracking, we recommend that you reach out to us or contribute to our open-source SDKs before attempting to manually send exceptions.
                     
-                            If you'd rather roll your own exception capturing (or if you're using a platform we don't have an SDK for), you can use the [capture API](/docs/api/capture.md) or \`capture\` method to capture an \`$exception\` event with the following properties:
+                            If you'd rather roll your own exception capturing (or if you're using a platform we don't have an SDK for), you can use the [capture API](https://posthog.com/docs/api/capture) or \`capture\` method to capture an \`$exception\` event with the following properties:
                         `}
                     </Markdown>
                     <div className="LemonMarkdown">

--- a/docs/onboarding/error-tracking/flutter.tsx
+++ b/docs/onboarding/error-tracking/flutter.tsx
@@ -170,11 +170,11 @@ export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                       We currently don't support the following features:
 
                       - No de-obfuscating stacktraces from obfuscated builds ([\\--obfuscate](https://docs.flutter.dev/deployment/obfuscate) and [\\--split-debug-info](https://docs.flutter.dev/deployment/obfuscate)) for Dart code
-                      - No [Source code context](/docs/error-tracking/stack-traces.md) associated with an exception (native Android Java/Kotlin errors and Flutter web only)
+                      - No [Source code context](https://posthog.com/docs/error-tracking/stack-traces) associated with an exception (native Android Java/Kotlin errors and Flutter web only)
                       - No native C/C++ exception capture on Android (Java/Kotlin only)
                       - No background isolate error capture
 
-                      For symbolicated stack traces on native platforms, see the [Flutter debug symbols guide](/docs/error-tracking/upload-source-maps/flutter).
+                      For symbolicated stack traces on native platforms, see the [Flutter debug symbols guide](https://posthog.com/docs/error-tracking/upload-source-maps/flutter).
 
                       These features will be added in future releases. We recommend you stay 
                       up to date with the latest version of the PostHog Flutter SDK.

--- a/docs/onboarding/error-tracking/nextjs.tsx
+++ b/docs/onboarding/error-tracking/nextjs.tsx
@@ -186,7 +186,7 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
             <>
                 <Markdown>
                     {dedent`
-                        Next.js enables you to both server-side render pages and add server-side functionality. To integrate PostHog into your Next.js app on the server-side, you can use the [Node SDK](/docs/libraries/node.md).
+                        Next.js enables you to both server-side render pages and add server-side functionality. To integrate PostHog into your Next.js app on the server-side, you can use the [Node SDK](https://posthog.com/docs/libraries/node).
 
                         First, install the \`posthog-node\` library:
                     `}
@@ -285,7 +285,7 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                         Importantly, you need to:
 
-                        1. Set up a \`posthog-node\` client in your server-side code. See our doc on [setting up Next.js server-side analytics](/docs/libraries/next-js#server-side-analytics.md) for more.
+                        1. Set up a \`posthog-node\` client in your server-side code. See our doc on [setting up Next.js server-side analytics](https://posthog.com/docs/libraries/next-js#server-side-analytics) for more.
                         2. Check the request is running in the \`nodejs\` runtime to ensure PostHog works. You can call \`posthog.debug()\` to get verbose logging.
                         3. Get the \`distinct_id\` from the cookie to connect the error to a specific user.
 
@@ -332,7 +332,7 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                 />
                 <Markdown>
                     {dedent`
-                        You can find a full example of both this and client-side error tracking in our [Next.js error monitoring tutorial](/tutorials/nextjs-error-monitoring.md).
+                        You can find a full example of both this and client-side error tracking in our [Next.js error monitoring tutorial](https://posthog.com/tutorials/nextjs-error-monitoring).
                     `}
                 </Markdown>
             </>

--- a/docs/onboarding/error-tracking/python.tsx
+++ b/docs/onboarding/error-tracking/python.tsx
@@ -45,9 +45,9 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                 />
                 <Markdown>
                     {dedent`
-                        We recommend setting up and using [contexts](/docs/libraries/python#contexts) so that exceptions automatically include distinct IDs, session IDs, and other properties you can set up with tags.
+                        We recommend setting up and using [contexts](https://posthog.com/docs/libraries/python#contexts) so that exceptions automatically include distinct IDs, session IDs, and other properties you can set up with tags.
 
-                        You can also enable [code variables capture](/docs/error-tracking/code-variables/python) to automatically capture the state of local variables when exceptions occur, giving you a debugger-like view of your application.
+                        You can also enable [code variables capture](https://posthog.com/docs/error-tracking/code-variables/python) to automatically capture the state of local variables when exceptions occur, giving you a debugger-like view of your application.
                     `}
                 </Markdown>
             </>
@@ -77,7 +77,7 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                 />
                 <Markdown>
                     {dedent`
-                        You can find a full example of all of this in our [Python (and Flask) error tracking tutorial](/tutorials/python-error-tracking).
+                        You can find a full example of all of this in our [Python (and Flask) error tracking tutorial](https://posthog.com/tutorials/python-error-tracking).
                     `}
                 </Markdown>
             </>
@@ -119,7 +119,7 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                         <Tab.Panel>
                             <Markdown>
                                 {dedent`
-                                    The Python SDK provides a Django middleware that automatically wraps all requests with a [context](/docs/libraries/python#contexts). Add the middleware to your Django settings:
+                                    The Python SDK provides a Django middleware that automatically wraps all requests with a [context](https://posthog.com/docs/libraries/python#contexts). Add the middleware to your Django settings:
                                 `}
                             </Markdown>
                             <CodeBlock
@@ -139,7 +139,7 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                             />
                             <Markdown>
                                 {dedent`
-                                    By default, the middleware captures exceptions and sends them to PostHog. Disable with \`POSTHOG_MW_CAPTURE_EXCEPTIONS = False\`. Use \`POSTHOG_MW_EXTRA_TAGS\`, \`POSTHOG_MW_REQUEST_FILTER\`, and \`POSTHOG_MW_TAG_MAP\` to customize. See the [Django integration docs](/docs/libraries/django) for full configuration.
+                                    By default, the middleware captures exceptions and sends them to PostHog. Disable with \`POSTHOG_MW_CAPTURE_EXCEPTIONS = False\`. Use \`POSTHOG_MW_EXTRA_TAGS\`, \`POSTHOG_MW_REQUEST_FILTER\`, and \`POSTHOG_MW_TAG_MAP\` to customize. See the [Django integration docs](https://posthog.com/docs/libraries/django) for full configuration.
                                 `}
                             </Markdown>
                         </Tab.Panel>

--- a/docs/onboarding/logs/go.tsx
+++ b/docs/onboarding/logs/go.tsx
@@ -134,7 +134,7 @@ export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] =
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
                         service name, severity, or any attribute you attach.
                     </Markdown>
                 </>

--- a/docs/onboarding/logs/go.tsx
+++ b/docs/onboarding/logs/go.tsx
@@ -134,8 +134,8 @@ export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] =
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
-                        service name, severity, or any attribute you attach.
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs)
+                        to search and filter by service name, severity, or any attribute you attach.
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/logs/java.tsx
+++ b/docs/onboarding/logs/java.tsx
@@ -146,7 +146,7 @@ export const getJavaSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
                         service name, severity, or any attribute you attach.
                     </Markdown>
                 </>

--- a/docs/onboarding/logs/java.tsx
+++ b/docs/onboarding/logs/java.tsx
@@ -146,8 +146,8 @@ export const getJavaSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
-                        service name, severity, or any attribute you attach.
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs)
+                        to search and filter by service name, severity, or any attribute you attach.
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/logs/nextjs.tsx
+++ b/docs/onboarding/logs/nextjs.tsx
@@ -152,7 +152,7 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
                         service name, severity, or any attribute you attach.
                     </Markdown>
                 </>

--- a/docs/onboarding/logs/nextjs.tsx
+++ b/docs/onboarding/logs/nextjs.tsx
@@ -152,8 +152,8 @@ export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
-                        service name, severity, or any attribute you attach.
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs)
+                        to search and filter by service name, severity, or any attribute you attach.
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/logs/nodejs.tsx
+++ b/docs/onboarding/logs/nodejs.tsx
@@ -124,7 +124,7 @@ export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition
                     />
                     <Markdown>
                         {dedent`
-                            Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter
+                            Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter
                             by service name, severity, or any attribute you attach.
                         `}
                     </Markdown>

--- a/docs/onboarding/logs/opentelemetry.tsx
+++ b/docs/onboarding/logs/opentelemetry.tsx
@@ -65,7 +65,7 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                             The endpoint accepts OTLP over HTTP in both \`application/x-protobuf\` and \`application/json\`
                             formats. gRPC is not supported, use the HTTP transport protocol instead.
 
-                            Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter
+                            Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter
                             by service name, severity, or any attribute you attach.
                         `}
                     </Markdown>

--- a/docs/onboarding/logs/python.tsx
+++ b/docs/onboarding/logs/python.tsx
@@ -96,7 +96,7 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](/logs) to search and filter by
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
                         service name, severity, or any attribute you attach.
                     </Markdown>
                 </>

--- a/docs/onboarding/logs/python.tsx
+++ b/docs/onboarding/logs/python.tsx
@@ -96,8 +96,8 @@ export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition
                         ]}
                     />
                     <Markdown>
-                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter by
-                        service name, severity, or any attribute you attach.
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs)
+                        to search and filter by service name, severity, or any attribute you attach.
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/session-replay/_snippets/session-replay-final-steps.tsx
+++ b/docs/onboarding/session-replay/_snippets/session-replay-final-steps.tsx
@@ -8,7 +8,7 @@ export const SessionReplayFinalSteps = (): React.ReactElement => {
                 between pages, click buttons, and fill out forms to capture meaningful interactions.
             </p>
             <p>
-                <a href="/replay/home">Watch your first recording →</a>
+                <a href="https://app.posthog.com/replay/home">Watch your first recording →</a>
             </p>
         </>
     )

--- a/docs/onboarding/surveys/_snippets/surveys-final-steps.tsx
+++ b/docs/onboarding/surveys/_snippets/surveys-final-steps.tsx
@@ -11,11 +11,11 @@ export const SurveysFinalSteps = (): JSX.Element => {
 
                 | Resource | Description |
                 |----------|-------------|
-                | [Creating surveys](/docs/surveys/creating-surveys) | Learn how to build and customize your surveys |
-                | [Targeting surveys](/docs/surveys/targeting) | Show surveys to specific users based on properties, events, or feature flags |
-                | [How to create custom surveys](/tutorials/survey) | Build advanced survey experiences with custom code |
-                | [Framework guides](/docs/surveys/tutorials#framework-guides) | Setup guides for React, Next.js, Vue, and other frameworks |
-                | [More tutorials](/docs/surveys/tutorials) | Other real-world examples and use cases |
+                | [Creating surveys](https://posthog.com/docs/surveys/creating-surveys) | Learn how to build and customize your surveys |
+                | [Targeting surveys](https://posthog.com/docs/surveys/targeting) | Show surveys to specific users based on properties, events, or feature flags |
+                | [How to create custom surveys](https://posthog.com/tutorials/survey) | Build advanced survey experiences with custom code |
+                | [Framework guides](https://posthog.com/docs/surveys/tutorials#framework-guides) | Setup guides for React, Next.js, Vue, and other frameworks |
+                | [More tutorials](https://posthog.com/docs/surveys/tutorials) | Other real-world examples and use cases |
 
                 You should also [identify](https://posthog.com/docs/product-analytics/identify) users and [capture events](https://posthog.com/docs/product-analytics/capture-events) with PostHog to control who and when to show surveys to your users.
 

--- a/docs/onboarding/surveys/flutter.tsx
+++ b/docs/onboarding/surveys/flutter.tsx
@@ -58,7 +58,7 @@ function getSurveysFlutterSteps(ctx: OnboardingComponentsContext): StepDefinitio
                         ]}
                     />
                     <Markdown>
-                        If you&apos;re using go_router, check [this page](/docs/surveys/installation/flutter) to learn
+                        If you&apos;re using go_router, check [this page](https://posthog.com/docs/surveys/installation/flutter) to learn
                         how to set up the PosthogObserver.
                     </Markdown>
                 </>

--- a/docs/onboarding/surveys/flutter.tsx
+++ b/docs/onboarding/surveys/flutter.tsx
@@ -58,8 +58,9 @@ function getSurveysFlutterSteps(ctx: OnboardingComponentsContext): StepDefinitio
                         ]}
                     />
                     <Markdown>
-                        If you&apos;re using go_router, check [this page](https://posthog.com/docs/surveys/installation/flutter) to learn
-                        how to set up the PosthogObserver.
+                        If you&apos;re using go_router, check [this
+                        page](https://posthog.com/docs/surveys/installation/flutter) to learn how to set up the
+                        PosthogObserver.
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/surveys/flutter.tsx
+++ b/docs/onboarding/surveys/flutter.tsx
@@ -58,9 +58,9 @@ function getSurveysFlutterSteps(ctx: OnboardingComponentsContext): StepDefinitio
                         ]}
                     />
                     <Markdown>
-                        If you&apos;re using go_router, check [this
-                        page](https://posthog.com/docs/surveys/installation/flutter) to learn how to set up the
-                        PosthogObserver.
+                        {dedent`
+                            If you're using go_router, check [this page](https://posthog.com/docs/surveys/installation/flutter) to learn how to set up the PosthogObserver.
+                        `}
                     </Markdown>
                 </>
             ),


### PR DESCRIPTION
## Problem

The shared onboarding step content under `docs/onboarding` is consumed by **both** the PostHog app **and** the marketing website (posthog.com pulls this folder in via `gatsby-source-git` and renders it through `OnboardingContentWrapper`).

Relative URLs like `<a href="/replay/home">` and `[Logs page](/logs)` work in the app but resolve to broken paths on `posthog.com` (e.g. `https://posthog.com/replay/home` 404s — replay is an app route, not a website route). Cory spotted the first one on https://posthog.com/docs/session-replay/installation/bubble step 3.

## Changes

Converted **all 25 relative links across 14 files** in `docs/onboarding` to absolute URLs:

- **App routes** (`/replay/home`, `/logs`) → `https://app.posthog.com/...`
  - `session-replay/_snippets/session-replay-final-steps.tsx` (the link Cory flagged)
  - `logs/{python,go,nodejs,nextjs,java,opentelemetry}.tsx` — all 6 "Logs page" links
- **Website routes** (`/docs/...`, `/tutorials/...`) → `https://posthog.com/...`
  - `surveys/_snippets/surveys-final-steps.tsx` (5 links in the "Resource" table)
  - `surveys/flutter.tsx`, `error-tracking/{android,api,flutter,nextjs,python}.tsx`

Also stripped a few stray `.md` extensions on URL paths (e.g. `/docs/api/capture.md` → `https://posthog.com/docs/api/capture`), since posthog.com doesn't serve `.md` URLs.

### Why `app.posthog.com` instead of `us.posthog.com`

Per Vincent — gives the website wrapper a single hostname to special-case for region-aware rewriting later. The website's existing `transformPosthogLink` in `OnboardingContentWrapper.tsx` already strips `posthog.com`/`www.posthog.com` back to relative paths so docs/tutorials links continue to navigate internally on the website. `app.posthog.com` links are passed through as-is and open the app correctly.

## How did you test this code?

Agent-authored. I did not run the app locally. Verification was static:

- `grep` for `href="/` and `](/` under `docs/onboarding` returns no results after the change.
- `git diff --stat` shows 14 files / 25 insertions / 25 deletions — no other content touched.
- Confirmed the website-side wrapper (`posthog.com/src/components/Docs/OnboardingContentWrapper.tsx`) handles `posthog.com` hostname rewriting; `app.posthog.com` is passed through.

Recommended manual checks before merge:

- [ ] Render the bubble session-replay onboarding (in-app) — confirm "Watch your first recording →" still navigates to `/replay/home`
- [ ] Visit https://posthog.com/docs/session-replay/installation/bubble — confirm the same link now opens the app
- [ ] Spot-check one logs page (e.g. https://posthog.com/docs/logs/installation/python) and one error-tracking page

## Publish to changelog?

No.

## Docs update

N/A — this **is** the docs fix.

## 🤖 Agent context

- **Tool**: PostHog Code (Claude)
- **Triggered by**: Slack thread between @corywatilo and @vincent — Cory found `/replay/home` on the bubble session-replay docs page; Vincent asked to audit `docs/onboarding` for relative links and fix them all.
- **Decisions**:
  - Used `app.posthog.com` (not `us.posthog.com` or `posthog.com`) per Vincent — leaves room for the website wrapper to add region-aware rewriting later.
  - Stripped `.md` extensions from URL paths while converting to absolute, since absolute `https://posthog.com/foo.md` URLs don't resolve. Considered out-of-scope but left in since the alternative absolute link still wouldn't work.
  - Did not refactor the wrapper to handle relative links centrally — keeping the change minimal; that's a follow-up Vincent mentioned ("We'll add some logic to manipulate these in the website's wrapper").