### PR TITLE
fix: use sync_to_async with thread_sensitive=False so we can unblock db connections

### DIFF
--- a/posthog/temporal/common/utils.py
+++ b/posthog/temporal/common/utils.py
@@ -93,11 +93,15 @@ def asyncify(fn: Callable[P, T]) -> Callable[P, Coroutine[Any, Any, T]]:
     return wrapper
 
 
+def _close_initialized_connections() -> None:
+    for conn in django.db.connections.all(initialized_only=True):
+        conn.close()
+
+
 def _close_db_connections() -> None:
     """Close old database connections to prevent usage of stale connections in long-running Temporal workers."""
     if not settings.TEST:
-        for conn in django.db.connections.all(initialized_only=True):
-            conn.close()
+        _close_initialized_connections()
 
 
 def close_db_connections(fn: Callable[P, T]) -> Callable[P, T]:

--- a/posthog/temporal/common/utils.py
+++ b/posthog/temporal/common/utils.py
@@ -6,8 +6,8 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, ParamSpec, TypeVar, cast
 
+import django.db
 from django.conf import settings
-from django.db import close_old_connections
 
 from asgiref.sync import sync_to_async
 from temporalio import activity, workflow
@@ -88,7 +88,7 @@ def asyncify(fn: Callable[P, T]) -> Callable[P, Coroutine[Any, Any, T]]:
                         },
                     )
 
-        return await sync_to_async(instrumented)()
+        return await sync_to_async(thread_sensitive=False)(close_db_connections(instrumented))()
 
     return wrapper
 
@@ -96,7 +96,8 @@ def asyncify(fn: Callable[P, T]) -> Callable[P, Coroutine[Any, Any, T]]:
 def _close_db_connections() -> None:
     """Close old database connections to prevent usage of stale connections in long-running Temporal workers."""
     if not settings.TEST:
-        close_old_connections()
+        for conn in django.db.connections.all(initialized_only=True):
+            conn.close()
 
 
 def close_db_connections(fn: Callable[P, T]) -> Callable[P, T]:
@@ -112,18 +113,11 @@ def close_db_connections(fn: Callable[P, T]) -> Callable[P, T]:
     Skipped under ``settings.TEST`` to avoid tearing down the test DB connection
     that ``transaction=True`` fixtures rely on.
 
-    Stack below ``@activity.defn``. For sync activities wrapped in ``@asyncify``,
-    place ``@close_db_connections`` *innermost* so connection cleanup runs on the
-    same ``sync_to_async`` thread as the ORM work::
-
+    Stack below ``@activity.defn``. Asyncified activities should use the ``@asyncify`` decorator instead,
+    which preserves type hints for Temporal's serialization while allowing sync Django ORM code.
         @activity.defn
         @close_db_connections
         async def my_activity(...): ...
-
-        @activity.defn
-        @asyncify
-        @close_db_connections
-        def my_sync_activity(...): ...
     """
     if inspect.iscoroutinefunction(fn):
 

--- a/posthog/temporal/tests/common/test_utils.py
+++ b/posthog/temporal/tests/common/test_utils.py
@@ -78,7 +78,7 @@ def test_make_sync_retryable_with_exponential_backoff_raises_if_not_retryable():
     assert counter == 1
 
 
-CLOSE_OLD_CONNECTIONS_TARGET = "posthog.temporal.common.utils.close_old_connections"
+CLOSE_OLD_CONNECTIONS_TARGET = "posthog.temporal.common.utils._close_initialized_connections"
 
 
 @pytest.mark.parametrize(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -33,7 +33,7 @@ class TestGetTaskProcessingContextActivity:
     def _cleanup_task(self, task):
         task.soft_delete()
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_success(self, activity_environment, test_task):
         task_run = test_task.create_run()
         input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
@@ -48,7 +48,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.repository == "posthog/posthog-js"
         assert result.create_pr is True
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_task_not_found(self, activity_environment):
         non_existent_run_id = "550e8400-e29b-41d4-a716-446655440000"
         input_data = GetTaskProcessingContextInput(run_id=non_existent_run_id)
@@ -56,7 +56,7 @@ class TestGetTaskProcessingContextActivity:
         with pytest.raises(TaskNotFoundError):
             async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_invalid_uuid(self, activity_environment):
         invalid_run_id = "not-a-uuid"
         input_data = GetTaskProcessingContextInput(run_id=invalid_run_id)
@@ -64,7 +64,7 @@ class TestGetTaskProcessingContextActivity:
         with pytest.raises(ValidationError):
             async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_with_different_repository(
         self, activity_environment, team, user, github_integration
     ):
@@ -83,7 +83,7 @@ class TestGetTaskProcessingContextActivity:
         finally:
             self._cleanup_task(task)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_with_create_pr_false(self, activity_environment, test_task):
         task_run = test_task.create_run()
         input_data = GetTaskProcessingContextInput(run_id=str(task_run.id), create_pr=False)
@@ -92,7 +92,7 @@ class TestGetTaskProcessingContextActivity:
         assert isinstance(result, TaskProcessingContext)
         assert result.create_pr is False
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_resolves_user_github_integration_without_repository(
         self, activity_environment, team, user
     ):
@@ -122,7 +122,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.github_user_integration_id == str(user_integration.id)
         assert result.has_github_credentials is True
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_uses_team_integration_without_repository(
         self, activity_environment, team, user, github_integration
     ):
@@ -146,7 +146,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.github_user_integration_id is None
         assert result.has_github_credentials is True
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_resolves_allowed_domains(self, activity_environment, test_task):
         sandbox_environment = SandboxEnvironment.objects.create(
             team=test_task.team,
@@ -164,7 +164,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.sandbox_environment_name == "Restricted env"
         assert result.allowed_domains == ["example.com"]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_preserves_empty_restricted_domains(self, activity_environment, test_task):
         sandbox_environment = SandboxEnvironment.objects.create(
             team=test_task.team,
@@ -181,7 +181,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.sandbox_environment_id == str(sandbox_environment.id)
         assert result.allowed_domains == []
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_keeps_full_access_unrestricted(self, activity_environment, test_task):
         sandbox_environment = SandboxEnvironment.objects.create(
             team=test_task.team,
@@ -198,7 +198,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.sandbox_environment_id == str(sandbox_environment.id)
         assert result.allowed_domains is None
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_rejects_other_users_private_sandbox_environment(
         self, activity_environment, test_task
     ):
@@ -225,7 +225,7 @@ class TestGetTaskProcessingContextActivity:
         with pytest.raises(TaskInvalidStateError):
             async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     @pytest.mark.parametrize(
         "flag_value, expected",
         [
@@ -253,7 +253,7 @@ class TestGetTaskProcessingContextActivity:
         assert kwargs["groups"] == {"organization": org_id}
         assert kwargs["group_properties"] == {"organization": {"id": org_id}}
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_exposes_ci_prompt(self, activity_environment, test_task):
         custom_prompt = "Re-run the failed mypy checks and push a fix."
         test_task.ci_prompt = custom_prompt
@@ -265,7 +265,7 @@ class TestGetTaskProcessingContextActivity:
 
         assert result.ci_prompt == custom_prompt
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_exposes_runtime_metadata(self, activity_environment, test_task):
         task_run = test_task.create_run(
             extra_state={

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_inject_fresh_tokens_on_resume.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_inject_fresh_tokens_on_resume.py
@@ -18,7 +18,7 @@ from products.tasks.backend.temporal.process_task.activities.provision_sandbox i
 )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestInjectFreshTokensOnResumeActivity:
     @pytest.fixture
     def sandbox(self):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -12,7 +12,7 @@ from products.tasks.backend.temporal.process_task.activities.update_task_run_sta
 
 @pytest.mark.requires_secrets
 class TestUpdateTaskRunStatusActivity:
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     @pytest.mark.parametrize(
         "status,sets_completed_at",
         [
@@ -33,7 +33,7 @@ class TestUpdateTaskRunStatusActivity:
         else:
             assert test_task_run.completed_at is None
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_updates_error_message(self, activity_environment, test_task_run):
         error_msg = "Something went wrong"
         input_data = UpdateTaskRunStatusInput(
@@ -46,7 +46,7 @@ class TestUpdateTaskRunStatusActivity:
         test_task_run.refresh_from_db()
         assert test_task_run.error_message == error_msg
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
     def test_publishes_stream_state_event(self, mock_publish_stream_state_event, activity_environment, test_task_run):
         input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=TaskRun.Status.IN_PROGRESS)
@@ -55,7 +55,7 @@ class TestUpdateTaskRunStatusActivity:
 
         mock_publish_stream_state_event.assert_called_once()
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     def test_handles_non_existent_task_run(self, activity_environment):
         non_existent_run_id = "550e8400-e29b-41d4-a716-446655440000"
         input_data = UpdateTaskRunStatusInput(


### PR DESCRIPTION
## Problem

`asyncify` currently calls `sync_to_async(fn)` with the default `thread_sensitive=True`. That setting funnels every asyncified call through asgiref's single shared executor thread, so all Django ORM work for every asyncified Temporal activity in a worker serializes on one thread. One slow query stalls every other asyncified activity, and the resulting head-of-line blocking masquerades as activity timeouts. The companion PR [#57740](https://github.com/PostHog/posthog/pull/57740) added `thread_wait_seconds` instrumentation that makes this contention visible.

We can't simply flip `thread_sensitive=False` on its own, though: when each call runs on a fresh executor thread, every thread accumulates its own Django connection state, and Temporal lives entirely outside the Django request lifecycle so the `request_started` / `request_finished` signals that normally trigger `close_old_connections()` never fire. That means stale connections accumulate per thread until queries start failing — and `CONN_MAX_AGE > 0` doesn't save us, because the request-cycle hooks that respect it never run here.

## Changes

- `asyncify` now wraps its instrumented inner function with `close_db_connections(...)` and submits it via `sync_to_async(thread_sensitive=False)`, so each asyncified Temporal activity runs on its own executor thread and explicitly cleans up its DB connections before and after the work.
- `_close_db_connections` now iterates `django.db.connections.all(initialized_only=True)` and calls `conn.close()` on each one, instead of `close_old_connections()`. This is intentional: because Temporal workers don't go through the request lifecycle, we can't rely on `CONN_MAX_AGE`-based eviction — we manage connection lifetime manually on the threads we own.
- Updated the `close_db_connections` docstring: the `@asyncify` + `@close_db_connections` stacking example is removed because `@asyncify` now performs the connection cleanup itself.

## How did you test this code?

Agent-authored. No automated tests were added in this PR — covered by existing tests for the wrapped activities. Verification will come from observing `thread_wait_seconds` in `asyncify_slow` logs (introduced by [#57740](https://github.com/PostHog/posthog/pull/57740)) drop on the affected workers post-deploy, and from the absence of stale-connection errors.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Co-authored with Claude Code. Human (@rsiil) wrote the implementation; agent was used to summarize and push the stack. Key intent the human provided: `thread_sensitive=True` was forcing all DB operations onto a single shared thread; flipping to `False` lets multiple threads run, and we manage connections explicitly via `close_db_connections` because Temporal lives outside the request lifecycle and we can't trust `CONN_MAX_AGE` alone.