### PR TITLE
fix(pipeline): redirect /functions/:id/:tab to query param format

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -724,8 +724,8 @@ export const redirects: Record<
     '/max': (_params, searchParams, hashParams) => combineUrl(urls.ai(), searchParams, hashParams).url,
     '/max/history': (_params, searchParams, hashParams) => combineUrl(urls.aiHistory(), searchParams, hashParams).url,
 
-    // Redirect /functions/:id/:tab to /functions/:id?tab=:tab (old path-based tabs to query params)
-    '/functions/:id/:tab': ({ id, tab }) => urls.hogFunction(id, tab),
+    // Redirect old path-based /configuration URLs to query param format
+    '/functions/:id/configuration': ({ id }) => urls.hogFunction(id, 'configuration'),
 
     ...productRedirects,
 }

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -724,6 +724,9 @@ export const redirects: Record<
     '/max': (_params, searchParams, hashParams) => combineUrl(urls.ai(), searchParams, hashParams).url,
     '/max/history': (_params, searchParams, hashParams) => combineUrl(urls.aiHistory(), searchParams, hashParams).url,
 
+    // Redirect /functions/:id/:tab to /functions/:id?tab=:tab (old path-based tabs to query params)
+    '/functions/:id/:tab': ({ id, tab }) => urls.hogFunction(id, tab),
+
     ...productRedirects,
 }
 


### PR DESCRIPTION
## Problem

URLs like `/project/:team_id/functions/:id/configuration` were returning 404s, breaking links to pipeline function configuration pages. This was reported affecting error tracking alert configuration links.

Slack thread: https://posthog.slack.com/archives/C07AA937K9A/p1778147204299789?thread_ts=1778143967.507399&cid=C07AA937K9A

## Changes

Added a redirect in `frontend/src/scenes/scenes.ts` that converts old path-based tab URLs (`/functions/:id/:tab`) to the new query parameter format (`/functions/:id?tab=:tab`).

The HogFunction scene now uses query parameters for tabs, but old links using path segments weren't being handled. This preserves backwards compatibility with existing links that include any of the valid tabs (configuration, metrics, logs, testing, runs, backfills, history).

## How did you test this code?

I am an agent. I verified the change compiles without TypeScript errors. The redirect follows the same pattern as existing pipeline redirects in the codebase (lines 697-700 handle similar `/pipeline/*/:id/:tab` patterns).

## Publish to changelog?

No

## 🤖 Agent context

- **Agent**: Claude Code (Opus 4.5)
- **Session**: https://claude.ai/code/session_017pj74pe8rKgyzvq5rTAb7T
- **Approach**: Investigated the URL routing in `scenes.ts` and found that `urls.hogFunction()` now uses `?tab=` query params while old links used path segments. Added a simple redirect that reuses the existing `urls.hogFunction(id, tab)` helper to convert the format.

---
_Generated by [Claude Code](https://claude.ai/code/session_017pj74pe8rKgyzvq5rTAb7T)_