### PR TITLE
fix: prevent file-system view log from blocking org deletion

### DIFF
--- a/posthog/models/file_system/file_system_view_log.py
+++ b/posthog/models/file_system/file_system_view_log.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from posthog.models.file_system.file_system import FileSystem
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
+from posthog.models.team.team import Team
 from posthog.models.utils import UUIDModel
 
 if TYPE_CHECKING:
@@ -48,6 +49,10 @@ def log_file_system_view(
         return
 
     resolved_team_id, representation = resolved
+
+    # Concurrent writes during org deletion race Team.delete()'s cascade and FK-violate the commit.
+    if Team.objects.filter(id=resolved_team_id, organization__is_pending_deletion=True).exists():
+        return
 
     now = viewed_at or timezone.now()
 

--- a/posthog/models/file_system/file_system_view_log.py
+++ b/posthog/models/file_system/file_system_view_log.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 
 from posthog.models.file_system.file_system import FileSystem
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
-from posthog.models.team.team import Team
 from posthog.models.utils import UUIDModel
 
 if TYPE_CHECKING:
@@ -49,10 +48,6 @@ def log_file_system_view(
         return
 
     resolved_team_id, representation = resolved
-
-    # Concurrent writes during org deletion race Team.delete()'s cascade and FK-violate the commit.
-    if Team.objects.filter(id=resolved_team_id, organization__is_pending_deletion=True).exists():
-        return
 
     now = viewed_at or timezone.now()
 

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -27,6 +27,7 @@ def delete_bulky_postgres_data(team_ids: list[int]):
 
     from posthog.models.cohort import Cohort
     from posthog.models.feature_flag.feature_flag import FeatureFlagHashKeyOverride
+    from posthog.models.file_system.file_system_view_log import FileSystemViewLog
     from posthog.models.insight_caching_state import InsightCachingState
     from posthog.models.person import PersonlessDistinctId
 
@@ -38,6 +39,8 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     # Team cascades to DataWarehouseSavedQuery, but it has PROTECT on delete.
     _raw_delete(Edge.objects.filter(team_id__in=team_ids))
     _raw_delete(Node.objects.filter(team_id__in=team_ids))
+
+    _raw_delete(FileSystemViewLog.objects.filter(team_id__in=team_ids))
 
     _raw_delete(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
     _raw_delete_batch(PersonlessDistinctId.objects.filter(team_id__in=team_ids))  # nosemgrep: no-direct-persons-db-orm

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 from uuid import UUID
 
 from django.conf import settings
-from django.db import connection
+from django.db import connection, transaction
 from django.utils import timezone
 
 import requests
@@ -1080,10 +1080,13 @@ def _delete_teams_and_data(team_ids: list[int], user_id: int, project_id: int | 
     delete_data_modeling_schedules(team_ids=team_ids)
 
     logger.info("Deleting team records", team_ids=team_ids)
-    if project_id:
-        Project.objects.filter(id=project_id).delete()
-    else:
-        Team.objects.filter(id__in=team_ids).delete()
+    # FOR UPDATE on teams blocks concurrent FK-inserts to any child table during cascade.
+    with transaction.atomic():
+        list(Team.objects.select_for_update().filter(id__in=team_ids))
+        if project_id:
+            Project.objects.filter(id=project_id).delete()
+        else:
+            Team.objects.filter(id__in=team_ids).delete()
 
     logger.info("Queueing ClickHouse deletion", team_ids=team_ids)
     AsyncDeletion.objects.bulk_create(


### PR DESCRIPTION
## Problem

`delete_organization_data_and_notify_task` fails on commit with a foreign-key violation against `posthog_filesystemviewlog`, leaving organizations stuck in `is_pending_deletion=True` indefinitely. Multiple orgs are currently affected.

Also, while`Team.delete()` cascade is in fligh, concurrent writes to team-scoped child tables can land between the collector's snapshot and the final COMMIT, and the whole transaction rolls back.

EU logs showing the failure across multiple orgs:
[https://eu.posthog.com/logs?searchTerm=Organization data deletion failed&dateRange={"date_from"%3A"-7d"}&serviceNames=posthog-worker-django&severityLevels=error](https://eu.posthog.com/logs?searchTerm=Organization%20data%20deletion%20failed&dateRange=%7B%22date_from%22%3A%22-7d%22%7D&serviceNames=posthog-worker-django&severityLevels=error)

## Changes

-  wrap team/project delete in `transaction.atomic()` + `SELECT … FOR UPDATE` on team rows. The lock blocks concurrent
FK-inserts into any team-scoped child table during cascade. 
- raw-delete FSVL rows in `delete_bulky_postgres_data`, so by the time `Team.delete()`'s collector runs the table is already empty.

## Publish to changelog?

no

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Include:
     - tools/agent used and link to session
     - key human prompts that shaped this work, so reviewers can see the intent behind the changes, not just the diff
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
-->