### PR TITLE
fix(test): point AUTO_REFRESH path back to dashboardUtils.ts

### DIFF
--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1109,7 +1109,7 @@ class TestSharedInsightsExecutionMode(BaseTest):
     def test_shared_force_blocking_min_age_matches_frontend_auto_refresh_interval(self) -> None:
         """Backend throttle must match frontend auto-refresh interval — drift would silently throttle periodic refreshes."""
         frontend_file = (
-            Path(__file__).resolve().parents[3] / "frontend" / "src" / "scenes" / "dashboard" / "dashboardConstants.ts"
+            Path(__file__).resolve().parents[3] / "frontend" / "src" / "scenes" / "dashboard" / "dashboardUtils.ts"
         )
         source = frontend_file.read_text()
 


### PR DESCRIPTION
## Problem

`test_shared_force_blocking_min_age_matches_frontend_auto_refresh_interval` is failing on master with `FileNotFoundError`. It scans `frontend/src/scenes/dashboard/dashboardConstants.ts`, which no longer exists.

Sequence on master:

- #57782 split the dashboard auto-refresh constants out into `dashboardConstants.ts`.
- #57808 updated this test to scan the new file.
- #57817 reverted #57782 (deleted `dashboardConstants.ts`, moved the constants back into `dashboardUtils.ts`) but did not update the test.

This is a follow-up to that revert, not new work.

## Changes

One-line path change from `dashboardConstants.ts` to `dashboardUtils.ts` in the test. `AUTO_REFRESH_INITIAL_INTERVAL_SECONDS` and `SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES` live at lines 118 and 126 of `dashboardUtils.ts`. Both regexes in the test match that file unchanged.

## How did you test this code?

Ran the previously broken test locally:

```
hogli test posthog/hogql_queries/test/test_query_runner.py::TestSharedInsightsExecutionMode::test_shared_force_blocking_min_age_matches_frontend_auto_refresh_interval
```

Result: 1 passed in 5.59s.

## Publish to changelog?

no