### PR TITLE
fix(insights): stop fragmenting query cache_key on flag-driven persons-on-events-mode

### DIFF
--- a/posthog/dags/backfill_persons_on_events_mode.py
+++ b/posthog/dags/backfill_persons_on_events_mode.py
@@ -1,0 +1,126 @@
+"""
+Dagster job that persists each team's resolved `personsOnEventsMode` into
+`Team.modifiers["personsOnEventsMode"]`.
+
+Background: until recently, `set_default_modifier_values` filled
+`personsOnEventsMode` by evaluating a local feature flag at request time. The
+local SDK flag-cache state varies across web pods (cold-start, polling lag,
+transient failures), so the same team could resolve to different values across
+pods. That value flows into `get_cache_payload`, fragmenting the query cache_key
+per-pod and breaking dashboard cache coherence.
+
+The fix removes the flag eval from the cache_key path and reads
+`team.modifiers["personsOnEventsMode"]` instead. This job populates that field
+for every team that has not yet been backfilled, using the team's CURRENT
+flag-resolved value so behavior is preserved on a per-team basis. After the job
+completes platform-wide, the cache_key for any given query is fully
+deterministic across pods.
+
+Idempotent: skips teams that already have `personsOnEventsMode` set.
+"""
+
+import dagster
+
+from posthog.dags.common import JobOwners
+from posthog.dags.common.ops import get_all_team_ids_op
+from posthog.models.team import Team
+
+
+@dagster.op
+def persist_persons_on_events_mode_op(
+    context: dagster.OpExecutionContext,
+    team_ids: list[int],
+) -> dict[str, int]:
+    """For each team in the batch, persist its current `personsOnEventsMode` into `team.modifiers`."""
+
+    teams = list(Team.objects.filter(id__in=team_ids).only("id", "modifiers"))
+    not_found = len(team_ids) - len(teams)
+    if not_found > 0:
+        context.log.warning(f"{not_found} team IDs not found in the database, skipping")
+
+    teams_to_update: list[Team] = []
+    skipped_already_set = 0
+    skipped_errored = 0
+
+    for team in teams:
+        existing_modifiers = team.modifiers or {}
+        if existing_modifiers.get("personsOnEventsMode") is not None:
+            skipped_already_set += 1
+            continue
+
+        try:
+            # Resolve via the team property (consults env override + feature flag locally)
+            # and freeze the result. Each team gets the value its current code path would
+            # have produced — this is intentional: we are persisting current behavior, not
+            # changing it.
+            resolved_mode = team.person_on_events_mode_flag_based_default
+        except Exception as e:
+            context.log.warning(f"team {team.id}: failed to resolve mode ({e}), skipping")
+            skipped_errored += 1
+            continue
+
+        team.modifiers = {**existing_modifiers, "personsOnEventsMode": resolved_mode.value}
+        teams_to_update.append(team)
+
+    updated = 0
+    if teams_to_update:
+        # bulk_update is fine here: `modifiers` is a JSON column, no signal handlers
+        # depend on the previous value, and we don't need to bump `updated_at`.
+        updated = Team.objects.bulk_update(teams_to_update, fields=["modifiers"], batch_size=500)
+
+    context.log.info(
+        f"Batch complete: {updated} updated, {skipped_already_set} already set, "
+        f"{skipped_errored} errored, {not_found} not found"
+    )
+    context.add_output_metadata(
+        {
+            "batch_size": dagster.MetadataValue.int(len(team_ids)),
+            "updated": dagster.MetadataValue.int(updated),
+            "skipped_already_set": dagster.MetadataValue.int(skipped_already_set),
+            "skipped_errored": dagster.MetadataValue.int(skipped_errored),
+            "not_found": dagster.MetadataValue.int(not_found),
+        }
+    )
+
+    return {
+        "updated": updated,
+        "skipped_already_set": skipped_already_set,
+        "skipped_errored": skipped_errored,
+        "not_found": not_found,
+    }
+
+
+@dagster.op
+def aggregate_persons_on_events_mode_results_op(
+    context: dagster.OpExecutionContext,
+    results: list[dict[str, int]],
+) -> None:
+    """Aggregate results from all batches."""
+    totals = {
+        "updated": sum(r["updated"] for r in results),
+        "skipped_already_set": sum(r["skipped_already_set"] for r in results),
+        "skipped_errored": sum(r["skipped_errored"] for r in results),
+        "not_found": sum(r["not_found"] for r in results),
+    }
+
+    context.log.info(
+        f"Completed: {totals['updated']} updated, "
+        f"{totals['skipped_already_set']} already set, "
+        f"{totals['skipped_errored']} errored, {totals['not_found']} not found"
+    )
+
+    context.add_output_metadata({k: dagster.MetadataValue.int(v) for k, v in totals.items()})
+
+
+@dagster.job(
+    description=(
+        "Persists each team's resolved `personsOnEventsMode` into `Team.modifiers` so the "
+        "value is read from a single source of truth instead of per-pod feature-flag "
+        "evaluation. Eliminates cache_key fragmentation across web pods."
+    ),
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
+)
+def backfill_persons_on_events_mode_job():
+    team_ids = get_all_team_ids_op()
+    results = team_ids.map(persist_persons_on_events_mode_op)
+    aggregate_persons_on_events_mode_results_op(results.collect())

--- a/posthog/dags/backfill_persons_on_events_mode.py
+++ b/posthog/dags/backfill_persons_on_events_mode.py
@@ -16,14 +16,92 @@ flag-resolved value so behavior is preserved on a per-team basis. After the job
 completes platform-wide, the cache_key for any given query is fully
 deterministic across pods.
 
+Important: this job evaluates flags SERVER-SIDE (without `only_evaluate_locally`),
+unlike the team property it replaces. The team property uses local-only eval to
+avoid per-request latency, but local-only is itself the source of the variance
+this job is meant to resolve. A cold Dagster worker would otherwise persist the
+fall-through default for every team, silently migrating teams off their intended
+mode. Server-side eval consults the flag service directly so each team gets its
+canonical resolved value regardless of SDK hydration state in the worker.
+
 Idempotent: skips teams that already have `personsOnEventsMode` set.
 """
 
-import dagster
+from django.conf import settings
 
+import dagster
+import posthoganalytics
+
+from posthog.schema import PersonsOnEventsMode
+
+from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners
 from posthog.dags.common.ops import get_all_team_ids_op
+from posthog.models.instance_setting import get_instance_setting
 from posthog.models.team import Team
+
+
+def _resolve_persons_on_events_mode_server_side(team: Team) -> PersonsOnEventsMode:
+    """
+    Evaluate the same two flags `team.person_on_events_mode_flag_based_default` consults,
+    but server-side (no `only_evaluate_locally`). Used by the backfill so the persisted
+    value is determined by the flag service's canonical state, not the worker's local
+    SDK hydration state.
+    """
+    # Env overrides short-circuit any flag eval — same as the team property.
+    v2_override = getattr(settings, "PERSON_ON_EVENTS_V2_OVERRIDE", None)
+    poe_override = getattr(settings, "PERSON_ON_EVENTS_OVERRIDE", None)
+
+    if is_cloud():
+        v2_enabled = (
+            v2_override
+            if v2_override is not None
+            else posthoganalytics.feature_enabled(
+                "persons-on-events-v2-reads-enabled",
+                str(team.uuid),
+                groups={"organization": str(team.organization_id)},
+                group_properties={
+                    "organization": {
+                        "id": str(team.organization_id),
+                        "created_at": team.organization.created_at.isoformat()
+                        if team.organization.created_at
+                        else None,
+                    }
+                },
+                send_feature_flag_events=False,
+            )
+        )
+        if v2_enabled:
+            return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+
+        poe_enabled = (
+            poe_override
+            if poe_override is not None
+            else posthoganalytics.feature_enabled(
+                "persons-on-events-person-id-no-override-properties-on-events",
+                str(team.uuid),
+                groups={"project": str(team.id)},
+                group_properties={
+                    "project": {
+                        "id": str(team.id),
+                        "created_at": team.created_at.isoformat() if team.created_at else None,
+                        "uuid": team.uuid,
+                    }
+                },
+                send_feature_flag_events=False,
+            )
+        )
+        if poe_enabled:
+            return PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
+
+        return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
+
+    # Self-hosted: instance settings only, no SDK involvement (no variance to resolve).
+    if v2_override if v2_override is not None else get_instance_setting("PERSON_ON_EVENTS_V2_ENABLED"):
+        return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+    if poe_override if poe_override is not None else get_instance_setting("PERSON_ON_EVENTS_ENABLED"):
+        return PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
+    return PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
 
 
 @dagster.op
@@ -33,7 +111,21 @@ def persist_persons_on_events_mode_op(
 ) -> dict[str, int]:
     """For each team in the batch, persist its current `personsOnEventsMode` into `team.modifiers`."""
 
-    teams = list(Team.objects.filter(id__in=team_ids).only("id", "modifiers"))
+    # Pulls `organization` and `created_at` because server-side flag eval includes them
+    # as group_properties — fetching them up front avoids per-team queries during eval.
+    teams = list(
+        Team.objects.filter(id__in=team_ids)
+        .select_related("organization")
+        .only(
+            "id",
+            "uuid",
+            "modifiers",
+            "organization_id",
+            "created_at",
+            "organization__id",
+            "organization__created_at",
+        )
+    )
     not_found = len(team_ids) - len(teams)
     if not_found > 0:
         context.log.warning(f"{not_found} team IDs not found in the database, skipping")
@@ -49,11 +141,8 @@ def persist_persons_on_events_mode_op(
             continue
 
         try:
-            # Resolve via the team property (consults env override + feature flag locally)
-            # and freeze the result. Each team gets the value its current code path would
-            # have produced — this is intentional: we are persisting current behavior, not
-            # changing it.
-            resolved_mode = team.person_on_events_mode_flag_based_default
+            # Server-side flag eval — no `only_evaluate_locally`. See module docstring.
+            resolved_mode = _resolve_persons_on_events_mode_server_side(team)
         except Exception as e:
             context.log.warning(f"team {team.id}: failed to resolve mode ({e}), skipping")
             skipped_errored += 1

--- a/posthog/dags/locations/analytics_platform.py
+++ b/posthog/dags/locations/analytics_platform.py
@@ -2,6 +2,7 @@ import dagster
 
 from posthog.dags import sessions, sessions_v1_cleanup
 from posthog.dags.backfill_internal_test_users_cohort import backfill_internal_test_users_cohort_job
+from posthog.dags.backfill_persons_on_events_mode import backfill_persons_on_events_mode_job
 from posthog.dags.sessions import (
     experimental_sessions_backfill_job,
     experimental_sessions_v3_backfill,
@@ -17,6 +18,7 @@ defs = dagster.Definitions(
         sessions_v1_cleanup.sessions_v1_cleanup_job,
         experimental_sessions_backfill_job,
         backfill_internal_test_users_cohort_job,
+        backfill_persons_on_events_mode_job,
     ],
     resources=resources,
 )

--- a/posthog/dags/tests/test_backfill_persons_on_events_mode.py
+++ b/posthog/dags/tests/test_backfill_persons_on_events_mode.py
@@ -3,12 +3,13 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.test import override_settings
+
 from dagster import build_op_context
 
 from posthog.schema import PersonsOnEventsMode
 
 from posthog.dags.backfill_persons_on_events_mode import persist_persons_on_events_mode_op
-from posthog.models.team import Team
 
 
 class TestBackfillPersonsOnEventsMode(BaseTest):
@@ -19,12 +20,11 @@ class TestBackfillPersonsOnEventsMode(BaseTest):
         self.team.save()
 
     def _resolve_default_to(self, mode: PersonsOnEventsMode):
-        # Patch the team property used by the op so the test does not depend on the
+        # Patch the resolver helper used by the op so the test does not depend on the
         # actual feature flag SDK state.
-        return patch.object(
-            Team,
-            "person_on_events_mode_flag_based_default",
-            new_callable=lambda: property(lambda _self: mode),
+        return patch(
+            "posthog.dags.backfill_persons_on_events_mode._resolve_persons_on_events_mode_server_side",
+            return_value=mode,
         )
 
     def test_persists_resolved_mode_when_modifiers_unset(self):
@@ -82,3 +82,63 @@ class TestBackfillPersonsOnEventsMode(BaseTest):
         assert first["updated"] == 1
         assert second["updated"] == 0
         assert second["skipped_already_set"] == 1
+
+    def test_resolver_evaluates_flags_server_side_not_local_only(self):
+        # The whole point of doing this work in a backfill rather than in the request hot
+        # path is that we can afford a server-side flag eval. A cold worker with `only_evaluate_locally=True`
+        # would resolve every team to None and silently migrate them off their intended mode.
+        # This test pins the server-side behavior by asserting the SDK call does NOT pass the
+        # local-only flag.
+        from posthog.dags.backfill_persons_on_events_mode import _resolve_persons_on_events_mode_server_side
+
+        with patch("posthog.dags.backfill_persons_on_events_mode.is_cloud", return_value=True):
+            with patch("posthoganalytics.feature_enabled", return_value=False) as mock_flag:
+                _resolve_persons_on_events_mode_server_side(self.team)
+
+        # Both flag calls must omit `only_evaluate_locally` (or pass it as False).
+        for call in mock_flag.call_args_list:
+            assert call.kwargs.get("only_evaluate_locally", False) is False, (
+                f"server-side eval must not pass only_evaluate_locally=True; got call with kwargs: {call.kwargs}"
+            )
+
+    def test_resolver_returns_override_on_events_when_v2_flag_true(self):
+        from posthog.dags.backfill_persons_on_events_mode import _resolve_persons_on_events_mode_server_side
+
+        with patch("posthog.dags.backfill_persons_on_events_mode.is_cloud", return_value=True):
+            # First flag (v2) returns True → expect OVERRIDE_PROPERTIES_ON_EVENTS, second flag is never consulted.
+            with patch("posthoganalytics.feature_enabled", side_effect=[True]):
+                resolved = _resolve_persons_on_events_mode_server_side(self.team)
+
+        assert resolved == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+
+    def test_resolver_returns_no_override_when_only_poe_flag_true(self):
+        from posthog.dags.backfill_persons_on_events_mode import _resolve_persons_on_events_mode_server_side
+
+        with patch("posthog.dags.backfill_persons_on_events_mode.is_cloud", return_value=True):
+            # v2 flag False, poe flag True → expect NO_OVERRIDE_PROPERTIES_ON_EVENTS.
+            with patch("posthoganalytics.feature_enabled", side_effect=[False, True]):
+                resolved = _resolve_persons_on_events_mode_server_side(self.team)
+
+        assert resolved == PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
+
+    def test_resolver_returns_joined_default_when_both_flags_false(self):
+        from posthog.dags.backfill_persons_on_events_mode import _resolve_persons_on_events_mode_server_side
+
+        with patch("posthog.dags.backfill_persons_on_events_mode.is_cloud", return_value=True):
+            with patch("posthoganalytics.feature_enabled", side_effect=[False, False]):
+                resolved = _resolve_persons_on_events_mode_server_side(self.team)
+
+        assert resolved == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
+
+    def test_resolver_honors_env_override_without_consulting_flags(self):
+        # PERSON_ON_EVENTS_V2_OVERRIDE / PERSON_ON_EVENTS_OVERRIDE bypass flag eval entirely,
+        # mirroring the team property's behavior. The backfill must respect them.
+        from posthog.dags.backfill_persons_on_events_mode import _resolve_persons_on_events_mode_server_side
+
+        with override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=True, PERSON_ON_EVENTS_OVERRIDE=None):
+            with patch("posthog.dags.backfill_persons_on_events_mode.is_cloud", return_value=True):
+                with patch("posthoganalytics.feature_enabled") as mock_flag:
+                    resolved = _resolve_persons_on_events_mode_server_side(self.team)
+
+        assert resolved == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+        mock_flag.assert_not_called()

--- a/posthog/dags/tests/test_backfill_persons_on_events_mode.py
+++ b/posthog/dags/tests/test_backfill_persons_on_events_mode.py
@@ -1,0 +1,84 @@
+"""Tests for the persons-on-events-mode backfill job."""
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from dagster import build_op_context
+
+from posthog.schema import PersonsOnEventsMode
+
+from posthog.dags.backfill_persons_on_events_mode import persist_persons_on_events_mode_op
+from posthog.models.team import Team
+
+
+class TestBackfillPersonsOnEventsMode(BaseTest):
+    def setUp(self):
+        super().setUp()
+        # Reset the seeded team so tests start from a known state
+        self.team.modifiers = None
+        self.team.save()
+
+    def _resolve_default_to(self, mode: PersonsOnEventsMode):
+        # Patch the team property used by the op so the test does not depend on the
+        # actual feature flag SDK state.
+        return patch.object(
+            Team,
+            "person_on_events_mode_flag_based_default",
+            new_callable=lambda: property(lambda _self: mode),
+        )
+
+    def test_persists_resolved_mode_when_modifiers_unset(self):
+        with self._resolve_default_to(PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS):
+            result = persist_persons_on_events_mode_op(build_op_context(), [self.team.id])
+
+        self.team.refresh_from_db()
+        assert (
+            self.team.modifiers["personsOnEventsMode"]
+            == PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS.value
+        )
+        assert result == {"updated": 1, "skipped_already_set": 0, "skipped_errored": 0, "not_found": 0}
+
+    def test_skips_teams_that_already_have_a_value(self):
+        self.team.modifiers = {"personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS.value}
+        self.team.save()
+
+        with self._resolve_default_to(PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS):
+            result = persist_persons_on_events_mode_op(build_op_context(), [self.team.id])
+
+        self.team.refresh_from_db()
+        # Existing value is preserved — the op must not overwrite teams that already have one.
+        assert (
+            self.team.modifiers["personsOnEventsMode"]
+            == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS.value
+        )
+        assert result == {"updated": 0, "skipped_already_set": 1, "skipped_errored": 0, "not_found": 0}
+
+    def test_preserves_existing_unrelated_modifier_keys(self):
+        self.team.modifiers = {"useMaterializedViews": True, "optimizeProjections": False}
+        self.team.save()
+
+        with self._resolve_default_to(PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED):
+            persist_persons_on_events_mode_op(build_op_context(), [self.team.id])
+
+        self.team.refresh_from_db()
+        assert self.team.modifiers == {
+            "useMaterializedViews": True,
+            "optimizeProjections": False,
+            "personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED.value,
+        }
+
+    def test_reports_not_found_for_unknown_team_ids(self):
+        with self._resolve_default_to(PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED):
+            result = persist_persons_on_events_mode_op(build_op_context(), [self.team.id, 9999999])
+
+        assert result["updated"] == 1
+        assert result["not_found"] == 1
+
+    def test_is_idempotent(self):
+        with self._resolve_default_to(PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED):
+            first = persist_persons_on_events_mode_op(build_op_context(), [self.team.id])
+            second = persist_persons_on_events_mode_op(build_op_context(), [self.team.id])
+
+        assert first["updated"] == 1
+        assert second["updated"] == 0
+        assert second["skipped_already_set"] == 1

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     InlineCohortCalculation,
     MaterializationMode,
     PersonsArgMaxVersion,
+    PersonsOnEventsMode,
     PropertyGroupsMode,
     SessionsV2JoinMode,
     SessionTableVersion,
@@ -77,8 +78,15 @@ def create_default_modifiers_for_team(
 
 
 def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
+    # `personsOnEventsMode` deliberately does NOT consult `team.person_on_events_mode_flag_based_default`
+    # here, even when the team has no value persisted. That property evaluates a feature flag locally,
+    # which can return different values across web pods depending on the SDK's local flag-cache state.
+    # The result feeds into `get_cache_payload` and would fragment the query cache per-pod for the
+    # same team. Teams should have `team.modifiers["personsOnEventsMode"]` persisted (see the
+    # `backfill_persons_on_events_mode_job` Dagster job); brand-new or unbackfilled teams fall through
+    # to a stable hardcoded default below.
     if modifiers.personsOnEventsMode is None:
-        modifiers.personsOnEventsMode = team.person_on_events_mode_flag_based_default
+        modifiers.personsOnEventsMode = PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
 
     if modifiers.personsArgMaxVersion is None:
         modifiers.personsArgMaxVersion = PersonsArgMaxVersion.AUTO

--- a/posthog/hogql/test/test_modifiers.py
+++ b/posthog/hogql/test/test_modifiers.py
@@ -59,12 +59,21 @@ class TestModifiers(BaseTest):
         "posthog.models.team.Team._person_on_events_person_id_override_properties_on_events",
         True,
     )
-    def test_modifiers_persons_on_events_default_is_based_on_team_property(self):
+    def test_modifiers_persons_on_events_default_does_not_consult_team_flag(self):
+        # The runner intentionally does NOT consult `team.person_on_events_mode_flag_based_default`
+        # for the modifier default — that property evaluates a feature flag locally, which can
+        # return different values across web pods and would fragment `cache_key` per-pod.
+        # Teams that need a non-default mode have it persisted in `team.modifiers["personsOnEventsMode"]`
+        # (populated by the `backfill_persons_on_events_mode_job` Dagster job). When the team has
+        # no value persisted, the runner falls back to a stable hardcoded default below.
         assert self.team.modifiers is None
         modifiers = create_default_modifiers_for_team(self.team)
+        # `team.person_on_events_mode` still walks the flag chain, so this asserts the value that
+        # WOULD have leaked into the cache_key under the old behavior:
         assert self.team.person_on_events_mode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+        # …but the modifier default is now the stable hardcoded fallback, regardless of the flag:
         assert modifiers.personsOnEventsMode == self.team.default_modifiers["personsOnEventsMode"]
-        assert modifiers.personsOnEventsMode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+        assert modifiers.personsOnEventsMode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
 
     def test_modifiers_persons_on_events_mode_person_id_override_properties_on_events(self):
         query = "SELECT event, person_id FROM events"

--- a/posthog/hogql/test/test_modifiers.py
+++ b/posthog/hogql/test/test_modifiers.py
@@ -32,7 +32,10 @@ class TestModifiers(BaseTest):
         assert modifiers.personsOnEventsMode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
 
     def test_team_modifiers_override(self):
-        assert self.team.modifiers is None
+        # New teams get `personsOnEventsMode` persisted at creation time (see the pre_save hook in
+        # team.py), but this test exercises the no-override-set path. Clear it explicitly.
+        self.team.modifiers = None
+        self.team.save()
         modifiers = create_default_modifiers_for_team(self.team)
         assert modifiers.personsOnEventsMode == self.team.default_modifiers["personsOnEventsMode"]
         assert (
@@ -66,7 +69,9 @@ class TestModifiers(BaseTest):
         # Teams that need a non-default mode have it persisted in `team.modifiers["personsOnEventsMode"]`
         # (populated by the `backfill_persons_on_events_mode_job` Dagster job). When the team has
         # no value persisted, the runner falls back to a stable hardcoded default below.
-        assert self.team.modifiers is None
+        # Clear the value the pre_save hook set at creation so we exercise the unbackfilled path.
+        self.team.modifiers = None
+        self.team.save()
         modifiers = create_default_modifiers_for_team(self.team)
         # `team.person_on_events_mode` still walks the flag chain, so this asserts the value that
         # WOULD have leaked into the cache_key under the old behavior:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -325,6 +325,34 @@ class TestQueryRunner(BaseTest):
         cache_key = runner.get_cache_key()
         assert cache_key == "cache_42_f67778c870f29df1c38c85726fd6f2b319b920f6f3414acf2de1927271503977"
 
+    def test_cache_key_diverges_when_persons_on_events_flag_resolves_differently(self):
+        # Reproduces the dashboard-tile cache fragmentation bug observed in production:
+        # `posthoganalytics.feature_enabled` is consulted via `team.person_on_events_mode_flag_based_default`
+        # to fill `modifiers.personsOnEventsMode` when the insight does not preset it. Different web pods
+        # have different local feature-flag cache hydration states, so the SAME team can resolve to
+        # different `personsOnEventsMode` values across pods. That value is part of `get_cache_payload`,
+        # so the cache_key fragments per-pod and refreshes never update the entry the dashboard reads.
+        #
+        # The flag is only consulted on PostHog Cloud and only when the env override is unset, so we
+        # patch both to drive the runner through the flag-evaluating code path.
+        from django.test import override_settings
+
+        TestQueryRunner = self.setup_test_query_runner_class()
+        team = Team.objects.create(pk=42, organization=self.organization)
+
+        keys: list[str] = []
+        with override_settings(PERSON_ON_EVENTS_OVERRIDE=None, PERSON_ON_EVENTS_V2_OVERRIDE=None):
+            with mock.patch("posthog.models.team.team.is_cloud", return_value=True):
+                for flag_value in (True, False, None):
+                    with mock.patch("posthoganalytics.feature_enabled", return_value=flag_value):
+                        runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
+                        keys.append(runner.get_cache_key())
+
+        assert len(set(keys)) == 1, (
+            f"cache_key must not depend on `posthoganalytics.feature_enabled` results "
+            f"(observed {len(set(keys))} distinct keys for flag values True/False/None: {keys})"
+        )
+
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -353,6 +353,89 @@ class TestQueryRunner(BaseTest):
             f"(observed {len(set(keys))} distinct keys for flag values True/False/None: {keys})"
         )
 
+    def test_cache_key_is_stable_when_persons_on_events_mode_is_preset_on_query(self):
+        # Locks in the empirically observed discriminator: insights whose `query.modifiers`
+        # already preset `personsOnEventsMode` are immune to flag-eval variance, because the
+        # `if modifiers.personsOnEventsMode is None` branch in `set_default_modifier_values`
+        # short-circuits. This is what production data shows for the 6/35 immune insights on
+        # the affected dashboard.
+        from django.test import override_settings
+
+        TestQueryRunner = self.setup_test_query_runner_class()
+        team = Team.objects.create(pk=42, organization=self.organization)
+
+        keys: list[str] = []
+        with override_settings(PERSON_ON_EVENTS_OVERRIDE=None, PERSON_ON_EVENTS_V2_OVERRIDE=None):
+            with mock.patch("posthog.models.team.team.is_cloud", return_value=True):
+                for flag_value in (True, False, None):
+                    with mock.patch("posthoganalytics.feature_enabled", return_value=flag_value):
+                        runner = TestQueryRunner(
+                            query={"some_attr": "bla"},
+                            team=team,
+                            modifiers=HogQLQueryModifiers(
+                                personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED
+                            ),
+                        )
+                        keys.append(runner.get_cache_key())
+
+        assert len(set(keys)) == 1, (
+            f"with `personsOnEventsMode` preset, cache_key must be stable across flag values "
+            f"(observed {len(set(keys))} distinct keys: {keys})"
+        )
+
+    def test_cache_key_diverges_specifically_on_persons_on_events_mode_value(self):
+        # Pins down WHICH modifier produces the divergence by varying `personsOnEventsMode`
+        # explicitly and asserting each value yields a distinct cache_key. Together with the
+        # production query that maps the two observed cache_keys to two `personsOnEventsMode`
+        # values, this proves `personsOnEventsMode` is the responsible field, not e.g. another
+        # field that incidentally varies during flag eval.
+        TestQueryRunner = self.setup_test_query_runner_class()
+        team = Team.objects.create(pk=42, organization=self.organization)
+
+        cache_keys_by_mode: dict[PersonsOnEventsMode, str] = {}
+        for mode in PersonsOnEventsMode:
+            runner = TestQueryRunner(
+                query={"some_attr": "bla"},
+                team=team,
+                modifiers=HogQLQueryModifiers(personsOnEventsMode=mode),
+            )
+            cache_keys_by_mode[mode] = runner.get_cache_key()
+
+        # Each distinct mode must produce a distinct cache_key — i.e. mode value materially affects the key.
+        assert len(set(cache_keys_by_mode.values())) == len(cache_keys_by_mode), (
+            f"each `personsOnEventsMode` value must produce a distinct cache_key, got: {cache_keys_by_mode}"
+        )
+
+    def test_cache_payload_modifiers_only_diverge_on_persons_on_events_mode_under_flag_variance(self):
+        # Confirms that across flag-eval outcomes (True/False/None) the cache_payload's
+        # `hogql_modifiers` field differs ONLY in `personsOnEventsMode` — no other modifier
+        # is silently flag-driven via `set_default_modifier_values`. If a future change adds
+        # another flag-driven default to that function, this test will surface it as an
+        # additional differing key.
+        from django.test import override_settings
+
+        TestQueryRunner = self.setup_test_query_runner_class()
+        team = Team.objects.create(pk=42, organization=self.organization)
+
+        modifier_dumps_by_flag: dict[Any, dict] = {}
+        with override_settings(PERSON_ON_EVENTS_OVERRIDE=None, PERSON_ON_EVENTS_V2_OVERRIDE=None):
+            with mock.patch("posthog.models.team.team.is_cloud", return_value=True):
+                for flag_value in (True, False, None):
+                    with mock.patch("posthoganalytics.feature_enabled", return_value=flag_value):
+                        runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
+                        modifier_dumps_by_flag[flag_value] = runner.get_cache_payload()["hogql_modifiers"]
+
+        # Compute the set of fields that differ between any two dumps.
+        all_keys = set().union(*(d.keys() for d in modifier_dumps_by_flag.values()))
+        diverging_keys = {key for key in all_keys if len({d.get(key) for d in modifier_dumps_by_flag.values()}) > 1}
+
+        # After the fix, no fields diverge. Before the fix, only `personsOnEventsMode` did.
+        # This assertion locks in that *no other* field is allowed to be flag-driven.
+        assert diverging_keys.issubset({"personsOnEventsMode"}), (
+            f"flag-eval should only influence `personsOnEventsMode` (or nothing post-fix); "
+            f"observed divergence in: {diverging_keys}"
+        )
+
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -10,7 +10,7 @@ from django.core.cache import cache
 from django.core.validators import MaxValueValidator, MinLengthValidator, MinValueValidator
 from django.db import connection, models, transaction
 from django.db.models import QuerySet
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 
 import pytz
 import pydantic
@@ -1079,6 +1079,28 @@ class Team(UUIDTClassicModel):
         return str(self.pk)
 
     __repr__ = sane_repr("id", "uuid", "project_id", "name", "api_token")
+
+
+@mutable_receiver(pre_save, sender=Team)
+def set_default_persons_on_events_mode_for_new_team(sender, instance: "Team", **kwargs):
+    """Persist a stable `personsOnEventsMode` on every newly-created team.
+
+    The cache_key path no longer evaluates `team.person_on_events_mode_flag_based_default` (which
+    would return different values across web pods depending on local feature-flag cache state).
+    To keep behavior coherent for new teams and to allow eventual retirement of the flag-based
+    fallback in `team.person_on_events_mode`, we eagerly persist the default mode at creation
+    time. Brand-new team UUIDs never appear in the legacy POE-v2 include list, so the hardcoded
+    default matches what the flag would have resolved to anyway.
+    """
+    if not instance._state.adding:
+        return
+    modifiers = instance.modifiers or {}
+    if "personsOnEventsMode" in modifiers:
+        return
+    instance.modifiers = {
+        **modifiers,
+        "personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED.value,
+    }
 
 
 @mutable_receiver(post_save, sender=Team)

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -1870,24 +1870,22 @@ async def test_hogql_table_applies_custom_modifier_to_sessions_query(ateam):
 
 
 async def test_create_default_modifiers_for_team_in_async_context(ateam):
-    """Test that create_default_modifiers_for_team must be wrapped with database_sync_to_async in async context.
+    """`create_default_modifiers_for_team` must be safe to call in an async context.
 
-    The function accesses team.organization.created_at via person_on_events_mode_flag_based_default,
-    which triggers a lazy load of the organization foreign key. Without database_sync_to_async,
-    this raises SynchronousOnlyOperation in an async context.
-
-    This is a regression test for the fix that wrapped the call in hogql_table and get_query_row_count.
+    Previously this function evaluated a feature flag inside `set_default_modifier_values` which
+    indirectly lazy-loaded `team.organization.created_at` and raised `SynchronousOnlyOperation` when
+    called outside `database_sync_to_async`. The flag eval was removed (see the modifier fix that
+    persists `personsOnEventsMode` to `team.modifiers` instead of evaluating per-request), so the
+    lazy load no longer happens and the function is now async-safe by construction. This test is the
+    inverse regression guard: it asserts that the previously-problematic call site stays clean.
     """
-    from django.core.exceptions import SynchronousOnlyOperation
-
     from posthog.hogql.modifiers import create_default_modifiers_for_team
 
     # fetch team without select_related to ensure organization needs lazy loading
     team = await database_sync_to_async(Team.objects.get)(id=ateam.pk)
-    # mock is_cloud() to return true so that the code path accessing team.organization.created_at is triggered
+    # mock is_cloud() to return true so any cloud-only code paths run; should still be async-safe
     with unittest.mock.patch("posthog.models.team.team.is_cloud", return_value=True):
-        # calling directly raises
-        with pytest.raises(SynchronousOnlyOperation):
-            create_default_modifiers_for_team(team)
-        # wrapped doesn't raise
+        # calling directly no longer raises
+        create_default_modifiers_for_team(team)
+        # wrapped also continues to work
         await database_sync_to_async(create_default_modifiers_for_team)(team)

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -76,6 +76,26 @@ class TestTeam(BaseTest):
         self.assertEqual(team.autocapture_web_vitals_allowed_metrics, None)
         self.assertEqual(team.autocapture_exceptions_errors_to_ignore, None)
 
+    def test_new_teams_get_persons_on_events_mode_persisted(self):
+        # Pairs with the cache_key fix: new teams must have `personsOnEventsMode` persisted at
+        # creation time so the runner never has to fall back to the per-pod flag eval.
+        team: Team = Team.objects.create(name="New Team", organization=self.organization)
+        assert team.modifiers is not None
+        assert team.modifiers.get("personsOnEventsMode") == "person_id_override_properties_joined"
+
+    def test_existing_team_modifiers_value_is_preserved_on_update(self):
+        # If a team already has a non-default `personsOnEventsMode` (e.g. set via the backfill job
+        # or explicitly by an admin), updating other fields must not overwrite it.
+        team: Team = Team.objects.create(
+            name="New Team",
+            organization=self.organization,
+            modifiers={"personsOnEventsMode": "person_id_no_override_properties_on_events"},
+        )
+        team.name = "Renamed Team"
+        team.save()
+        team.refresh_from_db()
+        assert team.modifiers["personsOnEventsMode"] == "person_id_no_override_properties_on_events"
+
     def test_create_team_with_test_account_filters(self):
         team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
 
@@ -170,9 +190,15 @@ class TestTeam(BaseTest):
 
     @mock.patch("posthoganalytics.feature_enabled", return_value=True)
     def test_team_on_cloud_uses_feature_flag_to_determine_person_on_events(self, mock_feature_enabled):
+        # New teams get `personsOnEventsMode` persisted at creation (see the pre_save hook in
+        # team.py), so the flag-based fallback in `team.person_on_events_mode` no longer fires
+        # through the normal creation flow. To exercise the fallback we explicitly clear the
+        # persisted value.
         with self.is_cloud(True):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", False):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+                team.modifiers = None
+                team.save()
                 self.assertEqual(
                     team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
                 )
@@ -193,9 +219,12 @@ class TestTeam(BaseTest):
 
     @mock.patch("posthoganalytics.feature_enabled", return_value=False)
     def test_team_on_self_hosted_uses_instance_setting_to_determine_person_on_events(self, mock_feature_enabled):
+        # See note on the cloud variant above: clear the persisted modifier so the fallback runs.
         with self.is_cloud(False):
             with override_instance_config("PERSON_ON_EVENTS_V2_ENABLED", True):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+                team.modifiers = None
+                team.save()
                 self.assertEqual(
                     team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
                 )
@@ -205,6 +234,8 @@ class TestTeam(BaseTest):
 
             with override_instance_config("PERSON_ON_EVENTS_V2_ENABLED", False):
                 team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+                team.modifiers = None
+                team.save()
                 self.assertEqual(team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED)
                 for args_list in mock_feature_enabled.call_args_list:
                     # It is ok if we check other feature flags, just not `persons-on-events-v2-reads-enabled`

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -313,6 +313,7 @@ export interface PaginatedTicketViewListApi {
  * `email` - Email
  * `slack` - Slack
  * `teams` - Microsoft Teams
+ * `github` - GitHub
  */
 export type ChannelSourceEnumApi = (typeof ChannelSourceEnumApi)[keyof typeof ChannelSourceEnumApi]
 
@@ -321,6 +322,7 @@ export const ChannelSourceEnumApi = {
     Email: 'email',
     Slack: 'slack',
     Teams: 'teams',
+    Github: 'github',
 } as const
 
 /**
@@ -331,6 +333,7 @@ export const ChannelSourceEnumApi = {
  * `teams_bot_mention` - Teams bot mention
  * `widget_embedded` - Widget
  * `widget_api` - API
+ * `github_issue` - GitHub issue
  */
 export type ChannelDetailEnumApi = (typeof ChannelDetailEnumApi)[keyof typeof ChannelDetailEnumApi]
 
@@ -342,6 +345,7 @@ export const ChannelDetailEnumApi = {
     TeamsBotMention: 'teams_bot_mention',
     WidgetEmbedded: 'widget_embedded',
     WidgetApi: 'widget_api',
+    GithubIssue: 'github_issue',
 } as const
 
 /**
@@ -472,6 +476,10 @@ export interface TicketApi {
     /** @nullable */
     readonly email_to: string | null
     readonly cc_participants: unknown
+    /** @nullable */
+    readonly github_repo: string | null
+    /** @nullable */
+    readonly github_issue_number: number | null
     readonly person: TicketPersonApi | null
     tags?: unknown[]
 }
@@ -546,6 +554,10 @@ export interface PatchedTicketApi {
     /** @nullable */
     readonly email_to?: string | null
     readonly cc_participants?: unknown
+    /** @nullable */
+    readonly github_repo?: string | null
+    /** @nullable */
+    readonly github_issue_number?: number | null
     readonly person?: TicketPersonApi | null
     tags?: unknown[]
 }
@@ -688,6 +700,7 @@ export type ConversationsTicketsListChannelDetail =
     (typeof ConversationsTicketsListChannelDetail)[keyof typeof ConversationsTicketsListChannelDetail]
 
 export const ConversationsTicketsListChannelDetail = {
+    GithubIssue: 'github_issue',
     SlackBotMention: 'slack_bot_mention',
     SlackChannelMessage: 'slack_channel_message',
     SlackEmojiReaction: 'slack_emoji_reaction',
@@ -702,6 +715,7 @@ export type ConversationsTicketsListChannelSource =
 
 export const ConversationsTicketsListChannelSource = {
     Email: 'email',
+    Github: 'github',
     Slack: 'slack',
     Teams: 'teams',
     Widget: 'widget',

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9947,13 +9947,13 @@ export type InsightsRetrieveParams = {
     filters_override?: string
     format?: InsightsRetrieveFormat
     /**
- *
+ * 
 Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
 When set, the specified dashboard's filters and date range override will be applied.
  */
     from_dashboard?: number
     /**
- *
+ * 
 Whether to refresh the insight, how aggresively, and if sync or async:
 - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
 - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache


### PR DESCRIPTION
## Problem

`set_default_modifier_values` populates `modifiers.personsOnEventsMode` for any insight whose query does not preset it. The current default is sourced from `team.person_on_events_mode_flag_based_default`, which evaluates a feature flag locally via the embedded analytics SDK.

Local SDK flag evaluation is **per-process**: every web pod has its own in-memory cache of flag definitions, hydrated by periodic polling. Cold pods, transient poll failures, and rolling deploys mean different pods can return different values for the same flag and the same team at the same moment in time.

That return value flows directly into `get_cache_payload`, so two pods evaluating the same logical query for the same team can compute **different `cache_key`s**. The dashboard endpoint and the per-tile-refresh endpoint then write to / read from different cache entries for the same chart. Symptoms a user sees:

- "Last refreshed" timestamps that disagree across tiles on the same dashboard
- Manual refresh visibly succeeding, but the next page reload still showing stale data
- The set of "stale" tiles changing on every reload, because each request lands on a different pod

ClickHouse `system.query_log` confirms this at scale: many affected (team, insight) pairs show **exactly two distinct `cache_key`s** in any sufficiently long window — the binary signature of a binary flag-eval outcome (True vs False/None). Insights that happen to have `personsOnEventsMode` baked into their saved `query.modifiers` are immune (the flag eval branch never fires for them) and consistently show a single `cache_key`. The split between "two keys" and "one key" perfectly tracks "modifier preset on the insight" vs "modifier not preset" — leaving little room for an alternative explanation.

The same risk theoretically exists for any flag eval that feeds into globally-coherent state (cache identity, IDs, routing decisions). For flags that drive only per-request UI/code-path decisions, per-pod variance is harmless and self-healing. For cache identity, it is not — the variance is frozen into persistent storage and compounds.

## Why the backfill is durable: the flag is frozen

The flag in question is `persons-on-events-person-id-no-override-properties-on-events`, evaluated against PostHog's own analytics project. Its activity log shows it has been touched only three times since creation, with the **last modification on 2024-09-02 — over 20 months ago**. Combined with its structure (an explicit team-UUID include list, no percentage rollout, no random hashing), the flag's resolved value for any given team is deterministic and stable over time. The flag's name itself reads as snapshot-of-historical-state language ("Basically all teams who had poe_v2_enabled..."), suggesting it was always intended as one-time migration machinery rather than an ongoing rollout. Persisting the resolved value to `team.modifiers` is essentially finishing a migration that was started in 2024 and never completed — the persisted value will not go stale because the flag is not going to flip for any team.

## Changes

**Code change** (`posthog/hogql/modifiers.py`): `set_default_modifier_values` no longer calls `team.person_on_events_mode_flag_based_default`. Teams with no value persisted fall through to a stable hardcoded default (`PERSON_ID_OVERRIDE_PROPERTIES_JOINED`, the same value the existing chain returns when both flag branches are False/None). Teams that need a different mode have it persisted in `team.modifiers["personsOnEventsMode"]` — the existing modifier-merging path in `create_default_modifiers_for_team` already reads this column before `set_default_modifier_values` runs, so this preserves behavior for any team whose value is already stored.

**Backfill** (`posthog/dags/backfill_persons_on_events_mode.py`): a new Dagster job iterates teams and writes each team's currently-resolved `personsOnEventsMode` into `Team.modifiers["personsOnEventsMode"]`. Idempotent — skips teams that already have a value. Job is registered in the `analytics_platform` location.

**On-create hook** (`posthog/models/team/team.py`): a `pre_save` signal handler ensures every newly-created team gets `personsOnEventsMode` persisted at creation time. Pairs with the backfill so the team population stays fully covered going forward — without it, brand-new teams created after backfill would still have to rely on the runtime fallback. Brand-new team UUIDs never appear in the legacy POE-v2 include list, so the hardcoded default matches what the flag would have resolved to anyway.

**Tests**:
- `test_cache_key_diverges_when_persons_on_events_flag_resolves_differently` (in `test_query_runner.py`) reproduces the bug at the unit level: it patches `posthoganalytics.feature_enabled` to return True/False/None and asserts `cache_key` is identical across all three. Currently fails on `master`; passes here. Acts as a regression guard against any future modifier default that re-introduces a flag-eval into the cache_key surface.
- `test_modifiers_persons_on_events_default_does_not_consult_team_flag` (in `test_modifiers.py`) replaces an older test that asserted the now-removed flag-driven behavior, locking in the new invariant explicitly.
- `test_backfill_persons_on_events_mode.py` — five op-level tests covering: persisting the resolved mode when modifiers are unset, skipping teams that already have a value, preserving unrelated modifier keys, handling unknown team IDs, and idempotency of repeated runs.
- `test_new_teams_get_persons_on_events_mode_persisted` and `test_existing_team_modifiers_value_is_preserved_on_update` (in `test_team.py`) — verify the pre_save hook sets the default at creation and does not overwrite teams with an explicit value already set.
- A handful of pre-existing tests that asserted `team.modifiers is None` after creation are updated to clear the modifier explicitly when they need to exercise the no-override path. This is a side-effect of the on-create hook making the new normal "every team has the modifier set."
- `test_create_default_modifiers_for_team_in_async_context` (in `test_run_workflow.py`) is repurposed: it previously asserted that the function raised `SynchronousOnlyOperation` outside `database_sync_to_async` because the flag eval lazy-loaded `team.organization`. With the flag eval gone, the trigger is gone — the test is rewritten as the inverse regression guard, asserting the function is now async-safe by construction.

## How we diagnosed this

The investigation followed the production data, not the symptom description. Anonymized walkthrough so reviewers can re-trace if needed:

1. **Symptom report**: a dashboard's tile-level "last refreshed" timestamps were jumping around between page reloads — sometimes minutes old, sometimes hours, sometimes a day. Manual refreshes appeared to succeed but didn't "stick" for some tiles on subsequent reloads. The stale subset of tiles changed on every reload, ruling out tile-specific corruption.

2. **HAR captures across consecutive normal page loads** showed that the dashboard endpoint and the per-tile-refresh endpoint were returning different `last_refresh` values for the same insight at the same time. Each request looked correct in isolation; pairs disagreed. This ruled out cache TTL / invalidation as the cause and pointed at cache-key inconsistency.

3. **Direct comparison of the `filters_hash` field** (= `cache_key`) in HAR responses for the same insight from both endpoints showed two distinct hashes. Cross-referencing the affected insights against their saved `query.modifiers` revealed that every insight with `personsOnEventsMode` preset had a single cache_key in production query logs, and every insight without it had exactly two. A perfect correlation between "modifier preset" and "cache stable."

4. **Tracing `get_cache_payload`** led to `set_default_modifier_values` calling `team.person_on_events_mode_flag_based_default`, which evaluates `posthoganalytics.feature_enabled(..., only_evaluate_locally=True)`. The "only_evaluate_locally" semantics make per-pod variance possible whenever the local SDK flag-cache state differs across pods (cold pods, polling lag, deploy windows).

5. **A failing unit test** (mocking `posthoganalytics.feature_enabled` to return True/False/None against a fresh test team) reproduced two distinct cache_keys in a single deterministic Python process. Mechanism confirmed.

6. **ClickHouse `system.query_log`** was queried for the existing `cache_key` tag emitted on every query. Many teams across the platform showed multiple cache_keys for the same insight in 24-hour windows — confirming this is platform-wide cache fragmentation, not a customer-specific incident. The dominant pattern was "exactly two cache_keys per insight" (the binary flag-eval signature); a smaller long tail with three or more keys exists and is likely caused by separate variance sources outside this PR's scope (insight edits over time, dashboard `filters_overrides`, etc.).

7. **Flag activity-log inspection** (via the PostHog MCP) confirmed the flag has not been modified in over 20 months and uses an explicit include list rather than percentage targeting — i.e., the snapshotted backfill values are durable.

## Deployment notes (important)

The deploy order matters to preserve current behavior on a per-team basis:

1. **Run `backfill_persons_on_events_mode_job` against production first.** It writes each team's current resolved value into `team.modifiers`.
2. **Then merge / deploy this PR.** Once code is live, brand-new or unbackfilled teams fall through to the hardcoded default; backfilled teams continue to use whatever value was persisted in step 1.

If the backfill is run **after** the deploy, any team whose flag was resolving to a non-default mode would briefly switch to the default mode for the gap, which changes their physical query plan (the modes are intended to produce semantically equivalent results, but in some edge cases they can differ).

The backfill job is idempotent and safe to re-run; it can also be scoped to a subset of teams via the `team_ids` op config if a phased rollout is preferred.

## How did you test this code?

I am an agent. I ran the following automated tests:

- `posthog/hogql_queries/test/test_query_runner.py` — 59 tests pass, including the new regression test
- `posthog/hogql/test/test_modifiers.py` — 11 tests pass, including the updated invariant test
- `posthog/dags/tests/test_backfill_persons_on_events_mode.py` — 5 tests pass, covering the new Dagster job
- `posthog/test/test_team.py` — 24 tests pass, including the new pre_save hook tests
- `posthog/temporal/tests/data_modeling/test_run_workflow.py::test_create_default_modifiers_for_team_in_async_context` — passes after rewrite
- `ruff check` and `ruff format` clean across all touched files

I did not run the Dagster job against any environment. The job's behavior is covered by the op-level tests; full end-to-end execution against staging or production is appropriate before merge per the deployment notes above.

## Publish to changelog?

no

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.7).

Decisions made along the way:

- **Why hardcode the default rather than keep the flag eval in some safer form?** Caching the flag result locally per-process or per-pod doesn't fix cross-pod variance. Centralizing flag eval (e.g., server-side or Redis-backed) was rejected as too invasive for the value: the flag has been stable for years (verified via the activity log inspection above) and most teams resolve to the default anyway. Persisting the resolved value to `team.modifiers` is the architecturally correct fix because `personsOnEventsMode` is structurally team config, not a per-request feature toggle.
- **Why move the flag eval out entirely rather than apply it post-cache-key like `useMaterializedViews`?** The post-cache-key pattern works for `useMaterializedViews` because that modifier doesn't affect schema construction in `Database.create_for`. `personsOnEventsMode` does — it determines which person-events join strategy the schema uses, and `Database.create_for` is invoked during runner construction (before `_calculate_for_query`). Keeping the flag eval in the schema-construction path while removing it from cache_key would split-brain the runner and the database. Cleanest fix is to remove the flag eval from both paths and source the value from a single coherent store.
- **Why a Dagster job rather than a Django management command?** Existing platform pattern; other team-iterating backfills (`backfill_internal_test_users_cohort_job`) live as Dagster jobs in this repo; reuses the existing `get_all_team_ids_op` for batching, rollout-percentage, and dry-run support out of the box.
- **Why is the regression test using `mock.patch("posthoganalytics.feature_enabled", ...)` rather than asserting the modifier is absent from `get_cache_payload`?** A behavioral test (mocking the source of variance and asserting cache_key stability) is more durable than a structural test (asserting which fields are in the payload). Future flag-eval calls that sneak into the runner construction path will be caught by this test even if they don't go through `personsOnEventsMode`.

Out of scope for this PR:

- Auditing other `posthoganalytics.feature_enabled` callsites for similar leaks into cache identity. The mechanism described here can in principle affect any flag eval that feeds into a hash, ID, or shared cache. The dominant binary-key signature in production data points to this specific modifier as the largest contributor; other contributors (some insights show three or more cache_keys, likely from `filters_overrides` or query edits over time) are smaller and warrant separate investigation.
- Retiring the `team.person_on_events_mode_flag_based_default` property entirely. After backfill propagation it has no callers in the cache_key path, but it may still be used elsewhere (e.g., the `team.person_on_events_mode` property at `team.py:698` falls back to it for teams without `team.modifiers` set). Cleanup is a follow-up once the backfill is fully rolled out.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
