### PR TITLE
fix(data-warehouse): keep "Update insight" enabled after editing SQL

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -284,12 +284,6 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                 }
 
                 const updatedName = activeTab?.name !== editingInsight.name
-                // Compare against `sourceQuery` (the durable reducer) rather than
-                // `dataVisualizationLogic.values.query`. The latter is not a declared selector
-                // dependency, so reading it here would memoize against a stale value and leave
-                // the button disabled until something else dirties `sourceQuery`. In-flight
-                // axis/display edits already flow back through `setSourceQuery`, so
-                // `sourceQuery` is always up to date.
                 const sourceQueryWithoutUndefinedAndNullKeys = removeUndefinedAndNull(sourceQuery)
                 // Normalize so DataTableNode-based insights don't look "changed" immediately after load.
                 const editingInsightQuery = toDataVisualizationNode(editingInsight.query) ?? editingInsight.query

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -13,12 +13,7 @@ import { DataVisualizationNode, FileSystemIconType, HogQLFilters, NodeKind } fro
 import { Breadcrumb } from '~/types'
 
 import type { editorSceneLogicType } from './editorSceneLogicType'
-import {
-    getCurrentVisualizationQuery,
-    normalizeFiltersForUrl,
-    sqlEditorLogic,
-    toDataVisualizationNode,
-} from './sqlEditorLogic'
+import { normalizeFiltersForUrl, sqlEditorLogic, toDataVisualizationNode } from './sqlEditorLogic'
 
 export interface SaveAsMenuItem {
     action: 'insight' | 'endpoint' | 'view'
@@ -282,16 +277,20 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             },
         ],
         updateInsightButtonEnabled: [
-            (s) => [s.sourceQuery, s.activeTab, s.editingInsight, s.dataLogicKey],
-            (sourceQuery, activeTab, editingInsight, dataLogicKey) => {
+            (s) => [s.sourceQuery, s.activeTab, s.editingInsight],
+            (sourceQuery, activeTab, editingInsight) => {
                 if (!editingInsight?.query) {
                     return false
                 }
 
                 const updatedName = activeTab?.name !== editingInsight.name
-                const currentVisualizationQuery = getCurrentVisualizationQuery(dataLogicKey, sourceQuery)
-
-                const sourceQueryWithoutUndefinedAndNullKeys = removeUndefinedAndNull(currentVisualizationQuery)
+                // Compare against `sourceQuery` (the durable reducer) rather than
+                // `dataVisualizationLogic.values.query`. The latter is not a declared selector
+                // dependency, so reading it here would memoize against a stale value and leave
+                // the button disabled until something else dirties `sourceQuery`. In-flight
+                // axis/display edits already flow back through `setSourceQuery`, so
+                // `sourceQuery` is always up to date.
+                const sourceQueryWithoutUndefinedAndNullKeys = removeUndefinedAndNull(sourceQuery)
                 // Normalize so DataTableNode-based insights don't look "changed" immediately after load.
                 const editingInsightQuery = toDataVisualizationNode(editingInsight.query) ?? editingInsight.query
 

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -7,6 +7,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
+import { dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 import * as queryRunner from '~/queries/query'
 import {
     DataTableNode,
@@ -678,6 +679,50 @@ describe('sqlEditorLogic', () => {
 
             // The button should not appear "dirty" immediately after load
             expect(editorRootLogic.values.updateInsightButtonEnabled).toEqual(false)
+        })
+
+        it('enables Update insight as soon as sourceQuery diverges from the saved insight, even when dataVisualizationLogic mirror lags behind', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+            editorRootLogic = editorSceneLogic({ tabId: TAB_ID })
+            editorRootLogic.mount()
+
+            router.actions.push(urls.sqlEditor(), { open_insight: MOCK_INSIGHT_SHORT_ID })
+
+            await expectLogic(logic)
+                .toDispatchActions(['editInsight', 'createTab', 'updateTab'])
+                .toMatchValues({
+                    editingInsight: partial({ short_id: MOCK_INSIGHT_SHORT_ID }),
+                })
+
+            // Mount dataVisualizationLogic with the saved query, mirroring what BindLogic
+            // does in production. This is the state right after the insight finishes loading.
+            const dataLogicKey = logic.values.dataLogicKey
+            const visualizationLogic = dataVisualizationLogic({
+                key: dataLogicKey,
+                query: MOCK_INSIGHT_QUERY,
+                dataNodeCollectionId: dataLogicKey,
+            })
+            visualizationLogic.mount()
+
+            expect(editorRootLogic.values.updateInsightButtonEnabled).toEqual(false)
+
+            // Simulate runQuery firing setSourceQuery with a different SQL string.
+            // dataVisualizationLogic.values.query still mirrors the OLD query at this point —
+            // in production it only catches up after React re-renders and propsChanged fires.
+            // The selector must reflect the change immediately so the user can save.
+            logic.actions.setSourceQuery({
+                ...MOCK_INSIGHT_QUERY,
+                source: { ...MOCK_INSIGHT_QUERY.source, query: 'SELECT count() FROM events WHERE event = $pageview' },
+            })
+
+            expect(editorRootLogic.values.updateInsightButtonEnabled).toEqual(true)
+
+            visualizationLogic.unmount()
         })
 
         it('does not dispatch syncUrlWithQuery before the API responds', async () => {


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1778092057409819

1. Open this insight https://us.posthog.com/project/2/insights/3i0hJ8xq
2. Click "Edit"
3. Change the table from `prod_postgres_invoice_with_annual` to `prod_postgres_invoice_with_annual_view`
4. Hit Cmd+Enter (note: the same issue does not exist when clicking on the "Run" button)
5. Observe that "Update insight" is still grayed out

## Changes

`frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx` — the `updateInsightButtonEnabled` selector compared `dataVisualizationLogic.values.query` against the saved insight via `getCurrentVisualizationQuery`. That mirror value is not a declared selector input, so reselect only recomputed when one of the declared inputs (`sourceQuery`, `activeTab`, `editingInsight`, `dataLogicKey`) changed. When `runQuery` fired `setSourceQuery` synchronously, the selector recomputed *while the visualization-logic mirror was still on the old query* (its `propsChanged` only fires on the next React render cycle). The selector returned `false` and stayed cached at `false` until something else dirtied a declared input.

Compare against `sourceQuery` directly. In-flight axis/display edits already flow back into `sourceQuery` through `applyDataVisualizationQueryUpdate` → `setSourceQuery` (`SQLEditor.tsx:157`), so it is the durable source of truth. Listener-based callers (`saveAsInsight`, `saveAsView`, etc.) keep using `getCurrentVisualizationQuery` since they read it once at action time, after the mirror has already caught up.

## How did you test this code?

Tested locally with a sample insight - you need to change something that doesn't change the results e.g. a comment for this issue to be visible