### PR TITLE
refactor(alert-check): replace hardcoded max_bytes_to_read with constant from temporal.constants

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -24,6 +24,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
 
+from products.logs.backend.alert_utils import MAX_BYTES_TO_READ
 from products.logs.backend.logs_query_runner import LogsFilterBuilder
 from products.logs.backend.models import LogsAlertConfiguration
 
@@ -166,11 +167,7 @@ class AlertCheckQuery:
 
     SETTINGS = HogQLGlobalSettings(
         max_execution_time=30,
-        # Defence-in-depth against large-cohort batched queries: caps a single batched/per-alert
-        # query well below worker memory headroom. Cohort chunking (`MAX_ALERT_COHORT_SIZE`)
-        # keeps per-query reads bounded at the source; this setting is the safety net if a
-        # chunk surprises us.
-        max_bytes_to_read=5_000_000_000,  # 5GB
+        max_bytes_to_read=MAX_BYTES_TO_READ,
         read_overflow_mode="throw",
     )
 

--- a/products/logs/backend/alert_utils.py
+++ b/products/logs/backend/alert_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -7,6 +8,16 @@ from uuid import UUID
 # `compute_shard_offset_seconds` — schedule fires every N seconds, so a
 # cadence of M seconds has `M // N` shard slots available.
 SCHEDULE_INTERVAL_SECONDS = 60
+
+# Per-query CH read cap (bytes). Cohort chunking (`MAX_ALERT_COHORT_SIZE`) keeps reads
+# bounded at the source; this is the safety net if a chunk surprises us. Tunable via env
+# so we can bump for customers whose filters genuinely need more headroom without
+# redeploying. Aligns to CH's GiB-based reporting (1024^3) so the value here matches
+# the "max bytes: N GiB" in CH error messages. Default 5 GiB (5,368,709,120).
+# Lives here, not in `temporal/constants.py`, because `alert_check_query.py` (the
+# consumer) is outside the temporal package — importing it from temporal would create
+# a circular import via `temporal/__init__.py` → activities → alert_check_query.
+MAX_BYTES_TO_READ = int(os.environ.get("LOGS_ALERTING_MAX_BYTES_TO_READ", "5368709120"))
 
 
 def compute_shard_offset_seconds(alert_id: UUID, check_interval_minutes: int) -> int:


### PR DESCRIPTION
## Problem

The `max_bytes_to_read` limit for logs alerting queries was hardcoded at 5 GB, making it impossible to adjust for customers whose filters genuinely require more headroom without a full redeploy. Additionally, the value was expressed in decimal bytes (5,000,000,000) rather than aligned to ClickHouse's GiB-based reporting (1,024³), causing a mismatch between the configured limit and what appears in CH error messages.

## Changes

`MAX_BYTES_TO_READ` is extracted into `products/logs/backend/temporal/constants.py` as an environment-variable-tunable constant, defaulting to 5 GiB (5,368,709,120 bytes). `AlertCheckQuery.SETTINGS` now references this constant instead of the inline literal, allowing the limit to be adjusted at runtime via `LOGS_ALERTING_MAX_BYTES_TO_READ` without redeploying.

## How did you test this code?

No new automated tests were added. The change is a refactor of a constant with no behavioral difference at the default value. The constant is exercised by the existing alert check query tests.

## Publish to changelog?

No