### PR TITLE
feat(capture): misc. small RFC parity papercuts for capture v1

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -246,6 +246,14 @@ pub struct Config {
     /// Empty string means the v1 sink layer is disabled.
     #[envconfig(default = "")]
     pub capture_v1_sinks: String,
+
+    /// Maximum compressed (wire) body size the v1 endpoint will accept (bytes).
+    #[envconfig(default = "10485760")]
+    pub capture_v1_max_compressed_body_bytes: usize,
+
+    /// Maximum decompressed body size the v1 endpoint will accept (bytes).
+    #[envconfig(default = "52428800")]
+    pub capture_v1_max_decompressed_body_bytes: usize,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -52,6 +52,8 @@ pub struct State {
     pub ai_blob_storage: Option<Arc<dyn BlobStorage>>,
     pub body_chunk_read_timeout: Option<Duration>,
     pub body_read_chunk_size_kb: usize,
+    pub capture_v1_max_compressed_body_bytes: usize,
+    pub capture_v1_max_decompressed_body_bytes: usize,
     /// In-process overflow limiter (governor-backed) for `DataType::AnalyticsMain`
     /// events. When present, every handler that emits analytics events runs
     /// the shared `events::overflow_stamping::stamp_overflow_reason` helper,
@@ -136,6 +138,8 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
     request_timeout_seconds: Option<u64>,
     body_chunk_read_timeout_ms: Option<u64>,
     body_read_chunk_size_kb: usize,
+    capture_v1_max_compressed_body_bytes: usize,
+    capture_v1_max_decompressed_body_bytes: usize,
     overflow_limiter: Option<Arc<OverflowLimiter>>,
     replay_overflow_limiter: Option<Arc<RedisLimiter>>,
 ) -> Router {
@@ -158,6 +162,8 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
         ai_blob_storage,
         body_chunk_read_timeout: body_chunk_read_timeout_ms.map(Duration::from_millis),
         body_read_chunk_size_kb,
+        capture_v1_max_compressed_body_bytes,
+        capture_v1_max_decompressed_body_bytes,
         overflow_limiter,
         replay_overflow_limiter,
     };

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -275,6 +275,8 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         config.request_timeout_seconds,
         config.body_chunk_read_timeout_ms,
         config.body_read_chunk_size_kb,
+        config.capture_v1_max_compressed_body_bytes,
+        config.capture_v1_max_decompressed_body_bytes,
         overflow_limiter,
         replay_overflow_limiter,
     );

--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -59,17 +59,6 @@ pub(super) const DETAIL_PERSON_PROCESSING_DISABLED: &str = "person_processing_di
 pub(super) const DETAIL_EVENT_RESTRICTION_DROP: &str = "event_restriction_drop";
 
 // ---------------------------------------------------------------------------
-// Payload size limits
-// ---------------------------------------------------------------------------
-
-/// Maximum compressed (wire) body size the v1 endpoint will accept.
-pub(super) const CAPTURE_V1_MAX_COMPRESSED_BODY_BYTES: usize = 10 * 1024 * 1024; // 10MB
-
-/// Maximum decompressed body size (5x compressed limit per RFC).
-pub(crate) const CAPTURE_V1_MAX_DECOMPRESSED_BODY_BYTES: usize =
-    CAPTURE_V1_MAX_COMPRESSED_BODY_BYTES * 5; // 50MB
-
-// ---------------------------------------------------------------------------
 // Validation limits
 // ---------------------------------------------------------------------------
 

--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -55,13 +55,19 @@ pub(crate) const CAPTURE_V1_RATE_LIMITER: &str = "capture_v1_rate_limiter";
 /// Matches the OpenAPI BatchEntryStatusError example for `result: limited`.
 pub(super) const DETAIL_PERSON_PROCESSING_DISABLED: &str = "person_processing_disabled";
 
+/// Detail tag for events dropped by the event restriction service.
+pub(super) const DETAIL_EVENT_RESTRICTION_DROP: &str = "event_restriction_drop";
+
 // ---------------------------------------------------------------------------
 // Payload size limits
 // ---------------------------------------------------------------------------
 
 /// Maximum compressed (wire) body size the v1 endpoint will accept.
-/// The decompressed limit is separately enforced via `state.event_payload_size_limit`.
 pub(super) const CAPTURE_V1_MAX_COMPRESSED_BODY_BYTES: usize = 10 * 1024 * 1024; // 10MB
+
+/// Maximum decompressed body size (5x compressed limit per RFC).
+pub(crate) const CAPTURE_V1_MAX_DECOMPRESSED_BODY_BYTES: usize =
+    CAPTURE_V1_MAX_COMPRESSED_BODY_BYTES * 5; // 50MB
 
 // ---------------------------------------------------------------------------
 // Validation limits

--- a/rust/capture/src/v1/analytics/handler.rs
+++ b/rust/capture/src/v1/analytics/handler.rs
@@ -3,7 +3,6 @@ use axum::extract::{MatchedPath, Query as AxumQuery, State};
 use axum::http::{header, HeaderMap, Method};
 use axum_client_ip::InsecureClientIp;
 
-use super::constants::*;
 use super::query::Query;
 use super::response::Response;
 use super::types::Batch;
@@ -30,7 +29,7 @@ pub async fn handle_request(
 
     let raw_bytes = v1::util::extract_body_with_timeout(
         body,
-        CAPTURE_V1_MAX_COMPRESSED_BODY_BYTES,
+        state.capture_v1_max_compressed_body_bytes,
         state.body_chunk_read_timeout,
         state.body_read_chunk_size_kb,
         &context.path,
@@ -44,7 +43,7 @@ pub async fn handle_request(
     let payload = v1::util::decompress_payload(
         context.content_encoding.as_deref(),
         raw_bytes,
-        CAPTURE_V1_MAX_DECOMPRESSED_BODY_BYTES,
+        state.capture_v1_max_decompressed_body_bytes,
         state.body_read_chunk_size_kb,
     )
     .await

--- a/rust/capture/src/v1/analytics/handler.rs
+++ b/rust/capture/src/v1/analytics/handler.rs
@@ -44,7 +44,7 @@ pub async fn handle_request(
     let payload = v1::util::decompress_payload(
         context.content_encoding.as_deref(),
         raw_bytes,
-        state.event_payload_size_limit,
+        CAPTURE_V1_MAX_DECOMPRESSED_BODY_BYTES,
         state.body_read_chunk_size_kb,
     )
     .await

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -93,8 +93,8 @@ fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>,
         if uuid_str.is_empty() {
             return Err(Error::MissingEventUuid);
         }
-        let uuid = Uuid::parse_str(uuid_str)
-            .map_err(|_| Error::InvalidEventUuid(uuid_str.to_owned()))?;
+        let uuid =
+            Uuid::parse_str(uuid_str).map_err(|_| Error::InvalidEventUuid(uuid_str.to_owned()))?;
         if !seen.insert(uuid) {
             return Err(Error::DuplicateEventUuid(event.uuid().to_owned()));
         }

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -6,8 +6,8 @@ use uuid::Uuid;
 use super::constants::{
     CAPTURE_V1_DISTINCT_ID_MAX_SIZE, CAPTURE_V1_EVENTS_DROPPED,
     CAPTURE_V1_EVENTS_REROUTED_HISTORICAL, CAPTURE_V1_MAX_EVENT_NAME_LENGTH,
-    CAPTURE_V1_PARSED_EVENTS, CAPTURE_V1_RATE_LIMITER, DETAIL_PERSON_PROCESSING_DISABLED,
-    FUTURE_EVENT_HOURS_CUTOFF_MS, ILLEGAL_DISTINCT_IDS,
+    CAPTURE_V1_PARSED_EVENTS, CAPTURE_V1_RATE_LIMITER, DETAIL_EVENT_RESTRICTION_DROP,
+    DETAIL_PERSON_PROCESSING_DISABLED, FUTURE_EVENT_HOURS_CUTOFF_MS, ILLEGAL_DISTINCT_IDS,
 };
 use super::response::Response;
 use super::types::{Batch, Event, EventResult, WrappedEvent};
@@ -89,7 +89,12 @@ fn validate_events(context: &Context, batch: Batch) -> Result<Vec<WrappedEvent>,
     let mut seen: HashSet<Uuid> = HashSet::with_capacity(batch.batch.len());
 
     for event in batch.batch.into_iter() {
-        let uuid = Uuid::parse_str(event.uuid()).map_err(|_| Error::MissingEventUuid)?;
+        let uuid_str = event.uuid();
+        if uuid_str.is_empty() {
+            return Err(Error::MissingEventUuid);
+        }
+        let uuid = Uuid::parse_str(uuid_str)
+            .map_err(|_| Error::InvalidEventUuid(uuid_str.to_owned()))?;
         if !seen.insert(uuid) {
             return Err(Error::DuplicateEventUuid(event.uuid().to_owned()));
         }
@@ -209,7 +214,7 @@ fn normalize_timestamp(
     event: &Event,
     raw_event_ts: DateTime<Utc>,
 ) -> DateTime<Utc> {
-    if event.options.disable_skew_adjustment.unwrap_or(false) {
+    if event.options.disable_skew_correction.unwrap_or(false) {
         return raw_event_ts;
     }
 
@@ -276,6 +281,7 @@ async fn apply_restrictions(
 
         if applied.should_drop() {
             event.result = EventResult::Drop;
+            event.details = Some(DETAIL_EVENT_RESTRICTION_DROP);
             event.destination = Destination::Drop;
             metrics::counter!(CAPTURE_V1_EVENTS_DROPPED, "reason" => "event_restriction")
                 .increment(1);
@@ -642,7 +648,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_events_missing_uuid_bails_batch() {
+    fn validate_events_invalid_uuid_bails_batch() {
         let ctx = test_utils::test_context();
         let batch = Batch {
             created_at: "2026-03-19T14:30:00.000Z".to_string(),
@@ -654,7 +660,7 @@ mod tests {
             }],
         };
         let err = validate_events(&ctx, batch).unwrap_err();
-        assert!(matches!(err, Error::MissingEventUuid));
+        assert!(matches!(err, Error::InvalidEventUuid(_)));
     }
 
     #[test]
@@ -722,7 +728,7 @@ mod tests {
         }
     }
 
-    fn event_with_disable_skew_adjustment(disable: bool) -> Event {
+    fn event_with_disable_skew_correction(disable: bool) -> Event {
         Event {
             event: "$pageview".to_string(),
             uuid: Uuid::new_v4().to_string(),
@@ -732,7 +738,7 @@ mod tests {
             window_id: None,
             options: Options {
                 cookieless_mode: None,
-                disable_skew_adjustment: Some(disable),
+                disable_skew_correction: Some(disable),
                 product_tour_id: None,
                 process_person_profile: None,
             },
@@ -791,20 +797,20 @@ mod tests {
     }
 
     #[test]
-    fn normalize_disable_skew_adjustment_skips_adjustment() {
+    fn normalize_disable_skew_correction_skips_adjustment() {
         let now = dt("2026-03-19T12:00:00Z");
         let ctx = ctx_with_skew(now, Duration::seconds(10));
-        let event = event_with_disable_skew_adjustment(true);
+        let event = event_with_disable_skew_correction(true);
         let event_ts = dt("2026-03-19T11:00:00Z");
         let result = normalize_timestamp(&ctx, &event, event_ts);
         assert_eq!(result, event_ts);
     }
 
     #[test]
-    fn normalize_disable_skew_adjustment_false_still_adjusts() {
+    fn normalize_disable_skew_correction_false_still_adjusts() {
         let now = dt("2026-03-19T12:00:00Z");
         let ctx = ctx_with_skew(now, Duration::seconds(10));
-        let event = event_with_disable_skew_adjustment(false);
+        let event = event_with_disable_skew_correction(false);
         let event_ts = dt("2026-03-19T11:00:00Z");
         let result = normalize_timestamp(&ctx, &event, event_ts);
         assert_eq!(result, dt("2026-03-19T10:59:50Z"));

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -56,8 +56,11 @@ pub struct Batch {
 pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cookieless_mode: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disable_skew_adjustment: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "disable_skew_adjustment"
+    )]
+    pub disable_skew_correction: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_tour_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -278,7 +281,7 @@ impl WrappedEvent {
         if let Some(cm) = self.event.options.cookieless_mode {
             inject!(buf, first, "$cookieless_mode", &cm);
         }
-        if let Some(dsa) = self.event.options.disable_skew_adjustment {
+        if let Some(dsa) = self.event.options.disable_skew_correction {
             inject!(buf, first, "$ignore_sent_at", &dsa);
         }
         if let Some(ref pti) = self.event.options.product_tour_id {
@@ -633,7 +636,7 @@ mod tests {
                 "window_id": "win-xyz",
                 "options": {
                     "cookieless_mode": true,
-                    "disable_skew_adjustment": true,
+                    "disable_skew_correction": true,
                     "product_tour_id": "tour-123",
                     "process_person_profile": false
                 }
@@ -644,7 +647,7 @@ mod tests {
         assert_eq!(event.session_id.as_deref(), Some("sess-abc"));
         assert_eq!(event.window_id.as_deref(), Some("win-xyz"));
         assert_eq!(event.options.cookieless_mode, Some(true));
-        assert_eq!(event.options.disable_skew_adjustment, Some(true));
+        assert_eq!(event.options.disable_skew_correction, Some(true));
         assert_eq!(event.options.product_tour_id.as_deref(), Some("tour-123"));
         assert_eq!(event.options.process_person_profile, Some(false));
     }
@@ -680,7 +683,7 @@ mod tests {
         assert_eq!(event.session_id, None);
         assert_eq!(event.window_id, None);
         assert_eq!(event.options.cookieless_mode, None);
-        assert_eq!(event.options.disable_skew_adjustment, None);
+        assert_eq!(event.options.disable_skew_correction, None);
         assert_eq!(event.options.product_tour_id, None);
         assert_eq!(event.options.process_person_profile, None);
     }
@@ -1056,7 +1059,7 @@ mod tests {
                 window_id: Some("win-xyz789".to_string()),
                 options: Options {
                     cookieless_mode: Some(false),
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: Some(true),
                 },
@@ -1147,7 +1150,7 @@ mod tests {
                 window_id: Some("win-xyz789".to_string()),
                 options: Options {
                     cookieless_mode: Some(true),
-                    disable_skew_adjustment: Some(true),
+                    disable_skew_correction: Some(true),
                     product_tour_id: Some("tour-onboarding-v2".to_string()),
                     process_person_profile: Some(false),
                 },
@@ -1187,7 +1190,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: Some(false),
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },
@@ -1226,7 +1229,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },
@@ -1258,7 +1261,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: Some(true),
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },
@@ -1293,7 +1296,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },
@@ -1412,7 +1415,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },
@@ -1453,7 +1456,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: Some(true),
                 },
@@ -1492,7 +1495,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },
@@ -1528,7 +1531,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: None,
                     process_person_profile: None,
                 },

--- a/rust/capture/src/v1/constants.rs
+++ b/rust/capture/src/v1/constants.rs
@@ -25,7 +25,6 @@ pub const POSTHOG_REQUEST_TIMESTAMP: &str = "PostHog-Request-Timestamp";
 // Standard header names are inlined as &str because HeaderName::as_str() isn't const.
 // They correspond to header::AUTHORIZATION, header::CONTENT_TYPE, header::USER_AGENT.
 pub(super) const REQUIRED_HEADERS: &[&str] = &[
-    "authorization",
     POSTHOG_SDK_INFO,
     POSTHOG_ATTEMPT,
     POSTHOG_REQUEST_ID,

--- a/rust/capture/src/v1/context.rs
+++ b/rust/capture/src/v1/context.rs
@@ -55,6 +55,11 @@ impl Context {
         method: Method,
         path: &str,
     ) -> Result<Self, Error> {
+        // Authorization checked first — missing auth is 401, not 400
+        if headers.get(header::AUTHORIZATION).is_none() {
+            return Err(Error::MissingAuthorization);
+        }
+
         // Missing-headers gate: collect all absent required headers at once
         let missing: Vec<String> = REQUIRED_HEADERS
             .iter()
@@ -67,8 +72,6 @@ impl Context {
         }
 
         // All required headers are present — validate each one
-
-        // Authorization header presence is guaranteed by the REQUIRED_HEADERS gate above.
         // The Bearer scheme is case-insensitive per RFC 6750 Section 1.1.
         let auth_raw = header_str(headers, header::AUTHORIZATION.as_str())?;
         let token_raw = if auth_raw.len() > 7 && auth_raw[..7].eq_ignore_ascii_case("Bearer ") {
@@ -228,13 +231,21 @@ mod tests {
     }
 
     #[test]
-    fn missing_single_required_header() {
+    fn missing_authorization_returns_401() {
         let mut headers = valid_headers();
         headers.remove(header::AUTHORIZATION.as_str());
         let err = test_context(&headers).unwrap_err();
+        assert!(matches!(err, Error::MissingAuthorization));
+    }
+
+    #[test]
+    fn missing_single_required_header() {
+        let mut headers = valid_headers();
+        headers.remove("user-agent");
+        let err = test_context(&headers).unwrap_err();
         match err {
             Error::MissingRequiredHeaders(names) => {
-                assert_eq!(names, vec![header::AUTHORIZATION.as_str()]);
+                assert_eq!(names, vec!["user-agent"]);
             }
             other => panic!("expected MissingRequiredHeaders, got: {other:?}"),
         }
@@ -243,13 +254,13 @@ mod tests {
     #[test]
     fn missing_multiple_required_headers() {
         let mut headers = valid_headers();
-        headers.remove(header::AUTHORIZATION.as_str());
         headers.remove("user-agent");
+        headers.remove("content-type");
         let err = test_context(&headers).unwrap_err();
         match err {
             Error::MissingRequiredHeaders(names) => {
-                assert!(names.contains(&header::AUTHORIZATION.as_str().to_string()));
                 assert!(names.contains(&"user-agent".to_string()));
+                assert!(names.contains(&"content-type".to_string()));
                 assert_eq!(names.len(), 2);
             }
             other => panic!("expected MissingRequiredHeaders, got: {other:?}"),

--- a/rust/capture/src/v1/error.rs
+++ b/rust/capture/src/v1/error.rs
@@ -56,6 +56,8 @@ pub enum Error {
     InvalidDistinctId(String),
     #[error("event submitted without a uuid")]
     MissingEventUuid,
+    #[error("event uuid is not valid: {0}")]
+    InvalidEventUuid(String),
     #[error("duplicate event uuid: {0}")]
     DuplicateEventUuid(String),
     #[error("event submitted with invalid timestamp")]
@@ -66,6 +68,8 @@ pub enum Error {
     DroppedPerformanceEvent,
 
     // 401 - authentication_error
+    #[error("missing Authorization header")]
+    MissingAuthorization,
     #[error("API token is not valid: {0}")]
     InvalidApiToken(String),
 
@@ -118,12 +122,14 @@ impl Error {
             Self::DistinctIdTooLarge => "distinct_id_too_large",
             Self::InvalidDistinctId(_) => "invalid_distinct_id",
             Self::MissingEventUuid => "missing_event_uuid",
+            Self::InvalidEventUuid(_) => "invalid_event_uuid",
             Self::DuplicateEventUuid(_) => "duplicate_event_uuid",
             Self::InvalidEventTimestamp => "invalid_event_timestamp",
             Self::MalformedEventProperties => "malformed_event_properties",
             Self::DroppedPerformanceEvent => "dropped_performance_event",
             Self::RequestTimeout => "request_timeout",
             Self::BodyReadTimeout(_) => "body_read_timeout",
+            Self::MissingAuthorization => "missing_authorization",
             Self::InvalidApiToken(_) => "invalid_api_token",
             Self::PayloadTooLarge(_) => "payload_too_large",
             Self::UnsupportedContentType(_) => "unsupported_content_type",
@@ -174,11 +180,13 @@ impl Error {
             | Self::DistinctIdTooLarge
             | Self::InvalidDistinctId(_)
             | Self::MissingEventUuid
+            | Self::InvalidEventUuid(_)
             | Self::DuplicateEventUuid(_)
             | Self::InvalidEventTimestamp
             | Self::MalformedEventProperties
             | Self::DroppedPerformanceEvent
             | Self::RequestTimeout
+            | Self::MissingAuthorization
             | Self::InvalidApiToken(_)
             | Self::PayloadTooLarge(_)
             | Self::UnsupportedContentType(_)
@@ -232,6 +240,7 @@ impl Error {
             | Self::DistinctIdTooLarge
             | Self::InvalidDistinctId(_)
             | Self::MissingEventUuid
+            | Self::InvalidEventUuid(_)
             | Self::DuplicateEventUuid(_)
             | Self::InvalidEventTimestamp
             | Self::MalformedEventProperties
@@ -239,7 +248,7 @@ impl Error {
 
             Self::RequestTimeout | Self::BodyReadTimeout(_) => StatusCode::REQUEST_TIMEOUT,
 
-            Self::InvalidApiToken(_) => StatusCode::UNAUTHORIZED,
+            Self::MissingAuthorization | Self::InvalidApiToken(_) => StatusCode::UNAUTHORIZED,
 
             Self::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
 

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -221,6 +221,8 @@ mod tests {
                 pyroscope_sample_rate: 100,
             },
             capture_v1_sinks: String::new(),
+            capture_v1_max_compressed_body_bytes: 10 * 1024 * 1024,
+            capture_v1_max_decompressed_body_bytes: 50 * 1024 * 1024,
         }
     }
 

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -276,7 +276,7 @@ mod tests {
                 window_id: None,
                 options: Options {
                     cookieless_mode: None,
-                    disable_skew_adjustment: None,
+                    disable_skew_correction: None,
                     product_tour_id: product_tour_id.map(String::from),
                     process_person_profile: None,
                 },

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -1009,7 +1009,7 @@ original property ordering and formatting.
 | `session_id` | `$session_id` | |
 | `window_id` | `$window_id` | |
 | `options.cookieless_mode` | `$cookieless_mode` | |
-| `options.disable_skew_adjustment` | `$ignore_sent_at` | Legacy rename |
+| `options.disable_skew_correction` | `$ignore_sent_at` | Legacy rename (alias: `disable_skew_adjustment`) |
 | `options.product_tour_id` | `$product_tour_id` | |
 | `options.process_person_profile` | `$process_person_profile` | |
 

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -19,7 +19,7 @@ pub fn raw_obj(s: &str) -> Box<RawValue> {
 pub fn default_options() -> Options {
     Options {
         cookieless_mode: None,
-        disable_skew_adjustment: None,
+        disable_skew_correction: None,
         product_tour_id: None,
         process_person_profile: None,
     }
@@ -170,7 +170,7 @@ pub fn realistic_pageview(distinct_id: &str) -> WrappedEvent {
             window_id: Some("01jq9xyz-0000-4321-8765-fedcba987654".to_string()),
             options: Options {
                 cookieless_mode: Some(false),
-                disable_skew_adjustment: None,
+                disable_skew_correction: None,
                 product_tour_id: None,
                 process_person_profile: Some(true),
             },
@@ -204,7 +204,7 @@ pub fn realistic_identify(distinct_id: &str) -> WrappedEvent {
             window_id: None,
             options: Options {
                 cookieless_mode: None,
-                disable_skew_adjustment: None,
+                disable_skew_correction: None,
                 product_tour_id: None,
                 process_person_profile: Some(true),
             },
@@ -238,7 +238,7 @@ pub fn realistic_custom(distinct_id: &str, event_name: &str) -> WrappedEvent {
             window_id: Some("01jq9xyz-0000-4321-8765-fedcba987654".to_string()),
             options: Options {
                 cookieless_mode: None,
-                disable_skew_adjustment: None,
+                disable_skew_correction: None,
                 product_tour_id: None,
                 process_person_profile: Some(true),
             },
@@ -315,7 +315,7 @@ pub fn realistic_dup_uuid_pair() -> (Event, Event) {
         window_id: Some("01jq9xyz-0000-4321-8765-fedcba987654".to_string()),
         options: Options {
             cookieless_mode: Some(false),
-            disable_skew_adjustment: None,
+            disable_skew_correction: None,
             product_tour_id: None,
             process_person_profile: Some(true),
         },

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -1010,13 +1010,15 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             historical_rerouting_threshold_days,
             is_mirror_deploy,
             verbose_sample_percent,
-            26_214_400, // 25MB default for AI endpoint
-            None,       // ai_blob_storage
-            Some(10),   // request_timeout_seconds
-            None,       // body_chunk_read_timeout_ms
-            256,        // body_read_chunk_size_kb
-            None,       // overflow_limiter
-            None,       // replay_overflow_limiter
+            26_214_400,       // 25MB default for AI endpoint
+            None,             // ai_blob_storage
+            Some(10),         // request_timeout_seconds
+            None,             // body_chunk_read_timeout_ms
+            256,              // body_read_chunk_size_kb
+            10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+            50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+            None,             // overflow_limiter
+            None,             // replay_overflow_limiter
         ),
         sink,
     )

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -144,6 +144,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         pyroscope_sample_rate: 100,
     },
     capture_v1_sinks: String::new(),
+    capture_v1_max_compressed_body_bytes: 10 * 1024 * 1024,
+    capture_v1_max_decompressed_body_bytes: 50 * 1024 * 1024,
 });
 
 static TRACING_INIT: Once = Once::new();

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -191,6 +191,8 @@ fn setup_ai_test_router() -> Router {
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        10 * 1024 * 1024,                 // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
     )
@@ -1650,6 +1652,8 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        10 * 1024 * 1024,                 // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
     );
@@ -2561,6 +2565,8 @@ fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Rout
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        10 * 1024 * 1024,                 // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
     );
@@ -2767,6 +2773,8 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        10 * 1024 * 1024,                 // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024,                 // capture_v1_max_decompressed_body_bytes
         None,                             // overflow_limiter
         None,                             // replay_overflow_limiter
     );
@@ -2918,6 +2926,8 @@ fn setup_ai_test_router_with_overflow_limiter(
         Some(10),
         None,
         256,
+        10 * 1024 * 1024,       // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024,       // capture_v1_max_decompressed_body_bytes
         Some(overflow_limiter), // overflow_limiter
         None,                   // replay_overflow_limiter
     );

--- a/rust/capture/tests/integration_ai_restrictions.rs
+++ b/rust/capture/tests/integration_ai_restrictions.rs
@@ -186,9 +186,11 @@ async fn setup_ai_router_with_restriction(
         Some(create_mock_blob_storage()),
         Some(10),
         None,
-        256,  // body_read_chunk_size_kb
-        None, // overflow_limiter
-        None, // replay_overflow_limiter
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -500,9 +502,11 @@ async fn setup_ai_router_with_redirect_to_topic(
         Some(create_mock_blob_storage()),
         Some(10),
         None,
-        256,  // body_read_chunk_size_kb
-        None, // overflow_limiter
-        None, // replay_overflow_limiter
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -572,6 +576,8 @@ async fn setup_ai_router_with_force_overflow_and_limiter(
         Some(10),
         None,
         256,
+        10 * 1024 * 1024,       // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024,       // capture_v1_max_decompressed_body_bytes
         Some(overflow_limiter), // overflow_limiter
         None,                   // replay_overflow_limiter
     );

--- a/rust/capture/tests/integration_analytics_restrictions.rs
+++ b/rust/capture/tests/integration_analytics_restrictions.rs
@@ -120,9 +120,11 @@ async fn setup_analytics_router_with_restriction(
         None, // no blob storage for analytics
         Some(10),
         None,
-        256,  // body_read_chunk_size_kb
-        None, // overflow_limiter
-        None, // replay_overflow_limiter
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -459,9 +461,11 @@ async fn setup_analytics_router_with_redirect_to_topic(
         None,
         Some(10),
         None,
-        256,  // body_read_chunk_size_kb
-        None, // overflow_limiter
-        None, // replay_overflow_limiter
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -181,6 +181,8 @@ fn make_test_client_with_options(sink: &CapturingSink, options: TestClientOption
         Some(10),         // request_timeout_seconds
         None,             // body_chunk_read_timeout_ms
         256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
         options.overflow_limiter, // overflow_limiter
         None,             // replay_overflow_limiter
     );

--- a/rust/capture/tests/integration_replay_restrictions.rs
+++ b/rust/capture/tests/integration_replay_restrictions.rs
@@ -121,9 +121,11 @@ async fn setup_recordings_router_with_restriction(
         None, // no blob storage for recordings
         Some(10),
         None,
-        256,  // body_read_chunk_size_kb
-        None, // overflow_limiter
-        None, // replay_overflow_limiter
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -485,9 +487,11 @@ async fn setup_recordings_router_with_redirect_to_topic(
         None, // no blob storage for recordings
         Some(10),
         None,
-        256,  // body_read_chunk_size_kb
-        None, // overflow_limiter
-        None, // replay_overflow_limiter
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/quota_limiters.rs
+++ b/rust/capture/tests/quota_limiters.rs
@@ -136,19 +136,21 @@ async fn setup_router_with_limits(
         false, // metrics
         CaptureMode::Events,
         String::from("capture"),
-        None,        // concurrency_limit
-        1024 * 1024, // event_payload_size_limit
-        false,       // enable_historical_rerouting
-        1,           // historical_rerouting_threshold_days
-        false,       // is_mirror_deploy
-        0.0,         // verbose_sample_percent
-        26_214_400,  // ai_max_sum_of_parts_bytes (25MB)
-        None,        // ai_blob_storage
-        Some(10),    // request_timeout_seconds
-        None,        // body_chunk_read_timeout_ms
-        256,         // body_read_chunk_size_kb
-        None,        // overflow_limiter
-        None,        // replay_overflow_limiter
+        None,             // concurrency_limit
+        1024 * 1024,      // event_payload_size_limit
+        false,            // enable_historical_rerouting
+        1,                // historical_rerouting_threshold_days
+        false,            // is_mirror_deploy
+        0.0,              // verbose_sample_percent
+        26_214_400,       // ai_max_sum_of_parts_bytes (25MB)
+        None,             // ai_blob_storage
+        Some(10),         // request_timeout_seconds
+        None,             // body_chunk_read_timeout_ms
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     (app, sink)
@@ -1191,12 +1193,14 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         false,
         0.0,
         26_214_400,
-        None,     // ai_blob_storage
-        Some(10), // request_timeout_seconds
-        None,     // body_chunk_read_timeout_ms
-        256,      // body_read_chunk_size_kb
-        None,     // overflow_limiter
-        None,     // replay_overflow_limiter
+        None,             // ai_blob_storage
+        Some(10),         // request_timeout_seconds
+        None,             // body_chunk_read_timeout_ms
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);
@@ -1277,12 +1281,14 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         false,
         0.0,
         26_214_400,
-        None,     // ai_blob_storage
-        Some(10), // request_timeout_seconds
-        None,     // body_chunk_read_timeout_ms
-        256,      // body_read_chunk_size_kb
-        None,     // overflow_limiter
-        None,     // replay_overflow_limiter
+        None,             // ai_blob_storage
+        Some(10),         // request_timeout_seconds
+        None,             // body_chunk_read_timeout_ms
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);
@@ -1367,12 +1373,14 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         false,
         0.0,
         26_214_400,
-        None,     // ai_blob_storage
-        Some(10), // request_timeout_seconds
-        None,     // body_chunk_read_timeout_ms
-        256,      // body_read_chunk_size_kb
-        None,     // overflow_limiter
-        None,     // replay_overflow_limiter
+        None,             // ai_blob_storage
+        Some(10),         // request_timeout_seconds
+        None,             // body_chunk_read_timeout_ms
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);
@@ -1794,12 +1802,14 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         false,
         0.0,
         26_214_400,
-        None,     // ai_blob_storage
-        Some(10), // request_timeout_seconds
-        None,     // body_chunk_read_timeout_ms
-        256,      // body_read_chunk_size_kb
-        None,     // overflow_limiter
-        None,     // replay_overflow_limiter
+        None,             // ai_blob_storage
+        Some(10),         // request_timeout_seconds
+        None,             // body_chunk_read_timeout_ms
+        256,              // body_read_chunk_size_kb
+        10 * 1024 * 1024, // capture_v1_max_compressed_body_bytes
+        50 * 1024 * 1024, // capture_v1_max_decompressed_body_bytes
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
As stated in title. Catch up on small divergences from RFC/API spec since the last round of v1 PRs landed.

## Changes

- Rename `disable_skew_adjustment` -> `disable_skew_correction` with serde alias for backward compat
- Missing `Authorization` header now returns 401 (previously folded into generic `MissingRequiredHeaders` 400)
- factor capture v1 compressed/decompressed max payload bytes app cfg out from legacy params
- `apply_restrictions` Drop path now sets `details = "event_restriction_drop"` for future response body compliance
- Split `InvalidEventUuid` (syntax error, includes the bad value) from `MissingEventUuid` (empty string)
- Rename `rate_limited_token_distinct_id` -> `person_processing_disabled` (matches OpenAPI BatchEntryStatusError example)

## How did you test this code?
Locally and in CI

## Publish to changelog?
N/A

## 🤖 Agent context
Coded from plan doc