### PR TITLE
fix(visual-review): default submit purpose to review, use observe on master

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -603,6 +603,9 @@ jobs:
                   VR_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
                   VR_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
                   VR_PR: ${{ github.event.pull_request.number }}
+                  # PRs are gating ("review"); master pushes are tracking-only ("observe") since
+                  # there's no PR to approve and we don't want master runs to block or prompt for approval.
+                  VR_PURPOSE: ${{ github.event_name == 'push' && 'observe' || 'review' }}
               run: |
                   RUN_ID=$(vr run create \
                     --type playwright \
@@ -610,6 +613,7 @@ jobs:
                     --branch "$VR_BRANCH" \
                     --commit "$VR_COMMIT" \
                     --pr "$VR_PR" \
+                    --purpose "$VR_PURPOSE" \
                     --token "$VR_TOKEN")
                   echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -201,6 +201,9 @@ jobs:
                   VR_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
                   VR_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
                   VR_PR: ${{ github.event.pull_request.number }}
+                  # PRs are gating ("review"); master pushes are tracking-only ("observe") since
+                  # there's no PR to approve and we don't want master runs to block or prompt for approval.
+                  VR_PURPOSE: ${{ github.event_name == 'push' && 'observe' || 'review' }}
               run: |
                   RUN_ID=$(vr run create \
                     --type storybook \
@@ -208,6 +211,7 @@ jobs:
                     --branch "$VR_BRANCH" \
                     --commit "$VR_COMMIT" \
                     --pr "$VR_PR" \
+                    --purpose "$VR_PURPOSE" \
                     --token "$VR_TOKEN")
                   echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 

--- a/products/visual_review/README.md
+++ b/products/visual_review/README.md
@@ -103,15 +103,20 @@ The CLI uploads directly to S3 via presigned POST URLs — the backend never pro
 
 ### Commands
 
-**`vr submit`** — single-command flow. Scans a directory, hashes PNGs, creates a run with full manifest, uploads, and completes. Without `--auto-approve`, exits 1 if unapproved changes are detected (gating). With `--auto-approve`, approves everything, writes the signed baseline, and exits 0.
+**`vr submit`** — single-command flow. Scans a directory, hashes PNGs, creates a run with full manifest, uploads, and completes. Default `--purpose review` (gating, exits 1 on unapproved changes). Pass `--purpose observe` on master/non-PR runs for tracking-only (won't block, won't prompt for approval). Pass `--auto-approve` to approve everything and write the signed baseline (forces `--purpose review`).
 
-**`vr verify`** — local baseline check without API.
+**`vr verify`** — local baseline check without API. Hashes PNGs in a directory and compares against `snapshots.yml`. No backend involvement.
 
-**`vr run create`** — creates an empty pending run, outputs the run ID to stdout. Call once before shards.
+**`vr run create`** — creates an empty pending run, outputs the run ID to stdout. Call once before shards. Default `--purpose review`; pass `--purpose observe` on master to make the run tracking-only (non-approvable, no PR comment).
 
 **`vr run upload`** — per-shard: hashes PNGs in a directory, sends identifiers + hashes via `add-snapshots`, uploads missing artifacts.
 
-**`vr run complete`** — triggers completion (classification, removal detection, diffs). Same exit code semantics as `vr submit`: exits 1 on unapproved changes, 0 if clean or `--auto-approve` is set.
+**`vr run complete`** — triggers completion (classification, removal detection, diffs). On `review` runs: exits 1 if unapproved changes are detected, 0 if clean or `--auto-approve` is set. On `observe` runs: always exits 0 (non-gating).
+
+### Run purposes
+
+- **`review`** (default) — approvable. Backend posts PR comment prompts; UI surfaces it under "needs review"; CLI gates on unapproved changes.
+- **`observe`** — tracking only. Backend rejects approval attempts; no PR comment; excluded from "needs review". Use on master pushes where there's no PR to approve.
 
 ## Current state
 

--- a/products/visual_review/cli/src/index.ts
+++ b/products/visual_review/cli/src/index.ts
@@ -39,6 +39,7 @@ program
     .option('--pr <number>', 'PR number')
     .option('--token <value>', 'Personal API token (Authorization: Bearer)')
     .option('--cookie <value>', 'Session cookie for authentication')
+    .option('--purpose <purpose>', 'Run purpose: review (gating, approvable) or observe (tracking only)', 'review')
     .option('--auto-approve', 'Auto-approve all changes and write signed baseline')
     .action(async (options: SubmitOptions) => {
         if (!baselineExists(options.baseline)) {
@@ -165,6 +166,7 @@ interface SubmitOptions {
     pr?: string
     token?: string
     cookie?: string
+    purpose?: string
     autoApprove?: boolean
 }
 
@@ -600,8 +602,13 @@ async function runSubmit(options: SubmitOptions): Promise<number> {
     // 3. Create run with full manifest — backend fetches baseline and classifies
     const branch = options.branch ?? getCurrentBranch()
     const commit = options.commit ?? getCurrentCommit()
+    // --auto-approve only makes sense on review runs; observe runs are non-approvable.
+    const purpose = options.autoApprove ? 'review' : (options.purpose ?? 'review')
+    if (options.autoApprove && options.purpose && options.purpose !== 'review') {
+        log(`Warning: --auto-approve forces purpose=review (got --purpose ${options.purpose})`)
+    }
     log(
-        `Creating run: type=${options.type}, ${snapshots.length} snapshots, branch=${branch}, commit=${commit.slice(0, 10)}`
+        `Creating run: type=${options.type}, ${snapshots.length} snapshots, branch=${branch}, commit=${commit.slice(0, 10)}, purpose=${purpose}`
     )
 
     const result = await retrySubmitApiCall('Create run', () =>
@@ -611,7 +618,7 @@ async function runSubmit(options: SubmitOptions): Promise<number> {
             commitSha: commit,
             branch,
             prNumber: options.pr ? parseInt(options.pr, 10) : undefined,
-            purpose: options.autoApprove ? 'review' : 'observe',
+            purpose,
             snapshots: snapshots.map((s) => ({
                 identifier: s.identifier,
                 content_hash: s.hash,


### PR DESCRIPTION
The CLI previously coupled purpose to --auto-approve: without --auto-approve
runs were silently created as observe (non-approvable), which meant the only
way to get an approvable run via `vr submit` was to also auto-approve. That's
backwards — the default should be a normal gating review run.

Changes:
- `vr submit` now accepts --purpose <review|observe> (default review),
  decoupled from --auto-approve. --auto-approve still forces review since
  observe runs are non-approvable on the backend.
- CI workflows pass --purpose observe on master pushes (no PR to approve,
  tracking only) and keep the review default for PR runs.
- README clarifies the run purposes and CLI command semantics.