### PR TITLE
feat(data-deletion) fix mat col for removal

### DIFF
--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -939,6 +939,7 @@ def mark_deletion_failed(context: dagster.HookContext) -> None:
     request_id = (
         ops_config.get("load_deletion_request", {}).get("config", {}).get("request_id")
         or ops_config.get("load_property_removal_request", {}).get("config", {}).get("request_id")
+        or ops_config.get("load_property_removal_for_replay", {}).get("config", {}).get("request_id")
         or ops_config.get("load_person_removal_request", {}).get("config", {}).get("request_id")
     )
     if not request_id:
@@ -956,7 +957,7 @@ def mark_deletion_failed(context: dagster.HookContext) -> None:
     # ``process_shard`` for that shard. We don't know which host that was at this
     # point, so broadcast the DROP to every host in every shard — DROP IF EXISTS
     # is a safe no-op on hosts that don't have it.
-    if ops_config.get("load_property_removal_request"):
+    if ops_config.get("load_property_removal_request") or ops_config.get("load_property_removal_for_replay"):
         try:
             from posthog.clickhouse.cluster import Query, get_cluster
 
@@ -1154,3 +1155,98 @@ def verify_queued_deletion_requests(context: dagster.RunStatusSensorContext):
             context.log.info(f"Deletion request {request.pk} promoted QUEUED → COMPLETED.")
 
     context.log.info(f"verify_queued_deletion_requests: {promoted} request(s) promoted this cycle.")
+
+
+# ---------------------------------------------------------------------------
+# Replay job for property removals that ran before the discover-mat-cols filter
+# fix landed. Re-uses the per-shard temp-table cycle so the heavy work happens
+# on a small local MergeTree, not via ALTER TABLE UPDATE on sharded_events.
+# ---------------------------------------------------------------------------
+
+
+@dagster.op(tags=OWNER_TAG)
+def load_property_removal_for_replay(
+    context: dagster.OpExecutionContext,
+    config: DataDeletionRequestConfig,
+) -> DeletionRequestContext:
+    """Load a PROPERTY_REMOVAL request in any status and bump it to IN_PROGRESS so the
+    standard per-shard cycle can be re-run against it.
+
+    Mirrors ``load_property_removal_request`` but accepts any starting status (not only
+    APPROVED). The intended use is replaying a request that finished before the
+    discover-mat-cols filter fix — the original cycle correctly dropped JSON keys but
+    never reset the associated ``mat_<prop>`` columns, so the rows now have stale
+    materialized values. Operators may also need to replay FAILED or partially-run
+    requests, hence the unrestricted status filter; the only enforced constraint is
+    ``request_type = PROPERTY_REMOVAL``.
+
+    Re-running ``process_property_removal_per_shard`` is naturally idempotent: its
+    presence predicate is ``JSONHas(properties, prop) OR mat_<col> != ''``, so a second
+    pass over a fully-clean request matches zero rows and does no work. Operators are
+    responsible for ensuring no other run is concurrently processing the same request
+    — there is no in-flight lock beyond the brief ``select_for_update`` window of this
+    load op.
+    """
+    from django.db import transaction
+
+    with transaction.atomic():
+        request = (
+            DataDeletionRequest.objects.select_for_update()
+            .filter(
+                pk=config.request_id,
+                request_type=RequestType.PROPERTY_REMOVAL,
+            )
+            .first()
+        )
+
+        if not request:
+            raise dagster.Failure(
+                f"Request {config.request_id} is not a property_removal request.",
+            )
+
+        _record_execution_attempt(request)
+
+    context.log.info(
+        f"Replaying property removal {request.pk} (team_id={request.team_id}, "
+        f"properties={request.properties}, events={request.events}, "
+        f"time_range={request.start_time}–{request.end_time})"
+    )
+    context.add_output_metadata(
+        {
+            "request_id": dagster.MetadataValue.text(str(request.pk)),
+            "team_id": dagster.MetadataValue.int(request.team_id),
+            "properties": dagster.MetadataValue.text(", ".join(request.properties)),
+            "events": dagster.MetadataValue.text(", ".join(request.events)),
+            "attempt_count": dagster.MetadataValue.int(request.attempt_count or 0),
+        }
+    )
+
+    assert request.start_time is not None and request.end_time is not None
+    return DeletionRequestContext(
+        request_id=str(request.pk),
+        team_id=request.team_id,
+        start_time=request.start_time,
+        end_time=request.end_time,
+        events=request.events,
+        properties=request.properties,
+        hogql_predicate=request.hogql_predicate or "",
+    )
+
+
+@dagster.job(tags=OWNER_TAG, hooks={mark_deletion_failed})
+def data_deletion_request_property_removal_replay():
+    """Replay a previously-COMPLETED PROPERTY_REMOVAL through the per-shard temp cycle.
+
+    Use this to clean up materialized-column drift left by the discover-mat-cols filter
+    bug (the cycle dropped JSON keys correctly but never reset the associated
+    ``mat_<prop>`` columns). Trigger manually from the Dagster UI per request_id.
+
+    The job uses the same copy-into-local-temp / mutate-temp / re-insert /
+    lightweight-delete-originals pipeline as the original execution, so it does NOT
+    issue ``ALTER TABLE UPDATE`` against ``sharded_events`` and works on clusters
+    without lightweight UPDATE support. Idempotent — fully-clean rows match no
+    presence predicate and the cycle no-ops.
+    """
+    request = load_property_removal_for_replay()
+    request = process_property_removal_per_shard(request)
+    finalize_deletion_request(request)

--- a/posthog/dags/locations/clickhouse.py
+++ b/posthog/dags/locations/clickhouse.py
@@ -47,6 +47,7 @@ defs = dagster.Definitions(
         backups.non_sharded_backup,
         data_deletion_requests.data_deletion_request_event_removal,
         data_deletion_requests.data_deletion_request_property_removal,
+        data_deletion_requests.data_deletion_request_property_removal_replay,
         part_breaker.break_oversized_parts,
     ],
     schedules=[

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -20,6 +20,7 @@ from posthog.dags.data_deletion_requests import (
     data_deletion_request_person_removal,
     data_deletion_request_pickup_sensor,
     data_deletion_request_property_removal,
+    data_deletion_request_property_removal_replay,
     delete_person_events_op,
     delete_person_profiles_op,
     delete_person_recordings_op,
@@ -1001,6 +1002,176 @@ def test_full_job_property_removal_clears_materialized_columns(
         assert request.status == RequestStatus.COMPLETED
     finally:
         cluster.any_host(partial(_drop_default_mat_columns, col_defs)).result()
+
+
+@pytest.mark.django_db
+def test_property_removal_replay_resets_drifted_mat_columns(cluster: ClickhouseCluster):
+    """Reproduce the historical bug (JSON cleaned, mat_<col> stale) and verify the replay
+    job heals it by re-running the per-shard temp cycle against a COMPLETED request.
+    The replay must NOT issue any ALTER TABLE UPDATE against sharded_events.
+    """
+    col_defs = [
+        ("mat_replay_a", "replay_a", "String"),
+        ("mat_replay_b", "replay_b", "Nullable(String)"),
+    ]
+    cluster.any_host(partial(_add_default_mat_columns, col_defs)).result()
+
+    other_team = PROP_TEAM_ID + 1
+    try:
+        now = datetime.now()
+        start_time = now - timedelta(days=7)
+        end_time = now + timedelta(minutes=1)
+
+        target_props = json.dumps({"replay_a": "secret_a", "replay_b": "secret_b", "keep": "yes"})
+        target_events = [
+            (PROP_TEAM_ID, "$pageview", uuid4(), now - timedelta(hours=i), target_props) for i in range(10)
+        ]
+        # Control: a different team that the replay must not touch.
+        control_events = [(other_team, "$pageview", uuid4(), now - timedelta(hours=i), target_props) for i in range(5)]
+        cluster.any_host(partial(_insert_events_with_properties, target_events + control_events)).result()
+
+        # Replay the historical bug: drop the keys from JSON, leave mat_<col> alone.
+        # Mirrors what the buggy property-removal cycle did (UPDATE properties only).
+        def _simulate_buggy_jsondrop(client: Client) -> None:
+            from django.conf import settings as ds
+
+            client.execute(
+                f"ALTER TABLE {ds.CLICKHOUSE_DATABASE}.sharded_events "
+                f"UPDATE properties = JSONDropKeys(['replay_a', 'replay_b'])(properties) "
+                f"WHERE team_id = {PROP_TEAM_ID}",
+                settings={"mutations_sync": 2},
+            )
+
+        cluster.any_host(_simulate_buggy_jsondrop).result()
+
+        # Sanity: properties cleaned for target team, but mat columns still stale.
+        for col in ("mat_replay_a", "mat_replay_b"):
+            mats = cluster.any_host(partial(_get_mat_column_values, PROP_TEAM_ID, "$pageview", col)).result()
+            assert any(v and "secret" in v for v in mats), f"setup: {col} should still be stale"
+        for props in cluster.any_host(partial(_get_properties, PROP_TEAM_ID, "$pageview")).result():
+            assert "replay_a" not in props and "replay_b" not in props
+            assert props.get("keep") == "yes"
+
+        # Record the historical execution as a COMPLETED request.
+        request = DataDeletionRequest.objects.create(
+            team_id=PROP_TEAM_ID,
+            request_type=RequestType.PROPERTY_REMOVAL,
+            events=["$pageview"],
+            properties=["replay_a", "replay_b"],
+            start_time=start_time,
+            end_time=end_time,
+            status=RequestStatus.COMPLETED,
+        )
+        # Mimic the original lifecycle counters so we can assert the replay bumps them.
+        DataDeletionRequest.objects.filter(pk=request.pk).update(
+            attempt_count=1, first_executed_at=now, last_executed_at=now
+        )
+
+        # No ALTER TABLE UPDATE on sharded_events is allowed: the temp cycle handles
+        # everything via copy/reinsert + lightweight delete. Patch the class so the test
+        # fails loudly if the replay regresses to direct mutation against the prod table.
+        from posthog.clickhouse import cluster as _cluster_mod
+
+        original_init = _cluster_mod.AlterTableMutationRunner.__init__
+
+        def _guarded_init(self, *args, **kwargs):
+            target = kwargs.get("table", args[0] if args else None)
+            assert target != "sharded_events", (
+                "AlterTableMutationRunner targeted sharded_events directly — "
+                "replay must run mutations on the local temp table only"
+            )
+            return original_init(self, *args, **kwargs)
+
+        with patch.object(_cluster_mod.AlterTableMutationRunner, "__init__", _guarded_init):
+            result = data_deletion_request_property_removal_replay.execute_in_process(
+                run_config={
+                    "ops": {
+                        "load_property_removal_for_replay": {
+                            "config": {"request_id": str(request.pk)},
+                        },
+                    },
+                },
+                resources={"cluster": cluster},
+            )
+        assert result.success
+
+        # Target team: mat columns reset.
+        for col in ("mat_replay_a", "mat_replay_b"):
+            mats = cluster.any_host(partial(_get_mat_column_values, PROP_TEAM_ID, "$pageview", col)).result()
+            non_empty = [v for v in mats if v]
+            assert not non_empty, f"{col} should be reset, got {set(non_empty)}"
+
+        # Control team untouched.
+        for col in ("mat_replay_a", "mat_replay_b"):
+            mats = cluster.any_host(partial(_get_mat_column_values, other_team, "$pageview", col)).result()
+            assert any(v and "secret" in v for v in mats), f"control {col} should be untouched"
+
+        # Lifecycle: bumped to IN_PROGRESS during run, finalized back to COMPLETED.
+        request.refresh_from_db()
+        assert request.status == RequestStatus.COMPLETED
+        assert request.attempt_count == 2
+        assert request.last_executed_at is not None
+    finally:
+        cluster.any_host(partial(_drop_default_mat_columns, col_defs)).result()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "starting_status",
+    [
+        RequestStatus.DRAFT,
+        RequestStatus.PENDING,
+        RequestStatus.APPROVED,
+        RequestStatus.IN_PROGRESS,
+        RequestStatus.COMPLETED,
+        RequestStatus.FAILED,
+    ],
+)
+def test_property_removal_replay_load_accepts_any_status(starting_status):
+    """Operators may need to replay PROPERTY_REMOVAL requests in any status — the load op
+    must accept all of them and bump to IN_PROGRESS regardless of the starting state.
+    Type is the only enforced constraint.
+    """
+    request = DataDeletionRequest.objects.create(
+        team_id=PROP_TEAM_ID,
+        request_type=RequestType.PROPERTY_REMOVAL,
+        events=["$pageview"],
+        properties=["x"],
+        start_time=datetime.now() - timedelta(days=1),
+        end_time=datetime.now(),
+        status=starting_status,
+    )
+    config = DataDeletionRequestConfig(request_id=str(request.pk))
+    ctx = build_op_context()
+
+    from posthog.dags.data_deletion_requests import load_property_removal_for_replay
+
+    result = load_property_removal_for_replay(ctx, config)
+
+    assert result.team_id == PROP_TEAM_ID
+    assert result.properties == ["x"]
+    request.refresh_from_db()
+    assert request.status == RequestStatus.IN_PROGRESS
+
+
+@pytest.mark.django_db
+def test_property_removal_replay_load_rejects_wrong_request_type():
+    """Type is the only enforced constraint — non-PROPERTY_REMOVAL requests must be
+    rejected even though every other status filter has been removed.
+    """
+    request = DataDeletionRequest.objects.create(
+        team_id=TEAM_ID,
+        request_type=RequestType.EVENT_REMOVAL,
+        events=["$pageview"],
+        start_time=datetime.now() - timedelta(days=1),
+        end_time=datetime.now(),
+        status=RequestStatus.COMPLETED,
+    )
+    config = DataDeletionRequestConfig(request_id=str(request.pk))
+    from posthog.dags.data_deletion_requests import load_property_removal_for_replay
+
+    with pytest.raises(Exception, match="not a property_removal request"):
+        load_property_removal_for_replay(build_op_context(), config)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

the bug caused some mat_col to not be cleaned despite property has been dropped

## Changes

rerun it.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
