### PR TITLE
feat(devex): backend test-timings report and CLI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1981,3 +1981,58 @@ jobs:
                   uv run --script .github/scripts/report_test_timings.py \
                       --min-duration-seconds=0.5 \
                       ./junit-artifacts
+
+    backend-test-timings-report:
+        # Renders a slowest-tests / regressions / flaky-rate report from JUnit
+        # artifacts for the team-wide CI dashboard angle. The hogli command
+        # `test-timings:*` covers per-developer triage from the same artifacts.
+        name: Backend test timings report
+        needs: [django_tests]
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        timeout-minutes: 10
+        # Master pushes always; PRs only when labelled `inspect-test-timings`. Skip forks (no secrets / PR comment access).
+        if: >-
+            always() &&
+            github.repository == 'PostHog/posthog' &&
+            needs.django_tests.result != 'skipped' &&
+            (
+            (github.event_name != 'pull_request' && github.ref == 'refs/heads/master') ||
+            (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == 'PostHog/posthog' &&
+            contains(github.event.pull_request.labels.*.name, 'inspect-test-timings'))
+            )
+        permissions:
+            contents: read
+            pull-requests: write
+            actions: read
+        steps:
+            - name: Download junit artifacts
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
+              with:
+                  path: ./junit-artifacts
+                  pattern: junit-results-backend-*
+            - name: Convert JUnit XML to CTRF
+              # Ubuntu runners ship Node by default; one-shot npx avoids a setup-node step.
+              run: |
+                  npx --yes junit-to-ctrf@0.0.14 \
+                      "./junit-artifacts/**/junit-*.xml" \
+                      -o ./ctrf/report.json \
+                      -t "Backend CI"
+            - name: Publish test timings report
+              # Step summary is on by default. PR comment is off by default and only
+              # turns on when the `inspect-test-timings` label is set on the PR.
+              # `upload-artifact: true` stores the processed CTRF so the next run can
+              # diff against it (this is how summary-delta-report does cross-run trends).
+              uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1.0.28
+              with:
+                  report-path: './ctrf/report.json'
+                  slowest-report: true
+                  summary-delta-report: true
+                  fail-rate-report: true
+                  flaky-rate-report: true
+                  upload-artifact: true
+                  pull-request: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'inspect-test-timings') }}
+                  update-comment: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -706,6 +706,21 @@ tests:
     test:e2e:
         bin_script: e2e-test-runner
         description: Set up test databases and run Playwright E2E tests
+    test-timings:latest:
+        click: hogli_commands.test_timings:latest
+        description: Top-N slowest backend tests from the latest master Backend CI run
+    test-timings:show:
+        click: hogli_commands.test_timings:show
+        description: Top-N slowest backend tests for a specific Backend CI run id
+    test-timings:compare:
+        click: hogli_commands.test_timings:compare
+        description: Compare two Backend CI runs and show biggest test-time movers
+    test-timings:regressions:
+        click: hogli_commands.test_timings:regressions
+        description: Flag tests in the latest master run that grew vs the median of recent runs
+    test-timings:cache:clear:
+        click: hogli_commands.test_timings:cache_clear
+        description: Clear the local test-timings cache
 quality:
     lint:
         cmd: ./bin/ruff.sh check . && pnpm --filter=@posthog/frontend run lint

--- a/tools/hogli-commands/hogli_commands/_junit_parser.py
+++ b/tools/hogli-commands/hogli_commands/_junit_parser.py
@@ -1,0 +1,166 @@
+"""Lean JUnit XML parser for the `hogli test-timings:*` commands.
+
+Deliberately separate from `.github/scripts/report_test_timings.py`: that
+script runs as a PEP 723 `uv run --script` with its own inline dep block, so
+cross-runtime sharing would require sys.path hacks. The duplication is
+~100 LOC and bounded; the runtimes never share modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import defusedxml.ElementTree as ET
+
+
+@dataclass(frozen=True)
+class TestCase:
+    nodeid: str
+    classname: str
+    name: str
+    duration: float
+    outcome: str  # passed | failed | error | skipped | rerun_passed
+    attempts: int
+
+
+@dataclass(frozen=True)
+class Shard:
+    artifact_name: str  # e.g. "junit-results-backend-core-29"
+    suite: str
+    segment: str
+    group: int | None
+    junit_filename: str
+    wall_seconds: float
+    tests: tuple[TestCase, ...]
+
+    @property
+    def testcase_seconds(self) -> float:
+        return sum(t.duration for t in self.tests)
+
+    @property
+    def overhead_seconds(self) -> float:
+        return max(0.0, self.wall_seconds - self.testcase_seconds)
+
+    @property
+    def label(self) -> str:
+        return f"{self.segment}-{self.group}" if self.group is not None else self.segment
+
+
+def parse_artifact_dir_name(name: str) -> tuple[str, str, int | None]:
+    """`junit-results-backend-core-29` -> ("backend", "core", 29)."""
+    suffix = name.removeprefix("junit-results-")
+    parts = suffix.split("-")
+    group = int(parts[-1]) if len(parts) > 1 and parts[-1].isdigit() else None
+    name_parts = parts[:-1] if group is not None else parts
+    if not name_parts:
+        return "", "", group
+    if name_parts[0] == "backend" and len(name_parts) > 1:
+        return "backend", "-".join(name_parts[1:]), group
+    joined = "-".join(name_parts)
+    return joined, joined, group
+
+
+def _classify_testcase(testcase: Any) -> tuple[str, int]:
+    """Return (outcome, attempts). pytest-rerunfailures emits prior attempts
+    as `<rerunFailure>` / `<rerunError>` siblings before the final outcome."""
+    rerun_count = 0
+    final: str | None = None
+    for child in testcase:
+        tag = child.tag
+        if tag.startswith("rerun"):
+            rerun_count += 1
+        elif tag in ("failure", "error", "skipped") and final is None:
+            final = "failed" if tag == "failure" else tag
+    if final is None:
+        final = "rerun_passed" if rerun_count else "passed"
+    return final, 1 + rerun_count
+
+
+def _to_nodeid(classname: str, name: str) -> str:
+    return f"{classname.replace('.', '/')}::{name}" if classname else name
+
+
+def parse_shard(xml_path: Path, artifact_name: str) -> Shard | None:
+    """Parse one `junit*.xml`. Returns None on malformed input."""
+    try:
+        root = ET.parse(xml_path).getroot()
+    except ET.ParseError:
+        return None
+    suite_elem = root if root.tag == "testsuite" else root.find("testsuite")
+    if suite_elem is None:
+        return None
+    try:
+        wall = float(suite_elem.get("time", "0"))
+    except ValueError:
+        wall = 0.0
+
+    suite, segment, group = parse_artifact_dir_name(artifact_name)
+    tests: list[TestCase] = []
+    for tc in suite_elem.iter("testcase"):
+        classname = tc.get("classname", "")
+        name = tc.get("name", "")
+        outcome, attempts = _classify_testcase(tc)
+        try:
+            duration = float(tc.get("time", "0"))
+        except ValueError:
+            duration = 0.0
+        tests.append(
+            TestCase(
+                nodeid=_to_nodeid(classname, name),
+                classname=classname,
+                name=name,
+                duration=duration,
+                outcome=outcome,
+                attempts=attempts,
+            )
+        )
+    return Shard(
+        artifact_name=artifact_name,
+        suite=suite,
+        segment=segment,
+        group=group,
+        junit_filename=xml_path.name,
+        wall_seconds=wall,
+        tests=tuple(tests),
+    )
+
+
+def collect_shards(artifacts_root: Path) -> list[Shard]:
+    """Walk `<artifacts_root>/junit-results-*/junit*.xml` -> list[Shard].
+
+    Falls through to the root itself if no subdirectories are present
+    (single-shard / locally-staged case).
+    """
+    if not artifacts_root.exists():
+        return []
+    subdirs = sorted(d for d in artifacts_root.iterdir() if d.is_dir())
+    artifact_dirs = subdirs if subdirs else [artifacts_root]
+    shards: list[Shard] = []
+    for d in artifact_dirs:
+        for xml_path in sorted(d.rglob("junit*.xml")):
+            shard = parse_shard(xml_path, d.name)
+            if shard is not None:
+                shards.append(shard)
+    return shards
+
+
+def per_test_durations(shards: list[Shard], *, segment: str | None = None) -> dict[str, float]:
+    """Collapse shards into a single nodeid -> duration map.
+
+    Skipped tests are dropped. When the same nodeid appears in multiple
+    shards (parametrized tests sharded on params share a base nodeid in
+    rare cases), the max duration wins so the slow case stays visible.
+    """
+    out: dict[str, float] = {}
+    for s in shards:
+        if segment is not None and s.segment != segment:
+            continue
+        for t in s.tests:
+            if t.outcome == "skipped":
+                continue
+            prev = out.get(t.nodeid)
+            if prev is None or t.duration > prev:
+                out[t.nodeid] = t.duration
+    return out

--- a/tools/hogli-commands/hogli_commands/test_timings.py
+++ b/tools/hogli-commands/hogli_commands/test_timings.py
@@ -45,14 +45,9 @@ def _gh_json(*args: str) -> list[dict] | dict:
 def _list_recent_master_runs(limit: int) -> list[dict]:
     """Return up to `limit` recent successful master runs of ci-backend.yml
     that actually executed tests (run duration > MIN_RUN_DURATION_SECONDS)."""
+    per_page = max(limit * 4, 20)
     payload = _gh_json(
-        f"repos/{REPO}/actions/workflows/{WORKFLOW}/runs",
-        "-f",
-        "status=success",
-        "-f",
-        "branch=master",
-        "-f",
-        f"per_page={max(limit * 4, 20)}",
+        f"repos/{REPO}/actions/workflows/{WORKFLOW}/runs?status=success&branch=master&per_page={per_page}"
     )
     runs = payload["workflow_runs"] if isinstance(payload, dict) else []
     selected: list[dict] = []

--- a/tools/hogli-commands/hogli_commands/test_timings.py
+++ b/tools/hogli-commands/hogli_commands/test_timings.py
@@ -162,6 +162,13 @@ def _coerce_segment(payload: dict, segment: str | None) -> dict[str, float]:
     return dict(segments.get(segment, {}))
 
 
+def _osc8(text: str, url: str) -> str:
+    """Wrap `text` in an OSC 8 hyperlink to `url` when stdout is a TTY."""
+    if not sys.stdout.isatty():
+        return text
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
 def _run_url(run_id: str) -> str:
     return f"https://github.com/{REPO}/actions/runs/{run_id}"
 
@@ -173,10 +180,33 @@ def _run_link(run_id: str) -> str:
     render this as a clickable run id; other surfaces (pipes, files, dumb
     shells) fall through to the plain id.
     """
-    if not sys.stdout.isatty():
-        return run_id
-    url = _run_url(run_id)
-    return f"\033]8;;{url}\033\\{run_id}\033]8;;\033\\"
+    return _osc8(run_id, _run_url(run_id))
+
+
+def _test_file_url(nodeid: str) -> str | None:
+    """Best-effort URL to the test file on master.
+
+    nodeid looks like `posthog/hogql/test/test_resolver/TestResolver::test_x` or
+    `posthog/test_x::test_y`. Strategy: take everything before `::`, drop the
+    trailing segment if it looks like a Python class (PascalCase), append `.py`.
+    Returns None when we can't form a reasonable path.
+    """
+    if "::" not in nodeid:
+        return None
+    path_part, _, _ = nodeid.partition("::")
+    parts = path_part.split("/")
+    if not parts or not parts[0]:
+        return None
+    if len(parts) > 1 and parts[-1][:1].isupper() and "_" not in parts[-1]:
+        parts = parts[:-1]
+    return f"https://github.com/{REPO}/blob/master/{'/'.join(parts)}.py"
+
+
+def _test_link(nodeid: str, *, max_width: int) -> str:
+    """`nodeid` truncated to `max_width`, wrapped as OSC 8 link to its test file."""
+    text = _truncate(nodeid, max_width)
+    url = _test_file_url(nodeid)
+    return _osc8(text, url) if url else text
 
 
 def _format_seconds(value: float) -> str:
@@ -200,7 +230,7 @@ def _render_top_n(durations: dict[str, float], *, top: int, run_id: str, segment
     click.echo(f"{'#':>4}  {'duration':>9}  test")
     click.echo("-" * 100)
     for i, (nodeid, duration) in enumerate(items, 1):
-        click.echo(f"{i:>4}  {_format_seconds(duration)}  {_truncate(nodeid, 84)}")
+        click.echo(f"{i:>4}  {_format_seconds(duration)}  {_test_link(nodeid, max_width=84)}")
     total = sum(durations.values())
     click.echo("-" * 100)
     click.echo(f"  total testcase time across {len(durations)} tests: {total:.1f}s ({total / 60:.1f} min)")
@@ -258,7 +288,7 @@ def _render_compare(
         for nodeid, delta in regressions:
             click.echo(
                 f"  {f'+{delta:.2f}s':>8}  {_format_seconds(a[nodeid])}  "
-                f"{_format_seconds(b[nodeid])}  {_truncate(nodeid, 64)}"
+                f"{_format_seconds(b[nodeid])}  {_test_link(nodeid, max_width=64)}"
             )
     else:
         click.echo("  no regressions above threshold")
@@ -270,7 +300,7 @@ def _render_compare(
                 break
             click.echo(
                 f"  {f'{delta:.2f}s':>8}  {_format_seconds(a[nodeid])}  "
-                f"{_format_seconds(b[nodeid])}  {_truncate(nodeid, 64)}"
+                f"{_format_seconds(b[nodeid])}  {_test_link(nodeid, max_width=64)}"
             )
 
     only_a = set(a) - set(b)
@@ -322,7 +352,10 @@ def _render_regressions(
     click.echo(f"  {'now':>8}  {'median':>8}  {'factor':>7}  test")
     click.echo("-" * 100)
     for nodeid, current, median, factor in rows:
-        click.echo(f"  {_format_seconds(current)}  {_format_seconds(median)}  {factor:>6.2f}x  {_truncate(nodeid, 60)}")
+        click.echo(
+            f"  {_format_seconds(current)}  {_format_seconds(median)}  "
+            f"{factor:>6.2f}x  {_test_link(nodeid, max_width=60)}"
+        )
 
 
 # ---------- click commands ----------

--- a/tools/hogli-commands/hogli_commands/test_timings.py
+++ b/tools/hogli-commands/hogli_commands/test_timings.py
@@ -1,0 +1,401 @@
+"""Local triage for backend test timings sourced from Backend CI JUnit artifacts.
+
+Subcommands fetch `junit-results-backend-*` artifacts via `gh run download`
+and render ASCII summaries: top-N slowest tests, shard wall-time imbalance,
+diffs between two runs, and regressions vs a rolling baseline.
+
+The CI side produces a richer team-wide dashboard via `ctrf-io/github-test-reporter`
+in the workflow run summary; this command is the per-developer triage path.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import statistics
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+from hogli_commands._junit_parser import Shard, collect_shards
+
+REPO = "PostHog/posthog"
+WORKFLOW = "ci-backend.yml"
+ARTIFACT_PATTERN = "junit-results-backend-*"
+# Runs that skip tests via path filtering complete in ~20s; real test runs
+# take 15+ minutes. 300s screens out almost all no-op runs.
+MIN_RUN_DURATION_SECONDS = 300
+CACHE_DIR = Path.home() / ".cache" / "posthog" / "test-timings"
+
+
+def _gh_json(*args: str) -> list[dict] | dict:
+    """Run `gh api` and return parsed JSON. Raises ClickException on failure."""
+    try:
+        result = subprocess.run(["gh", "api", *args], capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise click.ClickException(f"gh api failed: {exc.stderr.strip() or exc}") from exc
+    except FileNotFoundError as exc:
+        raise click.ClickException("`gh` CLI not found on PATH; install GitHub CLI to use this command") from exc
+    return json.loads(result.stdout)
+
+
+def _list_recent_master_runs(limit: int) -> list[dict]:
+    """Return up to `limit` recent successful master runs of ci-backend.yml
+    that actually executed tests (run duration > MIN_RUN_DURATION_SECONDS)."""
+    payload = _gh_json(
+        f"repos/{REPO}/actions/workflows/{WORKFLOW}/runs",
+        "-f",
+        "status=success",
+        "-f",
+        "branch=master",
+        "-f",
+        f"per_page={max(limit * 4, 20)}",
+    )
+    runs = payload["workflow_runs"] if isinstance(payload, dict) else []
+    selected: list[dict] = []
+    for run in runs:
+        try:
+            started = datetime.fromisoformat(run["run_started_at"].replace("Z", "+00:00"))
+            updated = datetime.fromisoformat(run["updated_at"].replace("Z", "+00:00"))
+        except (KeyError, ValueError):
+            continue
+        if (updated - started).total_seconds() <= MIN_RUN_DURATION_SECONDS:
+            continue
+        selected.append(run)
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def _find_latest_master_run() -> str:
+    runs = _list_recent_master_runs(1)
+    if not runs:
+        raise click.ClickException("no recent successful master Backend CI run found that ran tests")
+    return str(runs[0]["id"])
+
+
+def _download_junit_artifacts(run_id: str, dest: Path) -> Path:
+    """Download all `junit-results-backend-*` artifacts for a run into `dest`."""
+    dest.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "gh",
+        "run",
+        "download",
+        run_id,
+        "--repo",
+        REPO,
+        "--pattern",
+        ARTIFACT_PATTERN,
+        "--dir",
+        str(dest),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        raise click.ClickException(
+            f"`gh run download {run_id}` failed: {exc.stderr.strip() or exc}\n"
+            f"Likely cause: artifacts have expired (90 days) or run never produced junit output."
+        ) from exc
+    return dest
+
+
+def _cached_durations_path(run_id: str) -> Path:
+    return CACHE_DIR / f"{run_id}.json"
+
+
+def _load_run_durations(run_id: str, *, segment: str | None = None) -> dict[str, float]:
+    """Return per-test durations for a run, using the on-disk cache when present.
+
+    Cache contains the segmented map keyed by segment so a later --segment
+    filter doesn't force a re-download.
+    """
+    cache_path = _cached_durations_path(run_id)
+    if cache_path.exists():
+        try:
+            data = json.loads(cache_path.read_text())
+            if isinstance(data, dict) and "segments" in data:
+                return _coerce_segment(data, segment)
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    with tempfile.TemporaryDirectory() as tmp:
+        artifacts = _download_junit_artifacts(run_id, Path(tmp))
+        shards = collect_shards(artifacts)
+    payload = _build_cache_payload(shards)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(payload))
+    return _coerce_segment(payload, segment)
+
+
+def _build_cache_payload(shards: list[Shard]) -> dict:
+    segments: dict[str, dict[str, float]] = {}
+    for s in shards:
+        seg = segments.setdefault(s.segment, {})
+        for t in s.tests:
+            if t.outcome == "skipped":
+                continue
+            prev = seg.get(t.nodeid)
+            if prev is None or t.duration > prev:
+                seg[t.nodeid] = t.duration
+    shard_walls = [
+        {
+            "label": s.label,
+            "segment": s.segment,
+            "wall_seconds": s.wall_seconds,
+            "testcase_seconds": s.testcase_seconds,
+            "overhead_seconds": s.overhead_seconds,
+        }
+        for s in shards
+    ]
+    return {"segments": segments, "shards": shard_walls}
+
+
+def _coerce_segment(payload: dict, segment: str | None) -> dict[str, float]:
+    segments = payload.get("segments", {})
+    if segment is None:
+        merged: dict[str, float] = {}
+        for seg_map in segments.values():
+            for nodeid, duration in seg_map.items():
+                prev = merged.get(nodeid)
+                if prev is None or duration > prev:
+                    merged[nodeid] = duration
+        return merged
+    return dict(segments.get(segment, {}))
+
+
+def _format_seconds(value: float) -> str:
+    return f"{value:>7.2f}s"
+
+
+def _truncate(value: str, width: int) -> str:
+    if len(value) <= width:
+        return value
+    return "..." + value[-(width - 3) :]
+
+
+def _render_top_n(durations: dict[str, float], *, top: int, run_id: str, segment: str | None) -> None:
+    items = sorted(durations.items(), key=lambda x: x[1], reverse=True)[:top]
+    if not items:
+        click.echo("no test data available")
+        return
+    seg_str = f" [segment={segment}]" if segment else ""
+    click.echo(f"\nTop {len(items)} slowest tests for run {run_id}{seg_str}")
+    click.echo("-" * 100)
+    click.echo(f"{'#':>4}  {'duration':>9}  test")
+    click.echo("-" * 100)
+    for i, (nodeid, duration) in enumerate(items, 1):
+        click.echo(f"{i:>4}  {_format_seconds(duration)}  {_truncate(nodeid, 84)}")
+    total = sum(durations.values())
+    click.echo("-" * 100)
+    click.echo(f"  total testcase time across {len(durations)} tests: {total:.1f}s ({total / 60:.1f} min)")
+
+
+def _render_shard_imbalance(shards_payload: list[dict], *, segment: str | None) -> None:
+    if not shards_payload:
+        return
+    rows = [s for s in shards_payload if segment is None or s.get("segment") == segment]
+    if not rows:
+        return
+    rows.sort(key=lambda s: s["wall_seconds"], reverse=True)
+    walls = [s["wall_seconds"] for s in rows]
+    click.echo(f"\nShard wall time ({len(rows)} shards, longest first)")
+    click.echo("-" * 80)
+    click.echo(f"  {'shard':<20}  {'wall':>10}  {'tests':>10}  {'overhead':>10}")
+    click.echo("-" * 80)
+    for s in rows:
+        click.echo(
+            f"  {s['label']:<20}  {_format_seconds(s['wall_seconds'])}  "
+            f"{_format_seconds(s['testcase_seconds'])}  {_format_seconds(s['overhead_seconds'])}"
+        )
+    click.echo("-" * 80)
+    if len(walls) >= 2:
+        click.echo(
+            f"  imbalance: max={max(walls):.1f}s, min={min(walls):.1f}s, "
+            f"spread={max(walls) - min(walls):.1f}s, median={statistics.median(walls):.1f}s"
+        )
+
+
+def _render_compare(
+    a: dict[str, float],
+    b: dict[str, float],
+    *,
+    top: int,
+    run_a: str,
+    run_b: str,
+    min_delta: float,
+) -> None:
+    """Show biggest movers from run A to run B. Tests in only one run are listed separately."""
+    common = set(a) & set(b)
+    deltas = [(nodeid, b[nodeid] - a[nodeid]) for nodeid in common]
+    deltas = [d for d in deltas if abs(d[1]) >= min_delta]
+    deltas.sort(key=lambda x: x[1], reverse=True)
+
+    regressions = deltas[:top]
+    improvements = sorted(deltas, key=lambda x: x[1])[:top]
+
+    click.echo(f"\nCompare run {run_a} -> {run_b}  (min delta: {min_delta:.2f}s)")
+    if regressions:
+        click.echo("-" * 100)
+        click.echo(f"  {'delta':>8}  {'before':>8}  {'after':>8}  test")
+        click.echo("-" * 100)
+        click.echo(f"Top {len(regressions)} regressions:")
+        for nodeid, delta in regressions:
+            click.echo(
+                f"  {f'+{delta:.2f}s':>8}  {_format_seconds(a[nodeid])}  "
+                f"{_format_seconds(b[nodeid])}  {_truncate(nodeid, 64)}"
+            )
+    else:
+        click.echo("  no regressions above threshold")
+
+    if improvements and improvements[0][1] < 0:
+        click.echo(f"\nTop {len([d for d in improvements if d[1] < 0])} improvements:")
+        for nodeid, delta in improvements:
+            if delta >= 0:
+                break
+            click.echo(
+                f"  {f'{delta:.2f}s':>8}  {_format_seconds(a[nodeid])}  "
+                f"{_format_seconds(b[nodeid])}  {_truncate(nodeid, 64)}"
+            )
+
+    only_a = set(a) - set(b)
+    only_b = set(b) - set(a)
+    if only_a or only_b:
+        click.echo(f"\nTests only in {run_a}: {len(only_a)}    Tests only in {run_b}: {len(only_b)}")
+
+
+def _render_regressions(
+    head: dict[str, float],
+    baseline: dict[str, dict[str, float]],
+    *,
+    head_run_id: str,
+    top: int,
+    min_delta: float,
+    min_factor: float,
+) -> None:
+    """Compare head against the per-test median across baseline runs."""
+    medians: dict[str, float] = {}
+    for nodeid in head:
+        samples = [
+            durations[nodeid] for durations in baseline.values() if nodeid in durations and durations[nodeid] > 0
+        ]
+        if samples:
+            medians[nodeid] = statistics.median(samples)
+
+    flagged: list[tuple[str, float, float, float]] = []
+    for nodeid, current in head.items():
+        median = medians.get(nodeid)
+        if median is None or median <= 0:
+            continue
+        delta = current - median
+        factor = current / median
+        if delta >= min_delta and factor >= min_factor:
+            flagged.append((nodeid, current, median, factor))
+    flagged.sort(key=lambda x: x[1] - x[2], reverse=True)
+
+    click.echo(
+        f"\nRegressions in run {head_run_id} vs median of {len(baseline)} prior runs "
+        f"(min_delta={min_delta:.2f}s, min_factor={min_factor:.2f}x)"
+    )
+    if not flagged:
+        click.echo("  none")
+        return
+    rows = flagged[:top]
+    click.echo("-" * 100)
+    click.echo(f"  {'now':>8}  {'median':>8}  {'factor':>7}  test")
+    click.echo("-" * 100)
+    for nodeid, current, median, factor in rows:
+        click.echo(f"  {_format_seconds(current)}  {_format_seconds(median)}  {factor:>6.2f}x  {_truncate(nodeid, 60)}")
+
+
+# ---------- click commands ----------
+
+
+@click.command(name="test-timings:latest", help="Top-N slowest tests from the latest successful master Backend CI run")
+@click.option("--top", default=30, show_default=True, help="number of slowest tests to display")
+@click.option("--segment", default=None, help="filter to a single segment (e.g. core, temporal, products)")
+@click.option("--shards/--no-shards", default=True, show_default=True, help="show per-shard wall-time imbalance")
+def latest(top: int, segment: str | None, shards: bool) -> None:
+    run_id = _find_latest_master_run()
+    click.echo(f"Latest master run: {run_id}")
+    _show_run(run_id, top=top, segment=segment, with_shards=shards)
+
+
+@click.command(name="test-timings:show", help="Top-N slowest tests for a specific Backend CI run")
+@click.argument("run_id")
+@click.option("--top", default=30, show_default=True, help="number of slowest tests to display")
+@click.option("--segment", default=None, help="filter to a single segment (e.g. core, temporal, products)")
+@click.option("--shards/--no-shards", default=True, show_default=True, help="show per-shard wall-time imbalance")
+def show(run_id: str, top: int, segment: str | None, shards: bool) -> None:
+    _show_run(run_id, top=top, segment=segment, with_shards=shards)
+
+
+def _show_run(run_id: str, *, top: int, segment: str | None, with_shards: bool) -> None:
+    durations = _load_run_durations(run_id, segment=segment)
+    payload = _read_cache(run_id)
+    _render_top_n(durations, top=top, run_id=run_id, segment=segment)
+    if with_shards:
+        _render_shard_imbalance(payload.get("shards", []), segment=segment)
+
+
+def _read_cache(run_id: str) -> dict:
+    path = _cached_durations_path(run_id)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+@click.command(name="test-timings:compare", help="Compare two Backend CI runs and show biggest test-time movers")
+@click.argument("run_a")
+@click.argument("run_b")
+@click.option("--top", default=20, show_default=True, help="number of biggest movers to display")
+@click.option("--min-delta", default=2.0, show_default=True, help="minimum absolute delta in seconds to flag")
+@click.option("--segment", default=None, help="filter to a single segment (e.g. core, temporal, products)")
+def compare(run_a: str, run_b: str, top: int, min_delta: float, segment: str | None) -> None:
+    a = _load_run_durations(run_a, segment=segment)
+    b = _load_run_durations(run_b, segment=segment)
+    _render_compare(a, b, top=top, run_a=run_a, run_b=run_b, min_delta=min_delta)
+
+
+@click.command(
+    name="test-timings:regressions",
+    help="Flag tests in the latest master run that grew vs the median of the last N master runs",
+)
+@click.option("--baseline", default=10, show_default=True, help="number of prior master runs to use as baseline")
+@click.option("--top", default=30, show_default=True, help="number of biggest regressions to display")
+@click.option("--min-delta", default=2.0, show_default=True, help="minimum absolute regression in seconds to flag")
+@click.option("--min-factor", default=1.5, show_default=True, help="minimum slowdown factor (current / median)")
+@click.option("--segment", default=None, help="filter to a single segment (e.g. core, temporal, products)")
+def regressions(baseline: int, top: int, min_delta: float, min_factor: float, segment: str | None) -> None:
+    runs = _list_recent_master_runs(baseline + 1)
+    if len(runs) < 2:
+        raise click.ClickException(f"need at least 2 master runs, found {len(runs)}")
+    head_run = str(runs[0]["id"])
+    history_ids = [str(r["id"]) for r in runs[1 : baseline + 1]]
+    click.echo(
+        f"Head: master run {head_run}\n"
+        f"Baseline: {len(history_ids)} prior master runs (cached after first download in {CACHE_DIR})"
+    )
+    head = _load_run_durations(head_run, segment=segment)
+    history: dict[str, dict[str, float]] = {}
+    for rid in history_ids:
+        try:
+            history[rid] = _load_run_durations(rid, segment=segment)
+        except click.ClickException as exc:
+            click.echo(f"  warning: {rid}: {exc.message}", err=True)
+    _render_regressions(head, history, head_run_id=head_run, top=top, min_delta=min_delta, min_factor=min_factor)
+
+
+@click.command(name="test-timings:cache:clear", help="Clear the local test-timings cache")
+def cache_clear() -> None:
+    if CACHE_DIR.exists():
+        shutil.rmtree(CACHE_DIR)
+        click.echo(f"removed {CACHE_DIR}")
+    else:
+        click.echo(f"{CACHE_DIR} does not exist")

--- a/tools/hogli-commands/hogli_commands/test_timings.py
+++ b/tools/hogli-commands/hogli_commands/test_timings.py
@@ -10,6 +10,7 @@ in the workflow run summary; this command is the per-developer triage path.
 
 from __future__ import annotations
 
+import sys
 import json
 import shutil
 import tempfile
@@ -161,6 +162,23 @@ def _coerce_segment(payload: dict, segment: str | None) -> dict[str, float]:
     return dict(segments.get(segment, {}))
 
 
+def _run_url(run_id: str) -> str:
+    return f"https://github.com/{REPO}/actions/runs/{run_id}"
+
+
+def _run_link(run_id: str) -> str:
+    """OSC 8 hyperlink for `run_id` when stdout is a TTY; plain text otherwise.
+
+    Modern terminals (iTerm2, Wezterm, Ghostty, kitty, recent macOS Terminal)
+    render this as a clickable run id; other surfaces (pipes, files, dumb
+    shells) fall through to the plain id.
+    """
+    if not sys.stdout.isatty():
+        return run_id
+    url = _run_url(run_id)
+    return f"\033]8;;{url}\033\\{run_id}\033]8;;\033\\"
+
+
 def _format_seconds(value: float) -> str:
     return f"{value:>7.2f}s"
 
@@ -177,7 +195,7 @@ def _render_top_n(durations: dict[str, float], *, top: int, run_id: str, segment
         click.echo("no test data available")
         return
     seg_str = f" [segment={segment}]" if segment else ""
-    click.echo(f"\nTop {len(items)} slowest tests for run {run_id}{seg_str}")
+    click.echo(f"\nTop {len(items)} slowest tests for run {_run_link(run_id)}{seg_str}")
     click.echo("-" * 100)
     click.echo(f"{'#':>4}  {'duration':>9}  test")
     click.echo("-" * 100)
@@ -231,7 +249,7 @@ def _render_compare(
     regressions = deltas[:top]
     improvements = sorted(deltas, key=lambda x: x[1])[:top]
 
-    click.echo(f"\nCompare run {run_a} -> {run_b}  (min delta: {min_delta:.2f}s)")
+    click.echo(f"\nCompare run {_run_link(run_a)} -> {_run_link(run_b)}  (min delta: {min_delta:.2f}s)")
     if regressions:
         click.echo("-" * 100)
         click.echo(f"  {'delta':>8}  {'before':>8}  {'after':>8}  test")
@@ -258,7 +276,9 @@ def _render_compare(
     only_a = set(a) - set(b)
     only_b = set(b) - set(a)
     if only_a or only_b:
-        click.echo(f"\nTests only in {run_a}: {len(only_a)}    Tests only in {run_b}: {len(only_b)}")
+        click.echo(
+            f"\nTests only in {_run_link(run_a)}: {len(only_a)}    Tests only in {_run_link(run_b)}: {len(only_b)}"
+        )
 
 
 def _render_regressions(
@@ -291,7 +311,7 @@ def _render_regressions(
     flagged.sort(key=lambda x: x[1] - x[2], reverse=True)
 
     click.echo(
-        f"\nRegressions in run {head_run_id} vs median of {len(baseline)} prior runs "
+        f"\nRegressions in run {_run_link(head_run_id)} vs median of {len(baseline)} prior runs "
         f"(min_delta={min_delta:.2f}s, min_factor={min_factor:.2f}x)"
     )
     if not flagged:
@@ -314,7 +334,7 @@ def _render_regressions(
 @click.option("--shards/--no-shards", default=True, show_default=True, help="show per-shard wall-time imbalance")
 def latest(top: int, segment: str | None, shards: bool) -> None:
     run_id = _find_latest_master_run()
-    click.echo(f"Latest master run: {run_id}")
+    click.echo(f"Latest master run: {_run_link(run_id)}")
     _show_run(run_id, top=top, segment=segment, with_shards=shards)
 
 
@@ -374,7 +394,7 @@ def regressions(baseline: int, top: int, min_delta: float, min_factor: float, se
     head_run = str(runs[0]["id"])
     history_ids = [str(r["id"]) for r in runs[1 : baseline + 1]]
     click.echo(
-        f"Head: master run {head_run}\n"
+        f"Head: master run {_run_link(head_run)}\n"
         f"Baseline: {len(history_ids)} prior master runs (cached after first download in {CACHE_DIR})"
     )
     head = _load_run_durations(head_run, segment=segment)

--- a/tools/hogli-commands/hogli_commands/tests/test_test_timings.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_test_timings.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from hogli_commands import test_timings
+from hogli_commands._junit_parser import collect_shards, parse_artifact_dir_name, parse_shard, per_test_durations
+
+
+def _write_junit(artifact_dir: Path, *, filename: str = "junit-core.xml", body: str, time: str = "10.0") -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / filename
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            <?xml version="1.0"?>
+            <testsuites>
+              <testsuite name="pytest" timestamp="2026-05-04T10:00:00.000000" time="{time}">
+                {body}
+              </testsuite>
+            </testsuites>
+            """
+        )
+    )
+    return path
+
+
+# ---------- _junit_parser ----------
+
+
+@pytest.mark.parametrize(
+    "dir_name,expected",
+    [
+        ("junit-results-backend-core-29", ("backend", "core", 29)),
+        ("junit-results-backend-temporal-3", ("backend", "temporal", 3)),
+        ("junit-results-backend-products-with-dashes-7", ("backend", "products-with-dashes", 7)),
+        ("junit-results-async-migrations", ("async-migrations", "async-migrations", None)),
+    ],
+)
+def test_parse_artifact_dir_name(dir_name: str, expected: tuple[str, str, int | None]) -> None:
+    assert parse_artifact_dir_name(dir_name) == expected
+
+
+def test_parse_shard_extracts_durations_and_outcomes(tmp_path: Path) -> None:
+    artifact = tmp_path / "junit-results-backend-core-7"
+    xml_path = _write_junit(
+        artifact,
+        body="""\
+            <testcase classname="pkg.test_a.TestA" name="test_fast" time="0.10"/>
+            <testcase classname="pkg.test_a.TestA" name="test_slow" time="2.50"/>
+            <testcase classname="pkg.test_a.TestA" name="test_rerun" time="0.20"><rerunFailure message="x"/></testcase>
+            <testcase classname="pkg.test_a.TestA" name="test_fail" time="0.10"><failure message="x"/></testcase>
+            <testcase classname="pkg.test_a.TestA" name="test_skip" time="0.00"><skipped message="x"/></testcase>
+        """,
+    )
+    shard = parse_shard(xml_path, artifact.name)
+    assert shard is not None
+    assert shard.suite == "backend"
+    assert shard.segment == "core"
+    assert shard.group == 7
+    assert shard.label == "core-7"
+    assert shard.wall_seconds == pytest.approx(10.0)
+    assert shard.testcase_seconds == pytest.approx(2.9)
+    assert shard.overhead_seconds == pytest.approx(7.1)
+    assert [t.name for t in shard.tests] == ["test_fast", "test_slow", "test_rerun", "test_fail", "test_skip"]
+    assert shard.tests[2].outcome == "rerun_passed"
+    assert shard.tests[2].attempts == 2
+    assert shard.tests[3].outcome == "failed"
+    assert shard.tests[4].outcome == "skipped"
+    assert shard.tests[0].nodeid == "pkg/test_a/TestA::test_fast"
+
+
+def test_parse_shard_returns_none_for_malformed_xml(tmp_path: Path) -> None:
+    artifact = tmp_path / "junit-results-backend-core-1"
+    artifact.mkdir()
+    (artifact / "junit-core.xml").write_text("<not valid xml")
+    assert parse_shard(artifact / "junit-core.xml", artifact.name) is None
+
+
+def test_collect_shards_walks_artifact_dirs(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path / "junit-results-backend-core-1",
+        body='<testcase classname="m" name="t" time="1.0"/>',
+    )
+    _write_junit(
+        tmp_path / "junit-results-backend-core-2",
+        body='<testcase classname="m" name="u" time="2.0"/>',
+    )
+    shards = collect_shards(tmp_path)
+    assert len(shards) == 2
+    assert {s.group for s in shards} == {1, 2}
+
+
+def test_collect_shards_returns_empty_for_missing_dir(tmp_path: Path) -> None:
+    assert collect_shards(tmp_path / "does-not-exist") == []
+
+
+def test_per_test_durations_drops_skipped_and_takes_max(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path / "junit-results-backend-core-1",
+        body="""\
+            <testcase classname="m.T" name="dup" time="1.0"/>
+            <testcase classname="m.T" name="skipped" time="0.0"><skipped/></testcase>
+        """,
+    )
+    _write_junit(
+        tmp_path / "junit-results-backend-core-2",
+        body='<testcase classname="m.T" name="dup" time="3.5"/>',
+    )
+    durations = per_test_durations(collect_shards(tmp_path))
+    assert "m/T::skipped" not in durations
+    assert durations["m/T::dup"] == pytest.approx(3.5)
+
+
+def test_per_test_durations_segment_filter(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path / "junit-results-backend-core-1",
+        body='<testcase classname="m.T" name="a" time="1.0"/>',
+    )
+    _write_junit(
+        tmp_path / "junit-results-backend-temporal-1",
+        body='<testcase classname="m.T" name="b" time="2.0"/>',
+    )
+    shards = collect_shards(tmp_path)
+    core_only = per_test_durations(shards, segment="core")
+    assert set(core_only) == {"m/T::a"}
+    temporal_only = per_test_durations(shards, segment="temporal")
+    assert set(temporal_only) == {"m/T::b"}
+
+
+# ---------- cache + render helpers ----------
+
+
+def test_build_cache_payload_groups_by_segment(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path / "junit-results-backend-core-1",
+        body='<testcase classname="m" name="a" time="1.0"/>',
+        time="5.0",
+    )
+    _write_junit(
+        tmp_path / "junit-results-backend-temporal-1",
+        body='<testcase classname="m" name="b" time="2.0"/>',
+        time="6.0",
+    )
+    shards = collect_shards(tmp_path)
+    payload = test_timings._build_cache_payload(shards)
+    assert set(payload["segments"]) == {"core", "temporal"}
+    assert payload["segments"]["core"] == {"m::a": pytest.approx(1.0)}
+    assert payload["segments"]["temporal"] == {"m::b": pytest.approx(2.0)}
+    assert {s["label"] for s in payload["shards"]} == {"core-1", "temporal-1"}
+
+
+def test_coerce_segment_merges_when_no_filter() -> None:
+    payload = {
+        "segments": {
+            "core": {"a": 1.0, "shared": 2.0},
+            "temporal": {"b": 3.0, "shared": 5.0},
+        }
+    }
+    merged = test_timings._coerce_segment(payload, None)
+    assert merged == {"a": 1.0, "shared": 5.0, "b": 3.0}
+
+
+def test_coerce_segment_returns_only_one_segment() -> None:
+    payload = {"segments": {"core": {"a": 1.0}, "temporal": {"b": 2.0}}}
+    assert test_timings._coerce_segment(payload, "core") == {"a": 1.0}
+    assert test_timings._coerce_segment(payload, "missing") == {}
+
+
+def test_load_run_durations_uses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(test_timings, "CACHE_DIR", tmp_path)
+    cached = {"segments": {"core": {"posthog::a": 4.2}}, "shards": []}
+    (tmp_path / "12345.json").write_text(json.dumps(cached))
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("network fetch should not run when cache is fresh")
+
+    monkeypatch.setattr(test_timings, "_download_junit_artifacts", fail)
+    out = test_timings._load_run_durations("12345")
+    assert out == {"posthog::a": 4.2}
+
+
+def test_truncate_keeps_short_strings_and_clips_long_ones() -> None:
+    assert test_timings._truncate("short", 20) == "short"
+    long = "a/very/long/path/that/exceeds/the/configured/width/test::name"
+    out = test_timings._truncate(long, 20)
+    assert len(out) == 20
+    assert out.startswith("...")
+
+
+# ---------- regression detection ----------
+
+
+def test_render_regressions_flags_only_above_thresholds(capsys: pytest.CaptureFixture[str]) -> None:
+    head = {
+        "stable": 1.0,
+        "slow_grew_a_lot": 12.0,
+        "slow_grew_below_factor": 4.0,
+        "slow_grew_below_delta": 1.5,
+        "new_test": 9.0,
+    }
+    baseline = {
+        "run_a": {"stable": 1.0, "slow_grew_a_lot": 4.0, "slow_grew_below_factor": 3.0, "slow_grew_below_delta": 1.0},
+        "run_b": {"stable": 1.0, "slow_grew_a_lot": 4.0, "slow_grew_below_factor": 3.0, "slow_grew_below_delta": 1.0},
+    }
+    test_timings._render_regressions(head, baseline, head_run_id="HEAD", top=10, min_delta=2.0, min_factor=1.5)
+    out = capsys.readouterr().out
+    assert "slow_grew_a_lot" in out
+    assert "slow_grew_below_factor" not in out  # delta 1.0 < min_delta 2.0 and factor 1.33 < 1.5
+    assert "slow_grew_below_delta" not in out
+    assert "stable" not in out
+    assert "new_test" not in out  # no baseline -> no median -> not flagged
+
+
+def test_render_compare_lists_regressions_and_improvements(capsys: pytest.CaptureFixture[str]) -> None:
+    a = {"steady": 1.0, "got_slower": 2.0, "got_faster": 10.0, "below_threshold": 1.0}
+    b = {"steady": 1.0, "got_slower": 8.0, "got_faster": 1.0, "below_threshold": 2.0}
+    test_timings._render_compare(a, b, top=5, run_a="A", run_b="B", min_delta=2.0)
+    out = capsys.readouterr().out
+    assert "got_slower" in out
+    assert "got_faster" in out
+    assert "below_threshold" not in out
+    assert "steady" not in out

--- a/tools/hogli-commands/hogli_commands/tests/test_test_timings.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_test_timings.py
@@ -191,6 +191,42 @@ def test_truncate_keeps_short_strings_and_clips_long_ones() -> None:
     assert out.startswith("...")
 
 
+@pytest.mark.parametrize(
+    "nodeid,expected_path",
+    [
+        # class-style nodeid: drop trailing PascalCase class
+        (
+            "posthog/hogql/test/test_resolver/TestResolver::test_x",
+            "posthog/hogql/test/test_resolver.py",
+        ),
+        # function-style nodeid: no class to drop
+        ("posthog/test_create::test_y", "posthog/test_create.py"),
+        # parametrized nodeid: bracket lives after `::`, doesn't change file
+        (
+            "posthog/test_create::test_y[param1]",
+            "posthog/test_create.py",
+        ),
+        # multi-dot class with underscore stays intact
+        (
+            "products/x/test_workflow/TestWorkflow::test_z",
+            "products/x/test_workflow.py",
+        ),
+        # snake_case last segment is treated as module, not class
+        (
+            "posthog/api/test/test_team::test_a",
+            "posthog/api/test/test_team.py",
+        ),
+    ],
+)
+def test_test_file_url_builds_github_blob_url(nodeid: str, expected_path: str) -> None:
+    url = test_timings._test_file_url(nodeid)
+    assert url == f"https://github.com/PostHog/posthog/blob/master/{expected_path}"
+
+
+def test_test_file_url_returns_none_for_nodeid_without_separator() -> None:
+    assert test_timings._test_file_url("no_separator_here") is None
+
+
 # ---------- regression detection ----------
 
 


### PR DESCRIPTION
## Problem

Backend CI emits per-test JUnit XML on every run, but there's no team-wide or per-developer view of slowest tests, regressions, or shard imbalance. JUnit artifacts already on every run are enough to ship a useful view today without waiting on the in-progress tracing path.

## Changes

**CI side** (`.github/workflows/ci-backend.yml`): new `backend-test-timings-report` job after `django_tests`. `npx junit-to-ctrf@0.0.14` merges the `junit-results-backend-*` artifacts to CTRF; `ctrf-io/github-test-reporter@v1.0.28` (pinned by SHA) renders slowest / fail-rate / flaky-rate / summary-delta into the workflow run summary. Runs on master always; PRs only when labelled `inspect-test-timings`. PR comments are off unless labelled. `upload-artifact` on so subsequent runs can diff. `continue-on-error: true`.

**Local side** (`tools/hogli-commands/hogli_commands/test_timings.py` + `_junit_parser.py`): five `hogli test-timings:*` subcommands — `latest`, `show <run-id>`, `compare <a> <b>`, `regressions [--baseline N]`, `cache:clear`. Pulls artifacts via `gh run download`, prints ASCII top-N / shard imbalance / regression tables. Per-run parsed durations cached under `~/.cache/posthog/test-timings/` so `regressions` pays each download cost once.

OTel reporter (`.github/scripts/report_test_timings.py`) untouched. Considered extracting its parser; rejected because it's a PEP 723 `uv run --script` with its own dep block — cross-runtime sharing needs path hacks. ~100 LOC duplicated.

Off-the-shelf survey (`junit2html`, `EnricoMi/publish-unit-test-result-action`, `koaning/pytest-duration-insights`, Allure, BuildPulse, Trunk, Datadog) — `ctrf-io/github-test-reporter` was the only one with slowest-tests + cross-run trends + JUnit input + MIT + active maintenance, so adopting beat hand-rolling.

## How did you test this code?

Agent-authored; automated checks only:

- `pytest tools/hogli-commands/hogli_commands/tests/test_test_timings.py` — 17 passing
- Existing `pytest .github/scripts/test_report_test_timings.py` — 13 still passing
- `ruff check` + `ruff format --check` clean on the three new files
- `./bin/hogli test-timings:latest --help` / `:regressions --help` register correctly
- Workflow YAML parses; CTRF reporter inputs validated against the action's `action.yml` at the pinned SHA
- CI job not exercised end-to-end before push

## Publish to changelog?

no

## 🤖 Agent context

Written in Claude Code (Opus 4.7); human directed goal, reviewed approach choices (off-the-shelf vs hand-roll, label-gated PR comments, parser-extraction trade-off), and authorized push.