### PR TITLE
fix(llma): coerce $ai_error to string in traces list

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -368,10 +368,9 @@ const OutputMessageColumn: QueryContextColumnComponent = ({ record }) => {
         ? row.events.find((e) => e.properties?.$ai_error || e.properties?.$ai_is_error)
         : false
     if (errorEventFound) {
-        const errorText = formatAiErrorForDisplay(errorEventFound.properties?.$ai_error)
         return (
             <LemonTag type="danger" className="font-mono max-w-50 truncate">
-                {errorText || 'Unknown error'}
+                {formatAiErrorForDisplay(errorEventFound.properties?.$ai_error)}
             </LemonTag>
         )
     }

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -25,6 +25,7 @@ import { llmAnalyticsTracesTabLogic } from './tabs/llmAnalyticsTracesTabLogic'
 import { TraceMessages, traceMessagesLazyLoaderLogic } from './traceMessagesLazyLoaderLogic'
 import { traceReviewsLazyLoaderLogic } from './traceReviews/traceReviewsLazyLoaderLogic'
 import {
+    formatAiErrorForDisplay,
     formatLLMCost,
     formatLLMLatency,
     formatLLMUsage,
@@ -367,9 +368,10 @@ const OutputMessageColumn: QueryContextColumnComponent = ({ record }) => {
         ? row.events.find((e) => e.properties?.$ai_error || e.properties?.$ai_is_error)
         : false
     if (errorEventFound) {
+        const errorText = formatAiErrorForDisplay(errorEventFound.properties?.$ai_error)
         return (
             <LemonTag type="danger" className="font-mono max-w-50 truncate">
-                {errorEventFound.properties?.$ai_error || 'Unknown error'}
+                {errorText || 'Unknown error'}
             </LemonTag>
         )
     }

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -1982,9 +1982,9 @@ describe('LLM Analytics utils', () => {
     describe('formatAiErrorForDisplay', () => {
         it.each<[string, unknown, string]>([
             ['string passes through', 'rate limit exceeded', 'rate limit exceeded'],
-            ['empty string passes through', '', ''],
-            ['null returns empty string', null, ''],
-            ['undefined returns empty string', undefined, ''],
+            ['empty string falls back to Unknown error', '', 'Unknown error'],
+            ['null falls back to Unknown error', null, 'Unknown error'],
+            ['undefined falls back to Unknown error', undefined, 'Unknown error'],
             [
                 'plain object is JSON-stringified',
                 { message: 'boom', name: 'Error' },

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -4,6 +4,7 @@ import { AnthropicInputMessage, OpenAICompletionMessage } from './types'
 import {
     costContextFromProperties,
     costContextFromTrace,
+    formatAiErrorForDisplay,
     formatLLMEventTitle,
     getSessionID,
     getSessionStartTimestamp,
@@ -1975,6 +1976,33 @@ describe('LLM Analytics utils', () => {
         it('returns raw string when stringified value parses to a non-object scalar', () => {
             // partial-json may parse `"hello"` to the string "hello" — that's not a structured arg payload, fall back.
             expect(parseToolArgumentsForDisplay('"hello"')).toEqual({ kind: 'raw', value: '"hello"' })
+        })
+    })
+
+    describe('formatAiErrorForDisplay', () => {
+        it.each<[string, unknown, string]>([
+            ['string passes through', 'rate limit exceeded', 'rate limit exceeded'],
+            ['empty string passes through', '', ''],
+            ['null returns empty string', null, ''],
+            ['undefined returns empty string', undefined, ''],
+            [
+                'plain object is JSON-stringified',
+                { message: 'boom', name: 'Error' },
+                '{"message":"boom","name":"Error"}',
+            ],
+            ['array is JSON-stringified', ['a', 'b'], '["a","b"]'],
+            ['number is JSON-stringified', 500, '500'],
+            ['boolean is JSON-stringified', true, 'true'],
+        ])('%s', (_, input, expected) => {
+            expect(formatAiErrorForDisplay(input)).toBe(expected)
+        })
+
+        it('falls back to String() when JSON.stringify throws (e.g. circular refs)', () => {
+            const circular: Record<string, unknown> = {}
+            circular.self = circular
+            // JSON.stringify throws on circular refs; helper should fall back to String() and not throw.
+            expect(() => formatAiErrorForDisplay(circular)).not.toThrow()
+            expect(formatAiErrorForDisplay(circular)).toBe('[object Object]')
         })
     })
 })

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -221,6 +221,25 @@ export function formatTokens(tokens: number): string {
     return tokens.toFixed(0)
 }
 
+// SDKs may send `$ai_error` as a string, an object (e.g. a serialized Error
+// with `{ message, name }`), or any other shape. Coerce to a short string so
+// list-cell renderers don't blow up with "Objects are not valid as a React
+// child" (React error #31). Mirrors the ingestion-side coercion in
+// nodejs/src/ingestion/ai/errors/index.ts.
+export function formatAiErrorForDisplay(value: unknown): string {
+    if (typeof value === 'string') {
+        return value
+    }
+    if (value == null) {
+        return ''
+    }
+    try {
+        return JSON.stringify(value)
+    } catch {
+        return String(value)
+    }
+}
+
 export function formatErrorRate(errorRate: number): string {
     const percentage = errorRate * 100
     if (percentage === 0) {

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -221,11 +221,6 @@ export function formatTokens(tokens: number): string {
     return tokens.toFixed(0)
 }
 
-// SDKs may send `$ai_error` as a string, an object (e.g. a serialized Error
-// with `{ message, name }`), or any other shape. Coerce to a short string so
-// list-cell renderers don't blow up with "Objects are not valid as a React
-// child" (React error #31). Mirrors the ingestion-side coercion in
-// nodejs/src/ingestion/ai/errors/index.ts.
 export function formatAiErrorForDisplay(value: unknown): string {
     if (typeof value === 'string') {
         return value

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -223,10 +223,10 @@ export function formatTokens(tokens: number): string {
 
 export function formatAiErrorForDisplay(value: unknown): string {
     if (typeof value === 'string') {
-        return value
+        return value || 'Unknown error'
     }
     if (value == null) {
-        return ''
+        return 'Unknown error'
     }
     try {
         return JSON.stringify(value)


### PR DESCRIPTION
## Problem

The LLM analytics traces list (`/llm-analytics/traces`) crashes with React error #31 ("Objects are not valid as a React child") whenever any event in the visible page has `properties.$ai_error` set to a non-string value. The crash takes down the whole traces page.

The detail view, async event content path, and search utilities already guard against non-string `$ai_error` (via `isObject` checks and `JSON.stringify`). The traces list cell was the only renderer that assumed it was a string.

## Changes

- New `formatAiErrorForDisplay(value: unknown): string` helper in `products/llm_analytics/frontend/utils.ts`. Strings pass through; nullish and empty-string return `'Unknown error'`; everything else is `JSON.stringify`'d, with a `String()` fallback for cases like circular refs. The fallback lives entirely in the helper, so the call site doesn't need a `|| 'Unknown error'`.
- `OutputMessageColumn` in `LLMAnalyticsTracesScene.tsx` now calls the helper directly when rendering the error tag.
- Parameterized tests for the helper covering string, empty string, null, undefined, plain object (the `{message, name}` case from the report), array, number, boolean, plus a non-throw assertion for circular-ref objects.


## Open question for the reviewer(s)

This PR fixes the specific crash that was reported. While investigating, I noticed four more sites in `products/llm_analytics/frontend/` that follow the same pattern (`property || 'fallback'` rendered as a JSX child, with `properties: Record<string, any>`), and would crash the same way if a customer sends those properties as objects:

- `LLMAnalyticsEventCard.tsx:81` — `$ai_model`, `$ai_span_name`
- `LLMAnalyticsTraceScene.tsx:1309-1316` — `$ai_model`
- `utils.ts:1402` `formatLLMEventTitle` — declared `: string` return, but actually returns `$ai_model`/`$ai_span_name` verbatim. Used in 4 render sites.
- `ConversationDisplay/EvaluationDisplay.tsx:50-58` — `$ai_evaluation_name`, `$ai_model`/`$ai_evaluation_model`

These crash the trace detail page (and other LLM analytics surfaces), not the list, so they weren't part of the reported incident. Should this PR also cover these cases, to make it more complete?

## How did you test this code?

I haven't tested this manually yet, but here are the steps I would follow (waiting on feedback about scope of PR first):
- Send a test event with `$ai_is_error: true` and `$ai_error: { message: 'boom', name: 'Error' }`, open `/llm-analytics/traces`, confirm the page renders and the row shows the JSON-stringified error in the danger tag instead of crashing.
- Send another event with `$ai_error: 'plain string error'` and confirm the existing string path still renders unchanged.

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

- Co-authored by Claude Opus 4.7 via Claude Code
