### PR TITLE
feat(notebooks): log snapshots on collab save and reject

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
@@ -51,6 +51,16 @@ function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityL
                         const isCurrent = getFieldChange(logItem, 'version') === notebook?.version
                         const changedContent = getFieldChange(logItem, 'content')
                         const isButton = changedContent && !isCurrent
+                        const isRejected = logItem.activity.startsWith('save_rejected_')
+
+                        let actionLabel: string
+                        if (isRejected) {
+                            actionLabel = 'unsaved changes'
+                        } else if (changedContent) {
+                            actionLabel = 'made changes'
+                        } else {
+                            actionLabel = 'created this'
+                        }
 
                         const buttonContent = (
                             <span className="flex flex-1 gap-2 items-center p-2">
@@ -63,8 +73,7 @@ function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityL
                                     size="md"
                                 />
                                 <span className="flex-1">
-                                    <b className="ph-no-capture">{name}</b>{' '}
-                                    {changedContent ? 'made changes' : 'created this'}
+                                    <b className="ph-no-capture">{name}</b> {actionLabel}
                                 </span>
                                 <span className="text-secondary">
                                     <TZLabel time={logItem.created_at} />

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
@@ -27,6 +27,7 @@ const getFieldChange = (logItem: ActivityLogItem, field: string): any => {
 
 function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityLogItem) => void }): JSX.Element {
     const { shortId, notebook, previewContent } = useValues(notebookLogic)
+    const { clearPreviewContent } = useActions(notebookLogic)
 
     const logic = activityLogLogic({ scope: ActivityScope.NOTEBOOK, id: shortId })
     const { activity, pagination, activityLoading } = useValues(logic)
@@ -46,12 +47,16 @@ function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityL
                         <LemonSkeleton className="w-full h-10" repeat={10} />
                     </div>
                 ) : (
-                    activityWithChangedContent?.map((logItem: ActivityLogItem) => {
+                    activityWithChangedContent?.map((logItem: ActivityLogItem, idx: number) => {
                         const name = userNameForLogItem(logItem)
-                        const isCurrent = getFieldChange(logItem, 'version') === notebook?.version
-                        const changedContent = getFieldChange(logItem, 'content')
-                        const isButton = changedContent && !isCurrent
                         const isRejected = logItem.activity.startsWith('save_rejected_')
+                        const isLastSaved = !isRejected && getFieldChange(logItem, 'version') === notebook?.version
+                        // Top of the chronological list = most recent save attempt (accepted or rejected),
+                        // which is what the editor is currently showing.
+                        const isCurrent = idx === 0
+                        const changedContent = getFieldChange(logItem, 'content')
+                        // Current entry is also clickable
+                        const isButton = !!changedContent
 
                         let actionLabel: string
                         if (isRejected) {
@@ -78,7 +83,13 @@ function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityL
                                 <span className="text-secondary">
                                     <TZLabel time={logItem.created_at} />
                                 </span>
-                                {isCurrent ? <span className="text-secondary">(Current)</span> : null}
+                                {isCurrent && isLastSaved ? (
+                                    <span className="text-secondary">(Current, saved)</span>
+                                ) : isCurrent ? (
+                                    <span className="text-secondary">(Current)</span>
+                                ) : isLastSaved ? (
+                                    <span className="text-secondary">(Last saved)</span>
+                                ) : null}
                             </span>
                         )
 
@@ -88,8 +99,8 @@ function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityL
                                     <LemonButton
                                         fullWidth
                                         size="small"
-                                        active={previewContent === changedContent}
-                                        onClick={() => onItemClick(logItem)}
+                                        active={isCurrent ? !previewContent : previewContent === changedContent}
+                                        onClick={() => (isCurrent ? clearPreviewContent() : onItemClick(logItem))}
                                         noPadding
                                     >
                                         {buttonContent}

--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
@@ -51,9 +51,8 @@ function NotebookHistoryList({ onItemClick }: { onItemClick: (logItem: ActivityL
                         const name = userNameForLogItem(logItem)
                         const isRejected = logItem.activity.startsWith('save_rejected_')
                         const isLastSaved = !isRejected && getFieldChange(logItem, 'version') === notebook?.version
-                        // Top of the chronological list = most recent save attempt (accepted or rejected),
-                        // which is what the editor is currently showing.
-                        const isCurrent = idx === 0
+                        // Top of page 1 = most recent attempt (what the editor is showing)
+                        const isCurrent = idx === 0 && pagination.currentPage === 1
                         const changedContent = getFieldChange(logItem, 'content')
                         // Current entry is also clickable
                         const isButton = !!changedContent

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -761,8 +761,10 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             cursor_head=data.get("cursor_head"),
         )
 
+        content = data["content"]
+        notebook_before = Notebook.objects.get(pk=notebook.pk)
+
         if result.status == "accepted":
-            content = data["content"]
             Notebook.objects.filter(pk=notebook.pk).update(
                 content=annotate_python_nodes(content) if isinstance(content, dict) else content,
                 text_content=data.get("text_content", ""),
@@ -772,7 +774,40 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
                 last_modified_by=request.user,
             )
             notebook.refresh_from_db()
+
+            # Snapshot diffs into the activity logs for history
+            changes = changes_between("Notebook", previous=notebook_before, current=notebook)
+            log_notebook_activity(
+                activity="updated",
+                notebook=notebook,
+                organization_id=user.current_organization_id,
+                team_id=notebook.team_id,
+                user=user,
+                was_impersonated=is_impersonated_session(request),
+                changes=changes,
+            )
+
             return Response(NotebookSerializer(notebook, context=self.get_serializer_context()).data)
+
+        # Save was rejected, server's content is unchanged.
+        # Snapshot the attempted save state so the user has a recovery path.
+        log_notebook_activity(
+            activity=f"save_rejected_{result.status}",  # save_rejected_conflict | save_rejected_stale
+            notebook=notebook,
+            organization_id=user.current_organization_id,
+            team_id=notebook.team_id,
+            user=user,
+            was_impersonated=is_impersonated_session(request),
+            changes=[
+                Change(
+                    type="Notebook",
+                    field="content",
+                    action="changed",
+                    before=notebook_before.content,
+                    after=content,
+                ),
+            ],
+        )
 
         if result.status == "stale":
             return Response(

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -762,9 +762,9 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         )
 
         content = data["content"]
-        notebook_before = Notebook.objects.get(pk=notebook.pk)
 
         if result.status == "accepted":
+            notebook_before = Notebook.objects.get(pk=notebook.pk)
             Notebook.objects.filter(pk=notebook.pk).update(
                 content=annotate_python_nodes(content) if isinstance(content, dict) else content,
                 text_content=data.get("text_content", ""),
@@ -789,8 +789,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
             return Response(NotebookSerializer(notebook, context=self.get_serializer_context()).data)
 
-        # Save was rejected, server's content is unchanged.
-        # Snapshot the attempted save state so the user has a recovery path.
+        # Snapshot the rejected save attempt so user has a recovery path
         log_notebook_activity(
             activity=f"save_rejected_{result.status}",  # save_rejected_conflict | save_rejected_stale
             notebook=notebook,
@@ -803,7 +802,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
                     type="Notebook",
                     field="content",
                     action="changed",
-                    before=notebook_before.content,
+                    before=notebook.content,
                     after=content,
                 ),
             ],

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -780,7 +780,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             log_notebook_activity(
                 activity="updated",
                 notebook=notebook,
-                organization_id=user.current_organization_id,
+                organization_id=cast(UUIDT, user.current_organization_id),
                 team_id=notebook.team_id,
                 user=user,
                 was_impersonated=is_impersonated_session(request),
@@ -794,7 +794,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         log_notebook_activity(
             activity=f"save_rejected_{result.status}",  # save_rejected_conflict | save_rejected_stale
             notebook=notebook,
-            organization_id=user.current_organization_id,
+            organization_id=cast(UUIDT, user.current_organization_id),
             team_id=notebook.team_id,
             user=user,
             was_impersonated=is_impersonated_session(request),

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -8,6 +8,7 @@ from rest_framework import status
 
 from posthog import redis as redis_module
 from posthog.models import Team
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
@@ -169,6 +170,99 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
         assert response.status_code == status.HTTP_410_GONE
         data = response.json()
         assert data["code"] == "conflict_stale"
+
+    def test_collab_save_accepted_logs_diff_against_pre_update_snapshot(self):
+        # The activity log records a diff between `notebook_before` and `notebook`
+        # Django returns independent Python objects per `.get()`,
+        # so refreshing one must not bleed into the other
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = notebook["version"]
+
+        response = self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            content=UPDATED_DOC,
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        log = ActivityLog.objects.get(
+            team_id=self.team.id,
+            scope="Notebook",
+            item_id=notebook["short_id"],
+            activity="updated",
+        )
+        assert log.detail is not None
+        changes_by_field = {c["field"]: c for c in log.detail["changes"]}
+
+        assert changes_by_field["content"]["action"] == "changed"
+        assert changes_by_field["content"]["before"] == SAMPLE_DOC
+        assert changes_by_field["content"]["after"] == UPDATED_DOC
+
+        assert changes_by_field["version"]["action"] == "changed"
+        assert changes_by_field["version"]["before"] == version
+        assert changes_by_field["version"]["after"] == version + 1
+
+        # text_content is excluded from Notebook diffs and should never surface
+        assert "text_content" not in changes_by_field
+
+    def test_collab_save_rejected_stale_logs_attempted_content(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+
+        with patch("products.notebooks.backend.api.notebook.submit_steps") as mock_submit:
+            mock_submit.return_value = SubmitResult(status="stale", version=5, steps_since=None)
+            self._collab_save(
+                notebook,
+                version=0,
+                steps=[{"stepType": "replace", "from": 0, "to": 0}],
+                content=UPDATED_DOC,
+            )
+
+        log = ActivityLog.objects.get(
+            team_id=self.team.id,
+            scope="Notebook",
+            item_id=notebook["short_id"],
+            activity="save_rejected_stale",
+        )
+        assert log.detail is not None
+        [change] = log.detail["changes"]
+        assert change["field"] == "content"
+        assert change["before"] == SAMPLE_DOC
+        assert change["after"] == UPDATED_DOC
+
+    def test_collab_save_rejected_conflict_logs_attempted_content(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = notebook["version"]
+
+        self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            client_id="client-1",
+        )
+
+        rejected_doc = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "C2"}]}]}
+        response = self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 1, "to": 1}],
+            content=rejected_doc,
+            client_id="client-2",
+        )
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+        log = ActivityLog.objects.get(
+            team_id=self.team.id,
+            scope="Notebook",
+            item_id=notebook["short_id"],
+            activity="save_rejected_conflict",
+        )
+        assert log.detail is not None
+        [change] = log.detail["changes"]
+        assert change["field"] == "content"
+        # `before` is the server's content at rejection time (post client-1's accepted save)
+        assert change["before"] == UPDATED_DOC
+        assert change["after"] == rejected_doc
 
 
 # Keep the SSE generator lifetime tiny so tests terminate deterministically.


### PR DESCRIPTION
## Problem

The collab notebook save path (`/collab/save/`) isn't writing to the activity log. The legacy PATCH path used to log every accepted save via `NotebookSerializer.update()`,  but in the collab path, there is no per-save snapshot to fall back on if a user lost changes because of a sync glitch.

This PR adds logging on every save attempt - both accepted and rejected, surfacing them in the history sidebar.
 
> Note: the snapshot volume can become pretty large, so we could make it part of the Scale plan later. Now the history feature is available to all users

## Changes

**Backend**: 

- `collab_save` now writes an activity log entry on every save attempt, mirroring the legacy PATCH and adding new entries for rejected ones: 
    - Accepted → `activity="updated"`
    - 409 conflict → `activity="save_rejected_conflict"`
    - 410 stale → `activity="save_rejected_stale"` 
- The rejected-save snapshot is the only server-side record of in-progress work the user could lose if their local rebase fails before they reload, it's the recovery path.

**Frontend** :

- Labels rejected entries as **"unsaved changes"** instead of "made changes" so users can tell synced and unsynced rows apart.
- Adds two markers in the sidebar:
    - `(Last saved)` on the row matching the current Postgres `notebook.version`
    - `(Current)` on the topmost (most recent) entry, what the editor last attempted to save.
    - Collapses to `(Current, saved)` when both apply to the same row (no rejected attempts since the last save).
- The current entry is now clickable. Clicking it clears any active preview to return to the live view.

## How did you test this code?

<!-- Agent-assisted PR. Manual testing performed by the human author: -->

- Triggered a 410 and 409 conflict path locally
- Verified the history sidebar surfaces both with the "unsaved changes" label, that `(Last saved)` lands on the last accepted row, and that `(Current)` lands on the topmost entry.

**Save accepted:** 

![2026-05-07 01.17.39.gif](https://app.graphite.com/user-attachments/assets/b331d205-6690-4f53-b5ce-230c8697b913.gif)

**Save rejected:** 

![2026-05-07 13.06.00.gif](https://app.graphite.com/user-attachments/assets/90bdb9b0-a1a9-4d9f-9a4e-3f85c61b75b3.gif)

## Publish to changelog?

No

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->