### PR TITLE
fix(web-analytics): Cap weekly digest fan-out to avoid workflow deadlock

### DIFF
--- a/products/web_analytics/backend/temporal/weekly_digest/types.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/types.py
@@ -6,6 +6,7 @@ class WAWeeklyDigestInput:
     """Top-level input for the WA weekly digest coordinator workflow."""
 
     dry_run: bool = False
+    max_concurrent: int = 10
 
 
 @dataclasses.dataclass

--- a/products/web_analytics/backend/temporal/weekly_digest/workflows.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/workflows.py
@@ -47,9 +47,11 @@ class WAWeeklyDigestWorkflow(PostHogWorkflow):
 
         workflow.logger.info("Fanning out WA digest to %d orgs", len(org_ids))
 
-        results = await asyncio.gather(
-            *[
-                workflow.execute_activity(
+        semaphore = asyncio.Semaphore(input.max_concurrent)
+
+        async def _run_for_org(org_id: str) -> dict:
+            async with semaphore:
+                return await workflow.execute_activity(
                     build_and_send_wa_digest_for_org,
                     BuildAndSendDigestForOrgInput(org_id=org_id, dry_run=input.dry_run),
                     start_to_close_timeout=timedelta(minutes=30),
@@ -59,21 +61,20 @@ class WAWeeklyDigestWorkflow(PostHogWorkflow):
                         initial_interval=timedelta(minutes=2),
                     ),
                 )
-                for org_id in org_ids
-            ],
+
+        results = await asyncio.gather(
+            *[_run_for_org(org_id) for org_id in org_ids],
             return_exceptions=True,
         )
 
-        successes = sum(1 for r in results if not isinstance(r, BaseException))
-        failures = sum(1 for r in results if isinstance(r, BaseException))
-
-        for i, result in enumerate(results):
+        successes = 0
+        failures = 0
+        for org_id, result in zip(org_ids, results):
             if isinstance(result, BaseException):
-                workflow.logger.error(
-                    "WA digest failed for org %s: %s",
-                    org_ids[i],
-                    str(result),
-                )
+                failures += 1
+                workflow.logger.error("WA digest failed for org %s: %s", org_id, str(result))
+            else:
+                successes += 1
 
         workflow.logger.info(
             "WA weekly digest complete: %d succeeded, %d failed",


### PR DESCRIPTION
## Problem
The weekly digest workflow tried to kick off all per-org jobs at once causing a deadlock in temporal
  the workflow.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Limit how many jobs get queued at the same time

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
