### PR TITLE
test(temporal): mock tenacity sleep in REST retry tests

### DIFF
--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -217,8 +217,9 @@ class TestRESTClient:
         prepared_request = mock_session.prepare_request.call_args.args[0]
         assert prepared_request.params == {"limit": 100, "name": "alice"}
 
+    @patch("tenacity.nap.time.sleep")
     @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
-    def test_send_request_retries_on_429(self, MockSession) -> None:
+    def test_send_request_retries_on_429(self, MockSession, mock_sleep) -> None:
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()
@@ -235,8 +236,9 @@ class TestRESTClient:
         assert pages == [[{"id": 1}]]
         assert mock_session.send.call_count == 2
 
+    @patch("tenacity.nap.time.sleep")
     @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
-    def test_send_request_retries_on_500(self, MockSession) -> None:
+    def test_send_request_retries_on_500(self, MockSession, mock_sleep) -> None:
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()
@@ -253,8 +255,9 @@ class TestRESTClient:
         assert pages == [[{"id": 1}]]
         assert mock_session.send.call_count == 2
 
+    @patch("tenacity.nap.time.sleep")
     @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
-    def test_send_request_raises_after_max_retries(self, MockSession) -> None:
+    def test_send_request_raises_after_max_retries(self, MockSession, mock_sleep) -> None:
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()
@@ -267,8 +270,9 @@ class TestRESTClient:
         with pytest.raises(RESTClientRetryableError):
             list(client.paginate(path="/items", paginator=SinglePagePaginator()))
 
+    @patch("tenacity.nap.time.sleep")
     @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
-    def test_send_request_respects_retry_after_header(self, MockSession) -> None:
+    def test_send_request_respects_retry_after_header(self, MockSession, mock_sleep) -> None:
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()
@@ -285,3 +289,6 @@ class TestRESTClient:
 
         assert pages == [[{"id": 1}]]
         assert mock_session.send.call_count == 2
+        # Tenacity should have slept once with the Retry-After value (capped at 300s).
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args.args[0] == 90.0

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -289,6 +289,4 @@ class TestRESTClient:
 
         assert pages == [[{"id": 1}]]
         assert mock_session.send.call_count == 2
-        # Tenacity should have slept once with the Retry-After value (capped at 300s).
-        assert mock_sleep.call_count == 1
-        assert mock_sleep.call_args.args[0] == 90.0
+        mock_sleep.assert_called_once_with(90.0)


### PR DESCRIPTION
## Problem

`TestRESTClient` retry tests in `posthog/temporal/.../rest_source/tests/test_rest_client.py` actually wait on `tenacity` retry sleeps. The biggest offender, `test_send_request_respects_retry_after_header`, sets `Retry-After: 90` and then literally sleeps 90 seconds. CI attributes ~90s of test wall-time to that one case; the other three retry tests collectively burn another ~17s.

## Changes

Add `@patch("tenacity.nap.time.sleep")` to the four retry tests. Production retry behavior is unchanged; only the in-test sleep is neutralized. Also adds an assertion that the patched test actually verifies its name — `mock_sleep.call_args.args[0] == 90.0` — closing a small correctness gap.

Local timings on the four tests, run individually:

| test | before | after |
|---|---|---|
| `test_send_request_retries_on_429` | 24.4s | 23.3s |
| `test_send_request_retries_on_500` | 22.1s | 20.4s |
| `test_send_request_raises_after_max_retries` | 36.0s | 20.9s |
| `test_send_request_respects_retry_after_header` | 110.6s | 21.4s |

Run together: `4 passed in 0.78s` (most of the per-test time above is pytest startup, paid once when the file runs as a unit in CI).

## How did you test this code?

I'm an agent. Ran the four tests locally before and after, both individually and as a group, and confirmed all pass and all timings drop as expected. No manual testing beyond pytest.

## Publish to changelog?

no

## 🤖 Agent context

Built by Claude Code in a validation loop: each candidate change was applied, the affected tests were re-run, wall time and pass/fail were measured against a captured baseline, and the change was kept only when both faster and still passing. Original test file restored on every iteration via a script-side trap so the working tree was never left in a half-modified state.