### PR TITLE
chore(flags): add ff consumer poc to workflows

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -44,7 +44,6 @@
   target: runtime-jumphost
 
 - image: flags-consumer
-  bin: flags-consumer
   dockerfile: ./rust/Dockerfile
   project: vglf58qgzw
 

--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -43,6 +43,11 @@
   # Adds redis-cli + awscli for operator use (see bin/rust-jumphost).
   target: runtime-jumphost
 
+- image: flags-consumer
+  bin: flags-consumer
+  dockerfile: ./rust/Dockerfile
+  project: vglf58qgzw
+
 - image: batch-import-worker
   dockerfile: ./rust/Dockerfile
   project: 4ppc15q4bv

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -71,6 +71,9 @@ jobs:
                     - release: flags-cache-jumphost
                       digest_key: flags-cache-warmer
                       values_key: image
+                    - release: flags-consumer
+                      digest_key: flags-consumer
+                      values_key: image
                     - release: batch-import-worker
                       digest_key: batch-import-worker
                       values_key: image


### PR DESCRIPTION
## Problem

The https://github.com/PostHog/posthog/pull/54202/ was merged, but to be able to deploy it in dev, we should be able to generate the image using the CI.

## Changes

Add the image to workflow and docker build matrix.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
