### PR TITLE
fix(devex): improve agent PR context guidance in pull request template

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -143,6 +143,7 @@ posthog/temporal/weekly-digest @PostHog/team-growth
 .github/workflows/** @PostHog/team-devex
 .github/actions/** @PostHog/team-devex
 .github/dependabot.yml @PostHog/team-devex
+.github/pull_request_template.md @PostHog/team-devex
 Dockerfile @PostHog/team-devex
 docker-compose\*.yml @PostHog/team-devex
 .prettierrc @PostHog/team-devex

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,9 @@
-<!-- PR authoring rules — read before filling the sections below.
-
-     PR title (conventional commits): <type>(<scope>): <description>
-       Both type and scope are required. Agents commonly skip them — do not.
-       Type: feat | fix | chore (chore covers docs, tests, config, CI, refactors).
-       Scope: the area touched (e.g. insights, cohorts, devex, ci, llma for LLM analytics).
-       Description: lowercase, no trailing period, under 72 chars, imperative mood.
+<!-- Authoring rules (agents: read).
+     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
        ✅ feat(insights): add retention graph export
-       ✅ chore(ci): bump node to 24
-       ❌ Add retention export                — missing type and scope
-       ❌ feat: Add retention export.         — capitalized, trailing period, no scope
-
-     PR description: keep sections high-level. Focus on rationale and architecture
-     for the human reviewer, not a step-by-step replay of implementation work.
-
-     Public OSS repo: title and description must be safe for external readers.
-     No internal customer names, private incidents, private Slack threads, or
-     operational metrics (e.g. exact row counts, affected team counts).
-       ❌ fix: patches issue from acme-co prod
-       ❌ fix: works fine on our 12M-row table
+       ❌ feat: Added retention export.   (capitalized, period, no scope)
+     Description: high-level rationale, not a step-by-step replay.
+     Public OSS repo: no internal customers, incidents, or operational metrics.
 -->
 
 ## Problem

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,9 +35,9 @@
 <!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
 <!-- Include:
      - tools/agent used and link to session
-     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
      - decisions made along the way (what was tried, rejected, chosen, and why)
      - anything else that helps reviewers
+     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
 -->
 <!-- Rules for agent-authored PRs:
      - All PRs must be attributable to a human author, even if agent-assisted.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,25 @@
+<!-- PR authoring rules — read before filling the sections below.
+
+     PR title (conventional commits): <type>(<scope>): <description>
+       Both type and scope are required. Agents commonly skip them — do not.
+       Type: feat | fix | chore (chore covers docs, tests, config, CI, refactors).
+       Scope: the area touched (e.g. insights, cohorts, devex, ci, llma for LLM analytics).
+       Description: lowercase, no trailing period, under 72 chars, imperative mood.
+       ✅ feat(insights): add retention graph export
+       ✅ chore(ci): bump node to 24
+       ❌ Add retention export                — missing type and scope
+       ❌ feat: Add retention export.         — capitalized, trailing period, no scope
+
+     PR description: keep sections high-level. Focus on rationale and architecture
+     for the human reviewer, not a step-by-step replay of implementation work.
+
+     Public OSS repo: title and description must be safe for external readers.
+     No internal customer names, private incidents, private Slack threads, or
+     operational metrics (e.g. exact row counts, affected team counts).
+       ❌ fix: patches issue from acme-co prod
+       ❌ fix: works fine on our 12M-row table
+-->
+
 ## Problem
 
 <!-- Who are we building for, what are their needs, why is this important? -->
@@ -29,20 +51,6 @@
 ## Docs update
 
 <!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
-
-<!-- PR title format (conventional commits): <type>(<scope>): <description>
-     Both type and scope are required — agents skip them often, do not.
-     Type: feat (new functionality) | fix (bug fix) | chore (everything else: docs, tests, config, CI, refactors).
-     Scope: the area touched (e.g. insights, cohorts, devex, ci, llma for LLM analytics).
-     Description: lowercase, no trailing period, under 72 chars, imperative mood.
-     Public OSS repo — no internal customer names, private incidents, or operational metrics.
-     ✅ feat(insights): add retention graph export
-     ✅ chore(ci): bump node to 24
-     ✅ fix(cohorts): handle empty cohort in query builder
-     ❌ Add retention export                — missing type and scope
-     ❌ feat: Add retention export.         — capitalized, trailing period, no scope
-     ❌ fix: patches issue from acme-co     — references internal customer
--->
 
 ## 🤖 Agent context
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,20 @@
 
 <!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
 
+<!-- PR title format (conventional commits): <type>(<scope>): <description>
+     Both type and scope are required — agents skip them often, do not.
+     Type: feat (new functionality) | fix (bug fix) | chore (everything else: docs, tests, config, CI, refactors).
+     Scope: the area touched (e.g. insights, cohorts, devex, ci, llma for LLM analytics).
+     Description: lowercase, no trailing period, under 72 chars, imperative mood.
+     Public OSS repo — no internal customer names, private incidents, or operational metrics.
+     ✅ feat(insights): add retention graph export
+     ✅ chore(ci): bump node to 24
+     ✅ fix(cohorts): handle empty cohort in query builder
+     ❌ Add retention export                — missing type and scope
+     ❌ feat: Add retention export.         — capitalized, trailing period, no scope
+     ❌ fix: patches issue from acme-co     — references internal customer
+-->
+
 ## 🤖 Agent context
 
 <!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->


### PR DESCRIPTION
## Problem

The PR template's guidance for agent-authored PRs was unclear about how to present context to reviewers. The previous instructions asked for "key human prompts," which could lead to verbatim pasting of user input rather than thoughtful, reviewer-focused explanations of intent and decision-making.

## Changes

Updated the `🤖 Agent context` section in `.github/pull_request_template.md` to:
- Remove the specific mention of "key human prompts" as a required item
- Add explicit guidance to write reviewer-facing prose and paraphrase intent rather than pasting prompts verbatim
- Reorder items to emphasize decisions and reasoning (what was tried, rejected, chosen, and why)
- Clarify that the goal is helping reviewers understand the "why" behind changes, not just the "what"

## How did you test this code?

N/A - This is a documentation/template change with no functional code impact.

## Publish to changelog?

No - This is a template improvement for internal contribution processes.

https://claude.ai/code/session_015rQGug6hpgVmG4GLypv7f3