### PR TITLE
feat(data-warehouse): add Firebase Firestore source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -54,6 +54,7 @@ the row lists both.
 | convex        | HTTP                        | requests                                                        | ✅                          |
 | customer_io   | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
 | doit          | HTTP                        | requests                                                        | ✅                          |
+| firebase      | HTTP                        | requests + google-auth                                          | ✅                          |
 | github        | HTTP                        | requests                                                        | ✅                          |
 | google_ads    | gRPC                        | google-ads (googleads.client)                                   | ➖                          |
 | google_sheets | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
@@ -107,7 +108,7 @@ sync logic yet — picking up any of them means following the [implementing-ware
 active_campaign, adjust, aircall, airtable, amazon_ads, amplitude, apple_search_ads, appsflyer, asana,
 ashby, auth0, azure_blob, bamboohr, bigcommerce, box, braintree, braze, brevo, calendly, campaign_monitor,
 chartmogul, circleci, clickup, close, cockroachdb, confluence, convertkit, copper, datadog,
-drip, dynamodb, elasticsearch, eventbrite, facebook_pages, firebase, freshdesk, freshsales, front,
+drip, dynamodb, elasticsearch, eventbrite, facebook_pages, freshdesk, freshsales, front,
 fullstory, gitlab, gong, google_analytics, google_drive, gorgias, granola, greenhouse, helpscout,
 instagram, intercom, iterable, jira, kafka, launchdarkly, lever, mailerlite, mailjet, marketo,
 microsoft_teams, mixpanel, monday, netsuite, notion, okta, omnisend, onedrive, oracle, outreach,

--- a/posthog/temporal/data_imports/sources/firebase/firestore.py
+++ b/posthog/temporal/data_imports/sources/firebase/firestore.py
@@ -1,0 +1,481 @@
+import json
+import base64
+import dataclasses
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any, Optional
+
+import requests
+from google.auth.transport.requests import Request as GoogleRequest
+from google.oauth2 import service_account
+from structlog.types import FilteringBoundLogger
+
+from posthog.temporal.data_imports.naming_convention import NamingConvention
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.firebase.settings import (
+    DEFAULT_DATABASE_ID,
+    FIRESTORE_BASE_URL,
+    FIRESTORE_SCOPE,
+    LIST_PAGE_SIZE,
+    REQUEST_TIMEOUT_SECONDS,
+    SCHEMA_INFERENCE_SAMPLE_SIZE,
+)
+
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+
+@dataclasses.dataclass
+class FirebaseResumeConfig:
+    """Cursor for resuming a Firestore sync.
+
+    `mode` distinguishes a full-refresh `documents.list` page token from an
+    incremental `runQuery` cursor (the last seen `updateTime` ISO string).
+    """
+
+    mode: str
+    cursor: str
+
+
+def validate_service_account_credentials(key_info: dict[str, str]) -> None:
+    """Exchange a service-account JSON for an OAuth2 access token to confirm the
+    key is valid. Raises with a friendly message on failure."""
+    if not key_info.get("project_id"):
+        raise ValueError("Service account key must contain a project_id")
+
+    try:
+        credentials = service_account.Credentials.from_service_account_info(key_info, scopes=[FIRESTORE_SCOPE])
+        credentials.refresh(GoogleRequest())
+    except Exception as e:
+        raise ValueError(f"Failed to authenticate with provided Firebase service account key: {e}") from e
+
+
+def _get_access_token(key_info: dict[str, str]) -> str:
+    credentials = service_account.Credentials.from_service_account_info(key_info, scopes=[FIRESTORE_SCOPE])
+    credentials.refresh(GoogleRequest())
+    return credentials.token
+
+
+def _build_session(access_token: str) -> requests.Session:
+    return make_tracked_session(headers={"Authorization": f"Bearer {access_token}"})
+
+
+def _project_id(key_info: dict[str, str]) -> str:
+    project_id = key_info.get("project_id")
+    if not project_id:
+        raise ValueError("Service account key must contain a project_id")
+    return project_id
+
+
+def _documents_path(project_id: str, database_id: str) -> str:
+    return f"{FIRESTORE_BASE_URL}/projects/{project_id}/databases/{database_id}/documents"
+
+
+def list_collection_ids(
+    key_info: dict[str, str],
+    database_id: str = DEFAULT_DATABASE_ID,
+) -> list[str]:
+    """Enumerate top-level collections via Firestore's `:listCollectionIds` RPC.
+
+    The endpoint paginates with `nextPageToken`; we walk every page so partial
+    listings don't masquerade as the full collection set."""
+    project_id = _project_id(key_info)
+    access_token = _get_access_token(key_info)
+    session = _build_session(access_token)
+
+    url = f"{_documents_path(project_id, database_id)}:listCollectionIds"
+    collection_ids: list[str] = []
+    page_token: str | None = None
+    try:
+        while True:
+            body: dict[str, Any] = {"pageSize": 100}
+            if page_token:
+                body["pageToken"] = page_token
+            response = session.post(url, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            payload = response.json()
+            collection_ids.extend(payload.get("collectionIds", []))
+            page_token = payload.get("nextPageToken")
+            if not page_token:
+                break
+    finally:
+        session.close()
+
+    return collection_ids
+
+
+def get_collection_schemas(
+    key_info: dict[str, str],
+    database_id: str = DEFAULT_DATABASE_ID,
+    collection_names: list[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Return inferred schema info per collection.
+
+    Each value is a dict with `columns` (list of (name, type, nullable))
+    and `incremental_fields` (list of `IncrementalField`). Always includes
+    the synthetic `_id`, `_create_time`, `_update_time` columns; Firestore
+    doesn't expose real schemas, so further columns are inferred from a
+    bounded sample of documents."""
+    project_id = _project_id(key_info)
+    access_token = _get_access_token(key_info)
+    session = _build_session(access_token)
+
+    try:
+        all_collections = list_collection_ids(key_info, database_id=database_id)
+        if collection_names is not None:
+            wanted = set(collection_names)
+            all_collections = [c for c in all_collections if c in wanted]
+
+        result: dict[str, dict[str, Any]] = {}
+        for collection_id in all_collections:
+            sample = _sample_collection(
+                session=session,
+                project_id=project_id,
+                database_id=database_id,
+                collection_id=collection_id,
+                limit=SCHEMA_INFERENCE_SAMPLE_SIZE,
+            )
+            inferred_columns = _infer_columns_from_documents(sample)
+            base_columns: list[tuple[str, str, bool]] = [
+                ("_id", "string", False),
+                ("_create_time", "timestamp", False),
+                ("_update_time", "timestamp", False),
+            ]
+            seen = {name for name, _, _ in base_columns}
+            columns = base_columns + [c for c in inferred_columns if c[0] not in seen]
+            result[collection_id] = {
+                "columns": columns,
+                "incremental_fields": _build_incremental_fields(),
+            }
+        return result
+    finally:
+        session.close()
+
+
+def _build_incremental_fields() -> list[IncrementalField]:
+    return [
+        IncrementalField(
+            label="_update_time",
+            type=IncrementalFieldType.Timestamp,
+            field="_update_time",
+            field_type=IncrementalFieldType.Timestamp,
+            is_indexed=True,
+        )
+    ]
+
+
+def _sample_collection(
+    session: requests.Session,
+    project_id: str,
+    database_id: str,
+    collection_id: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    url = f"{_documents_path(project_id, database_id)}/{collection_id}"
+    params = {"pageSize": min(limit, LIST_PAGE_SIZE)}
+    response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    payload = response.json()
+    documents = payload.get("documents", []) or []
+    return documents[:limit]
+
+
+_FIRESTORE_TYPE_TO_INTERNAL = {
+    "stringValue": "string",
+    "booleanValue": "boolean",
+    "integerValue": "integer",
+    "doubleValue": "double",
+    "timestampValue": "timestamp",
+    "nullValue": "string",
+    "bytesValue": "string",
+    "referenceValue": "string",
+    "geoPointValue": "string",
+    "arrayValue": "string",
+    "mapValue": "string",
+}
+
+
+def _infer_columns_from_documents(documents: list[dict[str, Any]]) -> list[tuple[str, str, bool]]:
+    """Infer (column_name, type, nullable) tuples from a sample of docs.
+
+    A field is `nullable=True` if any sampled doc lacks it or sets it to null.
+    Type is taken from the first non-null occurrence; mixed types fall back to
+    `string` since we serialize the raw value to JSON anyway."""
+    field_observations: dict[str, set[str]] = {}
+    field_seen_in: dict[str, int] = {}
+    total_docs = len(documents)
+    for doc in documents:
+        fields = doc.get("fields") or {}
+        for field_name, value in fields.items():
+            field_seen_in[field_name] = field_seen_in.get(field_name, 0) + 1
+            value_type = next(iter(value.keys()), "stringValue") if isinstance(value, dict) else "stringValue"
+            field_observations.setdefault(field_name, set()).add(value_type)
+
+    columns: list[tuple[str, str, bool]] = []
+    for field_name, type_set in sorted(field_observations.items()):
+        type_set_no_null = type_set - {"nullValue"}
+        if len(type_set_no_null) == 1:
+            firestore_type = next(iter(type_set_no_null))
+        elif len(type_set_no_null) == 0:
+            firestore_type = "nullValue"
+        else:
+            firestore_type = "stringValue"
+        internal_type = _FIRESTORE_TYPE_TO_INTERNAL.get(firestore_type, "string")
+        nullable = field_seen_in.get(field_name, 0) < total_docs or "nullValue" in type_set
+        columns.append((field_name, internal_type, nullable))
+    return columns
+
+
+def _normalize_value(value: dict[str, Any]) -> Any:
+    """Unwrap a single Firestore tagged-union value into a Python primitive.
+
+    Maps and arrays serialize to JSON strings so they fit ClickHouse columnar
+    storage cleanly. Scalars (string, bool, int, double, timestamp) round-trip
+    as native types. Bytes decode from base64 to a UTF-8 string."""
+    if not isinstance(value, dict) or not value:
+        return None
+    key = next(iter(value.keys()))
+    raw = value[key]
+    if key == "nullValue":
+        return None
+    if key == "stringValue":
+        return raw
+    if key == "booleanValue":
+        return bool(raw)
+    if key == "integerValue":
+        return int(raw)
+    if key == "doubleValue":
+        return float(raw)
+    if key == "timestampValue":
+        return _parse_timestamp(raw)
+    if key == "bytesValue":
+        try:
+            return base64.b64decode(raw).decode("utf-8", errors="replace")
+        except Exception:
+            return raw
+    if key == "referenceValue":
+        return raw
+    if key == "geoPointValue":
+        return json.dumps({"latitude": raw.get("latitude"), "longitude": raw.get("longitude")})
+    if key == "arrayValue":
+        items = raw.get("values", []) if isinstance(raw, dict) else []
+        return json.dumps([_normalize_value(v) for v in items], default=str)
+    if key == "mapValue":
+        fields = raw.get("fields", {}) if isinstance(raw, dict) else {}
+        return json.dumps({k: _normalize_value(v) for k, v in fields.items()}, default=str)
+    return None
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    # Firestore returns RFC3339 with up to nanosecond precision and a trailing Z.
+    # Python's fromisoformat requires microseconds, so trim if needed.
+    cleaned = value.rstrip("Z")
+    # Trim any sub-microsecond digits.
+    if "." in cleaned:
+        head, _, frac = cleaned.partition(".")
+        # Keep up to 6 digits of fractional seconds.
+        cleaned = f"{head}.{frac[:6]}" if frac else head
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def _document_id(document: dict[str, Any]) -> str:
+    name = document.get("name", "") or ""
+    return name.rsplit("/", 1)[-1] if name else ""
+
+
+def _normalize_document(document: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Firestore document into a row.
+
+    Always emits `_id`, `_create_time`, `_update_time`, plus one column per
+    top-level field. Nested maps/arrays land as JSON strings."""
+    fields = document.get("fields", {}) or {}
+    row: dict[str, Any] = {
+        "_id": _document_id(document),
+        "_create_time": _parse_timestamp(document.get("createTime", "")),
+        "_update_time": _parse_timestamp(document.get("updateTime", "")),
+    }
+    for field_name, value in fields.items():
+        # Don't clobber the synthetic columns if the doc itself has fields with
+        # the same names — prefer the system metadata which is unambiguous.
+        if field_name in row:
+            continue
+        row[field_name] = _normalize_value(value)
+    return row
+
+
+def _iter_full_refresh(
+    session: requests.Session,
+    project_id: str,
+    database_id: str,
+    collection_id: str,
+    resume_token: Optional[str],
+    resumable_source_manager: ResumableSourceManager[FirebaseResumeConfig],
+    logger: FilteringBoundLogger,
+) -> Iterator[dict[str, Any]]:
+    url = f"{_documents_path(project_id, database_id)}/{collection_id}"
+    page_token = resume_token
+    while True:
+        params: dict[str, Any] = {"pageSize": LIST_PAGE_SIZE}
+        if page_token:
+            params["pageToken"] = page_token
+        response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+        documents = payload.get("documents", []) or []
+        for doc in documents:
+            yield _normalize_document(doc)
+        next_page_token = payload.get("nextPageToken")
+        if not next_page_token:
+            break
+        # Save state AFTER yielding the batch so a crash re-yields the last
+        # batch (merge dedupes on _id) rather than skipping it.
+        resumable_source_manager.save_state(FirebaseResumeConfig(mode="list", cursor=next_page_token))
+        logger.debug(f"Saved resume token for collection={collection_id}, page_token={next_page_token}")
+        page_token = next_page_token
+
+
+def _iter_incremental(
+    session: requests.Session,
+    project_id: str,
+    database_id: str,
+    collection_id: str,
+    last_update_time_iso: str,
+    resumable_source_manager: ResumableSourceManager[FirebaseResumeConfig],
+    logger: FilteringBoundLogger,
+) -> Iterator[dict[str, Any]]:
+    """Stream documents updated after `last_update_time_iso` via `:runQuery`.
+
+    Firestore's `runQuery` returns one element per document inline rather than
+    in pages, but it always orders deterministically — we cursor by re-issuing
+    the same query with `startAt` set to the last-seen document. We bound each
+    issue at LIST_PAGE_SIZE to keep memory predictable and to give the
+    resumable manager a place to save state."""
+    url = f"{_documents_path(project_id, database_id)}:runQuery"
+    cursor_iso = last_update_time_iso
+    while True:
+        body = _build_run_query_body(collection_id=collection_id, after_update_time_iso=cursor_iso)
+        response = session.post(url, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+        # `runQuery` returns an array of {document?: {...}, readTime: ...}; the
+        # first element may be empty when the result set is empty.
+        documents = [item.get("document") for item in payload if item.get("document")]
+        if not documents:
+            break
+        new_cursor: str | None = None
+        for doc in documents:
+            yield _normalize_document(doc)
+            update_time = doc.get("updateTime")
+            if update_time:
+                new_cursor = update_time
+        if not new_cursor or new_cursor == cursor_iso:
+            break
+        resumable_source_manager.save_state(FirebaseResumeConfig(mode="query", cursor=new_cursor))
+        logger.debug(f"Saved incremental cursor for collection={collection_id}, update_time={new_cursor}")
+        cursor_iso = new_cursor
+        if len(documents) < LIST_PAGE_SIZE:
+            break
+
+
+def _build_run_query_body(collection_id: str, after_update_time_iso: str) -> dict[str, Any]:
+    return {
+        "structuredQuery": {
+            "from": [{"collectionId": collection_id}],
+            "where": {
+                "fieldFilter": {
+                    "field": {"fieldPath": "__update_time__"},
+                    "op": "GREATER_THAN",
+                    "value": {"timestampValue": after_update_time_iso},
+                }
+            },
+            "orderBy": [
+                {"field": {"fieldPath": "__update_time__"}, "direction": "ASCENDING"},
+                {"field": {"fieldPath": "__name__"}, "direction": "ASCENDING"},
+            ],
+            "limit": LIST_PAGE_SIZE,
+        }
+    }
+
+
+def _initial_incremental_value(db_incremental_field_last_value: Optional[Any]) -> str:
+    if db_incremental_field_last_value is None:
+        return "1970-01-01T00:00:00Z"
+    if isinstance(db_incremental_field_last_value, datetime):
+        return db_incremental_field_last_value.isoformat() + (
+            "Z" if db_incremental_field_last_value.tzinfo is None else ""
+        )
+    return str(db_incremental_field_last_value)
+
+
+def firestore_source(
+    key_info: dict[str, str],
+    database_id: str,
+    collection_id: str,
+    should_use_incremental_field: bool,
+    incremental_field: Optional[str],
+    db_incremental_field_last_value: Optional[Any],
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[FirebaseResumeConfig],
+) -> SourceResponse:
+    """Top-level pipeline entry. Returns a `SourceResponse` whose `items`
+    callable performs the actual REST iteration on demand."""
+    project_id = _project_id(key_info)
+    use_incremental = should_use_incremental_field and incremental_field == "_update_time"
+
+    def get_rows() -> Iterator[dict[str, Any]]:
+        # New session per run so the access token reflects current expiry. The
+        # token lasts ~1 hour; long syncs may need a refresh — the tracked
+        # session adapter retries 5xx for us, but a 401 must be handled here.
+        access_token = _get_access_token(key_info)
+        session = _build_session(access_token)
+        try:
+            resume_state: FirebaseResumeConfig | None = None
+            if resumable_source_manager.can_resume():
+                resume_state = resumable_source_manager.load_state()
+                if resume_state is not None:
+                    logger.info(f"Resuming Firestore sync for collection={collection_id}, mode={resume_state.mode}")
+
+            if use_incremental:
+                cursor = (
+                    resume_state.cursor
+                    if resume_state and resume_state.mode == "query"
+                    else _initial_incremental_value(db_incremental_field_last_value)
+                )
+                yield from _iter_incremental(
+                    session=session,
+                    project_id=project_id,
+                    database_id=database_id,
+                    collection_id=collection_id,
+                    last_update_time_iso=cursor,
+                    resumable_source_manager=resumable_source_manager,
+                    logger=logger,
+                )
+            else:
+                token = resume_state.cursor if resume_state and resume_state.mode == "list" else None
+                yield from _iter_full_refresh(
+                    session=session,
+                    project_id=project_id,
+                    database_id=database_id,
+                    collection_id=collection_id,
+                    resume_token=token,
+                    resumable_source_manager=resumable_source_manager,
+                    logger=logger,
+                )
+        finally:
+            session.close()
+
+    return SourceResponse(
+        name=NamingConvention.normalize_identifier(collection_id),
+        items=get_rows,
+        primary_keys=["_id"],
+        sort_mode="asc",
+        partition_keys=["_create_time"],
+        partition_mode="datetime",
+        partition_format="month",
+    )

--- a/posthog/temporal/data_imports/sources/firebase/settings.py
+++ b/posthog/temporal/data_imports/sources/firebase/settings.py
@@ -1,0 +1,11 @@
+FIRESTORE_BASE_URL = "https://firestore.googleapis.com/v1"
+
+DEFAULT_DATABASE_ID = "(default)"
+
+FIRESTORE_SCOPE = "https://www.googleapis.com/auth/datastore"
+
+LIST_PAGE_SIZE = 300
+
+SCHEMA_INFERENCE_SAMPLE_SIZE = 100
+
+REQUEST_TIMEOUT_SECONDS = 60

--- a/posthog/temporal/data_imports/sources/firebase/source.py
+++ b/posthog/temporal/data_imports/sources/firebase/source.py
@@ -1,29 +1,156 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldFileUploadConfig,
+    SourceFieldFileUploadJsonFormatConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.firebase.firestore import (
+    FirebaseResumeConfig,
+    firestore_source,
+    get_collection_schemas,
+    list_collection_ids,
+    validate_service_account_credentials,
+)
 from posthog.temporal.data_imports.sources.generated_configs import FirebaseSourceConfig
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class FirebaseSource(SimpleSource[FirebaseSourceConfig]):
+class FirebaseSource(ResumableSource[FirebaseSourceConfig, FirebaseResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.FIREBASE
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized": "Service account credentials are invalid or expired. Please reconnect with a fresh service account JSON.",
+            "403 Client Error: Forbidden": "Service account is missing the required Firestore permissions. Grant the 'Cloud Datastore User' role (or equivalent) to the service account.",
+            "404 Client Error: Not Found": "The specified Firestore database does not exist for this project.",
+            "Failed to authenticate with provided Firebase service account key": None,
+            "Service account key must contain a project_id": None,
+        }
+
+    def get_schemas(
+        self,
+        config: FirebaseSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+    ) -> list[SourceSchema]:
+        database_id = config.database_id or "(default)"
+
+        collection_schemas = get_collection_schemas(
+            key_info=_key_info(config),
+            database_id=database_id,
+            collection_names=names,
+        )
+
+        return [
+            SourceSchema(
+                name=collection_id,
+                supports_incremental=True,
+                supports_append=True,
+                incremental_fields=collection_schemas[collection_id]["incremental_fields"],
+                columns=collection_schemas[collection_id]["columns"],
+                detected_primary_keys=["_id"],
+            )
+            for collection_id in collection_schemas
+        ]
+
+    def validate_credentials(
+        self,
+        config: FirebaseSourceConfig,
+        team_id: int,
+        schema_name: Optional[str] = None,
+    ) -> tuple[bool, str | None]:
+        database_id = config.database_id or "(default)"
+        try:
+            validate_service_account_credentials(_key_info(config))
+        except Exception as e:
+            return False, str(e)
+
+        try:
+            list_collection_ids(_key_info(config), database_id=database_id)
+        except Exception as e:
+            capture_exception(e)
+            return False, f"Failed to connect to Firestore database: {e}"
+
+        return True, None
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[FirebaseResumeConfig]:
+        return ResumableSourceManager[FirebaseResumeConfig](inputs, FirebaseResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: FirebaseSourceConfig,
+        resumable_source_manager: ResumableSourceManager[FirebaseResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return firestore_source(
+            key_info=_key_info(config),
+            database_id=config.database_id or "(default)",
+            collection_id=inputs.schema_name,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            incremental_field=inputs.incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+        )
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FIREBASE,
             label="Firebase",
+            caption="Sync collections from Cloud Firestore. Upload a Google Cloud service account JSON key with the **Cloud Datastore User** role (or equivalent Firestore read access).",
             iconPath="/static/services/firebase.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/firebase",
+            releaseStatus=ReleaseStatus.ALPHA,
+            featureFlag="dwh-firebase",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldFileUploadConfig(
+                        name="key_file",
+                        label="Google Cloud service account JSON key",
+                        fileFormat=SourceFieldFileUploadJsonFormatConfig(
+                            format=".json",
+                            keys=["project_id", "private_key", "private_key_id", "client_email", "token_uri"],
+                        ),
+                        required=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="database_id",
+                        label="Firestore database ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="(default)",
+                        caption="Most projects only have one Firestore database. Leave blank or set to `(default)` unless you use named databases.",
+                        secret=False,
+                    ),
+                ],
+            ),
         )
+
+
+def _key_info(config: FirebaseSourceConfig) -> dict[str, str]:
+    return {
+        "project_id": config.key_file.project_id,
+        "private_key": config.key_file.private_key,
+        "private_key_id": config.key_file.private_key_id,
+        "client_email": config.key_file.client_email,
+        "token_uri": config.key_file.token_uri,
+    }

--- a/posthog/temporal/data_imports/sources/firebase/tests/test_firebase_source.py
+++ b/posthog/temporal/data_imports/sources/firebase/tests/test_firebase_source.py
@@ -1,0 +1,212 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import (
+    ReleaseStatus,
+    SourceFieldFileUploadConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+)
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.firebase.firestore import FirebaseResumeConfig
+from posthog.temporal.data_imports.sources.firebase.source import FirebaseSource
+from posthog.temporal.data_imports.sources.generated_configs import FirebaseKeyFileConfig, FirebaseSourceConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType, IncrementalFieldType
+
+
+def _make_config(database_id: str | None = None) -> FirebaseSourceConfig:
+    return FirebaseSourceConfig(
+        key_file=FirebaseKeyFileConfig(
+            project_id="my-project",
+            private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+            private_key_id="kid",
+            client_email="svc@my-project.iam.gserviceaccount.com",
+            token_uri="https://oauth2.googleapis.com/token",
+        ),
+        database_id=database_id,
+    )
+
+
+class TestFirebaseSource:
+    def setup_method(self):
+        self.source = FirebaseSource()
+        self.team_id = 123
+        self.config = _make_config()
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.FIREBASE
+
+    def test_get_source_config_metadata(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Firebase"
+        assert config.label == "Firebase"
+        assert config.iconPath == "/static/services/firebase.png"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.featureFlag == "dwh-firebase"
+        assert config.unreleasedSource is None
+        assert len(config.fields) == 2
+
+    def test_get_source_config_key_file_field(self):
+        key_file_field = self.source.get_source_config.fields[0]
+
+        assert isinstance(key_file_field, SourceFieldFileUploadConfig)
+        assert key_file_field.name == "key_file"
+        assert key_file_field.required is True
+        assert isinstance(key_file_field.fileFormat.keys, list)
+        assert set(key_file_field.fileFormat.keys) == {
+            "project_id",
+            "private_key",
+            "private_key_id",
+            "client_email",
+            "token_uri",
+        }
+
+    def test_get_source_config_database_id_field(self):
+        database_id_field = self.source.get_source_config.fields[1]
+
+        assert isinstance(database_id_field, SourceFieldInputConfig)
+        assert database_id_field.name == "database_id"
+        assert database_id_field.type == SourceFieldInputConfigType.TEXT
+        assert database_id_field.required is False
+        assert database_id_field.placeholder == "(default)"
+
+    @pytest.mark.parametrize(
+        "expected_key",
+        [
+            "401 Client Error: Unauthorized",
+            "403 Client Error: Forbidden",
+            "404 Client Error: Not Found",
+        ],
+    )
+    def test_non_retryable_errors_covers_auth_and_not_found(self, expected_key):
+        errors = self.source.get_non_retryable_errors()
+
+        assert expected_key in errors
+
+    def test_get_resumable_source_manager_returns_correct_manager(self):
+        inputs = mock.Mock()
+        inputs.team_id = self.team_id
+        inputs.job_id = "job-1"
+        inputs.logger = mock.Mock()
+
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is FirebaseResumeConfig
+
+    def test_get_schemas_uses_default_database_when_blank(self):
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.firebase.source.get_collection_schemas"
+        ) as mock_get_schemas:
+            mock_get_schemas.return_value = {
+                "users": {
+                    "columns": [
+                        ("_id", "string", False),
+                        ("_create_time", "timestamp", False),
+                        ("_update_time", "timestamp", False),
+                        ("name", "string", True),
+                    ],
+                    "incremental_fields": [
+                        {
+                            "label": "_update_time",
+                            "type": IncrementalFieldType.Timestamp,
+                            "field": "_update_time",
+                            "field_type": IncrementalFieldType.Timestamp,
+                            "is_indexed": True,
+                        }
+                    ],
+                }
+            }
+
+            schemas = self.source.get_schemas(self.config, self.team_id)
+
+            mock_get_schemas.assert_called_once()
+            assert mock_get_schemas.call_args.kwargs["database_id"] == "(default)"
+            assert len(schemas) == 1
+            schema = schemas[0]
+            assert schema.name == "users"
+            assert schema.supports_incremental is True
+            assert schema.supports_append is True
+            assert schema.detected_primary_keys == ["_id"]
+            assert any(field["field"] == "_update_time" for field in schema.incremental_fields)
+
+    def test_get_schemas_uses_custom_database_id(self):
+        config = _make_config(database_id="prod-db")
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.firebase.source.get_collection_schemas"
+        ) as mock_get_schemas:
+            mock_get_schemas.return_value = {}
+            self.source.get_schemas(config, self.team_id)
+
+            assert mock_get_schemas.call_args.kwargs["database_id"] == "prod-db"
+
+    def test_validate_credentials_success(self):
+        with (
+            mock.patch(
+                "posthog.temporal.data_imports.sources.firebase.source.validate_service_account_credentials"
+            ) as mock_validate,
+            mock.patch("posthog.temporal.data_imports.sources.firebase.source.list_collection_ids") as mock_list,
+        ):
+            mock_validate.return_value = None
+            mock_list.return_value = ["users", "orders"]
+
+            valid, error = self.source.validate_credentials(self.config, self.team_id)
+
+            assert valid is True
+            assert error is None
+
+    def test_validate_credentials_failure_on_bad_key(self):
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.firebase.source.validate_service_account_credentials"
+        ) as mock_validate:
+            mock_validate.side_effect = ValueError(
+                "Failed to authenticate with provided Firebase service account key: bad key"
+            )
+
+            valid, error = self.source.validate_credentials(self.config, self.team_id)
+
+            assert valid is False
+            assert error is not None
+            assert "Failed to authenticate" in error
+
+    def test_validate_credentials_failure_on_list_collections(self):
+        with (
+            mock.patch("posthog.temporal.data_imports.sources.firebase.source.validate_service_account_credentials"),
+            mock.patch("posthog.temporal.data_imports.sources.firebase.source.list_collection_ids") as mock_list,
+            mock.patch("posthog.temporal.data_imports.sources.firebase.source.capture_exception"),
+        ):
+            mock_list.side_effect = RuntimeError("boom")
+
+            valid, error = self.source.validate_credentials(self.config, self.team_id)
+
+            assert valid is False
+            assert error is not None
+            assert "Failed to connect to Firestore" in error
+
+    def test_source_for_pipeline_passes_args_through(self):
+        inputs = mock.Mock()
+        inputs.schema_name = "users"
+        inputs.should_use_incremental_field = True
+        inputs.incremental_field = "_update_time"
+        inputs.db_incremental_field_last_value = None
+        inputs.team_id = self.team_id
+        inputs.logger = mock.Mock()
+
+        manager = mock.Mock(spec=ResumableSourceManager)
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.firebase.source.firestore_source"
+        ) as mock_firestore_source:
+            mock_firestore_source.return_value = mock.sentinel.response
+            response = self.source.source_for_pipeline(self.config, manager, inputs)
+
+            assert response is mock.sentinel.response
+            kwargs = mock_firestore_source.call_args.kwargs
+            assert kwargs["collection_id"] == "users"
+            assert kwargs["database_id"] == "(default)"
+            assert kwargs["should_use_incremental_field"] is True
+            assert kwargs["incremental_field"] == "_update_time"
+            assert kwargs["resumable_source_manager"] is manager

--- a/posthog/temporal/data_imports/sources/firebase/tests/test_firestore.py
+++ b/posthog/temporal/data_imports/sources/firebase/tests/test_firestore.py
@@ -1,0 +1,373 @@
+import json
+import base64
+from datetime import datetime
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.firebase import firestore as firestore_module
+from posthog.temporal.data_imports.sources.firebase.firestore import (
+    FirebaseResumeConfig,
+    _build_run_query_body,
+    _document_id,
+    _infer_columns_from_documents,
+    _initial_incremental_value,
+    _normalize_document,
+    _normalize_value,
+    _parse_timestamp,
+    firestore_source,
+)
+
+
+class TestNormalizeValue:
+    @pytest.mark.parametrize(
+        ("firestore_value", "expected"),
+        [
+            ({"stringValue": "hello"}, "hello"),
+            ({"booleanValue": True}, True),
+            ({"booleanValue": False}, False),
+            ({"integerValue": "42"}, 42),
+            ({"doubleValue": 3.14}, 3.14),
+            ({"nullValue": None}, None),
+            (
+                {"referenceValue": "projects/p/databases/(default)/documents/users/abc"},
+                "projects/p/databases/(default)/documents/users/abc",
+            ),
+        ],
+    )
+    def test_scalar_values(self, firestore_value, expected):
+        assert _normalize_value(firestore_value) == expected
+
+    def test_bytes_value_is_decoded_from_base64(self):
+        encoded = base64.b64encode(b"hello bytes").decode()
+        assert _normalize_value({"bytesValue": encoded}) == "hello bytes"
+
+    def test_geopoint_serializes_to_json(self):
+        result = _normalize_value({"geoPointValue": {"latitude": 12.5, "longitude": -1.0}})
+
+        assert json.loads(result) == {"latitude": 12.5, "longitude": -1.0}
+
+    def test_array_value_recursively_normalizes(self):
+        firestore_value = {
+            "arrayValue": {
+                "values": [
+                    {"stringValue": "a"},
+                    {"integerValue": "1"},
+                    {"booleanValue": True},
+                ]
+            }
+        }
+
+        result = _normalize_value(firestore_value)
+
+        assert json.loads(result) == ["a", 1, True]
+
+    def test_map_value_recursively_normalizes(self):
+        firestore_value = {
+            "mapValue": {
+                "fields": {
+                    "name": {"stringValue": "Alice"},
+                    "age": {"integerValue": "30"},
+                    "tags": {"arrayValue": {"values": [{"stringValue": "x"}]}},
+                }
+            }
+        }
+
+        result = _normalize_value(firestore_value)
+        parsed = json.loads(result)
+
+        assert parsed == {"name": "Alice", "age": 30, "tags": '["x"]'}
+
+    def test_timestamp_parsing(self):
+        result = _normalize_value({"timestampValue": "2025-01-02T03:04:05.123456Z"})
+
+        assert isinstance(result, datetime)
+        assert result.year == 2025
+        assert result.month == 1
+        assert result.day == 2
+
+    def test_unknown_type_returns_none(self):
+        assert _normalize_value({"unknownValue": "x"}) is None
+
+    def test_empty_dict_returns_none(self):
+        assert _normalize_value({}) is None
+
+
+class TestParseTimestamp:
+    def test_strips_trailing_z(self):
+        assert _parse_timestamp("2025-01-02T03:04:05Z") == datetime(2025, 1, 2, 3, 4, 5)
+
+    def test_truncates_subsecond_precision_beyond_microseconds(self):
+        # Firestore can return up to 9 fractional-second digits.
+        assert _parse_timestamp("2025-01-02T03:04:05.123456789Z").microsecond == 123456
+
+    def test_invalid_returns_none(self):
+        assert _parse_timestamp("not-a-date") is None
+
+    def test_empty_returns_none(self):
+        assert _parse_timestamp("") is None
+
+
+class TestDocumentId:
+    def test_extracts_last_path_segment(self):
+        document = {"name": "projects/p/databases/(default)/documents/users/abc-123"}
+
+        assert _document_id(document) == "abc-123"
+
+    def test_returns_empty_when_name_missing(self):
+        assert _document_id({}) == ""
+
+
+class TestNormalizeDocument:
+    def test_emits_synthetic_columns(self):
+        document = {
+            "name": "projects/p/databases/(default)/documents/users/u1",
+            "fields": {"name": {"stringValue": "Alice"}, "age": {"integerValue": "30"}},
+            "createTime": "2025-01-01T00:00:00Z",
+            "updateTime": "2025-01-02T00:00:00Z",
+        }
+
+        row = _normalize_document(document)
+
+        assert row["_id"] == "u1"
+        assert row["_create_time"] == datetime(2025, 1, 1)
+        assert row["_update_time"] == datetime(2025, 1, 2)
+        assert row["name"] == "Alice"
+        assert row["age"] == 30
+
+    def test_synthetic_columns_take_precedence_over_user_fields(self):
+        # If a doc has a user-defined `_id` field, the synthetic _id (doc path) wins.
+        document = {
+            "name": "projects/p/databases/(default)/documents/users/u1",
+            "fields": {"_id": {"stringValue": "hijacked"}},
+            "createTime": "2025-01-01T00:00:00Z",
+            "updateTime": "2025-01-02T00:00:00Z",
+        }
+
+        row = _normalize_document(document)
+
+        assert row["_id"] == "u1"
+
+
+class TestInferColumns:
+    def test_infers_types_and_nullability(self):
+        documents = [
+            {"fields": {"name": {"stringValue": "a"}, "age": {"integerValue": "1"}}},
+            {"fields": {"name": {"stringValue": "b"}}},  # no age in second doc
+            {"fields": {"name": {"stringValue": "c"}, "age": {"integerValue": "3"}}},
+        ]
+
+        columns = _infer_columns_from_documents(documents)
+
+        cols_by_name = {c[0]: c for c in columns}
+        assert cols_by_name["name"] == ("name", "string", False)
+        # Age is missing in the second doc — must be marked nullable.
+        assert cols_by_name["age"][0] == "age"
+        assert cols_by_name["age"][1] == "integer"
+        assert cols_by_name["age"][2] is True
+
+    def test_mixed_types_fall_back_to_string(self):
+        documents = [
+            {"fields": {"value": {"stringValue": "a"}}},
+            {"fields": {"value": {"integerValue": "1"}}},
+        ]
+
+        columns = _infer_columns_from_documents(documents)
+        assert columns == [("value", "string", False)]
+
+    def test_empty_sample_returns_no_columns(self):
+        assert _infer_columns_from_documents([]) == []
+
+
+class TestRunQueryBody:
+    def test_filters_orders_and_limits(self):
+        body = _build_run_query_body(collection_id="users", after_update_time_iso="2025-01-01T00:00:00Z")
+
+        query = body["structuredQuery"]
+        assert query["from"] == [{"collectionId": "users"}]
+        assert query["where"]["fieldFilter"]["op"] == "GREATER_THAN"
+        assert query["where"]["fieldFilter"]["field"] == {"fieldPath": "__update_time__"}
+        assert query["where"]["fieldFilter"]["value"] == {"timestampValue": "2025-01-01T00:00:00Z"}
+        assert query["orderBy"][0]["direction"] == "ASCENDING"
+        assert query["limit"] > 0
+
+
+class TestInitialIncrementalValue:
+    def test_none_yields_epoch(self):
+        assert _initial_incremental_value(None) == "1970-01-01T00:00:00Z"
+
+    def test_string_passes_through(self):
+        assert _initial_incremental_value("2025-01-01T00:00:00Z") == "2025-01-01T00:00:00Z"
+
+    def test_naive_datetime_appends_z(self):
+        assert _initial_incremental_value(datetime(2025, 1, 1, 0, 0, 0)) == "2025-01-01T00:00:00Z"
+
+
+def _key_info() -> dict:
+    return {
+        "project_id": "p",
+        "private_key": "k",
+        "private_key_id": "kid",
+        "client_email": "svc@p.iam.gserviceaccount.com",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+class TestFirestoreSourcePagination:
+    def _patch_auth_and_session(self, session_mock):
+        return [
+            mock.patch.object(firestore_module, "_get_access_token", return_value="token"),
+            mock.patch.object(firestore_module, "_build_session", return_value=session_mock),
+        ]
+
+    def _run(
+        self,
+        responses,
+        should_use_incremental_field=False,
+        db_incremental_field_last_value=None,
+        resumable_can_resume=False,
+        resumable_state=None,
+    ):
+        session = mock.MagicMock()
+        get_response = mock.MagicMock()
+        get_response.raise_for_status.return_value = None
+        get_response.json.side_effect = responses
+        session.get.return_value = get_response
+        session.post.return_value = get_response
+
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = resumable_can_resume
+        manager.load_state.return_value = resumable_state
+        manager.save_state = mock.MagicMock()
+
+        with self._patch_auth_and_session(session)[0]:
+            with self._patch_auth_and_session(session)[1]:
+                response = firestore_source(
+                    key_info=_key_info(),
+                    database_id="(default)",
+                    collection_id="users",
+                    should_use_incremental_field=should_use_incremental_field,
+                    incremental_field="_update_time" if should_use_incremental_field else None,
+                    db_incremental_field_last_value=db_incremental_field_last_value,
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=manager,
+                )
+                rows = list(response.items())
+
+        return rows, session, manager
+
+    def test_full_refresh_walks_pagination_and_terminates(self):
+        responses = [
+            {
+                "documents": [
+                    {
+                        "name": "projects/p/databases/(default)/documents/users/u1",
+                        "fields": {"name": {"stringValue": "Alice"}},
+                        "createTime": "2025-01-01T00:00:00Z",
+                        "updateTime": "2025-01-01T00:00:00Z",
+                    }
+                ],
+                "nextPageToken": "page-2",
+            },
+            {
+                "documents": [
+                    {
+                        "name": "projects/p/databases/(default)/documents/users/u2",
+                        "fields": {"name": {"stringValue": "Bob"}},
+                        "createTime": "2025-01-02T00:00:00Z",
+                        "updateTime": "2025-01-02T00:00:00Z",
+                    }
+                ],
+                # No nextPageToken — termination.
+            },
+        ]
+
+        rows, session, manager = self._run(responses)
+
+        assert [row["_id"] for row in rows] == ["u1", "u2"]
+        # Two GET requests for two pages.
+        assert session.get.call_count == 2
+        # State saved after the first batch (which had a nextPageToken). Not after the
+        # second (terminating) page.
+        manager.save_state.assert_called_once()
+        saved = manager.save_state.call_args.args[0]
+        assert isinstance(saved, FirebaseResumeConfig)
+        assert saved.mode == "list"
+        assert saved.cursor == "page-2"
+
+    def test_full_refresh_resume_starts_from_saved_token(self):
+        responses = [
+            {
+                "documents": [
+                    {
+                        "name": "projects/p/databases/(default)/documents/users/u3",
+                        "fields": {"name": {"stringValue": "Carol"}},
+                        "createTime": "2025-01-03T00:00:00Z",
+                        "updateTime": "2025-01-03T00:00:00Z",
+                    }
+                ],
+            },
+        ]
+
+        rows, session, _ = self._run(
+            responses,
+            resumable_can_resume=True,
+            resumable_state=FirebaseResumeConfig(mode="list", cursor="resume-token"),
+        )
+
+        assert [row["_id"] for row in rows] == ["u3"]
+        first_call_kwargs = session.get.call_args_list[0]
+        assert first_call_kwargs.kwargs["params"]["pageToken"] == "resume-token"
+
+    def test_incremental_uses_run_query_and_advances_cursor(self):
+        responses = [
+            [
+                {
+                    "document": {
+                        "name": "projects/p/databases/(default)/documents/users/u1",
+                        "fields": {"name": {"stringValue": "Alice"}},
+                        "createTime": "2025-01-01T00:00:00Z",
+                        "updateTime": "2025-01-02T00:00:00Z",
+                    }
+                },
+                {
+                    "document": {
+                        "name": "projects/p/databases/(default)/documents/users/u2",
+                        "fields": {"name": {"stringValue": "Bob"}},
+                        "createTime": "2025-01-01T00:00:00Z",
+                        "updateTime": "2025-01-03T00:00:00Z",
+                    }
+                },
+            ],
+            # Empty response — terminate.
+            [],
+        ]
+
+        rows, session, manager = self._run(
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value="2025-01-01T00:00:00Z",
+        )
+
+        assert [row["_id"] for row in rows] == ["u1", "u2"]
+        # First runQuery uses the initial cursor; second uses the updated one.
+        first_call_body = session.post.call_args_list[0].kwargs["json"]
+        assert first_call_body["structuredQuery"]["where"]["fieldFilter"]["value"] == {
+            "timestampValue": "2025-01-01T00:00:00Z"
+        }
+        # State saved after the batch yielded u1 and u2 — cursor moves to the latest updateTime.
+        saved = manager.save_state.call_args.args[0]
+        assert saved.mode == "query"
+        assert saved.cursor == "2025-01-03T00:00:00Z"
+
+    def test_incremental_resume_starts_from_saved_cursor(self):
+        _, session, _ = self._run(
+            [[]],  # empty response — terminate
+            should_use_incremental_field=True,
+            resumable_can_resume=True,
+            resumable_state=FirebaseResumeConfig(mode="query", cursor="2025-06-01T00:00:00Z"),
+        )
+
+        body = session.post.call_args.kwargs["json"]
+        assert body["structuredQuery"]["where"]["fieldFilter"]["value"] == {"timestampValue": "2025-06-01T00:00:00Z"}

--- a/posthog/temporal/data_imports/sources/firebase/tests/test_firestore.py
+++ b/posthog/temporal/data_imports/sources/firebase/tests/test_firestore.py
@@ -1,6 +1,8 @@
 import json
 import base64
+from collections.abc import Iterable
 from datetime import datetime
+from typing import cast
 
 import pytest
 from unittest import mock
@@ -100,7 +102,9 @@ class TestParseTimestamp:
 
     def test_truncates_subsecond_precision_beyond_microseconds(self):
         # Firestore can return up to 9 fractional-second digits.
-        assert _parse_timestamp("2025-01-02T03:04:05.123456789Z").microsecond == 123456
+        parsed = _parse_timestamp("2025-01-02T03:04:05.123456789Z")
+        assert parsed is not None
+        assert parsed.microsecond == 123456
 
     def test_invalid_returns_none(self):
         assert _parse_timestamp("not-a-date") is None
@@ -253,7 +257,7 @@ class TestFirestoreSourcePagination:
                     logger=mock.MagicMock(),
                     resumable_source_manager=manager,
                 )
-                rows = list(response.items())
+                rows = list(cast(Iterable[dict], response.items()))
 
         return rows, session, manager
 

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -37,6 +37,15 @@ class BigQueryUseCustomRegionConfig(config.Config):
 
 
 @config.config
+class FirebaseKeyFileConfig(config.Config):
+    project_id: str
+    private_key: str
+    private_key_id: str
+    client_email: str
+    token_uri: str
+
+
+@config.config
 class GithubAuthMethodConfig(config.Config):
     github_integration_id: int | None = config.value(converter=config.str_to_optional_int, default_factory=lambda: None)
     selection: Literal["oauth", "pat"] = "oauth"
@@ -323,7 +332,8 @@ class FacebookPagesSourceConfig(config.Config):
 
 @config.config
 class FirebaseSourceConfig(config.Config):
-    pass
+    key_file: FirebaseKeyFileConfig
+    database_id: str | None = None
 
 
 @config.config


### PR DESCRIPTION
## Problem

The Firebase data-warehouse source has been scaffolded for a while
(`unreleasedSource=True`, empty fields, no sync logic) but never implemented.
Customers using Firebase want to pull their Firestore collections into the
PostHog warehouse for analytics alongside event data — today the only path is
exporting via Cloud Functions or BigQuery, which is heavy-handed for the
common case.

This wires up an actual Firestore source so customers can connect a Firebase
project with a service-account JSON and sync top-level collections directly.

## Changes

- New `firebase/firestore.py`: REST client built on `make_tracked_session()`,
  Firestore tagged-union → row normalization, `nextPageToken` pagination for
  full refresh, structured `runQuery` with `__update_time__` cursor for
  incremental, and resumable state via `FirebaseResumeConfig` (mode +
  cursor) saved after each batch.
- `firebase/source.py`: replaces the stub. Inherits from `ResumableSource`,
  declares two fields (`key_file` upload + optional `database_id`), discovers
  collections via `:listCollectionIds`, infers columns by sampling ~100
  documents per collection, surfaces `_id` / `_create_time` / `_update_time`
  as synthetic columns. Ships behind `featureFlag="dwh-firebase"` at
  `releaseStatus=alpha`.
- `firebase/settings.py`: base URL, scope, page size, sample size.
- `generated_configs.py`: regenerated entry for `FirebaseSourceConfig` /
  `FirebaseKeyFileConfig` (regenerator output).
- `SOURCES.md`: moved firebase from scaffolded to implemented (HTTP, tracked).
- Tests: 47 unit tests covering normalization (every Firestore value type,
  nested maps/arrays), schema inference, pagination, resume from saved state
  for both modes, run-query body shape, and source-level metadata.

### Why REST instead of `google-cloud-firestore`

The vendor SDK is gRPC-first and exposes no `requests.Session` injection
seam, so it can't participate in our tracked transport — it would need a
`# nosemgrep` pragma and would be classified as `⚠️ Vendor SDK` in
`SOURCES.md`. The REST API gives us tracked logs/metrics/sample-capture for
free and is meaningfully less code.

### Out of scope for v1

Realtime Database, Firebase Auth users, Cloud Storage metadata, and
Firestore subcollections. The architecture leaves room to add any of these
behind the same source.

## How did you test this code?

I'm an agent. I ran:

- `pytest posthog/temporal/data_imports/sources/firebase/tests/` — 47 passed
- `pytest posthog/temporal/data_imports/sources/common/test/` — confirmed the
  source-config generator and registry tests still pass after regenerating
- `ruff check` and `ruff format` on the touched files — clean

I did **not** test against a live Firebase project. End-to-end verification
against a real Firestore instance is needed before flipping the feature flag
on for any customer.

## Publish to changelog?

Yes — once GA. Hold off while `releaseStatus=alpha` and the feature flag
is gating customer access.

## Docs update

A docs page at `posthog.com/docs/cdp/sources/firebase` should follow before
GA. The source's `docsUrl` already points there.

## 🤖 Agent context

Authored by PostHog Code. Key decisions made along the way:

- **Scope**: clarified with the requester that v1 should be Firestore only.
  Realtime DB has a different shape (tree, no collection model) and would
  effectively be a second source.
- **Schema strategy**: chose sample-and-infer (matching MongoDB) over a
  single `data` JSON column. NoSQL docs are heterogeneous but inferred
  columns give significantly better querying ergonomics, and a 100-doc
  sample at discovery is cheap.
- **Transport**: requester asked whether the SDK could be passed a tracked
  session. After checking, it can't (gRPC, no injection seam) — so REST API
  with `make_tracked_session()` was the easier path *and* the one that
  preserves tracked transport, classified as ✅ in `SOURCES.md`.
- **Partition key**: `_create_time` (stable), per the skill's rule against
  using `_update_time`.
- **Token refresh**: the access token is fetched at the start of each run.
  Long syncs that exceed a 1h token lifetime will need a refresh — punted
  to a follow-up; not yet a concern given the resumable design (a 401 will
  fail the run, and the next run resumes from the saved cursor).