### PR TITLE
fix(ingestion): fix rate limit logic bug that caused lag to increase drop rate

### DIFF
--- a/nodejs/src/common/redis/redis-token-bucket.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket.lua.ts
@@ -41,15 +41,16 @@ if currentTokens == false then
   currentTokens = poolMax
 end
 
-currentTokens = math.min(currentTokens + owedTokens, poolMax)
+currentTokens = currentTokens + owedTokens
 
 -- Store tokens before cost deduction
 local tokensBefore = currentTokens
 
--- Remove the cost and calculate tokens after
+-- Remove the cost and calculate tokens after; cap stored pool at poolMax so silent
+-- periods do not let saved credit grow unbounded across many calls.
 local tokensAfter
 if currentTokens - cost >= 0 then
-  tokensAfter = currentTokens - cost
+  tokensAfter = math.min(currentTokens - cost, poolMax)
 else
   tokensAfter = -1
 end

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -697,7 +697,7 @@ describe('LogsRateLimiterService', () => {
                 // configured rate is 1KB/s so ~half should be dropped.
                 const messages: any[] = []
                 for (let i = 0; i < 120; i++) {
-                    const seconds = 60 + Math.floor(i / 2)
+                    const seconds = 0 + Math.floor(i / 2)
                     const ts = new Date(
                         `2024-01-01T00:0${Math.floor(seconds / 60)}:${(seconds % 60).toString().padStart(2, '0')}Z`
                     ).toISOString()

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -166,18 +166,18 @@ describe('LogsRateLimiterService', () => {
             const start = await rateLimiter.rateLimitMany([[teamId1, 100, Math.round(now / 1000)]])
             expect(start[0][1].tokensAfter).toBe(0)
 
-            // Simulate a 10s "lag" with no rate-limiter calls. With refill rate 10KB/s
-            // that's 100KB of credit, plus the bucket has been empty so currentTokens=0.
-            advanceTime(10_000)
+            // Simulate a 20s "lag" with no rate-limiter calls. With refill rate 10KB/s
+            // that's 200KB of credit.
+            advanceTime(20_000)
 
             // Single catch-up call costing the full accrued credit. Without uncapped
             // tokensBefore this would see tokensBefore=poolMax=100 and reject anything
-            // beyond that — which is exactly the bug this is checking does not regress.
-            const catchup = await rateLimiter.rateLimitMany([[teamId1, 100, Math.round(now / 1000)]])
+            // beyond that — we should be able to consumer 200KB of credit without being rate-limited.
+            const catchup = await rateLimiter.rateLimitMany([[teamId1, 199, Math.round(now / 1000)]])
 
-            expect(catchup[0][1].tokensBefore).toBe(100) // = 0 prev + 10s × 10KB/s refill
-            expect(catchup[0][1].tokensAfter).toBe(0)
-            expect(catchup[0][1].isRateLimited).toBe(true)
+            expect(catchup[0][1].tokensBefore).toBe(200) // = 0 prev + 20s × 10KB/s refill
+            expect(catchup[0][1].tokensAfter).toBe(1)
+            expect(catchup[0][1].isRateLimited).toBe(false)
         })
 
         it('should handle sequential requests for same team in single call', async () => {

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -143,18 +143,41 @@ describe('LogsRateLimiterService', () => {
             expect(res3[0][1].isRateLimited).toBe(false)
         })
 
-        it('should not refill above bucket size', async () => {
+        it('should expose accrued credit in tokensBefore but cap stored pool at bucket size', async () => {
             const res = await rateLimiter.rateLimitMany([[teamId1, 10, Math.round(now / 1000)]])
 
             expect(res[0][1].tokensAfter).toBe(90)
 
-            advanceTime(5000) // 5 seconds = 50KB refilled, but capped at 100
+            advanceTime(5000) // 5 seconds at 10KB/s = 50KB of accrued refill credit
 
             const res2 = await rateLimiter.rateLimitMany([[teamId1, 0, Math.round(now / 1000)]])
 
-            expect(res2[0][1].tokensBefore).toBe(100) // capped at bucket size
+            // tokensBefore reflects actual accrued credit (90 + 50 = 140) so that a single
+            // catch-up call can spend more than the bucket size when the producer time span
+            // earned that credit. The stored pool (tokensAfter, after deducting cost) is
+            // still capped at poolMax to bound silent-period accumulation.
+            expect(res2[0][1].tokensBefore).toBe(140)
             expect(res2[0][1].tokensAfter).toBe(100)
             expect(res2[0][1].isRateLimited).toBe(false)
+        })
+
+        it('should let a catch-up call redeem refill credit larger than the bucket', async () => {
+            // Drain the bucket with a starting call.
+            const start = await rateLimiter.rateLimitMany([[teamId1, 100, Math.round(now / 1000)]])
+            expect(start[0][1].tokensAfter).toBe(0)
+
+            // Simulate a 10s "lag" with no rate-limiter calls. With refill rate 10KB/s
+            // that's 100KB of credit, plus the bucket has been empty so currentTokens=0.
+            advanceTime(10_000)
+
+            // Single catch-up call costing the full accrued credit. Without uncapped
+            // tokensBefore this would see tokensBefore=poolMax=100 and reject anything
+            // beyond that — which is exactly the bug this is checking does not regress.
+            const catchup = await rateLimiter.rateLimitMany([[teamId1, 100, Math.round(now / 1000)]])
+
+            expect(catchup[0][1].tokensBefore).toBe(100) // = 0 prev + 10s × 10KB/s refill
+            expect(catchup[0][1].tokensAfter).toBe(0)
+            expect(catchup[0][1].isRateLimited).toBe(true)
         })
 
         it('should handle sequential requests for same team in single call', async () => {
@@ -640,6 +663,52 @@ describe('LogsRateLimiterService', () => {
                 // Newest timestamp t10 gives 10KB refill from t0, enough for 5+3=8KB
                 expect(result2.allowed).toHaveLength(2)
                 expect(result2.dropped).toHaveLength(0)
+            })
+
+            it('should allow a catch-up batch larger than the bucket when refill credit covers it', async () => {
+                // Simulate steady-state ingestion landing the bucket near full at t0.
+                const t0 = new Date('2024-01-01T00:00:00Z').toISOString()
+                const result0 = await rateLimiter.filterMessages([
+                    createMessageWithHeaders(1, 1000, [{ created_at: t0 }]),
+                ])
+                expect(result0.allowed).toHaveLength(1)
+
+                // Now a single "catch-up" batch arrives covering 60 seconds of producer
+                // time at the configured rate (1KB/s × 60s = 60KB), six times the bucket
+                // size. Without uncapped tokensBefore, only ~10KB would pass.
+                const messages: any[] = []
+                for (let i = 1; i <= 60; i++) {
+                    const ts = new Date(`2024-01-01T00:01:${(i - 1).toString().padStart(2, '0')}Z`).toISOString()
+                    messages.push(createMessageWithHeaders(1, 1000, [{ created_at: ts }]))
+                }
+
+                const result = await rateLimiter.filterMessages(messages)
+
+                expect(result.allowed).toHaveLength(60)
+                expect(result.dropped).toHaveLength(0)
+            })
+
+            it('should still drop excess when catch-up batch exceeds the configured rate', async () => {
+                // Prior state at t0 so subsequent batch is not a "first call".
+                const t0 = new Date('2024-01-01T00:00:00Z').toISOString()
+                await rateLimiter.filterMessages([createMessageWithHeaders(1, 1000, [{ created_at: t0 }])])
+
+                // Producer ran at 2KB/s for 60s → 120KB total spanning 60s. The
+                // configured rate is 1KB/s so ~half should be dropped.
+                const messages: any[] = []
+                for (let i = 0; i < 120; i++) {
+                    const seconds = 60 + Math.floor(i / 2)
+                    const ts = new Date(
+                        `2024-01-01T00:0${Math.floor(seconds / 60)}:${(seconds % 60).toString().padStart(2, '0')}Z`
+                    ).toISOString()
+                    messages.push(createMessageWithHeaders(1, 1000, [{ created_at: ts }]))
+                }
+
+                const result = await rateLimiter.filterMessages(messages)
+
+                expect(result.allowed.length).toBeGreaterThan(50)
+                expect(result.allowed.length).toBeLessThan(80)
+                expect(result.dropped.length).toBeGreaterThan(40)
             })
 
             it('should handle empty headers array', async () => {


### PR DESCRIPTION
## Problem

when catching up from lag on ingestion, message drop rates were amplified (especially for logs)

this is because when a large batch is ingested which spans enough time to overflow the token pool, token allowances are dropped as we cap (currentTokens + usedTokens) to poolMax

## Changes

move the cap to poolMax until _after_ we've spent the tokens from the current batch
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

locally, unit tests, plus a lag catchup test script
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Include:
     - tools/agent used and link to session
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->
