### PR TITLE
fix(devex): emit valid tach config from product scaffold

### DIFF
--- a/tools/hogli-commands/hogli_commands/product/scaffold.py
+++ b/tools/hogli-commands/hogli_commands/product/scaffold.py
@@ -57,10 +57,14 @@ def _add_to_tach_toml(product_name: str, *, dry_run: bool) -> None:
         f"\n[[modules]]\n"
         f'path = "{module_path}"\n'
         f'depends_on = ["posthog"]\n'
-        f'layer = "products"\n'
-        f"interfaces = [\n"
-        f'    "{module_path}.backend.facade",\n'
-        f'    "{module_path}.backend.presentation.views",\n'
+        f'layer = "modules"\n'
+        f"\n[[interfaces]]\n"
+        f"expose = [\n"
+        f'    "backend\\\\.facade.*",\n'
+        f'    "backend\\\\.presentation\\\\.views.*",\n'
+        f"]\n"
+        f"from = [\n"
+        f'    "{module_path}",\n'
         f"]\n"
     )
     _register_in_file(


### PR DESCRIPTION
## Problem

Every fresh product PR fails CI on the `Run hogli framework tests` step with:

```
ValueError: TOML parse error at line 14, column 1
14 | [[modules]]
data did not match any variant of untagged enum ModuleConfigOrBulk
```

`hogli product:bootstrap` was appending an invalid block to `tach.toml`: an `interfaces = [...]` array inline on `[[modules]]` (tach's schema doesn't accept that key on modules — interfaces are top-level `[[interfaces]]` tables with `expose` / `from`), plus `layer = "products"` which isn't a declared layer.

Spotted in #57919 (business knowledge bootstrap) — the misleading error pointed at line 14 but the actual culprit was the appended block at the bottom.

## Changes

`tools/hogli-commands/hogli_commands/product/scaffold.py::_add_to_tach_toml` now emits the layout `tach.toml` actually expects, mirroring the existing `access_control` block:

```toml
[[modules]]
path = "products.<name>"
depends_on = ["posthog"]
layer = "modules"

[[interfaces]]
expose = [
    "backend\\.facade.*",
    "backend\\.presentation\\.views.*",
]
from = [
    "products.<name>",
]
```

## How did you test this code?

Agent (Claude Code). Verified locally by:
- running `hogli product:bootstrap scaffold_smoketest` against a clean checkout — appended block parses with `tomllib`
- `tach check --dependencies --interfaces` returns ✅
- reverted the smoketest scaffold output before committing

## Publish to changelog?

No.

## Docs update

No.

## 🤖 Agent context

- Tool: Claude Code (Opus 4.7), assisting @webjunkie diagnose Alex Veryayskiy's failing CI run on #57919
- Existing-product PR (#57919) needs a manual fix to its `tach.toml` to unblock — they can either move the new product's interfaces into a separate `[[interfaces]]` block by hand or rebase on top of this fix