### PR TITLE
fix(date-filter): allow setting start time before picking a date

### DIFF
--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
@@ -126,6 +126,31 @@ describe('FixedRangeWithTimePicker', () => {
         expect(dayjs(from).isBefore(dayjs(to))).toBe(true)
     })
 
+    it('allows setting the start time when no start date is initially set', async () => {
+        const { container } = render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={null}
+                rangeDateTo={null}
+                setDate={setDate}
+                onClose={onClose}
+                use24HourFormat
+            />
+        )
+
+        // Default mode is selectingStart=true. With no rangeDateFrom, clicking a
+        // time button used to silently do nothing. Verify the click takes effect.
+        const hourButton = container.querySelector('[data-attr="14-h"]') as HTMLElement
+        expect(hourButton).toBeTruthy()
+        await userEvent.click(hourButton)
+
+        const minuteButton = container.querySelector('[data-attr="30-m"]') as HTMLElement
+        expect(minuteButton).toBeTruthy()
+        await userEvent.click(minuteButton)
+
+        // Start label should reflect the chosen time (regardless of fallback date).
+        expect(screen.getByRole('button', { name: /^Start: .* 14:30$/ })).toBeInTheDocument()
+    })
+
     describe('24-hour format', () => {
         it('displays times in HH:mm format', () => {
             render(

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -151,41 +151,43 @@ export function FixedRangeWithTimePicker({
                             className: 'rounded-none',
                             'data-attr': `${timeProps.value}-${timeProps.unit}`,
                             onClick: () => {
-                                if (currentValue) {
-                                    let newDate = currentValue
-                                    if (timeProps.unit === 'h') {
-                                        if (use24HourFormat) {
-                                            newDate = currentValue.hour(Number(timeProps.value))
-                                        } else {
-                                            const isPM = currentValue.format('a') === 'pm'
-                                            newDate = currentValue.hour(
-                                                isPM && timeProps.value !== 12
-                                                    ? Number(timeProps.value) + 12
-                                                    : !isPM && timeProps.value === 12
-                                                      ? 0
-                                                      : Number(timeProps.value)
-                                            )
-                                        }
-                                    } else if (timeProps.unit === 'm') {
-                                        newDate = currentValue.minute(Number(timeProps.value))
-                                    } else if (timeProps.unit === 'a') {
-                                        const currentHour = currentValue.hour()
-                                        if (timeProps.value === 'am' && currentHour >= 12) {
-                                            newDate = currentValue.subtract(12, 'hour')
-                                        } else if (timeProps.value === 'pm' && currentHour < 12) {
-                                            newDate = currentValue.add(12, 'hour')
-                                        }
-                                    }
-                                    if (selectingStart) {
-                                        setLocalFrom(newDate)
-                                        if (localTo && newDate.isAfter(localTo)) {
-                                            setLocalTo(newDate.add(1, 'hour'))
-                                        }
+                                // Fall back to today so the user can set the time
+                                // before picking a date — otherwise clicking time
+                                // buttons in start mode silently does nothing
+                                // when no start date is selected yet.
+                                let newDate = currentValue ?? dayjs()
+                                if (timeProps.unit === 'h') {
+                                    if (use24HourFormat) {
+                                        newDate = newDate.hour(Number(timeProps.value))
                                     } else {
-                                        setLocalTo(newDate)
-                                        if (localFrom && newDate.isBefore(localFrom)) {
-                                            setLocalFrom(newDate.subtract(1, 'hour'))
-                                        }
+                                        const isPM = newDate.format('a') === 'pm'
+                                        newDate = newDate.hour(
+                                            isPM && timeProps.value !== 12
+                                                ? Number(timeProps.value) + 12
+                                                : !isPM && timeProps.value === 12
+                                                  ? 0
+                                                  : Number(timeProps.value)
+                                        )
+                                    }
+                                } else if (timeProps.unit === 'm') {
+                                    newDate = newDate.minute(Number(timeProps.value))
+                                } else if (timeProps.unit === 'a') {
+                                    const currentHour = newDate.hour()
+                                    if (timeProps.value === 'am' && currentHour >= 12) {
+                                        newDate = newDate.subtract(12, 'hour')
+                                    } else if (timeProps.value === 'pm' && currentHour < 12) {
+                                        newDate = newDate.add(12, 'hour')
+                                    }
+                                }
+                                if (selectingStart) {
+                                    setLocalFrom(newDate)
+                                    if (localTo && newDate.isAfter(localTo)) {
+                                        setLocalTo(newDate.add(1, 'hour'))
+                                    }
+                                } else {
+                                    setLocalTo(newDate)
+                                    if (localFrom && newDate.isBefore(localFrom)) {
+                                        setLocalFrom(newDate.subtract(1, 'hour'))
                                     }
                                 }
                             },


### PR DESCRIPTION
## Problem

In the fixed-range-with-time picker, users couldn't set a start time when no date range was selected yet. Clicking any time button (hour/minute/AM-PM) in the default Start mode silently did nothing — but End mode worked fine, which made the bug confusing to track down.

The asymmetry came from `dateFilterLogic`: `rangeDateTo` defaults to `dayjs()` (now) while `rangeDateFrom` defaults to `null`. The time picker's `onClick` then guarded the entire body behind `if (currentValue)`, so any click in Start mode while `localFrom` was null was a no-op.

## Changes

- `FixedRangeWithTimePicker.tsx`: drop the `if (currentValue)` guard in the time button `onClick` and fall back to `dayjs()` when no value is set yet, so the click always takes effect.
- `FixedRangeWithTimePicker.test.tsx`: add a regression test that opens the picker with `rangeDateFrom={null}` and asserts that clicking hour/minute buttons updates the Start label.

## How did you test this code?

Agent-authored. Verified the fix with the new and existing Jest tests:

- `npx jest src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx --no-coverage` — all 12 tests pass, including the new "allows setting the start time when no start date is initially set" case.
- No manual UI verification.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (agent) from a bug report describing "unable to set a start time" in a timestamp range filter.
- Investigation traced the symptom to the interaction between `dateFilterLogic`'s asymmetric default (`rangeDateFrom=null`, `rangeDateTo=now`) and the early-return guard in `getLemonButtonTimeProps.onClick`.
- Considered initialising `localFrom` to a default value instead, but that would auto-fill a Start date the user never picked. The chosen fix only kicks in when the user explicitly clicks a time button without a Start date, which keeps the visual state honest while still making the click responsive.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

## Note from Will the human: tested in the UI and it works:
<img width="448" height="482" alt="Time edited" src="https://github.com/user-attachments/assets/66e87ceb-0c20-474a-a5b6-d0ab2f9932f1" />
