### PR TITLE
feat(capture): retain batch ordering in v1 pipeline

### DIFF
--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -74,12 +74,13 @@ fn validate_batch(batch: &Batch) -> Result<(), Error> {
     Ok(())
 }
 
-fn validate_events(context: &Context, batch: Batch) -> Result<HashMap<Uuid, WrappedEvent>, Error> {
-    let mut events: HashMap<Uuid, WrappedEvent> = HashMap::with_capacity(batch.batch.len());
+fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>, Error> {
+    let mut events: Vec<WrappedEvent> = Vec::with_capacity(batch.batch.len());
+    let mut seen: HashSet<Uuid> = HashSet::with_capacity(batch.batch.len());
 
     for event in batch.batch.into_iter() {
         let uuid = Uuid::parse_str(event.uuid()).map_err(|_| Error::MissingEventUuid)?;
-        if events.contains_key(&uuid) {
+        if !seen.insert(uuid) {
             return Err(Error::DuplicateEventUuid(event.uuid().to_owned()));
         }
 
@@ -87,48 +88,42 @@ fn validate_events(context: &Context, batch: Batch) -> Result<HashMap<Uuid, Wrap
             Ok(raw_ts) => {
                 metrics::counter!(CAPTURE_V1_PARSED_EVENTS, "result" => "valid").increment(1);
                 let adjusted = normalize_timestamp(context, &event, raw_ts);
-                events.insert(
+                events.push(WrappedEvent {
+                    event,
                     uuid,
-                    WrappedEvent {
-                        event,
-                        uuid,
-                        adjusted_timestamp: Some(adjusted),
-                        result: EventResult::Ok,
-                        details: None,
-                        destination: Destination::default(),
-                        force_disable_person_processing: false,
-                    },
-                );
+                    adjusted_timestamp: Some(adjusted),
+                    result: EventResult::Ok,
+                    details: None,
+                    destination: Destination::default(),
+                    force_disable_person_processing: false,
+                });
             }
             Err(err) => {
-                events.insert(
+                events.push(WrappedEvent {
+                    event,
                     uuid,
-                    WrappedEvent {
-                        event,
-                        uuid,
-                        adjusted_timestamp: None,
-                        result: EventResult::Drop,
-                        details: Some(err.tag()),
-                        destination: Destination::default(),
-                        force_disable_person_processing: false,
-                    },
-                );
+                    adjusted_timestamp: None,
+                    result: EventResult::Drop,
+                    details: Some(err.tag()),
+                    destination: Destination::default(),
+                    force_disable_person_processing: false,
+                });
             }
         }
     }
 
-    if events.values().any(|e| e.result != EventResult::Ok) {
+    if events.iter().any(|e| e.result != EventResult::Ok) {
         observe_malformed_events(context, &events);
     }
 
     Ok(events)
 }
 
-fn observe_malformed_events(context: &Context, events: &HashMap<Uuid, WrappedEvent>) {
+fn observe_malformed_events(context: &Context, events: &[WrappedEvent]) {
     let mut malformed: HashMap<&'static str, u64> = HashMap::new();
     let mut illegal_distinct_ids: HashSet<&str> = HashSet::new();
 
-    for event in events.values() {
+    for event in events.iter() {
         if let Some(tag) = event.details {
             *malformed.entry(tag).or_insert(0) += 1;
             if tag == "invalid_distinct_id" {
@@ -217,9 +212,9 @@ fn normalize_timestamp(
 fn apply_historical_rerouting(
     cfg: &router::HistoricalConfig,
     context: &Context,
-    events: &mut HashMap<Uuid, WrappedEvent>,
+    events: &mut [WrappedEvent],
 ) {
-    for event in events.values_mut() {
+    for event in events.iter_mut() {
         if event.result != EventResult::Ok || event.destination != Destination::AnalyticsMain {
             continue;
         }
@@ -250,9 +245,9 @@ async fn apply_restrictions(
     service: &EventRestrictionService,
     token: &str,
     now_ts: i64,
-    events: &mut HashMap<Uuid, WrappedEvent>,
+    events: &mut [WrappedEvent],
 ) {
-    for event in events.values_mut() {
+    for event in events.iter_mut() {
         if event.result != EventResult::Ok {
             continue;
         }
@@ -295,12 +290,12 @@ async fn apply_restrictions(
 async fn apply_token_distinct_id_limits(
     limiter: &GlobalRateLimiter,
     context: &Context,
-    events: &mut HashMap<Uuid, WrappedEvent>,
+    events: &mut [WrappedEvent],
 ) {
     let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
     let mut allowed_count: u64 = 0;
 
-    for event in events.values_mut() {
+    for event in events.iter_mut() {
         if event.result != EventResult::Ok {
             continue;
         }
@@ -364,8 +359,8 @@ mod tests {
     use crate::v1::analytics::types::{Batch, Event, Options};
     use crate::v1::sinks::Destination;
     use crate::v1::test_utils::{
-        self, events_map, find_by_did, malformed_wrapped_event, raw_obj, valid_event,
-        wrapped_event, wrapped_event_at,
+        self, find_by_did, malformed_wrapped_event, raw_obj, valid_event, wrapped_event,
+        wrapped_event_at,
     };
     use crate::v1::Error;
 
@@ -578,10 +573,13 @@ mod tests {
         let batch = valid_batch(vec![perf, normal]);
         let events = validate_events(&ctx, batch).unwrap();
         assert_eq!(events.len(), 2);
-        let p = events.get(&perf_uuid).unwrap();
+        // Vec preserves input order: perf first, normal second.
+        let p = &events[0];
+        assert_eq!(p.uuid, perf_uuid);
         assert_eq!(p.result, EventResult::Drop);
         assert_eq!(p.details, Some("dropped_performance_event"));
-        let n = events.get(&normal_uuid).unwrap();
+        let n = &events[1];
+        assert_eq!(n.uuid, normal_uuid);
         assert_eq!(n.result, EventResult::Ok);
     }
 
@@ -599,7 +597,7 @@ mod tests {
         let batch = valid_batch(vec![p1, p2]);
         let events = validate_events(&ctx, batch).unwrap();
         assert_eq!(events.len(), 2);
-        for ev in events.values() {
+        for ev in &events {
             assert_eq!(ev.result, EventResult::Drop);
             assert_eq!(ev.details, Some("dropped_performance_event"));
         }
@@ -678,7 +676,8 @@ mod tests {
         };
         let events = validate_events(&ctx, batch).unwrap();
         assert_eq!(events.len(), 1);
-        let event = events.get(&uuid).unwrap();
+        let event = &events[0];
+        assert_eq!(event.uuid, uuid);
         assert_eq!(event.result, EventResult::Drop);
         assert_eq!(event.details, Some("malformed_event_properties"));
     }
@@ -818,7 +817,7 @@ mod tests {
             EventRestrictionService::new(CaptureMode::Events, StdDuration::from_secs(300));
         service.update(RestrictionManager::new()).await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -841,15 +840,15 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![
+        let mut events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$identify", "user-2"),
-        ]);
+        ];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
 
-        for ev in events.values() {
+        for ev in &events {
             assert_eq!(ev.result, EventResult::Drop);
             assert_eq!(ev.destination, Destination::Drop);
         }
@@ -869,7 +868,7 @@ mod tests {
 
         let malformed = malformed_wrapped_event();
         let malformed_did = malformed.event.distinct_id.clone();
-        let mut events = events_map(vec![malformed, wrapped_event("$pageview", "user-valid")]);
+        let mut events = vec![malformed, wrapped_event("$pageview", "user-valid")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -896,7 +895,7 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -918,7 +917,7 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -940,7 +939,7 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -965,7 +964,7 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -1000,7 +999,7 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -1022,7 +1021,7 @@ mod tests {
         )
         .await;
 
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1")]);
+        let mut events = vec![wrapped_event("$pageview", "user-1")];
         let now_ts = Utc::now().timestamp();
 
         apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
@@ -1103,14 +1102,14 @@ mod tests {
     async fn td_limits_under_limit_all_pass() {
         let limiter = mock_limiter(vec![]);
         let ctx = td_context();
-        let mut events = events_map(vec![
+        let mut events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$identify", "user-2"),
-        ]);
+        ];
 
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
-        for ev in events.values() {
+        for ev in &events {
             assert_eq!(ev.result, EventResult::Ok);
             assert_eq!(ev.destination, Destination::AnalyticsMain);
             assert!(ev.details.is_none());
@@ -1121,10 +1120,10 @@ mod tests {
     async fn td_limits_one_distinct_id_over_limit() {
         let limiter = mock_limiter(vec!["phc_tok:user-2"]);
         let ctx = td_context();
-        let mut events = events_map(vec![
+        let mut events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$identify", "user-2"),
-        ]);
+        ];
 
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
@@ -1146,11 +1145,11 @@ mod tests {
     async fn td_limits_skips_already_invalid_events() {
         let limiter = mock_limiter(vec!["phc_tok:user-1"]);
         let ctx = td_context();
-        let mut events = events_map(vec![malformed_wrapped_event()]);
+        let mut events = vec![malformed_wrapped_event()];
 
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
-        let ev = events.values().next().unwrap();
+        let ev = &events[0];
         assert_eq!(ev.result, EventResult::Drop);
         assert_eq!(ev.destination, Destination::default());
         assert!(ev.details.is_some());
@@ -1160,15 +1159,15 @@ mod tests {
     async fn td_limits_multiple_events_same_distinct_id_all_limited() {
         let limiter = mock_limiter(vec!["phc_tok:user-1"]);
         let ctx = td_context();
-        let mut events = events_map(vec![
+        let mut events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$identify", "user-1"),
             wrapped_event("$click", "user-1"),
-        ]);
+        ];
 
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
-        for ev in events.values() {
+        for ev in &events {
             assert_eq!(ev.result, EventResult::Ok, "should stay Ok");
             assert_eq!(
                 ev.destination,
@@ -1193,10 +1192,11 @@ mod tests {
         let ctx = td_context();
         let pre_drop = wrapped_event("$pageview", "user-1");
         let pre_drop_uuid = pre_drop.uuid;
-        let mut events = events_map(vec![pre_drop, wrapped_event("$identify", "user-2")]);
+        let mut events = vec![pre_drop, wrapped_event("$identify", "user-2")];
         // Simulate event already dropped by restrictions
-        events.get_mut(&pre_drop_uuid).unwrap().result = EventResult::Drop;
-        events.get_mut(&pre_drop_uuid).unwrap().destination = Destination::Drop;
+        let pd = events.iter_mut().find(|e| e.uuid == pre_drop_uuid).unwrap();
+        pd.result = EventResult::Drop;
+        pd.destination = Destination::Drop;
 
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
@@ -1219,14 +1219,14 @@ mod tests {
         let cfg = router::HistoricalConfig::new(false, 1);
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
-        let mut events = events_map(vec![
+        let mut events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$identify", "user-2"),
-        ]);
+        ];
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        for ev in events.values() {
+        for ev in &events {
             assert_eq!(ev.destination, Destination::AnalyticsHistorical);
         }
     }
@@ -1236,11 +1236,11 @@ mod tests {
         let cfg = router::HistoricalConfig::new(true, 30);
         let ctx = test_utils::test_context();
         let old_ts = Utc::now() - Duration::days(60);
-        let mut events = events_map(vec![wrapped_event_at(old_ts)]);
+        let mut events = vec![wrapped_event_at(old_ts)];
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        let ev = events.values().next().unwrap();
+        let ev = &events[0];
         assert_eq!(ev.destination, Destination::AnalyticsHistorical);
     }
 
@@ -1249,11 +1249,11 @@ mod tests {
         let cfg = router::HistoricalConfig::new(true, 30);
         let ctx = test_utils::test_context();
         let recent_ts = Utc::now() - Duration::hours(1);
-        let mut events = events_map(vec![wrapped_event_at(recent_ts)]);
+        let mut events = vec![wrapped_event_at(recent_ts)];
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        let ev = events.values().next().unwrap();
+        let ev = &events[0];
         assert_eq!(ev.destination, Destination::AnalyticsMain);
     }
 
@@ -1262,11 +1262,11 @@ mod tests {
         let cfg = router::HistoricalConfig::new(false, 30);
         let ctx = test_utils::test_context();
         let old_ts = Utc::now() - Duration::days(60);
-        let mut events = events_map(vec![wrapped_event_at(old_ts)]);
+        let mut events = vec![wrapped_event_at(old_ts)];
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        let ev = events.values().next().unwrap();
+        let ev = &events[0];
         assert_eq!(ev.destination, Destination::AnalyticsMain);
     }
 
@@ -1277,13 +1277,21 @@ mod tests {
         ctx.historical_migration = true;
         let ev = wrapped_event("$pageview", "user-1");
         let ev_uuid = ev.uuid;
-        let mut events = events_map(vec![ev]);
-        events.get_mut(&ev_uuid).unwrap().destination = Destination::Overflow;
+        let mut events = vec![ev];
+        events
+            .iter_mut()
+            .find(|e| e.uuid == ev_uuid)
+            .unwrap()
+            .destination = Destination::Overflow;
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
         assert_eq!(
-            events.get(&ev_uuid).unwrap().destination,
+            events
+                .iter()
+                .find(|e| e.uuid == ev_uuid)
+                .unwrap()
+                .destination,
             Destination::Overflow
         );
     }
@@ -1295,14 +1303,21 @@ mod tests {
         ctx.historical_migration = true;
         let ev = wrapped_event("$pageview", "user-1");
         let ev_uuid = ev.uuid;
-        let mut events = events_map(vec![ev]);
-        let e = events.get_mut(&ev_uuid).unwrap();
+        let mut events = vec![ev];
+        let e = events.iter_mut().find(|e| e.uuid == ev_uuid).unwrap();
         e.result = EventResult::Drop;
         e.destination = Destination::Drop;
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        assert_eq!(events.get(&ev_uuid).unwrap().destination, Destination::Drop);
+        assert_eq!(
+            events
+                .iter()
+                .find(|e| e.uuid == ev_uuid)
+                .unwrap()
+                .destination,
+            Destination::Drop
+        );
     }
 
     #[test]
@@ -1310,11 +1325,11 @@ mod tests {
         let cfg = router::HistoricalConfig::new(true, 30);
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
-        let mut events = events_map(vec![malformed_wrapped_event()]);
+        let mut events = vec![malformed_wrapped_event()];
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        let ev = events.values().next().unwrap();
+        let ev = &events[0];
         assert_eq!(ev.destination, Destination::AnalyticsMain);
     }
 
@@ -1325,14 +1340,226 @@ mod tests {
         ctx.historical_migration = true;
         let dlq_ev = wrapped_event("$identify", "user-2");
         let dlq_uuid = dlq_ev.uuid;
-        let mut events = events_map(vec![wrapped_event("$pageview", "user-1"), dlq_ev]);
-        events.get_mut(&dlq_uuid).unwrap().destination = Destination::Dlq;
+        let mut events = vec![wrapped_event("$pageview", "user-1"), dlq_ev];
+        events
+            .iter_mut()
+            .find(|e| e.uuid == dlq_uuid)
+            .unwrap()
+            .destination = Destination::Dlq;
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
         let main_ev = find_by_did(&events, "user-1");
         assert_eq!(main_ev.destination, Destination::AnalyticsHistorical);
         // DLQ event untouched
-        assert_eq!(events.get(&dlq_uuid).unwrap().destination, Destination::Dlq);
+        assert_eq!(
+            events
+                .iter()
+                .find(|e| e.uuid == dlq_uuid)
+                .unwrap()
+                .destination,
+            Destination::Dlq
+        );
+    }
+
+    // --- ordering preservation regressions ---
+    // Pin in-batch order through each stage and end-to-end (regressions
+    // against the old HashMap pipeline that silently shuffled events).
+
+    fn distinct_id_sequence(events: &[WrappedEvent]) -> Vec<&str> {
+        events
+            .iter()
+            .map(|e| e.event.distinct_id.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn validate_events_preserves_input_order() {
+        let ctx = test_utils::test_context();
+        // Mix valid + invalid to hit both match branches.
+        let perf = Event {
+            event: "$performance_event".to_string(),
+            distinct_id: "user-pos-1".to_string(),
+            ..valid_event()
+        };
+        let normal_a = Event {
+            distinct_id: "user-pos-0".to_string(),
+            ..valid_event()
+        };
+        let normal_b = Event {
+            distinct_id: "user-pos-2".to_string(),
+            ..valid_event()
+        };
+        let normal_c = Event {
+            distinct_id: "user-pos-3".to_string(),
+            ..valid_event()
+        };
+        let batch = valid_batch(vec![normal_a, perf, normal_b, normal_c]);
+
+        let events = validate_events(&ctx, batch).unwrap();
+
+        assert_eq!(
+            distinct_id_sequence(&events),
+            vec!["user-pos-0", "user-pos-1", "user-pos-2", "user-pos-3"],
+        );
+    }
+
+    #[test]
+    fn validate_events_duplicate_uuid_via_realistic_pair() {
+        // Two distinct events (name / distinct_id / props) colliding on uuid.
+        let ctx = test_utils::test_context();
+        let (first, second) = test_utils::realistic_dup_uuid_pair();
+        let batch = valid_batch(vec![first, second]);
+        let err = validate_events(&ctx, batch).unwrap_err();
+        assert!(matches!(err, Error::DuplicateEventUuid(_)));
+    }
+
+    #[tokio::test]
+    async fn apply_historical_rerouting_preserves_order() {
+        // Interleave old + recent so the timestamp branch flips some events.
+        let cfg = router::HistoricalConfig::new(true, 30);
+        let ctx = test_utils::test_context();
+        let now = Utc::now();
+        let mut e0 = wrapped_event_at(now - Duration::days(60));
+        e0.event.distinct_id = "user-pos-0".to_string();
+        let mut e1 = wrapped_event_at(now - Duration::hours(1));
+        e1.event.distinct_id = "user-pos-1".to_string();
+        let mut e2 = wrapped_event_at(now - Duration::days(90));
+        e2.event.distinct_id = "user-pos-2".to_string();
+        let mut e3 = wrapped_event_at(now - Duration::minutes(5));
+        e3.event.distinct_id = "user-pos-3".to_string();
+        let mut events = vec![e0, e1, e2, e3];
+
+        apply_historical_rerouting(&cfg, &ctx, &mut events);
+
+        assert_eq!(
+            distinct_id_sequence(&events),
+            vec!["user-pos-0", "user-pos-1", "user-pos-2", "user-pos-3"],
+        );
+        assert_eq!(events[0].destination, Destination::AnalyticsHistorical);
+        assert_eq!(events[1].destination, Destination::AnalyticsMain);
+        assert_eq!(events[2].destination, Destination::AnalyticsHistorical);
+        assert_eq!(events[3].destination, Destination::AnalyticsMain);
+    }
+
+    #[tokio::test]
+    async fn apply_restrictions_preserves_order() {
+        let service = restriction_service(
+            "phc_token",
+            vec![Restriction {
+                restriction_type: RestrictionType::DropEvent,
+                scope: RestrictionScope::AllEvents,
+                args: None,
+            }],
+        )
+        .await;
+
+        let mut events = vec![
+            wrapped_event("$pageview", "user-pos-0"),
+            wrapped_event("$identify", "user-pos-1"),
+            wrapped_event("$click", "user-pos-2"),
+        ];
+        let now_ts = Utc::now().timestamp();
+
+        apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
+
+        assert_eq!(
+            distinct_id_sequence(&events),
+            vec!["user-pos-0", "user-pos-1", "user-pos-2"],
+        );
+        for ev in &events {
+            assert_eq!(ev.result, EventResult::Drop);
+            assert_eq!(ev.destination, Destination::Drop);
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_token_distinct_id_limits_preserves_order_with_interleaved_limits() {
+        // Limit slots 1 and 3 only — verifies interleaved limited/non-limited
+        // entries don't shuffle.
+        let limiter = mock_limiter(vec!["phc_tok:user-pos-1", "phc_tok:user-pos-3"]);
+        let ctx = td_context();
+        let mut events = vec![
+            wrapped_event("$pageview", "user-pos-0"),
+            wrapped_event("$pageview", "user-pos-1"),
+            wrapped_event("$pageview", "user-pos-2"),
+            wrapped_event("$pageview", "user-pos-3"),
+            wrapped_event("$pageview", "user-pos-4"),
+        ];
+
+        apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
+
+        assert_eq!(
+            distinct_id_sequence(&events),
+            vec![
+                "user-pos-0",
+                "user-pos-1",
+                "user-pos-2",
+                "user-pos-3",
+                "user-pos-4",
+            ],
+        );
+        assert!(!events[0].force_disable_person_processing);
+        assert!(events[1].force_disable_person_processing);
+        assert_eq!(
+            events[1].details,
+            Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
+        );
+        assert!(!events[2].force_disable_person_processing);
+        assert!(events[3].force_disable_person_processing);
+        assert_eq!(
+            events[3].details,
+            Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
+        );
+        assert!(!events[4].force_disable_person_processing);
+    }
+
+    #[tokio::test]
+    async fn pipeline_preserves_order_through_all_stages() {
+        // End-to-end pin across every &mut [WrappedEvent] stage.
+        // apply_quota_limits is covered in v1::quota_limiter_shim tests.
+        let mut events = test_utils::realistic_ordered_mixed_batch();
+        let expected = [
+            "user-pos-0",
+            "user-pos-1",
+            "user-pos-2",
+            "user-pos-3",
+            "user-pos-4",
+            "user-pos-5",
+        ];
+
+        // Stage 1: historical rerouting (batch flag on).
+        let cfg = router::HistoricalConfig::new(false, 1);
+        let mut ctx = test_utils::test_context();
+        ctx.historical_migration = true;
+        apply_historical_rerouting(&cfg, &ctx, &mut events);
+        assert_eq!(
+            distinct_id_sequence(&events),
+            expected,
+            "order changed after apply_historical_rerouting",
+        );
+
+        // Stage 2: restrictions (no rules → passthrough, still iterates).
+        let service =
+            EventRestrictionService::new(CaptureMode::Events, StdDuration::from_secs(300));
+        service.update(RestrictionManager::new()).await;
+        let now_ts = Utc::now().timestamp();
+        apply_restrictions(&service, "phc_token", now_ts, &mut events).await;
+        assert_eq!(
+            distinct_id_sequence(&events),
+            expected,
+            "order changed after apply_restrictions",
+        );
+
+        // Stage 3: token+distinct_id limits — limit one Ok mid-batch.
+        let mut tdctx = test_utils::test_context();
+        tdctx.api_token = "phc_tok".to_string();
+        let limiter = mock_limiter(vec!["phc_tok:user-pos-2"]);
+        apply_token_distinct_id_limits(&limiter, &tdctx, &mut events).await;
+        assert_eq!(
+            distinct_id_sequence(&events),
+            expected,
+            "order changed after apply_token_distinct_id_limits",
+        );
     }
 }

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -1,9 +1,6 @@
-use std::collections::HashMap;
-
 use common_types::HasEventName;
 use limiters::redis::QuotaResource;
 use metrics::counter;
-use uuid::Uuid;
 
 use crate::quota_limiters::CaptureQuotaLimiter;
 use crate::quota_limiters::{is_exception_event, is_llm_event, is_survey_event, EventInfo};
@@ -28,7 +25,7 @@ const SCOPED_CHECKS: &[ScopedCheck] = &[
 pub async fn apply_quota_limits(
     limiter: &CaptureQuotaLimiter,
     token: &str,
-    events: &mut HashMap<Uuid, WrappedEvent>,
+    events: &mut [WrappedEvent],
 ) -> Result<(), Error> {
     if events.is_empty() {
         return Ok(());
@@ -53,7 +50,7 @@ pub async fn apply_quota_limits(
 
         let resource_tag = resource.as_str();
         let mut count: u64 = 0;
-        for ev in events.values_mut() {
+        for ev in events.iter_mut() {
             if ev.result != EventResult::Ok {
                 continue;
             }
@@ -79,7 +76,7 @@ pub async fn apply_quota_limits(
     }
 
     // If every event is now non-Ok, the whole batch is limited
-    for ev in events.values() {
+    for ev in events.iter() {
         if ev.result == EventResult::Ok {
             all_non_ok = false;
             break;
@@ -109,7 +106,6 @@ mod tests {
 
     use crate::config::{CaptureMode, Config, KafkaConfig};
     use crate::v1::analytics::types::{Event, Options};
-    use crate::v1::test_utils::events_map;
 
     fn test_config() -> Config {
         Config {
@@ -299,9 +295,9 @@ mod tests {
         }
     }
 
-    fn ok_event_names(events: &HashMap<Uuid, WrappedEvent>) -> Vec<&str> {
+    fn ok_event_names(events: &[WrappedEvent]) -> Vec<&str> {
         let mut names: Vec<&str> = events
-            .values()
+            .iter()
             .filter(|e| e.result == EventResult::Ok)
             .map(|e| e.event.event.as_str())
             .collect();
@@ -309,9 +305,9 @@ mod tests {
         names
     }
 
-    fn limited_event_names(events: &HashMap<Uuid, WrappedEvent>) -> Vec<&str> {
+    fn limited_event_names(events: &[WrappedEvent]) -> Vec<&str> {
         let mut names: Vec<&str> = events
-            .values()
+            .iter()
             .filter(|e| e.result == EventResult::Limited)
             .map(|e| e.event.event.as_str())
             .collect();
@@ -319,8 +315,16 @@ mod tests {
         names
     }
 
-    fn find_by_name<'a>(events: &'a HashMap<Uuid, WrappedEvent>, name: &str) -> &'a WrappedEvent {
-        events.values().find(|e| e.event.event == name).unwrap()
+    /// Panics on zero or multiple matches — callers rely on uniqueness.
+    fn find_unique_by_name<'a>(events: &'a [WrappedEvent], name: &str) -> &'a WrappedEvent {
+        let matches: Vec<&WrappedEvent> = events.iter().filter(|e| e.event.event == name).collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "expected exactly one event named {name:?}, found {}",
+            matches.len()
+        );
+        matches[0]
     }
 
     // -----------------------------------------------------------------------
@@ -330,12 +334,12 @@ mod tests {
     #[tokio::test]
     async fn no_limits_all_events_pass() {
         let limiter = build_limiter("tok", false, &[]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$pageview", None),
             make_event("$exception", None),
             make_event("survey sent", None),
             make_event("$ai_generation", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
@@ -350,12 +354,12 @@ mod tests {
     #[tokio::test]
     async fn global_limit_returns_error_without_marking_events() {
         let limiter = build_limiter("tok", true, &[]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$pageview", None),
             make_event("$exception", None),
             make_event("survey sent", None),
             make_event("$ai_generation", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_err());
@@ -370,9 +374,9 @@ mod tests {
         let limiter = build_limiter("tok", true, &[]).await;
         let bad = make_event("bad_event", None);
         let bad_uuid = bad.uuid;
-        let mut events = events_map(vec![make_event("$pageview", None), bad]);
+        let mut events = vec![make_event("$pageview", None), bad];
         // Pre-mark one event as Drop (e.g. from validation)
-        let bad_ev = events.get_mut(&bad_uuid).unwrap();
+        let bad_ev = events.iter_mut().find(|e| e.uuid == bad_uuid).unwrap();
         bad_ev.result = EventResult::Drop;
         bad_ev.destination = Destination::Drop;
         bad_ev.details = Some("invalid_event_name");
@@ -381,12 +385,12 @@ mod tests {
         assert!(result.is_err());
 
         // Global limit short-circuits — no events are mutated
-        let pv = find_by_name(&events, "$pageview");
+        let pv = find_unique_by_name(&events, "$pageview");
         assert_eq!(pv.result, EventResult::Ok);
         assert_eq!(pv.details, None);
 
         // Pre-existing Drop event also untouched
-        let bad_ev = events.get(&bad_uuid).unwrap();
+        let bad_ev = events.iter().find(|e| e.uuid == bad_uuid).unwrap();
         assert_eq!(bad_ev.result, EventResult::Drop);
         assert_eq!(bad_ev.details, Some("invalid_event_name"));
     }
@@ -394,10 +398,10 @@ mod tests {
     #[tokio::test]
     async fn global_limit_different_token_not_affected() {
         let limiter = build_limiter("limited_tok", true, &[]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$pageview", None),
             make_event("$exception", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "other_tok", &mut events).await;
         assert!(result.is_ok());
@@ -411,12 +415,12 @@ mod tests {
     #[tokio::test]
     async fn exception_limit_marks_only_exceptions() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$pageview", None),
             make_event("$exception", None),
             make_event("survey sent", None),
             make_event("$exception", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
@@ -428,7 +432,7 @@ mod tests {
             limited_event_names(&events),
             vec!["$exception", "$exception"]
         );
-        for ev in events.values().filter(|e| e.result == EventResult::Limited) {
+        for ev in events.iter().filter(|e| e.result == EventResult::Limited) {
             assert_eq!(ev.details, Some("exceptions_over_quota"));
         }
     }
@@ -436,10 +440,10 @@ mod tests {
     #[tokio::test]
     async fn exception_limit_all_exceptions_returns_error() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$exception", None),
             make_event("$exception", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_err());
@@ -453,13 +457,13 @@ mod tests {
     #[tokio::test]
     async fn survey_limit_marks_only_survey_events() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Surveys]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$pageview", None),
             make_event("survey sent", None),
             make_event("survey shown", None),
             make_event("survey dismissed", None),
             make_event("$exception", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
@@ -468,7 +472,7 @@ mod tests {
         ok.sort();
         assert_eq!(ok, vec!["$exception", "$pageview"]);
         assert_eq!(limited_event_names(&events).len(), 3);
-        for ev in events.values().filter(|e| e.result == EventResult::Limited) {
+        for ev in events.iter().filter(|e| e.result == EventResult::Limited) {
             assert_eq!(ev.details, Some("survey_responses_over_quota"));
         }
     }
@@ -478,13 +482,16 @@ mod tests {
         let limiter = build_limiter("tok", false, &[QuotaResource::Surveys]).await;
         let tour_ev = make_event("survey sent", Some("tour-123"));
         let tour_uuid = tour_ev.uuid;
-        let mut events = events_map(vec![make_event("survey sent", None), tour_ev]);
+        let mut events = vec![make_event("survey sent", None), tour_ev];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
 
         // Product tour survey → Ok, regular survey → Limited
-        assert_eq!(events.get(&tour_uuid).unwrap().result, EventResult::Ok);
+        assert_eq!(
+            events.iter().find(|e| e.uuid == tour_uuid).unwrap().result,
+            EventResult::Ok
+        );
         assert_eq!(limited_event_names(&events).len(), 1);
     }
 
@@ -495,19 +502,19 @@ mod tests {
     #[tokio::test]
     async fn llm_limit_marks_only_ai_events() {
         let limiter = build_limiter("tok", false, &[QuotaResource::LLMEvents]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$ai_generation", None),
             make_event("$ai_span", None),
             make_event("$pageview", None),
             make_event("$ai_trace", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
 
         assert_eq!(ok_event_names(&events), vec!["$pageview"]);
         assert_eq!(limited_event_names(&events).len(), 3);
-        for ev in events.values().filter(|e| e.result == EventResult::Limited) {
+        for ev in events.iter().filter(|e| e.result == EventResult::Limited) {
             assert_eq!(ev.details, Some("llm_events_over_quota"));
         }
     }
@@ -515,11 +522,11 @@ mod tests {
     #[tokio::test]
     async fn llm_limit_ignores_non_ai_prefix() {
         let limiter = build_limiter("tok", false, &[QuotaResource::LLMEvents]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$ai_generation", None),
             make_event("$ainotcounted", None), // no underscore
             make_event("ai_generation", None), // no $ prefix
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
@@ -546,12 +553,12 @@ mod tests {
             ],
         )
         .await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$exception", None),
             make_event("survey sent", None),
             make_event("$ai_generation", None),
             make_event("$pageview", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
@@ -559,15 +566,15 @@ mod tests {
         assert_eq!(ok_event_names(&events), vec!["$pageview"]);
         assert_eq!(limited_event_names(&events).len(), 3);
         assert_eq!(
-            find_by_name(&events, "$exception").details,
+            find_unique_by_name(&events, "$exception").details,
             Some("exceptions_over_quota")
         );
         assert_eq!(
-            find_by_name(&events, "survey sent").details,
+            find_unique_by_name(&events, "survey sent").details,
             Some("survey_responses_over_quota")
         );
         assert_eq!(
-            find_by_name(&events, "$ai_generation").details,
+            find_unique_by_name(&events, "$ai_generation").details,
             Some("llm_events_over_quota")
         );
     }
@@ -584,11 +591,11 @@ mod tests {
             ],
         )
         .await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$exception", None),
             make_event("survey sent", None),
             make_event("$ai_generation", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_err());
@@ -603,16 +610,16 @@ mod tests {
     async fn global_limit_short_circuits_before_scoped() {
         // Global limited, plus scoped exception limited
         let limiter = build_limiter("tok", true, &[QuotaResource::Exceptions]).await;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$pageview", None),
             make_event("$exception", None),
-        ]);
+        ];
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_err());
 
         // Global short-circuits without marking — scoped limiters never run
-        for ev in events.values() {
+        for ev in &events {
             assert_eq!(ev.result, EventResult::Ok);
             assert_eq!(ev.details, None);
         }
@@ -628,9 +635,9 @@ mod tests {
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
         let pv = make_event("$pageview", None);
         let pv_uuid = pv.uuid;
-        let mut events = events_map(vec![make_event("$exception", None), pv]);
+        let mut events = vec![make_event("$exception", None), pv];
         // Pre-mark pageview as Drop from a prior validation step
-        let pv_ev = events.get_mut(&pv_uuid).unwrap();
+        let pv_ev = events.iter_mut().find(|e| e.uuid == pv_uuid).unwrap();
         pv_ev.result = EventResult::Drop;
         pv_ev.destination = Destination::Drop;
 
@@ -644,12 +651,16 @@ mod tests {
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
         let pv = make_event("$pageview", None);
         let pv_uuid = pv.uuid;
-        let mut events = events_map(vec![
+        let mut events = vec![
             make_event("$exception", None),
             pv,
             make_event("click", None),
-        ]);
-        events.get_mut(&pv_uuid).unwrap().result = EventResult::Drop;
+        ];
+        events
+            .iter_mut()
+            .find(|e| e.uuid == pv_uuid)
+            .unwrap()
+            .result = EventResult::Drop;
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         // "click" still Ok, so should return Ok
@@ -664,7 +675,7 @@ mod tests {
     #[tokio::test]
     async fn empty_batch_returns_ok_when_global_limited() {
         let limiter = build_limiter("tok", true, &[]).await;
-        let mut events: HashMap<Uuid, WrappedEvent> = HashMap::new();
+        let mut events: Vec<WrappedEvent> = Vec::new();
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());
@@ -673,7 +684,7 @@ mod tests {
     #[tokio::test]
     async fn empty_batch_returns_ok_when_not_limited() {
         let limiter = build_limiter("tok", false, &[]).await;
-        let mut events: HashMap<Uuid, WrappedEvent> = HashMap::new();
+        let mut events: Vec<WrappedEvent> = Vec::new();
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
         assert!(result.is_ok());

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
 use axum::http::Method;
@@ -130,16 +129,9 @@ pub fn malformed_wrapped_event() -> WrappedEvent {
     }
 }
 
-pub fn events_map(events: Vec<WrappedEvent>) -> HashMap<Uuid, WrappedEvent> {
-    events.into_iter().map(|e| (e.uuid, e)).collect()
-}
-
-pub fn find_by_did<'a>(
-    events: &'a HashMap<Uuid, WrappedEvent>,
-    distinct_id: &str,
-) -> &'a WrappedEvent {
+pub fn find_by_did<'a>(events: &'a [WrappedEvent], distinct_id: &str) -> &'a WrappedEvent {
     events
-        .values()
+        .iter()
         .find(|e| e.event.distinct_id == distinct_id)
         .unwrap()
 }
@@ -271,6 +263,88 @@ pub fn realistic_batch() -> Vec<WrappedEvent> {
         realistic_identify("user-42"),
         realistic_custom("user-42", "button_clicked"),
     ]
+}
+
+/// 6-event batch with `user-pos-{0..5}` distinct_ids and per-slot state:
+/// 0=Ok/Main, 1=Drop, 2=Ok/Main, 3=Limited, 4=Ok/Overflow, 5=Ok/Historical.
+pub fn realistic_ordered_mixed_batch() -> Vec<WrappedEvent> {
+    let pageview_ok = realistic_pageview("user-pos-0");
+
+    let mut malformed = realistic_pageview("user-pos-1");
+    malformed.event.event = String::new();
+    malformed.event.timestamp = "bad".to_string();
+    malformed.adjusted_timestamp = None;
+    malformed.result = EventResult::Drop;
+    malformed.details = Some("missing_event_name");
+
+    let identify_ok = realistic_identify("user-pos-2");
+
+    let mut exception_limited = realistic_custom("user-pos-3", "$exception");
+    exception_limited.result = EventResult::Limited;
+    exception_limited.destination = Destination::Drop;
+    exception_limited.details = Some("exceptions_over_quota");
+
+    let click_overflow =
+        realistic_custom("user-pos-4", "button_clicked").with_destination(Destination::Overflow);
+
+    let pageview_historical =
+        realistic_pageview("user-pos-5").with_destination(Destination::AnalyticsHistorical);
+
+    vec![
+        pageview_ok,
+        malformed,
+        identify_ok,
+        exception_limited,
+        click_overflow,
+        pageview_historical,
+    ]
+}
+
+/// Two distinct `Event`s sharing one UUID — for the dup-uuid bail.
+pub fn realistic_dup_uuid_pair() -> (Event, Event) {
+    let shared_uuid = Uuid::new_v4().to_string();
+    let first = Event {
+        event: "$pageview".to_string(),
+        uuid: shared_uuid.clone(),
+        distinct_id: "user-dup-A".to_string(),
+        timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+        session_id: Some("01jq9abc-def0-1234-5678-9abcdef01234".to_string()),
+        window_id: Some("01jq9xyz-0000-4321-8765-fedcba987654".to_string()),
+        options: Options {
+            cookieless_mode: Some(false),
+            disable_skew_adjustment: None,
+            product_tour_id: None,
+            process_person_profile: Some(true),
+        },
+        properties: raw_obj(r#"{"$current_url":"https://app.example.com/dashboard"}"#),
+    };
+    let second = Event {
+        event: "$identify".to_string(),
+        uuid: shared_uuid,
+        distinct_id: "user-dup-B".to_string(),
+        timestamp: "2026-03-19T14:30:01.000Z".to_string(),
+        session_id: Some("01jq9abc-def0-1234-5678-9abcdef01234".to_string()),
+        window_id: None,
+        options: default_options(),
+        properties: raw_obj(r#"{"$set":{"email":"user@example.com"}}"#),
+    };
+    (first, second)
+}
+
+/// One Ok event per `Destination` variant + one pre-marked Drop, with
+/// ordinal `user-dest-{0..5}` distinct_ids.
+pub fn realistic_spread_destinations() -> Vec<WrappedEvent> {
+    let main = realistic_pageview("user-dest-0").with_destination(Destination::AnalyticsMain);
+    let historical =
+        realistic_pageview("user-dest-1").with_destination(Destination::AnalyticsHistorical);
+    let overflow = realistic_pageview("user-dest-2").with_destination(Destination::Overflow);
+    let dlq = realistic_pageview("user-dest-3").with_destination(Destination::Dlq);
+    let custom = realistic_pageview("user-dest-4")
+        .with_destination(Destination::Custom("custom_topic".to_string()));
+    let dropped = realistic_pageview("user-dest-5")
+        .with_result(EventResult::Drop, Some("invalid_distinct_id"))
+        .with_destination(Destination::Drop);
+    vec![main, historical, overflow, dlq, custom, dropped]
 }
 
 /// Builder for mutating a WrappedEvent after creation.


### PR DESCRIPTION
## Problem
We shouldn't remap the hydrated payload events in `capture` v1 processing pipeline until we're ready to build responses (post-publish to Kafka) so we retain original ordering in batch submissions.

Using a map of `UUID` -> `WrappedEvent` was handy but breaks contract for this.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Stick with a `Vec<WrappedEvent>` at hydration time
* Related test suite, code, and function signature updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
