### PR TITLE
chore(ci): only run AI evals when evals-ready label is set

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -2,16 +2,10 @@ name: AI
 on:
     pull_request:
         types: [opened, synchronize, reopened, labeled, unlabeled]
-    push:
-        branches:
-            - master
-        paths:
-            - 'ee/hogai/**'
-            - '.github/workflows/ci-ai.yml'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: ${{ github.event_name == 'pull_request' }} # We only want one AI CI run per PR concurrently
+    cancel-in-progress: true # We only want one AI CI run per PR concurrently
 
 jobs:
     eval:
@@ -20,9 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         # Skipping on forks as Braintrust credentials are not available there
         if: |
-            github.repository == 'PostHog/posthog' && (
-                github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'evals-ready')
-            )
+            github.repository == 'PostHog/posthog' && contains(github.event.pull_request.labels.*.name, 'evals-ready')
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Problem

Disable PostHog AI eval runs on master, as they don't have much value now.

## Changes

- Removed the `push: branches: [master]` trigger from `ci-ai.yml`.
- Simplified the job `if:` from `github.event_name == 'push' || contains(... 'evals-ready')` to just the label check.
- Simplified the `concurrency.cancel-in-progress` expression accordingly (it was guarded against the now-removed push event).

## How did you test this code?

I'm an agent (PostHog Code). I did not run the workflow itself — this is a CI config change with no runtime to exercise locally. Verified by re-reading the diff:

- The job `if:` no longer references `github.event_name == 'push'`, so a hypothetical push event could not satisfy it even if one were delivered.
- The `on:` block now lists only `pull_request`, so master pushes will not start this workflow at all.
- Cache `save-if: github.ref == 'refs/heads/master'` lines are now always-false on this workflow's runs (which only happen on PR refs); harmless — eval runs aren't a meaningful cache producer for the rest of CI.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by PostHog Code at the request of @skoob13 in response to a report that `eval_update_dashboard` teardown failed with `DatabaseOperationForbidden` on a master push triggered by an unrelated PR (#57797, which only touched the new Evals system not yet wired into CI). Root cause for the teardown failure isn't addressed here — this PR just stops the unintended trigger so unrelated PRs don't get blamed for eval-system flakiness on master. The underlying eval still needs a fix before re-enabling on master, if we ever want to.

Considered alternatives: keep the master trigger but narrow the matrix (rejected — same blast radius, just smaller); gate on a different event like `workflow_dispatch` (rejected — label-based opt-in already exists and is the documented path).

Generated-By: PostHog Code
Task-Id: 01d33d2e-5690-4f4a-b6d4-dffd1b1882bb