### PR TITLE
ci: block cyclotron-node migrations in same PR as nodejs/rust changes

### DIFF
--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -36,6 +36,7 @@ jobs:
                           - 'rust/persons_migrations/*.sql'
                           - 'rust/behavioral_cohorts_migrations/*.sql'
                           - 'rust/cyclotron-core/migrations/*.sql'
+                          - 'rust/cyclotron-node-migrations/*.sql'
                       nodejs:
                           - 'nodejs/**'
 
@@ -55,6 +56,7 @@ jobs:
                           - '!rust/persons_migrations/**'
                           - '!rust/behavioral_cohorts_migrations/**'
                           - '!rust/cyclotron-core/migrations/**'
+                          - '!rust/cyclotron-node-migrations/**'
 
             - name: Check for conflicting changes
               id: check


### PR DESCRIPTION
## Problem

The existing Migration & Service Separation Check at `.github/workflows/ci-migrations-service-separation-check.yml` blocks PRs that mix:
- Django migrations + nodejs changes
- sqlx migrations + nodejs changes
- sqlx migrations + rust service changes

…but the `sqlx_migrations` filter only covered `rust/cyclotron-core/migrations/*.sql` and missed `rust/cyclotron-node-migrations/*.sql`.

The 2026-05-06 EU incident (silent drop of ~1,136 hog_flow workflow runs) was caused exactly by this: code referencing new `cyclotron_jobs` columns shipped to `cdp-events-consumer-ws` ~38 minutes before the migration `20260417000001_add_lookup_columns.sql` (in `rust/cyclotron-node-migrations/`) ran in EU. During the gap, every cyclotron-v2 INSERT failed with `column "distinct_id" of relation "cyclotron_jobs" does not exist` and the events-consumer's fire-and-forget background task silently dropped the failed batches.

If this CI check had covered cyclotron-node-migrations, the originating PR would have been blocked and the incident wouldn't have happened.

## Changes

Two-line addition to the `sqlx_migrations` and `rust_services` filter patterns to include `rust/cyclotron-node-migrations/`.

## How did you test this code?

Agent-authored. I'm an LLM agent. No automated test runs - this is a workflow YAML change, the existing job logic is unchanged. The diff is purely additive (one new path glob in each filter).

To verify it works, a follow-up PR that touches both `rust/cyclotron-node-migrations/` and `nodejs/` should now fail the check.

## Publish to changelog?

no

## 🤖 Agent context

Discovered while investigating the 2026-05-06 EU hog_flow drop incident. The fix for the silent-drop code path is in PR #57904. This PR is the preventative measure to ensure a similar deploy ordering issue in the cyclotron-node migration path can't merge.