### PR TITLE
test(shared-views): playwright e2e for unauthenticated shared dashboard

### DIFF
--- a/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
+++ b/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
@@ -94,8 +94,8 @@ test.describe('Shared dashboard (unauthenticated)', () => {
             await unauthPage.goto(`/shared/${sharingData.access_token}`)
 
             await expect(unauthPage.locator('body.ExporterBody')).toBeVisible()
-            await expect(unauthPage.locator(`text=${dashboardName}`)).toBeVisible({ timeout: 30000 })
-            await expect(unauthPage.locator(`text=${insightName}`)).toBeVisible({ timeout: 30000 })
+            await expect(unauthPage.getByTestId('dashboard-item-title')).toHaveText(dashboardName, { timeout: 30000 })
+            await expect(unauthPage.getByText(insightName, { exact: true })).toBeVisible({ timeout: 30000 })
             await expect(unauthPage.locator('[data-attr="insights-graph"]').first()).toBeVisible({ timeout: 30000 })
 
             expect(pageErrors).toEqual([])

--- a/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
+++ b/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
@@ -22,8 +22,16 @@ async function createSharedDashboard(
         'Content-Type': 'application/json',
     }
 
+    const dashboardName = 'Unauth Shared Dashboard'
+    const dashboardResponse = await page.request.post(`/api/projects/${workspace.team_id}/dashboards/`, {
+        headers: authHeaders,
+        data: { name: dashboardName },
+    })
+    expect(dashboardResponse.ok()).toBe(true)
+    const dashboardData = await dashboardResponse.json()
+
     const insightName = 'Unauth Shared Dashboard Insight'
-    const insightPayload: { name: string; query: InsightVizNode<TrendsQuery> } = {
+    const insightPayload: { name: string; query: InsightVizNode<TrendsQuery>; dashboards: number[] } = {
         name: insightName,
         query: {
             kind: NodeKind.InsightVizNode,
@@ -33,6 +41,7 @@ async function createSharedDashboard(
                 dateRange: { date_from: '2024-10-04', date_to: '2024-11-03', explicitDate: true },
             },
         },
+        dashboards: [dashboardData.id],
     }
 
     const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
@@ -40,24 +49,6 @@ async function createSharedDashboard(
         data: insightPayload,
     })
     expect(insightResponse.ok()).toBe(true)
-    const insightData = await insightResponse.json()
-
-    const dashboardName = 'Unauth Shared Dashboard'
-    const dashboardResponse = await page.request.post(`/api/projects/${workspace.team_id}/dashboards/`, {
-        headers: authHeaders,
-        data: { name: dashboardName },
-    })
-    expect(dashboardResponse.ok()).toBe(true)
-    const dashboardData = await dashboardResponse.json()
-
-    const tileResponse = await page.request.patch(
-        `/api/projects/${workspace.team_id}/dashboards/${dashboardData.id}/`,
-        {
-            headers: authHeaders,
-            data: { tiles: [{ insight: { id: insightData.id } }] },
-        }
-    )
-    expect(tileResponse.ok()).toBe(true)
 
     const sharingResponse = await page.request.patch(
         `/api/projects/${workspace.team_id}/dashboards/${dashboardData.id}/sharing`,

--- a/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
+++ b/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
@@ -76,20 +76,6 @@ test.describe('Shared dashboard (unauthenticated)', () => {
         const unauthContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
         const unauthPage = await unauthContext.newPage()
 
-        const pageErrors: string[] = []
-        unauthPage.on('pageerror', (err) => pageErrors.push(err.message))
-
-        const failedRequests: string[] = []
-        unauthPage.on('response', (response) => {
-            const url = response.url()
-            const status = response.status()
-            const isApi = url.includes('/api/')
-            const isError = status >= 500 || (status >= 400 && status !== 401 && status !== 403)
-            if (isApi && isError) {
-                failedRequests.push(`${url} - ${status}`)
-            }
-        })
-
         try {
             await unauthPage.goto(`/shared/${sharingData.access_token}`)
 
@@ -97,9 +83,6 @@ test.describe('Shared dashboard (unauthenticated)', () => {
             await expect(unauthPage.locator(`text=${dashboardName}`)).toBeVisible({ timeout: 30000 })
             await expect(unauthPage.locator(`text=${insightName}`)).toBeVisible({ timeout: 30000 })
             await expect(unauthPage.locator('[data-attr="insights-graph"]').first()).toBeVisible({ timeout: 30000 })
-
-            expect(pageErrors).toEqual([])
-            expect(failedRequests).toEqual([])
         } finally {
             await unauthContext.close()
         }

--- a/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
+++ b/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
@@ -22,7 +22,7 @@ async function createSharedDashboard(
         'Content-Type': 'application/json',
     }
 
-    const dashboardName = 'Unauth Shared Dashboard'
+    const dashboardName = 'Logged-out dashboard render'
     const dashboardResponse = await page.request.post(`/api/projects/${workspace.team_id}/dashboards/`, {
         headers: authHeaders,
         data: { name: dashboardName },
@@ -30,7 +30,7 @@ async function createSharedDashboard(
     expect(dashboardResponse.ok()).toBe(true)
     const dashboardData = await dashboardResponse.json()
 
-    const insightName = 'Unauth Shared Dashboard Insight'
+    const insightName = 'Trends pageview tile'
     const insightPayload: { name: string; query: InsightVizNode<TrendsQuery>; dashboards: number[] } = {
         name: insightName,
         query: {
@@ -94,8 +94,8 @@ test.describe('Shared dashboard (unauthenticated)', () => {
             await unauthPage.goto(`/shared/${sharingData.access_token}`)
 
             await expect(unauthPage.locator('body.ExporterBody')).toBeVisible()
-            await expect(unauthPage.getByTestId('dashboard-item-title')).toHaveText(dashboardName, { timeout: 30000 })
-            await expect(unauthPage.getByText(insightName, { exact: true })).toBeVisible({ timeout: 30000 })
+            await expect(unauthPage.locator(`text=${dashboardName}`)).toBeVisible({ timeout: 30000 })
+            await expect(unauthPage.locator(`text=${insightName}`)).toBeVisible({ timeout: 30000 })
             await expect(unauthPage.locator('[data-attr="insights-graph"]').first()).toBeVisible({ timeout: 30000 })
 
             expect(pageErrors).toEqual([])

--- a/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
+++ b/playwright/e2e/shared-dashboard-unauthenticated.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test: shared dashboards must render in a fully unauthenticated browser context.
+ * Added after a fix that skipped "always-401" API calls in shared/exported views had to be
+ * reverted — the skip broke the shared dashboard render path. A logged-out goto of
+ * /shared/{token} reliably reproduces that class of regression.
+ */
+import { expect, Page } from '@playwright/test'
+
+import { InsightVizNode, NodeKind, TrendsQuery } from '../../frontend/src/queries/schema/schema-general'
+import { SharingConfigurationType } from '../../frontend/src/types'
+import { PlaywrightSetup } from '../utils/playwright-setup'
+import { test } from '../utils/workspace-test-base'
+
+async function createSharedDashboard(
+    page: Page,
+    playwrightSetup: PlaywrightSetup,
+    orgName: string
+): Promise<{ sharingData: SharingConfigurationType; dashboardName: string; insightName: string }> {
+    const workspace = await playwrightSetup.createWorkspace(orgName)
+    const authHeaders = {
+        Authorization: `Bearer ${workspace.personal_api_key}`,
+        'Content-Type': 'application/json',
+    }
+
+    const insightName = 'Unauth Shared Dashboard Insight'
+    const insightPayload: { name: string; query: InsightVizNode<TrendsQuery> } = {
+        name: insightName,
+        query: {
+            kind: NodeKind.InsightVizNode,
+            source: {
+                kind: NodeKind.TrendsQuery,
+                series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                dateRange: { date_from: '2024-10-04', date_to: '2024-11-03', explicitDate: true },
+            },
+        },
+    }
+
+    const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
+        headers: authHeaders,
+        data: insightPayload,
+    })
+    expect(insightResponse.ok()).toBe(true)
+    const insightData = await insightResponse.json()
+
+    const dashboardName = 'Unauth Shared Dashboard'
+    const dashboardResponse = await page.request.post(`/api/projects/${workspace.team_id}/dashboards/`, {
+        headers: authHeaders,
+        data: { name: dashboardName },
+    })
+    expect(dashboardResponse.ok()).toBe(true)
+    const dashboardData = await dashboardResponse.json()
+
+    const tileResponse = await page.request.patch(
+        `/api/projects/${workspace.team_id}/dashboards/${dashboardData.id}/`,
+        {
+            headers: authHeaders,
+            data: { tiles: [{ insight: { id: insightData.id } }] },
+        }
+    )
+    expect(tileResponse.ok()).toBe(true)
+
+    const sharingResponse = await page.request.patch(
+        `/api/projects/${workspace.team_id}/dashboards/${dashboardData.id}/sharing`,
+        {
+            headers: authHeaders,
+            data: { enabled: true },
+        }
+    )
+    expect(sharingResponse.ok()).toBe(true)
+    const sharingData: SharingConfigurationType = await sharingResponse.json()
+    expect(sharingData.access_token).toBeTruthy()
+    expect(sharingData.enabled).toBe(true)
+
+    return { sharingData, dashboardName, insightName }
+}
+
+test.describe('Shared dashboard (unauthenticated)', () => {
+    test('renders successfully in a logged-out browser context', async ({ browser, page, playwrightSetup }) => {
+        const { sharingData, dashboardName, insightName } = await createSharedDashboard(
+            page,
+            playwrightSetup,
+            'Unauth Shared Dashboard Test Org'
+        )
+
+        const unauthContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+        const unauthPage = await unauthContext.newPage()
+
+        const pageErrors: string[] = []
+        unauthPage.on('pageerror', (err) => pageErrors.push(err.message))
+
+        const failedRequests: string[] = []
+        unauthPage.on('response', (response) => {
+            const url = response.url()
+            const status = response.status()
+            const isApi = url.includes('/api/')
+            const isError = status >= 500 || (status >= 400 && status !== 401 && status !== 403)
+            if (isApi && isError) {
+                failedRequests.push(`${url} - ${status}`)
+            }
+        })
+
+        try {
+            await unauthPage.goto(`/shared/${sharingData.access_token}`)
+
+            await expect(unauthPage.locator('body.ExporterBody')).toBeVisible()
+            await expect(unauthPage.locator(`text=${dashboardName}`)).toBeVisible({ timeout: 30000 })
+            await expect(unauthPage.locator(`text=${insightName}`)).toBeVisible({ timeout: 30000 })
+            await expect(unauthPage.locator('[data-attr="insights-graph"]').first()).toBeVisible({ timeout: 30000 })
+
+            expect(pageErrors).toEqual([])
+            expect(failedRequests).toEqual([])
+        } finally {
+            await unauthContext.close()
+        }
+    })
+})


### PR DESCRIPTION
## Problem

The recent fix that tried to skip "always-401" API calls in shared/exported views (#57670) had to be reverted (#57814) because it broke shared dashboards in production. We didn't have an end-to-end test exercising the unauthenticated render path, so the regression slipped through.

## Changes

Add a Playwright e2e (`playwright/e2e/shared-dashboard-unauthenticated.spec.ts`) that:

- creates a workspace, an insight, and a dashboard with that insight tile via the API
- enables sharing on the dashboard
- opens a fresh `browser.newContext()` with empty storage state (guaranteed logged-out, no session leak from other tests)
- navigates to `/shared/{access_token}` and asserts the exporter body, dashboard title, insight title, and graph all render
- fails on any uncaught page error or any 4xx/5xx API response (excluding 401/403, which are part of the legitimate logged-out surface)

## How did you test this code?

I'm an agent. I did not run this test against a live environment — there was no local server available in this session.

What I did verify locally:

- `pnpm --filter=@posthog/playwright exec playwright test playwright/e2e/shared-dashboard-unauthenticated.spec.ts --list` parses and discovers the test cleanly (no TypeScript errors, no syntax errors)
- The structure mirrors the existing `playwright/e2e/shared-dashboard-styling.spec.ts` which is green in CI

This test should run as part of the playwright e2e suite (currently opt-in per #57657).

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Human prompt that shaped this: "open a PR for a playwright test for a shared dashboard. we want to hit the dashboard in a totally unauth'd window to validate that works - which doesn't with the broken set up"
- Decision: use a fresh `browser.newContext()` with empty `storageState` rather than relying on `workspace-test-base` not auto-logging-in. This makes the unauth invariant explicit and immune to fixture changes elsewhere.
- Decision: allow 401/403 in the API response listener — both are legitimate possibilities on a public/exported page and aren't what the revert bug was about.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*