### PR TITLE
fix(signals): Fix data warehouse table resolution

### DIFF
--- a/posthog/temporal/data_imports/signals/tests/test_emit_signals.py
+++ b/posthog/temporal/data_imports/signals/tests/test_emit_signals.py
@@ -30,10 +30,12 @@ from posthog.temporal.data_imports.signals.registry import SignalEmitterOutput, 
 from posthog.temporal.data_imports.workflow_activities.emit_signals import (
     EmitDataImportSignalsWorkflow,
     EmitSignalsActivityInputs,
+    emit_data_import_signals_activity,
 )
 
 PIPELINE_MODULE_PATH = "posthog.temporal.data_imports.signals.pipeline"
 FETCHER_MODULE_PATH = "posthog.temporal.data_imports.signals.fetchers.data_warehouse"
+ACTIVITY_MODULE_PATH = "posthog.temporal.data_imports.workflow_activities.emit_signals"
 
 
 def _make_config(**overrides: Any) -> SignalSourceTableConfig:
@@ -675,3 +677,66 @@ class TestEmitDataImportSignalsWorkflow:
         assert captured_inputs["team_id"] == 42
         assert captured_inputs["schema_id"] == schema_id
         assert captured_inputs["source_type"] == "Zendesk"
+
+
+class TestEmitActivityTableNameResolution:
+    # Regression: HogQL exposes warehouse tables under keys built by
+    # `get_data_warehouse_table_name` (e.g. `github.issues`), not under the raw
+    # `DataWarehouseTable.name` storage form (e.g. `github_issues`). Passing the
+    # storage name to the fetcher made every emit run fail with `Unknown table`.
+
+    @pytest.mark.parametrize(
+        "prefix,storage_name,expected_hogql_name",
+        [
+            (None, "github_issues", "github.issues"),
+            ("", "github_issues", "github.issues"),
+            ("website", "websitegithub_issues", "github.website.issues"),
+            ("website_", "website_github_issues", "github.website.issues"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_passes_hogql_resolvable_table_name_to_fetcher(
+        self, prefix: str | None, storage_name: str, expected_hogql_name: str
+    ):
+        from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
+
+        captured_context: dict[str, Any] = {}
+
+        def capture_fetcher(team, config, context):
+            captured_context.update(context)
+            return []
+
+        config = _make_config(record_fetcher=capture_fetcher)
+
+        source = MagicMock(spec=ExternalDataSource)
+        source.source_type = "GitHub"
+        source.prefix = prefix
+        source.access_method = ExternalDataSource.AccessMethod.WAREHOUSE
+        table = MagicMock()
+        table.name = storage_name
+        schema = MagicMock()
+        schema.table = table
+        schema.source = source
+
+        fetch_mock = AsyncMock(return_value=(schema, MagicMock()))
+
+        with (
+            patch(f"{ACTIVITY_MODULE_PATH}.Heartbeater"),
+            patch(f"{ACTIVITY_MODULE_PATH}.get_signal_config", return_value=config),
+            patch(f"{ACTIVITY_MODULE_PATH}._fetch_schema_and_team", fetch_mock),
+            patch(f"{ACTIVITY_MODULE_PATH}.run_signal_pipeline", new_callable=AsyncMock) as run_mock,
+        ):
+            run_mock.return_value = {"status": "success", "signals_emitted": 0}
+            await emit_data_import_signals_activity(
+                EmitSignalsActivityInputs(
+                    team_id=1,
+                    schema_id=uuid.uuid4(),
+                    source_id=uuid.uuid4(),
+                    job_id="job-x",
+                    source_type="GitHub",
+                    schema_name="issues",
+                    last_synced_at=None,
+                )
+            )
+
+        assert captured_context["table_name"] == expected_hogql_name

--- a/posthog/temporal/data_imports/workflow_activities/emit_signals.py
+++ b/posthog/temporal/data_imports/workflow_activities/emit_signals.py
@@ -8,6 +8,8 @@ import structlog
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
+from posthog.hogql.database.database import get_data_warehouse_table_name
+
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
@@ -60,9 +62,11 @@ async def emit_data_import_signals_activity(inputs: EmitSignalsActivityInputs) -
         if schema.table is None:
             log.warning(f"Schema {inputs.schema_id} has no table for emitting signals")
             return {"status": "skipped", "reason": "no_table", "signals_emitted": 0}
-        # Build fetcher context with data-warehouse-specific runtime values
+        # `DataWarehouseTable.name` is the storage form (e.g. `<prefix><source_type>_<schema>`),
+        # but HogQL exposes warehouse tables under the keys produced by `get_data_warehouse_table_name`
+        # (e.g. `github.issues` or `github.<prefix>.<schema>`). Querying the storage name fails to resolve.
         fetcher_context = {
-            "table_name": schema.table.name,
+            "table_name": get_data_warehouse_table_name(schema.source, schema.table.name),
             "last_synced_at": inputs.last_synced_at,
             "extra": inputs.properties_to_log,
         }


### PR DESCRIPTION
## Problem

GitHub Issues signal source has been failing in production. Spotted via a Temporal workflow failure: `Unknown table \`github_issues\`. Did you mean: websitegithub_issues, github.website.issues?` - [example in Temporal, team 2](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/emit-data-import-signals-019dfb7c-5583-0000-5afc-f3d3afbbf669/019dfb85-578d-7838-9368-37d89e8ecf83/timeline).

The activity was passing `schema.table.name` into HogQL in the storage form: like `github_issues` / `<prefix><source_type>_<schema>` (note underscores). The flat-alias path happened to work most of the time, but breaks when the storage name and the current prefix-derived alias drift apart (e.g. prefix changed after the table row was created). 

Same code path used by Zendesk and Linear signal sources too.

## Changes


Now HogQL exposes warehouse tables under the dot-separated keys produced by `get_data_warehouse_table_name` (`github.issues`, `github.<prefix>.<schema>`), and ALSO under a flat alias when the prefix is non-empty. This uses the canonical form.

Why GitHub failed specifically at least for our team: we have a setup where `schema.table.name` (`github_issues`) and the registered alias (`website.github_issues`) didn't match. 

## How did you test this code?

TestEmitActivityTableNameResolution tests.

## Publish to changelog?

no