### PR TITLE
fix(data deletion): discover materialized columns by comment alone

### DIFF
--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -231,13 +231,15 @@ def _get_affected_mat_columns(
     properties: list[str],
     log: QueryLogger | None = None,
 ) -> list[tuple[str, bool]]:
-    """Query a specific shard for DEFAULT materialized columns matching deleted properties.
+    """Query a specific shard for materialized columns matching deleted properties.
 
-    Returns ``(column_name, is_nullable)`` for DEFAULT columns whose comment follows
-    the ``column_materializer::properties::<prop>`` convention.  Only DEFAULT columns
-    are returned because they are included in ``SELECT *`` (so stale values propagate
-    on re-insert) and can be reset via ``ALTER TABLE UPDATE``.  MATERIALIZED columns
-    are excluded — ClickHouse recomputes them automatically at insert time.
+    Returns ``(column_name, is_nullable)`` for columns whose comment follows the
+    ``column_materializer::properties::<prop>`` convention.  Comments live on the
+    distributed ``events`` table while the DEFAULT expression lives on
+    ``sharded_events`` (see ``materialize()`` in ee/clickhouse/materialized_columns),
+    so we cannot filter by ``default_kind`` on the same row that carries the comment.
+    The comment itself is a sufficient identifier — it is PostHog-specific and the
+    ``elements_chain::*`` family is excluded explicitly.
     """
     database = django_settings.CLICKHOUSE_DATABASE
     sql = """
@@ -245,7 +247,6 @@ def _get_affected_mat_columns(
         FROM system.columns
         WHERE database = %(database)s
           AND table = %(table)s
-          AND default_kind = 'DEFAULT'
           AND comment LIKE '%%column_materializer::%%'
           AND comment NOT LIKE '%%column_materializer::elements_chain::%%'
         """

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -877,7 +877,12 @@ def test_full_job_property_removal_subfield_only(
 
 
 def _add_default_mat_columns(col_defs: list[tuple[str, str, str]], client: Client) -> None:
-    """Add DEFAULT materialized columns to events tables for testing.
+    """Add materialized columns to events tables for testing.
+
+    Mirrors production: ``sharded_events`` gets the column with the ``DEFAULT``
+    expression but no comment, ``events`` (distributed) gets just the type plus
+    the ``column_materializer::`` comment. See ``materialize()`` in
+    ee/clickhouse/materialized_columns/columns.py.
 
     Each entry is (col_name, prop_name, col_type).
     """
@@ -886,14 +891,12 @@ def _add_default_mat_columns(col_defs: list[tuple[str, str, str]], client: Clien
     db = settings.CLICKHOUSE_DATABASE
     for col_name, prop_name, col_type in col_defs:
         comment = f"column_materializer::properties::{prop_name}"
-        for table in ("sharded_events", "events"):
-            kw = f"COMMENT '{comment}'" if table == "events" else ""
-            client.execute(
-                f"ALTER TABLE {db}.{table} "
-                f"ADD COLUMN IF NOT EXISTS `{col_name}` {col_type} "
-                f"DEFAULT JSONExtractRaw(properties, '{prop_name}') "
-                f"{kw}"
-            )
+        client.execute(
+            f"ALTER TABLE {db}.sharded_events "
+            f"ADD COLUMN IF NOT EXISTS `{col_name}` {col_type} "
+            f"DEFAULT JSONExtractRaw(properties, '{prop_name}')"
+        )
+        client.execute(f"ALTER TABLE {db}.events ADD COLUMN IF NOT EXISTS `{col_name}` {col_type} COMMENT '{comment}'")
 
 
 def _drop_default_mat_columns(col_defs: list[tuple[str, str, str]], client: Client) -> None:


### PR DESCRIPTION
## Problem

The discover-mat-cols query filtered by `default_kind = 'DEFAULT'` on the distributed `events` table, but `materialize()` only attaches the DEFAULT expression to `sharded_events` and only attaches the `column_materializer::` comment to `events` — so the two facts never appear on the same `system.columns` row in production. The query returned zero rows, leaving the clean-temp mutation without any `mat_<prop>` resets.

## Changes

Drop the `default_kind` predicate; the comment is a sufficient identifier (PostHog-specific, with `elements_chain::*` already excluded).

Update the test helper to mirror production (DEFAULT only on sharded_events, comment only on events) so this class of bug is now caught by `test_full_job_property_removal_clears_materialized_columns`.

## How did you test this code?

Tests.