### PR TITLE
fix(activity): allow impersonators to bypass audit_logs paywall

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -15,6 +15,7 @@ import { IconWithCount } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import {
     SidePanelActivityTab,
@@ -52,6 +53,7 @@ export const SidePanelActivity = (): JSX.Element => {
 
     const { closeSidePanel } = useActions(sidePanelStateLogic)
 
+    const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const hasAccess = userHasAccess(AccessControlResourceType.ActivityLog, AccessControlLevel.Viewer)
@@ -99,7 +101,7 @@ export const SidePanelActivity = (): JSX.Element => {
             <PayGateMini
                 feature={AvailableFeature.AUDIT_LOGS}
                 className="flex flex-col flex-1 overflow-hidden"
-                overrideShouldShowGate={!!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
+                overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
             >
                 <div className="flex flex-col flex-1 overflow-hidden">
                     <div className="mx-2 shrink-0">

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -21,6 +21,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { billingLogic } from 'scenes/billing/billingLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, AvailableFeature } from '~/types'
@@ -259,6 +260,7 @@ export const ActivityLogRow = ({
 export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLogProps): JSX.Element | null => {
     const logic = activityLogLogic({ scope, id, caption, startingPage })
     const { humanizedActivity, activityLoading, pagination, highlightedActivityId } = useValues(logic)
+    const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { billingLoading } = useValues(billingLogic)
 
@@ -278,7 +280,7 @@ export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLo
             ) : (
                 <PayGateMini
                     feature={AvailableFeature.AUDIT_LOGS}
-                    overrideShouldShowGate={!!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
+                    overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
                 >
                     {humanizedActivity.length === 0 ? (
                         <Empty scope={scope} />

--- a/frontend/src/scenes/audit-logs/AdvancedActivityLogsScene.tsx
+++ b/frontend/src/scenes/audit-logs/AdvancedActivityLogsScene.tsx
@@ -9,6 +9,7 @@ import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -28,6 +29,7 @@ export function AdvancedActivityLogsScene(): JSX.Element | null {
     const { activeTab } = useValues(advancedActivityLogsLogic)
     const { setActiveTab } = useActions(advancedActivityLogsLogic)
     const { currentTeam } = useValues(teamLogic)
+    const { user } = useValues(userLogic)
 
     const hasAccess = userHasAccess(AccessControlResourceType.ActivityLog, AccessControlLevel.Viewer)
     const includesOrgLevelLogs = currentTeam?.receive_org_level_activity_logs
@@ -67,7 +69,7 @@ export function AdvancedActivityLogsScene(): JSX.Element | null {
                     forceIcon: <IconNotification />,
                 }}
             />
-            <PayGateMini feature={AvailableFeature.AUDIT_LOGS}>
+            <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
                 <LemonTabs
                     activeKey={activeTab}
                     onChange={(key) => setActiveTab(key as 'logs' | 'exports')}

--- a/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
+++ b/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
@@ -10,20 +10,23 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
 
 export function ActivityLogSettings(): JSX.Element {
+    const { user } = useValues(userLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
+    const effectiveRestriction = user?.is_impersonated ? null : restrictedReason
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS}>
+        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
             <div className="flex">
                 <p>
-                    <LemonButton to={urls.advancedActivityLogs()} type="primary" disabledReason={restrictedReason}>
+                    <LemonButton to={urls.advancedActivityLogs()} type="primary" disabledReason={effectiveRestriction}>
                         Browse all activity logs
                     </LemonButton>
                 </p>
@@ -33,6 +36,7 @@ export function ActivityLogSettings(): JSX.Element {
 }
 
 export function ActivityLogOrgLevelSettings(): JSX.Element {
+    const { user } = useValues(userLogic)
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportActivityLogSettingToggled } = useActions(eventUsageLogic)
@@ -45,7 +49,7 @@ export function ActivityLogOrgLevelSettings(): JSX.Element {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS}>
+        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
             <div>
                 <p className="flex items-center gap-1">
                     Include organization-level activity logs in this project.
@@ -76,6 +80,7 @@ export function ActivityLogOrgLevelSettings(): JSX.Element {
 }
 
 export function ActivityLogNotifications(): JSX.Element | null {
+    const { user } = useValues(userLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
@@ -86,7 +91,7 @@ export function ActivityLogNotifications(): JSX.Element | null {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS}>
+        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
             <div>
                 <p className="flex items-center gap-1">
                     Create notifications to get notified of activity logs.

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory, TickingDateTimeFactory
 from posthog.test.base import APIBaseTest, QueryMatchingTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -222,6 +223,16 @@ class TestActivityLogAuditLogsGate(APIBaseTest):
         self.organization.save()
 
         with self.is_cloud(False):
+            res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
+
+        assert res.status_code == status.HTTP_200_OK
+
+    @parameterized.expand([("activity_log",), ("advanced_activity_logs",)])
+    def test_endpoint_allowed_for_impersonator_without_audit_logs_feature(self, endpoint: str) -> None:
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        with self.is_cloud(True), patch("posthog.permissions.is_impersonated_session", return_value=True):
             res = self.client.get(f"/api/projects/{self.team.id}/{endpoint}/")
 
         assert res.status_code == status.HTTP_200_OK

--- a/posthog/api/test/test_materialized_column_slot.py
+++ b/posthog/api/test/test_materialized_column_slot.py
@@ -651,7 +651,7 @@ class TestMaterializedColumnSlotAPI(APIBaseTest):
             response = self.client.get(endpoint)
             assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @patch("loginas.utils.is_impersonated_session")
+    @patch("posthog.permissions.is_impersonated_session")
     @patch("posthog.api.materialized_column_slot.async_to_sync")
     def test_endpoints_allow_impersonated_sessions(self, mock_async_to_sync, mock_is_impersonated):
         """Test that impersonated sessions can access endpoints."""

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
 
 import posthoganalytics
+from loginas.utils import is_impersonated_session
 from rest_framework.exceptions import AuthenticationFailed, NotFound, PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAdminUser
 from rest_framework.request import Request
@@ -268,8 +269,6 @@ class IsStaffUserOrImpersonating(BasePermission):
     message = "You are not a staff user, contact your instance admin."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
-        from loginas.utils import is_impersonated_session
-
         return bool(
             request.user
             and request.user.is_authenticated
@@ -288,6 +287,11 @@ class PremiumFeaturePermission(BasePermission):
       Self-hosted instances are not gated.
 
     Exactly one of the two attributes must be set on the view.
+
+    Staff impersonating a customer (`is_impersonated_session`) bypass the feature check
+    so PostHog support can debug paid features for non-paying orgs. Plain staff sessions
+    are not bypassed — staff must actively start an impersonation session, which is
+    audit-logged via the `loginas` flow.
     """
 
     def has_permission(self, request: Request, view: APIView) -> bool:
@@ -304,6 +308,9 @@ class PremiumFeaturePermission(BasePermission):
             feature = cloud_only_feature
         else:
             feature = always_feature
+
+        if is_impersonated_session(request):
+            return True
 
         try:
             organization = get_organization_from_view(view)


### PR DESCRIPTION
## Problem

PostHog support staff impersonating a customer on a non-paying plan currently hit hard 402s and full paywalls when navigating activity logs, leaving them unable to debug customer issues. Closes the gap left by #56724. Supersedes #57873.

## Changes

- Bypass `PremiumFeaturePermission` for impersonated sessions; plain staff sessions still gated, so bypass remains audit-logged via the loginas flow
- Auto-skip the `audit_logs` paywall in the side panel, inline activity log, dedicated `/activity-logs` scene, and Settings → Activity logs when impersonating
- Allow impersonators to click "Browse all activity logs" from settings even when the customer they impersonate is below project-admin

## How did you test this code?

- 2 backend unit tests added (impersonator bypass on both `/activity_log/` and `/advanced_activity_logs/`)
- Manual: Playwright end-to-end as `test@test.com` impersonating a Boost-tier user. Confirmed paywall bypassed in Settings → Activity logs, "Browse all activity logs" enabled, dedicated page renders with filters, all three audit-log endpoints return 200. Regression: same target user logged in directly (not impersonated) still gets 402 + paywall.

## Publish to changelog?

no