### PR TITLE
feat: add policy for not sharing sensitive info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,10 +42,11 @@
 
 <!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
 <!-- Include:
-     - tools/agent used and link to session
+     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
      - decisions made along the way (what was tried, rejected, chosen, and why)
      - anything else that helps reviewers
      Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
+     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
 -->
 <!-- Rules for agent-authored PRs:
      - All PRs must be attributable to a human author, even if agent-assisted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Examples:
 Do not invent a different format.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 Keep descriptions high-level, focusing on rationale and architecture for the human reviewer.
+NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 
 ### Rules
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

[This commit](https://github.com/PostHog/posthog/pull/56122) added instructions for LLM to share intent information when writing PR descriptions. Although this is very useful for reviewers, it may pose a security risk of LLMs sharing sensitive information that may have been shared in an agent session.

## Changes

Added a policy for not sharing sensitive info in `AGENTS.md` and `pull_request_template.md`.


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->