### PR TITLE
fix(hog-charts): BarChart visual parity with chart.js

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -425,209 +425,209 @@ snapshots:
     components-hedgehogmode--static-hedgehog--light:
         hash: v1.k794b7964.43d71f5c3ad02bd9e1fa87433d34df79e0de653c4b55004188bed5de78a2c3f5.i2ATBYyqY7uq7UxwlL2Rdte6AuMyySa8Jnbeb1VouoQ
     components-hogcharts-barchart--custom-corner-radius--dark:
-        hash: v1.k794b7964.60b30a6eb30f619286e4bebcc0e826b7e0fe07dac50a619006abe62938448bd7.OoZdSO02WvRWfCVtbyktzl3lrxAuHlYyK1D0K4I6KcA
+        hash: v1.k794b7964.ea8c43650b4092cbc2e77d3c1434956791b055450fc71b250d80ce2d3797ab95.NbHdkbeXdOFxKNuQGpkrJ6DhLvrMg8UzB_p4T4U3_Ww
     components-hogcharts-barchart--custom-corner-radius--light:
-        hash: v1.k794b7964.aa682b36b763d46a78a890159bde69ffcae8003e2547d3d7efa1c0d935f586d1.RWBA9_K3zcJp9byDUgST-2bPDgm8eWbHPP5NH7XmI_I
+        hash: v1.k794b7964.0dac747f4e25c20af8ae87b1298ce78f740b1d61ffe17111e374beebbd4d4b67.qEe6wuSeislWK6Y_E6sW1cuocrbad55E7TCYPcqp9Fk
     components-hogcharts-barchart--grouped--dark:
-        hash: v1.k794b7964.078f28eccfd28f69fe80354e1218b16ff6d1fdb907b20f25dc41ec36c96a8ded.6TuJ_-La7kx8WNhhtPsshCCpob_PgOET5YjNg01Tu2o
+        hash: v1.k794b7964.519966f77e2f7f689d1ca8cc96a0af90e063e479964b28056a3a681457cd5d31.0phGCRGTRo6sxln_-Z2GAgJnsQBBTnZR4d9OH7anc60
     components-hogcharts-barchart--grouped--light:
-        hash: v1.k794b7964.e4158a7d99676b8055174598a6475b4697eaa9e55bc76d37671e5476c7093761.8XbfpKDl117VlCvKbu4elEF4sYocsR5Myfe6J9a2JD8
+        hash: v1.k794b7964.f49536094a6490194b3b7ad4629f72620e3fae579e07bfb55825446fa4439147.f8CoA2mJ9ZRwghAgK1HIaxtedLUH89hOuBeYE2-dis8
     components-hogcharts-barchart--hidden-series--dark:
-        hash: v1.k794b7964.226e680f95441191df589c1c779a610b1537700f68bcf9bcbcdfec6c3531a345.bz8MpbgWOOqkxbhQfycljsbaUZbqTJr5dI3IaEd8fLw
+        hash: v1.k794b7964.4af467a59d49665cbf0d910e008d4d7313bee85c231492b845b82d00bf1f5776.BJmEwR1rC0d114gLNnT9ZoL9XDYzyXRtba9rr0cRzhQ
     components-hogcharts-barchart--hidden-series--light:
-        hash: v1.k794b7964.67bf78dd08ccc1729e80201848313a29da13390b702392de682d3b943935c16c.M9L7pAh4A_NfRSM84smG0nK3sw283Hcq-8NlAZo7jGY
+        hash: v1.k794b7964.6b2b207bfbb22829a93b82e41df1e4185fe0b8f219bc56869c22a18a5b4fb0bf.4Vht6bREnl3XEdpNvsgVPqnhi3KYGdaLu9Gb9YyZf6w
     components-hogcharts-barchart--horizontal--dark:
-        hash: v1.k794b7964.c6a9c536925fbcd599b7eefdc26db8c9c1fd7a64d7daa0008554bf5bfd508f0f.SifNqo7XZEFidMvIhfUNM_mUo_j2YoslHi7LoCDPIiI
+        hash: v1.k794b7964.2e57b5eb67fe61cb0d615db8e602b5867b9965271f930576572486f5c3a381cf.rQJgmmPBwH0Jl_NALrmNhCrkHPrw3zfvQwW7NaUfCSU
     components-hogcharts-barchart--horizontal--light:
         hash: v1.k794b7964.c2d37efbb5f1a595f2ad8004b5b532ed557f5ef0cf8d66c6889c9ba60120d197.68oC5-4T8-zOosLcakG-rWYkDFsG_-GG6G60H69pI4g
     components-hogcharts-barchart--horizontal-grouped--dark:
-        hash: v1.k794b7964.e9fd8547f575b669aaf3417ced6eb4563c071e5f2370c5ed93f824a3e627b7bc.nCIpf29idWWUpnJpRTTgbU2tuOm9GFu7Y_GHQEJWp1A
+        hash: v1.k794b7964.f68e09df33fe1a42fa38a4c49b714f9f309995f5a9a76c45082cbfeefca19150.lfLphoQUP9BMClRf4sT9t3HD1DzyVZb99whBGWaVfqU
     components-hogcharts-barchart--horizontal-grouped--light:
-        hash: v1.k794b7964.f6ab716f1dfaf9167d6feff36d9cdc150cc8968e886432dfb1d954e4a71d03bf.aSXGMr0Pc27BbiIGy0S7IlxZHLbrtD3gyDRcCjcyEJU
+        hash: v1.k794b7964.beb8d534a94663d944290398d7c2946b739d8d6ad9af6e7cd5b5fa86eb53d4d9.0pZ70Z9dzCO4WrZNoZmeVP0ISM0vy8_QvWUggLAs-6o
     components-hogcharts-barchart--incomplete-period--dark:
-        hash: v1.k794b7964.cbf95b3ae4ac3bb3f0a1e5fc11332aff646eb36cd44ebab69fc70b9fb6a2488b.9MKPiNnIm2kYdY6l8l7VRst9usIeBWS4gEkZw2SDkO4
+        hash: v1.k794b7964.7d9ab6b6cc8c4937ae0db54e48fa9d49f38e653230aefeeb2e061285aa9e3c31.7A_9Vb8PAwK7BOANh_9R08598qOpiD3_BqCxBkOyPYI
     components-hogcharts-barchart--incomplete-period--light:
-        hash: v1.k794b7964.5b913431070036537f198b0ed3911993c03884115986738e41b8a97d0a456141.KCN9yCdHUcD1F44fb_JK9uSW-6NXZEQk5whMkyxTeaY
+        hash: v1.k794b7964.b26b71ff3d2ef29b6d59a676910a9f2e9b6ad71d75c16d47e1c4b7be4a805948.0u9C0PqxoKCUzcbZ2PZN8zps43tkIv2vLUsR9jkfBWw
     components-hogcharts-barchart--large-dataset--dark:
-        hash: v1.k794b7964.5bfee8d8dd80952af499365f7cbbd3fce621b052b9bd437059bb4497d68f1a3e.r5Mu4P8PFeTbGp2ePjB_FHIfbQYS_Hp9OA2_o_JKZ90
+        hash: v1.k794b7964.64d1fe8093b208974b969699b56bfac01f1bc453ed58f4c70115a4f1c6b1e82b.w2I1sk_SSeE2mZMpeStLPx3H4sQM4GcNLc_YFIkYBcg
     components-hogcharts-barchart--large-dataset--light:
-        hash: v1.k794b7964.dfac8d281447836dc09c37a4fc0c5e9e63af62893a6c9c6787411c9957edc510.3DEbF7aClg4pU2tmwqw_Dn8-eNxAzRsCvELVjYxXHG8
+        hash: v1.k794b7964.f2a511fd1da07d703c1098de939397a50d9974f9d8687901b0b45ddba2782a5f.UT09Z5anF_9S5egvdB5ZxMBPwPM3c-f1aOCcvO4FhJM
     components-hogcharts-barchart--negative-values--dark:
-        hash: v1.k794b7964.bb94019ea075d8fb8ff5f7fd720f199041bcc38648dedf33f313e22af7fc98c7.CZrdBAc0pcaLzPVuGu5ZpNfxZou7hgWqVScdxqTOUyw
+        hash: v1.k794b7964.7be2972f8a3e14bda2fd7acfe74d6cad5689b1ae966c3e3842bad6c596a924a0.xxU22quViue9ppMauwToQCdHHC6ArDwE-LQljhF6dxE
     components-hogcharts-barchart--negative-values--light:
-        hash: v1.k794b7964.c7a841bb9d0fcbb8de45efa6b4c19280cf49cf2b61e81899063e72811cea82e0.E_od5DiXozvmAVVq_bg7bFtG6U41p4Vs0fmuMf-6jPs
+        hash: v1.k794b7964.2fdbc9b8c3e9cfa131f1f7fa1e1ab321ef9ed75f97b576fd03d36006660d97ee.ucknFjThmJmGxxdORpVbfKrl41FIPhVkls_cCuOV78c
     components-hogcharts-barchart--no-grid--dark:
-        hash: v1.k794b7964.31d7520f9ec84017bdc1b8edd093581e11754176a875d300b3537ba5b165e6f7.VvwqC1evPMx6eTnIYgzqGPDct7lexJIszp_U84CYXR0
+        hash: v1.k794b7964.90daab75d531f70cf8385cef8ec2067bae194235abab81c8661dc12aee787974.VAjMDyYqg1H9k-tgXe6wdP6RR4oT8h5wYQ5CwRcp2I8
     components-hogcharts-barchart--no-grid--light:
-        hash: v1.k794b7964.38e1a72d4d0fb31fa8e44109789d2969c96677a05eca55825a601e7522a97602.kQuRQOXT9js2_d5G5zHJn2KQ5mxiA0A8WW5zTAsRP7w
+        hash: v1.k794b7964.9239da699a527fcf5c5891a6fc66c6b83df232eac4f30a2c102b782c41708189.zokAFnxXHUwzb1Tg95vDUUDMSKOOUddBf-MkZ8_b42o
     components-hogcharts-barchart--percent--dark:
-        hash: v1.k794b7964.0f9d9694000b7533bdef27cfe8bbb2bfd4302f1ba68f2811acdc29e1b2d94057.rUtLT0cSOlDzXiRiubOwsP6gjI5seBsCQrDK8RxHk1M
+        hash: v1.k794b7964.360a542c44b02c9cd07a5b15ca365fbaeb5672087ef65101861e6cd3fb4de67d.mQoa0vPbVaDEqcY23kqcMcfoFtfDwUZxMGdFcO6p9jY
     components-hogcharts-barchart--percent--light:
-        hash: v1.k794b7964.3199a55091d5aef027450a6c74bd07db4635115d32301f03ebd56827b94b6b4e.hC6o713wJLdjT4Db3tnu-tX4ZUXQ838o-3dBvrmZmsI
+        hash: v1.k794b7964.5e0bd2685b40d9b58abb975a201f45e71d15567ceb51ddf763e5c6d3b54b69d5.mckC7Bfq24tUdqBD_P4ZMq2Pc3aVXYtqguRquonJqeY
     components-hogcharts-barchart--single-series--dark:
-        hash: v1.k794b7964.4e19bf47762ba223d9dd161f45e6d8625baba1c3076b4e0cfc79c090dbcab780.ftz6uYnhYdmWKs7mzJx2wzB7p0lTaSpNNDQHTLdmWh8
+        hash: v1.k794b7964.3716275f954dbf832984e3ce976d4d8e19a4f2cbd9da2e051a781f7ce1c363a2.VnziWMf5T3AJXEjPVPYYpykd9HVHy9bm7iYNsXXzTtk
     components-hogcharts-barchart--single-series--light:
-        hash: v1.k794b7964.0322fa8bf8c52d2a22d99279c36b3c13676a410046f1a1214e6183dfcebfdd02.xI01Ul9WXrva-7pcp-HFIWco_PYil6iiSU3Nw0_YDyM
+        hash: v1.k794b7964.04f2e2728ac26dcb2b1b906206a7e581e426589352104d8991ff84b64367096b._Lz_dBQEQTgbGhtBoNxdmUTnRFlFNKP30PTJwjhcnAs
     components-hogcharts-barchart--stacked-default--dark:
-        hash: v1.k794b7964.8e54af8bd7289b86a625925b159f3a97b0d7e2cc91f51e49e8df82bf3a768235.DaZ84oTWY8DCaeyvtnAze-BOuggHuMXpzgZwE5WPyuI
+        hash: v1.k794b7964.29fd17adfbb8bec9dce9c8d5f9444fdea008f7c03130110028d235e36b9e5fb2.K4mf4BT0eoVIliBiHHd1zp8pHW9dIutpZyANueHBJjE
     components-hogcharts-barchart--stacked-default--light:
-        hash: v1.k794b7964.93120d98ce1dd7479f89b94d9c1fd63f9848bca7a18de115c6be77b0b297a29d.X9KgbPzKuz1NOXgQFwyBYrbaMtp9HqjNUggC6OBA2fM
+        hash: v1.k794b7964.7a8cc976af2bebc81e2537672c07b84f7ec51edc7f87778da4c4de16eb637b7f.Bs7OSdQ3MB3WcGrcs8KG_Ka8vOV-FHSlPCO8Vph1vCE
     components-hogcharts-barchart--stacked-mixed-sign--dark:
-        hash: v1.k794b7964.7b2c423832b7905806ed16876aacdd7ea4ec19d15c0f73b72059b1f310e0bac3.F7Y16r39vAX_WB-IAajDmLutSQNdMY-90TusfLyGNO4
+        hash: v1.k794b7964.78ae65df47f38a1591d7e7ea98143d1d52148505cc30d7aa15e41267ab7069ae.8ZZW5wd0CsmrQSjirpj1kpZjse2ii8F263u0owKxSWM
     components-hogcharts-barchart--stacked-mixed-sign--light:
-        hash: v1.k794b7964.520cec44a9bdf1647114354349bb796712202aa45e2c4f81994f334bce5bb685.ZQznGFg-M_qzXFfcfIabLDmIfGYMYYIp1fLKKMDzcnc
+        hash: v1.k794b7964.f85427c86ddf715de891c55aa499119ea88cbb161b2b37e8d4c943e07b6eeb27.UnBe38l0a2kG3Ney_67dJ5zTBSD-qHIUF3JWMBep2-k
     components-hogcharts-barchart--with-reference-line--dark:
-        hash: v1.k794b7964.7eb8d9098758b313d2aca5944f505c06b2dd519bd39a22d78cebe7651049c72e.4saRRb0_JaCHogNY2INcV88e8LYG7zl0H2J0bEWX1cI
+        hash: v1.k794b7964.b0c3c06250da7f04cb51a3044d2f6f54c9d6508e7aed6473bfd3f86991c9c358.pJc_WoUpP1J_PwVo6h-h_cXVue1gUJnph4-m95Xsd0I
     components-hogcharts-barchart--with-reference-line--light:
-        hash: v1.k794b7964.052b6062e4b577ddb6e8828d6e7d640ae61a4d1ac2d11e732efb78e85635db4e.94W62U6OELNkecVz7EIKA8NU-QnJTBGOHdbiDxYKn2g
+        hash: v1.k794b7964.081e6b6e0d8258756a42817806f81c4c2c934e5086728e4e57731d618cb0f5bb.LLR8JlGiNzCaW5F55LVIYQ9V5biMi1zPB6HpZ_tpmMk
     components-hogcharts-barchart--with-value-labels--dark:
-        hash: v1.k794b7964.578b7821d26e3c638eaca7ee223a892680e298a626aab95084505029c4d78fcd.fV_G7AnDZbcCI-FF-e2g3vWMpWt77jQAwnmhP6m4mUo
+        hash: v1.k794b7964.21dacbfe67216e10df7a4f2ef8e45bebff41b2399a3315c217601758c14d297a.VN5fn496LfQhUn60sjiNs58h5B0ZTBAi9jRhtGCX3Vs
     components-hogcharts-barchart--with-value-labels--light:
-        hash: v1.k794b7964.f5451d34516fe082b7a13b4727b9da3210eb0f703d33b65d24762e3550190b04.ugauYW7EYoMrsEBCg1_fYXUvJDbxP9b364VXiZg8X20
+        hash: v1.k794b7964.3a52da452bcd2bc7c4818c847440a38310c17c9caf834b753e01f90e43bbfe46.-P_DmB3jIS_5XQ0sh1h6BTjDoDGfHp1UJR4vtwmCE4c
     components-hogcharts-linechart--combined-overlays--dark:
-        hash: v1.k794b7964.7a5d75d739b30755468fe69e4b938e16d93630e7d2f444d2a76563563879a8f5.-qZogPFTjOPrh2r16ccI1VbZlTPiwhGHuF4WbzwpHT4
+        hash: v1.k794b7964.38753d5c6bab2f9d1be492d0e191aca21265953e220c0f37714913c89d7caf42.0wzgqeeUqe_bxIfIbS861HknzpuGVzxC664U1GTe9S8
     components-hogcharts-linechart--combined-overlays--light:
-        hash: v1.k794b7964.2278588bb82f5838d3fec1cd9404a616c63d92de1093847ff6b0efce95882cea.WiBltYxSZN09NESRdqGqFHCF58HTluiMubxTgu1EqoE
+        hash: v1.k794b7964.e0f8427b5643650cef898f599325c76f180066243ced0dacfbb84c35bda4af72.jZ1cNH9TnZJ4cppF70W6GKrg6XSnDDcybE7-pGlQZLA
     components-hogcharts-linechart--dual-y-axis--dark:
-        hash: v1.k794b7964.f8b286a709a2f921ad8e3d04e75d09154aac55b7d2e457abe18197618d20042d.NhrmmzxLUBExHhWEzIgWoMNx4_EkSeONnN9ggZdv4cY
+        hash: v1.k794b7964.3cefe10d6ff3149785df1215afa32f2967fcdc0563173576d822fb2f4084b285.hnLnBqiMMU41pY8MFOTLprY0onNZvjvZ_nWM_6SkTV0
     components-hogcharts-linechart--dual-y-axis--light:
-        hash: v1.k794b7964.3f9c3126c068d0f8539d04eb741b24d8e501b160cdd8a36e5af9b7d07af67172.nQZBFJxGRxwtZPjZWOXDmPGTxFw0_dd5BNEv0bv5iHs
+        hash: v1.k794b7964.490e972dbbb2faa917ef54034663b0c394d4f597ac678ceca5ed49c18f4899b7.LZJCjrUK4dR1cTasi6aW91SkNljiZtB87DAf7KRflXI
     components-hogcharts-linechart--empty--dark:
-        hash: v1.k794b7964.7a6b8e36701b93a9bebab15b93727325eaf346c0481197d5d27cd78a73a5f4bb.aUIOXdmfVTD3jj9zPc0Kp34ea-id895WSIn2d8H6PFw
+        hash: v1.k794b7964.63484323b9fad464aac034dc1c9075a006fe13f65b289fdd93f065436631b4bd.fFjhTQy_jkwlzaAzHz2TIBHNmuR0HiwwtscIExw5z4c
     components-hogcharts-linechart--empty--light:
-        hash: v1.k794b7964.da0284f9a90b3c06906e3414c7c3bf5cf362b7bb056d1ff4433007a429115cb0.tEKJxW2KmrBvuxxv_-WGNExaAbQL5Q04mvOAzObrnrg
+        hash: v1.k794b7964.de2c4548e86b72f409c9eb6cb968915aa3d56f14ebb66947a81eff76a2569ed1.T1jDtKGrJPRIdx4gTNJyr7q4UNFL_b2J7Xkma1zva-E
     components-hogcharts-linechart--error-boundary--dark:
         hash: v1.k794b7964.985e4fee358d8b78e99b9f44e36cb47d031c9acf2d5fcbeeedfd9df922fc2325.WdrzatVDLo9cB3tkcFBe8jUY0A4WAmYlhFJFdjmOqVM
     components-hogcharts-linechart--error-boundary--light:
         hash: v1.k794b7964.71c1966fb319e455c7d712cd4a480e99ea73e66b04d72d4d1fe4222b058a5a3e.A2RMx3ED_wk_NM0l603i9XWa8hTv5r9JQgHOT5M7L9U
     components-hogcharts-linechart--hovering-interior--dark:
-        hash: v1.k794b7964.18d2c15b48bc79e3aabb0637be32ab73f9c58ee5584f83e0ebf1b73cc9053043.imV72kIK_Qi2MeMFHU4MaaVYuUQsk605X6qEn_KLPiI
+        hash: v1.k794b7964.1ac82720ff22a7740a73a28b585019501455d93775554575d4ec1868356208bc.HWMaktyFrJBRz0n0JWlcymcOREoUgMtbrwziV_eVxcE
     components-hogcharts-linechart--hovering-interior--light:
-        hash: v1.k794b7964.97b24842568d31e103fbc14a74dbde8d127b1c989a286fb9335f6cd3fcbbadee.Thj7lo_fVYhKC-fmbyENCRb4oTWjQ-NaS68fQqQXGvU
+        hash: v1.k794b7964.a5de82ff7b46d82c52fc0d8ce4b4aba505884feadbc44c02bf216186ce1c8edd.wryTORlIhCWy9Ysreyx0oBnf_PwqdA3XUDWpiwx0uTQ
     components-hogcharts-linechart--hovering-multi-series--dark:
         hash: v1.k794b7964.11d54b94370b999de8977132e50b4922f7edb9a87fdba8c42db0f7a58e48d095.L6hlWxJuv0iwtqypuSwtCnVO0h3rBreA-khfP5Qjko0
     components-hogcharts-linechart--hovering-multi-series--light:
         hash: v1.k794b7964.70f132cdf8f58bbf43c6106ac793ac4f501afe8a94c7ed14346a8976aabe6e6d.6AF-ONm6_CqLz9nn5YutOAKlPcDXTpp26xS4OCT0n0A
     components-hogcharts-linechart--hovering-over-aux-series--dark:
-        hash: v1.k794b7964.9857b1d236a3c9dadeb4a2332f4045b3c5bec65818d13f39d341a0e2304ddc96.K502AOh7wooapo4DzNCdMSzvFGhmZ-LDqd74ZXe1rCo
+        hash: v1.k794b7964.d6ffc9d394d108971972f738635489d1cb489f3c387cf020bf4a344b1ff1b5db.1yZXwFuGm4Irs8WBI8X7xiHIcekjqhBH6CStMPd2LJ0
     components-hogcharts-linechart--hovering-over-aux-series--light:
         hash: v1.k794b7964.26041628ac0d2ad10d7c6766f892dc690682b9769961f3ca2bea359e1282f6c4.0jSpO7C8YFuz2uqw1vmYwAOPgWjEBRqlDRHGAO1iFnI
     components-hogcharts-linechart--in-progress-tail--dark:
-        hash: v1.k794b7964.415829efaf022fe397ec1b4b7b281d46d74aecadf49be5f2a8e4cd697fe86ca7.GfeuhLy6bfGg7q9ocVA5lbrg436kSbz5OfCCwQafUD0
+        hash: v1.k794b7964.c1f47391f93db83d4d9943cc8dec3bd9fcbbe8084ca3df54a1a74ebdf5afc656.q1YrKA5xq1YQMAYEh27agv4WfGjiWgVU5KaPC5LOLIM
     components-hogcharts-linechart--in-progress-tail--light:
-        hash: v1.k794b7964.06c7dc16b7ecf03652264008338df104d4af7a39b476a0e4e708d8cb22125260.KDMDTtCldlLUXxhHHaHjkgNUq8Py5pPMaifQWp7EhQQ
+        hash: v1.k794b7964.e88cfa0b18df5fb5d2c455847301325e8136a3ee641f6d3b549f50bb52e7d31b.eMIEcugc6P2wg2v4TJX9sf58DrivKiCQLTs618gL8ys
     components-hogcharts-linechart--log-scale--dark:
-        hash: v1.k794b7964.216aa14ff0925be97f1c77d7c55604804335bda3da68ae2351673e6da2f3f3db.GYAi1bIDDQVP6gb3bf1gblYZZ4JvjZe9n3T4rmSPXr4
+        hash: v1.k794b7964.5ec5cbb8147d50baf73ae6633d2fd3be4ce415b691858699ecd15a98e9cb06bc.v-1PMcu83YCtoHtF-kYuUz6w9XdBznRNro9y05y9-vc
     components-hogcharts-linechart--log-scale--light:
-        hash: v1.k794b7964.941fdf04dd6281b54c90dd0c43aacfd896209a05a90a0f3ce70f2a55fd6d7985.KAScYZyxEXwZt_asgr1r6NCtNa4_dDLWhYU8h6J4LSA
+        hash: v1.k794b7964.dfbdd21f8b36cdac550fd276708f1b933f345bb3050b58e5187113f374987cbb.BHKrPpQ84g9DG1gsa75PvYExI-Qy9oOU8bOlbCvu8_Y
     components-hogcharts-linechart--many-series--dark:
-        hash: v1.k794b7964.651d26aee99cdf52eaabede15157f44744373c2ee95c7ebe272213091992e155.A3UxxLDnt4fDzoyS6DZ8OQheGo_26ekphLERuShmyvY
+        hash: v1.k794b7964.788bb5fc231f824ffa3f09058ad47858dfaec775723b0c12185c1d2e3c15a621.YAFotdPG68YyZiwTgmGnS_gqODyeGtzErIByNlhcA-8
     components-hogcharts-linechart--many-series--light:
-        hash: v1.k794b7964.a73151386f30dcd2c2150b124ca80a57656f0a22c6aaf4953a23dc268bca2ef9.EymtQzCmC3RTiKKTBQYVj_J5nASJZVgE709nJLgAd38
+        hash: v1.k794b7964.13e641d52606505a7b6ae32ab2fc84699792d63d90871bd96a1efb1ccf2a5ebb.ANzZMjsyiH4hXS4lySmlAe2o9Rko4teGhbxxG083oE0
     components-hogcharts-linechart--multi-series--dark:
-        hash: v1.k794b7964.d17376a7ca912b10bf71077e011fdafa6d227a01be83dcc4b24008543e0c7054.7dY7490s_ZW4y9vK659DwPdPxWGGznM3OnxM5nNyz9w
+        hash: v1.k794b7964.4fcd0ff96ce1ff3fddbae38ac1e0fd91eea7e99d3cab8495f4fb07dafcd6b71e.f7XzHhHxQlpWWzs4_8FyLK7-h2_eY_Xt4ePh1DYPBpM
     components-hogcharts-linechart--multi-series--light:
-        hash: v1.k794b7964.db034f8fe411906e06b1ff3e3c8e4ac2d76d07ce9476a0765f308c874cd42f39._M2mLsUzM1ERnbl99iETXWR2rVRQwwSs5Ag7LHvxRLs
+        hash: v1.k794b7964.c374a9fe1607d1f307c675fb0d6e067f7769fee16c7ca9267a0c879d1f444ee0.KRGbG4YI__Vo9hyZd_uax2iloMlyi5mmqHHTCgwil9o
     components-hogcharts-linechart--percent-stacked--dark:
-        hash: v1.k794b7964.2d6be6ef557131c137770d4b0a80187a987f57692d93c9b45cb7934bc6123451.9gYpZI3PxZXqpbkYW4k0GRaThIs8o-TI_rAabh9woHM
+        hash: v1.k794b7964.d9f03d03040cc7d28346440eef609f907e542ee8e60fe012de3f71fbe48058c9.6OpEr-ZPJcUnJaSvRdQpFocLgw0h-lI5qpHzbauoHq4
     components-hogcharts-linechart--percent-stacked--light:
-        hash: v1.k794b7964.b6fe03ee1438dffbfbe2bf8394c2a3108fb89ff9444bf0d7264f5d3623d4ea6e.uHPWMqqFXORnRPN2wLgW1KxrN79TLNwXLXAs1bAKYJs
+        hash: v1.k794b7964.c05f8f8af8e691e2c53835f3a7d474225bc8207cd894c4d096e770c32308dc28.28OBU9vSfYWXxXrK_WXQP1NtBA6OscodzkzdXCNqtK0
     components-hogcharts-linechart--single-point--dark:
-        hash: v1.k794b7964.084f4f1e65ab3d0abd675392d90e5560e180c35f45875adfd4bc28ff75b8c969.0eQfxCHv6jI1cHyxFUmQCZsWnovj76qePLK6eL_175o
+        hash: v1.k794b7964.29f701b8f0d20465e62603c0652a1dd018c99b68e17001883fcc3fff92286683.O--AA-kWKVcgYBuFUBxs_3abKQov5NvpapBMn9BgCfg
     components-hogcharts-linechart--single-point--light:
-        hash: v1.k794b7964.76efd9de8c7c8aa527ac72fed88c33acaee91a73ab2cdba292394ee7754d1886.tcI38O9AEQ0k6fgvYrNT1L00pSgSoIKQPb0Y5tq0YnQ
+        hash: v1.k794b7964.4c9d7ddfa9835b3a6d1b1968ca8681d486ec6b58149037b30b9e004e9723c630.r8DnRepVSiC5bIlkAEae4oKfHXUV_B81O19moad48eE
     components-hogcharts-linechart--single-series--dark:
-        hash: v1.k794b7964.905b7a8104c293e4bffb689b1c572c852f0c925b3d632378ee2b4d3f8cce17cd.IeN1kOdiwrSLPxQ3-Xn3fxFWHIbZtqtCzPW3Ufp3wXw
+        hash: v1.k794b7964.b5697252db4b18be66e1a621d5cbc3649ae4c626001f2e20acdc20a562994c9b.7Pql2VeXXY3ijGK7oaGYw2_0xJHnZwgvxKn1CNZizjM
     components-hogcharts-linechart--single-series--light:
-        hash: v1.k794b7964.7e06990d72eba73cbe98a56980d6ad8b5dd848bb6795ad4a4567cfae9b7e5a6d.xs3PwlPLTw2m_aKKvNMgG3Rumqlx0PK5Faqabb3wBYw
+        hash: v1.k794b7964.8d5cbcb597dd6732187200e912a01c9930c1a04aebb704ec90d664ab247cd5c6.5JN-_4I9OdzZ8wrdfURwA7RjKhBZT57FWeDQOHaKtBU
     components-hogcharts-linechart--stacked-area--dark:
         hash: v1.k794b7964.69ef6aab838398322997d2bc1831762000119207c817656955184482bc47bfb3.i7DnJy-de0j7Jyjt0tVLPsyQ_X6TLHhm7lujuTNF-UE
     components-hogcharts-linechart--stacked-area--light:
         hash: v1.k794b7964.3bad452cd2aea2ca7374f0ab0e0b01527fca6ac9e258d39e91df50c8111486cc.zNi1BvI1s7bNfkosyRZW9U7fotrMAJws-77UJXJ4UN4
     components-hogcharts-linechart--visibility-flags--dark:
-        hash: v1.k794b7964.b926b5acefb82767f156e3f0b76fbe19be12f7f4bb998800f139b42a285fc536.fThACiM4ZrtUpqOnt30pzbkVKujO_1Sj7nSS9e7lNhk
+        hash: v1.k794b7964.9b1429b4bf9fe3c12f9d2673bc1ddd012caef77655f52d179beaab81dd1d2bc5.JDNurPd3ZWhPUex_BNZWdzBcK_6Une_dLTUckTeBL-E
     components-hogcharts-linechart--visibility-flags--light:
-        hash: v1.k794b7964.6e76d4f8e3a05dc0aaae9c828ef04c17a0a50af821e96422470131825ebaa196.a4Ms3oBBGFa67KmLc71cm8Wx5dn7ySk_N868Hzl_c0s
+        hash: v1.k794b7964.0ff74baae53fbd0beda36f1ef6696cb4da8c80da9804aa7c30d89443afad79ca.YrlyFZxlAgbE2XgOk7TkXQULm-2lKaHBgpYPaSzkQNQ
     components-hogcharts-linechart--with-zeros-and-negatives--dark:
-        hash: v1.k794b7964.6b868dd41cf9c31e7919efbb69ee9ea7a31ba146125aa8b5b2b5a2fb0469f700.wpxwS5Ve4o8Mm_dPNbQv1-jqbENsLJpIv02AY6N_WeQ
+        hash: v1.k794b7964.4c03eb4162445e32a74dc1ff8083feed9788b930aea5a4ce49e15c5da22d1b0b.OgPSbq_YYg9wIYaUs5jvjS-8YAzzBf5RgZIjtgXuZp8
     components-hogcharts-linechart--with-zeros-and-negatives--light:
-        hash: v1.k794b7964.3c2096610dd967b7736f6f9f2a4be43cee495d6b19586894aeceadf2849aa8e8.bMQyMS8C1ZbkdWveYKjwBPbilQUHrqiOfKWZ8crSfUk
+        hash: v1.k794b7964.5d0d5d5cf4963ac46b4ed2bfdcedf7b24a63a47b7d84e259882e0606cbf43ce1.UtJNbmKgq3ZFS9AdrrOLJzsEejeh19IDdI9aOwxy9Ps
     components-hogcharts-referenceline--fill-sides--dark:
-        hash: v1.k794b7964.90f4952ddfc3e8b1645a462a24fcbde0a40584ffb0b2450fba6df79726a30033.4kZQt2UNtLSWspx7msbeULVNxN7Bm6mV9hNEZ6hZNXs
+        hash: v1.k794b7964.88be514f5436eb4c62b3db30e81e6d2f2c2b71cc6cf19bca459ed13dc901258a.mhwEtPTUGmbBcNrc9l0arcCL92Fzc-tT6uIfVDkGgpg
     components-hogcharts-referenceline--fill-sides--light:
-        hash: v1.k794b7964.17f8a868cc4c7bfe44f68707e557ceed96ac65c3acd2a5baec7e047a5f77e4ca.byQG4cac7gaKBjoZNU6eaYIQDjA0fm1OiqhdUrkUryw
+        hash: v1.k794b7964.b3617f2aab1780e365660016c85f0daae62ff5851bfccd95fb3bbeb1e06448b6.4oB3BXkj0sJOkSW3h2lDmFy5zESjdgw2oi3Y67Ve0lA
     components-hogcharts-referenceline--horizontal-goal--dark:
-        hash: v1.k794b7964.c5fdf7008f2de74ccf46994fa1d1ad8fad8544eecf5e32b1ce72a2f269e25e55.9E2tPNgIObPg-huyFgvLfOWskL6u5XRRWfkRrCBOsc4
+        hash: v1.k794b7964.7789a578910fe26eee2a7770aca42913dc2156d4aa9d34bdb5cb6dda010a9670.cznULrSwCYSK5SHqc2emeWuQDRodAQQl1hroQ1py0is
     components-hogcharts-referenceline--horizontal-goal--light:
-        hash: v1.k794b7964.7741eb34b4f6d03446c484ded5ad8e4434f41b76655daa1e09baa11b0d1c70eb.SprwKaqpL6iBRoIADN1f5QBO_6qa828eNaVzfr2VU08
+        hash: v1.k794b7964.8d1e3040a3a29b030dea574024e56f8da1dec929a365ecb18f6e509a393d1fb1.1WY_3XTNVp3TVTx-phbZq0v16fSzxXppPiy1b86lnvM
     components-hogcharts-referenceline--horizontal-variants--dark:
-        hash: v1.k794b7964.ce54a72d5735a1cd190f76c1827905f9e7a93c18792bd01c4ec2ccc58b9217dd.n-puhpH3Af34pPHPlJgW4r59RnPZPGxhGfJHIZ1DS2M
+        hash: v1.k794b7964.a009ed64c01f2d4b3ecaefe13dc7df0de5a9a374e6b6bebb04a1614787985f2d.RlMiRInKSZuGSB-Txdl5qTEsZD7G_RdD1t-30Lofljg
     components-hogcharts-referenceline--horizontal-variants--light:
-        hash: v1.k794b7964.40ad007b12a16ef7ad94c25f12c2b34c78bd2ef40f73eff838cd6521eb14034d.M8yvNWxElaz-m9SW63NwWdC4wyX2COzEG-xrhXUJ7Wc
+        hash: v1.k794b7964.1ee7b0eb338bb930c2ae9467d9802e358f3664c6369f9c50e154759dd534a86c.ImOHfi0EunpIPJgtCE5zMPsZ7lGn14kZiYXPr69mB0Y
     components-hogcharts-referenceline--label-start-vs-end--dark:
-        hash: v1.k794b7964.4534934eac32d82ee4698dfe170bb8478b3544f7bf211ae18d2a4f68483aaf14.uz69Z-T9PlKLydMV2yZj0t9sTRtK1E0TEkmI3yrINVw
+        hash: v1.k794b7964.e5e4de0e29ac4c67272199153d29b4d92797d9c7659470b50c797e047d946b74.91CoXOeCA3i2En0OtQWVDmgo0gdHut9saX2cln84L_I
     components-hogcharts-referenceline--label-start-vs-end--light:
-        hash: v1.k794b7964.2011ccda46dcd2c0c96c43184eceb695aa6479f7022f9d267825fd6cb1dbd3b0.k8sfS2GNrp8nut6UlXp8wozq-jKBygfkS7OswbOsKw0
+        hash: v1.k794b7964.90ff54e19bd1817ec0da4fdfea22c05b57e59d709ec1fc82fbedbb6dcb2880b2.RWS_aFWJpBqvcPhSYo6K8qCEiO9fS7TD6hkAOpgOr0I
     components-hogcharts-referenceline--vertical-reference-lines--dark:
-        hash: v1.k794b7964.8f27aa8ee4161d4041693a5549046f0e348aab5fdccc466ea461d6a0f5cf97e2.KEpUtlvBURMPzv1Vyq9Pvf8i_sDKoF3t7fZO8Ed1yPs
+        hash: v1.k794b7964.bf6bedb1f09bacdd7008902e47f2118b353f59b59d2dfbf7abecb7ad8fa09bd1.-uNfx0wyQ72E6nc1PrqC8rHg8J7gY8-7i9nop7w4Y2M
     components-hogcharts-referenceline--vertical-reference-lines--light:
-        hash: v1.k794b7964.c5c09ab055b1b0fde7a5d73279e6a1adba9cc4165d0883ea8c641d4cd68ebf2b.hb7hZ9GBhWL6oRE5jtOZuUEer6xZ5dTyjpH0qB4Dfpk
+        hash: v1.k794b7964.fde30e22b2056f1e8e22850bb06c5220d2953cfc94fbfd66bfb7f7b8eeb7323f.mR0MdlvDVJmrXWFmM9o48B66Ikx9Qavg8VWdW4bYy6s
     components-hogcharts-timeserieslinechart--basic--dark:
-        hash: v1.k794b7964.529535e435c93c8f004cdba8f2ba29681dd679eb9bfbaff745a5f00c3b424ffd.2Kq3-2B9F2VNlkrFY-dge3vntnfrudonJ-Lle1s8m5E
+        hash: v1.k794b7964.fd4f061f91b805ee93979a43d90e3e3857f4edb6a08b486690e88234f19a3035.HIRic-fGdwhh9laajb8jCdtPZhYBALfKkU-PD3MkNDQ
     components-hogcharts-timeserieslinechart--basic--light:
-        hash: v1.k794b7964.3a097fd7390b5a54fcf6e20a1769cc9058b66f4d040ed58748d0d4dc55c8788b.zqLqP936uYDq025ot6wQL3TxRVnq4UzQAtiS92DFZp8
+        hash: v1.k794b7964.652106e631fb117d957755181efff2433a979246a9e4b166cda02750d7959d32.mbbek78lnwrxLhJX9JZkhB4msjvn2wIiKGJRL3xy9so
     components-hogcharts-timeserieslinechart--comparison-of--dark:
-        hash: v1.k794b7964.aa337a8f5a91d73e016f4f22959d401546472f882b4ed16c8f86c9dbea7313ee.b9ovlLn2FH-CDTyiX4aBo6eTitW98Sv3_iAnYo0igtg
+        hash: v1.k794b7964.953b2da2cd05362eed8a21a129ae802cbf705154d6de6f0dcf70485c83da7d48.eHY0iI9p_UOupWu8z5HVQwiYe14ic3y7571dS0Le270
     components-hogcharts-timeserieslinechart--comparison-of--light:
-        hash: v1.k794b7964.f765c2b9fa66bd68ddc97b1e12adde81f4bed9375be55238b4ce902cf18061c5.JgAvyFSvBD_UD9pTvlG2wTVDy5slZ7NEnvNH-8e4izg
+        hash: v1.k794b7964.ef053d1081aa3d1ef952efb74ad940f5db42ceb5935cb93f0f3868f86960b28f.w83l3JogwXo36yGivh4XAxjp_edOyOVSrFonkUWP1wM
     components-hogcharts-timeserieslinechart--confidence-intervals--dark:
-        hash: v1.k794b7964.604addbe746f827ade2350d9167a72d9a7fbedfd96bd621a7af7994cd489c4c8.M3UGtYXBVSJzocWg4vxO3GwAXWveRgWHTGCql8iWjec
+        hash: v1.k794b7964.2bfd68ababdd5915ce3027901b490bb4e178497e960f6a82afa941ad76855f85.RF5l4Qnq6JaoamZyrP4SGIPNq5NOk7Pl0V1xya1E3xs
     components-hogcharts-timeserieslinechart--confidence-intervals--light:
-        hash: v1.k794b7964.748b89470fc51d7943898d2c1b472c4a7c707251324be0d22e8fd8555e457afb.syed-39Rp1r--wavVUlzOaZ08JQ8kE1KgP4OCKvSrDw
+        hash: v1.k794b7964.b0042421c10a2581541d6030ac04947e65617e634f2fcf789c8211730eb9958a.CVwv8zsHTz8WMoKSwLbGU8C3iIzF6pwvxY5zUBEkoHE
     components-hogcharts-timeserieslinechart--date-axis--dark:
-        hash: v1.k794b7964.5805c3a1a9848b678164dcb7f71f6e6df63feb0528585a035d46ca9494080129.e7jpy3cDRnVfLZFjsQcScQdz8mwwULxW5TsnWUE_Rq4
+        hash: v1.k794b7964.00e79f8da331546fcc019306e605bde70c38549d92bf3f26f90621e404f8e0a3.VR52bmR2FRi8K9S5j41ve8pMeWs6BgHB7XVMPi3RSlg
     components-hogcharts-timeserieslinechart--date-axis--light:
-        hash: v1.k794b7964.7a2951f2481faf207966615e374818fb43d30ae3f16aeb2af836bc6955d80d77.WNimlXEb2nRgkA5J86byjnuJ3WUmvR_vb9glEJzoQJw
+        hash: v1.k794b7964.f3cf62927078c9ab23bbb052cce0599a175046bd2fa9a5da99e44da2ec5cfa45.m_Yw8UpdVpP6p5rrrbRFs8oukmSlEe_ZpbMjD2B_UyY
     components-hogcharts-timeserieslinechart--moving-average--dark:
-        hash: v1.k794b7964.276935f8bb553e4ab9fac3ace6eebb3d28dfdf96cffe2e034fedb97e74ce37d0.5SBoJ3War_QIpdVFWyeow-y8o4S-qReI1UdVs9HO6Ik
+        hash: v1.k794b7964.cd0d76712153b8131e8fc9e8fef24883a1a8c06efb17fa9e0d98abf314b379ac.POOO1althta6_L6eQowuToPSNcIk5kK9nIj_VK744FI
     components-hogcharts-timeserieslinechart--moving-average--light:
-        hash: v1.k794b7964.326fb129af77ff50842a525cabd6dc99bdda0184f67de96e57ad1c9a13be4ab3.e5Hz2jQlR4ZqIhUHnbbeFlfLsHNkw7_7_1JJqj1v2N0
+        hash: v1.k794b7964.fed42c8709ec38181e91742a1182047e951dd7fd61e2a7686a81b233cd9f2442.C9a82wa8Dr2e9D0IYVQyDbnKgao9hwoOriakNoPsRlk
     components-hogcharts-timeserieslinechart--trend-lines--dark:
-        hash: v1.k794b7964.542f8d5fee67e14dc285806bc677c0417df77c44589d005b0dea49ba75fc80e5.ZF5lPBCHngzzZ9Cw1ITdZbIJ-OGvJmU9OlK2V1wYeAE
+        hash: v1.k794b7964.6eab0dcdb74c17dcac793e4790a40b99d30a612901f34643eb91bd32c68d2758.bEsadsPJZyP34VnOjHnPhF8qpCrruz6MqZNC0eILIfc
     components-hogcharts-timeserieslinechart--trend-lines--light:
-        hash: v1.k794b7964.5801e5c4274cd0b2d2fdb3d69cfb0299804f62f39036e5a2901e78789e0d764b.x4egj_Wp44H8iI00Wsgho-a68dHFvkXzSziDZG0zwFw
+        hash: v1.k794b7964.a43f290278850a9a9fab6886caf5ba3a1f25aa77e2ee781225b96b750bbc21e5.RzVq0fsJjMOqzCs_R4ZuiEVoO64OIMoWroUA4SnDOTA
     components-hogcharts-timeserieslinechart--y-axis-formats--dark:
-        hash: v1.k794b7964.ab5470e4567b923b3414ddc27d0e40872a481d973df9e12d1765fbedff32c20d.JdA-hTR2nKp921x6JROPc0p43nBvLgWiXzJQRPLviMQ
+        hash: v1.k794b7964.9a96c054c748635c37966b316aa63d3746f8f38f6c8742ce20c2c1acb7561ee2.dRKiVITgt3sdf5YvDpzAmZpsubMhFXSoWtAuhpdQwpM
     components-hogcharts-timeserieslinechart--y-axis-formats--light:
-        hash: v1.k794b7964.1bf2b5bfdc76af285b65b77ecb8578acb108e6e4e5c4e4f63aaa0a4cc540cf5e.IMVfl5N9P9t8XqdMCDaShMvNyx2jl4vehYUUJvNx6Ac
+        hash: v1.k794b7964.2bef66aacecd65e45499ee99bf537162c17cb404a4c8d4871b7435fd463e8727.zc_zuF07aw8GGaVPuSnLNC-oWq1W6s78IjNb62kwLjo
     components-hogcharts-valuelabels--cross-series-overlap-removal--dark:
-        hash: v1.k794b7964.b766f038277710789aefeabc721df0c662a10aa672b24e14f7e68349f88f396a.Jef_dCFf6j8X_7hXhsuDQa6KMpkq-BS1akkcNUH46MU
+        hash: v1.k794b7964.b007e0b3d5d267086c7feac666e863bf138c94e442834f38d827d9866bcfdca7.XPNu2APWwr3st71RImwnGyR-XvpLOXXKvqOOIAWV9VM
     components-hogcharts-valuelabels--cross-series-overlap-removal--light:
-        hash: v1.k794b7964.738cf86744e8c623069b0424dc408121c0890856f0b238c327bf6ee80db752fa.cBXFNYsgpPGFXg8N2e2L4PNkzum6hyXTzNN6Du7efLc
+        hash: v1.k794b7964.448986696bb416400c7b45c0cead3c555fb08740a06107d4c67cd6de3eac778a.-CC2KkgSe2QGS72LRQi30FdWUr3HiiDwZMFszFORz50
     components-hogcharts-valuelabels--dual-y-axes--dark:
-        hash: v1.k794b7964.62abb507261bb063565586a275a004a0d3b47ac353e90fbeed26c65ca1269283.ml7ENWI5BKVLuWfSWeI5dJcsxVqvOtCxce_WEvxWrHU
+        hash: v1.k794b7964.70bd72cf9ac044f579156cb4075fb7473451e3ccfa92729d3c671526d78b2a4b.HDMQoBphdAnraD6C-ENB3-7NeEI_0cn5-SmvFtyVuyM
     components-hogcharts-valuelabels--dual-y-axes--light:
-        hash: v1.k794b7964.9eb63ed9bdc220590b2cae0af8776b41f6ec32d74182647f3f65d114b65f14ab.EB_OqrxJ2qvitx43QmgQjmkU1UX6aieZ2UTv3ufpSdw
+        hash: v1.k794b7964.8d272a586eaefd5300b639c69eec27dcd5d4504366c8ba882075ffeca2b0eb7d.HAEg6IfQsply4hRXGiwuAwWOugaU0Q4wuVySDkwOUVw
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--dark:
-        hash: v1.k794b7964.6d55aa7b02f1431eccce354fb2092f8d57f1a354930639e1eb4a550ba59540b5.0MOERS1S2FZ3gCdxsoz8PrMxurpfZq9ioaOO5X3dzWw
+        hash: v1.k794b7964.27ccff075c26c55cd18c29a7eb65e1d9061fa8c088f36ac18eeba84032078c5e.H3Es40UB8qFK59TggacWhPUAeMQSeARbW5pZd6M-dfw
     components-hogcharts-valuelabels--hidden-on-auxiliary-series--light:
-        hash: v1.k794b7964.b423c91cffbc16b4fb4c94bd3bb80c75cc6f5314eeaed5ba7c44f58a4dc02c9c._fTMFjN74s3JUZ8U5pcHlxTZzTe7uO9G2hixlWWuBV0
+        hash: v1.k794b7964.ef073ee5937ffe5656aa63f405bec2df9d3895d8ca32655e4f858440d0a765b1.zdr8mWCPij4LuuahG_7A9e3LwgRkemBw7kjPoDh40eM
     components-hogcharts-valuelabels--multi-series-collision--dark:
-        hash: v1.k794b7964.bfc6898117609b6447503f3a2a24497e526e6f37dd9225332b5d1645d5886920.SJhI4YbdThoOZSqnoyBO612qzUmm-YkzmFb-xVXmr74
+        hash: v1.k794b7964.dddb9d66849c3b35fd738a935beddf167333e24e7a5cdc6bd5456e82d6cdf0ae.iIr59bSnTVR3RLeUE5TqDm872I0GAn9BDW74KzyGEms
     components-hogcharts-valuelabels--multi-series-collision--light:
-        hash: v1.k794b7964.083a141ca72d3e4f54a9d39cd22ea27af8365702f1d9eb50aa657d606575264f.hYJk2mifWFWHmBLZh3T_SZTvC9FgryryhzAWwGbNaaY
+        hash: v1.k794b7964.c23bde296935a659c0b0fba418e181e28bd40553eb65e33118ee9d5ef756815e.kyG5_wDrCJDibyYje5aNC50OKkSTXwbOjvrPNism54A
     components-hogcharts-valuelabels--negative-values--dark:
-        hash: v1.k794b7964.084ed1c20e236fa9ccd59c10449535e91487c01029ffb7d39c103bde8d206e73.4uYU-zN-9MIL2gu_0wtPkYPFO9iKBLlM70dUcKsRsec
+        hash: v1.k794b7964.85806c992ae8fc1d5065538d5651fdadad9c1cbfc6ed1f4cee71397b7595f2dc.lPuqK3YqGX-luule2bDuyK5Foj2U6R9lABv5ONsoEL4
     components-hogcharts-valuelabels--negative-values--light:
-        hash: v1.k794b7964.d0ba0d11f0168b9861a9ab51ed874f239f30c58f730b094cbc319c464d69a915.2YZ5kCzOMQRlM8wwCD0VyJLldGWLOd_3SOxysL92k84
+        hash: v1.k794b7964.14f3e2a62ddb79eb1d8da0c95e3a1271c42f20284e674273266ce44ecae0d2f9.qNqJqbyCF5XKurVr0q9GKOoKmoZkcDNohIsggcDjYGI
     components-hogcharts-valuelabels--single-series--dark:
-        hash: v1.k794b7964.5f5f542bff21e42d779f36ffb063812be6426f9b978923f5a690ac4da831e23f.VnV0gDnMaQaGaTxV66nNL4lvumyI2nknOgY7tUiCi_w
+        hash: v1.k794b7964.b0e28b7da51ef53e4694133f8f708494e4dd11c0f1d6283f2d2a09e1df49595b.WL1K77elfWgQF5kN13AUnkqEP3GsinJT6bHUchWlBdY
     components-hogcharts-valuelabels--single-series--light:
-        hash: v1.k794b7964.c506075149be03109b832c92efaf1d12d9c57ff1679d2f5fc3cfeaad3b304971.6qLWBIFOKR77_s_qKcyxvDR0dS-RVooMQAp9JMuiRN4
+        hash: v1.k794b7964.6447a6c6d8d98307c89577287780211ff4f03fa6a4256433fecc510bf3d68494.0HJSxR2PuuEMESGyw7739udUYz2IUYHGxZqN5TNceFs
     components-hogcharts-valuelabels--with-custom-formatter--dark:
-        hash: v1.k794b7964.284c816866c7f67906abf9dd62203ab9a41dc886e7f1cca01a544d8e33316ad1.At2dmfyFhRyVBLUMETHoOy7_63K5F51s5l9N-FCP-94
+        hash: v1.k794b7964.bec935570a979267da39305b4972a6afd59e0184b8fbb31e5df8999bb919d858.XybQmlAnxWkeLQgdobmQ4XbH8cdSwDv4E2iEjoLOU2Y
     components-hogcharts-valuelabels--with-custom-formatter--light:
-        hash: v1.k794b7964.f75097bea54619a6b41c9b00084f09b5ab2b81eb3b3cbd1881310a09015e6380.E3Rs8YqC-5CH8xdU2x4Ri1qaLO84PEj17DrPrlJZDjE
+        hash: v1.k794b7964.e0468c7f18430adb5aa252fa23e2343331559300357c819446594a1f01e8193c.8zBDuJem9BawEIXvTLAHhHwS9Unq-B-IoCvOiNMeszY
     components-hogfetti--hogfetti--dark:
         hash: v1.k794b7964.dc6868e284e60433ae001da81ba90cf3f05eef1dae1765a849c6e9c63f1ae2ea.T9sV0zE441WqbpRr2zp64VZZfC1xlzxST-bxbW2egvI
     components-hogfetti--hogfetti--light:
@@ -1757,17 +1757,17 @@ snapshots:
     insights-insightstable--is-legend--light:
         hash: v1.k794b7964.d9eec920b0b2f3c9ea87c9e0d2b298bc37339217e4211d0cf1a147630f09b75d.xGcJlQO8pvoNnHyoMNZ4F58uqKh5PDg_UiGlO5bAMn8
     insights-trendslinechart--breakdown--dark:
-        hash: v1.k794b7964.511667c66648a8740d48cea9425dd7f30c0583db207e58aab0ee46cbec27a9a9.3lZjOZDN3Svay1SdE1xjxOqA4oboAADP18FT7C2Bsg4
+        hash: v1.k794b7964.4228a311a626ebf45a34acead267954b6b05686aa012ed54242b7a0c5ba298f1.MC_47zRRkXLTsrbhhq1hf2BuXmW8uRCu4fohSF303Is
     insights-trendslinechart--breakdown--light:
-        hash: v1.k794b7964.6edbc2691567ff4887b89913cb2cd3832ee94711e2a68628f8b490aa8378cd5a.oSLvbdT_KENf9RQAJfCSxLjiV8MtSB_3RLys4J2VcKE
+        hash: v1.k794b7964.518e2fe68fa15e8723fa5e1b6e837b2361b11f2c55a476e34b33e81efa6b676c.Ec7nhxUV6ArfOvRIV4GERg0Kq7hROoYJ-Tt0SiKeNI4
     insights-trendslinechart--default--dark:
-        hash: v1.k794b7964.ba01f9e7b22b990a71f1cea64557844040e3d9dfb6a024daa63626544a619223.kP9RKJQyHMnzhRJDn7r18PNpiIo9sT5wIzx3h0Z-098
+        hash: v1.k794b7964.cd6a4a176d7b90c562e21a085e6b14b7166d609b6b21c73eeba226eb57e5c63b.9hBnUcRgbwGS-d635MjAmMyECdDIIbZg2tMyiirsLvs
     insights-trendslinechart--default--light:
-        hash: v1.k794b7964.0caa0e62bdbd9da9b2bf7294f895fdbbe95df3da6ae9d6434fa941e4449adb3f.6v-VukuxHu0mue3SlYmq_1tYmVEEqTX7LC4LM_vOlrE
+        hash: v1.k794b7964.2a41ea2b702aa15bd4ec9c98e37a4268db6d0480f984a61243e3a1aa3e5aa42a.K-TpvzcRCmyQLuuzbxovQu2IPoza-kqQkuQOqPz2LK0
     insights-trendslinechart--single-series--dark:
-        hash: v1.k794b7964.7e0638961c239dd28313d9fad1ed6a4620022d85fab8f586670a71630b3add47.ORbg_Aka6pqgmoTpV2WaXTBv_bh399-2CPXaFW4aOAg
+        hash: v1.k794b7964.a00352433e596553684495be247c9d0476214c944ebb8f969cb790ddbe1cfb87.IR86LYH4Y3nWPFcqvV5YOtRAENQdgoq0Mw0Zndb04Sc
     insights-trendslinechart--single-series--light:
-        hash: v1.k794b7964.a235f28f74910bed6c83cc436b679a63fc1260b42600f42ff82691ec37f2efd5.PjjqM5m0C95JG6jLmuKHcqg4CWvDbaB0v4TvHAptUuU
+        hash: v1.k794b7964.e8d7c90005769112e971e55319b5e27731c8363aa977f21d5dbe8b9ec14b30ce.aaLz4Eg-X0FQkUCC9VXBjoVw902yotIdFJ4W5GzGu_8
     layout-feature-previews--basic--dark:
         hash: v1.k794b7964.65cb2d154c4f630bc48a9f6b45b24e641c97b4412ca5170e0c1de8bc5c7d759d.vu2XHwyh2oLXbqNS7NdZd2tABaC8nM7J0iJps6FVYl8
     layout-feature-previews--basic--light:

--- a/frontend/src/lib/hog-charts/charts/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart.tsx
@@ -24,6 +24,7 @@ import type {
     TooltipContext,
 } from '../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../core/types'
+import { computeVisibleXLabels } from '../overlays/AxisLabels'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
     const start = scales.band(label)
@@ -67,8 +68,9 @@ function BarChartInner<Meta = unknown>({
         yScaleType = 'linear',
         showGrid = false,
         barLayout = 'stacked',
-        barCornerRadius = 4,
+        barCornerRadius = 0,
         axisOrientation = 'vertical',
+        xTickFormatter,
     } = config ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
 
@@ -168,9 +170,27 @@ function BarChartInner<Meta = unknown>({
             }
 
             if (showGrid) {
+                // Square grid: draw cross-axis lines at the same coords as visible category labels
+                // so the grid aligns with the labels the user sees, not at every band.
+                let categoryTicks: number[] = []
+                if (isHorizontal) {
+                    for (const label of drawLabels) {
+                        const coord = bandCenter(d3Scales, label)
+                        if (coord != null && isFinite(coord)) {
+                            categoryTicks.push(coord)
+                        }
+                    }
+                } else {
+                    categoryTicks = computeVisibleXLabels(
+                        drawLabels,
+                        (label) => bandCenter(d3Scales, label),
+                        xTickFormatter
+                    ).map((entry) => entry.x)
+                }
                 drawGrid(baseDrawCtx, {
                     gridColor: theme.gridColor,
                     orientation: isHorizontal ? 'horizontal' : 'vertical',
+                    categoryTicks,
                 })
             }
 
@@ -198,16 +218,18 @@ function BarChartInner<Meta = unknown>({
                 )
             }
         },
-        [showGrid, stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius]
+        [showGrid, stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius, xTickFormatter]
     )
 
     const drawHover = useCallback(
-        ({ ctx, scales, series: coloredSeries, labels: drawLabels, hoverIndex, theme }: ChartDrawArgs) => {
+        ({ ctx, scales, series: coloredSeries, labels: drawLabels, hoverIndex }: ChartDrawArgs) => {
             const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
             if (!d3Scales || hoverIndex < 0) {
                 return
             }
-            const highlightColor = theme.crosshairColor ?? 'rgba(0, 0, 0, 0.4)'
+            // Translucent dark overlay layered on top of the static bar — composites with the
+            // bar pixel underneath to produce the "darker on hover" effect for any series color.
+            const highlightColor = 'rgba(0, 0, 0, 0.2)'
             const hoveredLabel = drawLabels[hoverIndex]
             for (const s of coloredSeries) {
                 if (s.visibility?.excluded) {

--- a/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/bar-canvas-renderer.test.ts
@@ -216,10 +216,11 @@ describe('hog-charts canvas-renderer (bars)', () => {
     })
 
     describe('drawBarHighlight', () => {
-        it('strokes a single rectangle', () => {
+        it('fills a single rectangle as a translucent overlay', () => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, BASE_BAR, '#000')
-            expect(ctx.stroke).toHaveBeenCalledTimes(1)
+            drawBarHighlight(ctx, BASE_BAR, 'rgba(0,0,0,0.2)')
+            expect(ctx.fill).toHaveBeenCalledTimes(1)
+            expect(ctx.stroke).not.toHaveBeenCalled()
         })
 
         it.each([
@@ -229,20 +230,14 @@ describe('hog-charts canvas-renderer (bars)', () => {
             { desc: 'negative height', width: 50, height: -5 },
         ])('does nothing on a bar with $desc', ({ width, height }) => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, { ...BASE_BAR, width, height }, '#000')
-            expect(ctx.stroke).not.toHaveBeenCalled()
+            drawBarHighlight(ctx, { ...BASE_BAR, width, height }, 'rgba(0,0,0,0.2)')
+            expect(ctx.fill).not.toHaveBeenCalled()
         })
 
-        it('uses the provided color as strokeStyle', () => {
+        it('uses the provided color as fillStyle', () => {
             const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, BASE_BAR, '#abcabc')
-            expect(ctx.strokeStyle).toBe('#abcabc')
-        })
-
-        it('clears the dash pattern before stroking', () => {
-            const ctx = mockCanvasContext()
-            drawBarHighlight(ctx, BASE_BAR, '#000')
-            expect(ctx.setLineDash).toHaveBeenCalledWith([])
+            drawBarHighlight(ctx, BASE_BAR, 'rgba(1,2,3,0.4)')
+            expect(ctx.fillStyle).toBe('rgba(1,2,3,0.4)')
         })
     })
 })

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -496,6 +496,103 @@ describe('hog-charts canvas-renderer', () => {
             expect(lastMoveTo[0]).toBe(dimensions.plotLeft)
             expect(lastLineTo[0]).toBe(dimensions.plotLeft + dimensions.plotWidth)
         })
+
+        describe('categoryTicks', () => {
+            // Helper: count strokes whose direction matches the requested axis. A "vertical"
+            // stroke moves only on y (moveX === lineX); a "horizontal" stroke moves only on x.
+            function countAxisAlignedStrokes(
+                ctx: jest.Mocked<CanvasRenderingContext2D>,
+                axis: 'vertical' | 'horizontal'
+            ): number {
+                const moves = ctx.moveTo.mock.calls as [number, number][]
+                const lines = ctx.lineTo.mock.calls as [number, number][]
+                let n = 0
+                for (let i = 0; i < moves.length; i++) {
+                    const [mx, my] = moves[i]
+                    const [lx, ly] = lines[i] ?? [NaN, NaN]
+                    if (axis === 'vertical' && mx === lx && my !== ly) {
+                        n++
+                    } else if (axis === 'horizontal' && my === ly && mx !== lx) {
+                        n++
+                    }
+                }
+                return n
+            }
+
+            it.each([
+                {
+                    desc: 'vertical mode draws one extra vertical stroke per finite categoryTick',
+                    orientation: 'vertical' as const,
+                    expectedAxis: 'vertical' as const,
+                    valueAxis: 'horizontal' as const,
+                },
+                {
+                    desc: 'horizontal mode draws one extra horizontal stroke per finite categoryTick',
+                    orientation: 'horizontal' as const,
+                    expectedAxis: 'horizontal' as const,
+                    valueAxis: 'vertical' as const,
+                },
+            ])('$desc', ({ orientation, expectedAxis, valueAxis }) => {
+                const baseline = mockCanvasContext()
+                const baselineCtx = makeDrawContext(baseline, ['a', 'b'])
+                drawGrid(baselineCtx, { orientation })
+                const baselineCrossAxis = countAxisAlignedStrokes(baseline, expectedAxis)
+
+                const ctx = mockCanvasContext()
+                const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+                const ticks = [100, 200, 300]
+                drawGrid(drawCtx, { orientation, categoryTicks: ticks })
+
+                expect(countAxisAlignedStrokes(ctx, expectedAxis)).toBe(baselineCrossAxis + ticks.length)
+                // Value-axis strokes should be unaffected by categoryTicks.
+                expect(countAxisAlignedStrokes(ctx, valueAxis)).toBe(countAxisAlignedStrokes(baseline, valueAxis))
+            })
+
+            it.each([{ orientation: 'vertical' as const }, { orientation: 'horizontal' as const }])(
+                'skips non-finite categoryTicks ($orientation)',
+                ({ orientation }) => {
+                    const ctx = mockCanvasContext()
+                    const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+                    const finiteTicks = [50, 150]
+                    drawGrid(drawCtx, {
+                        orientation,
+                        categoryTicks: [Number.NaN, ...finiteTicks, Number.POSITIVE_INFINITY],
+                    })
+                    const expectedAxis = orientation === 'vertical' ? 'vertical' : 'horizontal'
+
+                    const baseline = mockCanvasContext()
+                    const baselineCtx = makeDrawContext(baseline, ['a', 'b'])
+                    drawGrid(baselineCtx, { orientation })
+
+                    expect(countAxisAlignedStrokes(ctx, expectedAxis)).toBe(
+                        countAxisAlignedStrokes(baseline, expectedAxis) + finiteTicks.length
+                    )
+                }
+            )
+
+            it('vertical categoryTicks draw lines spanning the full plot height at the requested x', () => {
+                const ctx = mockCanvasContext()
+                const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+                drawGrid(drawCtx, { orientation: 'vertical', categoryTicks: [123] })
+                // Coordinate is snapped to integer + 0.5 (crisp 1px stroke), so 123 → 123.5.
+                const moves = ctx.moveTo.mock.calls as [number, number][]
+                const lines = ctx.lineTo.mock.calls as [number, number][]
+                const idx = moves.findIndex(([mx, my]) => mx === 123.5 && my === dimensions.plotTop)
+                expect(idx).toBeGreaterThanOrEqual(0)
+                expect(lines[idx]).toEqual([123.5, dimensions.plotTop + dimensions.plotHeight])
+            })
+
+            it('horizontal categoryTicks draw lines spanning the full plot width at the requested y', () => {
+                const ctx = mockCanvasContext()
+                const drawCtx = makeDrawContext(ctx, ['a', 'b'])
+                drawGrid(drawCtx, { orientation: 'horizontal', categoryTicks: [200] })
+                const moves = ctx.moveTo.mock.calls as [number, number][]
+                const lines = ctx.lineTo.mock.calls as [number, number][]
+                const idx = moves.findIndex(([mx, my]) => my === 200.5 && mx === dimensions.plotLeft)
+                expect(idx).toBeGreaterThanOrEqual(0)
+                expect(lines[idx]).toEqual([dimensions.plotLeft + dimensions.plotWidth, 200.5])
+            })
+        })
     })
 
     describe('composeDrawHoverWithCrosshair', () => {

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.ts
@@ -290,6 +290,16 @@ export function drawPoints(drawCtx: DrawContext, series: ResolvedSeries, yValues
     }
 }
 
+export interface DrawGridOptions {
+    gridColor?: string
+    orientation?: 'vertical' | 'horizontal'
+    /** Pixel positions on the categorical axis at which to draw cross-axis grid lines, producing
+     *  a square grid. In `'vertical'` mode these are x-pixel positions (vertical lines); in
+     *  `'horizontal'` mode they are y-pixel positions (horizontal lines). Empty/undefined keeps
+     *  the value-axis-only grid. */
+    categoryTicks?: number[]
+}
+
 /** Draws the grid lines and the categorical-axis baseline.
  *
  * `orientation`:
@@ -299,14 +309,12 @@ export function drawPoints(drawCtx: DrawContext, series: ResolvedSeries, yValues
  * In both modes, `yScale` maps a value to a pixel on the value axis — for vertical that's a y-pixel,
  * for horizontal that's an x-pixel. The function uses `dimensions` to size the perpendicular axis.
  */
-export function drawGrid(
-    drawCtx: DrawContext,
-    options: { gridColor?: string; orientation?: 'vertical' | 'horizontal' } = {}
-): void {
+export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): void {
     const { ctx, yScale, dimensions } = drawCtx
     const gridColor = options.gridColor ?? 'rgba(0, 0, 0, 0.1)'
     const orientation = options.orientation ?? 'vertical'
     const tickAxisLength = orientation === 'horizontal' ? dimensions.plotWidth : dimensions.plotHeight
+    const categoryTicks = options.categoryTicks ?? []
 
     const valueTicks = (yScale as d3.ScaleLinear<number, number>).ticks?.(yTickCountForHeight(tickAxisLength)) ?? []
 
@@ -322,6 +330,16 @@ export function drawGrid(
             ctx.lineTo(x, dimensions.plotTop + dimensions.plotHeight)
             ctx.stroke()
         }
+        for (const coord of categoryTicks) {
+            if (!isFinite(coord)) {
+                continue
+            }
+            const y = Math.round(coord) + 0.5
+            ctx.beginPath()
+            ctx.moveTo(dimensions.plotLeft, y)
+            ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, y)
+            ctx.stroke()
+        }
         const axisY = Math.round(dimensions.plotTop) + 0.5
         ctx.beginPath()
         ctx.moveTo(dimensions.plotLeft, axisY)
@@ -335,6 +353,17 @@ export function drawGrid(
         ctx.beginPath()
         ctx.moveTo(dimensions.plotLeft, y)
         ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, y)
+        ctx.stroke()
+    }
+
+    for (const coord of categoryTicks) {
+        if (!isFinite(coord)) {
+            continue
+        }
+        const x = Math.round(coord) + 0.5
+        ctx.beginPath()
+        ctx.moveTo(x, dimensions.plotTop)
+        ctx.lineTo(x, dimensions.plotTop + dimensions.plotHeight)
         ctx.stroke()
     }
 
@@ -455,21 +484,22 @@ export function drawBars(
     }
 }
 
+/** Hover highlight is a translucent fill on the *overlay* canvas, layered over the static bar.
+ *  The overlay's alpha composites with the bar pixel underneath, darkening it without us
+ *  having to know how to darken every possible color string the consumer passes. */
 export function drawBarHighlight(
     ctx: CanvasRenderingContext2D,
     bar: BarRect,
-    color: string,
+    overlayColor: string,
     cornerRadius: number = DEFAULT_BAR_CORNER_RADIUS
 ): void {
     if (bar.width <= 0 || bar.height <= 0) {
         return
     }
-    ctx.strokeStyle = color
-    ctx.lineWidth = 2
-    ctx.setLineDash([])
+    ctx.fillStyle = overlayColor
     ctx.beginPath()
     traceRoundedBarPath(ctx, bar.x, bar.y, bar.width, bar.height, cornerRadius, bar.corners)
-    ctx.stroke()
+    ctx.fill()
 }
 
 export function drawHighlightPoint(

--- a/frontend/src/lib/hog-charts/core/scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/scales.test.ts
@@ -454,12 +454,12 @@ describe('hog-charts scales', () => {
     describe('yTickCountForHeight', () => {
         it.each([
             { plotHeight: 0, expected: 2 },
-            { plotHeight: 80, expected: 2 },
-            { plotHeight: 160, expected: 2 },
-            { plotHeight: 240, expected: 3 },
-            { plotHeight: 480, expected: 6 },
-            { plotHeight: 640, expected: 8 },
-            { plotHeight: 1600, expected: 8 },
+            { plotHeight: 50, expected: 2 },
+            { plotHeight: 100, expected: 2 },
+            { plotHeight: 200, expected: 4 },
+            { plotHeight: 400, expected: 8 },
+            { plotHeight: 550, expected: 11 },
+            { plotHeight: 1600, expected: 11 },
         ])('plotHeight $plotHeight → $expected ticks', ({ plotHeight, expected }) => {
             expect(yTickCountForHeight(plotHeight)).toBe(expected)
         })

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -66,7 +66,7 @@ export function createXScale(labels: string[], dimensions: ChartDimensions): d3.
 }
 
 export function yTickCountForHeight(plotHeight: number): number {
-    return Math.max(2, Math.min(8, Math.floor(plotHeight / 80)))
+    return Math.max(2, Math.min(11, Math.floor(plotHeight / 50)))
 }
 
 export function createYScale(


### PR DESCRIPTION
## Problem

The new `hog-charts` `BarChart` (used by `TrendsBarChart` behind the `product-analytics-hog-charts-bar` flag) didn't match the existing chart.js trends bar chart visually — the grid was horizontal-only, there were too few y-axis ticks, bar tops were rounded, and hovering drew a stroked border instead of darkening the bar.

This PR is part 1 of a 3-PR stack:

- **PR 1 (this one)** — visual parity (square grid, denser ticks, flat tops, darken-on-hover overlay)
- [**PR 2**](https://github.com/PostHog/posthog/pull/57832) — per-bar hover & tooltip narrowing for grouped/compare layouts (stacks on PR 1)
- **PR 3** — folder reorg + test infra cleanup (stacks on PR 2)

## Changes

- `drawGrid` accepts an optional `categoryTicks: number[]` so callers can request a square grid; `BarChart` computes them from visible x labels (vertical) or every band center (horizontal).
- `yTickCountForHeight` tightened from `plotHeight/80, max 8` → `plotHeight/50, max 11`. Note: this helper is shared with `LineChart`, so line charts also get denser ticks — intentional cross-chart parity with the chart.js trends look.
- `barCornerRadius` default lowered from `4` → `0` to match chart.js flat tops.
- `drawBarHighlight` now fills with the provided color instead of stroking; `BarChart`'s `drawHover` passes `'rgba(0, 0, 0, 0.2)'` so the overlay alpha-composites with the static bar to darken any series color.
- Tests updated for the new tick formula and fill-vs-stroke highlight; new tests added for `drawGrid`'s `categoryTicks` paths in both orientations.

## How did you test this code?

I'm an agent — automated tests only:

- All `frontend/src/lib/hog-charts` Jest suites pass.
- All `frontend/src/scenes/trends/viz/trends-bar-chart` Jest suites pass.
- Visually verified in the running dev server with the feature flag enabled (light mode): square grid renders, ~9 y-ticks at 20-unit intervals, bar tops are flat, hovered bar darkens with no border outline.

## Publish to changelog?

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Originally landed as one PR; split into a 3-PR stack to make review easier.