### PR TITLE
feat(data-table): add absolute/relative time toggle to column header menu

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -37,7 +37,7 @@ import { DataTableSavedFiltersButton } from '~/queries/nodes/DataTable/DataTable
 import { EventRowActions } from '~/queries/nodes/DataTable/EventRowActions'
 import { InsightActorsQueryOptions } from '~/queries/nodes/DataTable/InsightActorsQueryOptions'
 import { QueryFeature } from '~/queries/nodes/DataTable/queryFeatures'
-import { getContextColumn, renderColumn } from '~/queries/nodes/DataTable/renderColumn'
+import { DATETIME_KEYS, getContextColumn, renderColumn } from '~/queries/nodes/DataTable/renderColumn'
 import { renderColumnMeta } from '~/queries/nodes/DataTable/renderColumnMeta'
 import { SavedQueries } from '~/queries/nodes/DataTable/SavedQueries'
 import { TableViewSelector } from '~/queries/nodes/DataTable/TableView/TableViewSelector'
@@ -329,6 +329,24 @@ export function DataTable({
                                     <div className="font-mono truncate">{removeExpressionComment(key)}</div>
                                 )}
                             </div>
+                            {(isEventsQuery(query.source) || isActorsQuery(query.source)) &&
+                            DATETIME_KEYS.includes(removeExpressionComment(key)) ? (
+                                <>
+                                    <LemonDivider />
+                                    <LemonButton
+                                        fullWidth
+                                        data-attr="datatable-toggle-absolute-time"
+                                        onClick={() => {
+                                            setQuery?.({
+                                                ...query,
+                                                showAbsoluteTime: !query.showAbsoluteTime,
+                                            })
+                                        }}
+                                    >
+                                        {query.showAbsoluteTime ? 'Show relative time' : 'Show absolute time'}
+                                    </LemonButton>
+                                </>
+                            ) : null}
                             {columnFeatures.includes(ColumnFeature.canEdit) && (
                                 <>
                                     <LemonDivider />

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -238,6 +238,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
                         showSavedQueries: query.showSavedQueries ?? false,
                         showSavedFilters: query.showSavedFilters ?? false,
                         showTableViews: query.showTableViews ?? false,
+                        showAbsoluteTime: query.showAbsoluteTime ?? false,
                         showHogQLEditor: query.showHogQLEditor ?? showIfFull,
                         allowSorting: query.allowSorting ?? true,
                         showOpenEditorButton:

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -169,7 +169,13 @@ export function renderColumn(
                 // do nothing
             }
             if (value.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,6})?(?:Z|[+-]\d{2}:\d{2})?$/)) {
-                return <TZLabel time={value} showSeconds />
+                return (
+                    <TZLabel
+                        time={value}
+                        showSeconds
+                        timestampStyle={query.showAbsoluteTime ? 'absolute' : 'relative'}
+                    />
+                )
             }
         }
         if (typeof value === 'object') {

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -47,7 +47,7 @@ import { llmAnalyticsColumnRenderers } from 'products/llm_analytics/frontend/llm
 
 import { extractExpressionComment, removeExpressionComment } from './utils'
 
-const DATETIME_KEYS = ['timestamp', 'created_at', 'last_seen', 'last_seen_at', 'session_start', 'session_end']
+export const DATETIME_KEYS = ['timestamp', 'created_at', 'last_seen', 'last_seen_at', 'session_start', 'session_end']
 
 // Registry for product-specific column renderers
 // Products can add their custom column renderers here to have them automatically applied across all DataTable instances
@@ -203,15 +203,18 @@ export function renderColumn(
         )
     } else if ((isActorsQuery(query.source) || isActorsQuery(query)) && key === 'last_seen_at') {
         const isWithinLastHour = dayjs().diff(dayjs(value), 'hour', true) < 1
+        // Hide the "last hour" pill when the absolute-time mode is on — TZLabel's children
+        // override the formatted text, so the pill would otherwise mask the absolute timestamp.
+        const showLastHourPill = isWithinLastHour && !query.showAbsoluteTime
         return (
-            <TZLabel time={value} showSeconds>
-                {isWithinLastHour ? (
+            <TZLabel time={value} showSeconds timestampStyle={query.showAbsoluteTime ? 'absolute' : 'relative'}>
+                {showLastHourPill ? (
                     <span className="whitespace-nowrap align-middle border-dotted border-b">last hour</span>
                 ) : undefined}
             </TZLabel>
         )
     } else if (DATETIME_KEYS.includes(key)) {
-        return <TZLabel time={value} showSeconds />
+        return <TZLabel time={value} showSeconds timestampStyle={query.showAbsoluteTime ? 'absolute' : 'relative'} />
     } else if (!Array.isArray(record) && key.startsWith('properties.')) {
         // TODO: remove after removing the old events table
         const propertyKey = trimQuotes(key.substring('properties.'.length))

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12788,7 +12788,7 @@
                     ]
                 },
                 "showAbsoluteTime": {
-                    "description": "Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative (\"X ago\"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.",
+                    "description": "Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative (\"X ago\"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.",
                     "type": "boolean"
                 },
                 "showActions": {
@@ -34096,7 +34096,7 @@
                     "$ref": "#/definitions/InsightShortId"
                 },
                 "showAbsoluteTime": {
-                    "description": "Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative (\"X ago\"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.",
+                    "description": "Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative (\"X ago\"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.",
                     "type": "boolean"
                 },
                 "showActions": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12787,6 +12787,10 @@
                         }
                     ]
                 },
+                "showAbsoluteTime": {
+                    "description": "Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative (\"X ago\"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.",
+                    "type": "boolean"
+                },
                 "showActions": {
                     "description": "Show the kebab menu at the end of the row",
                     "type": "boolean"
@@ -34090,6 +34094,10 @@
                 },
                 "shortId": {
                     "$ref": "#/definitions/InsightShortId"
+                },
+                "showAbsoluteTime": {
+                    "description": "Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative (\"X ago\"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.",
+                    "type": "boolean"
                 },
                 "showActions": {
                     "description": "Show the kebab menu at the end of the row",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1239,6 +1239,10 @@ interface DataTableNodeViewProps {
     showSavedFilters?: boolean
     /** Show table views feature for this table (requires uniqueKey) */
     showTableViews?: boolean
+    /** Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute
+     *  date+time instead of relative ("X ago"). The toggle is exposed in the column header
+     *  menu only on EventsQuery / ActorsQuery sources. */
+    showAbsoluteTime?: boolean
     /** Can expand row to show raw event data (default: true) */
     expandable?: boolean
     /** Link properties via the URL (default: false) */

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1239,9 +1239,9 @@ interface DataTableNodeViewProps {
     showSavedFilters?: boolean
     /** Show table views feature for this table (requires uniqueKey) */
     showTableViews?: boolean
-    /** Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute
-     *  date+time instead of relative ("X ago"). The toggle is exposed in the column header
-     *  menu only on EventsQuery / ActorsQuery sources. */
+    /** Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start,
+     *  session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed
+     *  in the column header menu only on EventsQuery / ActorsQuery sources. */
     showAbsoluteTime?: boolean
     /** Can expand row to show raw event data (default: true) */
     expandable?: boolean

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8050,6 +8050,15 @@ class SavedInsightNode(BaseModel):
     kind: Literal["SavedInsightNode"] = "SavedInsightNode"
     propertiesViaUrl: bool | None = Field(default=None, description="Link properties via the URL (default: false)")
     shortId: str
+    showAbsoluteTime: bool | None = Field(
+        default=None,
+        description=(
+            "Render date-time columns (timestamp, created_at, last_seen, last_seen_at)"
+            ' as absolute date+time instead of relative ("X ago"). The toggle is'
+            " exposed in the column header menu only on EventsQuery / ActorsQuery"
+            " sources."
+        ),
+    )
     showActions: bool | None = Field(default=None, description="Show the kebab menu at the end of the row")
     showColumnConfigurator: bool | None = Field(
         default=None,
@@ -22671,6 +22680,15 @@ class DataTableNode(BaseModel):
         | Response26
         | None
     ) = None
+    showAbsoluteTime: bool | None = Field(
+        default=None,
+        description=(
+            "Render date-time columns (timestamp, created_at, last_seen, last_seen_at)"
+            ' as absolute date+time instead of relative ("X ago"). The toggle is'
+            " exposed in the column header menu only on EventsQuery / ActorsQuery"
+            " sources."
+        ),
+    )
     showActions: bool | None = Field(default=None, description="Show the kebab menu at the end of the row")
     showColumnConfigurator: bool | None = Field(
         default=None,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8053,10 +8053,10 @@ class SavedInsightNode(BaseModel):
     showAbsoluteTime: bool | None = Field(
         default=None,
         description=(
-            "Render date-time columns (timestamp, created_at, last_seen, last_seen_at)"
-            ' as absolute date+time instead of relative ("X ago"). The toggle is'
-            " exposed in the column header menu only on EventsQuery / ActorsQuery"
-            " sources."
+            "Render date-time columns (timestamp, created_at, last_seen, last_seen_at,"
+            ' session_start, session_end) as absolute date+time instead of relative ("X'
+            ' ago"). The toggle is exposed in the column header menu only on'
+            " EventsQuery / ActorsQuery sources."
         ),
     )
     showActions: bool | None = Field(default=None, description="Show the kebab menu at the end of the row")
@@ -22683,10 +22683,10 @@ class DataTableNode(BaseModel):
     showAbsoluteTime: bool | None = Field(
         default=None,
         description=(
-            "Render date-time columns (timestamp, created_at, last_seen, last_seen_at)"
-            ' as absolute date+time instead of relative ("X ago"). The toggle is'
-            " exposed in the column header menu only on EventsQuery / ActorsQuery"
-            " sources."
+            "Render date-time columns (timestamp, created_at, last_seen, last_seen_at,"
+            ' session_start, session_end) as absolute date+time instead of relative ("X'
+            ' ago"). The toggle is exposed in the column header menu only on'
+            " EventsQuery / ActorsQuery sources."
         ),
     )
     showActions: bool | None = Field(default=None, description="Show the kebab menu at the end of the row")

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9069,7 +9069,7 @@ export interface DataTableNodeApi {
     propertiesViaUrl?: boolean | null
     response?: DataTableNodeApiResponse
     /**
-     * Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
+     * Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
      * @nullable
      */
     showAbsoluteTime?: boolean | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9069,6 +9069,11 @@ export interface DataTableNodeApi {
     propertiesViaUrl?: boolean | null
     response?: DataTableNodeApiResponse
     /**
+     * Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
+     * @nullable
+     */
+    showAbsoluteTime?: boolean | null
+    /**
      * Show the kebab menu at the end of the row
      * @nullable
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13716,7 +13716,7 @@ export namespace Schemas {
       propertiesViaUrl?: boolean | null;
       response?: DataTableNodeResponse;
       /**
-       * Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
+       * Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
        * @nullable
        */
       showAbsoluteTime?: boolean | null;
@@ -33867,7 +33867,7 @@ export namespace Schemas {
       propertiesViaUrl?: boolean | null;
       shortId: string;
       /**
-       * Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
+       * Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
        * @nullable
        */
       showAbsoluteTime?: boolean | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13716,6 +13716,11 @@ export namespace Schemas {
       propertiesViaUrl?: boolean | null;
       response?: DataTableNodeResponse;
       /**
+       * Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
+       * @nullable
+       */
+      showAbsoluteTime?: boolean | null;
+      /**
        * Show the kebab menu at the end of the row
        * @nullable
        */
@@ -33861,6 +33866,11 @@ export namespace Schemas {
        */
       propertiesViaUrl?: boolean | null;
       shortId: string;
+      /**
+       * Render date-time columns (timestamp, created_at, last_seen, last_seen_at) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources.
+       * @nullable
+       */
+      showAbsoluteTime?: boolean | null;
       /**
        * Show the kebab menu at the end of the row
        * @nullable


### PR DESCRIPTION
## Problem

On the Activity page and the Events tab of person profiles, the `timestamp` column only displays relative time (e.g. "2 minutes ago"). Seeing the absolute time requires hovering over the cell to see the absolute time popover, once per row. 

This PR adds a one-click toggle in the column header menu to switch the date-time columns between relative and absolute display.

## Changes

- **`frontend/src/queries/schema/schema-general.ts`** — new `showAbsoluteTime?: boolean` on `DataTableNodeViewProps`.
- **`posthog/schema.py` + `frontend/src/queries/schema.json`** — regenerated via `pnpm schema:build` (purely additive).
- **`frontend/src/queries/nodes/DataTable/renderColumn.tsx`** — exported `DATETIME_KEYS`; threaded `query.showAbsoluteTime` to the two `<TZLabel>` call sites that render date-time cells. Also suppressed the actors-query "last hour" pill when absolute mode is on, because `TZLabel`'s `children` prop overrides the formatted time and would mask the absolute display otherwise.
- **`frontend/src/queries/nodes/DataTable/DataTable.tsx`** — imported `DATETIME_KEYS`; added a "Show absolute time" / "Show relative time" `LemonButton` directly under the column-key header info (above "Edit column"), gated to `(isEventsQuery(query.source) || isActorsQuery(query.source)) && DATETIME_KEYS.includes(removeExpressionComment(key))`.

Reuses the existing `TZLabel timestampStyle="absolute"` rendering (`humanFriendlyDetailedTime` → "Wed, May 6, 2026 12:38:51 PM"). The hover popover is unchanged in both modes.

<img width="1178" height="1628" alt="CleanShot 2026-05-06 at 13 37 46@2x" src="https://github.com/user-attachments/assets/854faabb-ad43-4d45-8f20-03b6d3054c59" />

<img width="1126" height="1592" alt="CleanShot 2026-05-06 at 13 37 58@2x" src="https://github.com/user-attachments/assets/e56718fc-2096-483a-9561-2cf8d7d3eb1f" />


## How did you test this code?

I'm an agent (PostHog Code, Claude Opus 4.7).

Automated tests I actually ran:

- `pnpm --filter=@posthog/frontend jest frontend/src/queries/nodes/DataTable/` — 114 tests pass, no regressions.
- `pnpm exec tsc --noEmit -p tsconfig.json` (frontend) — type-check clean on the changed files.
- `pnpm schema:build` — confirmed `posthog/schema.py` mirror is in sync, with `showAbsoluteTime: bool | None` added in the two relevant `DataTableNode` definitions.
- No new unit tests added — the toggle is shape-equivalent to the existing Sort / Reset sorting / Pin column items in this menu, none of which have unit tests today. Adding one would mean introducing net-new test infrastructure for this component.

Manual testing performed by @slshults (the human who reviewed and approved):

- On the **Activity scene** (`/project/X/events`) and the **Events tab of a person profile** (`/persons/<uuid>#activeTab=events`), opened the column header `…` menu on the TIME column. Confirmed the new "Show absolute time" item appears between the column-key header and "Edit column".
- Clicked it — all rows in the Time column re-rendered as absolute date+time. Menu item flipped to "Show relative time". Clicked again — rows reverted to "20 hours ago".
- Hover popover (timezone conversion) still works in both modes.
- Hard-refreshed — the toggle resets to relative (intentional v1 behavior; in-memory only).
- Confirmed the previous PR's sort fix (PR #57859) still works on this branch.

## Publish to changelog?

Yes

## 🤖 Agent context

- Tool: PostHog Code (Claude Opus 4.7)
- Driven by @slshults 
- Decisions made along the way:
  - Boolean field vs `'relative' | 'absolute'` enum — chose boolean for symmetry with the other `show*` flags on `DataTableNodeViewProps`.
  - Per-table flag vs per-column — chose per-table; events/actors tables typically show one date-time column at a time.
  - In-memory persistence for v1 vs writing to the backend `ColumnConfiguration` model — chose in-memory; matches existing sort-state behavior on these scenes and avoids backend changes.
  - Source gate `EventsQuery | ActorsQuery` only — explicit user choice over "all DataTable consumers", to avoid affecting web analytics / error tracking / insights tables.
  - Menu placement — initial draft placed it after "Reset sorting"; Steven asked to move it to the top under the column key, framing it as "this column's display setting" rather than a structural action.
- Code review pass via the `code-reviewer` agent — caught a real bug where `TZLabel`'s `children` prop overrides the formatted time, meaning the actors "last hour" pill would mask absolute mode for users seen within the last hour. Fixed by suppressing the pill when `showAbsoluteTime` is on. Also tightened the schema docstring to accurately reflect which keys the toggle affects.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*