### PR TITLE
feat(property-values): rebuild text index with lowercase preprocessor

### DIFF
--- a/posthog/clickhouse/migrations/0250_property_values_lowercase_text_index.py
+++ b/posthog/clickhouse/migrations/0250_property_values_lowercase_text_index.py
@@ -1,0 +1,33 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+if settings.CLOUD_DEPLOYMENT in ("US", "EU"):
+    _ROLES = [NodeRole.AUX]
+elif settings.CLOUD_DEPLOYMENT == "DEV":
+    _ROLES = [NodeRole.DATA]
+else:
+    _ROLES = []
+
+operations = (
+    [
+        run_sql_with_exceptions(
+            "ALTER TABLE property_values DROP INDEX IF EXISTS idx_property_value",
+            node_roles=_ROLES,
+            is_alter_on_replicated_table=True,
+        ),
+        run_sql_with_exceptions(
+            "ALTER TABLE property_values ADD INDEX IF NOT EXISTS idx_property_value property_value "
+            "TYPE text(tokenizer = ngrams(3), preprocessor = lower(property_value)) GRANULARITY 1",
+            node_roles=_ROLES,
+            is_alter_on_replicated_table=True,
+        ),
+        run_sql_with_exceptions(
+            "ALTER TABLE property_values MATERIALIZE INDEX idx_property_value",
+            node_roles=_ROLES,
+            is_alter_on_replicated_table=True,
+        ),
+    ]
+    if _ROLES
+    else []
+)

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0249_property_values_kafka_named_collection
+0250_property_values_lowercase_text_index

--- a/posthog/clickhouse/property_values.py
+++ b/posthog/clickhouse/property_values.py
@@ -49,7 +49,7 @@ SETTINGS
         table_name=TABLE_NAME,
         engine=AggregatingMergeTree(TABLE_NAME, replication_scheme=ReplicationScheme.REPLICATED),
         extra_fields=""",
-    INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3)) GRANULARITY 1""",
+    INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3), preprocessor = lower(property_value)) GRANULARITY 1""",
     )
 
 

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3381,7 +3381,7 @@
       `property_count` SimpleAggregateFunction(sum, UInt64),
       `last_seen` SimpleAggregateFunction(max, DateTime) DEFAULT now()
       ,
-      INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3)) GRANULARITY 1
+      INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3), preprocessor = lower(property_value)) GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.property_values', '{replica}-{shard}')
   
   ORDER BY (team_id, property_type, property_key, property_value)
@@ -7561,7 +7561,7 @@
       `property_count` SimpleAggregateFunction(sum, UInt64),
       `last_seen` SimpleAggregateFunction(max, DateTime) DEFAULT now()
       ,
-      INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3)) GRANULARITY 1
+      INDEX idx_property_value property_value TYPE text(tokenizer = ngrams(3), preprocessor = lower(property_value)) GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.property_values', '{replica}-{shard}')
   
   ORDER BY (team_id, property_type, property_key, property_value)


### PR DESCRIPTION
## Problem

The `idx_property_value` text index on `property_values` is built without a case-handling preprocessor. `hasToken` / `hasAllTokens` engage the index but match case-sensitively against the stored ngrams, so a search for `posthog` silently misses stored values like `PostHog` / `POSTHOG`.

`EXPLAIN indexes=1` shows the index is consulted, but the result set is incomplete relative to the case-insensitive ground truth (`ILIKE '%posthog%'`).

## Changes

`posthog/clickhouse/property_values.py`
- `PROPERTY_VALUES_TABLE_SQL` now defines the index with `preprocessor = lower(property_value)`
- new migration

## How did you test this code?

Index is used: local CH (26.3.9.8) with the migration applied + ~20k mixed-case test rows in `default.property_values`:

```sql
EXPLAIN indexes=1
SELECT property_value
FROM property_values
WHERE team_id = 1
	AND property_type = 'event'
	AND property_key = '$current_url'
	AND hasAllTokens(property_value, ['pos','ost','sth','tho','hog'])
LIMIT 10
```

Output:
```
Expression ((Projection + Before ORDER BY))
  Limit (preliminary LIMIT)
    Expression
      ReadFromMergeTree (default.property_values)
      Indexes:
        PrimaryKey
          Keys:
            team_id
            property_type
            property_key
          Condition: and((property_key in [\'$current_url\', \'$current_url\']), and((property_type in [\'event\', \'event\']), (team_id in [1, 1])))
          Parts: 2/2
          Granules: 3/3
          Search Algorithm: binary search
        Skip
          Name: idx_property_value
          Description: text GRANULARITY 100000000
          Condition: (mode: All; tokens: ["hog", "ost", "pos", "sth", "tho"])
          Parts: 1/2
          Granules: 2/3
        Ranges: 1
```

Case-sensitive results returned: 
```sql
SELECT
      (SELECT count() FROM default.property_values
          WHERE team_id = 1 AND property_value LIKE  '%posthog%')                                              AS lowercase_only,
      (SELECT count() FROM default.property_values
          WHERE team_id = 1 AND property_value LIKE  '%PostHog%')                                              AS pascalcase_only,
      (SELECT count() FROM default.property_values
          WHERE team_id = 1 AND property_value LIKE  '%POSTHOG%')                                              AS uppercase_only,
      (SELECT count() FROM default.property_values
          WHERE team_id = 1 AND property_value ILIKE '%posthog%')                                              AS ilike_all_cases,
      (SELECT count() FROM default.property_values
          WHERE team_id = 1 AND hasAllTokens(property_value, ['pos','ost','sth','tho','hog']))                 AS hastokens_via_index
FORMAT Vertical
```

Output:
```
lowercase_only:      7536
pascalcase_only:     2512
uppercase_only:      2512
ilike_all_cases:     12560
hastokens_via_index: 12560
```

## Publish to changelog?

no

## Docs update

n/a
