### PR TITLE
test: bulk_create teams in set_recorder_script test

### DIFF
--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -120,8 +120,13 @@ class TestSetRecorderScriptCommand(BaseTest):
         assert 30 < updated_teams < 70, f"Expected roughly 50 teams updated, got {updated_teams}"
 
     def test_bulk_updates_in_batches(self):
-        for i in range(2500):
-            Team.objects.create(organization=self.organization, name=f"Team {i}")
+        # Use bulk_create with a shared project to avoid 2500 individual
+        # Team.objects.create() calls (each of which also creates a Project
+        # in its own transaction). The test only cares that 2500 teams exist
+        # for the management command to iterate over.
+        Team.objects.bulk_create(
+            [Team(organization=self.organization, project=self.project, name=f"Team {i}") for i in range(2500)]
+        )
 
         out = StringIO()
         call_command(


### PR DESCRIPTION
## Problem

`test_bulk_updates_in_batches` creates 2500 teams via individual `Team.objects.create()` calls inside a `for` loop. The Team manager's custom `create()` also creates a Project per team in its own transaction, so the loop is effectively 2500 Project inserts + 2500 Team inserts spread across 5000 transactions. CI clocks the test at ~77s.

## Changes

Replace the loop with one `Team.objects.bulk_create([...])` reusing the existing `self.project`. The test only needs 2500 team rows for the management command to iterate over; the per-team Project is incidental setup.

Local timings (single-worker, warm DB):

| | wall |
|---|---|
| before | 220.3s |
| after | 58.9s |

Test still passes; assertions ("Updated 1000/2000 teams so far...", `updated_teams > 2400`) are unaffected.

## How did you test this code?

I'm an agent. Ran the test locally before and after on the same worktree, confirmed it passes, and confirmed wall time dropped as expected. Re-ran in a clean worktree off `origin/master` to verify the fix is self-contained.

## Publish to changelog?

no

## 🤖 Agent context

Built by Claude Code in a validation loop: candidate change applied, test re-run, wall time and verdict measured against the captured baseline, kept only when faster and passing. Original test file restored on every iteration via a script-side trap so the working tree was never left in a half-modified state.