### PR TITLE
chore(cohort): cohort api personhog mv

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -75,6 +75,8 @@ from posthog.models.person.util import validate_person_uuids_exist
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDT
+from posthog.personhog_client.client import get_personhog_client
+from posthog.personhog_client.proto import GetPersonByUuidRequest
 from posthog.queries.actor_base_query import get_serialized_people
 from posthog.queries.base import determine_parsed_date_for_property_matching, property_group_to_Q
 from posthog.queries.person_query import PersonQuery
@@ -1407,14 +1409,8 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             raise ValidationError("person_id must be a valid UUID")
 
         # Check if person exists and belongs to this team
-        try:
-            person_uuid = (
-                # nosemgrep: no-direct-persons-db-orm
-                Person.objects.db_manager(READ_DB_FOR_PERSONS)
-                .get(team_id=self.team_id, uuid=person_id)
-                .uuid  # nosemgrep: no-direct-persons-db-orm
-            )  # nosemgrep: no-direct-persons-db-orm
-        except Person.DoesNotExist:
+        person_uuid = _get_person_uuid_by_uuid(self.team_id, person_id)
+        if person_uuid is None:
             raise NotFound("Person with this UUID does not exist in the cohort's team")
 
         # Remove is idempotent - succeeds even if person wasn't in cohort (handles CH/PG sync issues)
@@ -1542,6 +1538,31 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
 class LegacyCohortViewSet(CohortViewSet):
     param_derived_from_user_current_team = "team_id"
+
+
+def _get_person_uuid_by_uuid(team_id: int, person_uuid_str: str) -> uuid.UUID | None:
+    """Look up a person's UUID by their UUID string, verifying team membership.
+
+    Uses personhog gRPC when available, falls back to ORM.
+    """
+    client = get_personhog_client()
+    if client is not None:
+        try:
+            resp = client.get_person_by_uuid(GetPersonByUuidRequest(team_id=team_id, uuid=person_uuid_str))
+            if not resp.person or not resp.person.id or resp.person.team_id != team_id:
+                return None
+            return uuid.UUID(resp.person.uuid)
+        except Exception:
+            logger.warning("personhog_get_person_by_uuid_failure", team_id=team_id, exc_info=True)
+
+    try:
+        return (
+            Person.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
+            .get(team_id=team_id, uuid=person_uuid_str)
+            .uuid
+        )
+    except Person.DoesNotExist:
+        return None
 
 
 def will_create_loops(cohort: Cohort) -> bool:

--- a/posthog/api/test/test_cohort_personhog.py
+++ b/posthog/api/test/test_cohort_personhog.py
@@ -1,10 +1,13 @@
-"""Tests that validate_person_uuids_exist produces identical results
-via the ORM and personhog paths."""
+"""Tests that person-related helpers in the cohort API produce identical
+results via the ORM and personhog paths."""
+
+import uuid as uuid_mod
 
 from posthog.test.base import BaseTest
 
 from parameterized import parameterized_class
 
+from posthog.api.cohort import _get_person_uuid_by_uuid
 from posthog.models.person import Person
 from posthog.models.person.util import validate_person_uuids_exist
 from posthog.personhog_client.test_helpers import PersonhogTestMixin
@@ -70,3 +73,43 @@ class TestValidatePersonUuidsExist(PersonhogTestMixin, BaseTest):
         assert len(uuids) > 0
         assert all(isinstance(u, str) for u in uuids)
         self._assert_personhog_called("get_persons_by_uuids")
+
+
+@parameterized_class(("personhog",), [(False,), (True,)])
+class TestGetPersonUuidByUuid(PersonhogTestMixin, BaseTest):
+    def _create_person_with_uuid(self, *, team, person_uuid, distinct_ids):
+        person = Person.objects.create(team=team, uuid=person_uuid, distinct_ids=distinct_ids)
+        if self._fake_client is not None:
+            self._fake_client.add_person(
+                team_id=team.pk,
+                person_id=person.pk,
+                uuid=str(person.uuid),
+                distinct_ids=distinct_ids,
+            )
+        return person
+
+    def test_returns_uuid_when_person_exists(self):
+        person_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        self._create_person_with_uuid(team=self.team, person_uuid=person_uuid, distinct_ids=["d1"])
+
+        result = _get_person_uuid_by_uuid(self.team.pk, person_uuid)
+
+        assert result is not None
+        assert str(result) == person_uuid
+        assert isinstance(result, uuid_mod.UUID)
+        self._assert_personhog_called("get_person_by_uuid")
+
+    def test_returns_none_when_person_does_not_exist(self):
+        result = _get_person_uuid_by_uuid(self.team.pk, "550e8400-e29b-41d4-a716-446655440099")
+
+        assert result is None
+        self._assert_personhog_called("get_person_by_uuid")
+
+    def test_returns_none_for_wrong_team(self):
+        person_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        other_team = self.organization.teams.create(name="Other Team")
+        self._create_person_with_uuid(team=other_team, person_uuid=person_uuid, distinct_ids=["d1"])
+
+        result = _get_person_uuid_by_uuid(self.team.pk, person_uuid)
+
+        assert result is None


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
