### PR TITLE
fix(data-warehouse): prevent sql editor url feedback loop

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -20,7 +20,12 @@ import { ChartDisplayType, InsightShortId, QueryBasedInsightModel } from '~/type
 
 import { editorSceneLogic } from './editorSceneLogic'
 import { OutputTab } from './outputPaneLogic'
-import { activeTabMatchesUrlTarget, getDisplayTypeToSaveInsight, sqlEditorLogic } from './sqlEditorLogic'
+import {
+    activeTabMatchesUrlTarget,
+    getDisplayTypeToSaveInsight,
+    getSqlEditorActionToUrl,
+    sqlEditorLogic,
+} from './sqlEditorLogic'
 
 // endpointLogic uses permanentlyMount() with a keyed logic, which crashes in
 // tests without the full React component tree — disable auto-mounting
@@ -317,6 +322,26 @@ describe('sqlEditorLogic', () => {
         await new Promise((resolve) => setTimeout(resolve, 0))
 
         expect(createTabSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns inactive tab URL updates even when they match the active URL', async () => {
+        logic = sqlEditorLogic({
+            tabId: TAB_ID,
+            monaco: createMockMonaco(),
+            editor: createMockEditor(),
+        })
+        logic.mount()
+
+        router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1' })
+        await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+        expect(getSqlEditorActionToUrl(logic.values, undefined, { skipCurrentLocationCheck: true })).toBeUndefined()
+        expect(getSqlEditorActionToUrl(logic.values, undefined, { skipCurrentLocationCheck: false })).toEqual([
+            urls.sqlEditor(),
+            undefined,
+            expect.objectContaining({ q: 'SELECT 1' }),
+            { replace: true },
+        ])
     })
 
     it('syncs filters to the URL hash and removes them after reset', async () => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -296,6 +296,29 @@ describe('sqlEditorLogic', () => {
             })
     })
 
+    it('does not recreate the current raw query tab when its tab URL is pushed again', async () => {
+        logic = sqlEditorLogic({
+            tabId: TAB_ID,
+            monaco: createMockMonaco(),
+            editor: createMockEditor(),
+        })
+        logic.mount()
+
+        const createTabSpy = jest.spyOn(logic.actions, 'createTab')
+
+        router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1' })
+
+        await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+        expect(createTabSpy).toHaveBeenCalledTimes(1)
+
+        const { pathname, search, hash } = router.values.location
+        const currentTabUrl = `${pathname}${search}${hash}`
+        router.actions.push(currentTabUrl)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        expect(createTabSpy).toHaveBeenCalledTimes(1)
+    })
+
     it('syncs filters to the URL hash and removes them after reset', async () => {
         const filters: HogQLFilters = {
             dateRange: {
@@ -714,6 +737,24 @@ describe('sqlEditorLogic', () => {
                 true,
             ],
             ['plain tab vs empty target', { name: 'Untitled' }, {}, true],
+            [
+                'plain tab vs matching hash query target',
+                { name: 'Untitled' },
+                { hashQ: 'SELECT 1', queryInput: 'SELECT 1' },
+                true,
+            ],
+            [
+                'plain tab vs different hash query target',
+                { name: 'Untitled' },
+                { hashQ: 'SELECT 2', queryInput: 'SELECT 1' },
+                false,
+            ],
+            [
+                'plain tab vs matching open query target',
+                { name: 'Untitled' },
+                { openQuery: 'SELECT 1', queryInput: 'SELECT 1' },
+                true,
+            ],
             ['plain tab vs insight target', { name: 'Untitled' }, { insightShortId: MOCK_INSIGHT_SHORT_ID }, false],
             ['plain tab vs view target', { name: 'Untitled' }, { viewId: MOCK_VIEW.id }, false],
             ['plain tab vs draft target', { name: 'Untitled' }, { draftId: MOCK_DRAFT.id }, false],

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -37,6 +37,7 @@ import { databaseTableListLogic } from 'scenes/data-management/database/database
 import { parseQueryTablesAndColumns, queryUsesFiltersPlaceholder } from 'scenes/data-warehouse/editor/sql-utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightsApi } from 'scenes/insights/utils/api'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -375,14 +376,20 @@ export function activeTabMatchesUrlTarget(activeTab: QueryTab | null, target: Sq
     return !activeTab?.draft && !activeTab?.view && !activeTab?.insight && plainQueryMatches
 }
 
-function getSqlEditorActionToUrl(
+function isActiveSceneTab(tabId?: string): boolean {
+    return !sceneLogic.isMounted() || !tabId || sceneLogic.values.activeTabId === tabId
+}
+
+export function getSqlEditorActionToUrl(
     values: sqlEditorLogicType['values'],
-    hash: Record<string, any> = getTabHash(values)
+    hash: Record<string, any> = getTabHash(values),
+    options: { skipCurrentLocationCheck?: boolean } = {}
 ): SqlEditorActionToUrlResponse {
     const nextLocation = combineUrl(urls.sqlEditor(), undefined, hash)
-    const currentLocation = router.values.location
+    const currentLocation = options.skipCurrentLocationCheck ? router.values.location : null
 
     if (
+        currentLocation &&
         currentLocation.pathname === nextLocation.pathname &&
         currentLocation.search === nextLocation.search &&
         currentLocation.hash === nextLocation.hash
@@ -2168,24 +2175,30 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             { resultEqualityCheck: objectsEqual },
         ],
     }),
-    tabAwareActionToUrl(({ values }) => ({
+    tabAwareActionToUrl(({ values, props }) => ({
         syncUrlWithQuery: () => {
             if (values.isEmbeddedMode) {
                 return
             }
-            return getSqlEditorActionToUrl(values)
+            return getSqlEditorActionToUrl(values, undefined, {
+                skipCurrentLocationCheck: isActiveSceneTab(props.tabId),
+            })
         },
         createTab: ({ query, view, insight, draft }) => {
             if (values.isEmbeddedMode) {
                 return
             }
-            return getSqlEditorActionToUrl(values, getCreateTabHash(values, query, view, insight, draft))
+            return getSqlEditorActionToUrl(values, getCreateTabHash(values, query, view, insight, draft), {
+                skipCurrentLocationCheck: isActiveSceneTab(props.tabId),
+            })
         },
         setActiveTab: ({ tab }) => {
             if (values.isEmbeddedMode || !values.activeTab) {
                 return
             }
-            return getSqlEditorActionToUrl(values, getTabHash({ ...values, outputActiveTab: tab }))
+            return getSqlEditorActionToUrl(values, getTabHash({ ...values, outputActiveTab: tab }), {
+                skipCurrentLocationCheck: isActiveSceneTab(props.tabId),
+            })
         },
     })),
     tabAwareUrlToAction(({ actions, values, props }) => ({

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -2450,12 +2450,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     !draftIdFromUrl &&
                     !viewIdFromUrl &&
                     !insightShortIdFromUrl &&
-                    (values.queryInput === null ||
-                        !activeTabMatchesUrlTarget(values.activeTab, {
-                            hashQ: hashParams.q,
-                            queryInput: values.queryInput,
-                        }) ||
-                        values.queryInput !== hashParams.q)
+                    !activeTabMatchesUrlTarget(values.activeTab, {
+                        hashQ: hashParams.q,
+                        queryInput: values.queryInput,
+                    })
                 ) {
                     actions.createTab(hashParams.q)
                     tabAdded = true

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -14,7 +14,7 @@ import {
     selectors,
 } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { type IRange, Uri, editor } from 'monaco-editor'
 import posthog from 'posthog-js'
@@ -345,10 +345,21 @@ export function getDisplayTypeToSaveInsight(
     return effectiveVisualizationType || ChartDisplayType.ActionsLineGraph
 }
 
-export function activeTabMatchesUrlTarget(
-    activeTab: QueryTab | null,
-    target: { draftId?: string; insightShortId?: string; viewId?: string }
-): boolean {
+type SqlEditorUrlTarget = {
+    draftId?: string
+    hashQ?: string
+    insightShortId?: string
+    openQuery?: string
+    queryInput?: string | null
+    viewId?: string
+}
+
+type SqlEditorActionToUrlResponse = [string, undefined, Record<string, any>, { replace: true }] | undefined
+
+export function activeTabMatchesUrlTarget(activeTab: QueryTab | null, target: SqlEditorUrlTarget): boolean {
+    const plainQueryTarget = target.openQuery ?? target.hashQ
+    const plainQueryMatches = plainQueryTarget === undefined || target.queryInput === plainQueryTarget
+
     if (target.draftId) {
         return activeTab?.draft?.id === target.draftId
     }
@@ -361,7 +372,53 @@ export function activeTabMatchesUrlTarget(
         return activeTab?.insight?.short_id === target.insightShortId
     }
 
-    return !activeTab?.draft && !activeTab?.view && !activeTab?.insight
+    return !activeTab?.draft && !activeTab?.view && !activeTab?.insight && plainQueryMatches
+}
+
+function getSqlEditorActionToUrl(
+    values: sqlEditorLogicType['values'],
+    hash: Record<string, any> = getTabHash(values)
+): SqlEditorActionToUrlResponse {
+    const nextLocation = combineUrl(urls.sqlEditor(), undefined, hash)
+    const currentLocation = router.values.location
+
+    if (
+        currentLocation.pathname === nextLocation.pathname &&
+        currentLocation.search === nextLocation.search &&
+        currentLocation.hash === nextLocation.hash
+    ) {
+        return undefined
+    }
+
+    return [urls.sqlEditor(), undefined, hash, { replace: true }]
+}
+
+function getCreateTabHash(
+    values: sqlEditorLogicType['values'],
+    query?: string,
+    view?: DataWarehouseSavedQuery,
+    insight?: QueryBasedInsightModel,
+    draft?: DataWarehouseSavedQueryDraft
+): Record<string, any> {
+    const insightVisualizationQuery = toDataVisualizationNode(insight?.query)
+    const queryInput =
+        query ??
+        draft?.query.query ??
+        view?.query?.query ??
+        insightVisualizationQuery?.source.query ??
+        values.queryInput ??
+        ''
+
+    return getTabHash({
+        ...values,
+        queryInput,
+        activeTab: {
+            ...values.activeTab,
+            view,
+            insight,
+            draft,
+        } as QueryTab,
+    })
 }
 
 export const sqlEditorLogic = kea<sqlEditorLogicType>([
@@ -2116,19 +2173,19 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             if (values.isEmbeddedMode) {
                 return
             }
-            return [urls.sqlEditor(), undefined, getTabHash(values), { replace: true }]
+            return getSqlEditorActionToUrl(values)
         },
-        createTab: () => {
+        createTab: ({ query, view, insight, draft }) => {
             if (values.isEmbeddedMode) {
                 return
             }
-            return [urls.sqlEditor(), undefined, getTabHash(values), { replace: true }]
+            return getSqlEditorActionToUrl(values, getCreateTabHash(values, query, view, insight, draft))
         },
-        setActiveTab: () => {
+        setActiveTab: ({ tab }) => {
             if (values.isEmbeddedMode || !values.activeTab) {
                 return
             }
-            return [urls.sqlEditor(), undefined, getTabHash(values), { replace: true }]
+            return getSqlEditorActionToUrl(values, getTabHash({ ...values, outputActiveTab: tab }))
         },
     })),
     tabAwareUrlToAction(({ actions, values, props }) => ({
@@ -2237,10 +2294,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                 if (
                     draftIdFromUrl &&
-                    (searchParams.open_draft ||
-                        !activeTabMatchesUrlTarget(values.activeTab, {
-                            draftId: draftIdFromUrl,
-                        }))
+                    !activeTabMatchesUrlTarget(values.activeTab, {
+                        draftId: draftIdFromUrl,
+                    })
                 ) {
                     const draftId = draftIdFromUrl
                     const draft = values.drafts.find((draft) => {
@@ -2264,10 +2320,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     return
                 } else if (
                     viewIdFromUrl &&
-                    (searchParams.open_view ||
-                        !activeTabMatchesUrlTarget(values.activeTab, {
-                            viewId: viewIdFromUrl,
-                        }))
+                    !activeTabMatchesUrlTarget(values.activeTab, {
+                        viewId: viewIdFromUrl,
+                    })
                 ) {
                     // Open view
                     const viewId = viewIdFromUrl
@@ -2305,13 +2360,12 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     }
                     actions.setViewLoading(false)
                     tabAdded = true
-                    router.actions.replace(urls.sqlEditor(), undefined, getTabHash(values))
+                    router.actions.replace(urls.sqlEditor(), undefined, getCreateTabHash(values, queryToOpen, view))
                 } else if (
                     insightShortIdFromUrl &&
-                    (searchParams.open_insight ||
-                        !activeTabMatchesUrlTarget(values.activeTab, {
-                            insightShortId: insightShortIdFromUrl,
-                        }))
+                    !activeTabMatchesUrlTarget(values.activeTab, {
+                        insightShortId: insightShortIdFromUrl,
+                    })
                 ) {
                     // reset current tab
                     if (values.activeTab) {
@@ -2327,7 +2381,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                         // Add new blank tab
                         actions.createTab()
                         tabAdded = true
-                        router.actions.replace(urls.sqlEditor(), undefined, getTabHash(values))
+                        router.actions.replace(urls.sqlEditor(), undefined, getCreateTabHash(values))
                         return
                     }
 
@@ -2376,8 +2430,18 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     }
 
                     tabAdded = true
-                    router.actions.replace(urls.sqlEditor(), undefined, getTabHash(values))
-                } else if (searchParams.open_query) {
+                    router.actions.replace(
+                        urls.sqlEditor(),
+                        undefined,
+                        getCreateTabHash(values, queryToOpen, undefined, insight)
+                    )
+                } else if (
+                    searchParams.open_query &&
+                    !activeTabMatchesUrlTarget(values.activeTab, {
+                        openQuery: searchParams.open_query,
+                        queryInput: values.queryInput,
+                    })
+                ) {
                     // Open query string
                     actions.createTab(searchParams.open_query)
                     tabAdded = true
@@ -2387,12 +2451,15 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     !viewIdFromUrl &&
                     !insightShortIdFromUrl &&
                     (values.queryInput === null ||
-                        !activeTabMatchesUrlTarget(values.activeTab, {}) ||
+                        !activeTabMatchesUrlTarget(values.activeTab, {
+                            hashQ: hashParams.q,
+                            queryInput: values.queryInput,
+                        }) ||
                         values.queryInput !== hashParams.q)
                 ) {
                     actions.createTab(hashParams.q)
                     tabAdded = true
-                } else if (values.queryInput === null) {
+                } else if (values.queryInput === null && !values.activeTab) {
                     actions.createTab('')
                     tabAdded = true
                 }


### PR DESCRIPTION
## Problem

SQL editor tabs can re-dispatch URL-derived tab creation after the active tab already represents the current `/sql` URL.
That can produce a kea-router feedback loop when tab-aware scene URLs are pushed or replaced rapidly.

## Changes

- Make SQL editor action-to-URL handlers idempotent by returning `undefined` when the computed `/sql` URL already matches the current router location.
- Build the `createTab` URL hash from the action payload instead of stale pre-listener state.
- Teach the URL target guard to recognize plain query tabs by query text, and skip the empty-tab fallback when an active tab already exists.
- Add a regression test for pushing the active tab URL again, plus helper coverage for raw query URL matching.

## How did you test this code?

Automated test attempted:

`hogli test frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts`

This environment could not run it because `hogli` is not on PATH, `./bin/hogli` could not find `python`, and there is no repo venv with the `hogli` module.

Fallback attempted:

`pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts --runInBand`

This also could not run because frontend dependencies are not installed in this workspace (`Command "jest" not found`).

`git diff --check` passes.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 Agent context

Authored by Codex in response to a report of SQL editor tab-aware URL synchronization entering a router feedback loop.
The fix keeps the SQL editor's URL handlers from issuing no-op replacements and makes URL-derived `createTab` actions compute their hash from the requested tab payload, avoiding the stale-state empty-query replacement that can re-enter `urlToAction`.
