### PR TITLE
chore(ai): nudge anomaly investigation agent away from low-magnitude false positives

### DIFF
--- a/posthog/temporal/ai/anomaly_investigation/prompts.py
+++ b/posthog/temporal/ai/anomaly_investigation/prompts.py
@@ -20,8 +20,12 @@ Tools (be frugal — hard call budget, the user is waiting):
 
 Workflow:
 1. Read the anomaly context and look at the attached chart.
-2. Decide which tool, if any, confirms or refutes your leading hypothesis.
-3. Emit a final JSON report matching the schema below. Do not emit any free-form
+2. Sanity-check the magnitude *before* spending tool budget — see "Magnitude
+   check" below. If the absolute counts and relative deviation both look small,
+   lean toward `false_positive` or `inconclusive` and use any remaining budget
+   to confirm rather than to keep hunting for a story.
+3. Decide which tool, if any, confirms or refutes your leading hypothesis.
+4. Emit a final JSON report matching the schema below. Do not emit any free-form
    text around it — output the raw JSON object only.
 
 Final JSON schema (emit exactly these keys):
@@ -38,15 +42,47 @@ Final JSON schema (emit exactly these keys):
   "recommendations": ["Suggested next action.", "Another action."]
 }
 
+Magnitude check (do this before classifying):
+- Compare the triggered point against the typical baseline for the series (the
+  median and rough spread of recent buckets), not just against "is this the
+  highest point in the window". A new max that is only marginally above the
+  prior peak is rarely a true positive on its own.
+- Weigh absolute counts as well as relative change. Low-volume metrics
+  (single- or low-double-digit counts per bucket) are inherently noisy —
+  a single bucket at 2-3x its neighbours can be ordinary Poisson-style
+  variance, not a real shift. Be especially skeptical when:
+    * the triggered value is in the single digits, or
+    * the triggered value is within ~50% of recent typical buckets, or
+    * the framing is "highest in window" but the runner-up is close behind.
+- A real true positive should be visible to a human glancing at the chart:
+  a clear step-change, a sustained shift, a cliff, or a spike that is
+  multiple times any other point in the window. If you have to squint, it
+  probably isn't one.
+
+Verdict rubric:
+- `true_positive` — a real, business-relevant shift in the metric that a human
+  reviewer would also call out: a sustained level change, a cliff, a clear
+  spike well outside the series' normal range, or a regression/improvement
+  tied to a known release or property change.
+- `false_positive` — the firing is best explained by something other than a
+  real shift. Includes data artifacts (duplicated events, new property values,
+  recent release noise) AND ordinary noise on a low-volume or naturally
+  bursty series. If the magnitude check says "this could plausibly be normal
+  variance for this metric", that is a false positive, even if the detector
+  technically flagged it.
+- `inconclusive` — not enough evidence to call it either way within the
+  budget; say so plainly rather than forcing a verdict.
+
 Guidelines:
 - Prefer narrow queries over broad scans. Scope to the triggered dates.
-- Classify the firing as 'true_positive' (real business-relevant anomaly),
-  'false_positive' (data artifact, duplicated events, new property values,
-  recent release noise), or 'inconclusive' (not enough evidence).
-- If the detector looks overly sensitive for the metric's natural variance, flag
-  that as a recommendation.
-- Keep summaries concrete and short. No filler. No apologies. No hedging beyond
-  what the data supports.
+- If the detector looks overly sensitive for the metric's natural variance
+  (a low-volume count series scored by a detector tuned for higher volumes,
+  or repeated near-threshold firings on the same metric), flag that
+  explicitly as a recommendation — e.g. raise the threshold, switch detector
+  type, or aggregate the metric to a less noisy interval.
+- Keep summaries concrete and short. No filler. No apologies. No hedging
+  beyond what the data supports. If it's a false positive, say so directly
+  in the summary rather than burying it.
 """
 
 


### PR DESCRIPTION
## Problem

The anomaly investigation agent (`posthog/temporal/ai/anomaly_investigation/`) has been classifying small spikes on low-volume series as `true_positive` when they look more like ordinary variance. Concrete recent example: an hourly bucket showing 16 \"notebook created\" events flagged as a true positive on the strength of being the highest single-hour count in the 7-day window, despite the runner-up being close behind and the absolute counts being small enough to be Poisson-style noise.

The current prompt's verdict rubric doesn't push back on that pattern — `false_positive` is defined narrowly around data artifacts and release noise, with no language for \"ordinary noise on a low-volume series.\" There's also no explicit magnitude check before classification, so the agent can talk itself into a story for a small bump.

## Changes

Prompt-only nudges in `posthog/temporal/ai/anomaly_investigation/prompts.py`:

- New **Magnitude check** section the agent runs *before* classifying — compare against the median/spread of recent buckets (not just \"is this the highest in the window\"), weigh absolute counts alongside relative change, and call out the specific shapes that read as noise on low-volume series.
- New **Verdict rubric** that explicitly names \"ordinary noise on a low-volume or naturally bursty series\" as a `false_positive`, even when the detector technically flagged it.
- Workflow step 2 now points the agent at the magnitude check before spending tool budget, so any remaining calls are used to *confirm* the verdict rather than to keep hunting for a story.
- Strengthens the existing detector-over-sensitivity guideline with concrete examples (low-volume series scored by a high-volume detector, repeated near-threshold firings) and concrete recommendations to flag (raise threshold, switch detector type, aggregate to a less noisy interval).
- Adds a one-line nudge that false-positive verdicts must be stated directly in the summary rather than buried.

No code paths, schema, tools, or notebook rendering changed — purely prompt text.

## How did you test this code?

I'm an agent. I did not run a live anomaly investigation against this prompt. What I verified:

- File still parses (`ast.parse`).
- No other call sites of `SYSTEM_PROMPT` / `build_anomaly_context` were touched; the only importers are `runner.py` and `workflow.py` and they consume the strings opaquely.
- No tests assert on the prompt text (no `test_*` files exist under `posthog/temporal/ai/anomaly_investigation/` and no other test module references these symbols).

Reviewer: this is a behavior nudge to an LLM prompt — best validated by re-running it against the recent firings that were misclassified. Worth keeping a draft until someone has eyes on output for the next handful of investigations.

## Publish to changelog?

no

## 🤖 Agent context

- Authored by PostHog Code (Claude). Triggered from a Slack thread where the \"Headline anomaly: Notebook created\" alert fired with a `True positive` verdict on a clearly thin signal (16 events/hour, with the prior hour around 5).
- Considered but did not include in this PR:
  - Embedding the matplotlib chart from `charts.py` directly into the generated notebook (currently it's only attached to the LLM's first message). Owner asked for prompt nudges \"for now\" — left this for a follow-up.
  - Surfacing baseline stats (median / IQR) into `build_anomaly_context` so the agent doesn't have to fetch the series itself just to magnitude-check. Held off — wanted to keep the diff to prompt text only and see if the prompt nudges alone change behavior before adding more pre-tool-call context.
- Decisions:
  - Kept the change scoped to `prompts.py` only — no schema, tool, or notebook changes — so the rollout risk is just \"the model classifies differently,\" which is the intended outcome.
  - Phrased the new rubric as additive guidance rather than redefining `false_positive`, so existing well-classified true positives shouldn't flip.