### PR TITLE
fix(capture): update v1 Retry-After handling for spec parity

### DIFF
--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -10,8 +10,9 @@ pub const ACCEPT_JSON: HeaderValue = HeaderValue::from_static("application/json"
 /// Accepted compression encodings advertised in Accept-Encoding response header.
 pub const ACCEPT_ENCODING_ALL: HeaderValue = HeaderValue::from_static("gzip, deflate, br, zstd");
 
-/// Default Retry-After value (seconds) sent on rate-limited or server-error responses.
-pub const DEFAULT_RETRY_AFTER_SECS: HeaderValue = HeaderValue::from_static("60");
+/// Retry-After value (seconds) sent on retryable error responses (429, 408, 5xx).
+/// SDKs are expected to layer their own jittered exponential backoff on top of this floor.
+pub const DEFAULT_RETRY_AFTER_SECS: HeaderValue = HeaderValue::from_static("1");
 
 // ---------------------------------------------------------------------------
 // Supported content encodings

--- a/rust/capture/src/v1/error.rs
+++ b/rust/capture/src/v1/error.rs
@@ -271,7 +271,16 @@ impl Error {
         headers.insert(header::ACCEPT, ACCEPT_JSON);
         headers.insert(header::ACCEPT_ENCODING, ACCEPT_ENCODING_ALL);
 
-        if let Self::RateLimited(_) = self {
+        // 402 (BillingLimitExceeded) is intentionally non-retryable per RFC, so no Retry-After.
+        if matches!(
+            self,
+            Self::RateLimited(_)
+                | Self::RequestTimeout
+                | Self::BodyReadTimeout(_)
+                | Self::InternalError(_)
+                | Self::ServiceUnavailable(_)
+                | Self::GatewayTimeout
+        ) {
             headers.insert(header::RETRY_AFTER, DEFAULT_RETRY_AFTER_SECS);
         }
 
@@ -366,6 +375,7 @@ mod tests {
     use super::*;
     use axum::body::to_bytes;
     use axum::http::header::RETRY_AFTER;
+    use rstest::rstest;
 
     async fn response_body(resp: Response) -> serde_json::Value {
         let bytes = to_bytes(resp.into_body(), 65_536).await.unwrap();
@@ -383,14 +393,6 @@ mod tests {
         assert_eq!(body["error"], expected_tag);
         assert!(body["error_description"].is_string());
         assert!(body["error_uri"].is_string());
-    }
-
-    #[tokio::test]
-    async fn rate_limited_includes_retry_after() {
-        let err = Error::RateLimited("too many requests".into());
-        let resp = err.into_response();
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        assert!(resp.headers().contains_key(RETRY_AFTER));
     }
 
     #[tokio::test]
@@ -423,5 +425,42 @@ mod tests {
         let err = Error::GatewayTimeout;
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+    }
+
+    #[rstest]
+    #[case::rate_limited(Error::RateLimited("too many".into()), StatusCode::TOO_MANY_REQUESTS)]
+    #[case::request_timeout(Error::RequestTimeout, StatusCode::REQUEST_TIMEOUT)]
+    #[case::body_read_timeout(Error::BodyReadTimeout(1024), StatusCode::REQUEST_TIMEOUT)]
+    #[case::internal_error(Error::InternalError("boom".into()), StatusCode::INTERNAL_SERVER_ERROR)]
+    #[case::service_unavailable(Error::ServiceUnavailable("nope".into()), StatusCode::SERVICE_UNAVAILABLE)]
+    #[case::gateway_timeout(Error::GatewayTimeout, StatusCode::GATEWAY_TIMEOUT)]
+    #[tokio::test]
+    async fn retryable_errors_emit_retry_after_one_second(
+        #[case] err: Error,
+        #[case] expected_status: StatusCode,
+    ) {
+        let resp = err.into_response();
+        assert_eq!(resp.status(), expected_status);
+        let value = resp
+            .headers()
+            .get(RETRY_AFTER)
+            .expect("Retry-After header must be present on retryable errors");
+        assert_eq!(value.to_str().unwrap(), "1");
+    }
+
+    #[rstest]
+    #[case::billing_limit(Error::BillingLimitExceeded)]
+    #[case::invalid_api_token(Error::InvalidApiToken("bad".into()))]
+    #[case::empty_batch(Error::EmptyBatch)]
+    #[case::payload_too_large(Error::PayloadTooLarge("big".into()))]
+    #[case::unsupported_content_type(Error::UnsupportedContentType("text/plain".into()))]
+    #[tokio::test]
+    async fn non_retryable_errors_omit_retry_after(#[case] err: Error) {
+        let resp = err.into_response();
+        assert!(
+            !resp.headers().contains_key(RETRY_AFTER),
+            "Retry-After must NOT be present on non-retryable errors (status {})",
+            resp.status()
+        );
     }
 }

--- a/rust/capture/src/v1/error.rs
+++ b/rust/capture/src/v1/error.rs
@@ -85,13 +85,9 @@ pub enum Error {
     #[error("body read stalled after receiving {0} bytes")]
     BodyReadTimeout(usize),
 
-    // 402 - billing_error (non-retryable, unlike 429)
+    // 402 - billing_error (non-retryable)
     #[error("billing limit exceeded")]
     BillingLimitExceeded,
-
-    // 429 - rate_limit_error
-    #[error("rate limited: {0}")]
-    RateLimited(String),
 
     // 500 - server_error
     #[error("internal server error: {0}")]
@@ -133,7 +129,6 @@ impl Error {
             Self::UnsupportedContentType(_) => "unsupported_content_type",
             Self::UnsupportedEncoding(_) => "unsupported_encoding",
             Self::BillingLimitExceeded => "billing_limit_exceeded",
-            Self::RateLimited(_) => "rate_limited",
             Self::InternalError(_) => "internal_error",
             Self::ServiceUnavailable(_) => "service_unavailable",
             Self::GatewayTimeout => "gateway_timeout",
@@ -146,7 +141,6 @@ impl Error {
             Self::RequestParsingError(_) => "Failed to parse request body.".to_string(),
             Self::InvalidApiToken(_) => "The provided API token is not valid.".to_string(),
             Self::BillingLimitExceeded => "Billing quota exceeded. Events are being dropped. Upgrade your plan to resume ingestion.".to_string(),
-            Self::RateLimited(_) => "Rate limit exceeded.".to_string(),
             Self::InternalError(_) | Self::ServiceUnavailable(_) | Self::GatewayTimeout => self
                 .status_code()
                 .canonical_reason()
@@ -189,8 +183,7 @@ impl Error {
             | Self::PayloadTooLarge(_)
             | Self::UnsupportedContentType(_)
             | Self::UnsupportedEncoding(_)
-            | Self::BillingLimitExceeded
-            | Self::RateLimited(_) => Level::WARN,
+            | Self::BillingLimitExceeded => Level::WARN,
 
             // body read timeout: error-level despite being 4xx
             Self::BodyReadTimeout(_) => Level::ERROR,
@@ -256,8 +249,6 @@ impl Error {
 
             Self::BillingLimitExceeded => StatusCode::PAYMENT_REQUIRED,
 
-            Self::RateLimited(_) => StatusCode::TOO_MANY_REQUESTS,
-
             Self::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
 
             Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
@@ -274,8 +265,7 @@ impl Error {
         // 402 (BillingLimitExceeded) is intentionally non-retryable per RFC, so no Retry-After.
         if matches!(
             self,
-            Self::RateLimited(_)
-                | Self::RequestTimeout
+            Self::RequestTimeout
                 | Self::BodyReadTimeout(_)
                 | Self::InternalError(_)
                 | Self::ServiceUnavailable(_)
@@ -428,7 +418,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rate_limited(Error::RateLimited("too many".into()), StatusCode::TOO_MANY_REQUESTS)]
     #[case::request_timeout(Error::RequestTimeout, StatusCode::REQUEST_TIMEOUT)]
     #[case::body_read_timeout(Error::BodyReadTimeout(1024), StatusCode::REQUEST_TIMEOUT)]
     #[case::internal_error(Error::InternalError("boom".into()), StatusCode::INTERNAL_SERVER_ERROR)]


### PR DESCRIPTION
## Problem
Re-align `Retry-After` header mapping in responses w/recent RFC/API spec changes.

Now that we won't be dropping globally rate limited events, the scope of "actually retriable requests" has changed: now it's 5xx style requests where a faster turnaround (with SDK-backoff based on orig request's attempt count) is more appropriate.

For global rate limited events (high cardinality distinct_ids on events from a team) these will be marked as such in responses but won't require retries as they are simply rerouted to overflow w/o person processing.

For other rate limited types in capture (and v1) such as quota limited, these either cause a scoped partial-batch fail (individual events marked as dropped with the quota they exceeded; SDKs will not retry) or full batch is marked as rate limited (402; SDKs won't retry)

## Changes

- `DEFAULT_RETRY_AFTER_SECS` flipped from `"60"` to `"1"`
    - SDKs layer their own jittered backoff above the floor
    - Responses to SDKs will also include the request's attempt count header (handled elsewhere)
- `Error::response_headers` now emits `Retry-After` for  `RequestTimeout`, `BodyReadTimeout`, `InternalError`, `ServiceUnavailable`, and `GatewayTimeout`.
- `BillingLimitExceeded` (402) intentionally still omits the header — the RFC marks it non-retryable.
- Remove `RateLimited` error type and 429 response; as of the change to the Global Rate Limiter plan, we won't be returning these anywhere
- Added parameterized rstest coverage for retriable vs. non-retriable error-to-response-header mappings

Not implemented yet: inclusion of `Retry-After` on partial-batch-failure `2xx` responses. Will be added in a follow-on as part of the HTTP response handling

## How did you test this code?
Locally and in CI

## Publish to changelog?
N/A

## Docs update
N/A