### PR TITLE
fix(capture): update v1 event labeling for response to match new Global Rate Limiter behavior (spec parity)

### DIFF
--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -51,7 +51,8 @@ pub(crate) const CAPTURE_V1_EVENTS_QUOTA_LIMITED: &str = "capture_v1_events_quot
 pub(crate) const CAPTURE_V1_RATE_LIMITER: &str = "capture_v1_rate_limiter";
 
 /// Detail tag for events flagged by the per-token:distinct_id rate limiter.
-pub(super) const DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID: &str = "rate_limited_token_distinct_id";
+/// Matches the OpenAPI BatchEntryStatusError example for `result: limited`.
+pub(super) const DETAIL_PERSON_PROCESSING_DISABLED: &str = "person_processing_disabled";
 
 // ---------------------------------------------------------------------------
 // Payload size limits

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::constants::{
     CAPTURE_V1_DISTINCT_ID_MAX_SIZE, CAPTURE_V1_EVENTS_DROPPED,
     CAPTURE_V1_EVENTS_REROUTED_HISTORICAL, CAPTURE_V1_MAX_EVENT_NAME_LENGTH,
-    CAPTURE_V1_PARSED_EVENTS, CAPTURE_V1_RATE_LIMITER, DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID,
+    CAPTURE_V1_PARSED_EVENTS, CAPTURE_V1_RATE_LIMITER, DETAIL_PERSON_PROCESSING_DISABLED,
     FUTURE_EVENT_HOURS_CUTOFF_MS, ILLEGAL_DISTINCT_IDS,
 };
 use super::response::Response;
@@ -303,8 +303,9 @@ async fn apply_token_distinct_id_limits(
             GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
                 .to_cache_key();
         if limiter.is_limited(&cache_key, 1).await.is_some() {
+            event.result = EventResult::Limited;
             event.force_disable_person_processing = true;
-            event.details = Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID);
+            event.details = Some(DETAIL_PERSON_PROCESSING_DISABLED);
             limited_distinct_ids.insert(event.event.distinct_id.as_str());
         } else {
             allowed_count += 1;
@@ -1132,13 +1133,10 @@ mod tests {
         assert_eq!(ok_ev.destination, Destination::AnalyticsMain);
         assert!(ok_ev.details.is_none());
         let limited_ev = find_by_did(&events, "user-2");
-        assert_eq!(limited_ev.result, EventResult::Ok);
+        assert_eq!(limited_ev.result, EventResult::Limited);
         assert_eq!(limited_ev.destination, Destination::AnalyticsMain);
         assert!(limited_ev.force_disable_person_processing);
-        assert_eq!(
-            limited_ev.details,
-            Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
-        );
+        assert_eq!(limited_ev.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
 
     #[tokio::test]
@@ -1168,7 +1166,7 @@ mod tests {
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
         for ev in &events {
-            assert_eq!(ev.result, EventResult::Ok, "should stay Ok");
+            assert_eq!(ev.result, EventResult::Limited, "should be Limited");
             assert_eq!(
                 ev.destination,
                 Destination::AnalyticsMain,
@@ -1180,7 +1178,7 @@ mod tests {
             );
             assert_eq!(
                 ev.details,
-                Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID),
+                Some(DETAIL_PERSON_PROCESSING_DISABLED),
                 "should have details"
             );
         }
@@ -1206,10 +1204,10 @@ mod tests {
         assert_eq!(dropped.destination, Destination::Drop);
         // Other event rate-limited (person processing disabled, stays on main topic)
         let limited = find_by_did(&events, "user-2");
-        assert_eq!(limited.result, EventResult::Ok);
+        assert_eq!(limited.result, EventResult::Limited);
         assert_eq!(limited.destination, Destination::AnalyticsMain);
         assert!(limited.force_disable_person_processing);
-        assert_eq!(limited.details, Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID));
+        assert_eq!(limited.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
 
     // --- apply_historical_rerouting ---
@@ -1501,16 +1499,12 @@ mod tests {
         );
         assert!(!events[0].force_disable_person_processing);
         assert!(events[1].force_disable_person_processing);
-        assert_eq!(
-            events[1].details,
-            Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
-        );
+        assert_eq!(events[1].result, EventResult::Limited);
+        assert_eq!(events[1].details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
         assert!(!events[2].force_disable_person_processing);
         assert!(events[3].force_disable_person_processing);
-        assert_eq!(
-            events[3].details,
-            Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
-        );
+        assert_eq!(events[3].result, EventResult::Limited);
+        assert_eq!(events[3].details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
         assert!(!events[4].force_disable_person_processing);
     }
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -105,14 +105,9 @@ impl SinkEvent for WrappedEvent {
         self.uuid
     }
 
-    // Helps the Sink implementations filter events that were marked
-    // as ineligible for publishing in the request preprocessing step.
-    // Limited events DO publish (e.g. token:distinct_id rate limiting:
-    // event accepted with person processing disabled per RFC), unless
-    // they were also routed to Drop (e.g. scoped billing quota).
+    // Publish Ok and Limited events; skip Drop, Retry, and anything routed to Destination::Drop.
     fn should_publish(&self) -> bool {
-        self.result != EventResult::Drop
-            && self.result != EventResult::Retry
+        (self.result == EventResult::Ok || self.result == EventResult::Limited)
             && self.destination != Destination::Drop
     }
 
@@ -707,48 +702,30 @@ mod tests {
         test_utils::wrapped_event(event_name, distinct_id)
     }
 
-    #[test]
-    fn should_publish_ok_and_non_drop() {
-        let ev = ok_wrapped("$pageview", "user-1");
+    #[rstest::rstest]
+    #[case::ok_main(EventResult::Ok, Destination::AnalyticsMain)]
+    #[case::ok_historical(EventResult::Ok, Destination::AnalyticsHistorical)]
+    #[case::ok_overflow(EventResult::Ok, Destination::Overflow)]
+    #[case::limited_main(EventResult::Limited, Destination::AnalyticsMain)]
+    #[case::limited_historical(EventResult::Limited, Destination::AnalyticsHistorical)]
+    fn should_publish_true(#[case] result: EventResult, #[case] dest: Destination) {
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.result = result;
+        ev.destination = dest;
         assert!(ev.should_publish());
     }
 
-    #[test]
-    fn should_publish_false_when_dropped() {
+    #[rstest::rstest]
+    #[case::drop_main(EventResult::Drop, Destination::AnalyticsMain)]
+    #[case::retry_main(EventResult::Retry, Destination::AnalyticsMain)]
+    #[case::ok_dest_drop(EventResult::Ok, Destination::Drop)]
+    #[case::limited_dest_drop(EventResult::Limited, Destination::Drop)]
+    #[case::drop_dest_drop(EventResult::Drop, Destination::Drop)]
+    #[case::retry_dest_drop(EventResult::Retry, Destination::Drop)]
+    fn should_publish_false(#[case] result: EventResult, #[case] dest: Destination) {
         let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.result = EventResult::Drop;
-        assert!(!ev.should_publish());
-    }
-
-    #[test]
-    fn should_publish_false_when_destination_drop() {
-        let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.destination = Destination::Drop;
-        assert!(!ev.should_publish());
-    }
-
-    #[test]
-    fn should_publish_true_when_limited_and_main_destination() {
-        let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.result = EventResult::Limited;
-        assert!(
-            ev.should_publish(),
-            "Limited+main must publish per RFC: event accepted, person processing disabled"
-        );
-    }
-
-    #[test]
-    fn should_publish_false_when_limited_and_destination_drop() {
-        let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.result = EventResult::Limited;
-        ev.destination = Destination::Drop;
-        assert!(!ev.should_publish());
-    }
-
-    #[test]
-    fn should_publish_false_when_retry() {
-        let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.result = EventResult::Retry;
+        ev.result = result;
+        ev.destination = dest;
         assert!(!ev.should_publish());
     }
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -708,6 +708,7 @@ mod tests {
     #[case::ok_overflow(EventResult::Ok, Destination::Overflow)]
     #[case::limited_main(EventResult::Limited, Destination::AnalyticsMain)]
     #[case::limited_historical(EventResult::Limited, Destination::AnalyticsHistorical)]
+    #[case::limited_overflow(EventResult::Limited, Destination::Overflow)]
     fn should_publish_true(#[case] result: EventResult, #[case] dest: Destination) {
         let mut ev = ok_wrapped("$pageview", "user-1");
         ev.result = result;

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -107,8 +107,13 @@ impl SinkEvent for WrappedEvent {
 
     // Helps the Sink implementations filter events that were marked
     // as ineligible for publishing in the request preprocessing step.
+    // Limited events DO publish (e.g. token:distinct_id rate limiting:
+    // event accepted with person processing disabled per RFC), unless
+    // they were also routed to Drop (e.g. scoped billing quota).
     fn should_publish(&self) -> bool {
-        self.result == EventResult::Ok && self.destination != Destination::Drop
+        self.result != EventResult::Drop
+            && self.result != EventResult::Retry
+            && self.destination != Destination::Drop
     }
 
     // Resolve the storage-agnostic Destination scope for this event.
@@ -723,9 +728,27 @@ mod tests {
     }
 
     #[test]
-    fn should_publish_false_when_limited() {
+    fn should_publish_true_when_limited_and_main_destination() {
         let mut ev = ok_wrapped("$pageview", "user-1");
         ev.result = EventResult::Limited;
+        assert!(
+            ev.should_publish(),
+            "Limited+main must publish per RFC: event accepted, person processing disabled"
+        );
+    }
+
+    #[test]
+    fn should_publish_false_when_limited_and_destination_drop() {
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.result = EventResult::Limited;
+        ev.destination = Destination::Drop;
+        assert!(!ev.should_publish());
+    }
+
+    #[test]
+    fn should_publish_false_when_retry() {
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.result = EventResult::Retry;
         assert!(!ev.should_publish());
     }
 


### PR DESCRIPTION
## Problem
Get the new capture v1 event handling and response labeling in parity with recent Global Rate Limiter's overflow-rerouting changes.

## Changes

- `apply_token_distinct_id_limits` now sets `event.result = EventResult::Limited` alongside the existing `force_disable_person_processing = true` flag
- Detail tag renamed `rate_limited_token_distinct_id` -> `person_processing_disabled` (matches the OpenAPI `BatchEntryStatusError` example for `result: limited`)
- `WrappedEvent::should_publish` extended so Limited events still publish unless they were also routed to `Destination::Drop` (e.g. scoped billing quota). This preserves existing scoped-quota behavior (Limited + Destination::Drop still not published) while letting token:distinct_id rate-limited events publish with person processing disabled, as the RFC requires
- `should_publish` truth table filled out: Limited+main publishes, Limited+Drop does not, Retry does not
- `td_limits_*` test assertions flipped from `Ok` to `Limited` and tag references updated


## How did you test this code?
Locally and in CI

## Publish to changelog?
N/A


## Docs update
N/A
