### PR TITLE
feat(experiments): adds a notebook slash command to add experiments.

### DIFF
--- a/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/AddExperimentsToNotebookModal.tsx
+++ b/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/AddExperimentsToNotebookModal.tsx
@@ -1,0 +1,23 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+
+import { addExperimentsToNotebookModalLogic } from './addExperimentsToNotebookModalLogic'
+import { ExperimentsNotebookTable } from './ExperimentsNotebookTable'
+
+export function AddExperimentsToNotebookModal(): JSX.Element {
+    const { closeModal } = useActions(addExperimentsToNotebookModalLogic)
+    const { isAddExperimentsToNotebookModalOpen, insertionPosition } = useValues(addExperimentsToNotebookModalLogic)
+
+    return (
+        <LemonModal
+            title="Add experiment to notebook"
+            onClose={closeModal}
+            isOpen={isAddExperimentsToNotebookModalOpen}
+            footer={<LemonButton type="secondary" data-attr="notebook-cancel" onClick={closeModal} children="Close" />}
+        >
+            <ExperimentsNotebookTable insertionPosition={insertionPosition} />
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/ExperimentsNotebookTable.tsx
+++ b/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/ExperimentsNotebookTable.tsx
@@ -1,0 +1,171 @@
+import { useActions, useValues } from 'kea'
+
+import { IconCheck, IconFlask, IconPlus, IconX } from '@posthog/icons'
+import { LemonInput, LemonTag, Tooltip } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+
+import { getExperimentStatus } from '~/scenes/experiments/experimentsLogic'
+import { StatusTag } from '~/scenes/experiments/ExperimentView/components'
+import { isLegacyExperiment } from '~/scenes/experiments/utils'
+import { notebookLogic } from '~/scenes/notebooks/Notebook/notebookLogic'
+import { NotebookNodeType } from '~/scenes/notebooks/types'
+import { Experiment } from '~/types'
+
+import { addExperimentsToNotebookModalLogic } from './addExperimentsToNotebookModalLogic'
+
+type ExperimentsNotebookTableProps = {
+    insertionPosition: number | null
+}
+
+export function ExperimentsNotebookTable({ insertionPosition }: ExperimentsNotebookTableProps): JSX.Element {
+    const { experiments, experimentsLoading, filters, sorting, experimentsPerPage, count, modalPage } = useValues(
+        addExperimentsToNotebookModalLogic
+    )
+    const { setModalPage, setModalFilters, closeModal } = useActions(addExperimentsToNotebookModalLogic)
+
+    const { experimentIdsInNotebook, findNodeLogic } = useValues(notebookLogic)
+    const { addExperimentToNotebook } = useActions(notebookLogic)
+
+    const isSelected = (experiment: Experiment): boolean => {
+        return experimentIdsInNotebook?.includes(experiment.id as number) ?? false
+    }
+
+    const onToggle = (experiment: Experiment): void => {
+        // If already in notebook, remove it
+        if (isSelected(experiment)) {
+            const nodeLogic = findNodeLogic(NotebookNodeType.Experiment, { id: experiment.id })
+            if (nodeLogic) {
+                nodeLogic.actions.deleteNode()
+            }
+            return
+        }
+
+        addExperimentToNotebook(experiment.id as number, insertionPosition)
+        closeModal()
+    }
+
+    const columns: LemonTableColumns<Experiment> = [
+        {
+            key: 'id',
+            width: 32,
+            render: function renderIcon() {
+                return <IconFlask className="text-secondary text-2xl" />
+            },
+        },
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            width: 300,
+            render: function renderName(_, experiment: Experiment) {
+                return (
+                    <div className="flex flex-col gap-1 min-w-0 max-w-[300px] overflow-hidden">
+                        <div className="flex items-center gap-1 min-w-0 overflow-hidden">
+                            <Tooltip title={experiment.name}>
+                                <span className="block truncate max-w-full font-medium">{experiment.name}</span>
+                            </Tooltip>
+                            {isLegacyExperiment(experiment) && (
+                                <LemonTag type="warning" size="small">
+                                    Legacy
+                                </LemonTag>
+                            )}
+                        </div>
+                        {experiment.description && (
+                            <Tooltip title={experiment.description}>
+                                <div className="text-xs text-tertiary line-clamp-2">{experiment.description}</div>
+                            </Tooltip>
+                        )}
+                    </div>
+                )
+            },
+        },
+        {
+            title: 'Status',
+            key: 'status',
+            width: 100,
+            render: function renderStatus(_: unknown, experiment: Experiment) {
+                return <StatusTag status={getExperimentStatus(experiment)} />
+            },
+        },
+        createdByColumn() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
+        {
+            title: 'Created',
+            sorter: true,
+            dataIndex: 'created_at',
+            width: 0,
+            render: function renderCreatedAt(_, experiment: Experiment) {
+                return (
+                    <div className="whitespace-nowrap">
+                        {experiment.created_at && <TZLabel time={experiment.created_at} />}
+                    </div>
+                )
+            },
+        },
+        {
+            key: 'action',
+            width: 32,
+            render: function renderAction(_: unknown, experiment: Experiment) {
+                return isSelected(experiment) ? (
+                    <div className="group/status relative flex items-center justify-center">
+                        <IconCheck className="text-success text-xl transition-opacity duration-150 group-hover/status:opacity-0" />
+                        <IconX className="text-danger text-xl absolute inset-0 opacity-0 transition-opacity duration-150 group-hover/status:opacity-100" />
+                    </div>
+                ) : (
+                    <IconPlus className="text-muted text-xl opacity-40 group-hover:opacity-100 group-hover:text-success transition-all" />
+                )
+            },
+        },
+    ]
+
+    return (
+        <div className="experiments-notebook-table">
+            <div className="mb-3">
+                <LemonInput
+                    type="search"
+                    placeholder="Search experiments"
+                    onChange={(search) => setModalFilters({ search, page: 1 })}
+                    value={filters.search || ''}
+                />
+            </div>
+            <div className="overflow-x-hidden">
+                <LemonTable
+                    dataSource={experiments.results}
+                    columns={columns}
+                    loading={experimentsLoading}
+                    pagination={{
+                        controlled: true,
+                        currentPage: modalPage,
+                        pageSize: experimentsPerPage,
+                        entryCount: count,
+                        onForward: () => setModalPage(modalPage + 1),
+                        onBackward: () => setModalPage(modalPage - 1),
+                    }}
+                    sorting={sorting}
+                    onSort={(newSorting) =>
+                        setModalFilters({
+                            order: newSorting
+                                ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
+                                : undefined,
+                        })
+                    }
+                    rowKey="id"
+                    loadingSkeletonRows={experimentsPerPage}
+                    nouns={['experiment', 'experiments']}
+                    rowClassName={(experiment) =>
+                        isSelected(experiment)
+                            ? 'group bg-success-highlight border-l-2 border-l-success cursor-pointer hover:bg-success-highlight/70'
+                            : 'group cursor-pointer hover:bg-success-highlight/30 border-l-2 border-l-transparent hover:border-l-success/50'
+                    }
+                    onRow={(experiment) => ({
+                        onClick: () => onToggle(experiment),
+                        title: isSelected(experiment) ? 'Click to deselect' : 'Click to select',
+                    })}
+                    emptyState="No experiments found"
+                />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/addExperimentsToNotebookModalLogic.ts
+++ b/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/addExperimentsToNotebookModalLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
@@ -119,13 +119,6 @@ export const addExperimentsToNotebookModalLogic = kea<addExperimentsToNotebookMo
             const newFilters = values.filters
 
             if (!objectsEqual(oldFilters, newFilters)) {
-                actions.loadExperiments()
-            }
-        },
-    })),
-    events(({ actions, values }) => ({
-        afterMount: () => {
-            if (values.isAddExperimentsToNotebookModalOpen) {
                 actions.loadExperiments()
             }
         },

--- a/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/addExperimentsToNotebookModalLogic.ts
+++ b/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/addExperimentsToNotebookModalLogic.ts
@@ -1,0 +1,133 @@
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api, { CountedPaginatedResponse } from 'lib/api'
+import { Sorting } from 'lib/lemon-ui/LemonTable'
+import { objectsEqual, toParams } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { Experiment } from '~/types'
+
+import type { addExperimentsToNotebookModalLogicType } from './addExperimentsToNotebookModalLogicType'
+
+export interface ExperimentsModalFilters {
+    search?: string
+    page?: number
+    order?: string
+}
+
+const EXPERIMENTS_PER_PAGE = 10
+
+export const addExperimentsToNotebookModalLogic = kea<addExperimentsToNotebookModalLogicType>([
+    path(['scenes', 'notebooks', 'AddExperimentsToNotebookModal', 'addExperimentsToNotebookModalLogic']),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    actions({
+        openModal: (insertionPosition: number | null) => ({ insertionPosition }),
+        closeModal: true,
+        setModalFilters: (filters: Partial<ExperimentsModalFilters>, merge: boolean = true) => ({ filters, merge }),
+        setModalPage: (page: number) => ({ page }),
+        loadExperiments: true,
+    }),
+    loaders(({ values }) => ({
+        experiments: {
+            __default: { results: [] as Experiment[], count: 0 } as CountedPaginatedResponse<Experiment>,
+            loadExperiments: async (_, breakpoint) => {
+                await breakpoint(300)
+
+                const { order, page = 1, search } = values.filters
+                const perPage = EXPERIMENTS_PER_PAGE
+
+                const params: Record<string, any> = {
+                    limit: perPage,
+                    offset: Math.max(0, (page - 1) * perPage),
+                }
+
+                if (search) {
+                    params.search = search
+                }
+                if (order) {
+                    params.order = order
+                }
+
+                const response = await api.get(`api/projects/${values.currentTeamId}/experiments/?${toParams(params)}`)
+
+                breakpoint()
+                return response
+            },
+        },
+    })),
+    reducers({
+        isAddExperimentsToNotebookModalOpen: [
+            false,
+            {
+                openModal: () => true,
+                closeModal: () => false,
+            },
+        ],
+        insertionPosition: [
+            null as number | null,
+            {
+                openModal: (_, { insertionPosition }) => insertionPosition,
+                closeModal: () => null,
+            },
+        ],
+        rawModalFilters: [
+            { page: 1, order: '-created_at' } as ExperimentsModalFilters,
+            {
+                setModalFilters: (state, { filters, merge }) => ({
+                    ...(merge ? state : {}),
+                    ...filters,
+                    ...('page' in filters ? {} : { page: 1 }),
+                }),
+                closeModal: () => ({ page: 1, order: '-created_at' }),
+            },
+        ],
+    }),
+    selectors({
+        filters: [
+            (s) => [s.rawModalFilters],
+            (rawModalFilters): ExperimentsModalFilters => ({
+                page: 1,
+                order: '-created_at',
+                ...rawModalFilters,
+            }),
+        ],
+        experimentsPerPage: [() => [], (): number => EXPERIMENTS_PER_PAGE],
+        count: [(s) => [s.experiments], (experiments) => experiments.count],
+        modalPage: [(s) => [s.filters], (filters) => filters.page || 1],
+        sorting: [
+            (s) => [s.filters],
+            (filters): Sorting | null =>
+                filters.order
+                    ? filters.order.startsWith('-')
+                        ? { columnKey: filters.order.slice(1), order: -1 }
+                        : { columnKey: filters.order, order: 1 }
+                    : null,
+        ],
+    }),
+    listeners(({ actions, values, selectors }) => ({
+        openModal: () => {
+            actions.loadExperiments()
+        },
+        setModalPage: ({ page }) => {
+            actions.setModalFilters({ page }, true)
+        },
+        setModalFilters: (_, __, ___, previousState) => {
+            const oldFilters = selectors.filters(previousState)
+            const newFilters = values.filters
+
+            if (!objectsEqual(oldFilters, newFilters)) {
+                actions.loadExperiments()
+            }
+        },
+    })),
+    events(({ actions, values }) => ({
+        afterMount: () => {
+            if (values.isAddExperimentsToNotebookModalOpen) {
+                actions.loadExperiments()
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -15,6 +15,7 @@ import { NotebookLogicProps, notebookLogic } from 'scenes/notebooks/Notebook/not
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { SCRATCHPAD_NOTEBOOK } from '~/models/notebooksModel'
 
+import { AddExperimentsToNotebookModal } from '../AddExperimentsToNotebookModal/AddExperimentsToNotebookModal'
 import { AddInsightsToNotebookModal } from '../AddInsightsToNotebookModal/AddInsightsToNotebookModal'
 import { Editor } from './Editor'
 import { NotebookColumnLeft } from './NotebookColumnLeft'
@@ -149,6 +150,7 @@ export function Notebook({
                 </div>
             )}
             <AddInsightsToNotebookModal />
+            <AddExperimentsToNotebookModal />
         </BindLogic>
     )
 }

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -8,6 +8,7 @@ import {
     IconCode,
     IconCursor,
     IconDatabase,
+    IconFlask,
     IconFunnels,
     IconGraph,
     IconHogQL,
@@ -40,6 +41,7 @@ import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { BaseMathType, ChartDisplayType, FunnelVizType, PathType, RetentionPeriod } from '~/types'
 
+import { addExperimentsToNotebookModalLogic } from '../AddExperimentsToNotebookModal/addExperimentsToNotebookModalLogic'
 import { addInsightsToNotebookModalLogic } from '../AddInsightsToNotebookModal/addInsightsToNotebookModalLogic'
 import { buildInsightVizQueryContent, buildNodeEmbed, buildNodeQueryContent } from '../Nodes/nodeBuilders'
 import { NotebookNodeType } from '../types'
@@ -401,6 +403,21 @@ order by count() desc
                 icon: <IconRewindPlay />,
                 command: (chain, pos) =>
                     chain.insertContentAt(pos, { type: NotebookNodeType.RecordingPlaylist, attrs: {} }),
+            },
+        ],
+    },
+    {
+        title: 'Experiments',
+        icon: <IconFlask />,
+        items: [
+            {
+                title: 'Experiment',
+                search: 'experiment ab test saved existing browse',
+                icon: <IconFlask />,
+                command: (chain, pos) => {
+                    addExperimentsToNotebookModalLogic.actions.openModal(typeof pos === 'number' ? pos : null)
+                    return chain
+                },
             },
         ],
     },

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -212,6 +212,10 @@ export const notebookLogic = kea<notebookLogicType>([
             insightShortId,
             insertionPosition,
         }),
+        addExperimentToNotebook: (experimentId: number, insertionPosition: number | null = null) => ({
+            experimentId,
+            insertionPosition,
+        }),
         setShowHistory: (showHistory: boolean) => ({ showHistory }),
         setTableOfContents: (tableOfContents: TableOfContentData) => ({ tableOfContents }),
         setTextSelection: (selection: number | EditorRange) => ({ selection }),
@@ -774,6 +778,17 @@ export const notebookLogic = kea<notebookLogicType>([
             },
         ],
 
+        experimentIdsInNotebook: [
+            (s) => [s.content],
+            (content): number[] => {
+                if (!content) {
+                    return []
+                }
+                const experimentNodes = content?.content?.filter((node) => node.type === NotebookNodeType.Experiment)
+                return experimentNodes?.map((node) => node?.attrs?.id).filter(Boolean) as number[]
+            },
+        ],
+
         personUUIDFromCanvasOverride: [
             () => [(_, props) => props],
             (props: NotebookLogicProps): string | null => {
@@ -879,6 +894,48 @@ export const notebookLogic = kea<notebookLogicType>([
                 lemonToast.success('Insight added to notebook')
             } else {
                 lemonToast.warning('Could not add insight to notebook')
+            }
+        },
+        addExperimentToNotebook: async ({ experimentId, insertionPosition }) => {
+            const content = {
+                type: NotebookNodeType.Experiment,
+                attrs: {
+                    id: experimentId,
+                },
+            }
+
+            let inserted = false
+
+            if (insertionPosition !== null && values.editor) {
+                try {
+                    values.editor.insertContentAt(insertionPosition, content)
+                    inserted = true
+                } catch (e) {
+                    console.warn('Failed to insert at position, appending to end instead', e)
+                }
+            }
+
+            if (!inserted) {
+                const result = await runWhenEditorIsReady(
+                    () => !!values.editor && (values.isLocalOnly || !!values.notebook),
+                    () => {
+                        let pos = 0
+                        let nextNode = values.editor?.nextNode(pos)
+                        while (nextNode) {
+                            pos = nextNode.position
+                            nextNode = values.editor?.nextNode(pos)
+                        }
+                        values.editor?.insertContentAfterNode(pos, content)
+                        return true
+                    }
+                )
+                inserted = result === true
+            }
+
+            if (inserted) {
+                lemonToast.success('Experiment added to notebook')
+            } else {
+                lemonToast.warning('Could not add experiment to notebook')
             }
         },
         setLocalContent: async ({ updateEditor, jsonContent, skipCapture }, breakpoint) => {


### PR DESCRIPTION
## Problem

There was no way to browse and add existing experiments to a notebook from the slash command menu. Users had to manually paste experiment URLs.

## Changes

#### New experiments modal

- Created `AddExperimentsToNotebookModal` - a modal component with search and pagination.
- Created `ExperimentsNotebookTable` - table showing experiment name, status, creator, and created date.
- Created `addExperimentsToNotebookModalLogic` - Kea logic for modal state, filtering, and API calls.

#### Notebook logic updates

- Added `addExperimentToNotebook` action to `notebookLogic` (follows the same pattern as `addSavedInsightToNotebook`).
- Added `experimentIdsInNotebook` selector to track which experiments are already in the notebook.

#### Slash command integration

- Added "Experiments" category with "Experiment" command that opens the modal.

#### Features

- Search experiments by name.
- Pagination support.
- Sort by created date.
- Visual indicator for experiments already in notebook (green highlight).
- Click to add, click again to remove.
- Legacy experiment badge shown in the table.

## Screenshots

| Modal | Selection |
|-------|-----------|
| <img width="784" height="803" alt="image" src="https://github.com/user-attachments/assets/c6e4e57b-3353-4247-a3f3-eacb4532e9a3" /> | <img width="448" height="265" alt="image" src="https://github.com/user-attachments/assets/8210bc64-4d4f-48eb-8572-bf8e4f84a99b" /> |

## How did you test this code?

**Automated tests**

```bash
pnpm --filter=@posthog/frontend jest --testPathPattern="notebook"
```

**Manual verification**

1. Open a notebook and type `/experiment`.
2. Click "Experiment" to open the modal.
3. Search for an experiment, verify pagination works.
4. Click to add an experiment, verify it appears in the notebook.
5. Click a selected experiment to remove it.

![cat-type-small](https://github.com/user-attachments/assets/94c03e42-fe31-4a4b-bd8c-a70311d74ea8)