### PR TITLE
fix(dashboards): render all tiles in PNG dashboard exports

### DIFF
--- a/frontend/src/exporter/Exporter.scss
+++ b/frontend/src/exporter/Exporter.scss
@@ -59,6 +59,14 @@ html.export-type-image {
             'Emoji Flags Polyfill', Inter, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
             'Segoe UI Emoji', 'Segoe UI Symbol';
     }
+
+    // content-visibility:auto on dashboard tiles defers off-screen rendering, leaving below-the-fold tiles
+    // as intrinsic-size placeholders during the headless screenshot. The same problem was hit and worked
+    // around in the Storybook test-runner; mirror that here for PNG exports.
+    .react-grid-layout.dashboard-view-mode .react-grid-item {
+        content-visibility: visible;
+        contain-intrinsic-size: auto;
+    }
 }
 
 html.export-type-embed {


### PR DESCRIPTION
## Problem

Customers (#654) report that PNG dashboard exports look "not pretty" — tiles below the first viewport row render as blank placeholders or partially-rendered charts in the final image.

The headless Selenium exporter (`posthog/tasks/exports/image_exporter.py`) starts the browser at `1920x600`, navigates to `/exporter`, waits for the first `.InsightCard` to appear, then resizes the window to the measured page height and saves the screenshot 500ms later.

The dashboard grid in `frontend/src/scenes/dashboard/DashboardItems.scss` applies `content-visibility: auto; contain-intrinsic-size: auto 30rem;` to every `.dashboard-view-mode .react-grid-item`. That class is set whenever the dashboard isn't in edit mode — including `DashboardPlacement.Export`. The result is that during the initial 1920×600 render only the top row of tiles is actually painted; tiles below the fold are kept as 30rem-tall intrinsic-size boxes. After the window resize, 500ms is often not enough for chart libraries / `ResizeObserver` callbacks to repaint those tiles before the screenshot is taken.

The same problem was already encountered and patched in the Storybook test-runner (`common/storybook/.storybook/test-runner.ts:217`), where `content-visibility: auto` is forced to `visible` for deterministic snapshots. The PNG exporter has no equivalent override.

## Changes

Add a CSS override under `html.export-type-image` (the root class set by `posthog/api/sharing.py` for image exports, applied via `frontend/src/exporter/index.html`) that resets `content-visibility` to `visible` for dashboard grid items. Embedded and shared (Public) dashboards keep their lazy-render performance because the override is scoped to image exports only.

## How did you test this code?

I'm an agent. I did not run the export pipeline manually — that requires a Chromedriver-equipped Celery worker against a live frontend bundle, which isn't available in the agent environment. The fix is a CSS-only, scoped override that mirrors a precedent already used in this repo for the same browser feature, so the change is mechanically straightforward; reviewer should still:

- Trigger an "Export to PNG" on a multi-row dashboard before and after the change to confirm tiles render
- Spot-check that embedded dashboards (`html.export-type-embed`) and Public sharing keep `content-visibility: auto` (they should — the override is scoped to `html.export-type-image`)

No automated tests were added; the CSS is exercised any time the existing image-export e2e/integration paths run.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 Agent context

- Authored by PostHog Code (Claude-based agent), task id `eb0f3e22-223b-485b-b2e2-a992beffd3c6`.
- Followed the bug from the customer report → exporter pipeline (`image_exporter.py`) → exporter frontend entry (`Exporter.tsx`, `Exporter.scss`) → grid CSS (`DashboardItems.scss`).
- Considered three places to apply the fix:
  1. Disable `content-visibility: auto` outright in `DashboardItems.scss`. Rejected — it's a real perf win for interactive view.
  2. Override based on `placement === DashboardPlacement.Export` via a new className on the grid. Rejected — wider blast radius, requires plumbing through `Dashboard.tsx`/`DashboardItems.tsx` for what is purely a render-time concern.
  3. CSS-only override scoped to `html.export-type-image`. Chosen — minimal surface, mirrors the existing Storybook precedent, easy to reason about.
- The shallow git clone in the agent environment didn't expose history, so the regression is described from the current code state rather than blamed to a specific commit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*