### PR TITLE
feat(nav): improve recents empty state with onboarding callout and filter unviewed items from recents

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -41,6 +41,7 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { navRecentsLogic } from '~/layout/panel-layout/ai-first/tabs/navRecentsLogic'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { customProductsLogic } from '~/layout/panel-layout/ProjectTree/customProductsLogic'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
@@ -170,7 +171,8 @@ export function ProjectTree({
     const onItemChecked = onItemCheckedOverride ?? projectTreeOnItemChecked
 
     const { setPanelTreeRef, resetPanelLayout } = useActions(panelLayoutLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
+    const { mainContentRef, expandedNavSections } = useValues(panelLayoutLogic)
+    const { recentItems } = useValues(navRecentsLogic)
     const { currentTeamId } = useValues(teamLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const { openItemSelectModal } = useActions(itemSelectModalLogic)
@@ -262,7 +264,11 @@ export function ProjectTree({
             })
         }
 
-        if (root === 'custom-products://') {
+        // The Recents nav section shows its own onboarding callout when there are no items
+        // Suppress this banner in that case to avoid stacking two callouts in the AI-first sidebar
+        const recentsCalloutVisible = (expandedNavSections.recents ?? false) && recentItems.length === 0
+
+        if (root === 'custom-products://' && !recentsCalloutVisible) {
             const hasRecommendedProducts = customProducts.some(
                 (item) =>
                     item.reason === UserProductListReason.USED_BY_COLLEAGUES ||

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -33,12 +33,13 @@ import { urls } from 'scenes/urls'
 
 import { NavLink } from '~/layout/panel-layout/ai-first/NavLink'
 import { PanelLayoutNavIdentifier, panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import { customProductsLogic } from '~/layout/panel-layout/ProjectTree/customProductsLogic'
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { ProjectTree } from '~/layout/panel-layout/ProjectTree/ProjectTree'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { joinPath, splitPath, unescapePath } from '~/layout/panel-layout/ProjectTree/utils'
 import { FileSystemEntry, FileSystemIconType } from '~/queries/schema/schema-general'
-import { ActivityTab } from '~/types'
+import { ActivityTab, ReplayTabs } from '~/types'
 
 import { BrowserLikeMenuItems } from '../../ProjectTree/menus/BrowserLikeMenuItems'
 import { PanelIndicatorIcon, SectionTrigger } from '../Nav'
@@ -77,6 +78,15 @@ function getItemName(item: FileSystemEntry): string {
     const lastPart = pathSplit.pop()
     return unescapePath(lastPart ?? item.path)
 }
+
+const RECENTS_EMPTY_SUGGESTIONS: { label: string; href: string; iconType: FileSystemIconType }[] = [
+    { label: 'Product analytics', href: urls.savedInsights(), iconType: 'product_analytics' },
+    { label: 'Web analytics', href: urls.webAnalytics(), iconType: 'web_analytics' },
+    { label: 'Session replay', href: urls.replay(ReplayTabs.Home), iconType: 'session_replay' },
+    { label: 'Error tracking', href: urls.errorTracking(), iconType: 'error_tracking' },
+    { label: 'Feature flags', href: urls.featureFlags(), iconType: 'feature_flag' },
+    { label: 'Logs', href: urls.logs(), iconType: 'logs' },
+]
 
 function formatRelativeDate(dateStr: string | null | undefined): string {
     if (!dateStr) {
@@ -188,9 +198,14 @@ export function NavTabBrowse(): JSX.Element {
     const { firstTabIsActive } = useValues(sceneLogic)
     const isProductAutonomyEnabled = useFeatureFlag('PRODUCT_AUTONOMY')
     const { recentItems, recentItemsLoading } = useValues(navRecentsLogic)
+    const { customProducts } = useValues(customProductsLogic)
     const { isEditMode, checkedItems } = useValues(inlineEditAppsLogic)
     const { enterEditMode, saveAndExitEditMode, toggleProduct } = useActions(inlineEditAppsLogic)
+
     const currentPath = removeProjectIdIfPresent(pathname)
+
+    const enabledProductPaths = new Set(customProducts.filter((p) => p.enabled).map((p) => p.product_path))
+    const recentsSuggestion = RECENTS_EMPTY_SUGGESTIONS.find((s) => !enabledProductPaths.has(s.label))
 
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
         const isOpening = activePanelIdentifier !== item
@@ -337,7 +352,26 @@ export function NavTabBrowse(): JSX.Element {
                                 <Spinner className="size-4" />
                             </div>
                         ) : recentItems.length === 0 ? (
-                            <span className="text-xs text-tertiary px-2 py-1">No recent items</span>
+                            <div className="border border-primary text-xs mb-2 font-normal rounded-xs p-2 flex flex-col gap-2">
+                                <span>
+                                    Things you open will show up here, so you can quickly jump back to what you were
+                                    last working on.
+                                </span>
+                                {recentsSuggestion && (
+                                    <span className="text-tertiary">
+                                        Not sure where to start? Give{' '}
+                                        <Link
+                                            to={recentsSuggestion.href}
+                                            className="inline-flex items-center gap-1 align-middle [&_svg]:size-3.5"
+                                            data-attr={`nav-recents-suggestion-${recentsSuggestion.iconType}`}
+                                        >
+                                            {iconForType(recentsSuggestion.iconType)}
+                                            <span>{recentsSuggestion.label}</span>
+                                        </Link>{' '}
+                                        a try.
+                                    </span>
+                                )}
+                            </div>
                         ) : (
                             recentItems.map((item: FileSystemEntry) => {
                                 const name = getItemName(item)

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -158,7 +158,10 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
             },
         ],
         expandedNavSections: [
-            { ai: true, project: true, files: true, favorites: false, apps: true } as Record<string, boolean>,
+            { ai: true, project: true, files: true, favorites: false, recents: true, apps: true } as Record<
+                string,
+                boolean
+            >,
             { persist: true },
             {
                 toggleNavSection: (state, { section }) => ({

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -350,14 +350,18 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     user_id=self.request.user.id,
                     queryset=queryset,
                 )
-                queryset = queryset.order_by(F("last_viewed_at").desc(nulls_last=True), "-created_at")
+                queryset = queryset.filter(last_viewed_at__isnull=False).order_by(
+                    F("last_viewed_at").desc(), "-created_at"
+                )
             elif order_by_param == "last_viewed_at" and self.request.user.is_authenticated:
                 queryset = annotate_file_system_with_view_logs(
                     team_id=self.team.id,
                     user_id=self.request.user.id,
                     queryset=queryset,
                 )
-                queryset = queryset.order_by(F("last_viewed_at").asc(nulls_first=True), "created_at")
+                queryset = queryset.filter(last_viewed_at__isnull=False).order_by(
+                    F("last_viewed_at").asc(), "created_at"
+                )
             else:
                 queryset = queryset.order_by("-created_at")
         elif self.action == "list":

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -345,10 +345,30 @@ class TestFileSystemOrdering(APIBaseTest):
 
         results = response.json()["results"]
         paths = [item["path"] for item in results]
-        assert paths == ["Testing/Second", "Testing/First", "Testing/Fourth", "Testing/Third"]
+        # Only entries the user has actually viewed are returned, ordered by most recent view first.
+        assert paths == ["Testing/Second", "Testing/First"]
 
         assert parse_datetime(results[0]["last_viewed_at"]) == timestamp - timedelta(hours=1)
         assert parse_datetime(results[1]["last_viewed_at"]) == timestamp - timedelta(hours=3)
+
+    def test_order_by_last_viewed_at_desc_returns_empty_when_user_has_no_views(self) -> None:
+        FileSystem.objects.create(
+            team=self.team,
+            path="Testing/Untouched",
+            depth=2,
+            type="insight",
+            ref="untouched",
+            shortcut=False,
+            created_by=self.user,
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/file_system/",
+            {"order_by": "-last_viewed_at", "parent": "Testing", "not_type": "folder"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == []
 
 
 class TestFileSystemSearchNameOnly(APIBaseTest):


### PR DESCRIPTION
## Improve "Recents" section UX in the AI-first sidebar

### What changed

**Recents empty state**
Replaces the plain "No recent items" text with an informative callout explaining that recently opened items will appear there for quick access. When the user hasn't visited anything yet, a contextual suggestion links them to a product they haven't enabled, giving them a clear starting point.

**Suppress duplicate onboarding callouts**
When the Recents section is expanded and empty, the existing product recommendation banner (from `custom-products://`) is hidden to avoid stacking two onboarding callouts on top of each other.

**Recents section expanded by default**
The `recents` nav section is now included in the default expanded state so it is open on first load.

**API: filter out unviewed items from recents queries**
When ordering by `last_viewed_at` (ascending or descending), the file system endpoint now filters out entries the user has never viewed (`last_viewed_at__isnull=False`) rather than including them with nulls sorted to the end/beginning. This ensures the recents list only contains items the user has actually opened, and the empty state is shown correctly when no views exist yet.