### PR TITLE
fix(dashboards): guard templates list refresh against unmount

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardTemplateEditorLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateEditorLogic.ts
@@ -14,12 +14,17 @@ import type { dashboardTemplateEditorLogicType } from './dashboardTemplateEditor
 
 /**
  * Refresh every mounted `dashboardTemplatesLogic` slice we use in-product:
- * - templates tab: `default-all-templatesTab` (via callback)
+ * - templates tab: `default-all-templatesTab`
  * - new dashboard chooser: `default-all` / `feature_flag-all`
  * - dashboards page featured row: `default-featured`
+ *
+ * All four go through `findMounted` so we never dispatch into an unmounted instance.
+ * `connect.actions` did not reliably keep the templates-tab logic mounted across the
+ * editor/modal lifecycle, which surfaced as `[KEA] Can not find path … in the store.`
+ * when the post-save loader read its own reducers.
  */
-function refreshDashboardTemplateListsAfterMutation(templatesTabListGetAll: () => void): void {
-    templatesTabListGetAll()
+function refreshDashboardTemplateListsAfterMutation(): void {
+    dashboardTemplatesLogic.findMounted({ scope: 'default', templatesTabList: true })?.actions.getAllTemplates()
     dashboardTemplatesLogic.findMounted({ scope: 'default' })?.actions.getAllTemplates()
     dashboardTemplatesLogic.findMounted({ scope: 'feature_flag' })?.actions.getAllTemplates()
     dashboardTemplatesLogic
@@ -42,7 +47,6 @@ function parseDashboardTemplateEditorPayload(raw: string | undefined): Dashboard
 export const dashboardTemplateEditorLogic = kea<dashboardTemplateEditorLogicType>([
     path(['scenes', 'dashboard', 'dashboardTemplateEditorLogic']),
     connect(() => ({
-        actions: [dashboardTemplatesLogic({ scope: 'default', templatesTabList: true }), ['getAllTemplates']],
         values: [featureFlagLogic, ['featureFlags']],
     })),
     actions({
@@ -102,7 +106,7 @@ export const dashboardTemplateEditorLogic = kea<dashboardTemplateEditorLogicType
             },
         ],
     }),
-    loaders(({ values, actions }) => ({
+    loaders(({ values }) => ({
         dashboardTemplate: [
             undefined as DashboardTemplateEditorType | undefined | null,
             {
@@ -193,7 +197,7 @@ export const dashboardTemplateEditorLogic = kea<dashboardTemplateEditorLogicType
                                 action: async () => {
                                     try {
                                         await api.dashboardTemplates.update(id, { deleted: false })
-                                        refreshDashboardTemplateListsAfterMutation(actions.getAllTemplates)
+                                        refreshDashboardTemplateListsAfterMutation()
                                         lemonToast.success(
                                             trimmedName
                                                 ? createElement(
@@ -231,14 +235,14 @@ export const dashboardTemplateEditorLogic = kea<dashboardTemplateEditorLogicType
     listeners(({ values, actions }) => ({
         createDashboardTemplateSuccess: async () => {
             actions.closeDashboardTemplateEditor()
-            refreshDashboardTemplateListsAfterMutation(actions.getAllTemplates)
+            refreshDashboardTemplateListsAfterMutation()
         },
         updateDashboardTemplateSuccess: async () => {
             actions.closeDashboardTemplateEditor()
-            refreshDashboardTemplateListsAfterMutation(actions.getAllTemplates)
+            refreshDashboardTemplateListsAfterMutation()
         },
         deleteDashboardTemplateSuccess: async () => {
-            refreshDashboardTemplateListsAfterMutation(actions.getAllTemplates)
+            refreshDashboardTemplateListsAfterMutation()
         },
         closeDashboardTemplateEditor: () => {
             actions.clear()

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateModalLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateModalLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, reducers } from 'kea'
+import { actions, kea, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -15,9 +15,6 @@ export type CloseModalActionPayload = { readonly kind: 'closeModal' }
 
 export const dashboardTemplateModalLogic = kea<dashboardTemplateModalLogicType>([
     path(['scenes', 'dashboard', 'dashboards', 'templates', 'dashboardTemplateModalLogic']),
-    connect(() => ({
-        actions: [dashboardTemplatesLogic({ scope: 'default', templatesTabList: true }), ['getAllTemplates']],
-    })),
     actions({
         openCreate: (payload: DashboardTemplateEditorType) => ({ payload }),
         openEdit: (template: DashboardTemplateType) => ({ template }),
@@ -121,7 +118,9 @@ export const dashboardTemplateModalLogic = kea<dashboardTemplateModalLogicType>(
                             })
                             lemonToast.success('Template updated')
                         }
-                        actions.getAllTemplates()
+                        dashboardTemplatesLogic
+                            .findMounted({ scope: 'default', templatesTabList: true })
+                            ?.actions.getAllTemplates()
                         actions.closeModal()
                         return true
                     } catch (e: any) {


### PR DESCRIPTION
## Problem

The most common JS exception PostHog itself captures from app users on `app.posthog.com` is currently:

> [KEA] Can not find path "scenes.dashboard.dashboards.templates.dashboardTemplatesLogic.default-all-templatesTab" in the store.

The stack trace pins it to the `getAllTemplates` loader in `dashboardTemplatesLogic.tsx` reading `values.templateNameOrdering` after the `default-all-templatesTab` instance has unmounted. The loader is dispatched into via `connect.actions` from `dashboardTemplateEditorLogic` and `dashboardTemplateModalLogic`, and `connect.actions` does not reliably keep the templates-tab instance mounted across the editor/modal lifecycle on this Kea version (`kea@^4.0.0-pre.5`).

## Changes

- Drop the `connect.actions` shortcut to `dashboardTemplatesLogic({ scope: 'default', templatesTabList: true })` in both `dashboardTemplateEditorLogic` and `dashboardTemplateModalLogic`.
- Route the four post-mutation refreshes through `dashboardTemplatesLogic.findMounted(...)?.actions.getAllTemplates()` for **all** keys, including `templatesTabList: true`. The other three keys already used this pattern; only the tab list was special-cased through a connect-forwarded callback.
- `refreshDashboardTemplateListsAfterMutation()` no longer takes a callback — same call shape at every site.

Behaviorally identical when the relevant list is mounted; when it isn't, the refresh is silently skipped (the next mount refetches), which already matches the behavior for the other three list flavors and `dashboardTemplateCopyLogic`.

## How did you test this code?

I'm an agent (PostHog Code). I ran the automated checks below; I did **not** manually exercise the templates UI:

- `pnpm exec kea-typegen write --delete --use-cache` — regenerates logic types after the connect change.
- `pnpm --filter=@posthog/frontend typescript:check` — clean (0 errors across the frontend).
- `pnpm --filter=@posthog/frontend format` (oxlint --fix + oxfmt) — clean.
- Pre-commit `bin/hogli format:js` ran via the husky hook on commit.

The change is a swap of cross-logic dispatch mechanism with no logic-shape change, so unit tests on `dashboardTemplateEditorLogic` / `dashboardTemplateModalLogic` (none exist today) wouldn't add coverage beyond what the type system already enforces.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

Authored end-to-end by PostHog Code (Claude). Workflow:

1. User pasted an insight URL filtering `$exception` events captured on PostHog itself, asked which exception to stop, and selected the top kea-store-path one.
2. Pulled three recent matching events via `execute-sql` to read the resolved stack trace — pointed at `getAllTemplates` reading `values.templateNameOrdering`, ruling out a generic capture-site issue.
3. Surveyed every dispatch site of `getAllTemplates` for `{ scope: 'default', templatesTabList: true }`. Three patterns existed: in-logic listeners (safe), `findMounted` (safe), and `connect.actions` from editor/modal logics (unsafe — root cause).
4. Considered alternatives: keeping connect and wrapping the loader body in a mount check, or using try/catch around the value reads. Rejected both as papering over the lifetime mismatch instead of fixing it; consolidating on the `findMounted` pattern already used elsewhere is more consistent.

Agent-authored — needs human review before merge.