### PR TITLE
refactor(hog-charts): move BarChart into its own folder, simplify drawGrid tests

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { BarChart, ReferenceLine, ValueLabels } from 'lib/hog-charts'
 import type { BarChartConfig, Series } from 'lib/hog-charts'
 
-import { Stage, useReactiveTheme } from '../story-helpers'
+import { Stage, useReactiveTheme } from '../../story-helpers'
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.test.tsx
@@ -1,8 +1,8 @@
 import { cleanup, waitFor } from '@testing-library/react'
 
-import type { BarChartConfig, ChartTheme, Series } from '../core/types'
-import { ReferenceLine } from '../overlays/ReferenceLine'
-import { clickAtIndex, hoverAtIndex, renderHogChart, setupJsdom, setupSyncRaf } from '../testing'
+import type { BarChartConfig, ChartTheme, Series } from '../../core/types'
+import { ReferenceLine } from '../../overlays/ReferenceLine'
+import { clickAtIndex, hoverAtIndex, renderHogChart, setupJsdom, setupSyncRaf } from '../../testing'
 import { BarChart } from './BarChart'
 
 const THEME: ChartTheme = {

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -1,18 +1,16 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { type BarChartPrivate, computeBarAtIndex, computeSeriesBars } from '../core/bar-layout'
-import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../core/canvas-renderer'
-import { Chart } from '../core/Chart'
-import { useChartLayout } from '../core/chart-context'
-import { ChartErrorBoundary } from '../core/ChartErrorBoundary'
+import { type BarChartPrivate, computeBarAtIndex, computeSeriesBars } from '../../core/bar-layout'
+import { type BarRect, drawBarHighlight, drawBars, drawGrid, type DrawContext } from '../../core/canvas-renderer'
+import { Chart } from '../../core/Chart'
+import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import {
-    type BarScaleSet,
     computePercentStackData,
     computeStackData,
     createBarScales,
     type StackedBand,
     yTickCountForHeight,
-} from '../core/scales'
+} from '../../core/scales'
 import type {
     BarChartConfig,
     ChartDimensions,
@@ -24,58 +22,15 @@ import type {
     ResolvedSeries,
     Series,
     TooltipContext,
-} from '../core/types'
-import { DEFAULT_Y_AXIS_ID } from '../core/types'
-import { computeVisibleXLabels } from '../overlays/AxisLabels'
-import { DefaultTooltip } from '../overlays/DefaultTooltip'
+} from '../../core/types'
+import { DEFAULT_Y_AXIS_ID } from '../../core/types'
+import { computeVisibleXLabels } from '../../overlays/AxisLabels'
+import { BarTooltip } from './BarTooltip'
+import { seriesKeysAtCursor } from './utils/bars-under-cursor'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
     const start = scales.band(label)
     return start == null ? undefined : start + scales.band.bandwidth() / 2
-}
-
-function barContainsPoint(bar: BarRect, point: { x: number; y: number }): boolean {
-    return point.x >= bar.x && point.x <= bar.x + bar.width && point.y >= bar.y && point.y <= bar.y + bar.height
-}
-
-interface BarHitTestArgs {
-    series: readonly Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>[]
-    label: string
-    dataIndex: number
-    cursor: { x: number; y: number }
-    scales: BarScaleSet
-    layout: 'stacked' | 'grouped' | 'percent'
-    isHorizontal: boolean
-    stackedData?: Map<string, StackedBand>
-    topStackedKeyByAxis: Map<string, string>
-}
-
-/** Shared by drawHover and the tooltip wrapper so they can't drift. */
-function seriesKeysAtCursor(args: BarHitTestArgs): Set<string> {
-    const { series, label, dataIndex, cursor, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis } = args
-    const hits = new Set<string>()
-    for (const s of series) {
-        if (s.visibility?.excluded) {
-            continue
-        }
-        const stackedBand = stackedData?.get(s.key)
-        const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
-        const isTopOfStack = topStackedKeyByAxis.get(axisId) === s.key
-        const bar = computeBarAtIndex({
-            series: s as Series,
-            label,
-            dataIndex,
-            scales,
-            layout,
-            isHorizontal,
-            stackedBand,
-            isTopOfStack,
-        })
-        if (bar && barContainsPoint(bar, cursor)) {
-            hits.add(s.key)
-        }
-    }
-    return hits
 }
 
 export interface BarChartProps<Meta = unknown> {
@@ -331,20 +286,6 @@ function BarChartInner<Meta = unknown>({
         [stackedData, barLayout, isHorizontal, topStackedKeyByAxis, barCornerRadius]
     )
 
-    const wrappedTooltip = useCallback(
-        (ctx: TooltipContext<Meta>): React.ReactNode => (
-            <BarTooltipShell<Meta>
-                ctx={ctx}
-                userTooltip={tooltip}
-                stackedData={stackedData}
-                topStackedKeyByAxis={topStackedKeyByAxis}
-                layout={barLayout}
-                isHorizontal={isHorizontal}
-            />
-        ),
-        [tooltip, stackedData, topStackedKeyByAxis, barLayout, isHorizontal]
-    )
-
     const resolveValue = useMemo(() => {
         if (!stackedData) {
             return undefined
@@ -369,7 +310,16 @@ function BarChartInner<Meta = unknown>({
             createScales={createScales}
             drawStatic={drawStatic}
             drawHover={drawHover}
-            tooltip={wrappedTooltip}
+            tooltip={(ctx) => (
+                <BarTooltip<Meta>
+                    ctx={ctx}
+                    userTooltip={tooltip}
+                    stackedData={stackedData}
+                    topStackedKeyByAxis={topStackedKeyByAxis}
+                    layout={barLayout}
+                    isHorizontal={isHorizontal}
+                />
+            )}
             onPointClick={onPointClick}
             className={className}
             dataAttr={dataAttr}
@@ -378,61 +328,4 @@ function BarChartInner<Meta = unknown>({
             {children}
         </Chart>
     )
-}
-
-interface BarTooltipShellProps<Meta> {
-    ctx: TooltipContext<Meta>
-    userTooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
-    stackedData: Map<string, StackedBand> | undefined
-    topStackedKeyByAxis: Map<string, string>
-    layout: 'stacked' | 'grouped' | 'percent'
-    isHorizontal: boolean
-}
-
-function BarTooltipShell<Meta>({
-    ctx,
-    userTooltip,
-    stackedData,
-    topStackedKeyByAxis,
-    layout,
-    isHorizontal,
-}: BarTooltipShellProps<Meta>): React.ReactElement {
-    const { scales } = useChartLayout()
-    const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
-    // Stacked/percent: keep all rows so the tooltip mirrors the whole hovered column —
-    // matches the legacy chart.js bar tooltip's default `mode: 'nearest'` for stacked bars.
-    const narrowed =
-        layout === 'grouped' && d3Scales && ctx.hoverPosition && ctx.dataIndex >= 0
-            ? narrowSeriesByCursor(ctx, d3Scales, layout, isHorizontal, stackedData, topStackedKeyByAxis)
-            : ctx
-    return <>{userTooltip ? userTooltip(narrowed) : DefaultTooltip(narrowed)}</>
-}
-
-function narrowSeriesByCursor<Meta>(
-    ctx: TooltipContext<Meta>,
-    scales: BarScaleSet,
-    layout: 'stacked' | 'grouped' | 'percent',
-    isHorizontal: boolean,
-    stackedData: Map<string, StackedBand> | undefined,
-    topStackedKeyByAxis: Map<string, string>
-): TooltipContext<Meta> {
-    const cursor = ctx.hoverPosition
-    if (!cursor) {
-        return ctx
-    }
-    const hits = seriesKeysAtCursor({
-        series: ctx.seriesData.map((entry) => entry.series),
-        label: ctx.label,
-        dataIndex: ctx.dataIndex,
-        cursor,
-        scales,
-        layout,
-        isHorizontal,
-        stackedData,
-        topStackedKeyByAxis,
-    })
-    if (hits.size === 0) {
-        return ctx
-    }
-    return { ...ctx, seriesData: ctx.seriesData.filter((entry) => hits.has(entry.series.key)) }
 }

--- a/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarTooltip.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import type { BarChartPrivate } from '../../core/bar-layout'
+import { useChartLayout } from '../../core/chart-context'
+import type { BarScaleSet, StackedBand } from '../../core/scales'
+import type { TooltipContext } from '../../core/types'
+import { DefaultTooltip } from '../../overlays/DefaultTooltip'
+import { seriesKeysAtCursor } from './utils/bars-under-cursor'
+
+export interface BarTooltipProps<Meta> {
+    ctx: TooltipContext<Meta>
+    userTooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    stackedData: Map<string, StackedBand> | undefined
+    topStackedKeyByAxis: Map<string, string>
+    layout: 'stacked' | 'grouped' | 'percent'
+    isHorizontal: boolean
+}
+
+export function BarTooltip<Meta>({
+    ctx,
+    userTooltip,
+    stackedData,
+    topStackedKeyByAxis,
+    layout,
+    isHorizontal,
+}: BarTooltipProps<Meta>): React.ReactElement {
+    const { scales } = useChartLayout()
+    const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
+    const narrowed =
+        layout === 'grouped' && d3Scales && ctx.hoverPosition && ctx.dataIndex >= 0
+            ? narrowSeriesByCursor(ctx, d3Scales, layout, isHorizontal, stackedData, topStackedKeyByAxis)
+            : ctx
+    return <>{userTooltip ? userTooltip(narrowed) : DefaultTooltip(narrowed)}</>
+}
+
+function narrowSeriesByCursor<Meta>(
+    ctx: TooltipContext<Meta>,
+    scales: BarScaleSet,
+    layout: 'stacked' | 'grouped' | 'percent',
+    isHorizontal: boolean,
+    stackedData: Map<string, StackedBand> | undefined,
+    topStackedKeyByAxis: Map<string, string>
+): TooltipContext<Meta> {
+    const cursor = ctx.hoverPosition
+    if (!cursor) {
+        return ctx
+    }
+    const hits = seriesKeysAtCursor({
+        series: ctx.seriesData.map((entry) => entry.series),
+        label: ctx.label,
+        dataIndex: ctx.dataIndex,
+        cursor,
+        scales,
+        layout,
+        isHorizontal,
+        stackedData,
+        topStackedKeyByAxis,
+    })
+    if (hits.size === 0) {
+        return ctx
+    }
+    return { ...ctx, seriesData: ctx.seriesData.filter((entry) => hits.has(entry.series.key)) }
+}

--- a/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
+++ b/frontend/src/lib/hog-charts/charts/BarChart/utils/bars-under-cursor.ts
@@ -1,0 +1,49 @@
+import { computeBarAtIndex } from '../../../core/bar-layout'
+import type { BarRect } from '../../../core/canvas-renderer'
+import type { BarScaleSet, StackedBand } from '../../../core/scales'
+import type { Series } from '../../../core/types'
+import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
+
+export function barContainsPoint(bar: BarRect, point: { x: number; y: number }): boolean {
+    return point.x >= bar.x && point.x <= bar.x + bar.width && point.y >= bar.y && point.y <= bar.y + bar.height
+}
+
+export interface SeriesKeysAtCursorArgs {
+    series: readonly Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>[]
+    label: string
+    dataIndex: number
+    cursor: { x: number; y: number }
+    scales: BarScaleSet
+    layout: 'stacked' | 'grouped' | 'percent'
+    isHorizontal: boolean
+    stackedData?: Map<string, StackedBand>
+    topStackedKeyByAxis: Map<string, string>
+}
+
+/** Shared by drawHover and the tooltip wrapper so they can't drift. */
+export function seriesKeysAtCursor(args: SeriesKeysAtCursorArgs): Set<string> {
+    const { series, label, dataIndex, cursor, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis } = args
+    const hits = new Set<string>()
+    for (const s of series) {
+        if (s.visibility?.excluded) {
+            continue
+        }
+        const stackedBand = stackedData?.get(s.key)
+        const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+        const isTopOfStack = topStackedKeyByAxis.get(axisId) === s.key
+        const bar = computeBarAtIndex({
+            series: s as Series,
+            label,
+            dataIndex,
+            scales,
+            layout,
+            isHorizontal,
+            stackedBand,
+            isTopOfStack,
+        })
+        if (bar && barContainsPoint(bar, cursor)) {
+            hits.add(s.key)
+        }
+    }
+    return hits
+}

--- a/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
+++ b/frontend/src/lib/hog-charts/core/canvas-renderer.test.ts
@@ -442,153 +442,91 @@ describe('hog-charts canvas-renderer', () => {
     })
 
     describe('drawGrid', () => {
-        it('draws a horizontal line at every y-tick', () => {
+        it('draws a horizontal line at the first y-tick (vertical orientation)', () => {
             const ctx = mockCanvasContext()
-            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-            drawGrid(drawCtx)
-            const tickCount = ctx.moveTo.mock.calls.length - 1
-            expect(tickCount).toBeGreaterThan(0)
-            for (let i = 0; i < tickCount; i++) {
-                const [moveX, moveY] = ctx.moveTo.mock.calls[i] as [number, number]
-                const [lineX, lineY] = ctx.lineTo.mock.calls[i] as [number, number]
-                expect(moveX).toBe(dimensions.plotLeft)
-                expect(lineX).toBe(dimensions.plotLeft + dimensions.plotWidth)
-                expect(moveY).toBe(lineY)
-            }
+            drawGrid(makeDrawContext(ctx, ['a', 'b']))
+            // Implementation emits the same shape for every tick, so one representative is enough.
+            const [fromX, fromY] = ctx.moveTo.mock.calls[0]
+            const [toX, toY] = ctx.lineTo.mock.calls[0]
+            expect(fromX).toBe(dimensions.plotLeft)
+            expect(toX).toBe(dimensions.plotLeft + dimensions.plotWidth)
+            expect(fromY).toBe(toY)
         })
 
         it('draws a vertical y-axis line at plotLeft as the final stroke', () => {
             const ctx = mockCanvasContext()
-            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-            drawGrid(drawCtx)
-            const lastMoveTo = ctx.moveTo.mock.calls[ctx.moveTo.mock.calls.length - 1] as [number, number]
-            const lastLineTo = ctx.lineTo.mock.calls[ctx.lineTo.mock.calls.length - 1] as [number, number]
-            expect(lastMoveTo[0]).toBe(dimensions.plotLeft + 0.5)
-            expect(lastMoveTo[1]).toBe(dimensions.plotTop)
-            expect(lastLineTo[0]).toBe(dimensions.plotLeft + 0.5)
-            expect(lastLineTo[1]).toBe(dimensions.plotTop + dimensions.plotHeight)
+            drawGrid(makeDrawContext(ctx, ['a', 'b']))
+            const lastMove = ctx.moveTo.mock.calls.at(-1)
+            const lastLine = ctx.lineTo.mock.calls.at(-1)
+            expect(lastMove).toEqual([dimensions.plotLeft + 0.5, dimensions.plotTop])
+            expect(lastLine).toEqual([dimensions.plotLeft + 0.5, dimensions.plotTop + dimensions.plotHeight])
         })
 
         it('uses the provided gridColor', () => {
             const ctx = mockCanvasContext()
-            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-            drawGrid(drawCtx, { gridColor: 'rgb(1, 2, 3)' })
+            drawGrid(makeDrawContext(ctx, ['a', 'b']), { gridColor: 'rgb(1, 2, 3)' })
             expect(ctx.strokeStyle).toBe('rgb(1, 2, 3)')
         })
 
-        it('draws vertical grid lines and a top baseline in horizontal orientation', () => {
+        it('draws a vertical line at the first value-tick (horizontal orientation)', () => {
             const ctx = mockCanvasContext()
-            const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-            drawGrid(drawCtx, { orientation: 'horizontal' })
-            const tickCount = ctx.moveTo.mock.calls.length - 1
-            expect(tickCount).toBeGreaterThan(0)
-            for (let i = 0; i < tickCount; i++) {
-                const [moveX, moveY] = ctx.moveTo.mock.calls[i] as [number, number]
-                const [lineX, lineY] = ctx.lineTo.mock.calls[i] as [number, number]
-                expect(moveX).toBe(lineX)
-                expect(moveY).toBe(dimensions.plotTop)
-                expect(lineY).toBe(dimensions.plotTop + dimensions.plotHeight)
-            }
-            const lastMoveTo = ctx.moveTo.mock.calls[ctx.moveTo.mock.calls.length - 1] as [number, number]
-            const lastLineTo = ctx.lineTo.mock.calls[ctx.lineTo.mock.calls.length - 1] as [number, number]
-            expect(lastMoveTo[1]).toBe(dimensions.plotTop + 0.5)
-            expect(lastLineTo[1]).toBe(dimensions.plotTop + 0.5)
-            expect(lastMoveTo[0]).toBe(dimensions.plotLeft)
-            expect(lastLineTo[0]).toBe(dimensions.plotLeft + dimensions.plotWidth)
+            drawGrid(makeDrawContext(ctx, ['a', 'b']), { orientation: 'horizontal' })
+            const [fromX, fromY] = ctx.moveTo.mock.calls[0]
+            const [toX, toY] = ctx.lineTo.mock.calls[0]
+            expect(fromX).toBe(toX)
+            expect(fromY).toBe(dimensions.plotTop)
+            expect(toY).toBe(dimensions.plotTop + dimensions.plotHeight)
+        })
+
+        it('draws a horizontal top baseline as the final stroke (horizontal orientation)', () => {
+            const ctx = mockCanvasContext()
+            drawGrid(makeDrawContext(ctx, ['a', 'b']), { orientation: 'horizontal' })
+            const lastMove = ctx.moveTo.mock.calls.at(-1)
+            const lastLine = ctx.lineTo.mock.calls.at(-1)
+            expect(lastMove).toEqual([dimensions.plotLeft, dimensions.plotTop + 0.5])
+            expect(lastLine).toEqual([dimensions.plotLeft + dimensions.plotWidth, dimensions.plotTop + 0.5])
         })
 
         describe('categoryTicks', () => {
-            function countAxisAlignedStrokes(
-                ctx: jest.Mocked<CanvasRenderingContext2D>,
-                axis: 'vertical' | 'horizontal'
-            ): number {
-                const moves = ctx.moveTo.mock.calls as [number, number][]
-                const lines = ctx.lineTo.mock.calls as [number, number][]
-                let n = 0
-                for (let i = 0; i < moves.length; i++) {
-                    const [mx, my] = moves[i]
-                    const [lx, ly] = lines[i] ?? [NaN, NaN]
-                    if (axis === 'vertical' && mx === lx && my !== ly) {
-                        n++
-                    } else if (axis === 'horizontal' && my === ly && mx !== lx) {
-                        n++
-                    }
-                }
-                return n
-            }
-
+            // Coords snap to integer + 0.5 for crisp 1px strokes (e.g. 123 → 123.5).
             it.each([
                 {
-                    desc: 'vertical mode draws one extra vertical stroke per finite categoryTick',
                     orientation: 'vertical' as const,
-                    expectedAxis: 'vertical' as const,
-                    valueAxis: 'horizontal' as const,
+                    tick: 123,
+                    expectedMove: [123.5, dimensions.plotTop],
+                    expectedLine: [123.5, dimensions.plotTop + dimensions.plotHeight],
                 },
                 {
-                    desc: 'horizontal mode draws one extra horizontal stroke per finite categoryTick',
                     orientation: 'horizontal' as const,
-                    expectedAxis: 'horizontal' as const,
-                    valueAxis: 'vertical' as const,
+                    tick: 200,
+                    expectedMove: [dimensions.plotLeft, 200.5],
+                    expectedLine: [dimensions.plotLeft + dimensions.plotWidth, 200.5],
                 },
-            ])('$desc', ({ orientation, expectedAxis, valueAxis }) => {
-                const baseline = mockCanvasContext()
-                const baselineCtx = makeDrawContext(baseline, ['a', 'b'])
-                drawGrid(baselineCtx, { orientation })
-                const baselineCrossAxis = countAxisAlignedStrokes(baseline, expectedAxis)
-
-                const ctx = mockCanvasContext()
-                const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-                const ticks = [100, 200, 300]
-                drawGrid(drawCtx, { orientation, categoryTicks: ticks })
-
-                expect(countAxisAlignedStrokes(ctx, expectedAxis)).toBe(baselineCrossAxis + ticks.length)
-                expect(countAxisAlignedStrokes(ctx, valueAxis)).toBe(countAxisAlignedStrokes(baseline, valueAxis))
-            })
+            ])(
+                '$orientation categoryTicks span the full cross axis at the snapped coord',
+                ({ orientation, tick, expectedMove, expectedLine }) => {
+                    const ctx = mockCanvasContext()
+                    drawGrid(makeDrawContext(ctx, ['a', 'b']), { orientation, categoryTicks: [tick] })
+                    expect(ctx.moveTo.mock.calls).toContainEqual(expectedMove)
+                    expect(ctx.lineTo.mock.calls).toContainEqual(expectedLine)
+                }
+            )
 
             it.each([{ orientation: 'vertical' as const }, { orientation: 'horizontal' as const }])(
                 'skips non-finite categoryTicks ($orientation)',
                 ({ orientation }) => {
-                    const ctx = mockCanvasContext()
-                    const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-                    const finiteTicks = [50, 150]
-                    drawGrid(drawCtx, {
+                    const finiteOnly = mockCanvasContext()
+                    drawGrid(makeDrawContext(finiteOnly, ['a', 'b']), { orientation, categoryTicks: [200] })
+
+                    const withNonFinite = mockCanvasContext()
+                    drawGrid(makeDrawContext(withNonFinite, ['a', 'b']), {
                         orientation,
-                        categoryTicks: [Number.NaN, ...finiteTicks, Number.POSITIVE_INFINITY],
+                        categoryTicks: [Number.NaN, 200, Number.POSITIVE_INFINITY],
                     })
-                    const expectedAxis = orientation === 'vertical' ? 'vertical' : 'horizontal'
 
-                    const baseline = mockCanvasContext()
-                    const baselineCtx = makeDrawContext(baseline, ['a', 'b'])
-                    drawGrid(baselineCtx, { orientation })
-
-                    expect(countAxisAlignedStrokes(ctx, expectedAxis)).toBe(
-                        countAxisAlignedStrokes(baseline, expectedAxis) + finiteTicks.length
-                    )
+                    expect(withNonFinite.moveTo.mock.calls.length).toBe(finiteOnly.moveTo.mock.calls.length)
                 }
             )
-
-            it('vertical categoryTicks draw lines spanning the full plot height at the requested x', () => {
-                const ctx = mockCanvasContext()
-                const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-                drawGrid(drawCtx, { orientation: 'vertical', categoryTicks: [123] })
-                // Coordinate is snapped to integer + 0.5 (crisp 1px stroke), so 123 → 123.5.
-                const moves = ctx.moveTo.mock.calls as [number, number][]
-                const lines = ctx.lineTo.mock.calls as [number, number][]
-                const idx = moves.findIndex(([mx, my]) => mx === 123.5 && my === dimensions.plotTop)
-                expect(idx).toBeGreaterThanOrEqual(0)
-                expect(lines[idx]).toEqual([123.5, dimensions.plotTop + dimensions.plotHeight])
-            })
-
-            it('horizontal categoryTicks draw lines spanning the full plot width at the requested y', () => {
-                const ctx = mockCanvasContext()
-                const drawCtx = makeDrawContext(ctx, ['a', 'b'])
-                drawGrid(drawCtx, { orientation: 'horizontal', categoryTicks: [200] })
-                const moves = ctx.moveTo.mock.calls as [number, number][]
-                const lines = ctx.lineTo.mock.calls as [number, number][]
-                const idx = moves.findIndex(([mx, my]) => my === 200.5 && mx === dimensions.plotLeft)
-                expect(idx).toBeGreaterThanOrEqual(0)
-                expect(lines[idx]).toEqual([dimensions.plotLeft + dimensions.plotWidth, 200.5])
-            })
         })
     })
 

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -1,6 +1,6 @@
 // Components
-export { BarChart } from './charts/BarChart'
-export type { BarChartProps } from './charts/BarChart'
+export { BarChart } from './charts/BarChart/BarChart'
+export type { BarChartProps } from './charts/BarChart/BarChart'
 export { LineChart } from './charts/LineChart'
 export type { LineChartProps } from './charts/LineChart'
 export { TimeSeriesLineChart } from './charts/TimeSeriesLineChart/TimeSeriesLineChart'


### PR DESCRIPTION
## Problem

After the visual-parity work and per-bar hover refactor, `BarChart.tsx` had grown to ~425 lines and the `drawGrid` test file had branching helper logic that violated this repo's "no logic in tests" preference. Time for a tidy.

This PR is part 3 of a 3-PR stack — see [#57832](https://github.com/PostHog/posthog/pull/57832) and [#57916](https://github.com/PostHog/posthog/pull/57916).

## Changes

- Move `BarChart` into its own folder mirroring `TimeSeriesLineChart/`:
  ```
  charts/BarChart/
    BarChart.tsx
    BarChart.test.tsx
    BarChart.stories.tsx
    BarTooltip.tsx
    utils/
      bars-under-cursor.ts
  ```
- `drawGrid` tests: drop the for-loops that asserted "every stroke matches X" and the `countAxisAlignedStrokes` classification helper. Replaced with single representative-stroke samples (the production code routes every tick through the same path) and `toContainEqual` / length comparisons for the `categoryTicks` paths.

No behavior change.

## How did you test this code?

I'm an agent — automated tests only: hog-charts and trends-bar-chart Jest suites pass.

## Publish to changelog?

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7).
- Stacks on [#57916](https://github.com/PostHog/posthog/pull/57916).