### PR TITLE
fix(cdp): coerce non-UUID personId to null in cyclotron-v2 schema

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -265,21 +265,22 @@ describe('Cyclotron V2', () => {
             }
         })
 
-        it('createJob rejects non-UUID personId before reaching the database', async () => {
-            await expect(manager.createJob({ teamId: 1, queueName: QUEUE, personId: 'not-a-uuid' })).rejects.toThrow(
-                /uuid/i
-            )
+        it('createJob coerces non-UUID personId to null', async () => {
+            const id = await manager.createJob({ teamId: 1, queueName: QUEUE, personId: 'not-a-uuid' as any })
+            const row = await queryJob(id)
+            expect(row.person_id).toBeNull()
         })
 
-        it('bulkCreateJobs rejects non-UUID values without writing any rows', async () => {
-            const before = await totalJobCount()
-            await expect(
-                manager.bulkCreateJobs([
-                    { teamId: 1, queueName: QUEUE, personId: uuidv7() },
-                    { teamId: 1, queueName: QUEUE, personId: 'bad-uuid' as any },
-                ])
-            ).rejects.toThrow(/uuid/i)
-            expect(await totalJobCount()).toBe(before)
+        it('bulkCreateJobs coerces non-UUID personIds to null instead of failing the batch', async () => {
+            const validPersonId = uuidv7()
+            const ids = await manager.bulkCreateJobs([
+                { teamId: 1, queueName: QUEUE, personId: validPersonId },
+                { teamId: 1, queueName: QUEUE, personId: 'group-key-not-a-uuid' as any },
+            ])
+            expect(ids).toHaveLength(2)
+            const rows = await Promise.all(ids.map(queryJob))
+            expect(rows[0].person_id).toBe(validPersonId)
+            expect(rows[1].person_id).toBeNull()
         })
     })
 
@@ -422,9 +423,12 @@ describe('Cyclotron V2', () => {
             expect(job.actionId).toBe('a-on-job')
         })
 
-        it('reschedule rejects non-UUID personId before reaching the database', async () => {
-            const { job } = await seedAndDequeue()
-            await expect(job.reschedule({ personId: 'bad-uuid' as any })).rejects.toThrow(/uuid/i)
+        it('reschedule coerces non-UUID personId to null instead of failing', async () => {
+            const { id, job } = await seedAndDequeue({ personId: uuidv7() })
+            await job.reschedule({ personId: 'bad-uuid' as any })
+
+            const row = await queryJob(id)
+            expect(row.person_id).toBeNull()
         })
 
         it('reschedule({ distinctId }) updates distinct_id column', async () => {

--- a/nodejs/src/cdp/services/cyclotron-v2/types.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.test.ts
@@ -1,0 +1,67 @@
+import { v7 as uuidv7 } from 'uuid'
+
+import { CyclotronV2JobInitSchema, CyclotronV2RescheduleOptionsSchema } from './types'
+
+describe('CyclotronV2 schema validation', () => {
+    describe('personId coercion in CyclotronV2JobInitSchema', () => {
+        it('accepts a valid UUID and preserves it', () => {
+            const personId = uuidv7()
+            const parsed = CyclotronV2JobInitSchema.parse({ teamId: 1, queueName: 'q', personId })
+            expect(parsed.personId).toBe(personId)
+        })
+
+        it('coerces non-UUID strings to null (e.g. group keys from blast radius)', () => {
+            const parsed = CyclotronV2JobInitSchema.parse({
+                teamId: 1,
+                queueName: 'q',
+                personId: 'group-key-not-a-uuid',
+            })
+            expect(parsed.personId).toBeNull()
+        })
+
+        it.each([
+            ['empty string', ''],
+            ['arbitrary text', 'not-a-uuid'],
+            ['nearly-uuid', '12345678-1234-1234-1234-12345678901'],
+            ['numeric id', '12345'],
+            ['email-like', 'user@example.com'],
+        ])('coerces %s to null', (_, value) => {
+            const parsed = CyclotronV2JobInitSchema.parse({ teamId: 1, queueName: 'q', personId: value })
+            expect(parsed.personId).toBeNull()
+        })
+
+        it('passes through null', () => {
+            const parsed = CyclotronV2JobInitSchema.parse({ teamId: 1, queueName: 'q', personId: null })
+            expect(parsed.personId).toBeNull()
+        })
+
+        it('passes through undefined', () => {
+            const parsed = CyclotronV2JobInitSchema.parse({ teamId: 1, queueName: 'q' })
+            expect(parsed.personId).toBeUndefined()
+        })
+
+        it('accepts a UUID v4', () => {
+            const personId = '550e8400-e29b-41d4-a716-446655440000'
+            const parsed = CyclotronV2JobInitSchema.parse({ teamId: 1, queueName: 'q', personId })
+            expect(parsed.personId).toBe(personId)
+        })
+    })
+
+    describe('personId coercion in CyclotronV2RescheduleOptionsSchema', () => {
+        it('accepts a valid UUID', () => {
+            const personId = uuidv7()
+            const parsed = CyclotronV2RescheduleOptionsSchema.parse({ personId })
+            expect(parsed.personId).toBe(personId)
+        })
+
+        it('coerces non-UUID strings to null', () => {
+            const parsed = CyclotronV2RescheduleOptionsSchema.parse({ personId: 'group-key' })
+            expect(parsed.personId).toBeNull()
+        })
+
+        it('passes through null', () => {
+            const parsed = CyclotronV2RescheduleOptionsSchema.parse({ personId: null })
+            expect(parsed.personId).toBeNull()
+        })
+    })
+})

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -11,8 +11,17 @@ export type CyclotronV2PoolConfig = {
 
 // `id` and `functionId` use PostHog's UUIDT-style identifiers which don't set
 // valid UUID version bits, so we only validate them as non-empty strings here.
-// `personId` comes from posthog_person.uuid (a real UUID v4/v7) and ingestion's
-// resolution, so we validate it strictly to catch any bad data at the boundary.
+// `personId` comes from posthog_person.uuid (a real UUID v4/v7) for person-based
+// blast radius, but group-based blast radius returns group keys (non-UUID strings).
+// We coerce non-UUID values to null so the postgres UUID column accepts them
+// rather than failing the whole batch insert.
+const personIdSchema = z.preprocess((val) => {
+    if (typeof val === 'string' && !z.uuid().safeParse(val).success) {
+        return null
+    }
+    return val
+}, z.uuid().nullish())
+
 export const CyclotronV2JobInitSchema = z.object({
     id: z.string().min(1).optional(),
     teamId: z.number().int(),
@@ -23,7 +32,7 @@ export const CyclotronV2JobInitSchema = z.object({
     parentRunId: z.string().nullish(),
     state: z.instanceof(Buffer).nullish(),
     distinctId: z.string().nullish(),
-    personId: z.uuid().nullish(),
+    personId: personIdSchema,
     actionId: z.string().nullish(),
 })
 
@@ -33,7 +42,7 @@ export const CyclotronV2RescheduleOptionsSchema = z.object({
     scheduledAt: z.date().optional(),
     state: z.instanceof(Buffer).nullish(),
     distinctId: z.string().nullish(),
-    personId: z.uuid().nullish(),
+    personId: personIdSchema,
     actionId: z.string().nullish(),
 })
 


### PR DESCRIPTION
## Problem

`cdp-events-consumer-ws` is silently dropping batches of hog_flow workflow trigger jobs whenever any event in a batch has a non-UUID `personId`:

```
"path": ["personId"]
"message": "Invalid UUID"
"msg": "[CDP-PROCESSED-EVENTS] Error creating cyclotron V2 jobs"
```

The error throws inside the `queueInvocations` background task, which is fire-and-forget — Kafka offsets are committed before the task settles, so the failed batch is silently lost.

Source of non-UUID `personId` values is group-based blast radius (`/api/projects/.../internal/hog_flow_user_blast_radius_persons`): for group-based filters, `_get_group_blast_radius_persons` returns group keys (arbitrary strings), which then flow into `inv.person?.id` and fail Zod's `z.uuid()` validation.

## Changes

- Added a `personIdSchema` that uses `z.preprocess` to coerce non-UUID strings to `null` before the `z.uuid().nullish()` validation.
- Applied to both `CyclotronV2JobInitSchema` and `CyclotronV2RescheduleOptionsSchema`.
- Postgres column is `UUID` typed, so coercing to `null` (instead of leaving the bad string) lets the INSERT succeed without storing invalid data.

This is a quick fix to stop the silent drops. Full architectural fix (don't commit Kafka offsets when the background task fails) is tracked separately.

## How did you test this code?

Agent-authored. I'm an LLM agent and ran:

- `pnpm jest src/cdp/services/cyclotron-v2/types.test.ts` — 13 new unit tests pass, covering UUID/null/undefined/non-UUID inputs for both schemas.
- Updated 3 existing integration tests in `cyclotron-v2.test.ts` (which previously asserted rejection on non-UUID personId) to instead assert coercion-to-null. These need a running cyclotron-v2 postgres to verify; CI will run them.
- Manually tested happy paths with event and batch triggers on localhost.

## Publish to changelog?

no

## 🤖 Agent context

Discovered while investigating the 2026-05-06 EU hog_flow drop incident. The same fire-and-forget background task code path that caused that incident is also responsible for the ongoing `personId` Invalid UUID drops visible in Loki. This PR addresses the latter; the offset-commit architectural fix is being tracked separately as the more comprehensive remediation.