### PR TITLE
feat(oauth): show "Redirecting…" screen after authorize

### DIFF
--- a/frontend/src/scenes/oauth/OAuthAuthorize.tsx
+++ b/frontend/src/scenes/oauth/OAuthAuthorize.tsx
@@ -10,6 +10,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { organizationLogic } from 'scenes/organizationLogic'
 import ScopeAccessSelector from 'scenes/settings/user/scopes/ScopeAccessSelector'
@@ -37,6 +38,30 @@ export const OAuthAuthorizeSuccess = ({ appName }: { appName: string }): JSX.Ele
             <div className="text-sm text-muted text-center">
                 <p>{appName} has been authorized.</p>
                 <p className="mt-2">You can close this window.</p>
+            </div>
+        </div>
+    )
+}
+
+export const OAuthAuthorizeRedirecting = ({
+    appName,
+    redirectUrl,
+}: {
+    appName: string
+    redirectUrl: string
+}): JSX.Element => {
+    return (
+        <div className="flex flex-col items-center justify-center h-full gap-4 py-12 px-4">
+            <Spinner className="text-3xl" />
+            <div className="text-xl font-semibold">Redirecting to {appName}…</div>
+            <div className="text-sm text-muted text-center max-w-md">
+                <p>This usually only takes a moment.</p>
+                <p className="mt-2">
+                    Not redirected automatically? <Link to={redirectUrl}>Click here</Link>.
+                </p>
+                <p className="mt-2">
+                    If {appName} has already finished authorizing on your end, you can safely close this window.
+                </p>
             </div>
         </div>
     )
@@ -108,6 +133,8 @@ export const OAuthAuthorize = (): JSX.Element => {
         redirectDomain,
         requiredAccessLevel,
         authorizationComplete,
+        isRedirecting,
+        redirectUrl,
         scopesWereDefaulted,
         isMcpResource,
         resourceScopesLoading,
@@ -191,6 +218,10 @@ export const OAuthAuthorize = (): JSX.Element => {
 
     if (authorizationComplete) {
         return <OAuthAuthorizeSuccess appName={oauthApplication.name} />
+    }
+
+    if (isRedirecting) {
+        return <OAuthAuthorizeRedirecting appName={oauthApplication.name} redirectUrl={redirectUrl} />
     }
 
     return (

--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
@@ -33,10 +33,11 @@ const isNativeProtocol = (url: string): boolean => {
     }
 }
 
+type OAuthAuthorizeResult = { redirectTo: string; isNative: boolean }
+
 const oauthAuthorize = async (
-    values: OAuthAuthorizationFormValues & { allow: boolean; scopes: string[] },
-    onNativeRedirectComplete?: () => void
-): Promise<void> => {
+    values: OAuthAuthorizationFormValues & { allow: boolean; scopes: string[] }
+): Promise<OAuthAuthorizeResult | null> => {
     try {
         const response = await api.create('/oauth/authorize/', {
             client_id: router.values.searchParams['client_id'],
@@ -56,21 +57,17 @@ const oauthAuthorize = async (
         })
 
         if (response.redirect_to) {
-            const isNative = isNativeProtocol(response.redirect_to)
-            location.href = response.redirect_to
-
-            if (isNative && onNativeRedirectComplete) {
-                // Small delay to ensure redirect is initiated before showing success
-                setTimeout(() => onNativeRedirectComplete(), 100)
+            return {
+                redirectTo: response.redirect_to,
+                isNative: isNativeProtocol(response.redirect_to),
             }
         }
+        return null
     } catch (error: any) {
         const detail = error?.detail || error?.message || 'Something went wrong while authorizing the application'
         lemonToast.error(detail)
         throw error
     }
-
-    return
 }
 
 export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
@@ -88,6 +85,7 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
         cancel: () => ({}),
         setCanceling: (canceling: boolean) => ({ canceling }),
         setAuthorizationComplete: (complete: boolean) => ({ complete }),
+        setRedirecting: (redirectUrl: string) => ({ redirectUrl }),
         setSelectedOrganization: (organizationId: string, preferredTeamId?: number) => ({
             organizationId,
             preferredTeamId,
@@ -131,13 +129,16 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
         cancel: async () => {
             actions.setCanceling(true)
             try {
-                await oauthAuthorize({
+                const result = await oauthAuthorize({
                     scoped_organizations: values.oauthAuthorization.scoped_organizations,
                     scoped_teams: values.oauthAuthorization.scoped_teams,
                     access_type: values.oauthAuthorization.access_type,
                     allow: false,
                     scopes: values.scopes,
                 })
+                if (result) {
+                    location.href = result.redirectTo
+                }
             } finally {
                 actions.setCanceling(false)
             }
@@ -235,6 +236,18 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
                 setAuthorizationComplete: (_, { complete }) => complete,
             },
         ],
+        isRedirecting: [
+            false,
+            {
+                setRedirecting: () => true,
+            },
+        ],
+        redirectUrl: [
+            '',
+            {
+                setRedirecting: (_, { redirectUrl }) => redirectUrl,
+            },
+        ],
         selectedOrganization: [
             null as string | null,
             {
@@ -314,14 +327,25 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
             }),
             submit: async (values: OAuthAuthorizationFormValues) => {
                 const scopes = oauthAuthorizeLogic.values.scopes
-                await oauthAuthorize(
-                    {
-                        ...values,
-                        allow: true,
-                        scopes,
-                    },
-                    () => actions.setAuthorizationComplete(true)
-                )
+                const result = await oauthAuthorize({
+                    ...values,
+                    allow: true,
+                    scopes,
+                })
+                if (!result) {
+                    return
+                }
+                // Swap the form for a "Redirecting…" view so the user sees progress
+                // while the browser navigates — for HTTP loopback redirects (Cursor,
+                // Claude Code, etc.) the browser may sit waiting for the local
+                // listener to respond, which makes the original screen feel hung.
+                actions.setRedirecting(result.redirectTo)
+                location.href = result.redirectTo
+                if (result.isNative) {
+                    // Native protocol handlers (vscode://, cursor://, etc.) don't
+                    // navigate the browser away; show success after a brief delay.
+                    setTimeout(() => actions.setAuthorizationComplete(true), 100)
+                }
             },
         },
     })),


### PR DESCRIPTION
## Problem

When users click **Authorize** on the OAuth consent screen for native clients (Cursor, Claude Code, and similar MCP clients using loopback redirect URIs), the backend POST to `/oauth/authorize/` returns quickly — but the browser then sits navigating to `http://localhost:<port>/callback?code=…` while the client's local listener takes its time to respond, or sometimes never does. The original consent form stayed visible the whole time with the Authorize button stuck in a loading state, so it looked like PostHog itself was hung.

## Changes

- Refactored `oauthAuthorize()` in `oauthAuthorizeLogic.ts` to *return* `{ redirectTo, isNative }` instead of navigating itself, so the caller can update React state before triggering the navigation.
- Added a `setRedirecting(redirectUrl)` action plus `isRedirecting` / `redirectUrl` reducers.
- The form `submit` listener now sets `isRedirecting` *before* assigning `location.href`, so the screen swaps the moment the POST resolves. Native protocol clients (`vscode://`, `cursor://`, …) still transition to the success screen after the existing 100ms delay.
- New `OAuthAuthorizeRedirecting` component in `OAuthAuthorize.tsx`: spinner + "Redirecting to {appName}…", a small inline "Not redirected automatically? Click here." link (per RFC 8252-style native flows where the user may need to retry), and a note that it's safe to close the window if the client already finished.

## How did you test this code?

This PR was authored by an agent (Claude Opus 4.7) — no manual testing claims beyond what's listed below.

- Locally registered a DCR client via `POST /oauth/register`, opened `/oauth/authorize/?client_id=…&redirect_uri=http://localhost:54321/callback&…`, and parked a TCP listener on `54321` that accepts connections and never responds. The browser captured the loopback `GET /callback?code=…&state=test` request (proving the OAuth flow lands at the loopback) while the new "Redirecting to Local hang test…" screen was visible the whole time with the inline "Click here" link.
- `pnpm typegen:write` ran clean, regenerating `oauthAuthorizeLogicType.ts` with the new actions/reducers (no diff in the committed file — it was already up to date).
- No automated unit/integration tests added for this change.

## Publish to changelog?

no

## 🤖 Agent context

- **Agent:** Claude Opus 4.7 (1M context) via Claude Code
- **Human prompts that shaped this PR:**
  - "We have a screen where people land when they want to approve OAuth … sometimes it just hangs … is this a known problem with OAuth?"
  - "Let's implement something to make this look a bit faster. … swap left with the UI and instead display some text + a loading banner … offer a button to click to redirect manually … show some kind of text saying that they can close this if they've detected the auth has finished on the client."
  - "Don't *require* a click, just use a very small link 'click here if you're not being redirected' like most email clients do."
- **Decisions made along the way:**
  - Investigation concluded the "hang" is *not* PostHog being slow — the backend POST is fast, but the browser stalls on the loopback redirect URI waiting for the client's local listener. Confirmed there's no server-side request to wait on (only a CIMD metadata fetch with a 5s cap on first authorize per client).
  - Chose to swap to a new screen state instead of just changing the button copy, so the consent form is unmounted and can't be re-submitted.
  - Started with a `LemonButton` for the manual redirect, swapped to a small inline `Link` ("Click here") on user feedback to match the email-client convention (don't *require* a click; offer it as a fallback).
  - Cancel still navigates without showing the redirecting screen — same loopback risk applies but the user has already chosen to abort, so the simpler behavior is fine.
  - Did not change the backend — the only outbound server-side wait (CIMD metadata fetch) is already 5s-capped and cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)