### PR TITLE
chore(error-tracking): warn against broad MCP suppression rules

### DIFF
--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -310,8 +310,13 @@ tools:
             idempotent: false
         title: Create error tracking suppression rule
         description: >
-            Create an error tracking suppression rule for the current project. Provide optional `filters` and optional
-            `sampling_rate`; omit `filters` to create a match-all suppression rule.
+            Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed
+            indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted.
+            Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT
+            create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and
+            cause data loss that is hard to detect after the fact. Prefer `sampling_rate` to dampen noisy issues rather
+            than fully suppressing when uncertain. Confirm with the user before creating any rule that could match more
+            than one distinct error.
     error-tracking-suppression-rules-destroy:
         operation: error_tracking_suppression_rules_destroy
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1215,7 +1215,7 @@
         }
     },
     "error-tracking-suppression-rules-create": {
-        "description": "Create an error tracking suppression rule for the current project. Provide optional `filters` and optional `sampling_rate`; omit `filters` to create a match-all suppression rule.",
+        "description": "Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted. Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and cause data loss that is hard to detect after the fact. Prefer `sampling_rate` to dampen noisy issues rather than fully suppressing when uncertain. Confirm with the user before creating any rule that could match more than one distinct error.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Create error tracking suppression rule",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1261,7 +1261,7 @@
         }
     },
     "error-tracking-suppression-rules-create": {
-        "description": "Create an error tracking suppression rule for the current project. Provide optional `filters` and optional `sampling_rate`; omit `filters` to create a match-all suppression rule.",
+        "description": "Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted. Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and cause data loss that is hard to detect after the fact. Prefer `sampling_rate` to dampen noisy issues rather than fully suppressing when uncertain. Confirm with the user before creating any rule that could match more than one distinct error.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Create error tracking suppression rule",


### PR DESCRIPTION
## Problem

The MCP tool description for `error-tracking-suppression-rules-create` did not warn agents that suppression is indefinite, and even hinted that omitting `filters` to create a match-all rule was a normal option. That made it easy for an agent to silently drop a wide swath of unrelated errors.

## Changes

- Rewrote the description in `products/error_tracking/mcp/tools.yaml` to:
  - call out that matching errors are suppressed indefinitely (dropped at ingestion until the rule is disabled or deleted)
  - tell the agent to scope `filters` tightly to the exact exception type, message, URL, or properties
  - explicitly forbid match-all rules (omitting `filters`) and broad rules
  - prefer `sampling_rate` over full suppression when uncertain
  - require user confirmation before creating any rule that could match more than one distinct error
- Regenerated `services/mcp/schema/tool-definitions-all.json` and `services/mcp/schema/generated-tool-definitions.json` via `hogli build:openapi`.

## How did you test this code?

I'm an agent. No manual testing performed beyond running `hogli build:openapi` to confirm the generated JSON files pick up the new description (verified via grep). No automated tests are affected by this description change.

## Publish to changelog?

no

## Docs update

No docs changes — this is an MCP tool description aimed at agents.

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7) at the request of @ci.
- Human prompt asked to make it obvious that suppression is indefinite and that agents should be very specific (no match-all / very wide rules).
- Considered shortening the warning, but chose to keep the explicit list of risks and the "confirm with user" instruction since LLM tool descriptions only get one shot at conveying intent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*