### PR TITLE
feat(cdp): shorten Slack channel refresh cooldown

### DIFF
--- a/frontend/src/lib/hooks/usePeriodicRerender.ts
+++ b/frontend/src/lib/hooks/usePeriodicRerender.ts
@@ -27,7 +27,8 @@ export function usePeriodicRerender(milliseconds: number): void {
             }
         }
 
-        if (isVisible) {
+        // Pass 0 (or negative) to opt out of the interval entirely — useful for callers that only need to tick under specific conditions.
+        if (isVisible && milliseconds > 0) {
             startInterval()
         } else {
             stopInterval()

--- a/frontend/src/lib/hooks/usePeriodicRerender.ts
+++ b/frontend/src/lib/hooks/usePeriodicRerender.ts
@@ -27,8 +27,7 @@ export function usePeriodicRerender(milliseconds: number): void {
             }
         }
 
-        // Pass 0 (or negative) to opt out of the interval entirely — useful for callers that only need to tick under specific conditions.
-        if (isVisible && milliseconds > 0) {
+        if (isVisible) {
             startInterval()
         } else {
             stopInterval()

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -84,8 +84,8 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     const [localValue, setLocalValue] = useState<string | null>(null)
 
     const channelRefreshButtonDisabledReason = getChannelRefreshButtonDisabledReason()
-    // Tick every second only while the cooldown is active so the countdown updates; idle otherwise (kea state changes drive rerenders).
-    usePeriodicRerender(channelRefreshButtonDisabledReason ? 1000 : 0)
+    // 1s tick while the cooldown is active so the countdown updates; otherwise idle the rerender (60s, picker is short-lived).
+    usePeriodicRerender(channelRefreshButtonDisabledReason ? 1000 : 60_000)
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
     const rawSlackChannelOptions = useMemo(() => getSlackChannelOptions(slackChannels), [slackChannels])

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -83,7 +83,7 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     const { loadAllSlackChannels, loadSlackChannelById } = useActions(slackIntegrationLogic({ id: integration.id }))
     const [localValue, setLocalValue] = useState<string | null>(null)
 
-    usePeriodicRerender(15000) // Re-render every 15 seconds for up-to-date `getChannelRefreshButtonDisabledReason`
+    usePeriodicRerender(10000)
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
     const rawSlackChannelOptions = useMemo(() => getSlackChannelOptions(slackChannels), [slackChannels])

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -83,7 +83,8 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     const { loadAllSlackChannels, loadSlackChannelById } = useActions(slackIntegrationLogic({ id: integration.id }))
     const [localValue, setLocalValue] = useState<string | null>(null)
 
-    usePeriodicRerender(10000)
+    // 1s tick so the cooldown countdown rendered by `getChannelRefreshButtonDisabledReason` updates each second
+    usePeriodicRerender(1000)
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
     const rawSlackChannelOptions = useMemo(() => getSlackChannelOptions(slackChannels), [slackChannels])

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -83,8 +83,9 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     const { loadAllSlackChannels, loadSlackChannelById } = useActions(slackIntegrationLogic({ id: integration.id }))
     const [localValue, setLocalValue] = useState<string | null>(null)
 
-    // 1s tick so the cooldown countdown rendered by `getChannelRefreshButtonDisabledReason` updates each second
-    usePeriodicRerender(1000)
+    const channelRefreshButtonDisabledReason = getChannelRefreshButtonDisabledReason()
+    // Tick every second only while the cooldown is active so the countdown updates; idle otherwise (kea state changes drive rerenders).
+    usePeriodicRerender(channelRefreshButtonDisabledReason ? 1000 : 0)
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
     const rawSlackChannelOptions = useMemo(() => getSlackChannelOptions(slackChannels), [slackChannels])
@@ -138,7 +139,7 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
                 action={{
                     children: <span className="Link">Refresh channels</span>,
                     onClick: () => loadAllSlackChannels(true),
-                    disabledReason: getChannelRefreshButtonDisabledReason(),
+                    disabledReason: channelRefreshButtonDisabledReason,
                 }}
                 emptyStateComponent={
                     <p className="text-secondary italic p-1">

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -1,0 +1,62 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { dayjs } from 'lib/dayjs'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS, slackIntegrationLogic } from './slackIntegrationLogic'
+
+describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () => {
+    let logic: ReturnType<typeof slackIntegrationLogic.build>
+    let lastRefreshedAt: string
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/:id/channels': () => [200, { channels: [], lastRefreshedAt }],
+            },
+        })
+        initKeaTests()
+        logic = slackIntegrationLogic({ id: 1 })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    const refreshAt = async (timestamp: string): Promise<void> => {
+        lastRefreshedAt = timestamp
+        await expectLogic(logic, () => {
+            logic.actions.loadAllSlackChannels()
+        }).toFinishAllListeners()
+    }
+
+    it('uses a 30 second cooldown', () => {
+        expect(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS).toBe(30)
+    })
+
+    it('disables the refresh button immediately after a refresh', async () => {
+        await refreshAt(dayjs().toISOString())
+        expect(logic.values.getChannelRefreshButtonDisabledReason()).not.toBe('')
+    })
+
+    it('still disables the refresh button just before the cooldown elapses', async () => {
+        await refreshAt(
+            dayjs()
+                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS - 5, 'seconds')
+                .toISOString()
+        )
+        expect(logic.values.getChannelRefreshButtonDisabledReason()).not.toBe('')
+    })
+
+    it('enables the refresh button once the cooldown has elapsed', async () => {
+        await refreshAt(
+            dayjs()
+                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS + 5, 'seconds')
+                .toISOString()
+        )
+        expect(logic.values.getChannelRefreshButtonDisabledReason()).toBe('')
+    })
+})

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -7,11 +7,34 @@ import { initKeaTests } from '~/test/init'
 
 import { SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS, slackIntegrationLogic } from './slackIntegrationLogic'
 
+const FIXED_NOW = new Date('2026-01-01T12:00:00Z')
+
 describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () => {
     let logic: ReturnType<typeof slackIntegrationLogic.build>
     let lastRefreshedAt: string
 
     beforeEach(() => {
+        // Only fake `Date` so dayjs() reads a fixed wall clock; keep timers real so kea-test-utils async helpers run.
+        jest.useFakeTimers({
+            now: FIXED_NOW,
+            doNotFake: [
+                'hrtime',
+                'nextTick',
+                'performance',
+                'queueMicrotask',
+                'requestAnimationFrame',
+                'cancelAnimationFrame',
+                'requestIdleCallback',
+                'cancelIdleCallback',
+                'setImmediate',
+                'clearImmediate',
+                'setInterval',
+                'clearInterval',
+                'setTimeout',
+                'clearTimeout',
+            ],
+        })
+        lastRefreshedAt = ''
         useMocks({
             get: {
                 '/api/environments/:team_id/integrations/:id/channels': () => [200, { channels: [], lastRefreshedAt }],
@@ -24,6 +47,7 @@ describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () =
 
     afterEach(() => {
         logic.unmount()
+        jest.useRealTimers()
     })
 
     const refreshAt = async (timestamp: string): Promise<void> => {
@@ -33,19 +57,15 @@ describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () =
         }).toFinishAllListeners()
     }
 
-    it('uses a 30 second cooldown', () => {
-        expect(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS).toBe(30)
-    })
-
     it('disables the refresh button immediately after a refresh', async () => {
-        await refreshAt(dayjs().toISOString())
+        await refreshAt(dayjs(FIXED_NOW).toISOString())
         expect(logic.values.getChannelRefreshButtonDisabledReason()).not.toBe('')
     })
 
     it('still disables the refresh button just before the cooldown elapses', async () => {
         await refreshAt(
-            dayjs()
-                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS - 5, 'seconds')
+            dayjs(FIXED_NOW)
+                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS - 1, 'seconds')
                 .toISOString()
         )
         expect(logic.values.getChannelRefreshButtonDisabledReason()).not.toBe('')
@@ -53,8 +73,8 @@ describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () =
 
     it('enables the refresh button once the cooldown has elapsed', async () => {
         await refreshAt(
-            dayjs()
-                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS + 5, 'seconds')
+            dayjs(FIXED_NOW)
+                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS + 1, 'seconds')
                 .toISOString()
         )
         expect(logic.values.getChannelRefreshButtonDisabledReason()).toBe('')

--- a/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.test.ts
@@ -57,26 +57,17 @@ describe('slackIntegrationLogic — getChannelRefreshButtonDisabledReason', () =
         }).toFinishAllListeners()
     }
 
-    it('disables the refresh button immediately after a refresh', async () => {
-        await refreshAt(dayjs(FIXED_NOW).toISOString())
-        expect(logic.values.getChannelRefreshButtonDisabledReason()).not.toBe('')
-    })
-
-    it('still disables the refresh button just before the cooldown elapses', async () => {
-        await refreshAt(
-            dayjs(FIXED_NOW)
-                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS - 1, 'seconds')
-                .toISOString()
-        )
-        expect(logic.values.getChannelRefreshButtonDisabledReason()).not.toBe('')
-    })
-
-    it('enables the refresh button once the cooldown has elapsed', async () => {
-        await refreshAt(
-            dayjs(FIXED_NOW)
-                .subtract(SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS + 1, 'seconds')
-                .toISOString()
-        )
-        expect(logic.values.getChannelRefreshButtonDisabledReason()).toBe('')
+    it.each<[string, number, boolean]>([
+        ['stays disabled immediately after a refresh', 0, false],
+        ['stays disabled just before the cooldown elapses', SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS - 1, false],
+        ['enables once the cooldown has elapsed', SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS + 1, true],
+    ])('refresh button %s', async (_label, secondsAgo, expectEnabled) => {
+        await refreshAt(dayjs(FIXED_NOW).subtract(secondsAgo, 'seconds').toISOString())
+        const reason = logic.values.getChannelRefreshButtonDisabledReason()
+        if (expectEnabled) {
+            expect(reason).toBe('')
+        } else {
+            expect(reason).not.toBe('')
+        }
     })
 })

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -98,7 +98,10 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                         'seconds'
                     )
                     if (now.isBefore(earliestRefresh)) {
-                        return `You can refresh the channels again ${earliestRefresh.from(now)}`
+                        const secondsLeft = Math.ceil(earliestRefresh.diff(now) / 1000)
+                        return `You can refresh the channels again in ${secondsLeft} second${
+                            secondsLeft === 1 ? '' : 's'
+                        }`
                     }
                 }
                 return ''

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -9,7 +9,7 @@ import { SlackChannelType } from '~/types'
 
 import type { slackIntegrationLogicType } from './slackIntegrationLogicType'
 
-export const SLACK_CHANNELS_MIN_REFRESH_INTERVAL_MINUTES = 5
+export const SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS = 30
 
 export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     props({} as { id: number }),
@@ -94,8 +94,8 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                 const now = dayjs()
                 if (allSlackChannels) {
                     const earliestRefresh = dayjs(allSlackChannels.lastRefreshedAt).add(
-                        SLACK_CHANNELS_MIN_REFRESH_INTERVAL_MINUTES,
-                        'minutes'
+                        SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS,
+                        'seconds'
                     )
                     if (now.isBefore(earliestRefresh)) {
                         return `You can refresh the channels again ${earliestRefresh.from(now)}`

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -83,10 +83,10 @@ class TestSlackIntegration:
         channels = slack.list_channels(True, "test_user_id")
 
         mock_client.conversations_list.assert_called_once_with(
-            exclude_archived=True, types="public_channel", limit=200, cursor=None
+            exclude_archived=True, types="public_channel", limit=1000, cursor=None
         )
         mock_client.users_conversations.assert_called_once_with(
-            exclude_archived=True, types="private_channel", limit=200, cursor=None, user="test_user_id"
+            exclude_archived=True, types="private_channel", limit=1000, cursor=None, user="test_user_id"
         )
 
         assert len(channels) == 4
@@ -126,10 +126,10 @@ class TestSlackIntegration:
         channels = slack.list_channels(False, "test_user_id")
 
         mock_client.conversations_list.assert_called_once_with(
-            exclude_archived=True, types="public_channel", limit=200, cursor=None
+            exclude_archived=True, types="public_channel", limit=1000, cursor=None
         )
         mock_client.users_conversations.assert_called_once_with(
-            exclude_archived=True, types="private_channel", limit=200, cursor=None, user="test_user_id"
+            exclude_archived=True, types="private_channel", limit=1000, cursor=None, user="test_user_id"
         )
 
         assert len(channels) == 4

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1117,6 +1117,9 @@ class SlackIntegrationError(Exception):
 
 SLACK_INTEGRATION_KINDS: tuple[str, ...] = ("slack", "slack-posthog-code")
 
+SLACK_CHANNELS_PAGE_SIZE = 1000
+SLACK_CHANNELS_MAX_PAGES = 10
+
 
 class SlackIntegration:
     integration: Integration
@@ -1176,17 +1179,23 @@ class SlackIntegration:
         should_include_private_channels: bool = False,
         authed_user: str | None = None,
     ) -> list[dict]:
-        max_page = 50
+        max_page = SLACK_CHANNELS_MAX_PAGES
         channels = []
         cursor = None
 
         while max_page > 0:
             max_page -= 1
             if type == "public_channel":
-                res = self.client.conversations_list(exclude_archived=True, types=type, limit=200, cursor=cursor)
+                res = self.client.conversations_list(
+                    exclude_archived=True, types=type, limit=SLACK_CHANNELS_PAGE_SIZE, cursor=cursor
+                )
             else:
                 res = self.client.users_conversations(
-                    exclude_archived=True, types=type, limit=200, cursor=cursor, user=authed_user
+                    exclude_archived=True,
+                    types=type,
+                    limit=SLACK_CHANNELS_PAGE_SIZE,
+                    cursor=cursor,
+                    user=authed_user,
                 )
 
                 for channel in res["channels"]:


### PR DESCRIPTION
## Problem

In flows that pick a Slack channel (insight alerts, subscriptions, CDP / hog flow destinations), the **Refresh channels** / **Check again** button is gated by a 5-minute cooldown. This is much longer than the actual rate-limit headroom requires, and is long enough that users frequently feel the gate is broken when they've just added the PostHog app to a new channel.

## Findings

- Frontend cooldown: `SLACK_CHANNELS_MIN_REFRESH_INTERVAL_MINUTES = 5` (`slackIntegrationLogic.ts`).
- Backend cache: `IntegrationViewSet.channels` already caches the channel list for 1 hour per integration; `force_refresh=true` only bypasses the cache for cookie-authenticated callers.
- Pagination: `_list_channels_by_type` paginates `conversations.list` / `users.conversations` up to 50 pages of 200 results — i.e. up to 50 sequential API calls per refresh on a single workspace.
- Slack rate limits: `conversations.list` is Tier 2 (~20/min), `users.conversations` is Tier 3 (~50/min). These are per workspace × app × method.
- The 5-minute cooldown predates the 1-hour server cache and was originally added defensively after rate-limit errors when many destination forms mounted concurrently for one workspace. The server cache now solves that root cause; the frontend gate is just defense-in-depth.

The headroom math:
- 1k-channel workspace at 200/page = 5 calls per refresh; at 1000/page = 1 call.
- 10k-channel workspace at 200/page = 50 calls (well over Tier 2's 20/min); at 1000/page = 10 calls (within budget).

## Changes

- **Frontend cooldown 5 min → 30 s.** `SLACK_CHANNELS_MIN_REFRESH_INTERVAL_MINUTES` renamed to `SLACK_CHANNELS_MIN_REFRESH_INTERVAL_SECONDS = 30`. The disabled-reason text updates accordingly.
- **Cooldown rerender 15 s → 1 s** so the "You can refresh again in X" text stays accurate inside the shorter window.
- **Slack pagination: page size 200 → 1000, max pages 50 → 10.** Same 10k-channel ceiling, but in 10 calls instead of 50, which keeps a single refresh inside Tier 2's per-minute budget even on large workspaces. New module-level constants \`SLACK_CHANNELS_PAGE_SIZE\` / \`SLACK_CHANNELS_MAX_PAGES\` replace the inline magic numbers.

The 1-hour server cache and the cookie-only \`force_refresh\` gate are unchanged, so the underlying rate-limit defense is preserved.

## How did you test this code?

I'm an agent — I haven't manually exercised the picker. The existing \`posthog/api/test/test_integration.py\` assertions for \`_list_channels_by_type\` were updated for the new \`limit=1000\` and run as part of the suite.

Manual checklist for a human reviewer:
- [x] Open a Slack channel picker (insight alert, subscription, or CDP destination), click **Refresh channels** twice ~30 s apart and confirm the gate releases.
<img width="2168" height="776" alt="CleanShot 2026-05-07 at 16 28 41@2x" src="https://github.com/user-attachments/assets/47038d97-a95f-4eb2-9e5d-4ed6a117d587" />


## Publish to changelog?

no

## Docs update

No docs change.

## 🤖 Agent context

- Authored by PostHog Code (Claude Opus 4.7).
- Prompt context: investigation requested into the alert-flow Slack channel "Check again" cooldown, including Slack's rate-limit tiers and our pagination strategy, before any code change. The shape of the change (30 s cooldown + page-size 1000 + 10-page cap) was decided by the human author based on that investigation.
- Decisions: kept the 1-hour server cache and the cookie-only \`force_refresh\` gate; deferred any alignment with the structurally similar \`twilioIntegrationLogic\` because Twilio has different rate-limit semantics and was out of scope.