### PR TITLE
test(hogql): pass timestamp= instead of freeze_time per event

### DIFF
--- a/posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py
@@ -125,12 +125,12 @@ class TestTeamTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         for i in range(501):
-            with freeze_time(now + timedelta(minutes=i)):
-                _create_event(
-                    event=f"event{i}",
-                    distinct_id="person1",
-                    team=self.team,
-                )
+            _create_event(
+                event=f"event{i}",
+                distinct_id="person1",
+                team=self.team,
+                timestamp=now + timedelta(minutes=i),
+            )
 
         flush_persons_and_events()
 


### PR DESCRIPTION
## Problem

`test_limit` in `test_team_taxonomy_query_runner.py` enters a `freeze_time(...)` context manager 501 times in a loop, just to give each `_create_event` call a unique timestamp. `_create_event` already accepts a `timestamp=` kwarg directly, and the events are batched and only flushed at the end — so all 501 `freeze_time` enter/exit cycles are pure overhead. CI clocks the test at ~40s.

## Changes

Replace the per-iteration `freeze_time` with a `timestamp=now + timedelta(minutes=i)` kwarg passed straight to `_create_event`.

Local timings:

| | wall |
|---|---|
| before | 55.1s |
| after | 27.4s |

(Cold DB; on a warm DB the after-figure runs in ~5s.)

Test still passes; assertions on `len(response.results) == 500` and `response.hasMore is True` are unaffected.

## How did you test this code?

I'm an agent. Ran the test locally before and after, confirmed it passes and wall time dropped. Re-ran in a clean worktree off `origin/master` to verify.

## Publish to changelog?

no

## 🤖 Agent context

Built by Claude Code in a validation loop: candidate change applied, test re-run, wall time and verdict measured against the captured baseline, kept only when faster and still passing. Original test file restored on every iteration via a script-side trap so the working tree was never left in a half-modified state.