### PR TITLE
fix(hogql): resolve person.distinct_id filter under person-on-events

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -797,9 +797,17 @@ def property_to_expr(
         value = property.value
 
         if property.type == "person" and property.key == "distinct_id":
-            # distinct_id is not stored in person.properties — it lives in the
-            # person_distinct_id2 table and is exposed via the `pdi` lazy join on persons.
-            chain = ["person", "pdi"] if scope != "person" else ["pdi"]
+            # distinct_id is not stored in person.properties.
+            # - In event scope, events.distinct_id is a real column — no join needed.
+            # - In person scope, persons.pdi.distinct_id resolves via the lazy join on persons.
+            # Routing through `events.person.pdi` would break under person-on-events mode,
+            # where `events.person` is rebound to the `poe` virtual table which has no `pdi` field.
+            if scope == "event":
+                chain = []
+            elif scope == "person":
+                chain = ["pdi"]
+            else:
+                chain = ["person", "pdi"]
         elif property.type == "person" and scope != "person":
             chain = ["person", "properties"]
         elif property.type == "event" and scope == "replay_entity":

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -11,13 +11,18 @@ from posthog.schema import (
     EmptyPropertyFilter,
     FlagPropertyFilter,
     HogQLPropertyFilter,
+    HogQLQueryModifiers,
+    PersonsOnEventsMode,
     PropertyOperator,
     RetentionEntity,
 )
 
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr
+from posthog.hogql.printer.utils import prepare_and_print_ast
 from posthog.hogql.property import (
     entity_to_expr,
     has_aggregation,
@@ -939,12 +944,13 @@ class TestProperty(BaseTest):
 
     @parameterized.expand(
         [
-            ("event_scope", "event", "person.pdi.distinct_id = 'abc'"),
+            ("event_scope", "event", "distinct_id = 'abc'"),
             ("person_scope", "person", "pdi.distinct_id = 'abc'"),
         ]
     )
     def test_person_distinct_id_property(self, _name, scope, expected_expr):
-        # distinct_id is not stored in person.properties — it's exposed via the pdi lazy join.
+        # distinct_id is not stored in person.properties — it's the events.distinct_id column
+        # in event scope, and reachable via the pdi lazy join in person scope.
         self.assertEqual(
             self._property_to_expr(
                 {"type": "person", "key": "distinct_id", "value": "abc", "operator": "exact"},
@@ -952,6 +958,38 @@ class TestProperty(BaseTest):
             ),
             self._parse_expr(expected_expr),
         )
+
+    @parameterized.expand(
+        [
+            ("disabled", PersonsOnEventsMode.DISABLED),
+            ("no_override_props_on_events", PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS),
+            ("override_props_on_events", PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS),
+            ("override_props_joined", PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED),
+        ]
+    )
+    def test_person_distinct_id_property_resolves_under_all_poe_modes(self, _name, mode):
+        # Regression test for "Field not found: pdi" — previously, the special case for
+        # {type: person, key: distinct_id} routed through events.person.pdi, which broke under
+        # person-on-events modes that rebind events.person to the `poe` virtual table.
+        expr = property_to_expr(
+            {"type": "person", "key": "distinct_id", "value": "abc", "operator": "is_not"},
+            team=self.team,
+            scope="event",
+        )
+        query_ast = ast.SelectQuery(
+            select=[ast.Call(name="count", args=[])],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=expr,
+        )
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            modifiers=create_default_modifiers_for_team(self.team, HogQLQueryModifiers(personsOnEventsMode=mode)),
+        )
+        sql, _ = prepare_and_print_ast(query_ast, context=context, dialect="clickhouse")
+        # Used to raise QueryError("Field not found: pdi") under PoE modes that rebind
+        # events.person to the `poe` virtual table.
+        assert "distinct_id" in sql
 
     def test_entity_to_expr_actions_type_with_id(self):
         action_mock = MagicMock()

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -990,6 +990,7 @@ class TestProperty(BaseTest):
         # Used to raise QueryError("Field not found: pdi") under PoE modes that rebind
         # events.person to the `poe` virtual table.
         assert "distinct_id" in sql
+        assert "pdi" not in sql
 
     def test_entity_to_expr_actions_type_with_id(self):
         action_mock = MagicMock()


### PR DESCRIPTION
## Problem

Insights using `filterTestAccounts: true` failed with `QueryError: Field not found: pdi` when the team's `test_account_filters` included an entry of the shape:

```json
{ "key": "distinct_id", "type": "person", "operator": "is_not", "value": ["..."] }
```

`distinct_id` is not a person property — it lives in `person_distinct_id2` and is exposed via the `pdi` lazy join. `posthog/hogql/property.py` had a special case that tried to handle this gracefully by routing the lookup through `events.person.pdi.distinct_id`. Under person-on-events mode, `events.person` is rebound to the `poe` virtual table (`EventsPersonSubTable`), which has only `id`, `created_at`, `properties`, `revenue_analytics` — **no `pdi` field**. The chain failed to resolve and the whole insight blew up.

This affected every insight runner that applies `team.test_account_filters` (trends, lifecycle, retention, paths, stickiness, web analytics, the `{filters}` HogQL placeholder, etc.) on any team running with person-on-events enabled — which is the cloud default.

## Changes

`posthog/hogql/property.py`: replaced the `chain = ["person", "pdi"] if scope != "person" else ["pdi"]` branch with scope-aware routing:

- `scope == "event"` → bare `events.distinct_id` (no join — `events.distinct_id` is the same value as `events.pdi.distinct_id`)
- `scope == "person"` → `persons.pdi.distinct_id` (unchanged)
- other scopes → previous traversal preserved to avoid behavior changes outside the bug's blast radius

`posthog/hogql/test/test_property.py`:

- Updated `test_person_distinct_id_property` for the new event-scope shape (`distinct_id = 'abc'`).
- Added `test_person_distinct_id_property_resolves_under_all_poe_modes` that runs `prepare_and_print_ast` against all four `PersonsOnEventsMode` values. The original AST-equality test passed even with the broken code because it never exercised the resolver against a real schema; the new test would have caught the regression.

## How did you test this code?

I am an agent. I have only run automated checks I list here:

- `python3 -m py_compile` on both changed files: passed.
- `ruff check` and `ruff format --check` on both files: passed.

I did **not** run the test suite locally — the sandbox lacks Python 3.12.12 and the project's full venv. The new test does not need ClickHouse (uses `prepare_and_print_ast`, not `execute_hogql_query`), but it does need the standard Django test fixtures.

Reviewer verification:

- `hogli test posthog/hogql/test/test_property.py -k distinct_id` should pass for both the AST test and all four PoE-mode parameterizations.
- For full confidence, end-to-end: enable PoE on a local team, set `test_account_filters` to include the original problematic entry, run any trend insight with `filterTestAccounts: true`, and confirm no `Field not found: pdi`.

## Publish to changelog?

No.

## 🤖 Agent context

PostHog Code, in plan mode. Investigation traced the failure to lines 799–802 of `posthog/hogql/property.py`. The user-side workaround (change the filter to `type: "event"`) is also valid and was offered to the affected user; this PR fixes the server-side path so the misconfiguration auto-heals for any future team. I considered raising explicitly on the misconfigured filter shape, but that would be a behavior change for teams whose existing setups happen to work, so I went with the silent-fix approach.

Risk surface: only the `events`-scope routing of `{type: "person", key: "distinct_id"}` changes. Person-scope and the catch-all branch are unchanged. Test deltas are additive plus one expected-output update.