### PR TITLE
fix(activity): allow staff and impersonators to bypass audit_logs paywall

### DIFF
--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory, TickingDateTimeFactory
 from posthog.test.base import APIBaseTest, QueryMatchingTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -225,3 +226,43 @@ class TestActivityLogAuditLogsGate(APIBaseTest):
             res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
 
         assert res.status_code == status.HTTP_200_OK
+
+    @parameterized.expand([("activity_log",), ("advanced_activity_logs",)])
+    def test_endpoint_allowed_for_staff_user_without_audit_logs_feature(self, endpoint: str) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+        self.user.is_staff = True
+        self.user.save()
+
+        with self.is_cloud(True):
+            res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
+
+        assert res.status_code == status.HTTP_200_OK
+
+    @parameterized.expand([("activity_log",), ("advanced_activity_logs",)])
+    def test_endpoint_allowed_for_impersonated_session_without_audit_logs_feature(self, endpoint: str) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        with self.is_cloud(True), patch("posthog.permissions.is_impersonated_session", return_value=True):
+            res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
+
+        assert res.status_code == status.HTTP_200_OK
+
+    def test_available_filters_endpoint_allowed_for_impersonated_session(self) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        with self.is_cloud(True), patch("posthog.permissions.is_impersonated_session", return_value=True):
+            res = self.client.get(f"/api/projects/{self.team.id}/advanced_activity_logs/available_filters/")
+
+        assert res.status_code == status.HTTP_200_OK
+
+    def test_available_filters_endpoint_blocked_without_audit_logs_feature(self) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        with self.is_cloud(True):
+            res = self.client.get(f"/api/projects/{self.team.id}/advanced_activity_logs/available_filters/")
+
+        assert res.status_code == status.HTTP_402_PAYMENT_REQUIRED

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
 
 import posthoganalytics
+from loginas.utils import is_impersonated_session
 from rest_framework.exceptions import AuthenticationFailed, NotFound, PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAdminUser
 from rest_framework.request import Request
@@ -268,8 +269,6 @@ class IsStaffUserOrImpersonating(BasePermission):
     message = "You are not a staff user, contact your instance admin."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
-        from loginas.utils import is_impersonated_session
-
         return bool(
             request.user
             and request.user.is_authenticated
@@ -304,6 +303,13 @@ class PremiumFeaturePermission(BasePermission):
             feature = cloud_only_feature
         else:
             feature = always_feature
+
+        if (
+            request.user
+            and request.user.is_authenticated
+            and (request.user.is_staff or is_impersonated_session(request))
+        ):
+            return True
 
         try:
             organization = get_organization_from_view(view)


### PR DESCRIPTION
## Problem

PostHog admins regularly impersonate customers to investigate issues. Until two days ago, an impersonating admin could open Activity (sidepanel or scene) and view audit logs even on orgs without the `audit_logs` feature.

That broke after #56724 (`fix(activity): gate legacy and advanced endpoints on audit_logs`), which added `PremiumFeaturePermission` to both `ActivityLogViewSet` and `AdvancedActivityLogsViewSet`. The new gate has no staff/impersonation short-circuit, so the API now returns 402 for anyone whose org lacks the feature — even staff impersonating a customer. The visible symptom is:

> Load available filters failed: Audit logs requires a paid PostHog plan. Please upgrade to access this feature.

The frontend "Bypass paywall" button for impersonated users in `PayGateMini` still exists and is untouched, but pressing it doesn't help because the backend rejects the request regardless.

## Changes

`posthog/permissions.py` — `PremiumFeaturePermission.has_permission()` now short-circuits to allow the request when `request.user.is_staff or is_impersonated_session(request)`. This is the same trust model already used by `IsStaffUserOrImpersonating`, `SingleTenancyOrAdmin`, and the inline check in `posthog/api/debug_ch_queries.py`.

Security note: neither bypass condition is reachable by a non-paying customer. `is_staff` is a Django flag only set for PostHog employees (granting it would itself be the breach). `is_impersonated_session` checks a session-level flag that the `loginas` library only sets via its `login_as` flow, which is itself gated behind staff permission and CSRF. Other consumers of `PremiumFeaturePermission` (subscriptions in `ee/api/subscription.py`, approvals in `posthog/approvals/api.py`) gain the same bypass — same security argument applies, and it matches PostHog's existing invariant that admins can investigate customer-side features.

## How did you test this code?

I'm an agent. I did not run the tests or manually verify the UI. The local Python environment couldn't run the suite without further setup. Automated tests added in `posthog/api/test/test_activity_log.py::TestActivityLogAuditLogsGate`:

- `test_endpoint_allowed_for_staff_user_without_audit_logs_feature` (parametrized over `activity_log` and `advanced_activity_logs`)
- `test_endpoint_allowed_for_impersonated_session_without_audit_logs_feature` (parametrized over both endpoints)
- `test_available_filters_endpoint_allowed_for_impersonated_session` — the exact endpoint reported broken
- `test_available_filters_endpoint_blocked_without_audit_logs_feature` — regression guard for the original gate

Existing `test_endpoint_blocked_on_cloud_without_audit_logs_feature`, `test_endpoint_allowed_on_cloud_with_audit_logs_feature`, and `test_endpoint_allowed_on_self_hosted_without_audit_logs_feature` still cover the original gate behavior — they should continue passing in CI.

Manual smoke a human reviewer can run: sign in as staff, impersonate a user in an org without `audit_logs`, navigate to `/audit-logs/`, confirm filters load and rows render with no 402.

## Publish to changelog?

no

## 🤖 Agent context

- Tool: PostHog Code (Claude Code)
- Key human prompts that shaped the work:
  1. Initial bug report — "When logged in as a PostHog admin impersonating a user, you have the option to bypass the paywall to look at activity logs. This appears to have broken recently…"
  2. "Make the fix as simple as viable. Who made the commit that broke this?" — pushed me from a three-layer fix (backend + two frontend gates) down to a single backend bypass, since the existing frontend "Bypass paywall" button in `PayGateMini` already covers the UI path once the API stops rejecting impersonated requests.
  3. "Is that secure? Could the feature be gained by non-paying users?" — prompted the explicit security analysis above.
- Decisions:
  - Chose to add the bypass to `PremiumFeaturePermission` itself rather than wrapping only the two activity-log viewsets, so the same invariant applies consistently across all current and future paywalled endpoints. Flagged the broader scope here for review.
  - Did not touch the frontend. The previously-removed `user?.is_impersonated` term in two `overrideShouldShowGate` callers and the new `audit_logs` tab gate in `sidePanelLogic.tsx` are not strictly necessary to restore the reported bug — the manual "Bypass paywall" button in `PayGateMini.tsx` already exists for impersonated users and now works again.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*