### PR TITLE
chore: restrict tasks api queryset to task creator

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -196,6 +196,20 @@ def _resolve_cloud_pr_authorship_mode(
 TASK_RUN_ARTIFACT_UPLOAD_FORM_OVERHEAD_BYTES = 64 * 1024
 
 
+def task_visibility_q(user_id: int | None, prefix: str = "") -> Q:
+    """Filter for tasks visible to the given user.
+
+    A task is visible if its creator matches `user_id`, or if it has no
+    creator at all (legacy unowned tasks remain visible to any team member —
+    they cannot be executed in any case because oauth.py requires
+    `task.created_by` to mint OAuth tokens).
+
+    `prefix` lets callers traverse from related models (e.g. "task__" when
+    filtering a TaskRun or TaskAutomation queryset).
+    """
+    return Q(**{f"{prefix}created_by_id": user_id}) | Q(**{f"{prefix}created_by__isnull": True})
+
+
 class TasksAccessPermission(BasePermission):
     message = "You need a valid invite code to access this feature."
 
@@ -269,6 +283,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def repositories(self, request, **kwargs):
         repositories = (
             Task.objects.filter(team=self.team, deleted=False, internal=False)
+            .filter(task_visibility_q(getattr(self.request.user, "id", None)))
             .exclude(repository__isnull=True)
             .exclude(repository__exact="")
             .values_list("repository", flat=True)
@@ -324,6 +339,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
         tasks = (
             Task.objects.filter(team=self.team, deleted=False, id__in=ids)
+            .filter(task_visibility_q(getattr(self.request.user, "id", None)))
             .annotate(_latest_run=Subquery(latest_run.values("_data")[:1]))
             .order_by("-created_at", "id")
         )
@@ -365,7 +381,11 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response(result)
 
     def safely_get_queryset(self, queryset):
-        qs = queryset.filter(team=self.team, deleted=False).order_by("-created_at")
+        qs = (
+            queryset.filter(team=self.team, deleted=False)
+            .filter(task_visibility_q(getattr(self.request.user, "id", None)))
+            .order_by("-created_at")
+        )
 
         params = self.request.query_params if hasattr(self, "request") else {}
 
@@ -828,7 +848,11 @@ class TaskAutomationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     filter_rewrite_rules = {"team_id": "task__team_id"}
 
     def safely_get_queryset(self, queryset):
-        return queryset.filter(task__team=self.team).order_by("task__title", "-created_at")
+        return (
+            queryset.filter(task__team=self.team)
+            .filter(task_visibility_q(getattr(self.request.user, "id", None), prefix="task__"))
+            .order_by("task__title", "-created_at")
+        )
 
     def get_serializer_context(self):
         return {**super().get_serializer_context(), "team": self.team, "team_id": self.team.id}
@@ -914,7 +938,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if not task_id:
             raise NotFound("Task ID is required")
 
-        task = Task.objects.get(id=task_id, team=self.team)
+        task = (
+            Task.objects.filter(id=task_id, team=self.team)
+            .filter(task_visibility_q(getattr(request.user, "id", None)))
+            .first()
+        )
+        if task is None:
+            raise NotFound("Task not found")
         environment = request.validated_data.get("environment", TaskRun.Environment.LOCAL)
         mode = request.validated_data.get("mode", "background")
         branch = request.validated_data.get("branch")
@@ -1267,8 +1297,12 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if not task_id:
             raise NotFound("Task ID is required")
 
-        # Verify task belongs to team
-        if not Task.objects.filter(id=task_id, team=self.team).exists():
+        task_visible = (
+            Task.objects.filter(id=task_id, team=self.team)
+            .filter(task_visibility_q(getattr(self.request.user, "id", None)))
+            .exists()
+        )
+        if not task_visible:
             raise NotFound("Task not found")
 
         return queryset.filter(team=self.team, task_id=task_id)
@@ -1280,7 +1314,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         task_id = self.kwargs.get("parent_lookup_task_id")
         if not task_id:
             raise NotFound("Task ID is required")
-        task = Task.objects.get(id=task_id, team=self.team)
+        task = (
+            Task.objects.filter(id=task_id, team=self.team)
+            .filter(task_visibility_q(getattr(self.request.user, "id", None)))
+            .first()
+        )
+        if task is None:
+            raise NotFound("Task not found")
         serializer.save(team=self.team, task=task)
 
     def _trigger_workflow(self, task: Task, task_run: TaskRun, *, raise_on_error: bool = False) -> None:

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -196,18 +196,20 @@ def _resolve_cloud_pr_authorship_mode(
 TASK_RUN_ARTIFACT_UPLOAD_FORM_OVERHEAD_BYTES = 64 * 1024
 
 
-def task_visibility_q(user_id: int | None, prefix: str = "") -> Q:
+def task_visibility_q(user_id: int | None) -> Q:
     """Filter for tasks visible to the given user.
 
     A task is visible if its creator matches `user_id`, or if it has no
     creator at all (legacy unowned tasks remain visible to any team member —
     they cannot be executed in any case because oauth.py requires
     `task.created_by` to mint OAuth tokens).
-
-    `prefix` lets callers traverse from related models (e.g. "task__" when
-    filtering a TaskRun or TaskAutomation queryset).
     """
-    return Q(**{f"{prefix}created_by_id": user_id}) | Q(**{f"{prefix}created_by__isnull": True})
+    return Q(created_by_id=user_id) | Q(created_by__isnull=True)
+
+
+def task_run_visibility_q(user_id: int | None) -> Q:
+    """`task_visibility_q` traversed via the `task` FK on TaskRun / TaskAutomation."""
+    return Q(task__created_by_id=user_id) | Q(task__created_by__isnull=True)
 
 
 class TasksAccessPermission(BasePermission):
@@ -850,7 +852,7 @@ class TaskAutomationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def safely_get_queryset(self, queryset):
         return (
             queryset.filter(task__team=self.team)
-            .filter(task_visibility_q(getattr(self.request.user, "id", None), prefix="task__"))
+            .filter(task_run_visibility_q(getattr(self.request.user, "id", None)))
             .order_by("task__title", "-created_at")
         )
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -157,7 +157,7 @@ class BaseTaskAPITest(TestCase):
     def create_task(self, title="Test Task", created_by: User | None = None):
         return Task.objects.create(
             team=self.team,
-            created_by=created_by,
+            created_by=created_by or self.user,
             title=title,
             description="Test Description",
             origin_product=Task.OriginProduct.USER_CREATED,
@@ -194,6 +194,185 @@ class BaseTaskAPITest(TestCase):
             timezone="Europe/London",
             enabled=True,
         )
+
+
+class TestTaskCreatorScoping(BaseTaskAPITest):
+    def _create_legacy_task(self, title: str = "Legacy") -> Task:
+        return Task.objects.create(
+            team=self.team,
+            created_by=None,
+            title=title,
+            description="Legacy unowned",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+
+    def test_list_excludes_other_user_tasks_but_includes_legacy_unowned(self):
+        other_user = self.create_organization_user("victim")
+        self.create_task("Mine", created_by=self.user)
+        self.create_task("Theirs", created_by=other_user)
+        self._create_legacy_task("Legacy")
+
+        response = self.client.get("/api/projects/@current/tasks/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = sorted(task["title"] for task in response.json()["results"])
+        self.assertEqual(titles, ["Legacy", "Mine"])
+
+    def test_retrieve_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_legacy_unowned_task_is_visible(self):
+        task = self._create_legacy_task()
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_repositories_excludes_other_user_repos(self):
+        other_user = self.create_organization_user("victim")
+        mine = self.create_task("Mine", created_by=self.user)
+        mine.repository = "me/repo"
+        mine.save(update_fields=["repository"])
+        theirs = self.create_task("Theirs", created_by=other_user)
+        theirs.repository = "victim/secret"
+        theirs.save(update_fields=["repository"])
+
+        response = self.client.get("/api/projects/@current/tasks/repositories/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["repositories"], ["me/repo"])
+
+    def test_summaries_excludes_other_user_tasks(self):
+        other_user = self.create_organization_user("victim")
+        mine = self.create_task("Mine", created_by=self.user)
+        theirs = self.create_task("Theirs", created_by=other_user)
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/summaries/",
+            {"ids": [str(mine.id), str(theirs.id)]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = sorted(item["id"] for item in response.json()["results"])
+        self.assertEqual(ids, [str(mine.id)])
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_other_user_task_returns_404(self, mock_workflow):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
+        mock_workflow.assert_not_called()
+
+    def test_update_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user, title="Original")
+
+        response = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/",
+            {"title": "Hijacked"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        task.refresh_from_db()
+        self.assertEqual(task.title, "Original")
+
+    def test_delete_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+
+        response = self.client.delete(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        task.refresh_from_db()
+        self.assertFalse(task.deleted)
+
+    def test_staged_artifacts_prepare_upload_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/staged_artifacts/prepare_upload/",
+            {"artifacts": [{"name": "x.txt", "type": "user_attachment", "size": 1}]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_list_runs_for_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+        TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_run_for_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {"environment": "cloud"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
+
+    def test_command_on_other_user_run_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/command/",
+            {"jsonrpc": "2.0", "method": "user_message", "params": {"content": "leak secrets"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_set_output_on_other_user_run_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+
+        response = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/set_output/",
+            {"output": {"pr_url": "https://example.com/hijack"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_connection_token_on_other_user_run_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = self.create_task(created_by=other_user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+
+        response = self.client.get(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/connection_token/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_run_automation_for_other_user_task_returns_404(self):
+        other_user = self.create_organization_user("victim")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=other_user,
+            title="Their automation task",
+            description="prompt",
+            origin_product=Task.OriginProduct.AUTOMATION,
+            repository="victim/repo",
+        )
+        automation = TaskAutomation.objects.create(
+            task=task,
+            cron_expression="0 9 * * *",
+            timezone="Europe/London",
+            enabled=True,
+        )
+
+        response = self.client.post(f"/api/projects/@current/task_automations/{automation.id}/run/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class TestTaskAPI(BaseTaskAPITest):
@@ -1217,7 +1396,11 @@ class TestTaskAPI(BaseTaskAPITest):
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_rejects_user_authorship_when_requester_is_not_creator(self, mock_workflow: MagicMock) -> None:
+    def test_run_endpoint_rejects_non_creator_with_404(self, mock_workflow: MagicMock) -> None:
+        # Cross-user run attempts are blocked at the queryset level: a teammate
+        # cannot see (let alone run) someone else's task. The previous
+        # `github_authorization_required` 400 path is now unreachable for
+        # non-creators and is superseded by this 404.
         task = self.create_task(created_by=self.user)
         task.repository = "posthog/posthog"
         task.save(update_fields=["repository"])
@@ -1235,13 +1418,8 @@ class TestTaskAPI(BaseTaskAPITest):
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == {
-            "type": "validation_error",
-            "code": "github_authorization_required",
-            "detail": "User-authored runs must be started by the task creator, or provide github_user_token.",
-            "attr": "pr_authorship_mode",
-        }
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert not TaskRun.objects.filter(task=task).exists()
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
@@ -1587,9 +1765,12 @@ class TestTaskAPI(BaseTaskAPITest):
 
     @parameterized.expand(
         [
+            # Tasks are creator-scoped: a user can only ever see their own tasks
+            # plus legacy tasks without a creator. The `created_by` filter narrows
+            # within that visible set; it cannot widen it to other users' tasks.
             ("self_user", "self", [0]),
-            ("other_user", "other", [1]),
-            ("no_filter", None, [0, 1, 2]),
+            ("other_user", "other", []),
+            ("no_filter", None, [0, 2]),
         ]
     )
     def test_filter_by_created_by(self, _name, filter_user, expected_indices):


### PR DESCRIPTION
we should restrict these to the task creator, rather than share across teams