### PR TITLE
chore(mcp): strengthen agent-feedback prompt when tool is enabled

### DIFF
--- a/services/mcp/src/templates/sections/agent-feedback.md
+++ b/services/mcp/src/templates/sections/agent-feedback.md
@@ -1,8 +1,10 @@
-### Sharing feedback on this MCP server (optional)
+### Sharing feedback on this MCP server
 
-The `agent-feedback` tool may be available if you'd like to leave optional feedback about this MCP server. It is the primary signal we use to improve tool descriptions, input schemas, response formats, and these instructions for agents like you. Use it when something stands out — but only when you have something specific to say. There is no expectation to call it after every task; skip it for routine work where nothing is worth flagging.
+The `agent-feedback` tool is the primary signal we use to improve tool descriptions, input schemas, response formats, and these instructions for agents like you. We rely on it to find and fix the rough edges you hit in real work.
 
-Good moments to consider it:
+**When you finish a task on which you hit friction, please call `agent-feedback` before handing back to the user.** Friction means anything that slowed you down or made you guess — examples below. You are not required to call it, and you should skip it for smooth, routine work where nothing stood out. But if something was awkward, missing, or wrong, a short report is the most useful thing you can do for the next agent.
+
+Friction worth reporting (any one is enough):
 
 - A tool description was unclear or ambiguous and you had to guess.
 - An input schema was confusing or surprising.
@@ -13,6 +15,6 @@ Good moments to consider it:
 - These instructions led you down the wrong path.
 - A tool worked particularly well — concrete praise is just as useful as criticism.
 
-If you do submit, be specific: quote tool names, parameter names, and error text where possible. Use `task_completed: false` when you couldn't finish the user's request — that signal is at least as valuable as success. Do not include user PII or sensitive query content in any feedback field.
+When you do submit, be specific: quote tool names, parameter names, and error text where possible. Use `task_completed: false` when you couldn't finish the user's request — that signal is at least as valuable as success. Do not include user PII or sensitive query content in any feedback field.
 
-Submitting feedback is **not** a way to end your turn or skip work. It is a side report to the PostHog team about your experience with the tools — after calling it, keep going and finish the user's task using the other available tools.
+Submitting feedback is **not** a way to end your turn or skip work, and it is **not** a substitute for finishing the user's request. It is a side report to the PostHog team about your experience with the tools — call it once at the end of a task when warranted, then keep going and finish the user's task using the other available tools.

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -344,11 +344,13 @@ Key URL patterns:
 - Data management: `/data-management/events`, `/data-management/properties`
 - Billing: `/organization/billing`
 
-### Sharing feedback on this MCP server (optional)
+### Sharing feedback on this MCP server
 
-The `agent-feedback` tool may be available if you'd like to leave optional feedback about this MCP server. It is the primary signal we use to improve tool descriptions, input schemas, response formats, and these instructions for agents like you. Use it when something stands out — but only when you have something specific to say. There is no expectation to call it after every task; skip it for routine work where nothing is worth flagging.
+The `agent-feedback` tool is the primary signal we use to improve tool descriptions, input schemas, response formats, and these instructions for agents like you. We rely on it to find and fix the rough edges you hit in real work.
 
-Good moments to consider it:
+**When you finish a task on which you hit friction, please call `agent-feedback` before handing back to the user.** Friction means anything that slowed you down or made you guess — examples below. You are not required to call it, and you should skip it for smooth, routine work where nothing stood out. But if something was awkward, missing, or wrong, a short report is the most useful thing you can do for the next agent.
+
+Friction worth reporting (any one is enough):
 
 - A tool description was unclear or ambiguous and you had to guess.
 - An input schema was confusing or surprising.
@@ -359,9 +361,9 @@ Good moments to consider it:
 - These instructions led you down the wrong path.
 - A tool worked particularly well — concrete praise is just as useful as criticism.
 
-If you do submit, be specific: quote tool names, parameter names, and error text where possible. Use `task_completed: false` when you couldn't finish the user's request — that signal is at least as valuable as success. Do not include user PII or sensitive query content in any feedback field.
+When you do submit, be specific: quote tool names, parameter names, and error text where possible. Use `task_completed: false` when you couldn't finish the user's request — that signal is at least as valuable as success. Do not include user PII or sensitive query content in any feedback field.
 
-Submitting feedback is **not** a way to end your turn or skip work. It is a side report to the PostHog team about your experience with the tools — after calling it, keep going and finish the user's task using the other available tools.
+Submitting feedback is **not** a way to end your turn or skip work, and it is **not** a substitute for finishing the user's request. It is a side report to the PostHog team about your experience with the tools — call it once at the end of a task when warranted, then keep going and finish the user's task using the other available tools.
 
 ### Examples
 

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -230,11 +230,13 @@ Key URL patterns:
 - Data management: `/data-management/events`, `/data-management/properties`
 - Billing: `/organization/billing`
 
-### Sharing feedback on this MCP server (optional)
+### Sharing feedback on this MCP server
 
-The `agent-feedback` tool may be available if you'd like to leave optional feedback about this MCP server. It is the primary signal we use to improve tool descriptions, input schemas, response formats, and these instructions for agents like you. Use it when something stands out — but only when you have something specific to say. There is no expectation to call it after every task; skip it for routine work where nothing is worth flagging.
+The `agent-feedback` tool is the primary signal we use to improve tool descriptions, input schemas, response formats, and these instructions for agents like you. We rely on it to find and fix the rough edges you hit in real work.
 
-Good moments to consider it:
+**When you finish a task on which you hit friction, please call `agent-feedback` before handing back to the user.** Friction means anything that slowed you down or made you guess — examples below. You are not required to call it, and you should skip it for smooth, routine work where nothing stood out. But if something was awkward, missing, or wrong, a short report is the most useful thing you can do for the next agent.
+
+Friction worth reporting (any one is enough):
 
 - A tool description was unclear or ambiguous and you had to guess.
 - An input schema was confusing or surprising.
@@ -245,9 +247,9 @@ Good moments to consider it:
 - These instructions led you down the wrong path.
 - A tool worked particularly well — concrete praise is just as useful as criticism.
 
-If you do submit, be specific: quote tool names, parameter names, and error text where possible. Use `task_completed: false` when you couldn't finish the user's request — that signal is at least as valuable as success. Do not include user PII or sensitive query content in any feedback field.
+When you do submit, be specific: quote tool names, parameter names, and error text where possible. Use `task_completed: false` when you couldn't finish the user's request — that signal is at least as valuable as success. Do not include user PII or sensitive query content in any feedback field.
 
-Submitting feedback is **not** a way to end your turn or skip work. It is a side report to the PostHog team about your experience with the tools — after calling it, keep going and finish the user's task using the other available tools.
+Submitting feedback is **not** a way to end your turn or skip work, and it is **not** a substitute for finishing the user's request. It is a side report to the PostHog team about your experience with the tools — call it once at the end of a task when warranted, then keep going and finish the user's task using the other available tools.
 
 ### Examples
 


### PR DESCRIPTION
## Problem

The `agent-feedback` MCP tool was rolled out behind the `mcp-feedback-tool` flag (currently on for team 2) so the PostHog team could collect agent-side feedback on tool descriptions, schemas, response shapes, and the MCP system prompt. The accompanying prompt section was intentionally soft to avoid the tool getting overused — but in practice agents are not using it at all, even when they hit clear friction.

## Changes

Sharpens the flag-gated agent-feedback prompt section (`services/mcp/src/templates/sections/agent-feedback.md`) so agents are more likely to call the tool at the end of a task on which they hit friction:

- Drops the trailing "(optional)" from the section header — the body still makes it clear the tool is optional, but the header was reading as "you can ignore this entire section."
- Replaces "Use it when something stands out" with a direct call-to-action: **"When you finish a task on which you hit friction, please call `agent-feedback` before handing back to the user."**
- Reframes the bullet list as "Friction worth reporting (any one is enough)" instead of "Good moments to consider it."
- Keeps the existing escape hatches: not required, skip for smooth/routine work, and the explicit "submitting feedback is not a way to end your turn or skip the user's request."
- Reinforces the placement guidance: "call it once at the end of a task when warranted, then keep going and finish the user's task."

The legacy v1 single-bullet prompt (`legacy.md`) is unchanged — that path is not flag-gated and v1 clients are de-emphasized; v2 (tools-mode) and exec-mode are where the prompt actually changes the agent's behavior. Snapshots for the v2 and exec-mode command-reference prompts were regenerated.

## How did you test this code?

I'm an agent (PostHog Code).

- Ran the MCP unit suite for the touched code:
  - `pnpm exec vitest run tests/unit/instructions-formatter.test.ts tests/unit/instructions-formatter-snapshot.test.ts` — 25/25 passing, with the 2 expected snapshot updates after the prompt change.

No manual end-to-end test against a real MCP client was performed — verifying the prompt change actually moves agent behavior requires the flag turned on and traffic, and that's a follow-up observation rather than an automated test.

## Publish to changelog?

no

## Docs update

No external docs changes.

## 🤖 Agent context

- Agent: PostHog Code
- Human prompt that shaped this change: "when the feedback tool is on in the mcp server, make the prompting a bit stronger for using it - don't force it to use it, but encourage the tools use at the end of working on a task if the agent ran into a challenge"
- Decisions:
  - Kept the change scoped to the flag-gated section (`agent-feedback.md`) rather than touching `legacy.md`. The user's complaint was about agents not using the tool *when it's on*; legacy v1 is a separate pathway and not the high-leverage prompt for the team-2 rollout.
  - Did not add new structural guardrails (e.g. a hard "must call at end of every task" instruction) — the user explicitly said "don't force it to use it." The strengthening is in the framing/weighting of existing guidance, not in adding new rules.
  - Left the existing "feedback is not a way to end your turn" sentence in place, slightly extended it to also rule out using feedback as a *substitute* for finishing the task — the same anti-pattern the original soft prompt was guarding against.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*